### PR TITLE
Fix glyph embedding on Linux

### DIFF
--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -59,6 +59,12 @@ tiny-skia = "0.6.1"
 resvg = "0.21"
 usvg = "0.21"
 
+[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
+libc = { version = "0.2" }
+# Require font-config from the system on Linux. Issue #88 indicates that the copy provided by servo-fontconfig may be incompatible
+# with distros at times.
+servo-fontconfig = { version = "0.5", features = [ "force_system_lib" ] }
+
 [dev-dependencies]
 i-slint-parser-test-macro = { path = "./parser-test-macro" }
 

--- a/internal/compiler/passes/embed_glyphs/fontconfig.rs
+++ b/internal/compiler/passes/embed_glyphs/fontconfig.rs
@@ -3,8 +3,9 @@
 
 use fontconfig::fontconfig;
 
-// This is duplicated in the slint-compiler's glyph embedding code
+// This is duplicated from the GL backend
 pub fn find_families(requested_family: &str) -> Vec<String> {
+    #[allow(unsafe_code)]
     unsafe {
         let config = fontconfig::FcInitLoadConfigAndFonts();
         let family_cstr = std::ffi::CString::new(requested_family).unwrap();


### PR DESCRIPTION
Copy the fontconfig code from the GL backend to find out what the font for "sans-serif" is, in case we need a fallback.