### PR TITLE
Fix the frame per second counter when using refresh_full_speed

### DIFF
--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -69,7 +69,7 @@ impl GLWindow {
             currently_pressed_key_code: Default::default(),
             graphics_cache: Default::default(),
             texture_cache: Default::default(),
-            fps_counter: FPSCounter::new(),
+            fps_counter: FPSCounter::new(window_weak.clone()),
             rendering_notifier: Default::default(),
             #[cfg(target_arch = "wasm32")]
             canvas_id,

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1241,7 +1241,7 @@ impl QtWindow {
         let rc = Rc::new(QtWindow {
             widget_ptr,
             self_weak: window_weak.clone(),
-            fps_counter: FPSCounter::new(),
+            fps_counter: FPSCounter::new(window_weak.clone()),
             cache: Default::default(),
         });
         let self_weak = Rc::downgrade(&rc);


### PR DESCRIPTION
After commit 575665994aa348abec097178f3cc0b57333c110e we need to explictly schedule a repaint,
so that we draw and call `measure_frame_rendered`.