### PR TITLE
Janitor: Clap update + basic functionality addition to all binaries

### DIFF
--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -19,6 +19,6 @@ path = "main.rs"
 [dependencies]
 i-slint-compiler = { version = "=0.2.2", path = "../../internal/compiler", features = ["display-diagnostics", "cpp", "rust"]}
 
-clap = { version = "3.0.5", features=["derive", "wrap_help"] }
+clap = { version = "3.1", features = ["derive", "wrap_help"] }
 proc-macro2 = "1.0.11"
 spin_on = "0.1"

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -7,6 +7,7 @@ use i_slint_compiler::*;
 use std::io::Write;
 
 #[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
 struct Cli {
     /// Set output format
     #[clap(short = 'f', long = "format", default_value = "cpp")]

--- a/tools/figma_import/Cargo.toml
+++ b/tools/figma_import/Cargo.toml
@@ -5,13 +5,14 @@
 name = "figma_import"
 version = "0.2.2"
 authors = ["Slint Developers <info@slint-ui.com>"]
+description = "A figma file importer for Slint"
 edition = "2021"
 license = "GPL-3.0-only"
 publish = false
 
 [dependencies]
 float-cmp = "0.9.0"
-clap = { version = "3.0.5", features=["derive", "wrap_help"] }
+clap = { version = "3.1", features = ["derive", "wrap_help"] }
 reqwest = { version = "0.11", features = ["json", "stream"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"

--- a/tools/figma_import/src/main.rs
+++ b/tools/figma_import/src/main.rs
@@ -11,6 +11,7 @@ use std::fmt::Display;
 use tokio::io::AsyncWriteExt;
 
 #[derive(Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
 struct Opt {
     /// Figma asscess token
     #[clap(short = 't', long = "token")]

--- a/tools/fmt/Cargo.toml
+++ b/tools/fmt/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Slint Developers <info@slint-ui.com>"]
 edition = "2021"
 license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
 publish = false
-description = "Tool used to update .slint files when we do syntax upgrade"
+description = "A code formatter for slint files"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
 categories = ["gui", "development-tools"]
@@ -17,7 +17,7 @@ keywords = ["formatter", "gui", "ui", "toolkit"]
 [dependencies]
 i-slint-compiler = { path = "../../internal/compiler", features = ["display-diagnostics"] }
 
-clap = { version = "3.0.5", features=["derive", "wrap_help"] }
+clap = { version = "3.1", features = ["derive", "wrap_help"] }
 codemap = "0.1"
 codemap-diagnostic = "0.1.1"
 

--- a/tools/fmt/main.rs
+++ b/tools/fmt/main.rs
@@ -26,6 +26,7 @@ mod fmt;
 mod writer;
 
 #[derive(clap::Parser)]
+#[clap(author, version, about, long_about = None)]
 struct Cli {
     #[clap(name = "path to .slint file(s)", parse(from_os_str))]
     paths: Vec<std::path::PathBuf>,

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.2.2"
 authors = ["Slint Developers <info@slint-ui.com>"]
 edition = "2021"
 license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
-description = "Slint LSP server"
+description = "A language server protocol implementation for slint. "
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
 categories = ["gui", "development-tools"]
@@ -35,7 +35,7 @@ i-slint-core = { version = "=0.2.2", path = "../../internal/core"}
 slint-interpreter = { version = "=0.2.2", path = "../../internal/interpreter", default-features = false, features = ["compat-0-2-0"] }
 i-slint-backend-selector = { version = "=0.2.2", path="../../internal/backends/selector" }
 
-clap = { version = "3.0.5", features=["derive", "wrap_help"] }
+clap = { version = "3.1", features = ["derive", "wrap_help"] }
 crossbeam-channel = "0.5"  # must match the version used by lsp-server
 dunce = "1.0.1"
 euclid = "0.22"

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -38,6 +38,7 @@ type Error = Box<dyn std::error::Error>;
 const SHOW_PREVIEW_COMMAND: &str = "showPreview";
 
 #[derive(Clone, clap::Parser)]
+#[clap(author, version, about, long_about = None)]
 struct Cli {
     #[clap(
         short = 'I',

--- a/tools/syntax_updater/Cargo.toml
+++ b/tools/syntax_updater/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://slint-ui.com"
 [dependencies]
 i-slint-compiler = { path = "../../internal/compiler", features = ["display-diagnostics"] }
 
-clap = { version = "3.0.5", features=["derive", "wrap_help"] }
+clap = { version = "3.1", features = ["derive", "wrap_help"] }
 codemap = "0.1"
 codemap-diagnostic = "0.1.1"
 

--- a/tools/syntax_updater/main.rs
+++ b/tools/syntax_updater/main.rs
@@ -28,6 +28,7 @@ mod from_0_0_6;
 mod from_0_1_0;
 
 #[derive(clap::Parser)]
+#[clap(author, version, about, long_about = None)]
 struct Cli {
     #[clap(name = "path to .slint file(s)", parse(from_os_str))]
     paths: Vec<std::path::PathBuf>,

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.2.2"
 authors = ["Slint Developers <info@slint-ui.com>"]
 edition = "2021"
 license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
-description = "Viewer binary for Slint"
+description = "The viewer binary for Slint"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
 categories = ["gui", "development-tools"]
@@ -28,7 +28,7 @@ i-slint-backend-selector = { version = "=0.2.2", path="../../internal/backends/s
 
 vtable = { version = "0.1.6", path="../../helper_crates/vtable" }
 
-clap = { version = "3.0.5", features=["derive", "wrap_help"] }
+clap = { version = "3.1", features = ["derive", "wrap_help"] }
 codemap = "0.1"
 codemap-diagnostic = "0.1.1"
 notify = "4.0.15"

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -18,6 +18,7 @@ use clap::Parser;
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[derive(Clone, clap::Parser)]
+#[clap(author, version, about, long_about = None)]
 struct Cli {
     #[clap(
         short = 'I',

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,13 +5,14 @@
 name = "xtask"
 version = "0.2.2"
 authors = ["Slint Developers <info@slint-ui.com>"]
+description = "Development helper tool for the Slint project"
 edition = "2021"
 license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
 publish = false
 
 [dependencies]
 const_format = "0.2"
-clap = { version = "3.0.5", features=["derive", "wrap_help"] }
+clap = { version = "3.1", features = ["derive", "wrap_help"] }
 cargo_metadata = "0.14"
 anyhow = "1.0"
 lazy_static = "1.4.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod nodepackage;
 mod reuse_compliance_check;
 
 #[derive(Debug, clap::Parser)]
+#[clap(author, version, about, long_about = None)]
 pub enum TaskCommand {
     #[clap(name = "check_license_headers")]
     CheckLicenseHeaders(license_headers_check::LicenseHeaderCheck),


### PR DESCRIPTION
Make clap generate `--version`, and make it add more informtaion from
Cargo.toml available in `--help`.

Old output:

```
slint-lsp 

USAGE:
    slint-lsp [OPTIONS]

OPTIONS:
        --backend <backend>                                 The backend used for the preview ('GL' or 'Qt') [default: ]
    -h, --help                                              Print help information
    -I <Add include paths for the import statements>        
        --style <style name>                                The style name for the preview ('native', 'fluent' or 'ugly') [default: ]
```

New output:
```
slint-lsp 0.2.2
Slint Developers <info@slint-ui.com>
A language server protocol implementation for slint.

USAGE:
    slint-lsp [OPTIONS]

OPTIONS:
        --backend <backend>                                 The backend used for the preview ('GL' or 'Qt') [default: ]
    -h, --help                                              Print help information
    -I <Add include paths for the import statements>        
        --style <style name>                                The style name for the preview ('native', 'fluent' or 'ugly') [default: ]
    -V, --version                                           Print version information
```