### PR TITLE
C++: drops IntSize in favor of Size<T>

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -161,7 +161,6 @@ fn gen_corelib(
         "slint_image_size",
         "slint_image_path",
         "TimerMode",                 // included in generated_public.h
-        "IntSize",                   // included in generated_public.h
         "RenderingState",            // included in generated_public.h
         "SetRenderingNotifierError", // included in generated_public.h
         "GraphicsAPI",               // included in generated_public.h
@@ -267,7 +266,6 @@ fn gen_corelib(
             "slint_color_darker",
             "slint_image_size",
             "slint_image_path",
-            "IntSize",
         ]
         .iter()
         .filter(|exclusion| !rust_types.iter().any(|inclusion| inclusion == *exclusion))
@@ -317,19 +315,10 @@ fn gen_corelib(
     public_config.export.exclude.push("Point".into());
     public_config.export.include = vec![
         "TimerMode".into(),
-        "IntSize".into(),
         "RenderingState".into(),
         "SetRenderingNotifierError".into(),
         "GraphicsAPI".into(),
     ];
-
-    public_config.export.body.insert(
-        "IntSize".to_owned(),
-        r#"
-    /// Compares this IntSize with \a other and returns true if they are equal; false otherwise.
-    bool operator==(const IntSize &other) const = default;"#
-            .to_owned(),
-    );
 
     cbindgen::Builder::new()
         .with_config(public_config)

--- a/api/cpp/include/slint_image.h
+++ b/api/cpp/include/slint_image.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <string_view>
 #include "slint_generated_public.h"
+#include "slint_size.h"
 #include "slint_image_internal.h"
 #include "slint_string.h"
 #include "slint_sharedvector.h"
@@ -33,7 +34,7 @@ public:
     */
 
     /// Returns the size of the Image in pixels.
-    IntSize size() const { return cbindgen_private::types::slint_image_size(&data); }
+    Size<unsigned int> size() const { return cbindgen_private::types::slint_image_size(&data); }
 
     /// Returns the path of the image on disk, if it was constructed via Image::load_from_path().
     std::optional<slint::SharedString> path() const

--- a/api/cpp/include/slint_size.h
+++ b/api/cpp/include/slint_size.h
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
 
 #pragma once
-#include <string_view>
 
 
 namespace slint {

--- a/api/cpp/include/slint_size.h
+++ b/api/cpp/include/slint_size.h
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+#pragma once
+#include <string_view>
+
+
+namespace slint {
+
+/// The Size structure is used to represent a two-dimensional size
+/// with width and height.
+template <typename T>
+struct Size {
+    /// The width of the size
+    T width;
+    /// The height of the size
+    T height;
+
+    /// Compares with \a other and returns true if they are equal; false otherwise.
+    bool operator==(const Size &other) const = default;
+};
+
+namespace cbindgen_private {
+    // The Size types are expanded to the Size2D<...> type from the euclid crate which
+    // is binary compatible with Size<T>
+    template <typename T> using Size2D = Size<T>;
+}
+
+
+}

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -185,25 +185,5 @@ pub(crate) mod ffi {
         y: f32,
     }
 
-    /// Expand Size so that cbindgen can see it. ( is in fact euclid::default::Size2D<f32>)
-    #[cfg(cbindgen)]
-    #[repr(C)]
-    struct Size {
-        width: f32,
-        height: f32,
-    }
-
-    // Expand Size so that cbindgen can see it. ( is in fact euclid::default::Size2D<u32>)
-    /// The Size structure is used to represent a two-dimensional size
-    /// with width and height.
-    #[cfg(cbindgen)]
-    #[repr(C)]
-    struct IntSize {
-        /// The width of the size
-        width: u32,
-        /// The height of the size
-        height: u32,
-    }
-
     pub use super::path::ffi::*;
 }


### PR DESCRIPTION
Fixes #909

Since we declare the struct in C++, we don't need to declare it in
rust for cbindgen anymore, as long as we expose the Size2D type from
euclid to the cbindgen_private namespace