### PR TITLE
Add up and down cursor movement to TextInput

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -275,6 +275,8 @@ pub struct TextInput {
     pub pressed: core::cell::Cell<bool>,
     pub single_line: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
+    // The x position where the cursor wants to be.
+    // It is not updated when moving up and down even when the line is shorter.
     preferred_x_pos: core::cell::Cell<f32>,
 }
 


### PR DESCRIPTION
This adds up and down cursor movement to TextInput.
It uses `PlatformWindow`'s `text_input_position_for_byte_offset()` and `text_input_byte_offset_for_position()` functions.

Because of a bug in `text_input_byte_offset_for_position()` it returns to the top when pressing down on last line.
