### PR TITLE
Send less key events from the GL backend

### DIFF
--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -398,13 +398,7 @@ fn process_window_event(
                     .currently_pressed_key_code()
                     .take()
                     .and_then(winit_key_code_to_string)
-                    .and_then(|key_text| {
-                        if key_text.chars().next().map_or(false, char::is_control) {
-                            None
-                        } else {
-                            Some(key_text)
-                        }
-                    })
+                    .filter(|key_text| !key_text.starts_with(char::is_control))
             } else {
                 Some(ch.to_string().into())
             };

--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -390,8 +390,21 @@ fn process_window_event(
             corelib::animations::update_animations();
             // On Windows, X11 and Wayland sequences like Ctrl+C will send a ReceivedCharacter after the pressed keyboard input event,
             // with a control character. We choose not to forward those but try to use the current key code instead.
+            //
+            // We do not want to change the text to the value of the key press when that was a
+            // control key itself: We already sent that event when handling the KeyboardInput.
             let text: Option<SharedString> = if ch.is_control() {
-                window.currently_pressed_key_code().take().and_then(winit_key_code_to_string)
+                window
+                    .currently_pressed_key_code()
+                    .take()
+                    .and_then(winit_key_code_to_string)
+                    .and_then(|key_text| {
+                        if key_text.chars().next().map_or(false, char::is_control) {
+                            None
+                        } else {
+                            Some(key_text)
+                        }
+                    })
             } else {
                 Some(ch.to_string().into())
             };


### PR DESCRIPTION
When "combining" information from winit's ReceiveCharacter and
KeyboardInput events, then do not create a second KeyPress event
when the KeyboardInput contained a control character.

This makes us not send duplicate events for `Tab`, but leaves the
handling for e.g. `Ctrl-C` unchanged.