### PR TITLE
add From<&str> and From<String> to StandardListViewItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Added
+
+ - Added `From<&str>` and `From<SharedString>` to `StandardListViewItem` to make creation and modification of `StandardListView`'s models easier.
+
+### Fixed
+
 ## [0.2.1] - 2022-03-10
 
 ### Added

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -11,7 +11,7 @@ use crate::item_tree::TraversalOrder;
 use crate::items::ItemRef;
 use crate::layout::Orientation;
 use crate::properties::dependency_tracker::DependencyNode;
-use crate::{Property, SharedVector};
+use crate::{Property, SharedString, SharedVector};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
@@ -997,6 +997,18 @@ impl<C: RepeatedComponent> Repeater<C> {
 pub struct StandardListViewItem {
     /// The text content of the item
     pub text: crate::SharedString,
+}
+
+impl From<&str> for StandardListViewItem {
+    fn from(other: &str) -> Self {
+        return Self { text: other.into() };
+    }
+}
+
+impl From<SharedString> for StandardListViewItem {
+    fn from(other: SharedString) -> Self {
+        return Self { text: other };
+    }
 }
 
 #[test]


### PR DESCRIPTION
this makes it possible to create a model for StandardListView like this:
```rust
Rc::new(slint::VecModel::<slint::StandardListViewItem>::from(vec![
        "Emil, Hans".into(),
        "Mustermann, Max".into(),
        "Tisch, Roman".into(),
    ]));
```
push works like this:
```rust
let new_entry = "bla".to_string();
model.push(new_entry.into());
```