### PR TITLE
Add NativeStyleMetrics.dark-style property, supported by both backends

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -131,6 +131,7 @@ set(generated_headers
     ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_color_internal.h
     ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_pathdata_internal.h
     ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_qt_internal.h
+    ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_selector_internal.h
     ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_backend_internal.h
     ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_generated_public.h
     ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_interpreter_internal.h

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -433,6 +433,7 @@ fn gen_backend_qt(
         "NativeComboBoxPopup",
         "NativeTabWidget",
         "NativeTab",
+        "NativeStyleMetrics",
     ];
 
     config.export.include = items.iter().map(|x| x.to_string()).collect();
@@ -456,6 +457,31 @@ fn gen_backend_qt(
         .generate()
         .context("Unable to generate bindings for slint_qt_internal.h")?
         .write_to_file(include_dir.join("slint_qt_internal.h"));
+
+    Ok(())
+}
+
+fn gen_backend_selector(
+    root_dir: &Path,
+    include_dir: &Path,
+    dependencies: &mut Vec<PathBuf>,
+) -> anyhow::Result<()> {
+    let mut config = default_config();
+
+    config.export.include.clear();
+
+    let mut crate_dir = root_dir.to_owned();
+    crate_dir.extend(["internal", "backends", "selector"].iter());
+
+    ensure_cargo_rerun_for_crate(&crate_dir, dependencies)?;
+
+    cbindgen::Builder::new()
+        .with_config(config)
+        .with_crate(crate_dir)
+        .with_include("slint_qt_internal.h")
+        .generate()
+        .context("Unable to generate bindings for slint_selector_internal.h")?
+        .write_to_file(include_dir.join("slint_selector_internal.h"));
 
     Ok(())
 }
@@ -561,6 +587,7 @@ pub fn gen_all(root_dir: &Path, include_dir: &Path) -> anyhow::Result<Vec<PathBu
     let mut deps = Vec::new();
     gen_corelib(root_dir, include_dir, &mut deps)?;
     gen_backend_qt(root_dir, include_dir, &mut deps)?;
+    gen_backend_selector(root_dir, include_dir, &mut deps)?;
     gen_backend(root_dir, include_dir, &mut deps)?;
     gen_interpreter(root_dir, include_dir, &mut deps)?;
     Ok(deps)

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -27,6 +27,7 @@ struct ItemVTable;
 #include "slint_internal.h"
 #include "slint_backend_internal.h"
 #include "slint_qt_internal.h"
+#include "slint_selector_internal.h"
 
 /// \rst
 /// The :code:`slint` namespace is the primary entry point into the Slint C++ API.

--- a/internal/backends/gl/Cargo.toml
+++ b/internal/backends/gl/Cargo.toml
@@ -21,10 +21,13 @@ svg = ["resvg", "usvg", "tiny-skia"]
 wayland = ["winit/wayland", "glutin/wayland", "copypasta/wayland"]
 x11 = ["winit/x11", "glutin/x11", "copypasta/x11"]
 
-default = ["svg"]
+rtti = ["i-slint-core/rtti"]
+
+default = ["svg", "rtti"]
 
 [dependencies]
 i-slint-core = { version = "=0.2.1", path = "../../../internal/core" }
+i-slint-core-macros = { version = "=0.2.1", path = "../../../internal/core-macros" }
 i-slint-common = { version = "=0.2.1", path = "../../../internal/common" }
 
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
@@ -57,6 +60,7 @@ web_sys = { version = "0.3", package = "web-sys", features=["console", "WebGlCon
 wasm-bindgen = { version = "0.2" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+dark-light = "0.2.1"
 fontdb = { version = "0.9.0", features = ["memmap"] }
 glutin = { version = "0.28", default-features = false }
 usvg = { version= "0.22", optional = true, default-features = false, features = ["text", "memmap-fonts"] }

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -4,6 +4,8 @@
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint-ui.com/logo/slint-logo-square-light.svg")]
 
+extern crate alloc;
+
 use std::cell::RefCell;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -28,6 +30,8 @@ mod svg;
 use images::*;
 
 mod fonts;
+
+mod stylemetrics;
 
 type Canvas = femtovg::Canvas<femtovg::renderer::OpenGl>;
 type CanvasRc = Rc<RefCell<Canvas>>;
@@ -1152,10 +1156,14 @@ pub fn create_gl_window_with_canvas_id(canvas_id: String) -> Rc<Window> {
 pub fn use_modules() {}
 
 pub type NativeWidgets = ();
-pub type NativeGlobals = ();
-pub mod native_widgets {}
+pub type NativeGlobals = (stylemetrics::NativeStyleMetrics, ());
+pub mod native_widgets {
+    pub use super::stylemetrics::NativeStyleMetrics;
+}
 pub const HAS_NATIVE_STYLE: bool = false;
-pub const IS_AVAILABLE: bool = true;
+
+pub use stylemetrics::native_style_metrics_deinit;
+pub use stylemetrics::native_style_metrics_init;
 
 // TODO: We can't connect to the wayland clipboard yet because
 // it requires an external connection.

--- a/internal/backends/gl/stylemetrics.rs
+++ b/internal/backends/gl/stylemetrics.rs
@@ -1,0 +1,93 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use super::*;
+
+use const_field_offset::FieldOffsets;
+use core::pin::Pin;
+use i_slint_core::rtti::*;
+use i_slint_core::Property;
+use i_slint_core_macros::*;
+
+#[repr(C)]
+#[derive(FieldOffsets, SlintElement)]
+#[pin]
+#[pin_drop]
+pub struct NativeStyleMetrics {
+    pub layout_spacing: Property<f32>,
+    pub layout_padding: Property<f32>,
+    pub text_cursor_width: Property<f32>,
+    pub window_background: Property<Color>,
+    pub default_text_color: Property<Color>,
+    pub textedit_background: Property<Color>,
+    pub textedit_text_color: Property<Color>,
+    pub textedit_background_disabled: Property<Color>,
+    pub textedit_text_color_disabled: Property<Color>,
+
+    pub dark_style: Property<bool>,
+
+    pub placeholder_color: Property<Color>,
+    pub placeholder_color_disabled: Property<Color>,
+}
+
+impl const_field_offset::PinnedDrop for NativeStyleMetrics {
+    fn drop(self: Pin<&mut Self>) {
+        native_style_metrics_deinit(self);
+    }
+}
+
+impl NativeStyleMetrics {
+    pub fn new() -> Pin<Rc<Self>> {
+        let new = Rc::pin(NativeStyleMetrics {
+            layout_spacing: Default::default(),
+            layout_padding: Default::default(),
+            text_cursor_width: Default::default(),
+            window_background: Default::default(),
+            default_text_color: Default::default(),
+            textedit_background: Default::default(),
+            textedit_text_color: Default::default(),
+            textedit_background_disabled: Default::default(),
+            textedit_text_color_disabled: Default::default(),
+            dark_style: Default::default(),
+            placeholder_color: Default::default(),
+            placeholder_color_disabled: Default::default(),
+        });
+        new
+    }
+
+    pub fn init<T>(self: Pin<Rc<Self>>, _root: T) {
+        self.as_ref().init_impl();
+    }
+
+    // TODO: Windows- and Linux-specific implementations
+
+    // The palette on macOS is fixed, so the only property the macOS theme
+    // actually uses is dark_style.
+    // The actual colors are defined in the theme's .slint file.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn init_impl(self: Pin<&Self>) {
+        use dark_light::Mode;
+
+        self.dark_style.set(match dark_light::detect() {
+            Mode::Light => false,
+            Mode::Dark => true,
+        });
+    }
+
+    // dark-light currently has no support for WASM
+    #[cfg(target_arch = "wasm32")]
+    pub fn init_impl(self: Pin<&Self>) {}
+}
+
+#[cfg(feature = "rtti")]
+impl i_slint_core::rtti::BuiltinGlobal for NativeStyleMetrics {
+    fn new() -> Pin<Rc<Self>> {
+        NativeStyleMetrics::new()
+    }
+}
+
+pub fn native_style_metrics_init(self_: Pin<&NativeStyleMetrics>) {
+    self_.init_impl();
+}
+
+pub fn native_style_metrics_deinit(_self_: Pin<&mut NativeStyleMetrics>) {}

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -341,7 +341,6 @@ pub type NativeWidgets = ();
 pub type NativeGlobals = ();
 pub mod native_widgets {}
 pub const HAS_NATIVE_STYLE: bool = false;
-pub const IS_AVAILABLE: bool = true;
 
 #[cfg(feature = "simulator")]
 pub fn init_simulator() {

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -89,9 +89,31 @@ pub type NativeGlobals =
     (qt_widgets::NativeStyleMetrics,
         ());
 
+#[cfg(no_qt)]
+mod native_style_metrics_stub {
+    use const_field_offset::FieldOffsets;
+    use core::pin::Pin;
+    use i_slint_core::rtti::*;
+    use i_slint_core_macros::*;
+
+    /// cbindgen:ignore
+    #[repr(C)]
+    #[derive(FieldOffsets, SlintElement)]
+    #[pin]
+    #[pin_drop]
+    pub struct NativeStyleMetrics {}
+
+    impl const_field_offset::PinnedDrop for NativeStyleMetrics {
+        fn drop(self: Pin<&mut Self>) {}
+    }
+}
+
 pub mod native_widgets {
     #[cfg(not(no_qt))]
     pub use super::qt_widgets::*;
+
+    #[cfg(no_qt)]
+    pub use super::native_style_metrics_stub::NativeStyleMetrics;
 }
 
 #[cfg(no_qt)]
@@ -100,8 +122,17 @@ pub type NativeWidgets = ();
 pub type NativeGlobals = ();
 
 pub const HAS_NATIVE_STYLE: bool = cfg!(not(no_qt));
-/// False if the backend was compiled without Qt so it wouldn't do anything
-pub const IS_AVAILABLE: bool = cfg!(not(no_qt));
+
+#[cfg(not(no_qt))]
+pub use qt_widgets::{native_style_metrics_deinit, native_style_metrics_init};
+#[cfg(no_qt)]
+pub fn native_style_metrics_init(_: core::pin::Pin<&native_widgets::NativeStyleMetrics>) {
+    panic!("Qt backend not present");
+}
+#[cfg(no_qt)]
+pub fn native_style_metrics_deinit(_: core::pin::Pin<&mut native_widgets::NativeStyleMetrics>) {
+    panic!("Qt backend not present");
+}
 
 pub struct Backend;
 impl i_slint_core::backend::Backend for Backend {

--- a/internal/backends/qt/qt_widgets/stylemetrics.rs
+++ b/internal/backends/qt/qt_widgets/stylemetrics.rs
@@ -39,12 +39,14 @@ pub struct NativeStyleMetrics {
     pub placeholder_color: Property<Color>,
     pub placeholder_color_disabled: Property<Color>,
 
+    pub dark_style: Property<bool>,
+
     pub style_change_listener: core::cell::Cell<*const u8>,
 }
 
 impl const_field_offset::PinnedDrop for NativeStyleMetrics {
     fn drop(self: Pin<&mut Self>) {
-        slint_native_style_metrics_deinit(self);
+        native_style_metrics_deinit(self);
     }
 }
 
@@ -62,6 +64,7 @@ impl NativeStyleMetrics {
             textedit_text_color_disabled: Default::default(),
             placeholder_color: Default::default(),
             placeholder_color_disabled: Default::default(),
+            dark_style: Default::default(),
             style_change_listener: core::cell::Cell::new(core::ptr::null()),
         });
         new
@@ -99,7 +102,8 @@ impl NativeStyleMetrics {
         let window_background = cpp!(unsafe[] -> u32 as "QRgb" {
             return qApp->palette().color(QPalette::Window).rgba();
         });
-        self.window_background.set(Color::from_argb_encoded(window_background));
+        let window_background = Color::from_argb_encoded(window_background);
+        self.window_background.set(window_background);
         let default_text_color = cpp!(unsafe[] -> u32 as "QRgb" {
             return qApp->palette().color(QPalette::WindowText).rgba();
         });
@@ -130,6 +134,14 @@ impl NativeStyleMetrics {
             return qApp->palette().color(QPalette::Disabled, QPalette::PlaceholderText).rgba();
         });
         self.placeholder_color_disabled.set(Color::from_argb_encoded(placeholder_color_disabled));
+
+        self.dark_style.set(
+            (window_background.red() as u32
+                + window_background.green() as u32
+                + window_background.blue() as u32)
+                / 3
+                < 128,
+        );
     }
 }
 
@@ -142,14 +154,12 @@ impl i_slint_core::rtti::BuiltinGlobal for NativeStyleMetrics {
     }
 }
 
-#[no_mangle]
-pub extern "C" fn slint_native_style_metrics_init(self_: Pin<&NativeStyleMetrics>) {
+pub fn native_style_metrics_init(self_: Pin<&NativeStyleMetrics>) {
     self_.style_change_listener.set(core::ptr::null()); // because the C++ code don't initialize it
     self_.init_impl();
 }
 
-#[no_mangle]
-pub extern "C" fn slint_native_style_metrics_deinit(self_: Pin<&mut NativeStyleMetrics>) {
+pub fn native_style_metrics_deinit(self_: Pin<&mut NativeStyleMetrics>) {
     let scl = self_.style_change_listener.get();
     cpp!(unsafe [scl as "StyleChangeListener*"] { delete scl; });
     self_.style_change_listener.set(core::ptr::null());

--- a/internal/backends/selector/build.rs
+++ b/internal/backends/selector/build.rs
@@ -23,6 +23,10 @@ fn main() {
     let has_native_style =
         std::env::var("DEP_I_SLINT_BACKEND_QT_SUPPORTS_NATIVE_STYLE").unwrap_or_default() == "1";
 
+    if !has_native_style {
+        println!("cargo:rustc-cfg=no_qt");
+    }
+
     let out_dir = std::env::var_os("OUT_DIR").unwrap();
     // out_dir is something like
     // <target_dir>/build/i-slint-backend-selector-1fe5c4ab61eb0584/out

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -608,6 +608,8 @@ export global NativeStyleMetrics := {
     property <color> textedit-background-disabled : native_output;
     property <color> textedit-text-color-disabled : native_output;
 
+    property <bool> dark-style : native_output;
+
     // specific to the Native one
     property <color> placeholder-color : native_output;
     property <color> placeholder-color-disabled : native_output;

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -93,10 +93,7 @@ export AboutSlint := Rectangle {
             horizontal-alignment: center;
         }
         Image {
-            // Hack: try to guess if we should have the logo in black or in white depending in the default text color
-            // If when we make it much brighter it saturates to white, consider the white logo
-            property <color> t_color: t.color;
-            source: t_color.brighter(100%) == Colors.white ? @image-url("slint-logo-dark.svg") : @image-url("slint-logo-light.svg");
+            source: NativeStyleMetrics.dark-style ? @image-url("slint-logo-dark.svg") : @image-url("slint-logo-light.svg");
             preferred-width: 256px;
         }
         Text {


### PR DESCRIPTION
On GL, this uses the [`dark-light` crate](https://crates.io/crates/dark-light). On Qt, it checks whether the window background color's average is < 128.

On GL, this currently does not detect changes after the application is opened. This is blocked on [this PR for `dark-light`](https://github.com/frewsxcv/rust-dark-light/pull/10).

This is a re-do of #982, this time on a separate branch.