### PR TITLE
Keep the existing size re-using a window 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 ### Changed
  - On wasm, the input event are handled via a hidden `<input>` element, allowing the keyboard
    to show on mobile platform
+ - The size of the window is kept when reloading a window in the preview (instead of being reset to the preferred size)
 
 ### Added
 

--- a/docs/resources/slint-docs-preview.html
+++ b/docs/resources/slint-docs-preview.html
@@ -12,11 +12,6 @@
     async function render_or_error(source, div) {
         let canvas_id = 'canvas_' + Math.random().toString(36).substr(2, 9);
         let canvas = document.createElement("canvas");
-        // The GL backend tries to preserve a previously set size on the canvas. Make sure that any default the
-        // browser sets for these attributes are not used, but instead the examples can resize according to their
-        // constraints.
-        canvas.width = 0;
-        canvas.height = 0;
         canvas.id = canvas_id;
         div.appendChild(canvas);
 

--- a/editor/vscode/src/extension.ts
+++ b/editor/vscode/src/extension.ts
@@ -87,7 +87,8 @@ function startClient(context: vscode.ExtensionContext) {
     // Try a local ../target build first, then try the plain bundled binary and finally the architecture specific one.
     // A debug session will find the first one, a local package build the second and the distributed vsix the last.
     const lspSearchPaths = [
-        context.asAbsolutePath(path.join('..', 'target', 'debug', 'slint-lsp' + program_extension)),
+        path.join(context.extensionPath, '..', '..', 'target', 'debug', 'slint-lsp' + program_extension),
+        path.join(context.extensionPath, '..', '..', 'target', 'release', 'slint-lsp' + program_extension),
         path.join(context.extensionPath, "bin", "slint-lsp" + program_extension),
         path.join(context.extensionPath, "bin", lsp_platform.program_name),
     ];

--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -69,6 +69,7 @@ pub trait WinitWindow: PlatformWindow {
                 } else {
                     None
                 });
+                winit_window.set_resizable(min_width < max_width || min_height < max_height);
                 self.set_constraints((constraints_horizontal, constraints_vertical));
 
                 #[cfg(target_arch = "wasm32")]

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1408,8 +1408,7 @@ impl PlatformWindow for QtWindow {
         };
         if size.width == 0 || size.height == 0 {
             let existing_size = cpp!(unsafe [widget_ptr as "QWidget*"] -> qttypes::QSize as "QSize" {
-                auto sizeHint = widget_ptr->sizeHint();
-                return sizeHint.isValid() ? sizeHint : widget_ptr->size();
+                return widget_ptr->size();
             });
             if size.width == 0 {
                 window_item.width.set(existing_size.width as _);


### PR DESCRIPTION
Eg, in the viewer or in the preview.
    
The preferred size is still set as the size when the window is first open


Also make sure the preview in the docs have sensible default and not the winit default that is way too big
