### PR TITLE
Improve floating point comparisons with zero

### DIFF
--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -22,6 +22,7 @@ use corelib::items::{ItemRef, MouseCursor};
 use corelib::layout::Orientation;
 use corelib::window::{PlatformWindow, PopupWindow, PopupWindowLocation};
 use corelib::Property;
+use euclid::approxeq::ApproxEq;
 use i_slint_core as corelib;
 use winit::dpi::LogicalSize;
 
@@ -398,7 +399,7 @@ impl PlatformWindow for GLWindow {
             (
                 window_item.title().to_string(),
                 window_item.no_frame(),
-                window_item.height() == 0. && window_item.width() == 0.,
+                window_item.height().approx_eq(&0.) && window_item.width().approx_eq(&0.),
             )
         } else {
             ("Slint Window".to_string(), false, true)

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -570,9 +570,9 @@ impl ItemRenderer for GLItemRenderer {
     ///  * Draw the shadow image
     fn draw_box_shadow(&mut self, box_shadow: std::pin::Pin<&i_slint_core::items::BoxShadow>) {
         if box_shadow.color().alpha() == 0
-            || (box_shadow.blur() == 0.0
-                && box_shadow.offset_x() == 0.
-                && box_shadow.offset_y() == 0.)
+            || (box_shadow.blur().approx_eq(&0.)
+                && box_shadow.offset_x().approx_eq(&0.)
+                && box_shadow.offset_y().approx_eq(&0.))
         {
             return;
         }
@@ -788,7 +788,7 @@ impl ItemRenderer for GLItemRenderer {
 
         // femtovg only supports rectangular clipping. Non-rectangular clips must be handled via `apply_clip`,
         // which can render children into a layer.
-        debug_assert!(radius == 0.);
+        debug_assert!(radius.approx_eq(&0.));
     }
 
     fn get_current_clip(&self) -> Rect {
@@ -1275,7 +1275,7 @@ impl GLItemRenderer {
         if brush.is_transparent() {
             return None;
         }
-        if self.state.last().unwrap().global_alpha == 0.0 {
+        if self.state.last().unwrap().global_alpha < 0. {
             return None;
         }
         Some(match brush {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -36,6 +36,7 @@ use alloc::boxed::Box;
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
 use core::pin::Pin;
+use euclid::approxeq::ApproxEq;
 use i_slint_core_macros::*;
 use vtable::*;
 
@@ -277,7 +278,7 @@ impl ItemRc {
         let is_clipping = crate::item_rendering::is_enabled_clipping_item(item);
         let geometry = item.as_ref().geometry();
 
-        if is_clipping && (geometry.width() == 0.0 || geometry.height() == 0.0) {
+        if is_clipping && (geometry.width().approx_eq(&0.) || geometry.height().approx_eq(&0.)) {
             return false;
         }
 
@@ -1587,7 +1588,7 @@ impl WindowItem {
             },
             pixel_size: {
                 let font_size = self.default_font_size();
-                if font_size == 0.0 {
+                if font_size.approx_eq(&0.0) {
                     None
                 } else {
                     Some(font_size)

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -23,6 +23,7 @@ use crate::{Callback, Property, SharedString};
 use alloc::string::String;
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
+use euclid::approxeq::ApproxEq;
 use i_slint_core_macros::*;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -232,7 +233,7 @@ impl Text {
             },
             pixel_size: {
                 let font_size = self.font_size();
-                if font_size == 0.0 {
+                if font_size.approx_eq(&0.0) {
                     None
                 } else {
                     Some(font_size)
@@ -819,7 +820,7 @@ impl TextInput {
             },
             pixel_size: {
                 let font_size = self.font_size();
-                if font_size == 0.0 {
+                if font_size.approx_eq(&0.0) {
                     None
                 } else {
                     Some(font_size)


### PR DESCRIPTION
Use `approx_eq` where applicable and `< 0` for the opacity shortcut.