### PR TITLE
Don't create layers for opacity if it's not needed

### DIFF
--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -691,6 +691,9 @@ impl ItemRenderer for GLItemRenderer {
         if opacity != 1.0 {
             self.render_and_blend_layer(&opacity_item.cached_rendering_data, opacity, self_rc)
         } else {
+            opacity_item
+                .cached_rendering_data
+                .release(&mut self.graphics_window.clone().graphics_cache.borrow_mut());
             RenderingResult::ContinueRenderingChildren
         }
     }

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -687,11 +687,12 @@ impl ItemRenderer for GLItemRenderer {
     }
 
     fn visit_opacity(&mut self, opacity_item: Pin<&Opacity>, self_rc: &ItemRc) -> RenderingResult {
-        self.render_and_blend_layer(
-            &opacity_item.cached_rendering_data,
-            opacity_item.opacity(),
-            self_rc,
-        )
+        let opacity = opacity_item.opacity();
+        if opacity != 1.0 {
+            self.render_and_blend_layer(&opacity_item.cached_rendering_data, opacity, self_rc)
+        } else {
+            RenderingResult::ContinueRenderingChildren
+        }
     }
 
     fn visit_layer(&mut self, layer_item: Pin<&Layer>, self_rc: &ItemRc) -> RenderingResult {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -777,11 +777,12 @@ impl ItemRenderer for QtItemRenderer<'_> {
     }
 
     fn visit_opacity(&mut self, opacity_item: Pin<&Opacity>, self_rc: &ItemRc) -> RenderingResult {
-        self.render_and_blend_layer(
-            &opacity_item.cached_rendering_data,
-            opacity_item.opacity(),
-            self_rc,
-        )
+        let opacity = opacity_item.opacity();
+        if opacity != 1.0 {
+            self.render_and_blend_layer(&opacity_item.cached_rendering_data, opacity, self_rc)
+        } else {
+            RenderingResult::ContinueRenderingChildren
+        }
     }
 
     fn visit_layer(&mut self, layer_item: Pin<&Layer>, self_rc: &ItemRc) -> RenderingResult {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -781,6 +781,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
         if opacity != 1.0 {
             self.render_and_blend_layer(&opacity_item.cached_rendering_data, opacity, self_rc)
         } else {
+            opacity_item.cached_rendering_data.release(&mut self.cache.borrow_mut());
             RenderingResult::ContinueRenderingChildren
         }
     }


### PR DESCRIPTION
More could be done towards this, but after literally seeing `opacity: 1;` in
.slint files, this seems worth doing.