### PR TITLE
Bound Text contents width

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/fonts.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/fonts.rs
@@ -630,15 +630,19 @@ pub(crate) fn layout_text_lines(
         }
     };
 
-    let mut process_line =
-        |text: &str, y: f32, start: usize, line_metrics: &femtovg::TextMetrics| {
-            let x = match horizontal_alignment {
-                TextHorizontalAlignment::left => 0.,
-                TextHorizontalAlignment::center => max_width / 2. - line_metrics.width() / 2.,
-                TextHorizontalAlignment::right => max_width - line_metrics.width(),
-            };
-            layout_line(text, Point::new(x, y), start, line_metrics);
+    let mut process_line = |text: &str,
+                            y: f32,
+                            start: usize,
+                            line_metrics: &femtovg::TextMetrics| {
+        let x = match horizontal_alignment {
+            TextHorizontalAlignment::left => 0.,
+            TextHorizontalAlignment::center => {
+                max_width / 2. - f32::min(max_width, line_metrics.width()) / 2.
+            }
+            TextHorizontalAlignment::right => max_width - f32::min(max_width, line_metrics.width()),
         };
+        layout_line(text, Point::new(x, y), start, line_metrics);
+    };
 
     let baseline_y = match vertical_alignment {
         TextVerticalAlignment::top => 0.,


### PR DESCRIPTION
The positioning calculations for ``Text`` go wrong with non-left aligned
content when the text width exceeds that of the containing element. The
``VerticalLayout`` somehow plays into this, I couldn’t reproduce it with a
``Rectangle``.

Minimal example, type until the string reaches the width:

    fn main() {
        let win = W::new();
        win.on_terminate(move || { std::process::exit(0); });
        win.run();
    }
    
    sixtyfps::sixtyfps! {
        W := Window {
            callback terminate;
            forward-focus: scope;
            background: black;
    
            vl := VerticalLayout {
                buf := Text {
                    font-size: 50pt;
                    horizontal-alignment: center; /* also with “right” but not “left” */
                    overflow: TextOverflow.clip; /* no difference between “elide” and “clip” */
                    color: white;
                    text: "some initial text ";
                }
            }
    
            scope := FocusScope {
                key-pressed(ev) => {
                    if (ev.text == "q" && ev.modifiers.control) { terminate(); }
                    buf.text += ev.text;
                    debug("buf", buf.width, buf.height, "vl", vl.width, vl.height);
                    accept
                }
            }
        }
    }

(The patch is actually just minimal changes to two lines but for some reason
``rustfmt`` makes a bigger deal out of it.)
