### PR TITLE
Widget focus

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -134,6 +134,7 @@ export FocusScope := _ {
     property <length> y;
     property <length> width;
     property <length> height;
+    property <bool> enabled: true;
     property <bool> has-focus: native_output;
     callback key_pressed(KeyEvent) -> EventResult;
     callback key_released(KeyEvent) -> EventResult;
@@ -250,7 +251,7 @@ export Layer := _ {
     property <length> height;
     property <bool> cache-rendering-hint;
     //-default_size_binding:expands_to_parent_geometry
-    //-is_internal    
+    //-is_internal
 }
 
 Row := _ {

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore flickable textedit
 
 export global Palette := {
     property<color> themeDarker: #004578;
@@ -71,6 +72,7 @@ export global StyleMetrics := {
 export Button := Rectangle {
     callback clicked <=> touch.clicked;
     property<string> text <=> text.text;
+    property<bool> has-focus <=> fs.has-focus;
     property<bool> pressed: self.enabled && touch.pressed;
     property<bool> enabled <=> touch.enabled;
     property<image> icon;
@@ -106,8 +108,27 @@ export Button := Rectangle {
         }
     }
 
-
     touch := TouchArea {}
+
+    fs := FocusScope {
+        enabled <=> root.enabled;
+        key-pressed(event) => {
+            if (event.text == " " || event.text == "\n") {
+                 touch.clicked();
+                 return accept;
+            }
+            return reject;
+        }
+    }
+
+    Rectangle { // Focus rectangle
+        x: 3px;
+        y: x;
+        width: parent.width - 2*x;
+        height: parent.height - 2*y;
+        border-width: enabled && has-focus? 1px : 0px;
+        border-color: Palette.black;
+    }
 }
 
 ScrollBar := Rectangle {

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -95,7 +95,6 @@ export SpinBox := FocusScope {
     property <int> value;
     property <int> minimum;
     property <int> maximum: 100;
-    property <bool> enabled: true;
     property <image> icon;
     property <length> font-size <=> button.font-size;
 
@@ -420,7 +419,6 @@ export ComboBox := FocusScope {
     property <int> current-index : -1;
     property <string> current-value;
     //property <bool> is-open: false;
-    property<bool> enabled <=> touch.enabled;
     callback selected(string);
 
     Rectangle {
@@ -469,6 +467,7 @@ export ComboBox := FocusScope {
     }
 
     touch := TouchArea {
+        enabled <=> root.enabled;
         clicked => {
             root.focus();
             popup.show();

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -12,7 +12,8 @@ export CheckBox := Rectangle {
     callback toggled;
     property <string> text <=> text.text;
     property <bool> checked;
-    property<bool> enabled <=> touch.enabled;
+    property <bool> has-focus;
+    property<bool> enabled: true;
     min-height: 20px;
     horizontal-stretch: 0;
     vertical-stretch: 0;
@@ -64,6 +65,7 @@ export CheckBox := Rectangle {
     }
 
     touch := TouchArea {
+        enabled <=> root.enabled;
         clicked => {
             if (root.enabled) {
                 root.checked = !root.checked;
@@ -72,6 +74,27 @@ export CheckBox := Rectangle {
         }
     }
 
+    fs := FocusScope {
+        enabled <=> root.enabled;
+        has_focus <=> root.has-focus;
+
+        key-pressed(event) => {
+            if (event.text == " " || event.text == "\n") {
+                 touch.clicked();
+                 return accept;
+            }
+            return reject;
+        }
+    }
+
+    Rectangle { // Focus rectangle
+        x: -3px;
+        y: x;
+        width: parent.width - 2*x;
+        height: parent.height - 2*y;
+        border-width: enabled && has-focus ? 1px : 0px;
+        border-color: Palette.black;
+    }
 }
 
 SpinBoxButton := Rectangle {

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -439,10 +439,27 @@ export StandardListView := ListView {
 
 export ComboBox := FocusScope {
     property <[string]> model;
-    property <int> current-index : -1;
-    property <string> current-value;
+    property <int> current-index : 0;
+    property <string> current-value: model[current-index];
     //property <bool> is-open: false;
     callback selected(string);
+
+    key-pressed(event) => {
+        if (event.text == Keys.UpArrow) {
+            current-index = Math.max(current-index - 1, 0);
+            current-value = model[current-index];
+            return accept;
+        } else if (event.text == Keys.DownArrow) {
+            current-index = Math.min(current-index + 1, model.length - 1);
+            current-value = model[current-index];
+            return accept;
+        // PopupWindow can not get hidden again at this time, so do not allow to pop that up.
+        // } else if (event.text == Keys.Return) {
+        //     touch.clicked()
+        //     return accept;
+        }
+        return reject;
+    }
 
     Rectangle {
         background: !enabled ? Palette.neutralLighter : Palette.white;

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -548,6 +548,7 @@ pub struct FocusScope {
     pub y: Property<Coord>,
     pub width: Property<Coord>,
     pub height: Property<Coord>,
+    pub enabled: Property<bool>,
     pub has_focus: Property<bool>,
     pub key_pressed: Callback<KeyEventArg, EventResult>,
     pub key_released: Callback<KeyEventArg, EventResult>,
@@ -581,10 +582,7 @@ impl Item for FocusScope {
         window: &WindowRc,
         self_rc: &ItemRc,
     ) -> InputEventResult {
-        /*if !self.enabled() {
-            return InputEventResult::EventIgnored;
-        }*/
-        if matches!(event, MouseEvent::MousePressed { .. }) && !self.has_focus() {
+        if self.enabled() && matches!(event, MouseEvent::MousePressed { .. }) && !self.has_focus() {
             window.clone().set_focus_item(self_rc);
         }
         InputEventResult::EventIgnored
@@ -606,6 +604,10 @@ impl Item for FocusScope {
     }
 
     fn focus_event(self: Pin<&Self>, event: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+        if !self.enabled() {
+            return FocusEventResult::FocusIgnored;
+        }
+
         match event {
             FocusEvent::FocusIn | FocusEvent::WindowReceivedFocus => {
                 self.has_focus.set(true);

--- a/tests/cases/focus/keyboard_focus.slint
+++ b/tests/cases/focus/keyboard_focus.slint
@@ -45,9 +45,8 @@ TestCase := Window {
                     return reject;
                 }
             }
-            Text {
-                // Not a focus scope, the Focus should skip this
-                text: "Test " + i;
+            FocusScope {
+                enabled: false;
             }
             FocusScope {
                 key-pressed(event) => {


### PR DESCRIPTION
## Do not derive widgets from FocusScope

We expose less functionality this way:-)

## Add enabled property to FocusScope

Allow for a bool to enable/disable focus delivery.

## Make the Button accept focus

... and handle space/return keys to click() it!

