### PR TITLE
Fix non-interactive doc preview

### DIFF
--- a/api/wasm-interpreter/src/lib.rs
+++ b/api/wasm-interpreter/src/lib.rs
@@ -144,4 +144,45 @@ impl WrappedCompiledComp {
         let component = self.0.create_with_canvas_id(&canvas_id);
         component.run();
     }
+    /// Creates this compiled component in a canvas.
+    /// The HTML must contains a <canvas> element with the given `canvas_id`
+    /// where the result is gonna be rendered.
+    /// You need to call `show()` on the returned instance for rendering and
+    /// `slint.run_event_loop()` loop to make it interactive.
+    #[wasm_bindgen]
+    pub fn create(&self, canvas_id: String) -> Result<WrappedInstance, JsValue> {
+        Ok(WrappedInstance(self.0.create_with_canvas_id(&canvas_id)))
+    }
+}
+
+#[wasm_bindgen]
+pub struct WrappedInstance(slint_interpreter::ComponentInstance);
+
+impl Clone for WrappedInstance {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_strong())
+    }
+}
+
+#[wasm_bindgen]
+impl WrappedInstance {
+    /// Marks this instance for rendering and input handling.
+    #[wasm_bindgen]
+    pub fn show(&self) {
+        self.0.show();
+    }
+    /// Hides this instance and prevents further updates of the canvas element.
+    #[wasm_bindgen]
+    pub fn hide(&self) {
+        self.0.hide();
+    }
+}
+
+/// Register DOM event handlers on all instance and set up the event loop for that.
+/// You can call this function only once. It will throw an exception but that is safe
+/// to ignore.
+#[wasm_bindgen]
+pub fn run_event_loop() -> Result<(), JsValue> {
+    slint_interpreter::run_event_loop();
+    Ok(())
 }

--- a/docs/resources/slint-docs-preview.html
+++ b/docs/resources/slint-docs-preview.html
@@ -23,7 +23,8 @@
             div.innerHTML = "<pre style='color: red; background-color:#fee; margin:0'>" + p.innerHTML + "</pre>";
         }
         if (component !== undefined) {
-            component.run(canvas_id)
+            let instance = component.create(canvas_id);
+            instance.show();
         }
     }
 
@@ -35,8 +36,9 @@
             let div = document.createElement("div");
             div.style = "float: right; padding:0; margin:0;";
             elements[i].prepend(div);
-            setTimeout(function () { render_or_error(source, div); }, 1);
+            await render_or_error(source, div);
         }
+        slint.run_event_loop();
     }
     run();
 

--- a/docs/resources/slint-docs-preview.html
+++ b/docs/resources/slint-docs-preview.html
@@ -6,6 +6,8 @@
     "use strict";
     //import * as slint from 'https://slint-ui.com/releases/0.x.0/wasm-interpreter/slint_wasm_interpreter.js';
     import * as slint from 'https://slint-ui.com/snapshots/rename/wasm-interpreter/slint_wasm_interpreter.js';
+    // keep them alive
+    var all_instances = new Array;
 
     async function render_or_error(source, div) {
         let canvas_id = 'canvas_' + Math.random().toString(36).substr(2, 9);
@@ -25,6 +27,7 @@
         if (component !== undefined) {
             let instance = component.create(canvas_id);
             instance.show();
+            all_instances.push(instance);
         }
     }
 


### PR DESCRIPTION
Only the last shown preview was interactive. This was because we started the winit event loop for each preview,
which kind of invalidates the previous instance in winit.

Instead, create all components, call show() on each instance to register the window with winit
and spin the event loop with its exception magic only once.