### PR TITLE
Fix VecModel::set_vec reporting removed_rows at the wrong time

### DIFF
--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -335,7 +335,9 @@ impl<T: 'static> VecModel<T> {
 
     /// Replace inner Vec with new data
     pub fn set_vec(&self, new: impl Into<Vec<T>>) {
-        self.notify.row_removed(0, self.array.borrow().len());
+        let old_len = self.array.borrow().len();
+        self.array.borrow_mut().clear();
+        self.notify.row_removed(0, old_len);
         *self.array.borrow_mut() = new.into();
         self.notify.row_added(0, self.array.borrow().len());
     }
@@ -1131,9 +1133,13 @@ fn test_data_tracking() {
 fn test_vecmodel_set_vec() {
     #[derive(Default)]
     struct TestView {
-        changed_rows: RefCell<Vec<usize>>,
-        added_rows: RefCell<Vec<(usize, usize)>>,
-        removed_rows: RefCell<Vec<(usize, usize)>>,
+        // Track the parameters reported by the model (row counts, indices, etc.).
+        // The last field in the tuple is the row size the model reports at the time
+        // of callback
+        changed_rows: RefCell<Vec<(usize, usize)>>,
+        added_rows: RefCell<Vec<(usize, usize, usize)>>,
+        removed_rows: RefCell<Vec<(usize, usize, usize)>>,
+        model: RefCell<Option<std::rc::Weak<dyn Model<Data = i32>>>>,
     }
     impl TestView {
         fn clear(&self) {
@@ -1141,18 +1147,25 @@ fn test_vecmodel_set_vec() {
             self.added_rows.borrow_mut().clear();
             self.removed_rows.borrow_mut().clear();
         }
+        fn row_count(&self) -> usize {
+            self.model
+                .borrow()
+                .as_ref()
+                .and_then(|model| model.upgrade())
+                .map_or(0, |model| model.row_count())
+        }
     }
     impl ErasedRepeater for TestView {
         fn row_changed(&self, row: usize) {
-            self.changed_rows.borrow_mut().push(row);
+            self.changed_rows.borrow_mut().push((row, self.row_count()));
         }
 
         fn row_added(&self, index: usize, count: usize) {
-            self.added_rows.borrow_mut().push((index, count));
+            self.added_rows.borrow_mut().push((index, count, self.row_count()));
         }
 
         fn row_removed(&self, index: usize, count: usize) {
-            self.removed_rows.borrow_mut().push((index, count));
+            self.removed_rows.borrow_mut().push((index, count, self.row_count()));
         }
     }
 
@@ -1164,18 +1177,20 @@ fn test_vecmodel_set_vec() {
 
     let peer = ModelPeer { inner: PinWeak::downgrade(view_as_repeater.clone()) };
 
-    let model: VecModel<i32> = vec![1i32, 2, 3, 4].into();
+    let model = Rc::new(VecModel::from(vec![1i32, 2, 3, 4]));
     model.model_tracker().attach_peer(peer);
+    *view.model.borrow_mut() =
+        Some(std::rc::Rc::downgrade(&(model.clone() as Rc<dyn Model<Data = i32>>)));
 
     model.push(5);
     assert!(view.changed_rows.borrow().is_empty());
-    assert_eq!(&*view.added_rows.borrow(), &[(4, 1)]);
+    assert_eq!(&*view.added_rows.borrow(), &[(4, 1, 5)]);
     assert!(view.removed_rows.borrow().is_empty());
     view.clear();
 
     model.set_vec(vec![6, 7, 8]);
     assert!(view.changed_rows.borrow().is_empty());
-    assert_eq!(&*view.added_rows.borrow(), &[(0, 3)]);
-    assert_eq!(&*view.removed_rows.borrow(), &[(0, 5)]);
+    assert_eq!(&*view.added_rows.borrow(), &[(0, 3, 3)]);
+    assert_eq!(&*view.removed_rows.borrow(), &[(0, 5, 0)]);
     view.clear();
 }


### PR DESCRIPTION
The last tense indicates that when it's called the rows have already
been removed.  That was not the case and this patch corrects it, along
with a test that verifies the values the model reports in the call backs
for the row count.