### PR TITLE
fmt tool improvements

### DIFF
--- a/tools/fmt/README.md
+++ b/tools/fmt/README.md
@@ -1,0 +1,42 @@
+# SixtyFPS-fmt
+
+This tool for formatting .60 syntax is in a very early stage.
+There might be certain parts of the language that are not yet supported.
+If you find any such examples, please open an issue including the example and the expected output.
+
+## Building
+
+Use `cargo build --release` or similar to build this crate.
+
+## Usage
+
+The built binary can be used in following ways:
+
+- `sixtyfps-fmt <path>` - reads the file and outputs the formatted version to stdout
+- `sixtyfps-fmt -i <path>` - reads the file and saves the output to the same file
+- `sixtyfps-fmt /dev/stdin` - using /dev/stdin you can achieve the special behavior
+  of reading from stdin and writing to stdout
+
+Note that `.60` files are formatted, while `.md` and `.rs` files are searched for `.60` blocks.
+All other files are left untouched.
+
+## Usage with VSCode
+
+While we don't yet have a proper VSCode integration for this formatter,
+here is a simple way how you can get around it.
+
+1. Install the extension Custom Format by Vehmloewff. [Marketplace link](https://marketplace.visualstudio.com/items?itemName=Vehmloewff.custom-format)
+2. Build sixtyfps-fmt locally.
+3. Add a section like this to your vscode `settings.json`:
+```
+{
+  "custom-format.formatters": [
+    {
+      "language": "sixtyfps",
+      "command": "/path/to/your/built/sixtyfps-fmt /dev/stdin"
+    }
+  ]
+}
+```
+4. (Optional) Allow formatting or save, or set this formatter as default for .60 files.
+5. Enjoy! Your .60 files are now formatted.

--- a/tools/fmt/README.md
+++ b/tools/fmt/README.md
@@ -1,6 +1,6 @@
 # SixtyFPS-fmt
 
-This tool for formatting .60 syntax is in a very early stage.
+This tool for formatting .slint syntax is in a very early stage.
 There might be certain parts of the language that are not yet supported.
 If you find any such examples, please open an issue including the example and the expected output.
 
@@ -12,12 +12,12 @@ Use `cargo build --release` or similar to build this crate.
 
 The built binary can be used in following ways:
 
-- `sixtyfps-fmt <path>` - reads the file and outputs the formatted version to stdout
-- `sixtyfps-fmt -i <path>` - reads the file and saves the output to the same file
-- `sixtyfps-fmt /dev/stdin` - using /dev/stdin you can achieve the special behavior
+- `slint-fmt <path>` - reads the file and outputs the formatted version to stdout
+- `slint-fmt -i <path>` - reads the file and saves the output to the same file
+- `slint-fmt /dev/stdin` - using /dev/stdin you can achieve the special behavior
   of reading from stdin and writing to stdout
 
-Note that `.60` files are formatted, while `.md` and `.rs` files are searched for `.60` blocks.
+Note that `.slint` files are formatted, while `.md` and `.rs` files are searched for `.slint` blocks.
 All other files are left untouched.
 
 ## Usage with VSCode
@@ -26,17 +26,17 @@ While we don't yet have a proper VSCode integration for this formatter,
 here is a simple way how you can get around it.
 
 1. Install the extension Custom Format by Vehmloewff. [Marketplace link](https://marketplace.visualstudio.com/items?itemName=Vehmloewff.custom-format)
-2. Build sixtyfps-fmt locally.
+2. Build slint-fmt locally.
 3. Add a section like this to your vscode `settings.json`:
 ```
 {
   "custom-format.formatters": [
     {
-      "language": "sixtyfps",
-      "command": "/path/to/your/built/sixtyfps-fmt /dev/stdin"
+      "language": "slint",
+      "command": "/path/to/your/built/slint-fmt /dev/stdin"
     }
   ]
 }
 ```
-4. (Optional) Allow formatting or save, or set this formatter as default for .60 files.
-5. Enjoy! Your .60 files are now formatted.
+4. (Optional) Allow formatting or save, or set this formatter as default for .slint files.
+5. Enjoy! Your .slint files are now formatted.

--- a/tools/fmt/fmt.rs
+++ b/tools/fmt/fmt.rs
@@ -449,13 +449,13 @@ fn format_expression(
 mod tests {
     use super::*;
     use crate::writer::FileWriter;
-    use sixtyfps_compilerlib::diagnostics::BuildDiagnostics;
-    use sixtyfps_compilerlib::parser::syntax_nodes;
+    use i_slint_compiler::diagnostics::BuildDiagnostics;
+    use i_slint_compiler::parser::syntax_nodes;
 
     // FIXME more descriptive errors when an assertion fails
     fn assert_formatting(unformatted: &str, formatted: &str) {
         // Parse the unformatted string
-        let syntax_node = sixtyfps_compilerlib::parser::parse(
+        let syntax_node = i_slint_compiler::parser::parse(
             String::from(unformatted),
             None,
             &mut BuildDiagnostics::default(),
@@ -587,11 +587,11 @@ Main := Some {
     fn file_with_an_import() {
         assert_formatting(
             r#"
-import { Some } from "./here.60";
+import { Some } from "./here.slint";
 
 A := Some{    padding-left: 10px;    Text{        x: 3px;    }}"#,
             r#"
-import { Some } from "./here.60";
+import { Some } from "./here.slint";
 
 A := Some {
     padding-left: 10px;

--- a/tools/fmt/main.rs
+++ b/tools/fmt/main.rs
@@ -136,7 +136,7 @@ fn process_markdown_file(source: String, mut file: impl Write) -> std::io::Resul
     return file.write_all(source_slice.as_bytes());
 }
 
-fn process_60_file(
+fn process_slint_file(
     source: String,
     path: std::path::PathBuf,
     mut file: impl Write,
@@ -160,11 +160,11 @@ fn process_file(
     match path.extension() {
         Some(ext) if ext == "rs" => return process_rust_file(source, file),
         Some(ext) if ext == "md" => return process_markdown_file(source, file),
-        Some(ext) if ext == "60" => return process_60_file(source, path, file),
+        Some(ext) if ext == "slint" => return process_slint_file(source, path, file),
         _ => {
-            // This allows usage like `cat x.60 | sixtyfps-fmt /dev/stdin`
+            // This allows usage like `cat x.slint | slint-fmt /dev/stdin`
             if path.as_path() == Path::new("/dev/stdin") {
-                return process_60_file(source, path, file);
+                return process_slint_file(source, path, file);
             }
             // With other file types, we just output them in their original form.
             return file.write_all(source.as_bytes());

--- a/tools/fmt/main.rs
+++ b/tools/fmt/main.rs
@@ -12,16 +12,18 @@
     be refactored in a separate utility crate or module or something.
 
     The [`TokenWriter`] trait is meant to be able to support the LSP later as the
-    LSP wants just the edits , not the full file
+    LSP wants just the edits, not the full file
 */
 
 use i_slint_compiler::diagnostics::BuildDiagnostics;
-use i_slint_compiler::parser::{syntax_nodes, SyntaxNode, SyntaxToken};
+use i_slint_compiler::parser::{syntax_nodes, SyntaxNode};
 use std::io::Write;
+use std::path::Path;
 
 use clap::Parser;
 
 mod fmt;
+mod writer;
 
 #[derive(clap::Parser)]
 struct Cli {
@@ -95,7 +97,7 @@ fn process_rust_file(source: String, mut file: impl Write) -> std::io::Result<()
         let mut diag = BuildDiagnostics::default();
         let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, &mut diag);
         let len = syntax_node.text_range().end().into();
-        visit_node(syntax_node, &mut file, &mut State::default())?;
+        visit_node(syntax_node, &mut file)?;
         if diag.has_error() {
             file.write_all(&code.as_bytes()[len..])?;
             diag.print();
@@ -125,13 +127,29 @@ fn process_markdown_file(source: String, mut file: impl Write) -> std::io::Resul
         let mut diag = BuildDiagnostics::default();
         let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, &mut diag);
         let len = syntax_node.text_range().end().into();
-        visit_node(syntax_node, &mut file, &mut State::default())?;
+        visit_node(syntax_node, &mut file)?;
         if diag.has_error() {
             file.write_all(&code.as_bytes()[len..])?;
             diag.print();
         }
     }
     return file.write_all(source_slice.as_bytes());
+}
+
+fn process_60_file(
+    source: String,
+    path: std::path::PathBuf,
+    mut file: impl Write,
+) -> std::io::Result<()> {
+    let mut diag = BuildDiagnostics::default();
+    let syntax_node = i_slint_compiler::parser::parse(source.clone(), Some(&path), &mut diag);
+    let len = syntax_node.node.text_range().end().into();
+    visit_node(syntax_node, &mut file)?;
+    if diag.has_error() {
+        file.write_all(&source.as_bytes()[len..])?;
+        diag.print();
+    }
+    Ok(())
 }
 
 fn process_file(
@@ -142,55 +160,23 @@ fn process_file(
     match path.extension() {
         Some(ext) if ext == "rs" => return process_rust_file(source, file),
         Some(ext) if ext == "md" => return process_markdown_file(source, file),
-        _ => {}
+        Some(ext) if ext == "60" => return process_60_file(source, path, file),
+        _ => {
+            // This allows usage like `cat x.60 | sixtyfps-fmt /dev/stdin`
+            if path.as_path() == Path::new("/dev/stdin") {
+                return process_60_file(source, path, file);
+            }
+            // With other file types, we just output them in their original form.
+            return file.write_all(source.as_bytes());
+        }
     }
-
-    let mut diag = BuildDiagnostics::default();
-    let syntax_node = i_slint_compiler::parser::parse(source.clone(), Some(&path), &mut diag);
-    let len = syntax_node.node.text_range().end().into();
-    visit_node(syntax_node, &mut file, &mut State::default())?;
-    if diag.has_error() {
-        file.write_all(&source.as_bytes()[len..])?;
-        diag.print();
-    }
-    Ok(())
 }
 
-type State = ();
-
-fn visit_node(node: SyntaxNode, file: &mut impl Write, _state: &mut State) -> std::io::Result<()> {
+fn visit_node(node: SyntaxNode, file: &mut impl Write) -> std::io::Result<()> {
     if let Some(doc) = syntax_nodes::Document::new(node) {
-        let mut writer = FileWriter { file };
+        let mut writer = writer::FileWriter { file };
         fmt::format_document(doc, &mut writer)
     } else {
         Err(std::io::Error::new(std::io::ErrorKind::Other, "Not a Document"))
-    }
-}
-
-/// The idea is that each token need to go through this, either with no changes,
-/// or with a new content.
-trait TokenWriter {
-    fn no_change(&mut self, token: SyntaxToken) -> std::io::Result<()>;
-    fn with_new_content(&mut self, token: SyntaxToken, contents: &str) -> std::io::Result<()>;
-    fn insert_before(&mut self, token: SyntaxToken, contents: &str) -> std::io::Result<()>;
-}
-
-/// Just write the token stream to a file
-struct FileWriter<'a, W> {
-    file: &'a mut W,
-}
-
-impl<'a, W: Write> TokenWriter for FileWriter<'a, W> {
-    fn no_change(&mut self, token: SyntaxToken) -> std::io::Result<()> {
-        self.file.write_all(token.text().as_bytes())
-    }
-
-    fn with_new_content(&mut self, _token: SyntaxToken, contents: &str) -> std::io::Result<()> {
-        self.file.write_all(contents.as_bytes())
-    }
-
-    fn insert_before(&mut self, token: SyntaxToken, contents: &str) -> std::io::Result<()> {
-        self.file.write_all(contents.as_bytes())?;
-        self.file.write_all(token.text().as_bytes())
     }
 }

--- a/tools/fmt/main.rs
+++ b/tools/fmt/main.rs
@@ -160,7 +160,10 @@ fn process_file(
     match path.extension() {
         Some(ext) if ext == "rs" => return process_rust_file(source, file),
         Some(ext) if ext == "md" => return process_markdown_file(source, file),
-        Some(ext) if ext == "slint" => return process_slint_file(source, path, file),
+        // Formatting .60 files because of backwards compatibility (project was recently renamed)
+        Some(ext) if ext == "slint" || ext == ".60" => {
+            return process_slint_file(source, path, file)
+        }
         _ => {
             // This allows usage like `cat x.slint | slint-fmt /dev/stdin`
             if path.as_path() == Path::new("/dev/stdin") {

--- a/tools/fmt/writer.rs
+++ b/tools/fmt/writer.rs
@@ -1,5 +1,5 @@
-// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
-// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 use i_slint_compiler::parser::SyntaxToken;
 use std::io::Write;
 

--- a/tools/fmt/writer.rs
+++ b/tools/fmt/writer.rs
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+use sixtyfps_compilerlib::parser::SyntaxToken;
+use std::io::Write;
+
+/// The idea is that each token need to go through this, either with no changes,
+/// or with a new content.
+pub(crate) trait TokenWriter {
+    /// Write token to the writer without any change.
+    fn no_change(&mut self, token: SyntaxToken) -> std::io::Result<()>;
+
+    /// Write just contents into the writer (replacing token).
+    fn with_new_content(&mut self, token: SyntaxToken, contents: &str) -> std::io::Result<()>;
+
+    /// Write contents and then the token to the writer.
+    fn insert_before(&mut self, token: SyntaxToken, contents: &str) -> std::io::Result<()>;
+}
+
+/// Just write the token stream to a file
+pub(crate) struct FileWriter<'a, W> {
+    pub(super) file: &'a mut W,
+}
+
+impl<'a, W: Write> TokenWriter for FileWriter<'a, W> {
+    fn no_change(&mut self, token: SyntaxToken) -> std::io::Result<()> {
+        self.file.write_all(token.text().as_bytes())
+    }
+
+    fn with_new_content(&mut self, _token: SyntaxToken, contents: &str) -> std::io::Result<()> {
+        self.file.write_all(contents.as_bytes())
+    }
+
+    fn insert_before(&mut self, token: SyntaxToken, contents: &str) -> std::io::Result<()> {
+        self.file.write_all(contents.as_bytes())?;
+        self.file.write_all(token.text().as_bytes())
+    }
+}

--- a/tools/fmt/writer.rs
+++ b/tools/fmt/writer.rs
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@sixtyfps.io>
 // SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
-use sixtyfps_compilerlib::parser::SyntaxToken;
+use i_slint_compiler::parser::SyntaxToken;
 use std::io::Write;
 
 /// The idea is that each token need to go through this, either with no changes,


### PR DESCRIPTION
Closes #898 
Sorry it took a while - but i needed to learn more than anticipated :)

Changes in this PR:
- **unrelated to fmt** - I own an M1 Mac and the builds of most of the creates were failing for me unless I updated neon. I am not sure about the impact on this on the rest of the project though. Let me know if it breaks something and I'll remove the commit.

- Adds tests to fmt, with some basic examples
- Fixes the original issue from #898 as well as some things about BinaryExpression/Expression formatting
- Some code cleanup
- Adds a README with a tutorial on how to get this running in your vscode

Overall fmt is still far form perfect but I see this as a step in a good direction.

btw sorry if some of my changes still refer to the old name, you literally renamed 3 hours ago 😅 
