### PR TITLE
Add low-level Window API to affect the allocation of a transluceny su…

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -260,6 +260,8 @@ fn gen_corelib(
             "slint_windowrc_show_popup",
             "slint_windowrc_set_rendering_notifier",
             "slint_windowrc_request_redraw",
+            "slint_windowrc_set_opaque_background",
+            "slint_windowrc_opaque_background",
             "slint_new_path_elements",
             "slint_new_path_events",
             "slint_color_brighter",

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -160,6 +160,19 @@ public:
 
     void request_redraw() const { cbindgen_private::slint_windowrc_request_redraw(&inner); }
 
+    /// A window can be translucent if the scene's `Window` root element has a color set on the
+    /// `background` property that provides transluceny. Transluceny requires the allocation of a
+    /// graphics surface that is more expensive that one that is entirel opaque. Use this function
+    /// to override the behavior of depending on the `background` property. Use `false` as value for
+    /// the `opaque` parameter to force the allocation of a surface that supports transluceny.
+    void set_opaque_background(bool opaque) const
+    {
+        slint_windowrc_set_opaque_background(&inner, opaque);
+    }
+
+    /// Returns whether the background of the window is opaque.
+    bool opaque_background() const { return slint_windowrc_opaque_background(&inner); }
+
 private:
     cbindgen_private::WindowRcOpaque inner;
 };
@@ -345,6 +358,16 @@ public:
 
     /// This function issues a request to the windowing system to redraw the contents of the window.
     void request_redraw() const { inner.request_redraw(); }
+
+    /// A window can be translucent if the scene's `Window` root element has a color set on the
+    /// `background` property that provides transluceny. Transluceny requires the allocation of a
+    /// graphics surface that is more expensive that one that is entirel opaque. Use this function
+    /// to override the behavior of depending on the `background` property. Use `false` as value for
+    /// the `opaque` parameter to force the allocation of a surface that supports transluceny.
+    void set_opaque_background(bool opaque) const { inner.set_opaque_background(opaque); }
+
+    /// Returns whether the background of the window is opaque.
+    bool opaque_background() const { return inner.opaque_background(); }
 
     /// \private
     private_api::WindowRc &window_handle() { return inner; }

--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -401,7 +401,8 @@ impl PlatformWindow for GLWindow {
 
         let window_builder = winit::window::WindowBuilder::new()
             .with_title(window_title)
-            .with_resizable(is_resizable);
+            .with_resizable(is_resizable)
+            .with_transparent(!runtime_window.opaque_background());
 
         let scale_factor_override = std::env::var("SLINT_SCALE_FACTOR")
             .ok()

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1260,6 +1260,8 @@ impl PlatformWindow for QtWindow {
         let widget_ptr = self.widget_ptr();
         let title: qttypes::QString = window_item.title().as_str().into();
         let no_frame = window_item.no_frame();
+        let runtime_window = self.self_weak.upgrade().unwrap();
+        let opaque = runtime_window.opaque_background();
         let mut size = qttypes::QSize {
             width: window_item.width().ceil() as _,
             height: window_item.height().ceil() as _,
@@ -1297,7 +1299,7 @@ impl PlatformWindow for QtWindow {
             }
         };
 
-        cpp! {unsafe [widget_ptr as "QWidget*",  title as "QString", size as "QSize", background as "QRgb", no_frame as "bool"] {
+        cpp! {unsafe [widget_ptr as "QWidget*",  title as "QString", size as "QSize", background as "QRgb", no_frame as "bool", opaque as "bool"] {
             if (size != widget_ptr->size()) {
                 widget_ptr->resize(size.expandedTo({1, 1}));
             }
@@ -1318,6 +1320,7 @@ impl PlatformWindow for QtWindow {
             #endif
             pal.setColor(QPalette::Window, QColor::fromRgba(background));
             widget_ptr->setPalette(pal);
+            widget_ptr->setAttribute(Qt::WA_TranslucentBackground, !opaque);
         }};
     }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -112,6 +112,19 @@ impl Window {
         self.0.hide();
     }
 
+    /// A window can be translucent if the scene's `Window` root element has a color set on the `background` property
+    /// that provides transluceny. Transluceny requires the allocation of a graphics surface that is more expensive
+    /// that one that is entirel opaque. Use this function to override the behavior of depending on the `background`
+    /// property. Use `false` as value for the `opaque` parameter to force the allocation of a surface that supports transluceny.
+    pub fn set_opaque_background(&self, opaque: bool) {
+        self.0.set_opaque_background(opaque)
+    }
+
+    /// Returns whether the background of the window is opaque.
+    pub fn opaque_background(&self) -> bool {
+        self.0.opaque_background()
+    }
+
     /// This function allows registering a callback that's invoked during the different phases of
     /// rendering. This allows custom rendering on top or below of the scene.
     pub fn set_rendering_notifier(


### PR DESCRIPTION
…pporting window surface

This should mostly work by default by choice of the background color, but
it may be necessary to override that when using alpha masks in a rendering notifier.

This used to be in #908 but unfortunately it got lost in the rebase/squash :-(