### PR TITLE
cmake: Do not break when slint is build with empty CMAKE_BUILD_TYPE

### DIFF
--- a/api/cpp/cmake/SlintConfig.cmake.in
+++ b/api/cpp/cmake/SlintConfig.cmake.in
@@ -16,7 +16,7 @@ set_target_properties(slint-cpp-shared PROPERTIES @SLINT_LIB_PROPERTIES@)
 foreach(build_type Release RelWithDebInfo MinSizeRel Debug)
   string(TOUPPER "${build_type}" config_name)
   if(NOT("@CMAKE_BUILD_TYPE@" STREQUAL build_type))
-    set_target_properties(slint-cpp-shared PROPERTIES MAP_IMPORTED_CONFIG_${config_name} @CMAKE_BUILD_TYPE@)
+    set_target_properties(slint-cpp-shared PROPERTIES MAP_IMPORTED_CONFIG_${config_name} "@CMAKE_BUILD_TYPE@")
   endif()
 endforeach()
 


### PR DESCRIPTION
Do not break building against slint using CMake from C++ when no
CMAKE_BUILD_TYPE was set when building Slint.

This just makes sure the build type is properly quoted, which makes sure
we keep a (empty) string token where CMake expects one.

Fixes: #1065