### PR TITLE
mcu: fix popups not visibly closing

### DIFF
--- a/internal/backends/mcu/renderer.rs
+++ b/internal/backends/mcu/renderer.rs
@@ -25,10 +25,11 @@ pub fn render_window_frame(
     runtime_window: Rc<i_slint_core::window::Window>,
     background: super::TargetPixel,
     devices: &mut dyn Devices,
+    initial_dirty_region: i_slint_core::item_rendering::DirtyRegion,
     cache: &mut PartialRenderingCache,
 ) {
     let size = devices.screen_size();
-    let mut scene = prepare_scene(runtime_window, size, devices, cache);
+    let mut scene = prepare_scene(runtime_window, size, devices, initial_dirty_region, cache);
 
     let mut line_processing_profiler = profiler::Timer::new_stopped();
     let mut span_drawing_profiler = profiler::Timer::new_stopped();
@@ -314,13 +315,18 @@ fn prepare_scene(
     runtime_window: Rc<i_slint_core::window::Window>,
     size: PhysicalSize,
     devices: &dyn Devices,
+    initial_dirty_region: i_slint_core::item_rendering::DirtyRegion,
     cache: &mut PartialRenderingCache,
 ) -> Scene {
     let prepare_scene_profiler = profiler::Timer::new(devices);
     let mut compute_dirty_region_profiler = profiler::Timer::new_stopped();
     let factor = ScaleFactor::new(runtime_window.scale_factor());
     let prepare_scene = PrepareScene::new(size, factor, runtime_window.default_font_properties());
-    let mut renderer = i_slint_core::item_rendering::PartialRenderer::new(cache, prepare_scene);
+    let mut renderer = i_slint_core::item_rendering::PartialRenderer::new(
+        cache,
+        initial_dirty_region,
+        prepare_scene,
+    );
 
     runtime_window.draw_contents(|components| {
         compute_dirty_region_profiler.start(devices);

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -311,8 +311,12 @@ pub struct PartialRenderer<'a, T> {
 
 impl<'a, T> PartialRenderer<'a, T> {
     /// Create a new PartialRenderer
-    pub fn new(cache: &'a mut PartialRenderingCache, actual_renderer: T) -> Self {
-        Self { cache, dirty_region: Default::default(), actual_renderer }
+    pub fn new(
+        cache: &'a mut PartialRenderingCache,
+        initial_dirty_region: DirtyRegion,
+        actual_renderer: T,
+    ) -> Self {
+        Self { cache, dirty_region: initial_dirty_region, actual_renderer }
     }
 
     /// Visit the tree of item and compute what are the dirty regions

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -57,6 +57,9 @@ pub trait PlatformWindow {
     /// Show a popup at the given position
     fn show_popup(&self, popup: &ComponentRc, position: Point);
 
+    /// Notify the platform window about the closure of a previously opened popup.
+    fn close_popup(&self, _popup: &PopupWindow) {}
+
     /// Request for the event loop to wake up and call [`Window::update_window_properties()`].
     fn request_window_properties_update(&self);
     /// Request for the given title string to be set to the windowing system for use as window title.
@@ -592,6 +595,7 @@ impl Window {
     pub fn close_popup(&self) {
         if let Some(current_popup) = self.active_popup.replace(None) {
             if matches!(current_popup.location, PopupWindowLocation::ChildWindow(..)) {
+                self.platform_window.get().unwrap().close_popup(&current_popup);
                 // Refresh the area that was previously covered by the popup. I wonder if this
                 // is still needed, shouldn't the redraw tracker be dirty due to the removal of
                 // dependent properties?


### PR DESCRIPTION
When closing a popup, notify the platform window, so that the mcu
backend can remember that region and start the dirty region with it.

Also, free all the rendering cache items of deleted items, to avoid accidental re-use
when re-opening a popup.