### PR TITLE
WIP: Tab focus

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -290,8 +290,8 @@ pub mod re_exports {
         FocusEvent, InputEventResult, KeyEvent, KeyEventResult, KeyboardModifiers, MouseEvent,
     };
     pub use i_slint_core::item_tree::{
-        visit_item_tree, ItemTreeNode, ItemVisitorRefMut, ItemVisitorVTable, TraversalOrder,
-        VisitChildrenResult,
+        default_next_in_local_focus_chain, default_previous_in_local_focus_chain, visit_item_tree,
+        ItemTreeNode, ItemVisitorRefMut, ItemVisitorVTable, TraversalOrder, VisitChildrenResult,
     };
     pub use i_slint_core::items::*;
     pub use i_slint_core::layout::*;

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -936,6 +936,57 @@ fn generate_item_tree(
     target_struct.members.push((
         Access::Private,
         Declaration::Function(Function {
+            name: "next_in_local_focus_chain".into(),
+            signature: "(slint::private_api::ComponentRef component, uintptr_t index, uint32_t subindex, slint::private_api::ItemWeak *result) -> void".into(),
+            is_static: true,
+            statements: Some(vec![
+                "// Implement me!".into(),
+            ]),
+            ..Default::default()
+        }),
+    ));
+
+    target_struct.members.push((
+        Access::Private,
+        Declaration::Function(Function {
+            name: "previous_in_local_focus_chain".into(),
+            signature: "(slint::private_api::ComponentRef component, uintptr_t index, uint32_t subindex, slint::private_api::ItemWeak *result) -> void".into(),
+            is_static: true,
+            statements: Some(vec![
+                "// Implement me!".into(),
+            ]),
+            ..Default::default()
+        }),
+    ));
+    target_struct.members.push((
+        Access::Private,
+        Declaration::Function(Function {
+            name: "next_in_focus_chain".into(),
+            signature: "(slint::private_api::ComponentRef component, uintptr_t index, uint32_t subindex, slint::private_api::ItemWeak *result) -> void".into(),
+            is_static: true,
+            statements: Some(vec![
+                "// Implement me!".into(),
+            ]),
+            ..Default::default()
+        }),
+    ));
+
+    target_struct.members.push((
+        Access::Private,
+        Declaration::Function(Function {
+            name: "previous_in_focus_chain".into(),
+            signature: "(slint::private_api::ComponentRef component, uintptr_t index, uint32_t subindex, slint::private_api::ItemWeak *result) -> void".into(),
+            is_static: true,
+            statements: Some(vec![
+                "// Implement me!".into(),
+            ]),
+            ..Default::default()
+        }),
+    ));
+
+    target_struct.members.push((
+        Access::Private,
+        Declaration::Function(Function {
             name: "layout_info".into(),
             signature:
                 "([[maybe_unused]] slint::private_api::ComponentRef component, slint::cbindgen_private::Orientation o) -> slint::cbindgen_private::LayoutInfo"

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -782,6 +782,24 @@ fn generate_sub_component(
                 }
             }
 
+            fn next_in_local_focus_chain(self: ::core::pin::Pin<&Self>, _index: usize) -> usize {
+                // Implement this!
+                0
+            }
+
+            fn previous_in_local_focus_chain(self: ::core::pin::Pin<&Self>, _index: usize) -> usize {
+                // Implement this!
+                0
+            }
+
+            fn next_in_focus_chain(self: ::core::pin::Pin<&Self>, _index: usize, _subindex: u32, _result: &mut slint::re_exports::ItemWeak) {
+                // Implement this!
+            }
+
+            fn previous_in_focus_chain(self: ::core::pin::Pin<&Self>, _index: usize, _subindex: u32, _result: &mut slint::re_exports::ItemWeak) {
+                // Implement this!
+            }
+
             fn layout_info(self: ::core::pin::Pin<&Self>, orientation: slint::re_exports::Orientation) -> slint::re_exports::LayoutInfo {
                 #![allow(unused)]
                 use slint::re_exports::*;
@@ -1053,6 +1071,24 @@ fn generate_item_tree(
                     ItemTreeNode::DynamicTree { .. } => panic!("get_item_ref called on dynamic tree"),
 
                 }
+            }
+
+            fn next_in_local_focus_chain(self: ::core::pin::Pin<&Self>, _index: usize) -> usize {
+                // Implement this!
+                0
+            }
+
+            fn previous_in_local_focus_chain(self: ::core::pin::Pin<&Self>, _index: usize) -> usize {
+                // Implement this!
+                0
+            }
+
+            fn next_in_focus_chain(self: ::core::pin::Pin<&Self>, _index: usize, _subindex: u32, _result: &mut slint::re_exports::ItemWeak) {
+                // Implement this!
+            }
+
+            fn previous_in_focus_chain(self: ::core::pin::Pin<&Self>, _index: usize, _subindex: u32, _result: &mut slint::re_exports::ItemWeak) {
+                // Implement this!
             }
 
             fn parent_item(self: ::core::pin::Pin<&Self>, index: usize, result: &mut slint::re_exports::ItemWeak) {

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -31,6 +31,36 @@ pub struct ComponentVTable {
         index: usize,
     ) -> core::pin::Pin<VRef<ItemVTable>>,
 
+    /// The next item in the local focus chain. This does only
+    /// look at information local to the Component and does not work accross
+    /// Components. Typically this is implemented by the compiler,
+    /// while the global handling is generic.
+    pub next_in_local_focus_chain:
+        extern "C" fn(core::pin::Pin<VRef<ComponentVTable>>, index: usize) -> usize,
+
+    /// The previous item in the local focus chain. This does only
+    /// look at information local to the Component and does not work accross
+    /// Components. Typically this is implemented by the compiler,
+    /// while the global handling is generic.
+    pub previous_in_local_focus_chain:
+        extern "C" fn(core::pin::Pin<VRef<ComponentVTable>>, index: usize) -> usize,
+
+    /// The next item in the global focus chain
+    pub next_in_focus_chain: extern "C" fn(
+        core::pin::Pin<VRef<ComponentVTable>>,
+        index: usize,
+        subindex: u32,
+        result: &mut ItemWeak,
+    ),
+
+    /// The previous item in the global focus chain
+    pub previous_in_focus_chain: extern "C" fn(
+        core::pin::Pin<VRef<ComponentVTable>>,
+        index: usize,
+        subindex: u32,
+        result: &mut ItemWeak,
+    ),
+
     /// Return the parent item.
     /// The return value is an item weak because it can be null if there is no parent.
     /// And the return value is passed by &mut because ItemWeak has a destructor

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -18,7 +18,7 @@ When adding an item or a property, it needs to be kept in sync with different pl
 #![allow(non_upper_case_globals)]
 #![allow(missing_docs)] // because documenting each property of items is redundant
 
-use crate::component::ComponentVTable;
+use crate::component::{ComponentVTable, ComponentWeak};
 use crate::graphics::{Brush, Color, Point, Rect};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
@@ -199,6 +199,18 @@ pub struct ItemWeak {
 impl ItemWeak {
     pub fn upgrade(&self) -> Option<ItemRc> {
         self.component.upgrade().map(|c| ItemRc::new(c, self.index))
+    }
+
+    pub fn component(&self) -> ComponentWeak {
+        self.component.clone()
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    pub fn is_none(&self) -> bool {
+        VWeak::ptr_eq(&self.component, &Default::default())
     }
 }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -158,6 +158,7 @@ impl ItemRc {
     pub fn new(component: vtable::VRc<ComponentVTable>, index: usize) -> Self {
         Self { component, index }
     }
+
     /// Return a `Pin<ItemRef<'a>>`
     pub fn borrow<'a>(&'a self) -> Pin<ItemRef<'a>> {
         let comp_ref_pin = vtable::VRc::borrow_pin(&self.component);
@@ -166,15 +167,34 @@ impl ItemRc {
         // lifetime of the component, which is 'a.  Pin::as_ref removes the lifetime, but we can just put it back.
         unsafe { core::mem::transmute::<Pin<ItemRef<'_>>, Pin<ItemRef<'a>>>(result) }
     }
+
     pub fn downgrade(&self) -> ItemWeak {
         ItemWeak { component: VRc::downgrade(&self.component), index: self.index }
     }
+
     /// Return the parent Item in the item tree.
     /// This is weak because it can be null if there is no parent
     pub fn parent_item(&self) -> ItemWeak {
         let comp_ref_pin = vtable::VRc::borrow_pin(&self.component);
         let mut r = ItemWeak::default();
         comp_ref_pin.as_ref().parent_item(self.index, &mut r);
+        r
+    }
+
+    /// Return the next item in the focus chain
+    pub fn next_in_focus_chain(&self, subindex: u32) -> ItemWeak {
+        let comp_ref_pin = vtable::VRc::borrow_pin(&self.component);
+        let mut r = ItemWeak::default();
+        comp_ref_pin.as_ref().next_in_focus_chain(self.index, subindex, &mut r);
+        r
+    }
+
+    /// Return the parent Item in the item tree.
+    /// This is weak because it can be null if there is no parent
+    pub fn previous_in_focus_chain(&self, subindex: u32) -> ItemWeak {
+        let comp_ref_pin = vtable::VRc::borrow_pin(&self.component);
+        let mut r = ItemWeak::default();
+        comp_ref_pin.as_ref().previous_in_focus_chain(self.index, subindex, &mut r);
         r
     }
 

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -954,6 +954,38 @@ impl<C: RepeatedComponent> Repeater<C> {
         crate::item_tree::VisitChildrenResult::CONTINUE
     }
 
+    /// Move to the next focus item in the repeater
+    pub fn next_in_focus_chain(&self, subindex: Option<u32>, result: &mut crate::items::ItemWeak) {
+        let start = if let Some(subindex) = subindex {
+            subindex as usize + 1 - self.inner.borrow().offset
+        } else {
+            0
+        };
+
+        let count = self.inner.borrow().components.len();
+        for i in start..count {
+            let c = self.inner.borrow().components.get(i).and_then(|c| c.1.clone());
+            if let Some(c) = c {
+                c.as_pin_ref().next_in_focus_chain(
+                    0,
+                    (i + self.inner.borrow().offset) as u32,
+                    result,
+                );
+                if !result.is_none() {
+                    return; // found something!
+                }
+            }
+        }
+    }
+
+    /// Move to the next focus item in the repeater
+    pub fn previous_in_focus_chain(
+        &self,
+        _subindex: Option<u32>,
+        _result: &mut crate::items::ItemWeak,
+    ) {
+    }
+
     /// Return the amount of item currently in the component
     pub fn len(&self) -> usize {
         self.inner.borrow().components.len()

--- a/tests/cases/focus/keyboard_focus.slint
+++ b/tests/cases/focus/keyboard_focus.slint
@@ -1,0 +1,100 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import { Button, SpinBox, LineEdit, HorizontalBox, VerticalBox, TabWidget } from "std-widgets.slint";
+
+App := Window {
+    preferred-width: 500px;
+    preferred-height: 400px;
+    title: "Keyboard Focus Test";
+    icon: @image-url("../../logo/slint-logo-small-light-128x128.png");
+
+    property<[{name: string, account: string, score: float}]> model: [
+        {
+            name: "Olivier",
+            account: "ogoffart",
+            score: 456,
+        },
+        {
+            name: "Simon",
+            account: "tronical",
+            score: 789,
+        }
+    ];
+
+    VerticalBox {
+        HorizontalBox {
+            VerticalLayout {
+                alignment: start;
+                SpinBox {
+                    value: 42;
+                }
+            }
+        }
+
+        TabWidget {
+            Tab {
+                title: "Dynamic";
+
+                VerticalBox {
+                    SpinBox {
+                        value: 58;
+                    }
+                    for person[i] in model: HorizontalBox {
+                        property<int> index;
+
+                        SpinBox {
+                            value: person.score;
+                        }
+                        Button {
+                            text: "Test " + index;
+                        }
+                        SpinBox {
+                            value: i;
+                        }
+                    }
+                    SpinBox {
+                        value: 59;
+                    }
+                }
+            }
+            Tab {
+                title: "Static";
+                VerticalBox {
+                    HorizontalBox {
+                        alignment: start;
+                        VerticalBox {
+                            alignment: start;
+                            SpinBox {
+                                value: 10;
+                            }
+                            SpinBox {
+                                value: 11;
+                            }
+                            SpinBox {
+                                value: 12;
+                            }
+                        }
+
+
+                        VerticalBox {
+                        alignment: start;
+                            SpinBox {
+                                value: 20;
+                            }
+                            SpinBox {
+                                value: 21;
+                            }
+                            SpinBox {
+                                value: 22;
+                            }
+                        }
+                    }
+                    LineEdit {
+                        placeholder-text: "Enter some text";
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I added four methods to Component:

`previous/next_in_local_focus_chain` and `previous/next_in_focus_chain`.

The idea way to have the focus chain of one component in the `local_focus_chain` function. For many use-cases this will be mostly data-driven and I expect this has to be generated for each component.

The (non-local) `focus_chain` functions stitch together all the `local_focus_chain`s. I hope this functionality is comparatively stable and universal to all the backends.

Since these two have so different characteristics, I opted to separate them for now -- in the interest of keeping the generated code simple and small. I will merge these functions later if that makes sense.