### PR TITLE
MCU build system: pass information about embedding images and glyph to the compiler

### DIFF
--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -55,6 +55,7 @@ use std::io::Write;
 use std::path::Path;
 
 use i_slint_compiler::diagnostics::BuildDiagnostics;
+use i_slint_compiler::EmbedResourcesKind;
 
 /// The structure for configuring aspects of the compilation of `.slint` markup files to Rust.
 pub struct CompilerConfiguration {
@@ -199,9 +200,11 @@ pub fn compile_with_config(
 
     let mut compiler_config = config.config;
 
-    if let (Ok(target), Ok(host)) = (env::var("TARGET"), env::var("HOST")) {
+    if env::var_os("DEP_I_SLINT_BACKEND_MCU_EMBED_TEXTURES").is_some() {
+        compiler_config.embed_resources = EmbedResourcesKind::EmbedTextures;
+    } else if let (Ok(target), Ok(host)) = (env::var("TARGET"), env::var("HOST")) {
         if target != host {
-            compiler_config.embed_resources = true;
+            compiler_config.embed_resources = EmbedResourcesKind::EmbedAllResources;
         }
     };
     let mut rerun_if_changed = String::new();
@@ -269,9 +272,7 @@ pub fn compile_with_config(
     }
     println!("cargo:rerun-if-env-changed=SLINT_STYLE");
     println!("cargo:rerun-if-env-changed=SIXTYFPS_STYLE");
-    println!("cargo:rerun-if-env-changed=SLINT_EMBED_GLYPHS");
     println!("cargo:rerun-if-env-changed=SLINT_FONT_SIZES");
-    println!("cargo:rerun-if-env-changed=SLINT_PROCESS_IMAGES");
     println!("cargo:rerun-if-env-changed=SLINT_SCALE_FACTOR");
 
     println!("cargo:rustc-env=SLINT_INCLUDE_GENERATED={}", output_file_path.display());

--- a/internal/backends/mcu/README.md
+++ b/internal/backends/mcu/README.md
@@ -33,7 +33,7 @@ fn main() -> ! {
 }
 ```
 
-Since i_slint_backend_mcu is at the moment an internal crate not uploaded to crates.io, you must 
+Since i_slint_backend_mcu is at the moment an internal crate not uploaded to crates.io, you must
 use the git version of slint, slint-build, and i_slint_backend_mcu
 
 ```toml
@@ -47,18 +47,14 @@ slint-build = { git = "https://github.com/slint-ui/slint" }
 
 ## Run the demo:
 
-Some environment variable must be set when building so the Slint compiler knows to embedd the images and font into the binary
-
+We must tell the compiler what font sizes to embed in the final binary with the SLINT_FONT_SIZES environment variable.
 
 ```sh
-export SLINT_EMBED_GLYPHS=1 
 export SLINT_FONT_SIZES=8,11,10,12,13,14,15,16,18,20,22,24,32
-export SLINT_PROCESS_IMAGES=1
 ```
 
 ### The simulator
 
-(Assume env variables are set)
 
 ```sh
 cargo run -p printerdemo_mcu --features=i-slint-backend-mcu/simulator --release
@@ -68,7 +64,7 @@ cargo run -p printerdemo_mcu --features=i-slint-backend-mcu/simulator --release
 
 You need nightly rust because that's the only way to get an allocator.
 
-First set the environment variable above and build the demo with:
+Build the demo with:
 
 ```sh
 cargo +nightly build -p printerdemo_mcu --features=mcu-pico-st7789 --target=thumbv6m-none-eabi --release
@@ -81,13 +77,13 @@ cargo install elf2uf2-rs
 elf2uf2-rs target/thumbv6m-none-eabi/release/printerdemo_mcu
 ```
 
-Then upload the demo to the raspberry pi: push the "bootsel" white button on the device while connecting the 
+Then upload the demo to the raspberry pi: push the "bootsel" white button on the device while connecting the
 micro-usb cable to the device, this connect some storage where you can store the binary.
 
 Or from the command on linux: (connect the device while pressing the "bootsel" button.
 
 ```
-# mount the device 
+# mount the device
 udisksctl mount -b /dev/sda1
 # upload
 elf2uf2-rs -d target/thumbv6m-none-eabi/release/printerdemo_mcu
@@ -95,10 +91,10 @@ elf2uf2-rs -d target/thumbv6m-none-eabi/release/printerdemo_mcu
 
 #### Using probe-run
 
-This require [probe-run](https://github.com/knurling-rs/probe-run) (`cargo install probe-run`) 
+This require [probe-run](https://github.com/knurling-rs/probe-run) (`cargo install probe-run`)
 and to connect the pico via a probe (for example another pico running the probe)
 
-Then you can simply run with `cargo run` 
+Then you can simply run with `cargo run`
 
 ```sh
 CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER="flip-link" CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-run --chip RP2040" cargo +nightly run -p printerdemo_mcu --features=mcu-pico-st7789 --target=thumbv6m-none-eabi --release

--- a/internal/backends/mcu/build.rs
+++ b/internal/backends/mcu/build.rs
@@ -15,8 +15,7 @@ fn main() -> std::io::Result<()> {
         println!("cargo:BOARD_CONFIG_PATH={}", path.display())
     }
 
-    println!("cargo:PROCESS_IMAGES=1");
-    println!("cargo:EMBED_GLYPHS=1");
+    println!("cargo:EMBED_TEXTURES=1");
 
     Ok(())
 }

--- a/internal/backends/mcu/build.rs
+++ b/internal/backends/mcu/build.rs
@@ -15,5 +15,8 @@ fn main() -> std::io::Result<()> {
         println!("cargo:BOARD_CONFIG_PATH={}", path.display())
     }
 
+    println!("cargo:PROCESS_IMAGES=1");
+    println!("cargo:EMBED_GLYPHS=1");
+
     Ok(())
 }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -181,19 +181,19 @@ pub async fn run_passes(
     // collect globals once more: After optimizations we might have less globals
     collect_globals::collect_globals(doc, diag);
 
-    let embedded_fonts = embed_glyphs::embed_glyphs(
-        root_component,
-        compiler_config.scale_factor,
-        std::iter::once(&*doc).chain(type_loader.all_documents()),
-        diag,
-    );
-
-    // Create font registration calls for custom fonts, unless we're embedding pre-rendered glyphs
-    if !embedded_fonts {
+    if compiler_config.embed_resources == crate::EmbedResourcesKind::EmbedTextures {
+        embed_glyphs::embed_glyphs(
+            root_component,
+            compiler_config.scale_factor,
+            std::iter::once(&*doc).chain(type_loader.all_documents()),
+            diag,
+        );
+    } else {
+        // Create font registration calls for custom fonts, unless we're embedding pre-rendered glyphs
         collect_custom_fonts::collect_custom_fonts(
             root_component,
             std::iter::once(&*doc).chain(type_loader.all_documents()),
-            compiler_config.embed_resources,
+            compiler_config.embed_resources == crate::EmbedResourcesKind::EmbedAllResources,
         );
     }
 

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -25,13 +25,7 @@ pub fn embed_glyphs<'a>(
     scale_factor: f64,
     all_docs: impl Iterator<Item = &'a crate::object_tree::Document> + 'a,
     diag: &mut BuildDiagnostics,
-) -> bool {
-    if std::env::var("SLINT_EMBED_GLYPHS").is_err()
-        && std::env::var("DEP_I_SLINT_BACKEND_MCU_EMBED_GLYPHS").is_err()
-    {
-        return false;
-    }
-
+) {
     let mut fontdb = fontdb::Database::new();
     fontdb.load_system_fonts();
 
@@ -136,8 +130,6 @@ pub fn embed_glyphs<'a>(
         arguments: vec![Expression::NumberLiteral(resource_id as _, Unit::None)],
         source_location: None,
     });
-
-    true
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -26,7 +26,9 @@ pub fn embed_glyphs<'a>(
     all_docs: impl Iterator<Item = &'a crate::object_tree::Document> + 'a,
     diag: &mut BuildDiagnostics,
 ) -> bool {
-    if std::env::var("SLINT_EMBED_GLYPHS").is_err() {
+    if std::env::var("SLINT_EMBED_GLYPHS").is_err()
+        && std::env::var("DEP_I_SLINT_BACKEND_MCU_EMBED_GLYPHS").is_err()
+    {
         return false;
     }
 
@@ -149,7 +151,7 @@ fn embed_font(family_name: String, font: fontdue::Font, scale_factor: f64) -> Bi
                 })
                 .collect::<Vec<_>>()
         })
-        .expect("please specify SLINT_FONT_SIZES");
+        .expect("please specify SLINT_FONT_SIZES environment variable");
     pixel_sizes.sort();
 
     // TODO: configure coverage

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -88,7 +88,9 @@ fn embed_image(
             if let Some(file) = crate::fileaccess::load_file(std::path::Path::new(path)) {
                 let mut kind = EmbeddedResourcesKind::RawData;
                 #[cfg(not(target_arch = "wasm32"))]
-                if std::env::var("SLINT_PROCESS_IMAGES").is_ok() {
+                if std::env::var("SLINT_PROCESS_IMAGES").is_ok()
+                    || std::env::var("DEP_I_SLINT_BACKEND_MCU_PROCESS_IMAGES").is_ok()
+                {
                     match load_image(file, _scale_factor) {
                         Ok((img, original_size)) => {
                             kind = EmbeddedResourcesKind::TextureData(generate_texture(


### PR DESCRIPTION
... using metadata from the build script

Saves two environment variable that we don't have to pass