### PR TITLE
`Debug` for ItemRc

### DIFF
--- a/helper_crates/vtable/src/vrc.rs
+++ b/helper_crates/vtable/src/vrc.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore dealloc pointee repr
+
 //! implementation of vtable::Vrc
 
 use super::*;
@@ -123,6 +125,12 @@ impl<VTable: VTableMetaDropInPlace + 'static, X> Drop for VRc<VTable, X> {
                 }
             }
         }
+    }
+}
+
+impl<VTable: VTableMetaDropInPlace + 'static, X> core::fmt::Debug for VRc<VTable, X> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VRc").field("inner", &unsafe { self.inner.as_ref().data_ptr() }).finish()
     }
 }
 

--- a/helper_crates/vtable/src/vrc.rs
+++ b/helper_crates/vtable/src/vrc.rs
@@ -130,7 +130,7 @@ impl<VTable: VTableMetaDropInPlace + 'static, X> Drop for VRc<VTable, X> {
 
 impl<VTable: VTableMetaDropInPlace + 'static, X> core::fmt::Debug for VRc<VTable, X> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("VRc").field("inner", &unsafe { self.inner.as_ref().data_ptr() }).finish()
+        f.debug_struct("VRc").field("inner", &self.inner).finish()
     }
 }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -227,7 +227,7 @@ pub type ItemRef<'a> = vtable::VRef<'a, ItemVTable>;
 
 /// A ItemRc is holding a reference to a component containing the item, and the index of this item
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ItemRc {
     component: vtable::VRc<ComponentVTable>,
     index: usize,


### PR DESCRIPTION
Implement `core::fmt::Debug` for VRc and ItemRc.

This makes it so much easier to poke at problems with the ItemRcs.