### PR TITLE
Add MCU board config setup

### DIFF
--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -23,3 +23,4 @@ i-slint-compiler = { version = "=0.2.1", path = "../../../internal/compiler", fe
 
 spin_on = "0.1"
 thiserror = "1"
+toml_edit = "0.13.4"

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -275,5 +275,42 @@ pub fn compile_with_config(
     println!("cargo:rerun-if-env-changed=SLINT_SCALE_FACTOR");
 
     println!("cargo:rustc-env=SLINT_INCLUDE_GENERATED={}", output_file_path.display());
+
+    Ok(())
+}
+
+/// This function is for use the application's build script, in order to print any device specific
+/// build flags reported by the backend
+pub fn print_rustc_flags() -> std::io::Result<()> {
+    if let Some(board_config_path) =
+        std::env::var_os("DEP_I_SLINT_BACKEND_MCU_BOARD_CONFIG_PATH").map(std::path::PathBuf::from)
+    {
+        let config = std::fs::read_to_string(board_config_path.as_path())?;
+        let toml = config.parse::<toml_edit::Document>().expect("invalid board config toml");
+
+        for link_arg in
+            toml.get("link_args").map(toml_edit::Item::as_array).flatten().into_iter().flatten()
+        {
+            if let Some(option) = link_arg.as_str() {
+                println!("cargo:rustc-link-arg={}", option);
+            }
+        }
+
+        for link_search_path in toml
+            .get("link_search_path")
+            .map(toml_edit::Item::as_array)
+            .flatten()
+            .into_iter()
+            .flatten()
+        {
+            if let Some(mut path) = link_search_path.as_str().map(std::path::PathBuf::from) {
+                if path.is_relative() {
+                    path = board_config_path.parent().unwrap().join(path);
+                }
+                println!("cargo:rustc-link-search={}", path.to_string_lossy());
+            }
+        }
+    }
+
     Ok(())
 }

--- a/examples/printerdemo/rust/build.rs
+++ b/examples/printerdemo/rust/build.rs
@@ -3,4 +3,5 @@
 
 fn main() {
     slint_build::compile("../ui/printerdemo.slint").unwrap();
+    slint_build::print_rustc_flags().unwrap();
 }

--- a/internal/backends/mcu/Cargo.toml
+++ b/internal/backends/mcu/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 description = "Rendering backend for Slint for use on Microcontrollers"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
+links = "i_slint_backend_mcu" # just so we can pass metadata to the slint build crate
 
 [lib]
 path = "lib.rs"
@@ -64,3 +65,6 @@ panic-probe = { version = "0.3.0", optional = true, features = ["print-defmt"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = { version = "0.24.0" }
+
+[build-dependencies]
+cfg-if = "1.0.0"

--- a/internal/backends/mcu/build.rs
+++ b/internal/backends/mcu/build.rs
@@ -1,0 +1,19 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+fn main() -> std::io::Result<()> {
+    #[allow(unused)]
+    let mut board_config_path: Option<std::path::PathBuf> = None;
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "pico-st7789")] {
+            board_config_path = Some([env!("CARGO_MANIFEST_DIR"), "pico_st7789", "board_config.toml"].iter().collect());
+        }
+    }
+
+    if let Some(path) = board_config_path {
+        println!("cargo:BOARD_CONFIG_PATH={}", path.display())
+    }
+
+    Ok(())
+}

--- a/internal/backends/mcu/pico_st7789/board_config.toml
+++ b/internal/backends/mcu/pico_st7789/board_config.toml
@@ -1,0 +1,11 @@
+# Copyright © SixtyFPS GmbH <info@slint-ui.com>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+link_args = [
+    "--nmagic",
+    "-Tlink.x",
+    "-Tdefmt.x",
+]
+link_search_path = [
+    "."
+]

--- a/internal/backends/mcu/pico_st7789/memory.x
+++ b/internal/backends/mcu/pico_st7789/memory.x
@@ -1,5 +1,5 @@
 /* Copyright © 2021 rp-rs organization
- SPDX-License-Identifier: MIT OR Apache 2.0 */
+ SPDX-License-Identifier: MIT OR Apache-2.0 */
 
 MEMORY {
     BOOT2 : ORIGIN = 0x10000000, LENGTH = 0x100

--- a/internal/backends/mcu/pico_st7789/memory.x
+++ b/internal/backends/mcu/pico_st7789/memory.x
@@ -1,0 +1,18 @@
+/* Copyright © 2021 rp-rs organization
+ SPDX-License-Identifier: MIT OR Apache 2.0 */
+
+MEMORY {
+    BOOT2 : ORIGIN = 0x10000000, LENGTH = 0x100
+    FLASH : ORIGIN = 0x10000100, LENGTH = 2048K - 0x100
+    RAM   : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+EXTERN(BOOT2_FIRMWARE)
+
+SECTIONS {
+    /* ### Boot loader */
+    .boot2 ORIGIN(BOOT2) :
+    {
+        KEEP(*(.boot2));
+    } > BOOT2
+} INSERT BEFORE .text;

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -314,6 +314,7 @@ lazy_static! {
         ("LICENSE\\..*", LicenseLocation::NoLicense),
         (".+\\.txt$", LicenseLocation::NoLicense),
         ("(^|.+)\\.reuse/dep5$", LicenseLocation::NoLicense), // .reuse files have no license headers
+        ("memory.x$", LicenseLocation::NoLicense), // third-party file
         ("LICENSES/.+", LicenseLocation::NoLicense),
         ("^.mailmap$", LicenseLocation::NoLicense),
     ]


### PR DESCRIPTION
Let the mcu backend provide the link flags via I_DEP_* and the
Slint-build crate now offers a function to allow printing Slint-specific
rustc flags.