### PR TITLE
native: Implement keyboard focus support in Tab widget

### DIFF
--- a/internal/backends/gl/stylemetrics.rs
+++ b/internal/backends/gl/stylemetrics.rs
@@ -1,13 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore deinit
+
 use super::*;
 
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
 #[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
-use i_slint_core::Property;
+use i_slint_core::{items::LayoutAlignment, Property};
 use i_slint_core_macros::*;
 
 #[repr(C)]
@@ -29,6 +31,9 @@ pub struct NativeStyleMetrics {
 
     pub placeholder_color: Property<Color>,
     pub placeholder_color_disabled: Property<Color>,
+
+    // Tab Bar metrics:
+    pub tab_bar_alignment: Property<LayoutAlignment>,
 }
 
 impl const_field_offset::PinnedDrop for NativeStyleMetrics {
@@ -52,6 +57,7 @@ impl NativeStyleMetrics {
             dark_style: Default::default(),
             placeholder_color: Default::default(),
             placeholder_color_disabled: Default::default(),
+            tab_bar_alignment: Default::default(),
         });
         new
     }

--- a/internal/backends/qt/qt_widgets/stylemetrics.rs
+++ b/internal/backends/qt/qt_widgets/stylemetrics.rs
@@ -1,6 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore deinit
+
+use i_slint_core::items::LayoutAlignment;
+
 use super::*;
 
 cpp! {{
@@ -41,6 +45,9 @@ pub struct NativeStyleMetrics {
 
     pub dark_style: Property<bool>,
 
+    // Tab Bar metrics:
+    pub tab_bar_alignment: Property<LayoutAlignment>,
+
     pub style_change_listener: core::cell::Cell<*const u8>,
 }
 
@@ -65,6 +72,7 @@ impl NativeStyleMetrics {
             placeholder_color: Default::default(),
             placeholder_color_disabled: Default::default(),
             dark_style: Default::default(),
+            tab_bar_alignment: Default::default(),
             style_change_listener: core::cell::Cell::new(core::ptr::null()),
         });
         new
@@ -142,6 +150,21 @@ impl NativeStyleMetrics {
                 / 3
                 < 128,
         );
+
+        let tab_bar_alignment = cpp!(unsafe[] -> u32 as "uint32_t" {
+            switch (qApp->style()->styleHint(QStyle::SH_TabBar_Alignment)) {
+                case Qt::AlignLeft: return 1;
+                case Qt::AlignCenter: return 2;
+                case Qt::AlignRight: return 3;
+                default: return 0;
+            }
+        });
+        self.tab_bar_alignment.set(match tab_bar_alignment {
+            1 => LayoutAlignment::start,
+            2 => LayoutAlignment::center,
+            3 => LayoutAlignment::end,
+            _ => LayoutAlignment::space_between, // Should not happen! If it does, it should be noticeable;-)
+        });
     }
 }
 

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -444,6 +444,7 @@ impl Item for NativeTab {
         .unwrap_or_default();
         let enabled: bool = this.enabled();
         let current: i32 = this.current();
+        let current_focused: i32 = this.current_focused();
         let tab_index: i32 = this.tab_index();
         let num_tabs: i32 = this.num_tabs();
 
@@ -458,6 +459,7 @@ impl Item for NativeTab {
             dpr as "float",
             tab_index as "int",
             current as "int",
+            current_focused as "int",
             num_tabs as "int",
             initial_state as "int"
         ] {
@@ -486,6 +488,9 @@ impl Item for NativeTab {
             }
             if (current == tab_index)
                 option.state |= QStyle::State_Selected;
+            if (current_focused == tab_index) {
+                option.state |= QStyle::State_HasFocus | QStyle::State_KeyboardFocusChange | QStyle::State_Item;
+            }
             option.features |= QStyleOptionTab::HasFrame;
             qApp->style()->drawControl(QStyle::CE_TabBarTab, &option, painter, widget);
         });

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -634,6 +634,10 @@ export global NativeStyleMetrics := {
     property <color> placeholder-color : native_output;
     property <color> placeholder-color-disabled : native_output;
 
+    // Tab Bar metrics:
+    property <length> tab-bar-spacing : native_output;
+    property <LayoutAlignment> tab-bar-alignment : native_output;
+
     //-is_non_item_type
     //-is_internal
 }

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -124,6 +124,7 @@ export ComboBox := NativeComboBox {
 }
 
 export TabWidgetImpl := NativeTabWidget { }
+
 export TabImpl := NativeTab { }
 
 export TabBarImpl := Rectangle {
@@ -133,8 +134,8 @@ export TabBarImpl := Rectangle {
     property<int> num-tabs; // The total number of tabs
 
     HorizontalLayout {
-        spacing: 8px;
-        alignment: start;
+        spacing: 0px; // Qt renders Tabs next to each other and renders "spacing" as part of the tab itself
+        alignment: NativeStyleMetrics.tab-bar-alignment;
         @children
     }
 
@@ -152,6 +153,7 @@ export TabBarImpl := Rectangle {
         }
     }
 }
+
 export TabWidget := TabWidget {}
 
 export VerticalBox := VerticalLayout {

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -126,13 +126,31 @@ export ComboBox := NativeComboBox {
 export TabWidgetImpl := NativeTabWidget { }
 export TabImpl := NativeTab { }
 
-export TabBarImpl := HorizontalLayout {
+export TabBarImpl := Rectangle {
     // injected properties:
     property<int> current; // The currently selected tab
-    property<int> current-focused; // The current focused index (or -1 if no focus)
+    property<int> current-focused: current; // The currently focused tab
     property<int> num-tabs; // The total number of tabs
 
-    alignment: start;
+    HorizontalLayout {
+        spacing: 8px;
+        alignment: start;
+        @children
+    }
+
+    fs := FocusScope {
+        key-pressed(event) => {
+            if (event.text == Keys.LeftArrow) {
+                 root.current = Math.max(root.current - 1,  0);
+                 return accept;
+            }
+            if (event.text == Keys.RightArrow) {
+                 root.current = Math.min(root.current + 1, num-tabs - 1);
+                 return accept;
+            }
+            return reject;
+        }
+    }
 }
 export TabWidget := TabWidget {}
 

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -129,7 +129,7 @@ export TabImpl := NativeTab { }
 export TabBarImpl := Rectangle {
     // injected properties:
     property<int> current; // The currently selected tab
-    property<int> current-focused: current; // The currently focused tab
+    property<int> current-focused: fs.has-focus ? current : -1; // The currently focused tab
     property<int> num-tabs; // The total number of tabs
 
     HorizontalLayout {


### PR DESCRIPTION
Focus the tabs straight away when pressing cursor left/right keys.