### PR TITLE
Change non-rectangular clip implementation in the GL backend

### DIFF
--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -216,6 +216,7 @@ impl WinitWindow for GLWindow {
                     ),
                     global_alpha: 1.,
                     layer: None,
+                    current_render_target: femtovg::RenderTarget::Screen,
                 }],
             };
 

--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -215,7 +215,6 @@ impl WinitWindow for GLWindow {
                         Size::new(size.width as f32, size.height as f32) / scale_factor,
                     ),
                     global_alpha: 1.,
-                    layer: None,
                     current_render_target: femtovg::RenderTarget::Screen,
                 }],
             };

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -683,7 +683,7 @@ impl ItemRenderer for GLItemRenderer {
         });
     }
 
-    fn apply_clip(&mut self, clip_item: Pin<&Clip>, self_rc: &ItemRc) -> RenderingResult {
+    fn visit_clip(&mut self, clip_item: Pin<&Clip>, self_rc: &ItemRc) -> RenderingResult {
         if !clip_item.clip() {
             return RenderingResult::ContinueRenderingChildren;
         }

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -25,7 +25,7 @@ use i_slint_core::input::{
     FocusEvent, InputEventFilterResult, InputEventResult, KeyEvent, KeyEventResult, MouseEvent,
 };
 use i_slint_core::item_rendering::{CachedRenderingData, ItemRenderer};
-use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, VoidArg};
+use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, RenderingResult, VoidArg};
 use i_slint_core::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
@@ -55,7 +55,7 @@ macro_rules! get_size {
 
 macro_rules! fn_render {
     ($this:ident $dpr:ident $size:ident $painter:ident $widget:ident $initial_state:ident => $($tt:tt)*) => {
-        fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer) {
+        fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer, _self_rc: &ItemRc) -> RenderingResult {
             let $dpr: f32 = backend.scale_factor();
 
             let window = backend.window();
@@ -102,6 +102,7 @@ macro_rules! fn_render {
                     },
                 );
             }
+            RenderingResult::ContinueRenderingChildren
         }
     };
 }

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -174,7 +174,7 @@ pub trait ItemRenderer {
     // Apply the bounds of the Clip element, if enabled. The default implementation calls
     // combine_clip, but the render may choose an alternate way of implementing the clip.
     // For example the GL backend uses a layered rendering approach.
-    fn apply_clip(&mut self, clip_item: Pin<&Clip>, _self_rc: &ItemRc) -> RenderingResult {
+    fn visit_clip(&mut self, clip_item: Pin<&Clip>, _self_rc: &ItemRc) -> RenderingResult {
         if clip_item.clip() {
             let geometry = clip_item.geometry();
             self.combine_clip(

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -96,7 +96,12 @@ pub(crate) fn is_clipping_item(item: Pin<ItemRef>) -> bool {
         || ItemRef::downcast_pin::<Clip>(item).is_some()
 }
 
-fn render_item_children(renderer: &mut dyn ItemRenderer, component: &ComponentRc, index: isize) {
+/// Renders the children of the item with the specified index into the renderer.
+pub fn render_item_children(
+    renderer: &mut dyn ItemRenderer,
+    component: &ComponentRc,
+    index: isize,
+) {
     let mut actual_visitor =
         |component: &ComponentRc, index: usize, item: Pin<ItemRef>| -> VisitChildrenResult {
             renderer.save_state();
@@ -196,6 +201,20 @@ pub trait ItemRenderer {
     /// Draw the given string with the specified color at current (0, 0) with the default font. Mainly
     /// used by the performance counter overlay.
     fn draw_string(&mut self, string: &str, color: crate::Color);
+
+    // Renders the children of the specified item into a layer and subsequently renders the layer. The
+    // layer may be cached.
+    // Returns true if the operation is supported; false if the caller needs to take care of rendering
+    // the children without a layer.
+    fn render_layer(
+        &mut self,
+        _item_cache: &CachedRenderingData,
+        _item: &ItemRc,
+        _radius: f32,
+        _border_width: f32,
+    ) -> bool {
+        false
+    }
 
     /// This is called before it is being rendered (before the draw_* function).
     /// Returns

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -762,15 +762,29 @@ impl Item for Clip {
     fn render(
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
-        _self_rc: &ItemRc,
+        self_rc: &ItemRc,
     ) -> RenderingResult {
         if self.clip() {
-            let geometry = self.geometry();
-            (*backend).combine_clip(
-                euclid::rect(0., 0., geometry.width(), geometry.height()),
-                self.border_radius(),
-                self.border_width(),
-            )
+            let radius = self.border_radius();
+            let border_width = self.border_width();
+            let needs_layer = radius > 0.;
+            if needs_layer
+                && (*backend).render_layer(
+                    &self.cached_rendering_data,
+                    self_rc,
+                    radius,
+                    border_width,
+                )
+            {
+                return RenderingResult::ContinueRenderingWithoutChildren;
+            } else {
+                let geometry = self.geometry();
+                (*backend).combine_clip(
+                    euclid::rect(0., 0., geometry.width(), geometry.height()),
+                    radius,
+                    border_width,
+                )
+            }
         }
         RenderingResult::ContinueRenderingChildren
     }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -764,29 +764,7 @@ impl Item for Clip {
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
     ) -> RenderingResult {
-        if self.clip() {
-            let radius = self.border_radius();
-            let border_width = self.border_width();
-            let needs_layer = radius > 0.;
-            if needs_layer
-                && (*backend).render_layer(
-                    &self.cached_rendering_data,
-                    self_rc,
-                    radius,
-                    border_width,
-                )
-            {
-                return RenderingResult::ContinueRenderingWithoutChildren;
-            } else {
-                let geometry = self.geometry();
-                (*backend).combine_clip(
-                    euclid::rect(0., 0., geometry.width(), geometry.height()),
-                    radius,
-                    border_width,
-                )
-            }
-        }
-        RenderingResult::ContinueRenderingChildren
+        (*backend).apply_clip(self, self_rc)
     }
 }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -764,7 +764,7 @@ impl Item for Clip {
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
     ) -> RenderingResult {
-        (*backend).apply_clip(self, self_rc)
+        (*backend).visit_clip(self, self_rc)
     }
 }
 

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -7,7 +7,7 @@ This module contains the builtin image related items.
 When adding an item or a property, it needs to be kept in sync with different place.
 Lookup the [`crate::items`] module documentation.
 */
-use super::{Item, ItemConsts, ItemRc};
+use super::{Item, ItemConsts, ItemRc, RenderingResult};
 use crate::graphics::Rect;
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
@@ -115,8 +115,13 @@ impl Item for ImageItem {
         FocusEventResult::FocusIgnored
     }
 
-    fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer) {
-        (*backend).draw_image(self)
+    fn render(
+        self: Pin<&Self>,
+        backend: &mut &mut dyn ItemRenderer,
+        _self_rc: &ItemRc,
+    ) -> RenderingResult {
+        (*backend).draw_image(self);
+        RenderingResult::ContinueRenderingChildren
     }
 }
 
@@ -194,8 +199,13 @@ impl Item for ClippedImage {
         FocusEventResult::FocusIgnored
     }
 
-    fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer) {
-        (*backend).draw_clipped_image(self)
+    fn render(
+        self: Pin<&Self>,
+        backend: &mut &mut dyn ItemRenderer,
+        _self_rc: &ItemRc,
+    ) -> RenderingResult {
+        (*backend).draw_clipped_image(self);
+        RenderingResult::ContinueRenderingChildren
     }
 }
 

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -8,7 +8,7 @@ When adding an item or a property, it needs to be kept in sync with different pl
 Lookup the [`crate::items`] module documentation.
 */
 
-use super::{Item, ItemConsts, ItemRc, ItemRendererRef};
+use super::{Item, ItemConsts, ItemRc, ItemRendererRef, RenderingResult};
 use crate::graphics::{Brush, PathData, PathDataIterator, Rect};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
@@ -105,7 +105,11 @@ impl Item for Path {
         FocusEventResult::FocusIgnored
     }
 
-    fn render(self: Pin<&Self>, backend: &mut ItemRendererRef) {
+    fn render(
+        self: Pin<&Self>,
+        backend: &mut ItemRendererRef,
+        _self_rc: &ItemRc,
+    ) -> RenderingResult {
         let clip = self.clip();
         if clip {
             (*backend).save_state();
@@ -115,6 +119,7 @@ impl Item for Path {
         if clip {
             (*backend).restore_state();
         }
+        RenderingResult::ContinueRenderingChildren
     }
 }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -8,7 +8,7 @@ When adding an item or a property, it needs to be kept in sync with different pl
 Lookup the [`crate::items`] module documentation.
 */
 
-use super::{Item, ItemConsts, ItemRc, PointArg, PointerEventButton, VoidArg};
+use super::{Item, ItemConsts, ItemRc, PointArg, PointerEventButton, RenderingResult, VoidArg};
 use crate::graphics::{Brush, Color, FontRequest, Rect};
 use crate::input::{
     key_codes, FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
@@ -195,8 +195,13 @@ impl Item for Text {
         FocusEventResult::FocusIgnored
     }
 
-    fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer) {
-        (*backend).draw_text(self)
+    fn render(
+        self: Pin<&Self>,
+        backend: &mut &mut dyn ItemRenderer,
+        _self_rc: &ItemRc,
+    ) -> RenderingResult {
+        (*backend).draw_text(self);
+        RenderingResult::ContinueRenderingChildren
     }
 }
 
@@ -458,8 +463,13 @@ impl Item for TextInput {
         FocusEventResult::FocusAccepted
     }
 
-    fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer) {
+    fn render(
+        self: Pin<&Self>,
+        backend: &mut &mut dyn ItemRenderer,
+        _self_rc: &ItemRc,
+    ) -> RenderingResult {
         (*backend).draw_text_input(self);
+        RenderingResult::ContinueRenderingChildren
     }
 }
 


### PR DESCRIPTION
Persist the layer image we render the sub-tree for non-rectangular clips into.

Upsides:
 * This avoids repeated allocation and deletion of the layer textures
 * Unless the sub-tree changes, this speeds up complex scenes

Downsides:
 * This makes lazy clipping as proposed in #1053 impossible (or maybe just very hard?)
 * This increase the GPU memory consumption for every non-rectangular clip