### PR TITLE
mcu: determine font sizes from .slint code if possible

### DIFF
--- a/internal/backends/mcu/README.md
+++ b/internal/backends/mcu/README.md
@@ -47,12 +47,6 @@ slint-build = { git = "https://github.com/slint-ui/slint" }
 
 ## Run the demo:
 
-We must tell the compiler what font sizes to embed in the final binary with the SLINT_FONT_SIZES environment variable.
-
-```sh
-export SLINT_FONT_SIZES=8,11,10,12,13,14,15,16,18,20,22,24,32
-```
-
 ### The simulator
 
 

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -182,9 +182,21 @@ pub async fn run_passes(
     collect_globals::collect_globals(doc, diag);
 
     if compiler_config.embed_resources == crate::EmbedResourcesKind::EmbedTextures {
+        let mut font_pixel_sizes = Vec::new();
+        for component in (root_component.used_types.borrow().sub_components.iter())
+            .chain(std::iter::once(root_component))
+        {
+            embed_glyphs::collect_font_sizes_used(
+                component,
+                compiler_config.scale_factor,
+                &mut font_pixel_sizes,
+            );
+        }
+
         embed_glyphs::embed_glyphs(
             root_component,
             compiler_config.scale_factor,
+            font_pixel_sizes,
             std::iter::once(&*doc).chain(type_loader.all_documents()),
             diag,
         );

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -182,7 +182,8 @@ pub async fn run_passes(
     collect_globals::collect_globals(doc, diag);
 
     if compiler_config.embed_resources == crate::EmbedResourcesKind::EmbedTextures {
-        let mut font_pixel_sizes = Vec::new();
+        // Include at least the default font sizes used in the MCU backend
+        let mut font_pixel_sizes = vec![(12. * compiler_config.scale_factor) as i16];
         for component in (root_component.used_types.borrow().sub_components.iter())
             .chain(std::iter::once(root_component))
         {

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -47,7 +47,18 @@ fn simplify_expression(expr: &mut Expression) -> bool {
                 {
                     Some(Expression::NumberLiteral(*a - *b, *un1))
                 }
-                // TODO: * and / are more complicated because they need to take care about units
+                ('*', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
+                    if *un1 == Unit::None || *un2 == Unit::None =>
+                {
+                    let preserved_unit = if *un1 == Unit::None { *un2 } else { *un1 };
+                    Some(Expression::NumberLiteral(*a * *b, preserved_unit))
+                }
+                (
+                    '/',
+                    Expression::NumberLiteral(a, un1),
+                    Expression::NumberLiteral(b, Unit::None),
+                ) => Some(Expression::NumberLiteral(*a / *b, *un1)),
+                // TODO: take care of * and / when both numbers have units
                 ('=' | '!', Expression::NumberLiteral(a, _), Expression::NumberLiteral(b, _)) => {
                     Some(Expression::BoolLiteral((a == b) == (*op == '=')))
                 }

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -5,7 +5,8 @@ use crate::diagnostics::BuildDiagnostics;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::embedded_resources::{BitmapFont, BitmapGlyph, BitmapGlyphs, CharacterMapEntry};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::expression_tree::{BuiltinFunction, Expression, Unit};
+use crate::expression_tree::BuiltinFunction;
+use crate::expression_tree::{Expression, Unit};
 use crate::object_tree::*;
 use std::rc::Rc;
 


### PR DESCRIPTION
Remove the need to specify SLINT_FONT_SIZES if we can determine the font sizes used from constants in the .slint code.