### PR TITLE
Fix broken links to C++ types in C++ Type mapping documentation

### DIFF
--- a/api/cpp/docs/types.md
+++ b/api/cpp/docs/types.md
@@ -3,21 +3,24 @@
 The types used for properties in `.slint` design markup each translate to specific types in C++.
 The follow table summarizes the entire mapping:
 
-| `.slint` Type | C++ Type | Note |
-| --- | --- | --- |
-| `int` | `int` | |
-| `float` | `float` | |
-| `bool` | `bool` | |
-| `string` | [`slint::SharedString`](api/structslint_1_1_shared_string.html) | A reference-counted string type that uses UTF-8 encoding and can be easily converted to a std::string_view or a const char *. |
-| `color` | [`slint::Color`](api/classslint_1_1_color.html) | |
-| `brush` | [`slint::Brush`](api/classslint_1_1_brush.html) | |
-| `image` | [`slint::Image`](api/structslint_1_1_image.html) | |
-| `physical_length` | `float` | The unit are physical pixels. |
-| `length` | `float` | At run-time, logical lengths are automatically translated to physical pixels using the device pixel ratio. |
-| `duration` | `std::int64_t` | At run-time, durations are always represented as signed 64-bit integers with millisecond precision. |
-| `angle` | `float` | The value in degrees. |
-| structure | A `class` of the same name | The order of the data member are in the lexicographic order of their name |
-
+```{eval-rst}
+==========================  ==================================  =======================================================================================================================================
+ :code:`.slint` Type             C++ Type                        Note
+==========================  ==================================  =======================================================================================================================================
+ :code:`int`                 :code:`int`
+ :code:`float`               :code:`float`
+ :code:`bool`                :code:`bool`
+ :code:`string`              :cpp:class:`slint::SharedString`    A reference-counted string type that uses UTF-8 encoding and can be easily converted to a std::string_view or a :code:`const char *`.
+ :code:`color`               :cpp:class:`slint::Color`
+ :code:`brush`               :cpp:class:`slint::Brush`
+ :code:`image`               :cpp:class:`slint::Image`
+ :code:`physical_length`     :code:`float`                       The unit are physical pixels.
+ :code:`length`              :code:`float`                       At run-time, logical lengths are automatically translated to physical pixels using the device pixel ratio.
+ :code:`duration`            :code:`std::int64_t`                At run-time, durations are always represented as signed 64-bit integers with millisecond precision.
+ :code:`angle`               :code:`float`                       The value in degrees.
+ structure                   A :code:`class` of the same name    The order of the data member are in the lexicographic order of their name
+==========================  ==================================  =======================================================================================================================================
+```
 ## Structures
 
 For user-defined structures in the .slint code, a `class` of the same name is generated with data member


### PR DESCRIPTION
The links to slint::Color (and other types) was coded to their direct
.html file name, so for example classslint_1_1_color.html.
Unfortunately in the CI the class name became classslint_1_1color.html
and therefore the links on our website were broken.

Now my-st parser has a way of resolving links in markdown to references,
basically {cpp:class}`slint::Color`. Unfortunately that link resolution
is not working when used inside markdown tables.

Therefore this patch converts the entire table to restructured text,
where we can use native references to hopefully always generate the
correct links, regardless of the doxygen/breathe/exhale version.