### PR TITLE
Enable stack traces in our wasm demos

### DIFF
--- a/examples/gallery/Cargo.toml
+++ b/examples/gallery/Cargo.toml
@@ -32,3 +32,6 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# wasm-bindgen = { version = "0.2" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/gallery/main.rs
+++ b/examples/gallery/main.rs
@@ -10,9 +10,7 @@ slint::include_modules!();
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     console_error_panic_hook::set_once();
 
     let app = App::new();

--- a/examples/imagefilter/Cargo.toml
+++ b/examples/imagefilter/Cargo.toml
@@ -32,3 +32,6 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# wasm-bindgen = { version = "0.2" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/imagefilter/main.rs
+++ b/examples/imagefilter/main.rs
@@ -75,9 +75,7 @@ impl slint::Model for Filters {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     console_error_panic_hook::set_once();
 
     let main_window = MainWindow::new();

--- a/examples/memory/Cargo.toml
+++ b/examples/memory/Cargo.toml
@@ -33,3 +33,6 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
 #wasm# getrandom = { version = "0.2.2", features = ["js"] }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/memory/main.rs
+++ b/examples/memory/main.rs
@@ -14,9 +14,7 @@ slint::slint! {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     console_error_panic_hook::set_once();
 
     let main_window = MainWindow::new();

--- a/examples/opengl_underlay/Cargo.toml
+++ b/examples/opengl_underlay/Cargo.toml
@@ -35,3 +35,6 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
 #wasm# instant = { version = "0.1", features = [ "wasm-bindgen" ] }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/opengl_underlay/main.rs
+++ b/examples/opengl_underlay/main.rs
@@ -154,9 +154,7 @@ impl EGLUnderlay {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     console_error_panic_hook::set_once();
 
     let app = App::new();

--- a/examples/plotter/Cargo.toml
+++ b/examples/plotter/Cargo.toml
@@ -33,3 +33,6 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
 #wasm# plotters-backend = { version = "0.3.1" }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/plotter/main.rs
+++ b/examples/plotter/main.rs
@@ -71,9 +71,7 @@ fn render_plot(pitch: f32, yaw: f32, amplitude: f32) -> slint::Image {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     console_error_panic_hook::set_once();
 
     let main_window = MainWindow::new();

--- a/examples/printerdemo/rust/Cargo.toml
+++ b/examples/printerdemo/rust/Cargo.toml
@@ -34,3 +34,6 @@ slint-build = { path = "../../../api/rs/build" }
 #wasm# wasm-bindgen = { version = "0.2" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/printerdemo/rust/main.rs
+++ b/examples/printerdemo/rust/main.rs
@@ -38,9 +38,7 @@ impl PrinterQueueData {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     console_error_panic_hook::set_once();
 
     let main_window = MainWindow::new();

--- a/examples/printerdemo_old/rust/Cargo.toml
+++ b/examples/printerdemo_old/rust/Cargo.toml
@@ -32,3 +32,6 @@ slint-build = { path = "../../../api/rs/build" }
 #wasm# wasm-bindgen = { version = "0.2" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/printerdemo_old/rust/main.rs
+++ b/examples/printerdemo_old/rust/main.rs
@@ -8,9 +8,7 @@ slint::include_modules!();
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     console_error_panic_hook::set_once();
 
     let main_window = MainWindow::new();

--- a/examples/slide_puzzle/Cargo.toml
+++ b/examples/slide_puzzle/Cargo.toml
@@ -33,3 +33,6 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
 #wasm# getrandom = { version = "0.2.2", features = ["js"] }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/slide_puzzle/main.rs
+++ b/examples/slide_puzzle/main.rs
@@ -166,9 +166,7 @@ impl AppState {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     console_error_panic_hook::set_once();
 
     let main_window = MainWindow::new();

--- a/examples/todo/rust/Cargo.toml
+++ b/examples/todo/rust/Cargo.toml
@@ -32,3 +32,6 @@ slint-build = { path = "../../../api/rs/build" }
 #wasm# wasm-bindgen = { version = "0.2" }
 #wasm# web-sys = { version = "0.3", features=["console"] }
 #wasm# console_error_panic_hook = "0.1.5"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -11,9 +11,7 @@ slint::include_modules!();
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     console_error_panic_hook::set_once();
 
     let todo_model = Rc::new(slint::VecModel::<TodoItem>::from(vec![


### PR DESCRIPTION
* Disable wasm-opt to get symbol names
* Always install the panic hook to get panic messages

This changes the wasm demo binary sizes as follows:

| demo | old size | new size |
| - | - | - |
| gallery | 3.2M | 3.8M |
| imagefilter | 3.0M | 3.4M |
| memory | 2.9M | 3.4M |
| opengl_underlay | 2.9M | 3.3M |
| plotter | 2.9M | 3.3M |
| printerdemo | 3.6M | 4.5M |
| printerdemo_old | 3.1M | 3.7M |
| slide_puzzle | 3.3M | 3.8M |
| todo | 2.9M | 3.4M |

The sum of all is - according to `du -sh` - a bump from 28M to 33M.

Not sure it's worth it :-)