### PR TITLE
Fix animations not running in secondary windows with wasm

### DIFF
--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -384,7 +384,6 @@ fn process_window_event(
             }
         }
         WindowEvent::ReceivedCharacter(ch) => {
-            corelib::animations::update_animations();
             // On Windows, X11 and Wayland sequences like Ctrl+C will send a ReceivedCharacter after the pressed keyboard input event,
             // with a control character. We choose not to forward those but try to use the current key code instead.
             //
@@ -420,7 +419,6 @@ fn process_window_event(
             runtime_window.set_focus(have_focus);
         }
         WindowEvent::KeyboardInput { ref input, .. } => {
-            corelib::animations::update_animations();
             window.currently_pressed_key_code().set(match input.state {
                 winit::event::ElementState::Pressed => input.virtual_keycode,
                 _ => None,
@@ -449,7 +447,6 @@ fn process_window_event(
             window.current_keyboard_modifiers().set(modifiers);
         }
         WindowEvent::CursorMoved { position, .. } => {
-            corelib::animations::update_animations();
             let position = position.to_logical(runtime_window.scale_factor() as f64);
             *cursor_pos = euclid::point2(position.x, position.y);
             runtime_window.process_mouse_input(MouseEvent::MouseMoved { pos: *cursor_pos });
@@ -457,13 +454,11 @@ fn process_window_event(
         WindowEvent::CursorLeft { .. } => {
             // On the html canvas, we don't get the mouse move or release event when outside the canvas. So we have no choice but canceling the event
             if cfg!(target_arch = "wasm32") || !*pressed {
-                corelib::animations::update_animations();
                 *pressed = false;
                 runtime_window.process_mouse_input(MouseEvent::MouseExit);
             }
         }
         WindowEvent::MouseWheel { delta, .. } => {
-            corelib::animations::update_animations();
             let delta = match delta {
                 winit::event::MouseScrollDelta::LineDelta(lx, ly) => {
                     euclid::point2(lx * 60., ly * 60.)
@@ -476,7 +471,6 @@ fn process_window_event(
             runtime_window.process_mouse_input(MouseEvent::MouseWheel { pos: *cursor_pos, delta });
         }
         WindowEvent::MouseInput { state, button, .. } => {
-            corelib::animations::update_animations();
             let button = match button {
                 winit::event::MouseButton::Left => PointerEventButton::left,
                 winit::event::MouseButton::Right => PointerEventButton::right,
@@ -496,7 +490,6 @@ fn process_window_event(
             runtime_window.process_mouse_input(ev);
         }
         WindowEvent::Touch(touch) => {
-            corelib::animations::update_animations();
             let location = touch.location.to_logical(runtime_window.scale_factor() as f64);
             let pos = euclid::point2(location.x, location.y);
             let ev = match touch.phase {
@@ -573,7 +566,6 @@ pub fn run(quit_behavior: i_slint_core::backend::EventLoopQuitBehavior) {
                 }
 
                 winit::event::Event::RedrawRequested(id) => {
-                    corelib::animations::update_animations();
                     if let Some(window) = window_by_id(id) {
                         window.draw();
                     }
@@ -596,6 +588,10 @@ pub fn run(quit_behavior: i_slint_core::backend::EventLoopQuitBehavior) {
                 #[cfg(target_arch = "wasm32")]
                 winit::event::Event::UserEvent(CustomEvent::RedrawAllWindows) => {
                     redraw_all_windows()
+                }
+
+                winit::event::Event::MainEventsCleared => {
+                    corelib::animations::update_animations();
                 }
                 _ => (),
             }


### PR DESCRIPTION
When a second canvas is visible, only animations in the first canvas
resulted in updates and visible animation.  An animation in the second
canvas wouldn't result in repaints.

When we start an animation, we request a redraw on all windows and
return with `ControlFlow::Poll` to winit.

Winit then schedules an animation frame request, and in the callback the
redraw request events are delivered. For the first window we call
`update_animations()`, a new tick is detected (different than the
previous one) and animated properties are dirty and yield new windows.

Then right away we get called again with a redraw request for the second
window. update_animations() determines that the instant::now() is the
same, and has_animations() returns false. So at the end of the event
handler we return fail to return `Poll` and therefore no animation frame
request is created, which means the animations just stop.

Fix this by calling update_animations() only once, at the beginning of
the event delivery cycle.

This is visible in the preview canvases in the documentation, if a
canvas other than the first has animations.