### PR TITLE
wasm: fix tab and back tab

### DIFF
--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -280,7 +280,12 @@ impl WinitWindow for GLWindow {
 
     #[cfg(target_arch = "wasm32")]
     fn input_method_focused(&self) -> bool {
-        self.virtual_keyboard_helper.borrow().as_ref().map_or(false, |h| h.has_focus())
+        match self.virtual_keyboard_helper.try_borrow() {
+            Ok(vkh) => vkh.as_ref().map_or(false, |h| h.has_focus()),
+            // the only location in which the virtual_keyboard_helper is mutably borrowed is from
+            // show_virtual_keyboard, which means we have the focus
+            Err(_) => true,
+        }
     }
 }
 


### PR DESCRIPTION
The situation differs depending if the widget show the virtual keyboard or not:
For widget that don't show the virtual keyboard, we rely on the winit events,
but for some reason we don't recieve WindowEvent::ModifiersChanged events with
wasm. Since the event handling in winit is about to be rewriten, I did not
bother reporting the bug upstream, but just work around by using the deprecated
API. So that way shift + tab will no longer be understood as just tab.

For widget using the virtual keyboard, then the event handling is in
wasm_input_helper.rs.  There is a couple of issues:

 - We must map shift+tab to backtab.
 - We need to prevent the default events to trigger, so that tab and other
   shortcuts don't take effect on the browser. Winit already inhibit these
   events so we must do the same otherwise tab and shift+tab would change the
   html focus.
 - By luck, tab used to give the focus back to the canvas before (see previous
   point) and that's why it worked. But now that we don't do that anymore,
   hiding the virtual keyboard should actually re-focus the canvas
 - That will cause the focus event to be intercepted by winit, and will cause
   recursions and borrow error, so we make sure that we do not recurse when
   getting the focus event