### PR TITLE
Improve error handling when we fail to create a WebGL context in the …

### DIFF
--- a/internal/backends/gl/Cargo.toml
+++ b/internal/backends/gl/Cargo.toml
@@ -35,7 +35,7 @@ cfg-if = "1"
 copypasta = { version = "0.7.0", default-features = false }
 derive_more = "0.99.5"
 euclid = "0.22.1"
-femtovg = { version = "0.3.0" }
+femtovg = { version = "0.3.2" }
 fontdb = { version = "0.7.0", default-features = false }
 image = { version = "0.24.0", default-features = false, features = [ "png", "jpeg" ] }
 imgref = "1.6.1"


### PR DESCRIPTION
…browser

Bump the femtovg dependency to ensure we get the fix for error detection on the renderer side
and handle it in the GL backend side by rendering text to the 2D canvas, followed by a panic.

This was moved up to before the resize handler can be installed, as that would end up
clearing the canvas when resizing.

A message on the 2D canvas was chose over an alert message box, as the latter
is rather intrusive and would be a nightmare if many of them popped up
when viewing our docs with a browser
configured that way.