### PR TITLE
current state of `text_input_cursor_rect_for_byte_offset`

### DIFF
--- a/internal/backends/gl/fonts.rs
+++ b/internal/backends/gl/fonts.rs
@@ -114,6 +114,16 @@ impl Font {
         }
         euclid::size2(width, lines as f32 * font_metrics.height())
     }
+
+    pub fn height(&self) -> f32 {
+        let paint = self.init_paint(
+            // letter spacing doesn't affect height
+            0.,
+            femtovg::Paint::default(),
+        );
+        let font_metrics = self.text_context.measure_font(paint).unwrap();
+        font_metrics.height()
+    }
 }
 
 pub(crate) fn text_size(

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1615,11 +1615,11 @@ impl PlatformWindow for QtWindow {
         }}
     }
 
-    fn text_input_position_for_byte_offset(
+    fn text_input_cursor_rect_for_byte_offset(
         &self,
         text_input: Pin<&i_slint_core::items::TextInput>,
         byte_offset: usize,
-    ) -> Point {
+    ) -> Rect {
         let rect: qttypes::QRectF = get_geometry!(items::TextInput, text_input);
         let font: QFont =
             get_font(text_input.unresolved_font_request().merge(&self.default_font_properties()));
@@ -1652,7 +1652,17 @@ impl PlatformWindow for QtWindow {
                 return QPointF();
             return QPointF(textLine.x() + textLine.cursorToX(offset), textLine.y());
         }};
-        Point::new(r.x as _, r.y as _)
+        Rect::new(
+            Point::new(r.x as _, r.y as _),
+            Size::new(
+                1.0,
+                text_input
+                    .unresolved_font_request()
+                    .merge(&self.default_font_properties())
+                    .pixel_size
+                    .unwrap(),
+            ),
+        )
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -192,6 +192,7 @@ export struct Point := {
 }
 
 export TextInput := _ {
+    callback set-debug-rect(length,length,length,length);
     property <string> text: native_output;
     property <string> font-family;
     property <length> font-size;

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -62,6 +62,16 @@ export TextEdit := ScrollView {
     }
 
     input := TextInput {
+        debug_rect := Rectangle {
+            border-width: 1px;
+            border-color: red;
+        }
+        set-debug-rect(x,y,w,h) => {
+            debug-rect.x = x;
+            debug-rect.y = y;
+            debug-rect.width = w;
+            debug-rect.height = h;
+        }
         edited => { root.edited(self.text); }
         color: enabled ? StyleMetrics.textedit-text-color : StyleMetrics.textedit-text-color-disabled;
         single-line: false;

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -247,6 +247,7 @@ impl Text {
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
 pub struct TextInput {
+    pub set_debug_rect: Callback<(f32, f32, f32, f32)>,
     pub text: Property<SharedString>,
     pub font_family: Property<SharedString>,
     pub font_size: Property<f32>,
@@ -557,7 +558,8 @@ impl TextInput {
         let mut grapheme_cursor =
             unicode_segmentation::GraphemeCursor::new(last_cursor_pos, text.len(), true);
 
-        let font_height = window.text_size(self.unresolved_font_request(), "", None).height;
+        let font_height = window.text_size(self.unresolved_font_request(), " ", None).height
+            / window.scale_factor();
 
         let mut reset_preferred_x_pos = true;
 
@@ -571,18 +573,36 @@ impl TextInput {
             TextCursorDirection::NextLine => {
                 reset_preferred_x_pos = false;
 
-                let mut cursor_xy_pos =
-                    window.text_input_position_for_byte_offset(self, last_cursor_pos);
-                cursor_xy_pos.y += font_height * 1.5;
+                let cursor_rect =
+                    window.text_input_cursor_rect_for_byte_offset(self, last_cursor_pos);
+                let mut cursor_xy_pos = cursor_rect.center();
+
+                Self::FIELD_OFFSETS.set_debug_rect.apply_pin(self).call(&(
+                    cursor_rect.origin.x,
+                    cursor_rect.origin.y,
+                    cursor_rect.size.width,
+                    cursor_rect.size.height,
+                ));
+
+                cursor_xy_pos.y += font_height;
                 cursor_xy_pos.x = self.preferred_x_pos.get();
                 window.text_input_byte_offset_for_position(self, cursor_xy_pos)
             }
             TextCursorDirection::PreviousLine => {
                 reset_preferred_x_pos = false;
 
-                let mut cursor_xy_pos =
-                    window.text_input_position_for_byte_offset(self, last_cursor_pos);
-                cursor_xy_pos.y -= font_height * 0.5;
+                let cursor_rect =
+                    window.text_input_cursor_rect_for_byte_offset(self, last_cursor_pos);
+                let mut cursor_xy_pos = cursor_rect.center();
+
+                Self::FIELD_OFFSETS.set_debug_rect.apply_pin(self).call(&(
+                    cursor_rect.origin.x,
+                    cursor_rect.origin.y,
+                    cursor_rect.size.width,
+                    cursor_rect.size.height,
+                ));
+
+                cursor_xy_pos.y -= font_height;
                 cursor_xy_pos.x = self.preferred_x_pos.get();
                 window.text_input_byte_offset_for_position(self, cursor_xy_pos)
             }
@@ -612,7 +632,7 @@ impl TextInput {
 
         if reset_preferred_x_pos {
             self.preferred_x_pos
-                .set(window.text_input_position_for_byte_offset(self, new_cursor_pos).x);
+                .set(window.text_input_cursor_rect_for_byte_offset(self, new_cursor_pos).origin.x);
         }
 
         // Keep the cursor visible when moving. Blinking should only occur when
@@ -625,7 +645,8 @@ impl TextInput {
     fn set_cursor_position(self: Pin<&Self>, new_position: i32, window: &WindowRc) {
         self.cursor_position.set(new_position);
         if new_position >= 0 {
-            let pos = window.text_input_position_for_byte_offset(self, new_position as usize);
+            let pos =
+                window.text_input_cursor_rect_for_byte_offset(self, new_position as usize).origin;
             Self::FIELD_OFFSETS.cursor_position_changed.apply_pin(self).call(&(pos,));
         }
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -6,7 +6,7 @@
 
 use crate::api::CloseRequestResponse;
 use crate::component::{ComponentRc, ComponentWeak};
-use crate::graphics::{Point, Size};
+use crate::graphics::{Point, Rect, Size};
 use crate::input::{KeyEvent, MouseEvent, MouseInputState, TextCursorBlinker};
 use crate::items::{ItemRc, ItemRef, ItemWeak, MouseCursor};
 use crate::properties::{Property, PropertyTracker};
@@ -81,11 +81,11 @@ pub trait PlatformWindow {
 
     /// That's the opposite of [`Self::text_input_byte_offset_for_position`]
     /// It takes a (UTF-8) byte offset in the text property, and returns its position
-    fn text_input_position_for_byte_offset(
+    fn text_input_cursor_rect_for_byte_offset(
         &self,
         text_input: Pin<&crate::items::TextInput>,
         byte_offset: usize,
-    ) -> Point;
+    ) -> Rect;
 
     /// This is called when the virtual keyboard should be shown because a widget that
     /// uses input has the focus.


### PR DESCRIPTION
here's the current state of the `text_input_cursor_rect_for_byte_offset` thing.
with the gl version there are still some problems with high res. Probably forgot something with scale_factor somewhere.
the qt version does not work, because
````rust
text_input
.unresolved_font_request()
.merge(&self.default_font_properties())
.pixel_size
.unwrap()`
```
evaluates to None somewhere and panics.