### PR TITLE
Add an InputType enum to allow password fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
  - C++ interpreter API: added a `Value::Value(int)` constructor
  - Globals Singleton may now refer to other global singletons
+ - Added an enum to TextInput that allows for characters to be replaced which is useful for password fields
 
 ### Fixed
 

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -117,6 +117,7 @@ fn gen_corelib(
         "ImageFit",
         "FillRule",
         "MouseCursor",
+        "InputType",
         "StandardButtonKind",
         "DialogButtonRole",
         "PointerEventKind",

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -639,7 +639,6 @@ When not part of a layout, its width or height defaults to 100% of the parent el
 * **`single-line`** (bool): When set to `true`, no newlines are allowed (default value: `true`)
 * **`wrap`** (*enum [`TextWrap`](#textwrap)*): The way the text input wraps.  Only makes sense when `single-line` is false. (default: no-wrap)
 * **`input-type`** (*enum [`InputType`](#InputType)*): The way to allow special input viewing properties such as password fields (default value: `text`).
-* **`password-replace-char`** (*string*): The character to use when replacing characters in the input field. The default is "*"
 
 ### Methods
 
@@ -901,7 +900,7 @@ should be shown, for example.
 ### Values
 
 * **`text`**: The default value. This will render all characters normally
-* **`password`**: This will render all characters with the character stored in `password_replace_char` which defaults to "*"
+* **`password`**: This will render all characters with a character that defaults to "*"
 
 # Namespaces
 

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -638,6 +638,8 @@ When not part of a layout, its width or height defaults to 100% of the parent el
   and a negative value decreases the distance. The default value is 0.
 * **`single-line`** (bool): When set to `true`, no newlines are allowed (default value: `true`)
 * **`wrap`** (*enum [`TextWrap`](#textwrap)*): The way the text input wraps.  Only makes sense when `single-line` is false. (default: no-wrap)
+* **`input-type`** (*enum [`InputType`](#InputType)*): The way to allow special input viewing properties such as password fields (default value: `text`).
+* **`password-replace-char`** (*string*): The character to use when replacing characters in the input field. The default is "*"
 
 ### Methods
 
@@ -889,6 +891,17 @@ Depending on the backend and used OS unidirectional resize cursors may be replac
 * **`ns-resize`**: Bidirectional resize north-south.
 * **`nesw-resize`**: Bidirectional resize north-east-south-west.
 * **`nwse-resize`**: Bidirectional resize north-west-south-east.
+
+## `InputType`
+
+This enum is used to define the type of the input field. Currently this only differentiates between
+text and password inputs but in the future it could be expanded to also define what type of virtual keyboard
+should be shown, for example.
+
+### Values
+
+* **`text`**: The default value. This will render all characters normally
+* **`password`**: This will render all characters with the character stored in `password_replace_char` which defaults to "*"
 
 # Namespaces
 

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -12,11 +12,12 @@ use std::rc::Rc;
 
 use euclid::approxeq::ApproxEq;
 use event_loop::WinitWindow;
+use i_slint_core::SharedString;
 use i_slint_core::graphics::{
     Brush, Color, Image, ImageInner, IntRect, IntSize, Point, Rect, RenderingCache, Size,
 };
 use i_slint_core::item_rendering::{CachedRenderingData, ItemRenderer};
-use i_slint_core::items::{FillRule, ImageFit, ImageRendering};
+use i_slint_core::items::{FillRule, ImageFit, ImageRendering, InputType};
 use i_slint_core::properties::Property;
 use i_slint_core::window::{Window, WindowRc};
 
@@ -282,7 +283,12 @@ impl ItemRenderer for GLItemRenderer {
         let cursor_visible = cursor_pos >= 0 && text_input.cursor_visible() && text_input.enabled();
         let mut canvas = self.canvas.borrow_mut();
         let font_height = canvas.measure_font(paint).unwrap().height();
-        let text = text_input.text();
+        let mut text = text_input.text();
+        if let InputType::password = text_input.input_type() {
+            text = SharedString::from(text_input.text().as_str().replace(|_| true, text_input.password_replace_char().as_str()));
+
+        }
+
 
         let mut cursor_point: Option<Point> = None;
 

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -12,7 +12,6 @@ use std::rc::Rc;
 
 use euclid::approxeq::ApproxEq;
 use event_loop::WinitWindow;
-use i_slint_core::SharedString;
 use i_slint_core::graphics::{
     Brush, Color, Image, ImageInner, IntRect, IntSize, Point, Rect, RenderingCache, Size,
 };
@@ -20,6 +19,7 @@ use i_slint_core::item_rendering::{CachedRenderingData, ItemRenderer};
 use i_slint_core::items::{FillRule, ImageFit, ImageRendering, InputType};
 use i_slint_core::properties::Property;
 use i_slint_core::window::{Window, WindowRc};
+use i_slint_core::SharedString;
 
 mod glwindow;
 use glwindow::*;
@@ -283,12 +283,11 @@ impl ItemRenderer for GLItemRenderer {
         let cursor_visible = cursor_pos >= 0 && text_input.cursor_visible() && text_input.enabled();
         let mut canvas = self.canvas.borrow_mut();
         let font_height = canvas.measure_font(paint).unwrap().height();
-        let mut text = text_input.text();
-        if let InputType::password = text_input.input_type() {
-            text = SharedString::from(text_input.text().as_str().replace(|_| true, text_input.password_replace_char().as_str()));
-
-        }
-
+        let text = if let InputType::password = text_input.input_type() {
+            SharedString::from("*".repeat(text_input.text().as_str().len()))
+        } else {
+            text_input.text()
+        };
 
         let mut cursor_point: Option<Point> = None;
 

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 use i_slint_core::input::FocusEventResult;
+use i_slint_core::items::InputType;
 
 use super::*;
 
@@ -20,6 +21,7 @@ pub struct NativeLineEdit {
     pub native_padding_bottom: Property<f32>,
     pub has_focus: Property<bool>,
     pub enabled: Property<bool>,
+    pub input_type: Property<InputType>,
 }
 
 impl Item for NativeLineEdit {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -12,8 +12,8 @@ use i_slint_core::graphics::{
 use i_slint_core::input::{KeyEvent, KeyEventType, MouseEvent};
 use i_slint_core::item_rendering::{CachedRenderingData, ItemRenderer};
 use i_slint_core::items::{
-    self, FillRule, ImageRendering, ItemRef, MouseCursor, PointerEventButton, TextOverflow,
-    TextWrap, InputType,
+    self, FillRule, ImageRendering, InputType, ItemRef, MouseCursor, PointerEventButton,
+    TextOverflow, TextWrap,
 };
 use i_slint_core::layout::Orientation;
 use i_slint_core::window::{PlatformWindow, PopupWindow, PopupWindowLocation, WindowRc};
@@ -518,12 +518,13 @@ impl ItemRenderer for QtItemRenderer<'_> {
         let selection_background_color: u32 =
             text_input.selection_background_color().as_argb_encoded();
 
-        let mut text = text_input.text();
-        if let InputType::password = text_input.input_type() {
-            text = SharedString::from(text_input.text().as_str().replace(|_| true, text_input.password_replace_char().as_str()));
+        let text = text_input.text();
+        let mut string: qttypes::QString = if let InputType::password = text_input.input_type() {
+            "*".repeat(text.as_str().len()).into()
+        } else {
+            text.as_str().into()
+        };
 
-        }
-        let mut string: qttypes::QString = text.as_str().into();
         let font: QFont =
             get_font(text_input.unresolved_font_request().merge(&self.default_font_properties));
         let flags = match text_input.horizontal_alignment() {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -13,7 +13,7 @@ use i_slint_core::input::{KeyEvent, KeyEventType, MouseEvent};
 use i_slint_core::item_rendering::{CachedRenderingData, ItemRenderer};
 use i_slint_core::items::{
     self, FillRule, ImageRendering, ItemRef, MouseCursor, PointerEventButton, TextOverflow,
-    TextWrap,
+    TextWrap, InputType,
 };
 use i_slint_core::layout::Orientation;
 use i_slint_core::window::{PlatformWindow, PopupWindow, PopupWindowLocation, WindowRc};
@@ -518,7 +518,11 @@ impl ItemRenderer for QtItemRenderer<'_> {
         let selection_background_color: u32 =
             text_input.selection_background_color().as_argb_encoded();
 
-        let text = text_input.text();
+        let mut text = text_input.text();
+        if let InputType::password = text_input.input_type() {
+            text = SharedString::from(text_input.text().as_str().replace(|_| true, text_input.password_replace_char().as_str()));
+
+        }
         let mut string: qttypes::QString = text.as_str().into();
         let font: QFont =
             get_font(text_input.unresolved_font_request().merge(&self.default_font_properties));

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -208,6 +208,8 @@ export TextInput := _ {
     property <length> width;
     property <length> height;
     property <length> text-cursor-width; // StyleMetrics.text-cursor-width  set in apply_default_properties_from_style
+    property <InputType> input-type;
+    property <string> password-replace-char: "*";
     property <int> cursor-position: native_output;
     property <int> anchor-position: native_output;
     property <bool> has-focus: native_output;

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -209,7 +209,6 @@ export TextInput := _ {
     property <length> height;
     property <length> text-cursor-width; // StyleMetrics.text-cursor-width  set in apply_default_properties_from_style
     property <InputType> input-type;
-    property <string> password-replace-char: "*";
     property <int> cursor-position: native_output;
     property <int> anchor-position: native_output;
     property <bool> has-focus: native_output;

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -201,6 +201,7 @@ impl TypeRegister {
         declare_enum("ImageRendering", &["smooth", "pixelated"]);
         declare_enum("EventResult", &["reject", "accept"]);
         declare_enum("FillRule", &["nonzero", "evenodd"]);
+        declare_enum("InputType", &["text", "password"]);
         declare_enum(
             "MouseCursor",
             &[

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -28,6 +28,23 @@ use i_slint_core_macros::*;
 #[cfg(not(feature = "std"))]
 use num_traits::float::Float;
 
+/// This enum defines the input type in a text input which for now only distinguishes a normal
+/// input from a password input
+#[derive(Copy, Clone, Debug, PartialEq, strum::EnumString, strum::Display)]
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum InputType {
+    /// This type is used for a normal text input
+    text,
+    /// This type is used for password inputs where the characters are represented as *'s
+    password,
+}
+impl Default for InputType {
+    fn default() -> Self {
+        Self::text
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, strum::EnumString, strum::Display)]
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -235,6 +252,8 @@ pub struct TextInput {
     pub horizontal_alignment: Property<TextHorizontalAlignment>,
     pub vertical_alignment: Property<TextVerticalAlignment>,
     pub wrap: Property<TextWrap>,
+    pub input_type: Property<InputType>,
+    pub password_replace_char: Property<SharedString>,
     pub letter_spacing: Property<f32>,
     pub x: Property<f32>,
     pub y: Property<f32>,
@@ -441,7 +460,7 @@ impl Item for TextInput {
     }
 
     fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer) {
-        (*backend).draw_text_input(self)
+        (*backend).draw_text_input(self);
     }
 }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -253,7 +253,6 @@ pub struct TextInput {
     pub vertical_alignment: Property<TextVerticalAlignment>,
     pub wrap: Property<TextWrap>,
     pub input_type: Property<InputType>,
-    pub password_replace_char: Property<SharedString>,
     pub letter_spacing: Property<f32>,
     pub x: Property<f32>,
     pub y: Property<f32>,

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -49,6 +49,7 @@ declare_ValueType![
     crate::items::PointerEvent,
     crate::items::PointerEventButton,
     crate::items::PointerEventKind,
+    crate::items::InputType,
 ];
 
 /// What kind of animation is on a binding

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -313,6 +313,7 @@ declare_value_enum_conversion!(i_slint_core::items::StandardButtonKind, Standard
 declare_value_enum_conversion!(i_slint_core::items::PointerEventKind, PointerEventKind);
 declare_value_enum_conversion!(i_slint_core::items::PointerEventButton, PointerEventButton);
 declare_value_enum_conversion!(i_slint_core::items::DialogButtonRole, DialogButtonRole);
+declare_value_enum_conversion!(i_slint_core::items::InputType, InputType);
 declare_value_enum_conversion!(i_slint_core::graphics::PathEvent, PathEvent);
 
 impl From<i_slint_core::animations::Instant> for Value {

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -930,7 +930,7 @@ pub(crate) fn generate_component<'id>(
                 "TextVerticalAlignment" => {
                     property_info::<i_slint_core::items::TextVerticalAlignment>()
                 }
-                "InputType" => { property_info::<i_slint_core::items::InputType>() }
+                "InputType" => property_info::<i_slint_core::items::InputType>(),
                 "TextWrap" => property_info::<i_slint_core::items::TextWrap>(),
                 "TextOverflow" => property_info::<i_slint_core::items::TextOverflow>(),
                 "ImageFit" => property_info::<i_slint_core::items::ImageFit>(),

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -930,6 +930,7 @@ pub(crate) fn generate_component<'id>(
                 "TextVerticalAlignment" => {
                     property_info::<i_slint_core::items::TextVerticalAlignment>()
                 }
+                "InputType" => { property_info::<i_slint_core::items::InputType>() }
                 "TextWrap" => property_info::<i_slint_core::items::TextWrap>(),
                 "TextOverflow" => property_info::<i_slint_core::items::TextOverflow>(),
                 "ImageFit" => property_info::<i_slint_core::items::ImageFit>(),

--- a/tests/cases/text/input_type.slint
+++ b/tests/cases/text/input_type.slint
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+TestCase := TextInput {
+    text: "hello";
+    input-type: InputType.password;
+}
+


### PR DESCRIPTION
Fixes #882 

This adds the option to replace characters in an input field with another character that defaults to "*".