### PR TITLE
Pr/subtree1

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -42,10 +42,12 @@ namespace slint {
 namespace private_api {
 using cbindgen_private::ComponentVTable;
 using cbindgen_private::ItemVTable;
+using ComponentRc = vtable::VRc<private_api::ComponentVTable>;
 using ComponentRef = vtable::VRef<private_api::ComponentVTable>;
+using IndexRange = cbindgen_private::IndexRange;
 using ItemRef = vtable::VRef<private_api::ItemVTable>;
 using ItemVisitorRefMut = vtable::VRefMut<cbindgen_private::ItemVisitorVTable>;
-using cbindgen_private::ComponentRc;
+using cbindgen_private::ComponentWeak;
 using cbindgen_private::ItemWeak;
 using cbindgen_private::TraversalOrder;
 }
@@ -844,6 +846,16 @@ public:
     {
         const auto &x = inner->data.at(i);
         return { &C::static_vtable, const_cast<C *>(&(**x.ptr)) };
+    }
+
+    void component_at(int i, vtable::VWeak<private_api::ComponentVTable> *result) const
+    {
+        const auto &x = inner->data.at(i);
+        *result = vtable::VWeak<private_api::ComponentVTable>{x.ptr->into_dyn()};
+    }
+
+    private_api::IndexRange index_range() const {
+        return private_api::IndexRange { 0, inner->data.size() };
     }
 
     float compute_layout_listview(const private_api::Property<float> *viewport_width,

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -848,10 +848,10 @@ public:
         return { &C::static_vtable, const_cast<C *>(&(**x.ptr)) };
     }
 
-    void component_at(int i, vtable::VWeak<private_api::ComponentVTable> *result) const
+    vtable::VWeak<private_api::ComponentVTable> component_at(int i) const
     {
         const auto &x = inner->data.at(i);
-        *result = vtable::VWeak<private_api::ComponentVTable>{x.ptr->into_dyn()};
+        return vtable::VWeak<private_api::ComponentVTable>{x.ptr->into_dyn()};
     }
 
     private_api::IndexRange index_range() const {

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore buildrs
+
 /*!
 # Slint
 
@@ -283,7 +285,7 @@ pub mod re_exports {
     pub use i_slint_core::callbacks::Callback;
     pub use i_slint_core::component::{
         free_component_item_graphics_resources, init_component_items, Component, ComponentRefPin,
-        ComponentVTable,
+        ComponentVTable, ComponentWeak, IndexRange,
     };
     pub use i_slint_core::graphics::*;
     pub use i_slint_core::input::{

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1395,7 +1395,7 @@ fn generate_sub_component(
         subtrees_components_cases.push(format!(
             "\n        case {i}: {{
                 {e_u}
-                self->{id}.component_at(subtree_index, result);
+                *result = self->{id}.component_at(subtree_index);
                 return;
             }}",
             i = idx,

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -82,6 +82,9 @@ pub struct ComponentVTable {
     pub dealloc: unsafe fn(&ComponentVTable, ptr: *mut u8, layout: vtable::Layout),
 }
 
+#[cfg(test)]
+pub(crate) use ComponentVTable_static;
+
 /// Alias for `vtable::VRef<ComponentVTable>` which represent a pointer to a `dyn Component` with
 /// the associated vtable
 pub type ComponentRef<'a> = vtable::VRef<'a, ComponentVTable>;

--- a/internal/core/item_focus.rs
+++ b/internal/core/item_focus.rs
@@ -1,0 +1,53 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// cSpell: ignore dealloc nesw
+
+/*!
+This module contains the code moving the keyboard focus between items
+*/
+
+use crate::item_tree::ComponentItemTree;
+
+pub fn default_next_in_local_focus_chain(
+    index: usize,
+    item_tree: &crate::item_tree::ComponentItemTree,
+) -> Option<usize> {
+    if let Some(child) = item_tree.first_child(index) {
+        return Some(child);
+    }
+
+    let mut self_or_ancestor = index;
+    loop {
+        if let Some(sibling) = item_tree.next_sibling(self_or_ancestor) {
+            return Some(sibling);
+        }
+        if let Some(ancestor) = item_tree.parent(self_or_ancestor) {
+            self_or_ancestor = ancestor;
+        } else {
+            return None;
+        }
+    }
+}
+
+pub fn default_previous_in_local_focus_chain(
+    index: usize,
+    item_tree: &crate::item_tree::ComponentItemTree,
+) -> Option<usize> {
+    fn rightmost_node(item_tree: &ComponentItemTree, index: usize) -> usize {
+        let mut node = index;
+        loop {
+            if let Some(last_child) = item_tree.last_child(node) {
+                node = last_child;
+            } else {
+                return node;
+            }
+        }
+    }
+
+    if let Some(previous) = item_tree.previous_sibling(index) {
+        Some(rightmost_node(item_tree, previous))
+    } else {
+        item_tree.parent(index)
+    }
+}

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -112,8 +112,8 @@ pub struct ComponentItemTree<'a> {
 
 impl<'a> ComponentItemTree<'a> {
     /// Create a new `ItemTree` from its raw data.
-    pub fn new(item_tree: &'a [ItemTreeNode]) -> Self {
-        Self { item_tree }
+    pub fn new(comp_ref_pin: &'a Pin<VRef<'a, ComponentVTable>>) -> Self {
+        Self { item_tree: comp_ref_pin.as_ref().get_item_tree().as_slice() }
     }
 
     /// Get a ItemTreeNode

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -281,6 +281,23 @@ impl ItemRc {
         r
     }
 
+    // FIXME: This should be nicer/done elsewhere?
+    pub fn is_visible(&self) -> bool {
+        let item = self.borrow();
+        let is_clipping = crate::item_rendering::is_enabled_clipping_item(item);
+        let geometry = item.as_ref().geometry();
+
+        if is_clipping && (geometry.width() == 0.0 || geometry.height() == 0.0) {
+            return false;
+        }
+
+        if let Some(parent) = self.parent_item().upgrade() {
+            parent.is_visible()
+        } else {
+            true
+        }
+    }
+
     /// Return the index of the item within the component
     pub fn index(&self) -> usize {
         self.index

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore sharedvector textlayout
+
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint-ui.com/logo/slint-logo-square-light.svg")]
 #![deny(unsafe_code)]
@@ -68,6 +70,7 @@ pub mod component;
 pub(crate) mod flickable;
 pub mod graphics;
 pub mod input;
+pub mod item_focus;
 pub mod item_rendering;
 pub mod item_tree;
 pub mod items;

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -355,7 +355,7 @@ impl Window {
     /// Sets the focus to the item pointed to by item_ptr. This will remove the focus from any
     /// currently focused item.
     pub fn set_focus_item(self: Rc<Self>, focus_item: &ItemRc) {
-        self.clone().take_focus_item();
+        self.take_focus_item();
         self.move_focus(focus_item.clone(), next_focus_item);
     }
 
@@ -376,7 +376,7 @@ impl Window {
     /// Take the focus_item out of this Window
     ///
     /// This sends the FocusOut event!
-    fn take_focus_item(self: Rc<Self>) -> Option<ItemRc> {
+    fn take_focus_item(self: &Rc<Self>) -> Option<ItemRc> {
         let focus_item = self.as_ref().focus_item.take();
 
         if let Some(focus_item_rc) = focus_item.upgrade() {
@@ -427,7 +427,6 @@ impl Window {
     pub fn focus_next_item(self: Rc<Self>) {
         let component = self.component();
         let start_item = self
-            .clone()
             .take_focus_item()
             .map(next_focus_item)
             .unwrap_or_else(|| ItemRc::new(component, 0));
@@ -438,7 +437,7 @@ impl Window {
     pub fn focus_previous_item(self: Rc<Self>) {
         let component = self.component();
         let start_item = previous_focus_item(
-            self.clone().take_focus_item().unwrap_or_else(|| ItemRc::new(component, 0)),
+            self.take_focus_item().unwrap_or_else(|| ItemRc::new(component, 0)),
         );
         self.move_focus(start_item, previous_focus_item);
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -405,7 +405,7 @@ impl Window {
 
     fn move_focus(self: Rc<Self>, start_item: ItemRc, forward: impl Fn(ItemRc) -> ItemRc) {
         let mut current_item = start_item;
-        let mut visited = vec![];
+        let mut visited = alloc::vec::Vec::new();
 
         loop {
             if current_item.is_visible()

--- a/tests/manual/keyboard_focus.slint
+++ b/tests/manual/keyboard_focus.slint
@@ -1,0 +1,102 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// cSpell: ignore ogoffart tronical
+
+import { Button, SpinBox, LineEdit, HorizontalBox, VerticalBox, TabWidget } from "std-widgets.slint";
+
+App := Window {
+    preferred-width: 500px;
+    preferred-height: 400px;
+    title: "Keyboard Focus Test";
+    icon: @image-url("../../../logo/slint-logo-small-light-128x128.png");
+
+    property<[{name: string, account: string, score: float}]> model: [
+        {
+            name: "Olivier",
+            account: "ogoffart",
+            score: 456,
+        },
+        {
+            name: "Simon",
+            account: "tronical",
+            score: 789,
+        }
+    ];
+
+    VerticalBox {
+        HorizontalBox {
+            VerticalLayout {
+                alignment: start;
+                SpinBox {
+                    value: 42;
+                }
+            }
+        }
+
+        TabWidget {
+            Tab {
+                title: "Dynamic";
+
+                VerticalBox {
+                    SpinBox {
+                        value: 58;
+                    }
+                    for person[i] in model: HorizontalBox {
+                        property<int> index;
+
+                        SpinBox {
+                            value: person.score;
+                        }
+                        Button {
+                            text: "Test " + index;
+                        }
+                        SpinBox {
+                            value: i;
+                        }
+                    }
+                    SpinBox {
+                        value: 59;
+                    }
+                }
+            }
+            Tab {
+                title: "Static";
+                VerticalBox {
+                    HorizontalBox {
+                        alignment: start;
+                        VerticalBox {
+                            alignment: start;
+                            SpinBox {
+                                value: 10;
+                            }
+                            SpinBox {
+                                value: 11;
+                            }
+                            SpinBox {
+                                value: 12;
+                            }
+                        }
+
+
+                        VerticalBox {
+                        alignment: start;
+                            SpinBox {
+                                value: 20;
+                            }
+                            SpinBox {
+                                value: 21;
+                            }
+                            SpinBox {
+                                value: 22;
+                            }
+                        }
+                    }
+                    LineEdit {
+                        placeholder-text: "Enter some text";
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
There are some things to clean up still -- but I'd like to do those later:

* I would like to use "subtree" for the DynamicNode in the ItemTree more consistently.
* I am not particularly happy with `Component::subtree_index()`. Maybe rename that to `Component::index_property()` or something?
* I would like to remove the visitor from the ComponentVTable and replace that with rust code walking the logical ItemTree
* We need to add a function to the Component to overrride the default focus chain. I left that out for now as we do not support that on the slint side. The focus code looks at the Component ItemTree only, so it is easy to add extra information to override the Component-wide focus chain once we have that.
* I'd like to change the Component's parent_item function to "parent_subtree" or something and make that return the Component/Node-index of the place where this Component is in the parent Component only. The parent_item is readily available from the ItemTree and does not need to be handled by generated code at all.

The `focus_event_propagation_2" test currently fails for me. Looking into that right now.