### PR TITLE
Support for referring to other globals from globals

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -439,7 +439,8 @@ fn gen_backend_qt(
 
     config.export.body.insert(
         "NativeStyleMetrics".to_owned(),
-        "    inline NativeStyleMetrics(); inline ~NativeStyleMetrics();".to_owned(),
+        "    inline explicit NativeStyleMetrics(void* = nullptr); inline ~NativeStyleMetrics();"
+            .to_owned(),
     );
 
     let mut crate_dir = root_dir.to_owned();

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -865,7 +865,7 @@ cbindgen_private::Flickable::~Flickable()
     slint_flickable_data_free(&data);
 }
 
-cbindgen_private::NativeStyleMetrics::NativeStyleMetrics()
+cbindgen_private::NativeStyleMetrics::NativeStyleMetrics(void *)
 {
     slint_native_style_metrics_init(this);
 }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -326,7 +326,13 @@ impl PublicComponent {
             }
             visitor(&sc.layout_info_h, ctx);
             visitor(&sc.layout_info_v, ctx);
-        })
+        });
+        for g in &self.globals {
+            let ctx = EvaluationContext::new_global(self, g, ());
+            for e in g.init_values.iter().filter_map(|x| x.as_ref()) {
+                visitor(&e.expression, &ctx)
+            }
+        }
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -318,6 +318,7 @@ impl ContextMap {
                         property_index: *property_index,
                     }
                 }
+                g @ PropertyReference::Global { .. } => g.clone(),
                 _ => unreachable!(),
             },
         }

--- a/internal/compiler/passes/collect_globals.rs
+++ b/internal/compiler/passes/collect_globals.rs
@@ -10,30 +10,44 @@ use crate::expression_tree::NamedReference;
 use crate::langtype::Type;
 use crate::object_tree::*;
 use std::collections::HashSet;
+use std::rc::Rc;
 
 /// Fill the root_component's used_types.globals
 pub fn collect_globals(doc: &Document, _diag: &mut BuildDiagnostics) {
     doc.root_component.used_types.borrow_mut().globals.clear();
     let mut set = HashSet::new();
+    let mut sorted_globals = vec![];
     for (_, ty) in doc.exports() {
         if let Type::Component(c) = ty {
             if c.is_global() {
-                set.insert(ByAddress(c.clone()));
+                if set.insert(ByAddress(c.clone())) {
+                    collect_in_component(c, &mut set, &mut sorted_globals);
+                    sorted_globals.push(c.clone());
+                }
             }
         }
     }
+    collect_in_component(&doc.root_component, &mut set, &mut sorted_globals);
+    doc.root_component.used_types.borrow_mut().globals = sorted_globals;
+}
+
+fn collect_in_component(
+    component: &Rc<Component>,
+    global_set: &mut HashSet<ByAddress<Rc<Component>>>,
+    sorted_globals: &mut Vec<Rc<Component>>,
+) {
     let mut maybe_collect_global = |nr: &mut NamedReference| {
         let element = nr.element();
         let global_component = element.borrow().enclosing_component.upgrade().unwrap();
         if global_component.is_global() {
-            set.insert(ByAddress(global_component));
+            if global_set.insert(ByAddress(global_component.clone())) {
+                collect_in_component(&global_component, global_set, sorted_globals);
+                sorted_globals.push(global_component);
+            }
         }
     };
-    visit_all_named_references(&doc.root_component, &mut maybe_collect_global);
-    for component in &doc.root_component.used_types.borrow().sub_components {
+    visit_all_named_references(&component, &mut maybe_collect_global);
+    for component in &component.used_types.borrow().sub_components {
         visit_all_named_references(component, &mut maybe_collect_global);
     }
-    let mut used_types = doc.root_component.used_types.borrow_mut();
-    used_types.globals = set.into_iter().map(|x| x.0).collect();
-    used_types.globals.sort_by(|a, b| a.id.cmp(&b.id));
 }

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -60,12 +60,12 @@ export global StyleMetrics := {
     property<length> layout-spacing: 8px;
     property<length> layout-padding: 8px;
     property<length> text-cursor-width: 2px;
-    property<color> window-background: white; //FIXME: Palette.white  does not compile (cannot access globals from other globals #175)
-    property<color> default-text-color: #201f1e; // neutralDark
-    property<brush> textedit-background: white;
-    property<color> textedit-text-color: #323130; //Palette.neutralPrimary;
-    property<brush> textedit-background-disabled: #f3f2f1; //Palette.neutralLighter;
-    property<color> textedit-text-color-disabled: #a19f9d;//Palette.neutralTertiary;
+    property<color> window-background: Palette.white;
+    property<color> default-text-color: Palette.neutralDark;
+    property<brush> textedit-background: Palette.white;
+    property<color> textedit-text-color: Palette.neutralPrimary;
+    property<brush> textedit-background-disabled: Palette.neutralLighter;
+    property<color> textedit-text-color-disabled: Palette.neutralTertiary;
 }
 
 export Button := Rectangle {

--- a/internal/compiler/widgets/ugly/std-widgets-impl.slint
+++ b/internal/compiler/widgets/ugly/std-widgets-impl.slint
@@ -21,12 +21,12 @@ export global StyleMetrics := {
     property<length> layout-spacing: 5px;
     property<length> layout-padding: 5px;
     property<length> text-cursor-width: 2px;
-    property<color> window-background: #ecedeb; //FIXME: Palette.window-background  does not compile (cannot access globals from other globals #175)
-    property<color> default-text-color: #090909;
-    property<brush> textedit-background: white; //Palette.base-background-color;
-    property<color> textedit-text-color: #090909;//Palette.text-color;
-    property<brush> textedit-background-disabled: white; //Palette.neutralLighter;
-    property<color> textedit-text-color-disabled: lightgray;// Palette.text-color-disabled;
+    property<color> window-background: Palette.window-background;
+    property<color> default-text-color: Palette.text-color;
+    property<brush> textedit-background: Palette.base-background-color;
+    property<color> textedit-text-color: Palette.text-color;
+    property<brush> textedit-background-disabled: white;
+    property<color> textedit-text-color-disabled: Palette.text-color-disabled;
 }
 
 export Button := Rectangle {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1030,7 +1030,7 @@ pub(crate) fn enclosing_component_instance_for_element<'a, 'old_id, 'new_id>(
     let enclosing = &element.borrow().enclosing_component.upgrade().unwrap();
     match component_instance {
         ComponentInstance::InstanceRef(component) => {
-            if enclosing.is_global() && !component.component_type.original.is_global() {
+            if enclosing.is_global() && !Rc::ptr_eq(enclosing, &component.component_type.original) {
                 // we need a 'static guard in order to be able to borrow from `root` otherwise it does not work because of variance.
                 // Safety: This is the only 'static Id in scope.
                 let static_guard =

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -224,6 +224,7 @@ fn box_layout_data(
                     rep.1.clone(),
                     Some(component.borrow()),
                     Some(window),
+                    Default::default(),
                 );
                 instance.run_setup_code();
                 instance
@@ -282,6 +283,7 @@ fn repeater_indices(children: &[ElementRc], component: InstanceRef) -> Vec<u32> 
                     rep.1.clone(),
                     Some(component.borrow()),
                     Some(window),
+                    Default::default(),
                 );
                 instance.run_setup_code();
                 instance

--- a/tests/cases/globals/global_depends_on_global.slint
+++ b/tests/cases/globals/global_depends_on_global.slint
@@ -1,0 +1,57 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+global Numbers := {
+    property <int> three: 3;
+    property <int> ten: three * Numbers.three + 1;
+}
+
+export global A := {
+    property <int> a_alias <=> a;
+    property <int> a: 3;
+    property <int> b: a + three;
+    property <int> three: Numbers.three;
+}
+
+export global B := {
+   // property <int> a_alias <=> A.a_alias;
+    property <int> c: {
+        debug(A.b, Numbers.ten);
+        A.b + Numbers.ten;
+    }
+}
+
+TestCase := Rectangle {
+    callback set_a(int);
+    set_a(a) => {
+        A.a_alias = a;
+    }
+    property <int> value1: B.c;
+    property <bool> test: value1 == 3 + 13;
+}
+
+/*
+```rust
+let instance = TestCase::new();
+assert_eq!(instance.get_value1(), 3 + 13);
+instance.invoke_set_a(4);
+assert_eq!(instance.get_value1(), 4 + 13);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_value1(), 3 + 13);
+instance.invoke_set_a(4);
+assert_eq(instance.get_value1(), 4 + 13);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert.equal(instance.value1, 3 + 13);
+instance.set_a(4);
+assert.equal(instance.value1, 4 + 13);
+```
+
+*/


### PR DESCRIPTION
 - We need to make sure that the initialization of global is in the right order.
 - In C++ and rust, we need to add accessor to the global component
 - There can be `PropertyReference::Global` in binding of globals
 - The interpreter globals need to hold references to the global they may depend on
    
Fixes #175
