### PR TITLE
Text shortcuts

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -215,14 +215,14 @@ impl KeyEvent {
         match TextCursorDirection::try_from(keycode) {
             Ok(TextCursorDirection::Forward) => {
                 if by_word {
-                    // return Some(TextShortcut::Move(TextCursorDirection::ForwardByWord));
+                    return Some(TextShortcut::Move(TextCursorDirection::ForwardByWord));
                 } else {
                     return Some(TextShortcut::Move(TextCursorDirection::Forward));
                 }
             }
             Ok(TextCursorDirection::Backward) => {
                 if by_word {
-                    // return Some(TextShortcut::Move(TextCursorDirection::BackwardByWord));
+                    return Some(TextShortcut::Move(TextCursorDirection::BackwardByWord));
                 } else {
                     return Some(TextShortcut::Move(TextCursorDirection::Backward));
                 }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -617,23 +617,19 @@ impl TextInput {
                 }
             }
             // Currently moving by word behaves like macos: next end of word(forward) or previous beginning of word(backward)
-            TextCursorDirection::ForwardByWord => {
-                if let Some((word_offset, slice)) = text
-                    .unicode_word_indices()
-                    .skip_while(|(offset, slice)| *offset + slice.len() <= last_cursor_pos)
-                    .next()
-                {
-                    word_offset + slice.len()
-                } else {
-                    text.len()
-                }
-            }
+            TextCursorDirection::ForwardByWord => text
+                .unicode_word_indices()
+                .skip_while(|(offset, slice)| *offset + slice.len() <= last_cursor_pos)
+                .next()
+                .map_or(text.len(), |(offset, slice)| offset + slice.len()),
             TextCursorDirection::BackwardByWord => {
                 let mut word_offset = 0;
 
                 for (current_word_offset, _) in text.unicode_word_indices() {
                     if current_word_offset < last_cursor_pos {
                         word_offset = current_word_offset;
+                    } else {
+                        break;
                     }
                 }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -624,13 +624,12 @@ impl TextInput {
                 }
             }
             TextCursorDirection::BackwardByWord => {
-                let mut peekable_words = text.unicode_word_indices().peekable();
-
                 let mut word_offset = 0;
-                while let Some((current_word_offset, _)) =
-                    peekable_words.next_if(|(offset, _)| *offset < last_cursor_pos)
-                {
-                    word_offset = current_word_offset;
+
+                for (current_word_offset, _) in text.unicode_word_indices() {
+                    if current_word_offset < last_cursor_pos {
+                        word_offset = current_word_offset;
+                    }
                 }
 
                 word_offset

--- a/tests/cases/text/cursor_move.slint
+++ b/tests/cases/text/cursor_move.slint
@@ -14,14 +14,21 @@ TestCase := TextInput {
 /*
 ```rust
 
+const UP_CODE: char = '\u{F700}';
+const DOWN_CODE: char = '\u{F701}';
 const LEFT_CODE: char = '\u{F702}';
 const RIGHT_CODE: char = '\u{F703}';
-const HOME_CODE: char = '\u{F729}';
-const END_CODE: char = '\u{F72B}';
 const BACK_CODE: char = '\u{0008}'; // backspace \b
 
 let shift_modifier = slint::re_exports::KeyboardModifiers {
     shift: true,
+    ..Default::default()
+};
+
+let move_mod_shift_modifier = slint::re_exports::KeyboardModifiers {
+    shift: true,
+    control: cfg!(not(target_os = "macos")),
+    alt: cfg!(target_os = "macos"),
     ..Default::default()
 };
 
@@ -55,8 +62,8 @@ slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string())
 slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 assert_eq!(instance.get_test_cursor_pos(), 0);
 
-slint::testing::set_current_keyboard_modifiers(&instance, shift_modifier);
-slint::testing::send_keyboard_string_sequence(&instance, &END_CODE.to_string());
+slint::testing::set_current_keyboard_modifiers(&instance, move_mod_shift_modifier);
+slint::testing::send_keyboard_string_sequence(&instance, &DOWN_CODE.to_string());
 slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 2);
@@ -65,8 +72,8 @@ assert_eq!(instance.get_test_anchor_pos(), 0);
 slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 assert!(!instance.get_has_selection());
 
-slint::testing::set_current_keyboard_modifiers(&instance, shift_modifier);
-slint::testing::send_keyboard_string_sequence(&instance, &HOME_CODE.to_string());
+slint::testing::set_current_keyboard_modifiers(&instance, move_mod_shift_modifier);
+slint::testing::send_keyboard_string_sequence(&instance, &UP_CODE.to_string());
 slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 0);


### PR DESCRIPTION
Until now this contains move to start and end of line or paragraph.
It also corrects Home and End behavior.

Moving to the start or end of the line still doesn't work properly, because of the buggy `text_input_byte_offset_for_position` function.