### PR TITLE
Build the backends without rtti unless needed

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -74,6 +74,15 @@ define_cargo_feature(backend-gl-wayland "Enable the OpenGL ES 2.0 backend with w
 
 define_cargo_feature(backend-qt "Enable Qt based rendering backend" ON)
 
+if(SLINT_FEATURE_INTERPRETER)
+    if (SLINT_FEATURE_BACKEND_QT)
+        list(APPEND features rtti-qt)
+    endif
+    if(SLINT_FEATURE_BACKEND_GL_ALL OR SLINT_FEATURE_BACKEND_GL_X11 OR SLINT_FEATURE_BACKEND_GL_WAYLAND)
+        list(APPEND features rtti-gl)
+    endif()
+endif()
+
 set_property(
     TARGET slint-cpp
     PROPERTY CORROSION_FEATURES

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -77,7 +77,7 @@ define_cargo_feature(backend-qt "Enable Qt based rendering backend" ON)
 if(SLINT_FEATURE_INTERPRETER)
     if (SLINT_FEATURE_BACKEND_QT)
         list(APPEND features rtti-qt)
-    endif
+    endif()
     if(SLINT_FEATURE_BACKEND_GL_ALL OR SLINT_FEATURE_BACKEND_GL_X11 OR SLINT_FEATURE_BACKEND_GL_WAYLAND)
         list(APPEND features rtti-gl)
     endif()

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -29,6 +29,9 @@ backend-gl-all = ["i-slint-backend-selector/backend-gl-all"]
 backend-gl-wayland = ["i-slint-backend-selector/backend-gl-wayland"]
 backend-gl-x11 = ["i-slint-backend-selector/backend-gl-x11"]
 
+rtti-qt = ["i-slint-backend-selector/rtti-qt"]
+rtti-gl = ["i-slint-backend-selector/rtti-gl"]
+
 default = ["backend-gl-all", "backend-qt"]
 
 [dependencies]

--- a/internal/backends/gl/Cargo.toml
+++ b/internal/backends/gl/Cargo.toml
@@ -23,7 +23,7 @@ x11 = ["winit/x11", "glutin/x11", "copypasta/x11"]
 
 rtti = ["i-slint-core/rtti"]
 
-default = ["svg", "rtti"]
+default = ["svg"]
 
 [dependencies]
 i-slint-core = { version = "=0.2.1", path = "../../../internal/core" }

--- a/internal/backends/gl/stylemetrics.rs
+++ b/internal/backends/gl/stylemetrics.rs
@@ -5,6 +5,7 @@ use super::*;
 
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
+#[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
 use i_slint_core::Property;
 use i_slint_core_macros::*;

--- a/internal/backends/qt/Cargo.toml
+++ b/internal/backends/qt/Cargo.toml
@@ -14,7 +14,6 @@ links = "i_slint_backend_qt" # just so we can pass metadata to the dependee's bu
 
 [features]
 rtti = ["i-slint-core/rtti"]
-default = ["rtti"]
 
 [lib]
 path = "lib.rs"

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -93,6 +93,7 @@ pub type NativeGlobals =
 mod native_style_metrics_stub {
     use const_field_offset::FieldOffsets;
     use core::pin::Pin;
+    #[cfg(feature = "rtti")]
     use i_slint_core::rtti::*;
     use i_slint_core_macros::*;
 

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -27,6 +27,7 @@ use i_slint_core::input::{
 use i_slint_core::item_rendering::{CachedRenderingData, ItemRenderer};
 use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, VoidArg};
 use i_slint_core::layout::{LayoutInfo, Orientation};
+#[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
 use i_slint_core::window::WindowRc;
 use i_slint_core::{

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -19,6 +19,9 @@ backend-gl-all = ["backend-gl-x11", "backend-gl-wayland"]
 backend-gl-wayland = ["i-slint-backend-gl/wayland"]
 backend-gl-x11 = ["i-slint-backend-gl/x11"]
 
+rtti-gl = ["i-slint-backend-gl/rtti"]
+rtti-qt = ["i-slint-backend-qt/rtti"]
+
 [dependencies]
 i-slint-core = { version = "=0.2.1", path = "../../../internal/core", default-features = false }
 i-slint-backend-gl = { version = "=0.2.1", path = "../gl", optional = true }

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -41,19 +41,19 @@ std = ["i-slint-core/std"]
 ## This backend is required to use the `native` style.
 ## It requires Qt 5.15 or later to be installed. If Qt is not installed, the
 ## backend will not be operational
-backend-qt = ["i-slint-backend-selector/i-slint-backend-qt", "std"]
+backend-qt = ["i-slint-backend-selector/i-slint-backend-qt", "i-slint-backend-selector/rtti-qt", "std"]
 
 ## The GL backend uses the `winit` crate for the windowing system integration,
 ## and the `femtovg` crate for the rendering. With this feature, all windowing
 ## systems are supported. For a smaller build, omit this feature and select
 ## one of the other specific `backend-gl-XX` features.
-backend-gl-all = ["i-slint-backend-selector/backend-gl-all", "std"]
+backend-gl-all = ["i-slint-backend-selector/backend-gl-all", "i-slint-backend-selector/rtti-gl", "std"]
 ## Simliar to `backend-gl-all` this enables the GL backend but only with support for the
 ## X Window System on Unix.
-backend-gl-x11 = ["i-slint-backend-selector/backend-gl-x11", "std"]
+backend-gl-x11 = ["i-slint-backend-selector/backend-gl-x11", "i-slint-backend-selector/rtti-gl", "std"]
 ## Simliar to `backend-gl-all` this enables the GL backend but only with support for the
 ## Wayland window system on Unix.
-backend-gl-wayland = ["i-slint-backend-selector/backend-gl-wayland", "std"]
+backend-gl-wayland = ["i-slint-backend-selector/backend-gl-wayland", "i-slint-backend-selector/rtti-gl", "std"]
 
 
 [dependencies]


### PR DESCRIPTION
Only the interpreter needs the rtti generated code.

 * Since `SlintElement` emits `#[cfg(feature = "rtti")]` tokens, each
 crate using `SlintElement` needs to have an `rtti` feature.
 * The selector gets backend specific rtti selection features, in order
   for the interpreter to enable them.