### PR TITLE
switch to yeslogic-fontconfig-sys from servo-fontconfig

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -21,6 +21,11 @@ For Linux a few additional packages beyond the usual build essentials are needed
 - fontconfig library (`libfontconfig-dev` on debian based distributions)
 - (optional) Qt will be used when `qmake` is found in `PATH`
 
+`xcb` and `xcbcommon` are not needed if you are only using `backend-winit-wayland` without `backend-winit-x11`.
+
+fontconfig can be `dlopen`ed at runtime instead of linking it at build time by setting the
+environment variable `RUST_FONTCONFIG_DLOPEN=on`. This can be useful for [cross-compiling](#cross-compiling).
+
 ### macOS
 
 - Make sure the "Xcode Command Line Tools" are installed: `xcode-select --install`
@@ -125,7 +130,7 @@ in the dependencies section of your `package.json`:
 Slint can be cross-compiled to different target architectures and environments. For the Rust build we
 have had a good experience using [`cross`](https://github.com/rust-embedded/cross). For convenience we're
 including a `Cross.toml` configuration file for `cross` in the source tree along with Docker containers that
-allow targeting a Debian ARMv7 and ARMv8 based Distribution with X11 or Wayland, out of the box.
+allow targeting a Debian ARMv7 and ARMv8 based Distribution with X11 or Wayland, out of the box. If you want to use the default Cross containers or your own, make sure the [dependencies](#Prerequisites) are in the container.
 
 This includes for example the Raspberry Pi OS. Using the following steps you can run the examples on a
 pi:

--- a/examples/plotter/Cargo.toml
+++ b/examples/plotter/Cargo.toml
@@ -15,7 +15,7 @@ name = "plotter"
 
 [dependencies]
 slint = { path = "../../api/rs/slint" }
-plotters = { version = "0.3.1", default-features = false, features = ["bitmap_backend", "surface_series"] }
+plotters = { version = "0.3.4", default-features = false, features = ["bitmap_backend", "surface_series"] }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -20,7 +20,7 @@ path = "lib.rs"
 [features]
 wayland = ["winit/wayland", "glutin/wayland", "copypasta/wayland"]
 x11 = ["winit/x11", "glutin/x11", "copypasta/x11"]
-renderer-winit-femtovg = ["femtovg", "fontdb", "libc", "servo-fontconfig", "winapi", "dwrote", "imgref", "unicode-script", "ttf-parser", "rgb"]
+renderer-winit-femtovg = ["femtovg", "fontdb", "libc", "yeslogic-fontconfig-sys", "winapi", "dwrote", "imgref", "unicode-script", "ttf-parser", "rgb"]
 renderer-winit-skia = ["skia-safe", "glow", "unicode-segmentation", "metal", "objc", "core-graphics-types", "foreign-types", "wio", "winapi/d3d12", "winapi/dxgi", "winapi/dxgi1_2", "winapi/dxgi1_3", "winapi/dxgi1_4", "winapi/d3d12sdklayers", "winapi/synchapi"]
 renderer-winit-skia-opengl = ["skia-safe/gl", "glow", "unicode-segmentation"]
 renderer-winit-software = ["femtovg", "imgref", "rgb"]
@@ -77,9 +77,7 @@ wio = { version = "0.2.2", optional = true }
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
 libc = { version = "0.2", optional = true }
-# Require font-config from the system on Linux. Issue #88 indicates that the copy provided by servo-fontconfig may be incompatible
-# with distros at times.
-servo-fontconfig = { version = "0.5", optional = true, features = [ "force_system_lib" ] }
+yeslogic-fontconfig-sys = { version = "3.2", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # For GL rendering

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -11,4 +11,10 @@ fn main() {
        skia_backend_metal: { all(target_os = "macos", not(feature = "renderer-winit-skia-opengl")) },
        skia_backend_d3d: { all(target_family = "windows", not(feature = "renderer-winit-skia-opengl")) },
     }
+
+    println!("cargo:rerun-if-env-changed=RUST_FONTCONFIG_DLOPEN");
+    let dlopen = std::env::var("RUST_FONTCONFIG_DLOPEN").is_ok();
+    if dlopen {
+        println!("cargo:rustc-cfg=feature=\"fontconfig-dlopen\"");
+    }
 }

--- a/internal/backends/winit/renderer/femtovg/fonts/fontconfig.rs
+++ b/internal/backends/winit/renderer/femtovg/fonts/fontconfig.rs
@@ -1,29 +1,58 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use fontconfig::fontconfig;
+use fontconfig_sys as ffi;
+use fontconfig_sys::ffi_dispatch;
+
+#[cfg(feature = "fontconfig-dlopen")]
+use ffi::statics::LIB;
+#[cfg(not(feature = "fontconfig-dlopen"))]
+use ffi::*;
 
 // This is duplicated in the slint-compiler's glyph embedding code
 pub fn find_families(requested_family: &str) -> Vec<String> {
     unsafe {
-        let config = fontconfig::FcInitLoadConfigAndFonts();
+        let config = ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcInitLoadConfigAndFonts,);
         let family_cstr = std::ffi::CString::new(requested_family).unwrap();
-        let pattern = fontconfig::FcNameParse(family_cstr.as_ptr() as *mut libc::c_uchar);
-        fontconfig::FcConfigSubstitute(std::ptr::null_mut(), pattern, fontconfig::FcMatchPattern);
-        fontconfig::FcDefaultSubstitute(pattern);
-        let mut sort_result = fontconfig::FcResultMatch;
-        let result_set =
-            fontconfig::FcFontSort(config, pattern, 1, std::ptr::null_mut(), &mut sort_result);
+        let pattern = ffi_dispatch!(
+            feature = "fontconfig-dlopen",
+            LIB,
+            FcNameParse,
+            family_cstr.as_ptr() as *mut libc::c_uchar
+        );
+        ffi_dispatch!(
+            feature = "fontconfig-dlopen",
+            LIB,
+            FcConfigSubstitute,
+            std::ptr::null_mut(),
+            pattern,
+            ffi::FcMatchPattern
+        );
+        ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcDefaultSubstitute, pattern);
+        let mut sort_result = ffi::FcResultMatch;
+        let result_set = ffi_dispatch!(
+            feature = "fontconfig-dlopen",
+            LIB,
+            FcFontSort,
+            config,
+            pattern,
+            1,
+            std::ptr::null_mut(),
+            &mut sort_result
+        );
 
         let mut families = Vec::new();
         for idx in 0..(*result_set).nfont {
             let mut raw_family_name = std::ptr::null_mut();
-            if fontconfig::FcPatternGetString(
+            if ffi_dispatch!(
+                feature = "fontconfig-dlopen",
+                LIB,
+                FcPatternGetString,
                 *(*result_set).fonts.offset(idx as isize),
                 b"family\0".as_ptr() as *const libc::c_char,
                 0,
-                &mut raw_family_name,
-            ) != fontconfig::FcResultMatch
+                &mut raw_family_name
+            ) != ffi::FcResultMatch
             {
                 continue;
             }
@@ -41,9 +70,9 @@ pub fn find_families(requested_family: &str) -> Vec<String> {
             }
         }
 
-        fontconfig::FcFontSetDestroy(result_set);
-        fontconfig::FcPatternDestroy(pattern);
-        fontconfig::FcConfigDestroy(config);
+        ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcFontSetDestroy, result_set);
+        ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcPatternDestroy, pattern);
+        ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcConfigDestroy, config);
         families
     }
 }

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -61,9 +61,7 @@ usvg = "0.23"
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
 libc = { version = "0.2" }
-# Require font-config from the system on Linux. Issue #88 indicates that the copy provided by servo-fontconfig may be incompatible
-# with distros at times.
-servo-fontconfig = { version = "0.5", features = [ "force_system_lib" ] }
+yeslogic-fontconfig-sys = "3.2.0"
 
 [dev-dependencies]
 i-slint-parser-test-macro = { path = "./parser-test-macro" }

--- a/internal/compiler/build.rs
+++ b/internal/compiler/build.rs
@@ -6,6 +6,12 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 fn main() -> std::io::Result<()> {
+    println!("cargo:rerun-if-env-changed=RUST_FONTCONFIG_DLOPEN");
+    let dlopen = std::env::var("RUST_FONTCONFIG_DLOPEN").is_ok();
+    if dlopen {
+        println!("cargo:rustc-cfg=feature=\"fontconfig-dlopen\"");
+    }
+
     let mut library_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     library_dir.push("widgets");
 

--- a/internal/compiler/passes/embed_glyphs/fontconfig.rs
+++ b/internal/compiler/passes/embed_glyphs/fontconfig.rs
@@ -1,30 +1,59 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use fontconfig::fontconfig;
+use fontconfig_sys as ffi;
+use fontconfig_sys::ffi_dispatch;
 
-// This is duplicated from the GL backend
+#[cfg(feature = "fontconfig-dlopen")]
+use ffi::statics::LIB;
+#[cfg(not(feature = "fontconfig-dlopen"))]
+use ffi::*;
+
+// This is duplicated in the slint-compiler's glyph embedding code
 pub fn find_families(requested_family: &str) -> Vec<String> {
     #[allow(unsafe_code)]
     unsafe {
-        let config = fontconfig::FcInitLoadConfigAndFonts();
+        let config = ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcInitLoadConfigAndFonts,);
         let family_cstr = std::ffi::CString::new(requested_family).unwrap();
-        let pattern = fontconfig::FcNameParse(family_cstr.as_ptr() as *mut libc::c_uchar);
-        fontconfig::FcConfigSubstitute(std::ptr::null_mut(), pattern, fontconfig::FcMatchPattern);
-        fontconfig::FcDefaultSubstitute(pattern);
-        let mut sort_result = fontconfig::FcResultMatch;
-        let result_set =
-            fontconfig::FcFontSort(config, pattern, 1, std::ptr::null_mut(), &mut sort_result);
+        let pattern = ffi_dispatch!(
+            feature = "fontconfig-dlopen",
+            LIB,
+            FcNameParse,
+            family_cstr.as_ptr() as *mut libc::c_uchar
+        );
+        ffi_dispatch!(
+            feature = "fontconfig-dlopen",
+            LIB,
+            FcConfigSubstitute,
+            std::ptr::null_mut(),
+            pattern,
+            ffi::FcMatchPattern
+        );
+        ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcDefaultSubstitute, pattern);
+        let mut sort_result = ffi::FcResultMatch;
+        let result_set = ffi_dispatch!(
+            feature = "fontconfig-dlopen",
+            LIB,
+            FcFontSort,
+            config,
+            pattern,
+            1,
+            std::ptr::null_mut(),
+            &mut sort_result
+        );
 
         let mut families = Vec::new();
         for idx in 0..(*result_set).nfont {
             let mut raw_family_name = std::ptr::null_mut();
-            if fontconfig::FcPatternGetString(
+            if ffi_dispatch!(
+                feature = "fontconfig-dlopen",
+                LIB,
+                FcPatternGetString,
                 *(*result_set).fonts.offset(idx as isize),
                 b"family\0".as_ptr() as *const libc::c_char,
                 0,
-                &mut raw_family_name,
-            ) != fontconfig::FcResultMatch
+                &mut raw_family_name
+            ) != ffi::FcResultMatch
             {
                 continue;
             }
@@ -42,9 +71,9 @@ pub fn find_families(requested_family: &str) -> Vec<String> {
             }
         }
 
-        fontconfig::FcFontSetDestroy(result_set);
-        fontconfig::FcPatternDestroy(pattern);
-        fontconfig::FcConfigDestroy(config);
+        ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcFontSetDestroy, result_set);
+        ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcPatternDestroy, pattern);
+        ffi_dispatch!(feature = "fontconfig-dlopen", LIB, FcConfigDestroy, config);
         families
     }
 }


### PR DESCRIPTION
to use `dlopen` for fontconfig instead of linking fontconfig at build time. This allows for easier cross compilation, which I am using to cross compile from x86_64-unknown-linux-gnu to aarch64-unknown-linux-gnu with [cross](https://github.com/cross-rs/cross):

![image](https://user-images.githubusercontent.com/9455094/154213283-ac305c5d-8c04-42b3-973b-e9ecc9c80c73.png)

Blocked by:
  * [x] https://github.com/yeslogic/fontconfig-rs/pull/12
  * [x] https://github.com/servo/font-kit/pull/192
  * [ ] https://github.com/38/plotters/pull/337