### PR TITLE
cargo-audit: Remove indirect dependency on outdated time crate

### DIFF
--- a/examples/7gui/Cargo.toml
+++ b/examples/7gui/Cargo.toml
@@ -12,4 +12,4 @@ name = "booker"
 
 [dependencies]
 sixtyfps = { path = "../../api/sixtyfps-rs" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"]}

--- a/examples/printerdemo/rust/Cargo.toml
+++ b/examples/printerdemo/rust/Cargo.toml
@@ -13,7 +13,7 @@ name = "printerdemo"
 
 [dependencies]
 sixtyfps = { path = "../../../api/sixtyfps-rs" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"]}
 
 [build-dependencies]
 sixtyfps-build = { path = "../../../api/sixtyfps-rs/sixtyfps-build" }


### PR DESCRIPTION
Fixes this report from `cargo-audit`:

```
Crate:         time
Version:       0.1.43
Title:         Potential segfault in the time crate
Date:          2020-11-18
ID:            RUSTSEC-2020-0071
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:      Upgrade to >=0.2.23
Dependency tree: 
time 0.1.43
└── chrono 0.4.19
    ├── printerdemo 0.1.4
    └── _7gui 0.1.4
```

by removing the dependency on the `time` crate  from `chrono`. This is done by disabling the default features and then re-enableing all the features but `oldtime` again.