### PR TITLE
reset StandardListView's current-item if it is out of bounds

### DIFF
--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -377,8 +377,7 @@ export ListView := ScrollView {
 
 export StandardListView := ListView {
     property<[StandardListViewItem]> model;
-    property<int> current-item: min(actual-current-item, model.length - 1);
-    property<int> actual-current-item: -1;
+    property<int> current-item: min(fs.actual-current-item, model.length - 1);
     for item[idx] in model : Rectangle {
         l := HorizontalLayout {
             padding: 8px;
@@ -393,10 +392,11 @@ export StandardListView := ListView {
         touch := TouchArea {
             width: parent.width;
             height: parent.height;
-            clicked => { actual-current-item = idx; }
+            clicked => { fs.actual-current-item = idx; }
         }
     }
-    FocusScope {
+    fs := FocusScope {
+        property<int> actual-current-item: -1;
         key-pressed(event) => {
             if (event.text == Keys.UpArrow && current-item > 0) {
                 actual-current-item -= 1;

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -377,7 +377,8 @@ export ListView := ScrollView {
 
 export StandardListView := ListView {
     property<[StandardListViewItem]> model;
-    property<int> current-item: -1;
+    property<int> current-item: min(actual-current-item, model.length - 1);
+    property<int> actual-current-item: -1;
     for item[idx] in model : Rectangle {
         l := HorizontalLayout {
             padding: 8px;
@@ -392,16 +393,16 @@ export StandardListView := ListView {
         touch := TouchArea {
             width: parent.width;
             height: parent.height;
-            clicked => { current-item = idx; }
+            clicked => { actual-current-item = idx; }
         }
     }
     FocusScope {
         key-pressed(event) => {
             if (event.text == Keys.UpArrow && current-item > 0) {
-                current-item -= 1;
+                actual-current-item -= 1;
                 return accept;
             } else if (event.text == Keys.DownArrow && current-item + 1 < model.length) {
-                current-item += 1;
+                actual-current-item += 1;
                 return accept;
             }
             reject

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -69,23 +69,24 @@ export ListView := ScrollView {
 
 export StandardListView := ListView {
     property<[StandardListViewItem]> model;
-    property<int> current-item: -1;
+    property<int> current-item: min(actual-current-item, model.length - 1);
+    property<int> actual-current-item: -1;
     for item[i] in model : NativeStandardListViewItem {
         item: item;
         index: i;
         is-selected: current-item == i;
         TouchArea {
-            clicked => { current-item = i; }
+            clicked => { actual-current-item = i; }
             has-hover <=> parent.has-hover;
         }
     }
     FocusScope {
         key-pressed(event) => {
             if (event.text == Keys.UpArrow && current-item > 0) {
-                current-item -= 1;
+                actual-current-item -= 1;
                 return accept;
             } else if (event.text == Keys.DownArrow && current-item + 1 < model.length) {
-                current-item += 1;
+                actual-current-item += 1;
                 return accept;
             }
             reject

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -69,18 +69,18 @@ export ListView := ScrollView {
 
 export StandardListView := ListView {
     property<[StandardListViewItem]> model;
-    property<int> current-item: min(actual-current-item, model.length - 1);
-    property<int> actual-current-item: -1;
+    property<int> current-item: min(fs.actual-current-item, model.length - 1);
     for item[i] in model : NativeStandardListViewItem {
         item: item;
         index: i;
         is-selected: current-item == i;
         TouchArea {
-            clicked => { actual-current-item = i; }
+            clicked => { fs.actual-current-item = i; }
             has-hover <=> parent.has-hover;
         }
     }
-    FocusScope {
+    fs := FocusScope {
+        property<int> actual-current-item: -1;
         key-pressed(event) => {
             if (event.text == Keys.UpArrow && current-item > 0) {
                 actual-current-item -= 1;


### PR DESCRIPTION
This is the implementation of @ogoffart 's idea to reset `StandardListView`'s `current-item` to the last item or -1 if it is out of bounds.
It is a simple hack and causes problems if the current-item is set from code, but it was easy to do and is better than no reset at all.