### PR TITLE
Fix application of popup window item background with the GL renderer

### DIFF
--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -172,7 +172,7 @@ impl WinitWindow for GLWindow {
     fn draw(self: Rc<Self>) {
         let runtime_window = self.self_weak.upgrade().unwrap();
         let scale_factor = runtime_window.scale_factor();
-        runtime_window.clone().draw_contents(|components| {
+        runtime_window.clone().draw_contents(|root_component, popups| {
             let window = match self.borrow_mapped_window() {
                 Some(window) => window,
                 None => return, // caller bug, doesn't make sense to call draw() when not mapped
@@ -217,9 +217,12 @@ impl WinitWindow for GLWindow {
                 size,
             );
 
-            for (component, origin) in components {
-                corelib::item_rendering::render_component_items(component, &mut renderer, *origin);
-            }
+            corelib::item_rendering::render_component_items(
+                root_component,
+                &mut renderer,
+                Default::default(),
+            );
+            corelib::item_rendering::render_inline_popups(popups, &mut renderer);
 
             if let Some(collector) = &self.rendering_metrics_collector {
                 collector.measure_frame_rendered(&mut renderer);

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -166,20 +166,6 @@ fn clip_path_for_rect_alike_item(
 }
 
 impl ItemRenderer for GLItemRenderer {
-    fn draw_rectangle(&mut self, rect: std::pin::Pin<&i_slint_core::items::Rectangle>) {
-        let geometry = item_rect(rect, self.scale_factor);
-        if geometry.is_empty() {
-            return;
-        }
-        // TODO: cache path in item to avoid re-tesselation
-        let mut path = rect_to_path(geometry);
-        let paint = match self.brush_to_paint(rect.background(), &mut path) {
-            Some(paint) => paint,
-            None => return,
-        };
-        self.canvas.borrow_mut().fill_path(&mut path, paint)
-    }
-
     fn draw_border_rectangle(
         &mut self,
         rect: std::pin::Pin<&i_slint_core::items::BorderRectangle>,
@@ -841,6 +827,20 @@ impl ItemRenderer for GLItemRenderer {
         let paint = font.init_paint(0.0, femtovg::Paint::color(to_femtovg_color(&color)));
         let mut canvas = self.canvas.borrow_mut();
         canvas.fill_text(0., 0., string, paint).unwrap();
+    }
+
+    fn fill_rect(&mut self, logical_rect: &Rect, brush: crate::Brush) {
+        if logical_rect.is_empty() {
+            return;
+        }
+        let physical_rect = *logical_rect * self.scale_factor;
+        let mut path = rect_to_path(physical_rect);
+
+        let paint = match self.brush_to_paint(brush, &mut path) {
+            Some(paint) => paint,
+            None => return,
+        };
+        self.canvas.borrow_mut().fill_path(&mut path, paint)
     }
 
     fn window(&self) -> WindowRc {


### PR DESCRIPTION
... and simplify the inline popup rendering code path across the renderers.

The GL backend failed to render the background of the `WindowItem` of a `PopupWindow`. This became visible with slint-ui/slint#1120 .

This change relaces the mandatory `draw_rectangle` in the item rendere with a mandatory `fill_rect`, which the former as well as the
centralized inline popup rendering can now use.

As an upside, this micro-optimizes away a property dependency to the background in
`draw_rectangle` for the QtItemRenderer
when the geometry was invalid, due to an early return.