### PR TITLE
Fix import of types with an underscore

### DIFF
--- a/sixtyfps_compiler/typeloader.rs
+++ b/sixtyfps_compiler/typeloader.rs
@@ -15,7 +15,7 @@ use std::rc::Rc;
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::object_tree::{self, Document};
-use crate::parser::{syntax_nodes, NodeOrToken, SyntaxKind, SyntaxToken};
+use crate::parser::{normalize_identifier, syntax_nodes, NodeOrToken, SyntaxKind, SyntaxToken};
 use crate::typeregister::TypeRegister;
 use crate::CompilerConfiguration;
 
@@ -58,10 +58,11 @@ impl ImportedName {
     }
 
     pub fn from_node(importident: syntax_nodes::ImportIdentifier) -> Self {
-        let external_name = importident.ExternalName().text().to_string().trim().to_string();
+        let external_name =
+            normalize_identifier(importident.ExternalName().text().to_string().trim());
 
         let internal_name = match importident.InternalName() {
-            Some(name_ident) => name_ident.text().to_string().trim().to_string(),
+            Some(name_ident) => normalize_identifier(name_ident.text().to_string().trim()),
             None => external_name.clone(),
         };
 

--- a/tests/cases/imports/external_type.60
+++ b/tests/cases/imports/external_type.60
@@ -12,6 +12,7 @@ import { TestButton as RealButton } from "test_button.60";
 import { ColorButton } from "../helper_components/test_button.60";
 import { Button } from "sixtyfps_widgets.60";
 import { TestButton as ReExportedButton } from "re_export.60";
+import { Main_Window } from "main_window.60";
 TestCase := Rectangle {
     RealButton {} // aliased from external file
     ColorButton {} // from external file

--- a/tests/helper_components/main_window.60
+++ b/tests/helper_components/main_window.60
@@ -11,3 +11,5 @@ LICENSE END */
 export MainWindow := Window {
     property <int> some_prop: 42;
 }
+
+export { MainWindow as Main-Window }


### PR DESCRIPTION
In Exports::from_node() we use parser::identifier_text to extract the
names, which are normalized (with dashes). We need to do the same in

ImportedName::from_node() in order to allow something like

    export Main_Window := ...

and then

    import { Main-Window } from "foo.60";

or even just

    import { Main_Window } from "foo.60";

(that regressed)