### PR TITLE
Focus: Do not send keyboard event to invisible widgets

### DIFF
--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -339,7 +339,7 @@ export TabImpl := Rectangle {
             current = tab-index;
         }
     }
-    t:= Text {
+    t := Text {
         width: parent.width;
         height: parent.height;
         vertical-alignment: center;

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -322,10 +322,15 @@ impl Window {
     pub fn process_key_input(self: Rc<Self>, event: &KeyEvent) {
         let mut item = self.focus_item.borrow().clone();
         while let Some(focus_item) = item.upgrade() {
-            if focus_item.borrow().as_ref().key_event(event, &self.clone())
-                == crate::input::KeyEventResult::EventAccepted
-            {
-                return;
+            if !focus_item.is_visible() {
+                // Reset the focus... not great, but better than keeping it.
+                self.take_focus_item();
+            } else {
+                if focus_item.borrow().as_ref().key_event(event, &self.clone())
+                    == crate::input::KeyEventResult::EventAccepted
+                {
+                    return;
+                }
             }
             item = focus_item.parent_item();
         }


### PR DESCRIPTION
Do not send keyboard events to invisible widgets, reset the keyboard
focus instead.

That fixes #798 again with a bit less of a work-around. To properly fix
this we will need to make the tab widget (and probably others) more
intelligent though.