### PR TITLE
Add keyboard controls to SpinBox

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -458,9 +458,12 @@ export NativeSpinBox := _ {
     property <length> width;
     property <length> height;
     property <bool> enabled: true;
+    property <bool> has-focus: native_output;
     property <int> value: native_output;
     property <int> minimum;
     property <int> maximum: 100;
+    callback key_pressed(KeyEvent) -> EventResult;
+    callback key_released(KeyEvent) -> EventResult;
     //-is_internal
 }
 

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -163,7 +163,15 @@ export SpinBox := FocusScope {
             : has-focus ? Palette.themeSecondary
             : Palette.neutralDark;
     }
-
+    
+    key-pressed(event) => {
+        if (enabled && event.text == Keys.UpArrow && value < maximum) {
+            value += 1;
+        } else if (enabled && event.text == Keys.DownArrow && value > minimum) {
+            value -= 1;
+        }
+        accept
+    }
 }
 
 export Slider := Rectangle {

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -16,7 +16,18 @@ export StandardButton := NativeButton {
     is-standard-button: true;
 }
 export CheckBox := NativeCheckBox { }
-export SpinBox := NativeSpinBox { property<length> font-size; }
+export SpinBox := NativeSpinBox {
+    property<length> font-size;
+        
+    key-pressed(event) => {
+        if (enabled && event.text == Keys.UpArrow && value < maximum) {
+            value += 1;
+        } else if (enabled && event.text == Keys.DownArrow && value > minimum) {
+            value -= 1;
+        }
+        accept
+    }
+}
 export Slider := NativeSlider { }
 export GroupBox := NativeGroupBox {
     GridLayout {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -52,7 +52,7 @@ type ItemRendererRef<'a> = &'a mut dyn crate::item_rendering::ItemRenderer;
 
 /// Workarounds for cbindgen
 pub type VoidArg = ();
-type KeyEventArg = (KeyEvent,);
+pub type KeyEventArg = (KeyEvent,);
 type PointerEventArg = (PointerEvent,);
 type PointArg = (Point,);
 


### PR DESCRIPTION
This PR adds keyboard controls to the SpinBox widget.
If focused and enabled, the value can be incremented and decremented with the up and down key.

### fluent
for fluent i just added a 'key-pressed' callback to the SpinBox in std-widgets.slint (which is a FocusScope).

### native
to do something similar the native SpinBox I implemented focus handling and a has-focus property in NativeSpinBox.
After that the same implementation of the actual keyboard handling was used.