### PR TITLE
corelib: allow to use i32 for coordinate instead of f32

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -310,6 +310,7 @@ jobs:
       SLINT_EMBED_GLYPHS: 1
       SLINT_FONT_SIZES: 8,11,10,12,13,14,15,16,18,20,22,24,32
       SLINT_PROCESS_IMAGES: 1
+      RUSTFLAGS: --cfg slint_int_coord
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -40,6 +40,7 @@ fn default_config() -> cbindgen::Config {
                 ("PointerEventArg".into(), "PointerEvent".into()),
                 ("PointArg".into(), "Point".into()),
                 ("FloatArg".into(), "float".into()),
+                ("Coord".into(), "float".into()),
             ]
             .iter()
             .cloned()
@@ -172,6 +173,7 @@ fn gen_corelib(
         "slint_color_darker",
         "slint_image_size",
         "slint_image_path",
+        "Coord",
     ]
     .iter()
     .chain(public_exported_types.iter())

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -304,6 +304,7 @@ pub mod re_exports {
     pub use i_slint_core::window::{Window, WindowHandleAccess, WindowRc};
     pub use i_slint_core::Color;
     pub use i_slint_core::ComponentVTable_static;
+    pub use i_slint_core::Coord;
     pub use i_slint_core::SharedString;
     pub use i_slint_core::SharedVector;
     pub use num_traits::float::Float;

--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -12,8 +12,8 @@ use i_slint_core as corelib;
 
 use corelib::graphics::Point;
 use corelib::input::{KeyEvent, KeyEventType, KeyboardModifiers, MouseEvent};
-use corelib::SharedString;
 use corelib::{window::*, Color};
+use corelib::{Coord, SharedString};
 use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
 use winit::event::WindowEvent;
@@ -49,10 +49,10 @@ pub trait WinitWindow: PlatformWindow {
             }
 
             if (constraints_horizontal, constraints_vertical) != self.constraints() {
-                let min_width = constraints_horizontal.min.min(constraints_horizontal.max);
-                let min_height = constraints_vertical.min.min(constraints_vertical.max);
-                let max_width = constraints_horizontal.max.max(constraints_horizontal.min);
-                let max_height = constraints_vertical.max.max(constraints_vertical.min);
+                let min_width = constraints_horizontal.min.min(constraints_horizontal.max) as f32;
+                let min_height = constraints_vertical.min.min(constraints_vertical.max) as f32;
+                let max_width = constraints_horizontal.max.max(constraints_horizontal.min) as f32;
+                let max_height = constraints_vertical.max.max(constraints_vertical.min) as f32;
 
                 let sf = self.runtime_window().scale_factor();
 
@@ -61,14 +61,16 @@ pub trait WinitWindow: PlatformWindow {
                 } else {
                     None
                 });
-                winit_window.set_max_inner_size(if max_width < f32::MAX || max_height < f32::MAX {
-                    Some(winit::dpi::PhysicalSize::new(
-                        (max_width * sf).min(65535.),
-                        (max_height * sf).min(65535.),
-                    ))
-                } else {
-                    None
-                });
+                winit_window.set_max_inner_size(
+                    if max_width < i32::MAX as f32 || max_height < i32::MAX as f32 {
+                        Some(winit::dpi::PhysicalSize::new(
+                            (max_width * sf).min(65535.),
+                            (max_height * sf).min(65535.),
+                        ))
+                    } else {
+                        None
+                    },
+                );
                 winit_window.set_resizable(min_width < max_width || min_height < max_height);
                 self.set_constraints((constraints_horizontal, constraints_vertical));
 
@@ -99,8 +101,8 @@ pub trait WinitWindow: PlatformWindow {
         let title = window_item.title();
         let no_frame = window_item.no_frame();
         let icon = window_item.icon();
-        let mut width = window_item.width();
-        let mut height = window_item.height();
+        let mut width = window_item.width() as f32;
+        let mut height = window_item.height() as f32;
 
         self.set_background_color(background);
         self.set_icon(icon);
@@ -460,7 +462,8 @@ fn process_window_event(
                     let d = d.to_logical(runtime_window.scale_factor() as f64);
                     euclid::point2(d.x, d.y)
                 }
-            };
+            }
+            .cast::<Coord>();
             runtime_window.process_mouse_input(MouseEvent::MouseWheel { pos: *cursor_pos, delta });
         }
         WindowEvent::MouseInput { state, button, .. } => {

--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -16,12 +16,12 @@ use const_field_offset::FieldOffsets;
 use corelib::api::{GraphicsAPI, RenderingNotifier, RenderingState, SetRenderingNotifierError};
 use corelib::component::ComponentRc;
 use corelib::graphics::rendering_metrics_collector::RenderingMetricsCollector;
-use corelib::graphics::*;
 use corelib::input::KeyboardModifiers;
 use corelib::items::{ItemRef, MouseCursor};
 use corelib::layout::Orientation;
 use corelib::window::{PlatformWindow, PopupWindow, PopupWindowLocation};
 use corelib::Property;
+use corelib::{graphics::*, Coord};
 use i_slint_core as corelib;
 use winit::dpi::LogicalSize;
 
@@ -398,7 +398,7 @@ impl PlatformWindow for GLWindow {
             (
                 window_item.title().to_string(),
                 window_item.no_frame(),
-                window_item.height() == 0. && window_item.width() == 0.,
+                window_item.height() <= 0 as _ && window_item.width() <= 0 as _,
             )
         } else {
             ("Slint Window".to_string(), false, true)
@@ -423,7 +423,7 @@ impl PlatformWindow for GLWindow {
                 layout_info_v.preferred_bounded(),
             );
 
-            if s.width > 0. && s.height > 0. {
+            if s.width > 0 as Coord && s.height > 0 as Coord {
                 // Make sure that the window's inner size is in sync with the root window item's
                 // width/height.
                 runtime_window.set_window_item_geometry(s.width, s.height);
@@ -566,7 +566,7 @@ impl PlatformWindow for GLWindow {
         &self,
         font_request: corelib::graphics::FontRequest,
         text: &str,
-        max_width: Option<f32>,
+        max_width: Option<Coord>,
     ) -> Size {
         let font_request = font_request.merge(&self.default_font_properties());
 

--- a/internal/backends/mcu/fonts.rs
+++ b/internal/backends/mcu/fonts.rs
@@ -12,6 +12,7 @@ use i_slint_core::{
     graphics::{BitmapFont, BitmapGlyph, BitmapGlyphs, FontRequest},
     slice::Slice,
     textlayout::TextShaper,
+    Coord,
 };
 
 thread_local! {
@@ -66,7 +67,7 @@ impl FontMetrics for BitmapGlyphs {
     }
 }
 
-pub const DEFAULT_FONT_SIZE: f32 = 12.0;
+pub const DEFAULT_FONT_SIZE: Coord = 12 as Coord;
 
 // A font that is resolved to a specific pixel size.
 pub struct PixelFont {
@@ -146,7 +147,8 @@ pub fn match_font(request: &FontRequest, scale_factor: ScaleFactor) -> PixelFont
     });
 
     let requested_pixel_size: PhysicalLength =
-        (LogicalLength::new(request.pixel_size.unwrap_or(DEFAULT_FONT_SIZE)) * scale_factor).cast();
+        (LogicalLength::new(request.pixel_size.unwrap_or(DEFAULT_FONT_SIZE)).cast() * scale_factor)
+            .cast();
 
     let nearest_pixel_size = font
         .glyphs
@@ -172,7 +174,7 @@ pub fn register_bitmap_font(font_data: &'static BitmapFont) {
 pub fn text_size(
     font_request: FontRequest,
     text: &str,
-    max_width: Option<f32>,
+    max_width: Option<Coord>,
     scale_factor: ScaleFactor,
 ) -> LogicalSize {
     let font = match_font(&font_request, scale_factor);
@@ -180,9 +182,10 @@ pub fn text_size(
     let (longest_line_width, num_lines) = i_slint_core::textlayout::text_size(
         &font,
         text,
-        max_width.map(|max_width| (LogicalLength::new(max_width) * scale_factor).cast()),
+        max_width.map(|max_width| (LogicalLength::new(max_width).cast() * scale_factor).cast()),
     );
 
-    PhysicalSize::from_lengths(longest_line_width, font.height() * (num_lines as i16)).cast()
-        / scale_factor
+    (PhysicalSize::from_lengths(longest_line_width, font.height() * (num_lines as i16)).cast()
+        / scale_factor)
+        .cast()
 }

--- a/internal/backends/mcu/lengths.rs
+++ b/internal/backends/mcu/lengths.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+use i_slint_core::Coord;
 pub struct PhysicalPx;
 pub type PhysicalLength = euclid::Length<i16, PhysicalPx>;
 pub type PhysicalRect = euclid::Rect<i16, PhysicalPx>;
@@ -8,10 +9,10 @@ pub type PhysicalSize = euclid::Size2D<i16, PhysicalPx>;
 pub type PhysicalPoint = euclid::Point2D<i16, PhysicalPx>;
 
 pub struct LogicalPx;
-pub type LogicalLength = euclid::Length<f32, LogicalPx>;
-pub type LogicalRect = euclid::Rect<f32, LogicalPx>;
-pub type LogicalPoint = euclid::Point2D<f32, LogicalPx>;
-pub type LogicalSize = euclid::Size2D<f32, LogicalPx>;
+pub type LogicalLength = euclid::Length<Coord, LogicalPx>;
+pub type LogicalRect = euclid::Rect<Coord, LogicalPx>;
+pub type LogicalPoint = euclid::Point2D<Coord, LogicalPx>;
+pub type LogicalSize = euclid::Size2D<Coord, LogicalPx>;
 
 pub type ScaleFactor = euclid::Scale<f32, LogicalPx, PhysicalPx>;
 

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -100,7 +100,7 @@ mod the_backend {
     use i_slint_core::items::ItemRef;
     use i_slint_core::window::PlatformWindow;
     use i_slint_core::window::Window;
-    use i_slint_core::{ImageInner, StaticTextures};
+    use i_slint_core::{Coord, ImageInner, StaticTextures};
 
     thread_local! { static WINDOWS: RefCell<Option<Rc<McuWindow>>> = RefCell::new(None) }
 
@@ -164,7 +164,7 @@ mod the_backend {
             &self,
             font_request: i_slint_core::graphics::FontRequest,
             text: &str,
-            max_width: Option<f32>,
+            max_width: Option<Coord>,
         ) -> Size {
             let runtime_window = self.self_weak.upgrade().unwrap();
             crate::fonts::text_size(
@@ -294,7 +294,7 @@ mod the_backend {
                             let w = window.self_weak.upgrade().unwrap();
                             // scale the event by the scale factor:
                             if let Some(p) = event.pos() {
-                                event.translate(p / w.scale_factor() - p);
+                                event.translate((p.cast() / w.scale_factor()).cast() - p);
                             }
                             w.process_mouse_input(event);
                         }

--- a/internal/backends/mcu/pico_st7789.rs
+++ b/internal/backends/mcu/pico_st7789.rs
@@ -136,7 +136,7 @@ impl<Display: Devices, IRQ: InputPin, CS: OutputPin<Error = IRQ::Error>, SPI: Tr
             .unwrap()
             .map(|point| {
                 let size = self.display.screen_size().to_f32();
-                let pos = euclid::point2(point.x * size.width, point.y * size.height);
+                let pos = euclid::point2(point.x * size.width, point.y * size.height).cast();
                 match self.last_touch.replace(pos) {
                     Some(_) => i_slint_core::input::MouseEvent::MouseMoved { pos },
                     None => i_slint_core::input::MouseEvent::MousePressed { pos, button },

--- a/internal/backends/mcu/renderer.rs
+++ b/internal/backends/mcu/renderer.rs
@@ -17,7 +17,7 @@ use i_slint_core::graphics::{FontRequest, IntRect, PixelFormat, Rect as RectF};
 use i_slint_core::item_rendering::{ItemRenderer, PartialRenderingCache};
 use i_slint_core::items::ImageFit;
 use i_slint_core::textlayout::TextParagraphLayout;
-use i_slint_core::{Color, ImageInner, StaticTextures};
+use i_slint_core::{Color, Coord, ImageInner, StaticTextures};
 
 type DirtyRegion = PhysicalRect;
 
@@ -328,18 +328,21 @@ fn prepare_scene(
             renderer.compute_dirty_regions(component, *origin);
         }
         renderer.combine_clip(
-            ((LogicalRect::from_untyped(&renderer.dirty_region.to_rect()) * factor).round_out()
+            ((LogicalRect::from_untyped(&renderer.dirty_region.to_rect()).cast() * factor)
+                .round_out()
                 / factor)
-                .to_untyped(),
-            0.,
-            0.,
+                .to_untyped()
+                .cast(),
+            0 as _,
+            0 as _,
         );
         compute_dirty_region_profiler.stop(devices);
         for (component, origin) in components {
             i_slint_core::item_rendering::render_component_items(component, &mut renderer, *origin);
         }
     });
-    let dirty_region = (LogicalRect::from_untyped(&renderer.dirty_region.to_rect()) * factor)
+    let dirty_region = (LogicalRect::from_untyped(&renderer.dirty_region.to_rect()).cast()
+        * factor)
         .round_out()
         .cast()
         .intersection(&PhysicalRect { origin: euclid::point2(0, 0), size })
@@ -375,7 +378,10 @@ impl PrepareScene {
             current_state: RenderState {
                 alpha: 1.,
                 offset: LogicalPoint::default(),
-                clip: LogicalRect::new(LogicalPoint::default(), size.cast() / scale_factor),
+                clip: LogicalRect::new(
+                    LogicalPoint::default(),
+                    (size.cast() / scale_factor).cast(),
+                ),
             },
             scale_factor,
             default_font,
@@ -399,7 +405,7 @@ impl PrepareScene {
     }
 
     fn new_scene_item(&mut self, geometry: LogicalRect, command: SceneCommand) {
-        let geometry = (geometry.translate(self.current_state.offset.to_vector())
+        let geometry = (geometry.translate(self.current_state.offset.to_vector()).cast()
             * self.scale_factor)
             .round()
             .cast();
@@ -427,20 +433,20 @@ impl PrepareScene {
             }
             ImageInner::EmbeddedImage(_) => todo!(),
             ImageInner::StaticTextures(StaticTextures { size, data, textures, .. }) => {
-                let sx = geom.width() / (size.width as f32);
-                let sy = geom.height() / (size.height as f32);
+                let sx = geom.width() as f32 / (size.width as f32);
+                let sy = geom.height() as f32 / (size.height as f32);
                 let mut image_fit_offset = euclid::Vector2D::default();
                 let (sx, sy) = match image_fit {
                     ImageFit::fill => (sx, sy),
                     ImageFit::cover => {
                         let ratio = f32::max(sx, sy);
-                        if size.width as f32 > geom.width() / ratio {
-                            let diff = (size.width as f32 - geom.width() / ratio) as i32;
+                        if size.width as f32 > geom.width() as f32 / ratio {
+                            let diff = (size.width as f32 - geom.width() as f32 / ratio) as i32;
                             source_clip.origin.x += diff / 2;
                             source_clip.size.width -= diff;
                         }
-                        if size.height as f32 > geom.height() / ratio {
-                            let diff = (size.height as f32 - geom.height() / ratio) as i32;
+                        if size.height as f32 > geom.height() as f32 / ratio {
+                            let diff = (size.height as f32 - geom.height() as f32 / ratio) as i32;
                             source_clip.origin.y += diff / 2;
                             source_clip.size.height -= diff;
                         }
@@ -448,17 +454,20 @@ impl PrepareScene {
                     }
                     ImageFit::contain => {
                         let ratio = f32::min(sx, sy);
-                        if (size.width as f32) < geom.width() / ratio {
-                            image_fit_offset.x = (geom.width() - size.width as f32 * ratio) / 2.;
+                        if (size.width as f32) < geom.width() as f32 / ratio {
+                            image_fit_offset.x =
+                                (geom.width() as f32 - size.width as f32 * ratio) / 2.;
                         }
-                        if (size.height as f32) < geom.height() / ratio {
-                            image_fit_offset.y = (geom.height() - size.height as f32 * ratio) / 2.;
+                        if (size.height as f32) < geom.height() as f32 / ratio {
+                            image_fit_offset.y =
+                                (geom.height() as f32 - size.height as f32 * ratio) / 2.;
                         }
                         (ratio, ratio)
                     }
                 };
 
-                let scaled_clip = self.current_state.clip.to_untyped().scale(1. / sx, 1. / sy);
+                let scaled_clip =
+                    self.current_state.clip.to_untyped().cast::<f32>().scale(1. / sx, 1. / sy);
                 for t in textures.as_slice() {
                     if let Some(clipped_src) = t
                         .rect
@@ -469,8 +478,9 @@ impl PrepareScene {
                         let actual_y = clipped_src.origin.y as usize - t.rect.origin.y as usize;
                         let stride = t.rect.width() as u16 * bpp(t.format);
                         self.new_scene_texture(
-                            LogicalRect::from_untyped(&clipped_src.scale(sx, sy))
-                                .translate(image_fit_offset),
+                            LogicalRect::from_untyped(
+                                &clipped_src.scale(sx, sy).translate(image_fit_offset).cast(),
+                            ),
                             SceneTexture {
                                 data: &data.as_slice()[(t.index
                                     + (stride as usize) * actual_y
@@ -522,17 +532,17 @@ impl i_slint_core::item_rendering::ItemRenderer for PrepareScene {
             let radius = rect.border_radius();
             // FIXME: gradients
             let color = rect.background().color();
-            if radius > 0. {
+            if radius > 0 as _ {
                 let radius = LogicalLength::new(radius)
-                    .min(geom.width_length() / 2.)
-                    .min(geom.height_length() / 2.);
+                    .min(geom.width_length() / 2 as Coord)
+                    .min(geom.height_length() / 2 as Coord);
                 if let Some(clipped) = geom.intersection(&self.current_state.clip) {
-                    let geom2 = geom * self.scale_factor;
-                    let clipped2 = clipped * self.scale_factor;
+                    let geom2 = geom.cast() * self.scale_factor;
+                    let clipped2 = clipped.cast() * self.scale_factor;
                     let rectangle_index = self.rounded_rectangles.len() as u16;
                     self.rounded_rectangles.push(RoundedRectangle {
-                        radius: (radius * self.scale_factor).cast(),
-                        width: (LogicalLength::new(border) * self.scale_factor).cast(),
+                        radius: (radius.cast() * self.scale_factor).cast(),
+                        width: (LogicalLength::new(border).cast() * self.scale_factor).cast(),
                         border_color: rect.border_color().color(),
                         inner_color: color,
                         top_clip: PhysicalLength::new((clipped2.min_y() - geom2.min_y()) as _),
@@ -555,7 +565,7 @@ impl i_slint_core::item_rendering::ItemRenderer for PrepareScene {
                     self.new_scene_rectangle(r, color);
                 }
             }
-            if border > 0.01 {
+            if border > 0.01 as Coord {
                 // FIXME: radius
                 // FIXME: gradients
                 let border_color = rect.border_color().color();
@@ -565,15 +575,11 @@ impl i_slint_core::item_rendering::ItemRenderer for PrepareScene {
                             self.new_scene_rectangle(r, border_color);
                         }
                     };
-                    add_border(euclid::rect(0., 0., geom.width(), border));
-                    add_border(euclid::rect(0., geom.height() - border, geom.width(), border));
-                    add_border(euclid::rect(0., border, border, geom.height() - border - border));
-                    add_border(euclid::rect(
-                        geom.width() - border,
-                        border,
-                        border,
-                        geom.height() - border - border,
-                    ));
+                    let b = border;
+                    add_border(euclid::rect(0 as _, 0 as _, geom.width(), b));
+                    add_border(euclid::rect(0 as _, geom.height() - b, geom.width(), b));
+                    add_border(euclid::rect(0 as _, b, b, geom.height() - b - b));
+                    add_border(euclid::rect(geom.width() - b, b, b, geom.height() - b - b));
                 }
             }
         }
@@ -629,7 +635,7 @@ impl i_slint_core::item_rendering::ItemRenderer for PrepareScene {
         let font = crate::fonts::match_font(&font_request, self.scale_factor);
 
         let color = text.color().color();
-        let max_size = (geom.size * self.scale_factor).cast();
+        let max_size = (geom.size.cast() * self.scale_factor).cast();
 
         let paragraph = TextParagraphLayout {
             string: &string,
@@ -660,16 +666,16 @@ impl i_slint_core::item_rendering::ItemRenderer for PrepareScene {
                 )
                 .cast();
 
-                if let Some(clipped_rect) =
-                    src_rect.intersection(&(self.current_state.clip * self.scale_factor))
-                {
+                if let Some(clipped_rect) = src_rect.intersection(
+                    &(self.current_state.clip.cast() * self.scale_factor).cast::<Coord>(),
+                ) {
                     let actual_x = clipped_rect.origin.x as usize - src_rect.origin.x as usize;
                     let actual_y = clipped_rect.origin.y as usize - src_rect.origin.y as usize;
 
                     let stride = bitmap_glyph.width().get() as u16;
 
                     self.new_scene_texture(
-                        clipped_rect / self.scale_factor,
+                        (clipped_rect.cast() / self.scale_factor).cast(),
                         SceneTexture {
                             data: &bitmap_glyph.data().as_slice()
                                 [actual_x + actual_y * stride as usize..],
@@ -697,7 +703,7 @@ impl i_slint_core::item_rendering::ItemRenderer for PrepareScene {
         // TODO
     }
 
-    fn combine_clip(&mut self, other: RectF, _radius: f32, _border_width: f32) {
+    fn combine_clip(&mut self, other: RectF, _radius: Coord, _border_width: Coord) {
         match self.current_state.clip.intersection(&LogicalRect::from_untyped(&other)) {
             Some(r) => {
                 self.current_state.clip = r;
@@ -713,7 +719,7 @@ impl i_slint_core::item_rendering::ItemRenderer for PrepareScene {
         self.current_state.clip.to_untyped()
     }
 
-    fn translate(&mut self, x: f32, y: f32) {
+    fn translate(&mut self, x: Coord, y: Coord) {
         self.current_state.offset.x += x;
         self.current_state.offset.y += y;
         self.current_state.clip = self.current_state.clip.translate((-x, -y).into())

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -12,7 +12,7 @@ use i_slint_core::input::KeyboardModifiers;
 use i_slint_core::items::ItemRef;
 use i_slint_core::layout::Orientation;
 use i_slint_core::window::{PlatformWindow, Window};
-use i_slint_core::Color;
+use i_slint_core::{Color, Coord};
 use rgb::FromSlice;
 
 use self::event_loop::WinitWindow;
@@ -108,7 +108,7 @@ impl PlatformWindow for SimulatorWindow {
                 layout_info_h.preferred_bounded(),
                 layout_info_v.preferred_bounded(),
             );
-            if s.width > 0. && s.height > 0. {
+            if s.width > 0 as Coord && s.height > 0 as Coord {
                 // Make sure that the window's inner size is in sync with the root window item's
                 // width/height.
                 runtime_window.set_window_item_geometry(s.width, s.height);
@@ -195,7 +195,7 @@ impl PlatformWindow for SimulatorWindow {
         &self,
         font_request: i_slint_core::graphics::FontRequest,
         text: &str,
-        max_width: Option<f32>,
+        max_width: Option<Coord>,
     ) -> i_slint_core::graphics::Size {
         let runtime_window = self.self_weak.upgrade().unwrap();
         crate::fonts::text_size(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -67,8 +67,8 @@ fn rust_type(ty: &Type) -> Option<proc_macro2::TokenStream> {
         Type::Color => Some(quote!(slint::re_exports::Color)),
         Type::Duration => Some(quote!(i64)),
         Type::Angle => Some(quote!(f32)),
-        Type::PhysicalLength => Some(quote!(f32)),
-        Type::LogicalLength => Some(quote!(f32)),
+        Type::PhysicalLength => Some(quote!(slint::re_exports::Coord)),
+        Type::LogicalLength => Some(quote!(slint::re_exports::Coord)),
         Type::Percent => Some(quote!(f32)),
         Type::Bool => Some(quote!(bool)),
         Type::Image => Some(quote!(slint::re_exports::Image)),
@@ -87,7 +87,9 @@ fn rust_type(ty: &Type) -> Option<proc_macro2::TokenStream> {
             Some(quote!(slint::re_exports::#e))
         }
         Type::Brush => Some(quote!(slint::Brush)),
-        Type::LayoutCache => Some(quote!(SharedVector<f32>)),
+        Type::LayoutCache => {
+            Some(quote!(slint::re_exports::SharedVector<slint::re_exports::Coord>))
+        }
         _ => None,
     }
 }
@@ -1229,8 +1231,8 @@ fn generate_repeated_component(
         quote! {
             fn listview_layout(
                 self: core::pin::Pin<&Self>,
-                offset_y: &mut f32,
-                viewport_width: core::pin::Pin<&slint::re_exports::Property<f32>>,
+                offset_y: &mut slint::re_exports::Coord,
+                viewport_width: core::pin::Pin<&slint::re_exports::Property<slint::re_exports::Coord>>,
             ) {
                 use slint::re_exports::*;
                 let _self = self;
@@ -1826,7 +1828,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                 let offset = compile_expression(ri, ctx);
                 quote!({
                     let cache = #cache.get();
-                    *cache.get((cache[#index] as usize) + #offset as usize * 2).unwrap_or(&0.)
+                    *cache.get((cache[#index] as usize) + #offset as usize * 2).unwrap_or(&(0 as slint::re_exports::Coord))
                 })
             } else {
                 quote!(#cache.get()[#index])
@@ -1906,7 +1908,7 @@ fn compile_builtin_function_call(
                 quote!(
                     #window_tokens.show_popup(
                         &VRc::into_dyn(#popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone()).into()),
-                        Point::new(#x as f32, #y as f32),
+                        Point::new(#x as slint::re_exports::Coord, #y as slint::re_exports::Coord),
                         #parent_component
                     );
                 )

--- a/internal/core/flickable.rs
+++ b/internal/core/flickable.rs
@@ -11,13 +11,15 @@ use crate::graphics::Point;
 use crate::input::{InputEventFilterResult, InputEventResult, MouseEvent};
 use crate::items::PointerEventButton;
 use crate::items::{Flickable, PropertyAnimation, Rectangle};
+use crate::Coord;
 use core::cell::RefCell;
 use core::pin::Pin;
 #[cfg(not(feature = "std"))]
+#[allow(unused)]
 use num_traits::Float;
 
 /// The distance required before it starts flicking if there is another item intercepting the mouse.
-const DISTANCE_THRESHOLD: f32 = 8.;
+const DISTANCE_THRESHOLD: Coord = 8 as _;
 /// Time required before we stop caring about child event if the mouse hasn't been moved
 const DURATION_THRESHOLD: Duration = Duration::from_millis(500);
 
@@ -160,14 +162,14 @@ impl FlickableData {
 
     fn mouse_released(inner: &mut FlickableDataInner, flick: Pin<&Flickable>, event: MouseEvent) {
         if let (Some(pressed_time), Some(pos)) = (inner.pressed_time, event.pos()) {
-            let dist = pos - inner.pressed_pos;
+            let dist = (pos - inner.pressed_pos).cast::<f32>();
             let speed =
                 dist / ((crate::animations::current_tick() - pressed_time).as_millis() as f32);
 
             let duration = 100;
             let final_pos = ensure_in_bound(
                 flick,
-                inner.pressed_viewport_pos + dist + speed * (duration as f32),
+                (inner.pressed_viewport_pos.cast() + dist + speed * (duration as f32)).cast(),
             );
             let anim = PropertyAnimation {
                 duration,
@@ -197,6 +199,6 @@ fn ensure_in_bound(flick: Pin<&Flickable>, p: Point) -> Point {
         .get();
 
     let min = Point::new(w - vw, h - vh);
-    let max = Point::new(0., 0.);
+    let max = Point::new(0 as _, 0 as _);
     p.max(min).min(max)
 }

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -11,22 +11,23 @@
     created by the backend in a type-erased manner.
 */
 extern crate alloc;
+use crate::Coord;
 use crate::SharedString;
 use alloc::boxed::Box;
 
 pub use euclid;
 /// 2D Rectangle
-pub type Rect = euclid::default::Rect<f32>;
+pub type Rect = euclid::default::Rect<Coord>;
 /// 2D Rectangle with integer coordinates
 pub type IntRect = euclid::default::Rect<i32>;
 /// 2D Point
-pub type Point = euclid::default::Point2D<f32>;
+pub type Point = euclid::default::Point2D<Coord>;
 /// 2D Size
-pub type Size = euclid::default::Size2D<f32>;
+pub type Size = euclid::default::Size2D<Coord>;
 /// 2D Size in integer coordinates
 pub type IntSize = euclid::default::Size2D<u32>;
 /// 2D Transform
-pub type Transform = euclid::default::Transform2D<f32>;
+pub type Transform = euclid::default::Transform2D<Coord>;
 
 pub(crate) mod color;
 pub use color::*;
@@ -134,10 +135,10 @@ pub struct FontRequest {
     /// If the weight is None, the system default font weight should be used.
     pub weight: Option<i32>,
     /// If the pixel size is None, the system default font size should be used.
-    pub pixel_size: Option<f32>,
+    pub pixel_size: Option<Coord>,
     /// The additional spacing (or shrinking if negative) between glyphs. This is usually not submitted to
     /// the font-subsystem but collected here for API convenience
-    pub letter_spacing: Option<f32>,
+    pub letter_spacing: Option<Coord>,
 }
 
 impl FontRequest {

--- a/internal/core/graphics/brush.rs
+++ b/internal/core/graphics/brush.rs
@@ -5,9 +5,10 @@
 This module contains brush related types for the run-time library.
 */
 
-use super::{Color, Point};
+use super::Color;
 use crate::properties::InterpolatedPropertyValue;
 use crate::SharedVector;
+use euclid::default::Point2D;
 
 #[cfg(not(feature = "std"))]
 use num_traits::float::Float;
@@ -106,13 +107,13 @@ pub struct GradientStop {
 }
 
 /// Returns the start / end points of a gradient within the [-0.5; 0.5] unit square, based on the angle (in degree).
-pub fn line_for_angle(angle: f32) -> (Point, Point) {
+pub fn line_for_angle(angle: f32) -> (Point2D<f32>, Point2D<f32>) {
     let angle = angle.to_radians();
     let r = (angle.sin().abs() + angle.cos().abs()) / 2.;
     let (y, x) = (angle - core::f32::consts::PI / 2.).sin_cos();
     let (y, x) = (y * r, x * r);
-    let start = Point::new(0.5 - x, 0.5 - y);
-    let end = Point::new(0.5 + x, 0.5 + y);
+    let start = Point2D::new(0.5 - x, 0.5 - y);
+    let end = Point2D::new(0.5 + x, 0.5 + y);
     (start, end)
 }
 

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -5,7 +5,6 @@
 This module contains path related types and functions for the run-time library.
 */
 
-use super::{Point, Rect, Size};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use auto_enums::auto_enum;
@@ -157,9 +156,9 @@ pub enum PathEvent {
 
 struct ToLyonPathEventIterator<'a> {
     events_it: core::slice::Iter<'a, PathEvent>,
-    coordinates_it: core::slice::Iter<'a, Point>,
-    first: Option<&'a Point>,
-    last: Option<&'a Point>,
+    coordinates_it: core::slice::Iter<'a, lyon_path::math::Point>,
+    first: Option<&'a lyon_path::math::Point>,
+    last: Option<&'a lyon_path::math::Point>,
 }
 
 impl<'a> Iterator for ToLyonPathEventIterator<'a> {
@@ -236,7 +235,7 @@ pub struct PathDataIterator {
 
 enum LyonPathIteratorVariant {
     FromPath(lyon_path::Path),
-    FromEvents(crate::SharedVector<PathEvent>, crate::SharedVector<Point>),
+    FromEvents(crate::SharedVector<PathEvent>, crate::SharedVector<lyon_path::math::Point>),
 }
 
 impl PathDataIterator {
@@ -267,13 +266,13 @@ impl PathDataIterator {
     /// Applies a transformation on the elements this iterator provides that tries to fit everything
     /// into the specified width/height, respecting the provided viewbox. If no viewbox is specified,
     /// the bounding rectangle of the path is used.
-    pub fn fit(&mut self, width: f32, height: f32, viewbox: Option<Rect>) {
+    pub fn fit(&mut self, width: f32, height: f32, viewbox: Option<lyon_path::math::Rect>) {
         if width > 0. || height > 0. {
             let viewbox =
                 viewbox.unwrap_or_else(|| lyon_algorithms::aabb::bounding_rect(self.iter()));
             self.transform = lyon_algorithms::fit::fit_rectangle(
                 &viewbox,
-                &Rect::from_size(Size::new(width, height)),
+                &lyon_path::math::Rect::from_size(lyon_path::math::Size::new(width, height)),
                 lyon_algorithms::fit::FitStyle::Min,
             );
         }
@@ -291,7 +290,7 @@ pub enum PathData {
     Elements(crate::SharedVector<PathElement>),
     /// The Events variant describes the path as a series of low-level events and
     /// associated coordinates.
-    Events(crate::SharedVector<PathEvent>, crate::SharedVector<Point>),
+    Events(crate::SharedVector<PathEvent>, crate::SharedVector<lyon_path::math::Point>),
     /// The Commands variant describes the path as a series of SVG encoded path commands.
     Commands(crate::SharedString),
 }

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -9,8 +9,8 @@ use crate::graphics::Point;
 use crate::item_tree::{ItemRc, ItemVisitorResult, ItemWeak, VisitChildrenResult};
 use crate::items::{ItemRef, PointerEventButton, TextCursorDirection};
 use crate::window::WindowRc;
-use crate::Property;
 use crate::{component::ComponentRc, SharedString};
+use crate::{Coord, Property};
 use alloc::rc::Rc;
 use alloc::vec::Vec;
 use const_field_offset::FieldOffsets;
@@ -49,7 +49,7 @@ impl MouseEvent {
     }
 
     /// Translate the position by the given value
-    pub fn translate(&mut self, vec: Vector2D<f32>) {
+    pub fn translate(&mut self, vec: Vector2D<Coord>) {
         let pos = match self {
             MouseEvent::MousePressed { pos, .. } => Some(pos),
             MouseEvent::MouseReleased { pos, .. } => Some(pos),
@@ -448,7 +448,7 @@ pub fn process_mouse_input(
     send_exit_events(&mouse_input_state, mouse_event.pos(), window);
 
     let mut result = MouseInputState::default();
-    type State = (Vector2D<f32>, Vec<(ItemWeak, InputEventFilterResult)>);
+    type State = (Vector2D<Coord>, Vec<(ItemWeak, InputEventFilterResult)>);
     crate::item_tree::visit_items_with_post_visit(
         &component,
         crate::item_tree::TraversalOrder::FrontToBack,
@@ -522,7 +522,7 @@ pub fn process_mouse_input(
             }
             r
         },
-        (Vector2D::new(0., 0.), Vec::new()),
+        (Vector2D::new(0 as Coord, 0 as Coord), Vec::new()),
     );
     result
 }

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -11,6 +11,7 @@ use crate::graphics::{CachedGraphicsData, Point, Rect};
 use crate::item_tree::{
     ItemRc, ItemVisitor, ItemVisitorResult, ItemVisitorVTable, VisitChildrenResult,
 };
+use crate::Coord;
 use alloc::boxed::Box;
 use core::cell::{Cell, RefCell};
 use core::pin::Pin;
@@ -233,7 +234,7 @@ pub trait ItemRenderer {
         if clip_item.clip() {
             let geometry = clip_item.geometry();
             self.combine_clip(
-                euclid::rect(0., 0., geometry.width(), geometry.height()),
+                euclid::rect(0 as Coord, 0 as Coord, geometry.width(), geometry.height()),
                 clip_item.border_radius(),
                 clip_item.border_width(),
             )
@@ -244,11 +245,11 @@ pub trait ItemRenderer {
     /// Clip the further call until restore_state.
     /// radius/border_width can be used for border rectangle clip.
     /// (FIXME: consider removing radius/border_width and have another  function that take a path instead)
-    fn combine_clip(&mut self, rect: Rect, radius: f32, border_width: f32);
+    fn combine_clip(&mut self, rect: Rect, radius: Coord, border_width: Coord);
     /// Get the current clip bounding box in the current transformed coordinate.
     fn get_current_clip(&self) -> Rect;
 
-    fn translate(&mut self, x: f32, y: f32);
+    fn translate(&mut self, x: Coord, y: Coord);
     fn rotate(&mut self, angle_in_degrees: f32);
     /// Apply the opacity (between 0 and 1) for all following items until the next call to restore_state.
     fn apply_opacity(&mut self, opacity: f32);
@@ -299,7 +300,7 @@ pub trait ItemRenderer {
 pub type PartialRenderingCache = RenderingCache<Rect>;
 
 /// FIXME: Should actually be a region and not just a rectangle
-pub type DirtyRegion = euclid::default::Box2D<f32>;
+pub type DirtyRegion = euclid::default::Box2D<Coord>;
 
 /// Put this structure in the renderer to help with partial rendering
 pub struct PartialRenderer<'a, T> {
@@ -347,7 +348,7 @@ impl<'a, T> PartialRenderer<'a, T> {
         });
     }
 
-    fn mark_dirty_rect(&mut self, rect: Rect, offset: euclid::default::Vector2D<f32>) {
+    fn mark_dirty_rect(&mut self, rect: Rect, offset: euclid::default::Vector2D<Coord>) {
         if !rect.is_empty() {
             self.dirty_region = self.dirty_region.union(&rect.translate(offset).to_box2d());
         }
@@ -431,7 +432,7 @@ impl<'a, T: ItemRenderer> ItemRenderer for PartialRenderer<'a, T> {
     forward_rendering_call!(fn draw_path(Path));
     forward_rendering_call!(fn draw_box_shadow(BoxShadow));
 
-    fn combine_clip(&mut self, rect: Rect, radius: f32, border_width: f32) {
+    fn combine_clip(&mut self, rect: Rect, radius: Coord, border_width: Coord) {
         self.actual_renderer.combine_clip(rect, radius, border_width)
     }
 
@@ -439,7 +440,7 @@ impl<'a, T: ItemRenderer> ItemRenderer for PartialRenderer<'a, T> {
         self.actual_renderer.get_current_clip()
     }
 
-    fn translate(&mut self, x: f32, y: f32) {
+    fn translate(&mut self, x: Coord, y: Coord) {
         self.actual_renderer.translate(x, y)
     }
 

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -122,7 +122,7 @@ impl ItemRc {
         let is_clipping = crate::item_rendering::is_enabled_clipping_item(item);
         let geometry = item.as_ref().geometry();
 
-        if is_clipping && (geometry.width() == 0.0 || geometry.height() == 0.0) {
+        if is_clipping && (geometry.width() <= 0.01 as _ || geometry.height() <= 0.01 as _) {
             return false;
         }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -31,7 +31,7 @@ use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use crate::window::WindowRc;
-use crate::{Callback, Property, SharedString};
+use crate::{Callback, Coord, Property, SharedString};
 use alloc::boxed::Box;
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
@@ -172,10 +172,10 @@ pub type ItemRef<'a> = vtable::VRef<'a, ItemVTable>;
 /// The implementation of the `Rectangle` element
 pub struct Rectangle {
     pub background: Property<Brush>,
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub cached_rendering_data: CachedRenderingData,
 }
 
@@ -243,12 +243,12 @@ declare_item_vtable! {
 /// The implementation of the `BorderRectangle` element
 pub struct BorderRectangle {
     pub background: Property<Brush>,
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
-    pub border_width: Property<f32>,
-    pub border_radius: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
+    pub border_width: Property<Coord>,
+    pub border_radius: Property<Coord>,
     pub border_color: Property<Brush>,
     pub cached_rendering_data: CachedRenderingData,
 }
@@ -363,10 +363,10 @@ impl Default for MouseCursor {
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
 pub struct TouchArea {
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub enabled: Property<bool>,
     /// FIXME: We should annotate this as an "output" property.
     pub pressed: Property<bool>,
@@ -374,11 +374,11 @@ pub struct TouchArea {
     /// FIXME: there should be just one property for the point instead of two.
     /// Could even be merged with pressed in a Property<Option<Point>> (of course, in the
     /// implementation item only, for the compiler it would stay separate properties)
-    pub pressed_x: Property<f32>,
-    pub pressed_y: Property<f32>,
+    pub pressed_x: Property<Coord>,
+    pub pressed_y: Property<Coord>,
     /// FIXME: should maybe be as parameter to the mouse event instead. Or at least just one property
-    pub mouse_x: Property<f32>,
-    pub mouse_y: Property<f32>,
+    pub mouse_x: Property<Coord>,
+    pub mouse_y: Property<Coord>,
     pub mouse_cursor: Property<MouseCursor>,
     pub clicked: Callback<VoidArg>,
     pub moved: Callback<VoidArg>,
@@ -436,7 +436,7 @@ impl Item for TouchArea {
         }
         let result = if let MouseEvent::MouseReleased { pos, button } = event {
             if button == PointerEventButton::left
-                && euclid::rect(0., 0., self.width(), self.height()).contains(pos)
+                && euclid::rect(0 as Coord, 0 as Coord, self.width(), self.height()).contains(pos)
             {
                 Self::FIELD_OFFSETS.clicked.apply_pin(self).call(&());
             }
@@ -544,10 +544,10 @@ impl Default for EventResult {
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
 pub struct FocusScope {
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub has_focus: Property<bool>,
     pub key_pressed: Callback<KeyEventArg, EventResult>,
     pub key_released: Callback<KeyEventArg, EventResult>,
@@ -642,12 +642,12 @@ declare_item_vtable! {
 #[pin]
 /// The implementation of the `Clip` element
 pub struct Clip {
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
-    pub border_radius: Property<f32>,
-    pub border_width: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
+    pub border_radius: Property<Coord>,
+    pub border_width: Property<Coord>,
     pub cached_rendering_data: CachedRenderingData,
     pub clip: Property<bool>,
 }
@@ -671,7 +671,10 @@ impl Item for Clip {
     ) -> InputEventFilterResult {
         if let Some(pos) = event.pos() {
             if self.clip()
-                && (pos.x < 0. || pos.y < 0. || pos.x > self.width() || pos.y > self.height())
+                && (pos.x < 0 as Coord
+                    || pos.y < 0 as Coord
+                    || pos.x > self.width()
+                    || pos.y > self.height())
             {
                 return InputEventFilterResult::Intercept;
             }
@@ -720,10 +723,10 @@ declare_item_vtable! {
 /// The Opacity Item is not meant to be used directly by the .slint code, instead, the `opacity: xxx` or `visible: false` should be used
 pub struct Opacity {
     // FIXME: this element shouldn't need these geometry property
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub opacity: Property<f32>,
     pub cached_rendering_data: CachedRenderingData,
 }
@@ -822,10 +825,10 @@ declare_item_vtable! {
 /// The Layer Item is not meant to be used directly by the .slint code, instead, the `layer: xxx` property should be used
 pub struct Layer {
     // FIXME: this element shouldn't need these geometry property
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub cache_rendering_hint: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
 }
@@ -893,10 +896,10 @@ declare_item_vtable! {
 /// The implementation of the `Rotate` element
 pub struct Rotate {
     pub angle: Property<f32>,
-    pub origin_x: Property<f32>,
-    pub origin_y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub origin_x: Property<Coord>,
+    pub origin_y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub cached_rendering_data: CachedRenderingData,
 }
 
@@ -904,7 +907,7 @@ impl Item for Rotate {
     fn init(self: Pin<&Self>, _window: &WindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
-        euclid::rect(0., 0., 0., 0.)
+        euclid::rect(0, 0, 0, 0).cast()
     }
 
     fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
@@ -965,10 +968,10 @@ declare_item_vtable! {
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
 pub struct Flickable {
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub viewport: Rectangle,
     pub interactive: Property<bool>,
     data: FlickableDataBox,
@@ -995,7 +998,7 @@ impl Item for Flickable {
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.pos() {
-            if pos.x < 0. || pos.y < 0. || pos.x > self.width() || pos.y > self.height() {
+            if pos.x < 0 as _ || pos.y < 0 as _ || pos.x > self.width() || pos.y > self.height() {
                 return InputEventFilterResult::Intercept;
             }
         }
@@ -1016,7 +1019,10 @@ impl Item for Flickable {
         }
         if let Some(pos) = event.pos() {
             if matches!(event, MouseEvent::MouseWheel { .. } | MouseEvent::MousePressed { .. })
-                && (pos.x < 0. || pos.y < 0. || pos.x > self.width() || pos.y > self.height())
+                && (pos.x < 0 as _
+                    || pos.y < 0 as _
+                    || pos.x > self.width()
+                    || pos.y > self.height())
             {
                 return InputEventResult::EventIgnored;
             }
@@ -1039,7 +1045,11 @@ impl Item for Flickable {
         _self_rc: &ItemRc,
     ) -> RenderingResult {
         let geometry = self.geometry();
-        (*backend).combine_clip(euclid::rect(0., 0., geometry.width(), geometry.height()), 0., 0.);
+        (*backend).combine_clip(
+            euclid::rect(0 as _, 0 as _, geometry.width(), geometry.height()),
+            0 as _,
+            0 as _,
+        );
         RenderingResult::ContinueRenderingChildren
     }
 }
@@ -1123,14 +1133,14 @@ impl Default for PropertyAnimation {
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
 pub struct WindowItem {
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub background: Property<Color>,
     pub title: Property<SharedString>,
     pub no_frame: Property<bool>,
     pub icon: Property<crate::graphics::Image>,
     pub default_font_family: Property<SharedString>,
-    pub default_font_size: Property<f32>,
+    pub default_font_size: Property<Coord>,
     pub default_font_weight: Property<i32>,
     pub cached_rendering_data: CachedRenderingData,
 }
@@ -1139,7 +1149,7 @@ impl Item for WindowItem {
     fn init(self: Pin<&Self>, _window: &WindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
-        euclid::rect(0., 0., self.width(), self.height())
+        euclid::rect(0 as _, 0 as _, self.width(), self.height())
     }
 
     fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
@@ -1195,7 +1205,7 @@ impl WindowItem {
             },
             pixel_size: {
                 let font_size = self.default_font_size();
-                if font_size == 0.0 {
+                if font_size <= 0 as Coord {
                     None
                 } else {
                     Some(font_size)
@@ -1229,16 +1239,16 @@ declare_item_vtable! {
 #[pin]
 pub struct BoxShadow {
     // Rectangle properties
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
-    pub border_radius: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
+    pub border_radius: Property<Coord>,
     // Shadow specific properties
-    pub offset_x: Property<f32>,
-    pub offset_y: Property<f32>,
+    pub offset_x: Property<Coord>,
+    pub offset_y: Property<Coord>,
     pub color: Property<Color>,
-    pub blur: Property<f32>,
+    pub blur: Property<Coord>,
     pub cached_rendering_data: CachedRenderingData,
 }
 

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -19,7 +19,7 @@ use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use crate::window::WindowRc;
-use crate::{Brush, Property};
+use crate::{Brush, Coord, Property};
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
 use i_slint_core_macros::*;
@@ -59,10 +59,10 @@ impl Default for ImageRendering {
 /// The implementation of the `Image` element
 pub struct ImageItem {
     pub source: Property<crate::graphics::Image>,
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub image_fit: Property<ImageFit>,
     pub image_rendering: Property<ImageRendering>,
     pub cached_rendering_data: CachedRenderingData,
@@ -79,10 +79,10 @@ impl Item for ImageItem {
         let natural_size = self.source().size();
         LayoutInfo {
             preferred: match orientation {
-                _ if natural_size.width == 0 || natural_size.height == 0 => 0.,
-                Orientation::Horizontal => natural_size.width as f32,
+                _ if natural_size.width == 0 || natural_size.height == 0 => 0 as Coord,
+                Orientation::Horizontal => natural_size.width as Coord,
                 Orientation::Vertical => {
-                    natural_size.height as f32 * self.width() / natural_size.width as f32
+                    natural_size.height as Coord * self.width() / natural_size.width as Coord
                 }
             },
             ..Default::default()
@@ -138,10 +138,10 @@ impl ItemConsts for ImageItem {
 /// The implementation of the `ClippedImage` element
 pub struct ClippedImage {
     pub source: Property<crate::graphics::Image>,
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub image_fit: Property<ImageFit>,
     pub image_rendering: Property<ImageRendering>,
     pub colorize: Property<Brush>,
@@ -163,10 +163,10 @@ impl Item for ClippedImage {
         let natural_size = self.source().size();
         LayoutInfo {
             preferred: match orientation {
-                _ if natural_size.width == 0 || natural_size.height == 0 => 0.,
-                Orientation::Horizontal => natural_size.width as f32,
+                _ if natural_size.width == 0 || natural_size.height == 0 => 0 as Coord,
+                Orientation::Horizontal => natural_size.width as Coord,
                 Orientation::Vertical => {
-                    natural_size.height as f32 * self.width() / natural_size.width as f32
+                    natural_size.height as Coord * self.width() / natural_size.width as Coord
                 }
             },
             ..Default::default()

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -20,7 +20,7 @@ use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use crate::window::WindowRc;
-use crate::Property;
+use crate::{Coord, Property};
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
 use i_slint_core_macros::*;
@@ -44,15 +44,15 @@ impl Default for FillRule {
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
 pub struct Path {
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub elements: Property<PathData>,
     pub fill: Property<Brush>,
     pub fill_rule: Property<FillRule>,
     pub stroke: Property<Brush>,
-    pub stroke_width: Property<f32>,
+    pub stroke_width: Property<Coord>,
     pub viewbox_x: Property<f32>,
     pub viewbox_y: Property<f32>,
     pub viewbox_width: Property<f32>,
@@ -80,7 +80,10 @@ impl Item for Path {
     ) -> InputEventFilterResult {
         if let Some(pos) = event.pos() {
             if self.clip()
-                && (pos.x < 0. || pos.y < 0. || pos.x > self.width() || pos.y > self.height())
+                && (pos.x < 0 as _
+                    || pos.y < 0 as _
+                    || pos.x > self.width()
+                    || pos.y > self.height())
             {
                 return InputEventFilterResult::Intercept;
             }
@@ -113,7 +116,7 @@ impl Item for Path {
         let clip = self.clip();
         if clip {
             (*backend).save_state();
-            (*backend).combine_clip(self.geometry(), 0., 0.)
+            (*backend).combine_clip(self.geometry(), 0 as _, 0 as _)
         }
         (*backend).draw_path(self);
         if clip {
@@ -129,11 +132,12 @@ impl Path {
     /// width.
     pub fn fitted_path_events(
         self: Pin<&Self>,
-    ) -> (euclid::default::Vector2D<f32>, PathDataIterator) {
+    ) -> (euclid::default::Vector2D<Coord>, PathDataIterator) {
         let stroke_width = self.stroke_width();
-        let bounds_width = (self.width() - stroke_width).max(0.);
-        let bounds_height = (self.height() - stroke_width).max(0.);
-        let offset = euclid::default::Vector2D::new(stroke_width / 2., stroke_width / 2.);
+        let bounds_width = (self.width() - stroke_width).max(0 as _);
+        let bounds_height = (self.height() - stroke_width).max(0 as _);
+        let offset =
+            euclid::default::Vector2D::new(stroke_width / 2 as Coord, stroke_width / 2 as Coord);
 
         let viewbox_width = self.viewbox_width();
         let viewbox_height = self.viewbox_height();
@@ -146,7 +150,7 @@ impl Path {
             None
         };
 
-        elements_iter.fit(bounds_width, bounds_height, maybe_viewbox);
+        elements_iter.fit(bounds_width as _, bounds_height as _, maybe_viewbox);
         (offset, elements_iter)
     }
 }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -19,15 +19,14 @@ use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use crate::window::WindowRc;
-use crate::{Callback, Property, SharedString};
+use crate::{Callback, Coord, Property, SharedString};
 use alloc::string::String;
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
+#[allow(unused)]
+use euclid::num::Ceil;
 use i_slint_core_macros::*;
 use unicode_segmentation::UnicodeSegmentation;
-
-#[cfg(not(feature = "std"))]
-use num_traits::float::Float;
 
 /// This enum defines the input type in a text input which for now only distinguishes a normal
 /// input from a password input
@@ -111,18 +110,18 @@ impl Default for TextOverflow {
 pub struct Text {
     pub text: Property<SharedString>,
     pub font_family: Property<SharedString>,
-    pub font_size: Property<f32>,
+    pub font_size: Property<Coord>,
     pub font_weight: Property<i32>,
     pub color: Property<Brush>,
     pub horizontal_alignment: Property<TextHorizontalAlignment>,
     pub vertical_alignment: Property<TextVerticalAlignment>,
     pub wrap: Property<TextWrap>,
     pub overflow: Property<TextOverflow>,
-    pub letter_spacing: Property<f32>,
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub letter_spacing: Property<Coord>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub cached_rendering_data: CachedRenderingData,
 }
 
@@ -150,7 +149,7 @@ impl Item for Text {
                         .min(window.text_size(self.unresolved_font_request(), "…", None).width),
                     TextOverflow::clip => match self.wrap() {
                         TextWrap::no_wrap => implicit_size.width,
-                        TextWrap::word_wrap => 0.,
+                        TextWrap::word_wrap => 0 as _,
                     },
                 };
                 LayoutInfo {
@@ -232,7 +231,7 @@ impl Text {
             },
             pixel_size: {
                 let font_size = self.font_size();
-                if font_size == 0.0 {
+                if font_size == 0 as _ {
                     None
                 } else {
                     Some(font_size)
@@ -250,7 +249,7 @@ impl Text {
 pub struct TextInput {
     pub text: Property<SharedString>,
     pub font_family: Property<SharedString>,
-    pub font_size: Property<f32>,
+    pub font_size: Property<Coord>,
     pub font_weight: Property<i32>,
     pub color: Property<Brush>,
     pub selection_foreground_color: Property<Color>,
@@ -259,14 +258,14 @@ pub struct TextInput {
     pub vertical_alignment: Property<TextVerticalAlignment>,
     pub wrap: Property<TextWrap>,
     pub input_type: Property<InputType>,
-    pub letter_spacing: Property<f32>,
-    pub x: Property<f32>,
-    pub y: Property<f32>,
-    pub width: Property<f32>,
-    pub height: Property<f32>,
+    pub letter_spacing: Property<Coord>,
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
+    pub width: Property<Coord>,
+    pub height: Property<Coord>,
     pub cursor_position: Property<i32>, // byte offset,
     pub anchor_position: Property<i32>, // byte offset
-    pub text_cursor_width: Property<f32>,
+    pub text_cursor_width: Property<Coord>,
     pub cursor_visible: Property<bool>,
     pub has_focus: Property<bool>,
     pub enabled: Property<bool>,
@@ -278,7 +277,7 @@ pub struct TextInput {
     pub cached_rendering_data: CachedRenderingData,
     // The x position where the cursor wants to be.
     // It is not updated when moving up and down even when the line is shorter.
-    preferred_x_pos: core::cell::Cell<f32>,
+    preferred_x_pos: core::cell::Cell<Coord>,
 }
 
 impl Item for TextInput {
@@ -313,7 +312,7 @@ impl Item for TextInput {
                 let implicit_size = implicit_size(None);
                 let min = match self.wrap() {
                     TextWrap::no_wrap => implicit_size.width,
-                    TextWrap::word_wrap => 0.,
+                    TextWrap::word_wrap => 0 as _,
                 };
                 LayoutInfo {
                     min: min.ceil(),
@@ -640,7 +639,7 @@ impl TextInput {
                     window.text_input_cursor_rect_for_byte_offset(self, last_cursor_pos);
                 let mut cursor_xy_pos = cursor_rect.center();
 
-                cursor_xy_pos.x = 0.0;
+                cursor_xy_pos.x = 0 as Coord;
                 window.text_input_byte_offset_for_position(self, cursor_xy_pos)
             }
             TextCursorDirection::EndOfLine => {
@@ -648,7 +647,7 @@ impl TextInput {
                     window.text_input_cursor_rect_for_byte_offset(self, last_cursor_pos);
                 let mut cursor_xy_pos = cursor_rect.center();
 
-                cursor_xy_pos.x = f32::MAX;
+                cursor_xy_pos.x = Coord::MAX;
                 window.text_input_byte_offset_for_position(self, cursor_xy_pos)
             }
             TextCursorDirection::StartOfParagraph => text
@@ -819,7 +818,7 @@ impl TextInput {
             },
             pixel_size: {
                 let font_size = self.font_size();
-                if font_size == 0.0 {
+                if font_size == 0 as _ {
                     None
                 } else {
                     Some(font_size)

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -118,6 +118,11 @@ pub use graphics::RgbaColor;
 #[doc(inline)]
 pub use graphics::PathData;
 
+#[cfg(not(slint_int_coord))]
+pub type Coord = f32;
+#[cfg(slint_int_coord)]
+pub type Coord = i32;
+
 /// One need to use at least one function in each module in order to get them
 /// exported in the final binary.
 /// This only use functions from modules which are not otherwise used.

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -7,6 +7,7 @@
 
 use crate::input::{KeyEvent, KeyEventType, KeyboardModifiers, MouseEvent};
 use crate::window::WindowRc;
+use crate::Coord;
 use crate::SharedString;
 
 /// Slint animations do not use real time, but use a mocked time.
@@ -26,8 +27,8 @@ pub extern "C" fn slint_mock_elapsed_time(time_in_ms: u64) {
 #[no_mangle]
 pub extern "C" fn slint_send_mouse_click(
     component: &crate::component::ComponentRc,
-    x: f32,
-    y: f32,
+    x: Coord,
+    y: Coord,
     window: &WindowRc,
 ) {
     let mut state = crate::input::MouseInputState::default();

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -15,7 +15,7 @@ use crate::input::{
 use crate::item_tree::ItemRc;
 use crate::items::{ItemRef, MouseCursor};
 use crate::properties::{Property, PropertyTracker};
-use crate::Callback;
+use crate::{Callback, Coord};
 use alloc::boxed::Box;
 use alloc::rc::{Rc, Weak};
 use core::cell::{Cell, RefCell};
@@ -79,7 +79,7 @@ pub trait PlatformWindow {
         &self,
         font_request: crate::graphics::FontRequest,
         text: &str,
-        max_width: Option<f32>,
+        max_width: Option<Coord>,
     ) -> Size;
 
     /// Returns the (UTF-8) byte offset in the text property that refers to the character that contributed to
@@ -542,7 +542,7 @@ impl Window {
         {
             (window_item.width(), window_item.height())
         } else {
-            (0., 0.)
+            (0 as Coord, 0 as Coord)
         };
 
         let layout_info_h =
@@ -550,10 +550,10 @@ impl Window {
         let layout_info_v =
             popup_component.as_ref().layout_info(crate::layout::Orientation::Vertical);
 
-        if w <= 0. {
+        if w <= 0 as Coord {
             w = layout_info_h.preferred;
         }
-        if h <= 0. {
+        if h <= 0 as Coord {
             h = layout_info_v.preferred;
         }
         w = w.clamp(layout_info_h.min, layout_info_h.max);
@@ -633,7 +633,7 @@ impl Window {
     /// Sets the size of the window item. This method is typically called in response to receiving a
     /// window resize event from the windowing system.
     /// Size is in logical pixels.
-    pub fn set_window_item_geometry(&self, width: f32, height: f32) {
+    pub fn set_window_item_geometry(&self, width: Coord, height: Coord) {
         if let Some(component_rc) = self.try_component() {
             let component = ComponentRc::borrow_pin(&component_rc);
             let root_item = component.as_ref().get_item_ref(0);


### PR DESCRIPTION
The prepare scene time for the scene that changes to the night mode in the printerdemo_mcu goes from 60ms to 50ms