### PR TITLE
GL backend: add shortcut for zero opacity

### DIFF
--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -1275,6 +1275,9 @@ impl GLItemRenderer {
         if brush.is_transparent() {
             return None;
         }
+        if self.state.last().unwrap().global_alpha == 0.0 {
+            return None;
+        }
         Some(match brush {
             Brush::SolidColor(color) => femtovg::Paint::color(to_femtovg_color(&color)),
             Brush::LinearGradient(gradient) => {


### PR DESCRIPTION
If the global opacity is zero, we don't need to paint rectangles, etc.

This shortcut is a compromise between opting out much later on femtovg
level and too early before querying properties of the rectangle.  We
still want to do the latter as somebody might depend on that.