### PR TITLE
Prospective build fix for the CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -50,8 +50,9 @@ jobs:
       with:
           command: test
           args: --verbose
+    - name: Prepare cmake module
+      run: cargo xtask cmake --prefix $HOME/sixtyfps_install --install
     - name: C++ Test
       uses: lukka/run-cmake@v2.4
       with:
         cmakeListsTxtPath: examples/cpptest/CMakeLists.txt
-

--- a/examples/cpptest/CMakeLists.txt
+++ b/examples/cpptest/CMakeLists.txt
@@ -32,7 +32,7 @@ function(SIXTYFPS_TARGET_60_SOURCES target)
     target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 endfunction()
 
-find_package(SixtyFPS REQUIRED)
+find_package(SixtyFPS REQUIRED HINTS ${_SIXTYFPS_TARGET_DIR})
 
 ### END This should be moce in some file in api/sixtyfps-cpp/cmake
 


### PR DESCRIPTION
The use of the cmake prefix path is now required.