### PR TITLE
WIP: Add a `Window::close(int)` builtin function

### DIFF
--- a/api/sixtyfps-cpp/include/sixtyfps.h
+++ b/api/sixtyfps-cpp/include/sixtyfps.h
@@ -748,19 +748,19 @@ struct VersionCheckHelper
 /// Enters the main event loop. This is necessary in order to receive
 /// events from the windowing system in order to render to the screen
 /// and react to user input.
-inline void run_event_loop()
+inline int run_event_loop()
 {
     private_api::assert_main_thread();
-    cbindgen_private::sixtyfps_run_event_loop();
+    return cbindgen_private::sixtyfps_run_event_loop();
 }
 
 /// Schedules the main event loop for termination. This function is meant
 /// to be called from callbacks triggered by the UI. After calling the function,
 /// it will return immediately and once control is passed back to the event loop,
 /// the initial call to sixtyfps::run_event_loop() will return.
-inline void quit_event_loop()
+inline void quit_event_loop(int error_code = 0)
 {
-    cbindgen_private::sixtyfps_quit_event_loop();
+    cbindgen_private::sixtyfps_quit_event_loop(error_code);
 }
 
 /// Adds the specified functor to an internal queue, notifies the event loop to wake up.

--- a/api/sixtyfps-cpp/lib.rs
+++ b/api/sixtyfps-cpp/lib.rs
@@ -30,9 +30,9 @@ pub unsafe extern "C" fn sixtyfps_windowrc_init(out: *mut WindowRcOpaque) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sixtyfps_run_event_loop() {
+pub unsafe extern "C" fn sixtyfps_run_event_loop() -> i32 {
     crate::backend()
-        .run_event_loop(sixtyfps_corelib::backend::EventLoopQuitBehavior::QuitOnLastWindowClosed);
+        .run_event_loop(sixtyfps_corelib::backend::EventLoopQuitBehavior::QuitOnLastWindowClosed)
 }
 
 /// Will execute the given functor in the main thread
@@ -63,8 +63,8 @@ pub unsafe extern "C" fn sixtyfps_post_event(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sixtyfps_quit_event_loop() {
-    crate::backend().quit_event_loop();
+pub unsafe extern "C" fn sixtyfps_quit_event_loop(exit_code: i32) {
+    crate::backend().quit_event_loop(exit_code);
 }
 
 #[no_mangle]

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -387,6 +387,11 @@ pub mod internal {
             handler(<StrongRef as StrongComponentRef>::from_weak(&weak).unwrap(), arg)
         })
     }
+
+    // fixme: merge with sixtyfps::quit_event_loop
+    pub fn quit_event_loop_with_error_code(error_code: i32) {
+        sixtyfps_rendering_backend_default::backend().quit_event_loop(error_code);
+    }
 }
 
 /// Creates a new window to render components in.
@@ -398,9 +403,9 @@ pub fn create_window() -> re_exports::WindowRc {
 /// Enters the main event loop. This is necessary in order to receive
 /// events from the windowing system in order to render to the screen
 /// and react to user input.
-pub fn run_event_loop() {
+pub fn run_event_loop() -> i32 {
     sixtyfps_rendering_backend_default::backend()
-        .run_event_loop(sixtyfps_corelib::backend::EventLoopQuitBehavior::QuitOnLastWindowClosed);
+        .run_event_loop(sixtyfps_corelib::backend::EventLoopQuitBehavior::QuitOnLastWindowClosed)
 }
 
 /// Schedules the main event loop for termination. This function is meant
@@ -408,7 +413,7 @@ pub fn run_event_loop() {
 /// it will return immediately and once control is passed back to the event loop,
 /// the initial call to [`run_event_loop()`] will return.
 pub fn quit_event_loop() {
-    sixtyfps_rendering_backend_default::backend().quit_event_loop();
+    sixtyfps_rendering_backend_default::backend().quit_event_loop(0);
 }
 
 /// Adds the specified function to an internal queue, notifies the event loop to wake up.

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -53,6 +53,11 @@ or smaller. The initial width can be controlled with the `preferred-width` prope
 * **`default-font-weight`** (*int*): The font weight to use as default in text elements inside this window, that don't
   have their weight set. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
 
+### Methods
+
+* **`close(int)`** Call this function to close the window and exit the application with that error code.
+
+
 ## `Rectangle`
 
 By default, the rectangle is just an empty item that shows nothing. By setting a color or a border

--- a/sixtyfps_compiler/builtins.60
+++ b/sixtyfps_compiler/builtins.60
@@ -163,6 +163,8 @@ export WindowItem := _ {
     property <length> default-font-size;
     property <int> default-font-weight;
     property <image> icon;
+
+    // close(int) is hardcoded in typeregister.rs
 }
 
 export { WindowItem as Window }

--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -38,6 +38,7 @@ pub enum BuiltinFunction {
     ATan,
     SetFocusItem,
     ShowPopupWindow,
+    CloseWindow,
     /// the "42".to_float()
     StringToFloat,
     /// the "42".is_float()
@@ -94,6 +95,10 @@ impl BuiltinFunction {
             BuiltinFunction::ShowPopupWindow => Type::Function {
                 return_type: Box::new(Type::Void),
                 args: vec![Type::ElementReference],
+            },
+            BuiltinFunction::CloseWindow => Type::Function {
+                return_type: Box::new(Type::Void),
+                args: vec![Type::ElementReference, Type::Int32],
             },
             BuiltinFunction::StringToFloat => {
                 Type::Function { return_type: Box::new(Type::Float32), args: vec![Type::String] }
@@ -158,6 +163,7 @@ impl BuiltinFunction {
             | BuiltinFunction::ATan => true,
             BuiltinFunction::SetFocusItem => false,
             BuiltinFunction::ShowPopupWindow => false,
+            BuiltinFunction::CloseWindow => false,
             BuiltinFunction::StringToFloat | BuiltinFunction::StringIsFloat => true,
             BuiltinFunction::ColorBrighter | BuiltinFunction::ColorDarker => true,
             // ImageSize is pure, except when loading images via the network. Then the initial size will be 0/0 and

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -1550,11 +1550,8 @@ fn compile_expression(
             BuiltinFunction::ASin => format!("[](float a){{ return std::asin(a) / {}; }}", std::f32::consts::PI / 180.),
             BuiltinFunction::ACos => format!("[](float a){{ return std::acos(a) / {}; }}", std::f32::consts::PI / 180.),
             BuiltinFunction::ATan => format!("[](float a){{ return std::atan(a) / {}; }}", std::f32::consts::PI / 180.),
-            BuiltinFunction::SetFocusItem => {
-                "self->m_window.window_handle().set_focus_item".into()
-            }
-            BuiltinFunction::ShowPopupWindow => {
-                "self->m_window.window_handle().show_popup".into()
+            BuiltinFunction::SetFocusItem | BuiltinFunction::ShowPopupWindow | BuiltinFunction::CloseWindow => {
+                panic!("handle in the call expression")
             }
 
            /*  std::from_chars is unfortunately not yet implemented in gcc
@@ -1698,7 +1695,7 @@ fn compile_expression(
             }
             Expression::BuiltinFunctionReference(BuiltinFunction::ShowPopupWindow, _) => {
                 if arguments.len() != 1 {
-                    panic!("internal error: incorrect argument count to SetFocusItem call");
+                    panic!("internal error: incorrect argument count to ShowPopupWindow call");
                 }
                 if let Expression::ElementReference(popup_window) = &arguments[0] {
                     let popup_window = popup_window.upgrade().unwrap();
@@ -1713,6 +1710,12 @@ fn compile_expression(
                 } else {
                     panic!("internal error: argument to SetFocusItem must be an element")
                 }
+            }
+            Expression::BuiltinFunctionReference(BuiltinFunction::CloseWindow, _) => {
+                if arguments.len() != 2 {
+                    panic!("internal error: incorrect argument count to CloseWindow call");
+                }
+                format!("sixtyfps::quit_event_loop({})", compile_expression(&arguments[1], component))
             }
             Expression::BuiltinFunctionReference(BuiltinFunction::ImplicitLayoutInfo(orientation), _) => {
                 if arguments.len() != 1 {

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1219,7 +1219,7 @@ fn compile_expression(expr: &Expression, component: &Rc<Component>) -> TokenStre
             BuiltinFunction::ASin => quote!((|a| (a as f64).asin().to_degrees())),
             BuiltinFunction::ACos => quote!((|a| (a as f64).acos().to_degrees())),
             BuiltinFunction::ATan => quote!((|a| (a as f64).atan().to_degrees())),
-            BuiltinFunction::SetFocusItem | BuiltinFunction::ShowPopupWindow | BuiltinFunction::ImplicitLayoutInfo(_) => {
+            BuiltinFunction::SetFocusItem | BuiltinFunction::ShowPopupWindow | BuiltinFunction::CloseWindow | BuiltinFunction::ImplicitLayoutInfo(_) => {
                 panic!("internal error: should be handled directly in CallFunction")
             }
             BuiltinFunction::StringToFloat => {
@@ -1347,6 +1347,13 @@ fn compile_expression(expr: &Expression, component: &Rc<Component>) -> TokenStre
                     } else {
                         panic!("internal error: argument to SetFocusItem must be an element")
                     }
+                }
+                Expression::BuiltinFunctionReference(BuiltinFunction::CloseWindow, _) => {
+                    if arguments.len() != 2 {
+                        panic!("internal error: incorrect argument count to ShowPopupWindow call");
+                    }
+                    let exit_code = compile_expression(&arguments[1], component);
+                    quote!(sixtyfps::internal::quit_event_loop_with_error_code(#exit_code as _);)
                 }
                 Expression::BuiltinFunctionReference(BuiltinFunction::ImplicitLayoutInfo(orient), _) => {
                     if arguments.len() != 1 {

--- a/sixtyfps_compiler/typeregister.rs
+++ b/sixtyfps_compiler/typeregister.rs
@@ -204,6 +204,19 @@ impl TypeRegister {
             }
             _ => unreachable!(),
         };
+        match &mut register.types.get_mut("Window").unwrap() {
+            Type::Builtin(ref mut b) => {
+                Rc::get_mut(b).unwrap().properties.insert(
+                    "close".into(),
+                    BuiltinPropertyInfo::new(BuiltinFunction::CloseWindow.ty()),
+                );
+                Rc::get_mut(b).unwrap().member_functions.insert(
+                    "close".into(),
+                    Expression::BuiltinFunctionReference(BuiltinFunction::CloseWindow, None),
+                );
+            }
+            _ => unreachable!(),
+        };
 
         Rc::new(RefCell::new(register))
     }

--- a/sixtyfps_runtime/corelib/backend.rs
+++ b/sixtyfps_runtime/corelib/backend.rs
@@ -32,10 +32,14 @@ pub trait Backend: Send + Sync {
     fn create_window(&'static self) -> Rc<Window>;
 
     /// Spins an event loop and renders the visible windows.
-    fn run_event_loop(&'static self, behavior: EventLoopQuitBehavior);
+    ///
+    /// Returns the code passed to quit_event_loop or 0 if this was the last window
+    fn run_event_loop(&'static self, behavior: EventLoopQuitBehavior) -> i32;
 
     /// Exits the event loop.
-    fn quit_event_loop(&'static self);
+    ///
+    /// the result_code will be the returned value of run_event_loop
+    fn quit_event_loop(&'static self, result_code: i32);
 
     /// This function can be used to register a custom TrueType font with SixtyFPS,
     /// for use with the `font-family` property. The provided slice must be a valid TrueType

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -937,12 +937,13 @@ impl ComponentInstance {
 
     /// This is a convenience function that first calls [`Self::show`], followed by [`crate::run_event_loop()`]
     /// and [`Self::hide`].
-    pub fn run(&self) {
+    pub fn run(&self) -> i32 {
         self.show();
-        sixtyfps_rendering_backend_default::backend().run_event_loop(
+        let result = sixtyfps_rendering_backend_default::backend().run_event_loop(
             sixtyfps_corelib::backend::EventLoopQuitBehavior::QuitOnLastWindowClosed,
         );
         self.hide();
+        result
     }
 
     /// Clone this `ComponentInstance`.

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -311,6 +311,13 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     panic!("internal error: argument to SetFocusItem must be an element")
                 }
             }
+            Expression::BuiltinFunctionReference(BuiltinFunction::CloseWindow, _) => {
+                if arguments.len() != 2 {
+                    panic!("internal error: incorrect argument count to ShowPopupWindow")
+                }
+                sixtyfps_rendering_backend_default::backend().quit_event_loop(eval_expression(&arguments[1], local_context).try_into().unwrap());
+                Value::Void
+            }
             Expression::BuiltinFunctionReference(BuiltinFunction::StringIsFloat, _) => {
                 if arguments.len() != 1 {
                     panic!("internal error: incorrect argument count to StringIsFloat")

--- a/sixtyfps_runtime/rendering_backends/testing/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/testing/lib.rs
@@ -37,11 +37,14 @@ impl sixtyfps_corelib::backend::Backend for TestingBackend {
         Window::new(|_| Rc::new(TestingWindow::default()))
     }
 
-    fn run_event_loop(&'static self, _behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
+    fn run_event_loop(
+        &'static self,
+        _behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior,
+    ) -> i32 {
         unimplemented!("running an event loop with the testing backend");
     }
 
-    fn quit_event_loop(&'static self) {}
+    fn quit_event_loop(&'static self, _exit_code: i32) {}
 
     fn register_font_from_memory(
         &'static self,

--- a/tests/cases/elements/window.60
+++ b/tests/cases/elements/window.60
@@ -1,0 +1,15 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+
+
+TestCase := Window {
+    TouchArea { clicked => { root.close(42); } }
+}

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -67,8 +67,8 @@ fn main() -> Result<()> {
         CURRENT_INSTANCE.with(|current| current.replace(Some(component.clone_strong())));
     }
 
-    component.run();
-    Ok(())
+    let result = component.run();
+    std::process::exit(result);
 }
 
 fn init_compiler(


### PR DESCRIPTION
This will close the window (and currently the application because there is only
one window)

Also add an exit_code int to the eventloop quit function and make thi run_in_event_loop
return a i32

Compatibility note:
 - In C++, i think it is OK to do the change because of the default argument and the
   return value should also be ok-ish breaking change as i don't think anyone rely on
   the exact type

 - In rust, this is more complicated, adding a `-> i32` might be a problem as
   it changes the type of the function. Or if the function were called at the
   end of a block without a `;` Maybe we shouldn't do the change and add new
   function with a different name?

 - Also in rust, the quit_event_loop function can't be re-used so just add an
   internal function with a different name. That function is probably not
   going to be called from rust with an exit code.

Todo:
 - Fix or discuss compatibility issue
 - More tests