### PR TITLE
Fix a bunch more issue with PopupWindow

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -458,6 +458,10 @@ pub struct Element {
     /// true if this Element is the fake Flickable viewport
     pub is_flickable_viewport: bool,
 
+    /// true if this Element may have a popup as child meaning it cannot be optimized
+    /// because the popup references it.
+    pub has_popup_child: bool,
+
     /// This is the component-local index of this item in the item tree array.
     /// It is generated after the last pass and before the generators run.
     pub item_index: once_cell::unsync::OnceCell<usize>,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -116,8 +116,8 @@ pub async fn run_passes(
         .chain(std::iter::once(root_component))
     {
         flickable::handle_flickable(component, &global_type_registry.borrow());
-        lower_popups::lower_popups(component, &doc.local_registry, diag);
         repeater_component::process_repeater_components(component);
+        lower_popups::lower_popups(component, &doc.local_registry, diag);
         lower_layout::lower_layouts(component, type_loader, diag).await;
         default_geometry::default_geometry(component, diag);
         z_order::reorder_by_z_order(component, diag);

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -41,6 +41,7 @@ pub fn ensure_window(
         states: Default::default(),
         transitions: Default::default(),
         child_of_layout: false,
+        has_popup_child: false,
         layout_info_prop: Default::default(),
         is_flickable_viewport: false,
         item_index: Default::default(),

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -218,6 +218,7 @@ fn duplicate_element_with_mapping(
         item_index: Default::default(), // Not determined yet
         item_index_of_first_children: Default::default(),
         is_flickable_viewport: elem.is_flickable_viewport,
+        has_popup_child: elem.has_popup_child,
         inline_depth: elem.inline_depth + 1,
     }));
     mapping.insert(element_key(element.clone()), new.clone());

--- a/internal/compiler/passes/optimize_useless_rectangles.rs
+++ b/internal/compiler/passes/optimize_useless_rectangles.rs
@@ -36,7 +36,7 @@ pub fn optimize_useless_rectangles(root_component: &Rc<Component>) {
 /// Check that this is a element we can optimize
 fn can_optimize(elem: &ElementRc) -> bool {
     let e = elem.borrow();
-    if e.is_flickable_viewport {
+    if e.is_flickable_viewport || e.has_popup_child {
         return false;
     };
 

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -14,7 +14,6 @@ use std::rc::Rc;
 pub fn process_repeater_components(component: &Rc<Component>) {
     create_repeater_components(component);
     adjust_references(component);
-    adjust_popups(component);
 }
 
 fn create_repeater_components(component: &Rc<Component>) {
@@ -43,6 +42,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 child_of_layout: elem.child_of_layout || is_listview.is_some(),
                 layout_info_prop: elem.layout_info_prop.take(),
                 is_flickable_viewport: elem.is_flickable_viewport,
+                has_popup_child: elem.has_popup_child,
                 item_index: Default::default(), // Not determined yet
                 item_index_of_first_children: Default::default(),
                 inline_depth: 0,
@@ -112,24 +112,5 @@ fn adjust_references(comp: &Rc<Component>) {
                 }
             }
         })
-    });
-}
-
-fn adjust_popups(component: &Rc<Component>) {
-    component.popup_windows.borrow_mut().retain(|popup| {
-        let parent = popup
-            .component
-            .parent_element
-            .upgrade()
-            .unwrap()
-            .borrow()
-            .enclosing_component
-            .upgrade()
-            .unwrap();
-        if Rc::ptr_eq(&parent, component) {
-            return true;
-        }
-        parent.popup_windows.borrow_mut().push(popup.clone());
-        false
     });
 }

--- a/tests/cases/crashes/issue1113_popup_in_repeater.slint
+++ b/tests/cases/crashes/issue1113_popup_in_repeater.slint
@@ -12,5 +12,26 @@ App := Window {
             }
        }
     }
+
+    if true : Rectangle {
+        Rectangle {
+            TouchArea {
+                clicked => {
+                    popup2.show();
+                }
+            }
+            popup2 := PopupWindow { }
+        }
+    }
+
+    // Issue #1132
+    for menu-item in [0] : TouchArea {
+        clicked => { popup3.show(); }
+        if true: TouchArea {
+            clicked => { popup3.show(); }
+        }
+        popup3 := PopupWindow { }
+    }
+
 }
 


### PR DESCRIPTION
 * Make sure that the compiler don't panic if the parent of a PopupWindow
   is optimized (by not optiizing such element)

 * Ensure that we can call popup.show() from within a deeper repeater

 * Ensure that the parent element of the popup is the right one in case of
   repeater (and not the node in the parent component)

This partially revert ad5991f8fad9936016ce77c103f41f1fd93fa53d and
6c7a7aed0e1a0fedd0a7164dc21d5be2255f61d5 because we must do the lower_popup
adter the repeater pass, because otherwise the parent element of the
created component for the PopupWindow might be wrong and it is not easy to
adjust (we would have to make Component::parent_element a RefCell or duplicate
it again.

Fixes #1132