### PR TITLE
layer hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented in this file.
  - Added `From<&str>` and `From<SharedString>` to `StandardListViewItem` to make creation and modification of `StandardListView`'s models easier.
  - Added `on_close_requested` function to `Window` to register callbacks that are emitted when the user tries to close a window.
  - Added `VecModel::set_vec` to replace the entire contents with new data.
+ - Added a `layer` boolean property that can be applied to any element, to hint to the renderer that it should cache the element and its children
+   into a cached layer. This may speed up rendering of complex sub-trees if they rarely change.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented in this file.
  - Added `From<&str>` and `From<SharedString>` to `StandardListViewItem` to make creation and modification of `StandardListView`'s models easier.
  - Added `on_close_requested` function to `Window` to register callbacks that are emitted when the user tries to close a window.
  - Added `VecModel::set_vec` to replace the entire contents with new data.
- - Added a `layer` boolean property that can be applied to any element, to hint to the renderer that it should cache the element and its children
+ - Added a `cache-rendering-hint` boolean property that can be applied to any element, to hint to the renderer that it should cache the element and its children
    into a cached layer. This may speed up rendering of complex sub-trees if they rarely change.
 
 ### Fixed

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -102,6 +102,7 @@ fn gen_corelib(
         "BoxShadow",
         "Rotate",
         "Opacity",
+        "Layer",
     ];
 
     config.export.include = [

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -17,9 +17,11 @@ These properties are valid on all visible items
   children with transparency. 0 is fully transparent (invisible), and 1 is fully opaque. (default: 1)
 * **`visible`** (*bool*): When set to `false`, the element and all his children will not be drawn
   and not react to mouse input (default: `true`)
-* **`layer`** (*bool*): When set to `true`, this provides a hint to the renderer to cache the contents of the element and all the children into an intermediate cached layer.
-  For complex sub-trees that rarely change this may speed up the rendering, at the expense of increased memory consumption. Not all rendering backends support this, so this
-  is merely a hint.
+* **`cache-rendering-hint`** (*bool*): When set to `true` (default: `false'), this provides a hint
+  to the renderer to cache the contents of the element and all the children into an intermediate
+  cached layer. For complex sub-trees that rarely change this may speed up the rendering, at the
+  expense of increased memory consumption. Not all rendering backends support this, so this is
+  merely a hint.
 * **`dialog-button-role`** (*enum DialogButtonRole*): Specify that this is a button in a `Dialog`.
 
 

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -17,11 +17,11 @@ These properties are valid on all visible items
   children with transparency. 0 is fully transparent (invisible), and 1 is fully opaque. (default: 1)
 * **`visible`** (*bool*): When set to `false`, the element and all his children will not be drawn
   and not react to mouse input (default: `true`)
-* **`cache-rendering-hint`** (*bool*): When set to `true` (default: `false'), this provides a hint
+* **`cache-rendering-hint`** (*bool*): When set to `true`, this provides a hint
   to the renderer to cache the contents of the element and all the children into an intermediate
   cached layer. For complex sub-trees that rarely change this may speed up the rendering, at the
   expense of increased memory consumption. Not all rendering backends support this, so this is
-  merely a hint.
+  merely a hint. (default: `false`)
 * **`dialog-button-role`** (*enum DialogButtonRole*): Specify that this is a button in a `Dialog`.
 
 

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -17,6 +17,9 @@ These properties are valid on all visible items
   children with transparency. 0 is fully transparent (invisible), and 1 is fully opaque. (default: 1)
 * **`visible`** (*bool*): When set to `false`, the element and all his children will not be drawn
   and not react to mouse input (default: `true`)
+* **`layer`** (*bool*): When set to `true`, this provides a hint to the renderer to cache the contents of the element and all the children into an intermediate cached layer.
+  For complex sub-trees that rarely change this may speed up the rendering, at the expense of increased memory consumption. Not all rendering backends support this, so this
+  is merely a hint.
 * **`dialog-button-role`** (*enum DialogButtonRole*): Specify that this is a button in a `Dialog`.
 
 

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -693,7 +693,7 @@ impl ItemRenderer for GLItemRenderer {
     }
 
     fn visit_layer(&mut self, layer_item: Pin<&Layer>, self_rc: &ItemRc) -> RenderingResult {
-        if layer_item.layer() {
+        if layer_item.cache_rendering_hint() {
             self.render_and_blend_layer(&layer_item.cached_rendering_data, 1.0, self_rc)
         } else {
             RenderingResult::ContinueRenderingChildren

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -693,7 +693,11 @@ impl ItemRenderer for GLItemRenderer {
     }
 
     fn visit_layer(&mut self, layer_item: Pin<&Layer>, self_rc: &ItemRc) -> RenderingResult {
-        self.render_and_blend_layer(&layer_item.cached_rendering_data, 1.0, self_rc)
+        if layer_item.layer() {
+            self.render_and_blend_layer(&layer_item.cached_rendering_data, 1.0, self_rc)
+        } else {
+            RenderingResult::ContinueRenderingChildren
+        }
     }
 
     fn visit_clip(&mut self, clip_item: Pin<&Clip>, self_rc: &ItemRc) -> RenderingResult {

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -17,7 +17,8 @@ use i_slint_core::graphics::{
 };
 use i_slint_core::item_rendering::{CachedRenderingData, ItemRenderer};
 use i_slint_core::items::{
-    Clip, FillRule, ImageFit, ImageRendering, InputType, Item, ItemRc, Opacity, RenderingResult,
+    Clip, FillRule, ImageFit, ImageRendering, InputType, Item, ItemRc, Layer, Opacity,
+    RenderingResult,
 };
 use i_slint_core::properties::Property;
 use i_slint_core::window::{Window, WindowRc};
@@ -689,6 +690,10 @@ impl ItemRenderer for GLItemRenderer {
             opacity_item.opacity(),
             self_rc,
         )
+    }
+
+    fn visit_layer(&mut self, layer_item: Pin<&Layer>, self_rc: &ItemRc) -> RenderingResult {
+        self.render_and_blend_layer(&layer_item.cached_rendering_data, 1.0, self_rc)
     }
 
     fn visit_clip(&mut self, clip_item: Pin<&Clip>, self_rc: &ItemRc) -> RenderingResult {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -12,7 +12,7 @@ use i_slint_core::graphics::{
 use i_slint_core::input::{KeyEvent, KeyEventType, MouseEvent};
 use i_slint_core::item_rendering::{CachedRenderingData, ItemRenderer};
 use i_slint_core::items::{
-    self, FillRule, ImageRendering, InputType, ItemRc, ItemRef, MouseCursor, Opacity,
+    self, FillRule, ImageRendering, InputType, ItemRc, ItemRef, Layer, MouseCursor, Opacity,
     PointerEventButton, RenderingResult, TextOverflow, TextWrap,
 };
 use i_slint_core::layout::Orientation;
@@ -782,6 +782,10 @@ impl ItemRenderer for QtItemRenderer<'_> {
             opacity_item.opacity(),
             self_rc,
         )
+    }
+
+    fn visit_layer(&mut self, layer_item: Pin<&Layer>, self_rc: &ItemRc) -> RenderingResult {
+        self.render_and_blend_layer(&layer_item.cached_rendering_data, 1.0, self_rc)
     }
 
     fn combine_clip(&mut self, rect: Rect, radius: f32, mut border_width: f32) {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -785,7 +785,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
     }
 
     fn visit_layer(&mut self, layer_item: Pin<&Layer>, self_rc: &ItemRc) -> RenderingResult {
-        if layer_item.layer() {
+        if layer_item.cache_rendering_hint() {
             self.render_and_blend_layer(&layer_item.cached_rendering_data, 1.0, self_rc)
         } else {
             RenderingResult::ContinueRenderingChildren

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -785,7 +785,11 @@ impl ItemRenderer for QtItemRenderer<'_> {
     }
 
     fn visit_layer(&mut self, layer_item: Pin<&Layer>, self_rc: &ItemRc) -> RenderingResult {
-        self.render_and_blend_layer(&layer_item.cached_rendering_data, 1.0, self_rc)
+        if layer_item.layer() {
+            self.render_and_blend_layer(&layer_item.cached_rendering_data, 1.0, self_rc)
+        } else {
+            RenderingResult::ContinueRenderingChildren
+        }
     }
 
     fn combine_clip(&mut self, rect: Rect, radius: f32, mut border_width: f32) {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -248,7 +248,7 @@ export Layer := _ {
     property <length> y;
     property <length> width;
     property <length> height;
-    property <bool> layer;
+    property <bool> cache-rendering-hint;
     //-default_size_binding:expands_to_parent_geometry
     //-is_internal    
 }

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -243,6 +243,16 @@ export Opacity := _ {
     //-is_internal
 }
 
+export Layer := _ {
+    property <length> x;
+    property <length> y;
+    property <length> width;
+    property <length> height;
+    property <bool> layer;
+    //-default_size_binding:expands_to_parent_geometry
+    //-is_internal    
+}
+
 Row := _ {
     //-is_non_item_type
 }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -130,7 +130,7 @@ pub async fn run_passes(
         );
         lower_property_to_element::lower_property_to_element(
             component,
-            "layer",
+            "cache-rendering-hint",
             "Layer",
             &global_type_registry.borrow(),
             diag,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -24,6 +24,7 @@ mod infer_aliases_types;
 mod inlining;
 mod lower_layout;
 mod lower_popups;
+mod lower_property_to_element;
 mod lower_shadows;
 mod lower_states;
 mod lower_tabwidget;
@@ -35,7 +36,6 @@ mod remove_unused_properties;
 mod repeater_component;
 mod resolve_native_classes;
 mod resolving;
-mod transform_and_opacity;
 mod unique_id;
 mod visible;
 mod z_order;
@@ -121,8 +121,17 @@ pub async fn run_passes(
         lower_layout::lower_layouts(component, type_loader, diag).await;
         default_geometry::default_geometry(component, diag);
         z_order::reorder_by_z_order(component, diag);
-        transform_and_opacity::handle_transform_and_opacity(
+        lower_property_to_element::lower_property_to_element(
             component,
+            "opacity",
+            "Opacity",
+            &global_type_registry.borrow(),
+            diag,
+        );
+        lower_property_to_element::lower_property_to_element(
+            component,
+            "layer",
+            "Layer",
             &global_type_registry.borrow(),
             diag,
         );

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -76,6 +76,7 @@ thread_local! {
 const RESERVED_OTHER_PROPERTIES: &[(&str, Type)] = &[
     ("clip", Type::Bool),
     ("opacity", Type::Float32),
+    ("layer", Type::Bool),
     ("visible", Type::Bool), // ("enabled", Type::Bool),
 ];
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -76,7 +76,7 @@ thread_local! {
 const RESERVED_OTHER_PROPERTIES: &[(&str, Type)] = &[
     ("clip", Type::Bool),
     ("opacity", Type::Float32),
-    ("layer", Type::Bool),
+    ("cache-rendering-hint", Type::Bool),
     ("visible", Type::Bool), // ("enabled", Type::Bool),
 ];
 

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -219,6 +219,10 @@ pub trait ItemRenderer {
         self.apply_opacity(opacity_item.opacity());
         RenderingResult::ContinueRenderingChildren
     }
+    fn visit_layer(&mut self, _layer_item: Pin<&Layer>, _self_rc: &ItemRc) -> RenderingResult {
+        // Not supported
+        RenderingResult::ContinueRenderingChildren
+    }
 
     // Apply the bounds of the Clip element, if enabled. The default implementation calls
     // combine_clip, but the render may choose an alternate way of implementing the clip.

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -858,7 +858,7 @@ pub struct Layer {
     pub y: Property<f32>,
     pub width: Property<f32>,
     pub height: Property<f32>,
-    pub layer: Property<bool>,
+    pub cache_rendering_hint: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
 }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -851,6 +851,77 @@ declare_item_vtable! {
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
+/// The Layer Item is not meant to be used directly by the .slint code, instead, the `layer: xxx` property should be used
+pub struct Layer {
+    // FIXME: this element shouldn't need these geometry property
+    pub x: Property<f32>,
+    pub y: Property<f32>,
+    pub width: Property<f32>,
+    pub height: Property<f32>,
+    pub layer: Property<bool>,
+    pub cached_rendering_data: CachedRenderingData,
+}
+
+impl Item for Layer {
+    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+
+    fn geometry(self: Pin<&Self>) -> Rect {
+        euclid::rect(self.x(), self.y(), self.width(), self.height())
+    }
+
+    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+        LayoutInfo { stretch: 1., ..LayoutInfo::default() }
+    }
+
+    fn input_event_filter_before_children(
+        self: Pin<&Self>,
+        _: MouseEvent,
+        _window: &WindowRc,
+        _self_rc: &ItemRc,
+    ) -> InputEventFilterResult {
+        InputEventFilterResult::ForwardAndIgnore
+    }
+
+    fn input_event(
+        self: Pin<&Self>,
+        _: MouseEvent,
+        _window: &WindowRc,
+        _self_rc: &ItemRc,
+    ) -> InputEventResult {
+        InputEventResult::EventIgnored
+    }
+
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+        KeyEventResult::EventIgnored
+    }
+
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+        FocusEventResult::FocusIgnored
+    }
+
+    fn render(
+        self: Pin<&Self>,
+        backend: &mut ItemRendererRef,
+        self_rc: &ItemRc,
+    ) -> RenderingResult {
+        backend.visit_layer(self, self_rc)
+    }
+}
+
+impl ItemConsts for Layer {
+    const cached_rendering_data_offset: const_field_offset::FieldOffset<
+        Layer,
+        CachedRenderingData,
+    > = Layer::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
+}
+
+declare_item_vtable! {
+    fn slint_get_LayerVTable() -> LayerVTable for Layer
+}
+
+#[repr(C)]
+#[derive(FieldOffsets, Default, SlintElement)]
+#[pin]
 /// The implementation of the `Rotate` element
 pub struct Rotate {
     pub angle: Property<f32>,

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -743,6 +743,7 @@ pub(crate) fn generate_component<'id>(
                 rtti_for::<BoxShadow>(),
                 rtti_for::<Rotate>(),
                 rtti_for::<Opacity>(),
+                rtti_for::<Layer>(),
             ]
             .iter()
             .cloned(),

--- a/tests/cases/layer.slint
+++ b/tests/cases/layer.slint
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// Test case for manual visual verification that layering does not pessimize the
+// output, and to have a compile-time verification that the lowering to the Layer
+// element compiles.
+
+export TestCase := Window {
+    preferred-width: 800px;
+    preferred-height: 600px;
+    background: white;
+
+    Rectangle {        
+        layer: true;
+        width: 200px;
+        height: 100px;
+
+        background: red;
+
+        Text {
+            text: "This rectangle should be red";
+        }
+
+        Rectangle {
+            background: blue;
+            width: 400px;
+            height: 50px;
+            x: 25px;
+            y: 25px;
+
+            Text {
+                text: "This rectangle should be green\nas well as be wider than the red rectangle.";
+                color: green;
+            }
+        }
+    }
+}

--- a/tests/cases/layer.slint
+++ b/tests/cases/layer.slint
@@ -46,6 +46,7 @@ export TestCase := Window {
                 background: red;
                 
                 for i in 1000: Rectangle {
+                    cache-rendering-hint: i == 8;
                     background: blue;
                     drop-shadow-blur: 10px;
                     drop-shadow-offset-x: 5px;

--- a/tests/cases/layer.slint
+++ b/tests/cases/layer.slint
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+import { Button } from "std-widgets.slint";
+
 // Test case for manual visual verification that layering does not pessimize the
 // output, and to have a compile-time verification that the lowering to the Layer
 // element compiles.
@@ -10,28 +12,50 @@ export TestCase := Window {
     preferred-height: 600px;
     background: white;
 
-    Rectangle {        
-        layer: true;
-        width: 200px;
-        height: 100px;
+    VerticalLayout {
 
-        background: red;
-
-        Text {
-            text: "This rectangle should be red";
+        Button {
+            text: "Press me to start the animation and check that it is smooth.";
+            clicked => {
+                layered.place_to_the_right = true;
+            }
         }
 
         Rectangle {
-            background: blue;
-            width: 400px;
-            height: 50px;
-            x: 25px;
-            y: 25px;
 
-            Text {
-                text: "This rectangle should be green\nas well as be wider than the red rectangle.";
-                color: green;
+            // This will be a layer
+            layered := Rectangle {
+                layer: true;
+                width: 200px;
+                height: 100px;
+
+                property <bool> place_to_the_right;
+                states [
+                    right when place_to_the_right: {
+                        x: 200px;
+                    }
+                    left when !place_to_the_right: {
+                        x: 10px;
+                    }
+                ]
+
+                animate x {
+                    duration: 15s;
+                }
+
+                background: red;
+                
+                for i in 1000: Rectangle {
+                    background: blue;
+                    drop-shadow-blur: 10px;
+                    drop-shadow-offset-x: 5px;
+                    drop-shadow-offset-y: 5px;
+                    drop-shadow-color: green;
+                    Text {
+                        text: "Many text items over each other";
+                    }
+                }
             }
         }
-    }
+    }    
 }

--- a/tests/cases/layer.slint
+++ b/tests/cases/layer.slint
@@ -25,7 +25,7 @@ export TestCase := Window {
 
             // This will be a layer
             layered := Rectangle {
-                layer: true;
+                cache-rendering-hint: true;
                 width: 200px;
                 height: 100px;
 


### PR DESCRIPTION
This is the last part of #1058 that adds new API to provide a hint to the renderer to cache an element and its sub-tree.

Open questions:

  - ~~[ ] Should this change set also implement an optimisation to omit the `Layer` element injection if the value of the property is a constant `false`?~~
  - [x] Is `layer` the correct name? Other names that have come up:
    - ~~[ ] `cache: true;`~~
    - ~~[ ] `cache-hint: true;`~~
    - ~~[ ] `rendering-cache-hint: true;`~~
    - [x] `cache-rendering-hint: true;`