### PR TITLE
Properly compute the binding priority in case of several level of inlining

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -464,6 +464,9 @@ pub struct Element {
     /// the index of the first children in the tree, set with item_index
     pub item_index_of_first_children: once_cell::unsync::OnceCell<usize>,
 
+    /// How many times the element was inlined
+    pub inline_depth: i32,
+
     /// The AST node, if available
     pub node: Option<syntax_nodes::Element>,
 }

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -46,6 +46,7 @@ pub fn ensure_window(
         item_index: Default::default(),
         item_index_of_first_children: Default::default(),
         node: win_elem_mut.node.clone(),
+        inline_depth: 0,
     };
     let new_root = Rc::new(RefCell::new(new_root));
     win_elem_mut.children.push(new_root.clone());

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -44,6 +44,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 is_flickable_viewport: elem.is_flickable_viewport,
                 item_index: Default::default(), // Not determined yet
                 item_index_of_first_children: Default::default(),
+                inline_depth: 0,
             })),
             parent_element,
             ..Component::default()

--- a/tests/cases/bindings/issue_1026_opacity_alias.slint
+++ b/tests/cases/bindings/issue_1026_opacity_alias.slint
@@ -1,0 +1,44 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+RoundedIcon := Rectangle {
+    property <float> background-opacity <=> background-fill.opacity;
+    background-fill := Rectangle {
+        background:  #ff7d34;
+        opacity: 1.0;
+    }
+    property <float> o: background-fill.opacity;
+}
+
+Device := VerticalLayout {
+    spacing: 5px;
+    ri := RoundedIcon {
+        background-opacity: 0.15;
+    }
+
+    property<float> o: ri.o;
+}
+
+Sub := Rectangle {
+    property o <=> d.o;
+    d := Device {}
+}
+
+
+TestCase := Rectangle {
+    s := Sub {}
+    d := Device {}
+    property o1 <=> s.o;
+    property o2 <=> d.o;
+    property <bool> test: abs(o1 - 0.15) < 0.001 && abs(o2 - 0.15) < 0.001;
+}
+
+/*
+
+```rust
+let instance = TestCase::new();
+assert!(instance.get_test());
+```
+
+*/


### PR DESCRIPTION
The problem is that if some bindings are coming from already inlined elements
they should have a higher priority field, so that whenmerging the two way
binding, we keep the least deep value

Fixes: #1026