### PR TITLE
Upgrade qttypes

### DIFF
--- a/internal/backends/qt/Cargo.toml
+++ b/internal/backends/qt/Cargo.toml
@@ -34,7 +34,7 @@ once_cell = "1"
 pin-weak = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-qttypes = { version = "0.2.5", default-features = false }
+qttypes = { version = "0.2.7", default-features = false }
 
 [build-dependencies]
 cpp_build = "0.5.5"


### PR DESCRIPTION
It now expose the flag via env variable, and allow to report
the reason why Qt was not found