### PR TITLE
Just for quick feedback for keyboard modifier handling

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -410,7 +410,7 @@ impl Item for TextInput {
                 {
                     return KeyEventResult::EventIgnored;
                 }
-                if event.modifiers.control {
+                if event.modifiers.has_semantic(SemanticModifier::StandardShortcut) {
                     if event.text == "a" {
                         self.select_all(window);
                         return KeyEventResult::EventAccepted;
@@ -510,6 +510,30 @@ impl core::convert::TryFrom<char> for TextCursorDirection {
             key_codes::End => Self::EndOfLine,
             _ => return Err(()),
         })
+    }
+}
+
+enum SemanticModifier {
+    StandardShortcut,
+    MoveByWord,
+}
+
+impl KeyboardModifiers {
+    fn has_semantic(&self, sem: SemanticModifier) -> bool {
+        match sem {
+            // if we stop doing the cmd to ctrl mapping we can change this to meta on macos
+            SemanticModifier::StandardShortcut => self.control,
+            SemanticModifier::MoveByWord => {
+                #[cfg(target_os = "macos")]
+                {
+                    self.alt
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    self.control
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This is not final at all the `move_cursor_by_word()` is more or less a copy with duplication of `move_cursor` etc.
I just need some quick feedback about the `SemanticModifier` part.
@tronical: you didn't like that when I wanted to add it to `KeyboardModifiers`.

But I think some sort of abstraction like that is good. Actually there already exists the `AnchorMode`, which serves a similar purpose, but it needs a struct and a From implementation for every semantic/mode.

If you are ok with my approach, I would also replace the `AnchorMode` with the `SemanticModifier`, by adding a `KeepAnchor` to it.

Of course if you have an idea for a better abstraction, I wanna hear about it.