### PR TITLE
Add TextShortcut and Shortcut and use them in TextInput

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -173,7 +173,7 @@ pub struct KeyEvent {
 }
 
 impl KeyEvent {
-    /// If a shortcut was pressed, this function returns `Some(Shortcut)`.
+    /// If a shortcut was pressed, this function returns `Some(StandardShortcut)`.
     /// Otherwise it returns None.
     pub fn shortcut(&self) -> Option<StandardShortcut> {
         if self.modifiers.control && !self.modifiers.shift {
@@ -186,14 +186,14 @@ impl KeyEvent {
                 "s" => Some(StandardShortcut::Save),
                 "p" => Some(StandardShortcut::Print),
                 "z" => Some(StandardShortcut::Undo),
-                #[cfg(not(target_os = "macos"))]
-                "y" => Some(Shortcut::Redo),
+                #[cfg(target_os = "windows")]
+                "y" => Some(StandardShortcut::Redo),
                 "r" => Some(StandardShortcut::Refresh),
                 _ => None,
             }
         } else if self.modifiers.control && self.modifiers.shift {
             match self.text.as_str() {
-                #[cfg(target_os = "macos")]
+                #[cfg(not(target_os = "windows"))]
                 "z" => Some(StandardShortcut::Redo),
                 _ => None,
             }

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -7,7 +7,7 @@
 
 use crate::graphics::Point;
 use crate::item_tree::{ItemVisitorResult, VisitChildrenResult};
-use crate::items::{ItemRc, ItemRef, ItemWeak, PointerEventButton};
+use crate::items::{ItemRc, ItemRef, ItemWeak, PointerEventButton, TextCursorDirection};
 use crate::window::WindowRc;
 use crate::Property;
 use crate::{component::ComponentRc, SharedString};
@@ -175,36 +175,72 @@ pub struct KeyEvent {
 impl KeyEvent {
     /// If a shortcut was pressed, this function returns `Some(Shortcut)`.
     /// Otherwise it returns None.
-    pub fn shortcut(&self) -> Option<Shortcut> {
+    pub fn shortcut(&self) -> Option<StandardShortcut> {
         if self.modifiers.control && !self.modifiers.shift {
             match self.text.as_str() {
-                "c" => Some(Shortcut::Copy),
-                "x" => Some(Shortcut::Cut),
-                "v" => Some(Shortcut::Paste),
-                "a" => Some(Shortcut::SelectAll),
-                "f" => Some(Shortcut::Find),
-                "s" => Some(Shortcut::Save),
-                "p" => Some(Shortcut::Print),
-                "z" => Some(Shortcut::Undo),
+                "c" => Some(StandardShortcut::Copy),
+                "x" => Some(StandardShortcut::Cut),
+                "v" => Some(StandardShortcut::Paste),
+                "a" => Some(StandardShortcut::SelectAll),
+                "f" => Some(StandardShortcut::Find),
+                "s" => Some(StandardShortcut::Save),
+                "p" => Some(StandardShortcut::Print),
+                "z" => Some(StandardShortcut::Undo),
                 #[cfg(not(target_os = "macos"))]
                 "y" => Some(Shortcut::Redo),
-                "r" => Some(Shortcut::Refresh),
+                "r" => Some(StandardShortcut::Refresh),
                 _ => None,
             }
         } else if self.modifiers.control && self.modifiers.shift {
             match self.text.as_str() {
                 #[cfg(target_os = "macos")]
-                "z" => Some(Shortcut::Redo),
+                "z" => Some(StandardShortcut::Redo),
                 _ => None,
             }
         } else {
             None
         }
     }
+
+    /// If a shortcut concerning text editing was pressed, this function
+    /// returns `Some(TextShortcut)`. Otherwise it returns None.
+    pub fn text_shortcut(&self) -> Option<TextShortcut> {
+        let keycode = self.text.chars().next()?;
+
+        let by_word = if cfg!(target_os = "macos") {
+            self.modifiers.alt && !self.modifiers.control && !self.modifiers.meta
+        } else {
+            self.modifiers.control && !self.modifiers.alt && !self.modifiers.meta
+        };
+        match TextCursorDirection::try_from(keycode) {
+            Ok(TextCursorDirection::Forward) => {
+                if by_word {
+                    // return Some(TextShortcut::Move(TextCursorDirection::ForwardByWord));
+                } else {
+                    return Some(TextShortcut::Move(TextCursorDirection::Forward));
+                }
+            }
+            Ok(TextCursorDirection::Backward) => {
+                if by_word {
+                    // return Some(TextShortcut::Move(TextCursorDirection::BackwardByWord));
+                } else {
+                    return Some(TextShortcut::Move(TextCursorDirection::Backward));
+                }
+            }
+            Ok(direction) => return Some(TextShortcut::Move(direction)),
+            _ => (),
+        };
+
+        match keycode {
+            key_codes::Backspace => Some(TextShortcut::DeleteBackward),
+            key_codes::Delete => Some(TextShortcut::DeleteForward),
+            _ => None,
+        }
+    }
 }
-/// Represents a non context specific shortcut. Shortcuts that are specific to
-/// a special context e.g. text movement shortcuts should be handled were they are used.
-pub enum Shortcut {
+
+/// Represents a non context specific shortcut.
+pub enum StandardShortcut {
     /// Copy Something
     Copy,
     /// Cut Something
@@ -225,6 +261,16 @@ pub enum Shortcut {
     Redo,
     /// Redo the last undone action
     Refresh,
+}
+
+/// Shortcuts that are used when editing text
+pub enum TextShortcut {
+    /// Move the cursor
+    Move(TextCursorDirection),
+    /// Delete the Character to the right of the cursor
+    DeleteForward,
+    /// Delete the Character to the left of the cursor (aka Backspace).
+    DeleteBackward,
 }
 
 /// Represents how an item's key_event handler dealt with a key event.

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -172,6 +172,61 @@ pub struct KeyEvent {
     pub event_type: KeyEventType,
 }
 
+impl KeyEvent {
+    /// If a shortcut was pressed, this function returns `Some(Shortcut)`.
+    /// Otherwise it returns None.
+    pub fn shortcut(&self) -> Option<Shortcut> {
+        if self.modifiers.control && !self.modifiers.shift {
+            match self.text.as_str() {
+                "c" => Some(Shortcut::Copy),
+                "x" => Some(Shortcut::Cut),
+                "v" => Some(Shortcut::Paste),
+                "a" => Some(Shortcut::SelectAll),
+                "f" => Some(Shortcut::Find),
+                "s" => Some(Shortcut::Save),
+                "p" => Some(Shortcut::Print),
+                "z" => Some(Shortcut::Undo),
+                #[cfg(not(target_os = "macos"))]
+                "y" => Some(Shortcut::Redo),
+                "r" => Some(Shortcut::Refresh),
+                _ => None,
+            }
+        } else if self.modifiers.control && self.modifiers.shift {
+            match self.text.as_str() {
+                #[cfg(target_os = "macos")]
+                "z" => Some(Shortcut::Redo),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+/// Represents a non context specific shortcut. Shortcuts that are specific to
+/// a special context e.g. text movement shortcuts should be handled were they are used.
+pub enum Shortcut {
+    /// Copy Something
+    Copy,
+    /// Cut Something
+    Cut,
+    /// Paste Something
+    Paste,
+    /// Copy Something
+    SelectAll,
+    /// Select All
+    Find,
+    /// Find/Search Something
+    Save,
+    /// Save Something
+    Print,
+    /// Print Something
+    Undo,
+    /// Undo the last action
+    Redo,
+    /// Redo the last undone action
+    Refresh,
+}
+
 /// Represents how an item's key_event handler dealt with a key event.
 /// An accepted event results in no further event propagation.
 #[repr(C)]

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -12,7 +12,7 @@ use super::{Item, ItemConsts, ItemRc, PointArg, PointerEventButton, RenderingRes
 use crate::graphics::{Brush, Color, FontRequest, Rect};
 use crate::input::{
     key_codes, FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
-    KeyEventResult, KeyEventType, KeyboardModifiers, MouseEvent,
+    KeyEventResult, KeyEventType, KeyboardModifiers, MouseEvent, Shortcut,
 };
 use crate::item_rendering::{CachedRenderingData, ItemRenderer};
 use crate::layout::{LayoutInfo, Orientation};
@@ -414,21 +414,30 @@ impl Item for TextInput {
                 {
                     return KeyEventResult::EventIgnored;
                 }
+                match event.shortcut() {
+                    Some(shortcut) => match shortcut {
+                        Shortcut::SelectAll => {
+                            self.select_all(window);
+                            return KeyEventResult::EventAccepted;
+                        }
+                        Shortcut::Copy => {
+                            self.copy();
+                            return KeyEventResult::EventAccepted;
+                        }
+                        Shortcut::Paste => {
+                            self.paste(window);
+                            return KeyEventResult::EventAccepted;
+                        }
+                        Shortcut::Cut => {
+                            self.copy();
+                            self.delete_selection(window);
+                            return KeyEventResult::EventAccepted;
+                        }
+                        _ => (),
+                    },
+                    None => (),
+                }
                 if event.modifiers.control {
-                    if event.text == "a" {
-                        self.select_all(window);
-                        return KeyEventResult::EventAccepted;
-                    } else if event.text == "c" {
-                        self.copy();
-                        return KeyEventResult::EventAccepted;
-                    } else if event.text == "v" {
-                        self.paste(window);
-                        return KeyEventResult::EventAccepted;
-                    } else if event.text == "x" {
-                        self.copy();
-                        self.delete_selection(window);
-                        return KeyEventResult::EventAccepted;
-                    }
                     return KeyEventResult::EventIgnored;
                 }
                 self.delete_selection(window);


### PR DESCRIPTION
This PR adds the Shortcut abstraction that we talked about in #1110

Right now the Shortcuts are separated into `TextShortcut`s in text.rs and `Shortcut`s in input.rs.
Both are implemented on `KeyEvent`.