### PR TITLE
Fix scaling of glyphs and improve type safety in the MCU backend

### DIFF
--- a/internal/backends/mcu/lengths.rs
+++ b/internal/backends/mcu/lengths.rs
@@ -1,0 +1,87 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+pub struct PhysicalPx;
+pub type PhysicalLength = euclid::Length<i16, PhysicalPx>;
+pub type PhysicalRect = euclid::Rect<i16, PhysicalPx>;
+pub type PhysicalSize = euclid::Size2D<i16, PhysicalPx>;
+pub type PhysicalPoint = euclid::Point2D<i16, PhysicalPx>;
+
+pub struct LogicalPx;
+pub type LogicalLength = euclid::Length<f32, LogicalPx>;
+pub type LogicalRect = euclid::Rect<f32, LogicalPx>;
+pub type LogicalPoint = euclid::Point2D<f32, LogicalPx>;
+pub type LogicalSize = euclid::Size2D<f32, LogicalPx>;
+
+pub type ScaleFactor = euclid::Scale<f32, LogicalPx, PhysicalPx>;
+
+pub trait SizeLengths<LengthType> {
+    fn width_length(&self) -> LengthType;
+    fn height_length(&self) -> LengthType;
+}
+
+impl SizeLengths<LogicalLength> for LogicalSize {
+    fn width_length(&self) -> LogicalLength {
+        LogicalLength::new(self.width)
+    }
+
+    fn height_length(&self) -> LogicalLength {
+        LogicalLength::new(self.height)
+    }
+}
+
+impl SizeLengths<PhysicalLength> for PhysicalSize {
+    fn width_length(&self) -> PhysicalLength {
+        PhysicalLength::new(self.width)
+    }
+
+    fn height_length(&self) -> PhysicalLength {
+        PhysicalLength::new(self.height)
+    }
+}
+
+pub trait PointLengths<LengthType> {
+    fn x_length(&self) -> LengthType;
+    fn y_length(&self) -> LengthType;
+}
+
+impl PointLengths<LogicalLength> for LogicalPoint {
+    fn x_length(&self) -> LogicalLength {
+        LogicalLength::new(self.x)
+    }
+
+    fn y_length(&self) -> LogicalLength {
+        LogicalLength::new(self.y)
+    }
+}
+
+impl PointLengths<PhysicalLength> for PhysicalPoint {
+    fn x_length(&self) -> PhysicalLength {
+        PhysicalLength::new(self.x)
+    }
+
+    fn y_length(&self) -> PhysicalLength {
+        PhysicalLength::new(self.y)
+    }
+}
+
+pub trait RectLengths<SizeType> {
+    fn size_length(&self) -> SizeType;
+}
+
+impl RectLengths<LogicalSize> for LogicalRect {
+    fn size_length(&self) -> LogicalSize {
+        let size = self.size;
+        LogicalSize::from_lengths(size.width_length(), size.height_length())
+    }
+}
+
+pub trait LogicalItemGeometry {
+    fn logical_geometry(self: core::pin::Pin<&Self>) -> LogicalRect;
+}
+
+impl<T: i_slint_core::items::Item> LogicalItemGeometry for T {
+    fn logical_geometry(self: core::pin::Pin<&Self>) -> LogicalRect {
+        LogicalRect::from_untyped(&self.geometry())
+    }
+}

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -186,8 +186,9 @@ impl PlatformWindow for SimulatorWindow {
             font_request.merge(&self.self_weak.upgrade().unwrap().default_font_properties()),
             text,
             max_width,
-            crate::renderer::ScaleFactor(runtime_window.scale_factor()),
+            crate::ScaleFactor::new(runtime_window.scale_factor()),
         )
+        .to_untyped()
     }
 
     fn text_input_byte_offset_for_position(

--- a/internal/compiler/embedded_resources.rs
+++ b/internal/compiler/embedded_resources.rs
@@ -46,8 +46,8 @@ impl Texture {
 pub struct BitmapGlyph {
     pub x: i16,
     pub y: i16,
-    pub width: u16,
-    pub height: u16,
+    pub width: i16,
+    pub height: i16,
     pub x_advance: i16,
     pub data: Vec<u8>, // 8bit alpha map
 }
@@ -55,7 +55,7 @@ pub struct BitmapGlyph {
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone)]
 pub struct BitmapGlyphs {
-    pub pixel_size: u16,
+    pub pixel_size: i16,
     pub glyph_data: Vec<BitmapGlyph>,
 }
 

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -132,7 +132,7 @@ fn embed_font(family_name: String, font: fontdue::Font) -> BitmapFont {
             sizes_str
                 .split(',')
                 .map(|size_str| {
-                    (size_str.parse::<f64>().expect("invalid font size") * scale_factor) as u16
+                    (size_str.parse::<f64>().expect("invalid font size") * scale_factor) as i16
                 })
                 .collect::<Vec<_>>()
         })
@@ -164,8 +164,8 @@ fn embed_font(family_name: String, font: fontdue::Font) -> BitmapFont {
                 let glyph = BitmapGlyph {
                     x: i16::try_from(metrics.xmin).expect("large glyph x coordinate"),
                     y: i16::try_from(metrics.ymin).expect("large glyph y coordinate"),
-                    width: u16::try_from(metrics.width).expect("large width"),
-                    height: u16::try_from(metrics.height).expect("large height"),
+                    width: i16::try_from(metrics.width).expect("large width"),
+                    height: i16::try_from(metrics.height).expect("large height"),
                     x_advance: i16::try_from(metrics.advance_width as i64)
                         .expect("large advance width"),
                     data: bitmap,

--- a/internal/core/graphics/bitmapfont.rs
+++ b/internal/core/graphics/bitmapfont.rs
@@ -12,9 +12,9 @@ pub struct BitmapGlyph {
     /// The starting y-coordinate for the glyph, relative to the base line
     pub y: i16,
     /// The width of the glyph in pixels
-    pub width: u16,
+    pub width: i16,
     /// The height of the glyph in pixels
-    pub height: u16,
+    pub height: i16,
     /// The horizontal distance to the next glyph
     pub x_advance: i16,
     /// The 8-bit alpha map that's to be blended with the current text color
@@ -27,7 +27,7 @@ pub struct BitmapGlyph {
 pub struct BitmapGlyphs {
     /// The font size in pixels at which the glyphs were pre-rendered. The boundaries of glyphs may exceed this
     /// size, if the font designer has chosen so. This is only used for matching.
-    pub pixel_size: u16,
+    pub pixel_size: i16,
     /// The data of the pre-rendered glyphs
     pub glyph_data: Slice<'static, BitmapGlyph>,
 }


### PR DESCRIPTION
The code was mixing logical and physical sizes, causing glyphs being
doubly scaled down. Instead, this patch introduces:

 * Physical* and Logical* euclid length/size/rect aliases
 * some extraction traits for getting the scalars in rects/sizes as lengths (until euclid has them
built-in)
 * wrapper traits/types for safely extracting the physical font metrics the
 compiler generates (i16)
 * Fix a bug in the text height calculation where we failed to take the
   descent into account