### PR TITLE
Start working on accessibility: The compiler part

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -180,10 +180,12 @@ private:
 };
 
 constexpr inline ItemTreeNode make_item_node(uint32_t child_count, uint32_t child_index,
-                                             uint32_t parent_index, uint32_t item_array_index)
+                                             uint32_t parent_index, uint32_t item_array_index,
+                                             bool is_accessible)
 {
-    return ItemTreeNode { ItemTreeNode::Item_Body { ItemTreeNode::Tag::Item, false, child_count,
-                                                    child_index, parent_index, item_array_index } };
+    return ItemTreeNode { ItemTreeNode::Item_Body { ItemTreeNode::Tag::Item, is_accessible,
+                                                    child_count, child_index, parent_index,
+                                                    item_array_index } };
 }
 
 constexpr inline ItemTreeNode make_dyn_node(std::uintptr_t offset, std::uint32_t parent_index)

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -182,7 +182,7 @@ private:
 constexpr inline ItemTreeNode make_item_node(uint32_t child_count, uint32_t child_index,
                                              uint32_t parent_index, uint32_t item_array_index)
 {
-    return ItemTreeNode { ItemTreeNode::Item_Body { ItemTreeNode::Tag::Item, child_count,
+    return ItemTreeNode { ItemTreeNode::Item_Body { ItemTreeNode::Tag::Item, false, child_count,
                                                     child_index, parent_index, item_array_index } };
 }
 

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -282,6 +282,7 @@ pub mod re_exports {
     pub use const_field_offset::{self, FieldOffsets, PinnedDrop};
     pub use core::iter::FromIterator;
     pub use i_slint_backend_selector::native_widgets::*;
+    pub use i_slint_core::accessibility::AccessibleStringProperty;
     pub use i_slint_core::animations::EasingCurve;
     pub use i_slint_core::callbacks::Callback;
     pub use i_slint_core::component::{

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -176,6 +176,14 @@ macro_rules! for_each_enums {
                 /// A key on a keyboard was released.
                 KeyReleased,
             }
+
+            /// The role for the `accessible-role` property
+            enum AccessibleRole {
+                none,
+                button,
+                checkbox,
+                //...
+            }
         ];
     };
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -832,8 +832,8 @@ fn generate_item_tree(
             let item_array_index = item_array.len() as u32;
 
             item_tree_array.push(format!(
-                "slint::private_api::make_item_node({}, {}, {}, {})",
-                children_count, children_index, parent_index, item_array_index,
+                "slint::private_api::make_item_node({}, {}, {}, {}, {})",
+                children_count, children_index, parent_index, item_array_index, node.is_accessible
             ));
             item_array.push(format!(
                 "{{ {}, {} offsetof({}, {}) }}",
@@ -1023,6 +1023,38 @@ fn generate_item_tree(
     ));
 
     target_struct.members.push((
+        Access::Private,
+        Declaration::Function(Function {
+            name: "accessible_role".into(),
+            signature:
+                "([[maybe_unused]] slint::private_api::ComponentRef component, uintptr_t index) -> slint::cbindgen_private::AccessibleRole"
+                    .into(),
+            is_static: true,
+            statements: Some(vec![format!(
+                "return reinterpret_cast<const {}*>(component.instance)->accessible_role(index);",
+                item_tree_class_name
+            )]),
+            ..Default::default()
+        }),
+    ));
+
+    target_struct.members.push((
+        Access::Private,
+        Declaration::Function(Function {
+            name: "accessible_string_property".into(),
+            signature:
+                "([[maybe_unused]] slint::private_api::ComponentRef component, uintptr_t index, slint::cbindgen_private::AccessibleStringProperty what, slint::SharedString *result) -> void"
+                    .into(),
+            is_static: true,
+            statements: Some(vec![format!(
+                "*result = reinterpret_cast<const {}*>(component.instance)->accessible_string_property(index, what);",
+                item_tree_class_name
+            )]),
+            ..Default::default()
+        }),
+    ));
+
+    target_struct.members.push((
         Access::Public,
         Declaration::Var(Var {
             ty: "static const slint::private_api::ComponentVTable".to_owned(),
@@ -1036,7 +1068,8 @@ fn generate_item_tree(
         name: format!("{}::static_vtable", item_tree_class_name),
         init: Some(format!(
             "{{ visit_children, get_item_ref, get_subtree_range, get_subtree_component, \
-                get_item_tree, parent_node, subtree_index, layout_info, nullptr, nullptr, \
+                get_item_tree, parent_node, subtree_index, layout_info, \
+                accessible_role, accessible_string_property, \
                 slint::private_api::drop_in_place<{}>, slint::private_api::dealloc }}",
             item_tree_class_name
         )),
@@ -1447,6 +1480,72 @@ fn generate_sub_component(
             ..Default::default()
         }),
     ));
+
+    let mut accessible_function = |name: &str,
+                                   signature: &str,
+                                   forward_args: &str,
+                                   code: Vec<String>| {
+        let mut code = ["[[maybe_unused]] auto self = this;".into()]
+            .into_iter()
+            .chain(code.into_iter())
+            .collect::<Vec<_>>();
+
+        let mut else_ = "";
+        for sub in &component.sub_components {
+            let sub_items_count = sub.ty.child_item_count();
+            code.push(format!("{else_}if (index == {}) {{", sub.index_in_tree,));
+            code.push(format!("    return self->{}.{name}(0{forward_args});", ident(&sub.name)));
+            if sub_items_count > 1 {
+                code.push(format!(
+                    "}} else if (index >= {} && index < {}) {{",
+                    sub.index_of_first_child_in_tree,
+                    sub.index_of_first_child_in_tree + sub_items_count - 1
+                ));
+                code.push(format!(
+                    "    return self->{}.{name}(index - {}{forward_args});",
+                    ident(&sub.name),
+                    sub.index_of_first_child_in_tree - 1
+                ));
+            }
+            else_ = "} else ";
+        }
+        code.push(format!("{else_}return {{}};"));
+        target_struct.members.push((
+            field_access,
+            Declaration::Function(Function {
+                name: name.into(),
+                signature: signature.into(),
+                statements: Some(code),
+                ..Default::default()
+            }),
+        ));
+    };
+
+    let mut accessible_role_cases = vec!["switch (index) {".into()];
+    let mut accessible_string_cases = vec!["switch ((index << 8) | uintptr_t(what)) {".into()];
+    for ((index, what), expr) in &component.accessible_prop {
+        let expr = compile_expression(&expr.borrow(), &ctx);
+        if what == "Role" {
+            accessible_role_cases.push(format!("    case {index}: return {expr};"));
+        } else {
+            accessible_string_cases.push(format!("    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibleStringProperty::{what}): return {expr};"));
+        }
+    }
+    accessible_role_cases.push("}".into());
+    accessible_string_cases.push("}".into());
+
+    accessible_function(
+        "accessible_role",
+        "(uintptr_t index) const -> slint::cbindgen_private::AccessibleRole",
+        "",
+        accessible_role_cases,
+    );
+    accessible_function(
+        "accessible_string_property",
+        "(uintptr_t index, slint::cbindgen_private::AccessibleStringProperty what) const -> slint::SharedString",
+        ", what",
+        accessible_string_cases,
+    );
 
     if !children_visitor_cases.is_empty() {
         target_struct.members.push((

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1035,9 +1035,11 @@ fn generate_item_tree(
         ty: "const slint::private_api::ComponentVTable".to_owned(),
         name: format!("{}::static_vtable", item_tree_class_name),
         init: Some(format!(
-            "{{ visit_children, get_item_ref, get_subtree_range, get_subtree_component, get_item_tree, parent_node, subtree_index, layout_info, slint::private_api::drop_in_place<{}>, slint::private_api::dealloc }}",
-            item_tree_class_name)
-        ),
+            "{{ visit_children, get_item_ref, get_subtree_range, get_subtree_component, \
+                get_item_tree, parent_node, subtree_index, layout_info, nullptr, nullptr, \
+                slint::private_api::drop_in_place<{}>, slint::private_api::dealloc }}",
+            item_tree_class_name
+        )),
         ..Default::default()
     }));
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1070,7 +1070,8 @@ fn generate_item_tree(
             let children_index = children_offset as u32;
             let item_array_len = item_array.len() as u32;
             item_tree_array.push(quote!(
-                slint::re_exports::ItemTreeNode::Item{
+                slint::re_exports::ItemTreeNode::Item {
+                    is_accessible: false, // TODO
                     children_count: #children_count,
                     children_index: #children_index,
                     parent_index: #parent_index,

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -667,6 +667,19 @@ fn generate_sub_component(
         repeated_element_components.push(rep_inner_component_id);
     }
 
+    let mut accessible_role_branch = vec![];
+    let mut accessible_string_property_branch = vec![];
+    for ((index, what), expr) in &component.accessible_prop {
+        let expr = compile_expression(&expr.borrow(), &ctx);
+        if what == "Role" {
+            accessible_role_branch.push(quote!(#index => #expr,));
+        } else {
+            let what = ident(&what);
+            accessible_string_property_branch
+                .push(quote!((#index, AccessibleStringProperty::#what) => #expr,));
+        }
+    }
+
     let mut sub_component_names: Vec<Ident> = vec![];
     let mut sub_component_types: Vec<Ident> = vec![];
 
@@ -716,6 +729,25 @@ fn generate_sub_component(
                 #repeater_offset..=#last_repeater => {
                     #sub_compo_field.apply_pin(_self).subtree_component(dyn_index - #repeater_offset, subtree_index, result)
                 }
+            ));
+        }
+
+        let sub_items_count = sub.ty.child_item_count();
+        let local_tree_index = local_tree_index as usize;
+        accessible_role_branch.push(quote!(
+            #local_tree_index => #sub_compo_field.apply_pin(_self).accessible_role(0),
+        ));
+        accessible_string_property_branch.push(quote!(
+            (#local_tree_index, _) => #sub_compo_field.apply_pin(_self).accessible_string_property(0, what),
+        ));
+        if sub_items_count > 1 {
+            let range_begin = local_index_of_first_child as usize;
+            let range_end = range_begin + sub_items_count - 2;
+            accessible_role_branch.push(quote!(
+                #range_begin..=#range_end => #sub_compo_field.apply_pin(_self).accessible_role(index - #range_begin + 1),
+            ));
+            accessible_string_property_branch.push(quote!(
+                (#range_begin..=#range_end, _) => #sub_compo_field.apply_pin(_self).accessible_string_property(index - #range_begin + 1, what),
             ));
         }
 
@@ -862,6 +894,31 @@ fn generate_sub_component(
                 use slint::re_exports::*;
                 let _self = self;
                 #subtree_index_function
+            }
+
+            fn accessible_role(self: ::core::pin::Pin<&Self>, index: usize) -> slint::re_exports::AccessibleRole {
+                #![allow(unused)]
+                use slint::re_exports::*;
+                let _self = self;
+                match index {
+                    #(#accessible_role_branch)*
+                    //#(#forward_sub_ranges => #forward_sub_field.apply_pin(_self).accessible_role())*
+                    _ => AccessibleRole::default(),
+                }
+            }
+
+            fn accessible_string_property(
+                self: ::core::pin::Pin<&Self>,
+                index: usize,
+                what: slint::re_exports::AccessibleStringProperty,
+            ) -> slint::re_exports::SharedString {
+                #![allow(unused)]
+                use slint::re_exports::*;
+                let _self = self;
+                match (index, what) {
+                    #(#accessible_string_property_branch)*
+                    _ => Default::default(),
+                }
             }
         }
 
@@ -1069,9 +1126,10 @@ fn generate_item_tree(
             let children_count = node.children.len() as u32;
             let children_index = children_offset as u32;
             let item_array_len = item_array.len() as u32;
+            let is_accessible = node.is_accessible;
             item_tree_array.push(quote!(
                 slint::re_exports::ItemTreeNode::Item {
-                    is_accessible: false, // TODO
+                    is_accessible: #is_accessible,
                     children_count: #children_count,
                     children_index: #children_index,
                     parent_index: #parent_index,
@@ -1188,7 +1246,7 @@ fn generate_item_tree(
             }
 
             fn accessible_role(self: ::core::pin::Pin<&Self>, index: usize) -> slint::re_exports::AccessibleRole {
-                todo!()
+                self.accessible_role(index)
             }
 
             fn accessible_string_property(
@@ -1197,7 +1255,7 @@ fn generate_item_tree(
                 what: slint::re_exports::AccessibleStringProperty,
                 result: &mut slint::re_exports::SharedString,
             ) {
-                todo!()
+                *result = self.accessible_string_property(index, what);
             }
         }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1185,6 +1185,19 @@ fn generate_item_tree(
             fn layout_info(self: ::core::pin::Pin<&Self>, orientation: slint::re_exports::Orientation) -> slint::re_exports::LayoutInfo {
                 self.layout_info(orientation)
             }
+
+            fn accessible_role(self: ::core::pin::Pin<&Self>, index: usize) -> slint::re_exports::AccessibleRole {
+                todo!()
+            }
+
+            fn accessible_string_property(
+                self: ::core::pin::Pin<&Self>,
+                index: usize,
+                what: slint::re_exports::AccessibleStringProperty,
+                result: &mut slint::re_exports::SharedString,
+            ) {
+                todo!()
+            }
         }
 
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -418,6 +418,10 @@ impl Clone for PropertyAnimation {
     }
 }
 
+/// Map the accessibility property (eg "accessible-role", "accessible-label") to its named reference
+#[derive(Default, Clone)]
+pub struct AccessibilityProps(pub BTreeMap<String, NamedReference>);
+
 pub type BindingsMap = BTreeMap<String, RefCell<BindingExpression>>;
 
 /// An Element is an instantiation of a Component
@@ -454,6 +458,8 @@ pub struct Element {
     pub child_of_layout: bool,
     /// The property pointing to the layout info. `(horizontal, vertical)`
     pub layout_info_prop: Option<(NamedReference, NamedReference)>,
+
+    pub accessibility_props: AccessibilityProps,
 
     /// true if this Element is the fake Flickable viewport
     pub is_flickable_viewport: bool,
@@ -1619,6 +1625,10 @@ pub fn visit_all_named_references_in_element(
     let mut layout_info_prop = std::mem::take(&mut elem.borrow_mut().layout_info_prop);
     layout_info_prop.as_mut().map(|(h, b)| (vis(h), vis(b)));
     elem.borrow_mut().layout_info_prop = layout_info_prop;
+
+    let mut accessibility_props = std::mem::take(&mut elem.borrow_mut().accessibility_props);
+    accessibility_props.0.iter_mut().for_each(|(_, x)| vis(x));
+    elem.borrow_mut().accessibility_props = accessibility_props;
 
     // visit two way bindings
     for expr in elem.borrow().bindings.values() {

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -22,6 +22,7 @@ mod focus_item;
 mod generate_item_indices;
 mod infer_aliases_types;
 mod inlining;
+mod lower_accessibility;
 mod lower_layout;
 mod lower_popups;
 mod lower_property_to_element;
@@ -139,6 +140,7 @@ pub async fn run_passes(
         clip::handle_clip(component, &global_type_registry.borrow(), diag);
         visible::handle_visible(component, &global_type_registry.borrow());
         materialize_fake_properties::materialize_fake_properties(component);
+        lower_accessibility::lower_accessibility_properties(component, diag);
     }
     collect_globals::collect_globals(doc, diag);
 

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -43,6 +43,7 @@ pub fn ensure_window(
         child_of_layout: false,
         has_popup_child: false,
         layout_info_prop: Default::default(),
+        accessibility_props: Default::default(),
         is_flickable_viewport: false,
         item_index: Default::default(),
         item_index_of_first_children: Default::default(),

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -214,6 +214,7 @@ fn duplicate_element_with_mapping(
             .collect(),
         child_of_layout: elem.child_of_layout,
         layout_info_prop: elem.layout_info_prop.clone(),
+        accessibility_props: elem.accessibility_props.clone(),
         named_references: Default::default(),
         item_index: Default::default(), // Not determined yet
         item_index_of_first_children: Default::default(),

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+//! Pass that lowers synthetic `accessible-*` properties
+
+use crate::diagnostics::BuildDiagnostics;
+use crate::expression_tree::NamedReference;
+use crate::object_tree::Component;
+use crate::typeregister::TypeRegister;
+
+use std::rc::Rc;
+
+pub fn lower_accessibility_properties(component: &Rc<Component>, _diag: &mut BuildDiagnostics) {
+    crate::object_tree::recurse_elem_including_sub_components_no_borrow(
+        component,
+        &(),
+        &mut |elem, _| {
+            for prop_name in crate::typeregister::RESERVED_ACCESSIBILITY_PROPERTIES
+                .iter()
+                .map(|x| x.0)
+                .chain(std::iter::once("accessible-role"))
+            {
+                if elem.borrow().is_binding_set(prop_name, true) {
+                    let nr = NamedReference::new(elem, prop_name);
+                    elem.borrow_mut().accessibility_props.0.insert(prop_name.into(), nr);
+                }
+            }
+        },
+    )
+}

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -6,7 +6,6 @@
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::NamedReference;
 use crate::object_tree::Component;
-use crate::typeregister::TypeRegister;
 
 use std::rc::Rc;
 

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -41,6 +41,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 transitions: std::mem::take(&mut elem.transitions),
                 child_of_layout: elem.child_of_layout || is_listview.is_some(),
                 layout_info_prop: elem.layout_info_prop.take(),
+                accessibility_props: std::mem::take(&mut elem.accessibility_props),
                 is_flickable_viewport: elem.is_flickable_viewport,
                 has_popup_child: elem.has_popup_child,
                 item_index: Default::default(), // Not determined yet

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -84,6 +84,11 @@ pub(crate) const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
     ("drop-shadow-color", Type::Color),
 ];
 
+pub(crate) const RESERVED_ACCESSIBILITY_PROPERTIES: &[(&str, Type)] = &[
+    //("accessible-role", ...)
+    ("accessible-label", Type::String),
+];
+
 /// list of reserved property injected in every item
 pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type)> {
     RESERVED_GEOMETRY_PROPERTIES
@@ -91,6 +96,7 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type)> {
         .chain(RESERVED_LAYOUT_PROPERTIES.iter())
         .chain(RESERVED_OTHER_PROPERTIES.iter())
         .chain(RESERVED_DROP_SHADOW_PROPERTIES.iter())
+        .chain(RESERVED_ACCESSIBILITY_PROPERTIES.iter())
         .map(|(k, v)| (*k, v.clone()))
         .chain(IntoIterator::into_iter([
             ("forward-focus", Type::ElementReference),
@@ -98,6 +104,10 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type)> {
             (
                 "dialog-button-role",
                 Type::Enumeration(BUILTIN_ENUMS.with(|e| e.DialogButtonRole.clone())),
+            ),
+            (
+                "accessible-role",
+                Type::Enumeration(BUILTIN_ENUMS.with(|e| e.AccessibleRole.clone())),
             ),
         ]))
 }

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+#[repr(C)]
+#[derive(PartialEq, Eq, Copy, Clone, strum::Display)]
+pub enum AccessibleStringProperty {
+    Label,
+}

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -5,13 +5,15 @@
 
 //! This module contains the basic datastructures that are exposed to the C API
 
+use crate::accessibility::AccessibleStringProperty;
 use crate::item_tree::{
     ItemTreeNode, ItemVisitorVTable, ItemWeak, TraversalOrder, VisitChildrenResult,
 };
-use crate::items::ItemVTable;
+use crate::items::{AccessibleRole, ItemVTable};
 use crate::layout::{LayoutInfo, Orientation};
 use crate::slice::Slice;
 use crate::window::WindowRc;
+use crate::SharedString;
 use vtable::*;
 
 #[repr(C)]
@@ -74,6 +76,18 @@ pub struct ComponentVTable {
     /// Returns the layout info for this component
     pub layout_info:
         extern "C" fn(core::pin::Pin<VRef<ComponentVTable>>, Orientation) -> LayoutInfo,
+
+    /// Returns the accessible role for a given item
+    pub accessible_role:
+        extern "C" fn(core::pin::Pin<VRef<ComponentVTable>>, item_index: usize) -> AccessibleRole,
+
+    /// Returns the accessible property
+    pub accessible_string_property: extern "C" fn(
+        core::pin::Pin<VRef<ComponentVTable>>,
+        item_index: usize,
+        what: AccessibleStringProperty,
+        result: &mut SharedString,
+    ),
 
     /// in-place destructor (for VRc)
     pub drop_in_place: unsafe fn(VRefMut<ComponentVTable>) -> vtable::Layout,

--- a/internal/core/item_focus.rs
+++ b/internal/core/item_focus.rs
@@ -103,6 +103,7 @@ mod tests {
     #[test]
     fn test_focus_chain_root_only() {
         let nodes = vec![ItemTreeNode::Item {
+            is_accessible: false,
             children_count: 0,
             children_index: 1,
             parent_index: 0,
@@ -117,12 +118,14 @@ mod tests {
     fn test_focus_chain_one_child() {
         let nodes = vec![
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 1,
                 children_index: 1,
                 parent_index: 0,
                 item_array_index: 0,
             },
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 2,
                 parent_index: 0,
@@ -138,24 +141,28 @@ mod tests {
     fn test_focus_chain_three_children() {
         let nodes = vec![
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 3,
                 children_index: 1,
                 parent_index: 0,
                 item_array_index: 0,
             },
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 4,
                 parent_index: 0,
                 item_array_index: 0,
             },
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 4,
                 parent_index: 0,
                 item_array_index: 0,
             },
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 4,
                 parent_index: 0,
@@ -172,6 +179,7 @@ mod tests {
         let nodes = vec![
             ItemTreeNode::Item {
                 // 0
+                is_accessible: false,
                 children_count: 2,
                 children_index: 1,
                 parent_index: 0,
@@ -179,6 +187,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 1
+                is_accessible: false,
                 children_count: 2,
                 children_index: 3,
                 parent_index: 0,
@@ -186,6 +195,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 2
+                is_accessible: false,
                 children_count: 1,
                 children_index: 11,
                 parent_index: 0,
@@ -193,6 +203,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 3
+                is_accessible: false,
                 children_count: 1,
                 children_index: 5,
                 parent_index: 1,
@@ -200,6 +211,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 4
+                is_accessible: false,
                 children_count: 2,
                 children_index: 6,
                 parent_index: 1,
@@ -207,6 +219,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 5
+                is_accessible: false,
                 children_count: 0,
                 children_index: 0,
                 parent_index: 3,
@@ -214,6 +227,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 6
+                is_accessible: false,
                 children_count: 2,
                 children_index: 8,
                 parent_index: 4,
@@ -221,6 +235,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 7
+                is_accessible: false,
                 children_count: 1,
                 children_index: 10,
                 parent_index: 4,
@@ -228,6 +243,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 8
+                is_accessible: false,
                 children_count: 0,
                 children_index: 0,
                 parent_index: 6,
@@ -235,6 +251,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 9
+                is_accessible: false,
                 children_count: 0,
                 children_index: 0,
                 parent_index: 6,
@@ -242,6 +259,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 10
+                is_accessible: false,
                 children_count: 0,
                 children_index: 0,
                 parent_index: 7,
@@ -249,6 +267,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 11
+                is_accessible: false,
                 children_count: 2,
                 children_index: 12,
                 parent_index: 2,
@@ -256,6 +275,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 12
+                is_accessible: false,
                 children_count: 0,
                 children_index: 0,
                 parent_index: 11,
@@ -263,6 +283,7 @@ mod tests {
             },
             ItemTreeNode::Item {
                 // 13
+                is_accessible: false,
                 children_count: 0,
                 children_index: 0,
                 parent_index: 11,

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -457,6 +457,9 @@ impl core::fmt::Debug for VisitChildrenResult {
 pub enum ItemTreeNode {
     /// Static item
     Item {
+        /// True when the item has accessibility properties attached
+        is_accessible: bool,
+
         /// number of children
         children_count: u32,
 
@@ -803,9 +806,12 @@ mod tests {
 
     use super::*;
 
+    use crate::accessibility::AccessibleStringProperty;
     use crate::component::{Component, ComponentRc, ComponentVTable, ComponentWeak, IndexRange};
+    use crate::items::AccessibleRole;
     use crate::layout::{LayoutInfo, Orientation};
     use crate::slice::Slice;
+    use crate::SharedString;
 
     use vtable::VRc;
 
@@ -866,6 +872,18 @@ mod tests {
                 self.subtrees.borrow()[subtree_index][component_index].clone(),
             ))
         }
+
+        fn accessible_role(self: Pin<&Self>, _: usize) -> AccessibleRole {
+            unimplemented!("Not needed for this test")
+        }
+
+        fn accessible_string_property(
+            self: Pin<&Self>,
+            _: usize,
+            _: AccessibleStringProperty,
+            _: &mut SharedString,
+        ) {
+        }
     }
 
     crate::component::ComponentVTable_static!(static TEST_COMPONENT_VT for TestComponent);
@@ -874,6 +892,7 @@ mod tests {
         let component = VRc::new(TestComponent {
             parent_component: None,
             item_tree: vec![ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 1,
                 parent_index: 0,
@@ -922,24 +941,28 @@ mod tests {
             parent_component: None,
             item_tree: vec![
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 3,
                     children_index: 1,
                     parent_index: 0,
                     item_array_index: 0,
                 },
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 4,
                     parent_index: 0,
                     item_array_index: 1,
                 },
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 4,
                     parent_index: 0,
                     item_array_index: 2,
                 },
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 4,
                     parent_index: 0,
@@ -1048,6 +1071,7 @@ mod tests {
             parent_component: None,
             item_tree: vec![
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 1,
                     children_index: 1,
                     parent_index: 0,
@@ -1102,12 +1126,14 @@ mod tests {
             parent_component: None,
             item_tree: vec![
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 3,
                     children_index: 1,
                     parent_index: 0,
                     item_array_index: 0,
                 },
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 4,
                     parent_index: 0,
@@ -1115,6 +1141,7 @@ mod tests {
                 },
                 ItemTreeNode::DynamicTree { index: 0, parent_index: 0 },
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 4,
                     parent_index: 0,
@@ -1128,6 +1155,7 @@ mod tests {
         component.as_pin_ref().subtrees.replace(vec![vec![VRc::new(TestComponent {
             parent_component: Some(VRc::into_dyn(component.clone())),
             item_tree: vec![ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 1,
                 parent_index: 2,
@@ -1223,12 +1251,14 @@ mod tests {
             parent_component: None,
             item_tree: vec![
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 3,
                     children_index: 1,
                     parent_index: 0,
                     item_array_index: 0,
                 },
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 4,
                     parent_index: 0,
@@ -1236,6 +1266,7 @@ mod tests {
                 },
                 ItemTreeNode::DynamicTree { index: 0, parent_index: 0 },
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 4,
                     parent_index: 0,
@@ -1250,6 +1281,7 @@ mod tests {
             parent_component: Some(VRc::into_dyn(component.clone())),
             item_tree: vec![
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 1,
                     children_index: 1,
                     parent_index: 2,
@@ -1264,12 +1296,14 @@ mod tests {
             parent_component: Some(VRc::into_dyn(sub_component1.clone())),
             item_tree: vec![
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 1,
                     children_index: 1,
                     parent_index: 1,
                     item_array_index: 0,
                 },
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 2,
                     parent_index: 0,
@@ -1401,6 +1435,7 @@ mod tests {
             parent_component: None,
             item_tree: vec![
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 2,
                     children_index: 1,
                     parent_index: 0,
@@ -1408,6 +1443,7 @@ mod tests {
                 },
                 ItemTreeNode::DynamicTree { index: 0, parent_index: 0 },
                 ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 4,
                     parent_index: 0,
@@ -1422,6 +1458,7 @@ mod tests {
             VRc::new(TestComponent {
                 parent_component: Some(VRc::into_dyn(component.clone())),
                 item_tree: vec![ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 1,
                     parent_index: 1,
@@ -1433,6 +1470,7 @@ mod tests {
             VRc::new(TestComponent {
                 parent_component: Some(VRc::into_dyn(component.clone())),
                 item_tree: vec![ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 1,
                     parent_index: 1,
@@ -1444,6 +1482,7 @@ mod tests {
             VRc::new(TestComponent {
                 parent_component: Some(VRc::into_dyn(component.clone())),
                 item_tree: vec![ItemTreeNode::Item {
+                    is_accessible: false,
                     children_count: 0,
                     children_index: 1,
                     parent_index: 1,
@@ -1491,6 +1530,7 @@ mod tests {
     #[test]
     fn test_component_item_tree_root_only() {
         let nodes = vec![ItemTreeNode::Item {
+            is_accessible: false,
             children_count: 0,
             children_index: 1,
             parent_index: 0,
@@ -1510,12 +1550,14 @@ mod tests {
     fn test_component_item_tree_one_child() {
         let nodes = vec![
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 1,
                 children_index: 1,
                 parent_index: 0,
                 item_array_index: 0,
             },
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 2,
                 parent_index: 0,
@@ -1539,24 +1581,28 @@ mod tests {
     fn test_component_item_tree_tree_children() {
         let nodes = vec![
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 3,
                 children_index: 1,
                 parent_index: 0,
                 item_array_index: 0,
             },
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 4,
                 parent_index: 0,
                 item_array_index: 0,
             },
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 4,
                 parent_index: 0,
                 item_array_index: 0,
             },
             ItemTreeNode::Item {
+                is_accessible: false,
                 children_count: 0,
                 children_index: 4,
                 parent_index: 0,

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -62,6 +62,7 @@ pub mod unsafe_single_core {
     unsafe impl<T> Sync for OnceCell<T> {}
 }
 
+pub mod accessibility;
 pub mod animations;
 pub mod api;
 pub mod backend;

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -869,6 +869,7 @@ pub(crate) fn generate_component<'id>(
                 self.type_builder.add_field(rt.type_info)
             };
             self.tree_array.push(ItemTreeNode::Item {
+                is_accessible: !item.accessibility_props.0.is_empty(),
                 children_index: child_offset,
                 children_count: item.children.len() as u32,
                 parent_index,

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -13,6 +13,7 @@ use i_slint_compiler::langtype::Type;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::*;
 use i_slint_compiler::{diagnostics::BuildDiagnostics, object_tree::PropertyDeclaration};
+use i_slint_core::accessibility::AccessibleStringProperty;
 use i_slint_core::api::Window;
 use i_slint_core::component::{
     Component, ComponentRef, ComponentRefPin, ComponentVTable, ComponentWeak, IndexRange,
@@ -21,7 +22,7 @@ use i_slint_core::item_tree::{
     ItemRc, ItemTreeNode, ItemVisitorRefMut, ItemVisitorVTable, ItemWeak, TraversalOrder,
     VisitChildrenResult,
 };
-use i_slint_core::items::{Flickable, ItemRef, ItemVTable, PropertyAnimation};
+use i_slint_core::items::{AccessibleRole, Flickable, ItemRef, ItemVTable, PropertyAnimation};
 use i_slint_core::layout::{BoxLayoutCellData, LayoutInfo, Orientation};
 use i_slint_core::model::RepeatedComponent;
 use i_slint_core::model::Repeater;
@@ -199,6 +200,19 @@ impl Component for ErasedComponentBox {
     fn subtree_index(self: Pin<&Self>) -> usize {
         self.borrow().as_ref().subtree_index()
     }
+
+    fn accessible_role(self: Pin<&Self>, index: usize) -> AccessibleRole {
+        self.borrow().as_ref().accessible_role(index)
+    }
+
+    fn accessible_string_property(
+        self: Pin<&Self>,
+        index: usize,
+        what: AccessibleStringProperty,
+        result: &mut SharedString,
+    ) {
+        self.borrow().as_ref().accessible_string_property(index, what, result)
+    }
 }
 
 i_slint_core::ComponentVTable_static!(static COMPONENT_BOX_VT for ErasedComponentBox);
@@ -307,6 +321,8 @@ pub struct ComponentDescription<'id> {
     pub(crate) extra_data_offset: FieldOffset<Instance<'id>, ComponentExtraData>,
     /// Keep the Rc alive
     pub(crate) original: Rc<object_tree::Component>,
+    /// Maps from an item_id to the original element it came from
+    pub(crate) original_elements: Vec<ElementRc>,
     /// Copy of original.root_element.property_declarations, without a guarded refcell
     public_properties: BTreeMap<String, PropertyDeclaration>,
 
@@ -795,6 +811,7 @@ pub(crate) fn generate_component<'id>(
         tree_array: Vec<ItemTreeNode>,
         item_array:
             Vec<vtable::VOffset<crate::dynamic_type::Instance<'id>, ItemVTable, vtable::AllowPin>>,
+        original_elements: Vec<ElementRc>,
         items_types: HashMap<String, ItemWithinComponent>,
         type_builder: dynamic_type::TypeBuilder<'id>,
         repeater: Vec<ErasedRepeaterWithinComponent<'id>>,
@@ -813,6 +830,7 @@ pub(crate) fn generate_component<'id>(
         ) {
             self.tree_array
                 .push(ItemTreeNode::DynamicTree { index: repeater_count as usize, parent_index });
+            self.original_elements.push(item_rc.clone());
             let item = item_rc.borrow();
             let base_component = item.base_type.as_component();
             self.repeater_names.insert(item.id.clone(), self.repeater.len());
@@ -857,6 +875,8 @@ pub(crate) fn generate_component<'id>(
                 item_array_index: self.item_array.len() as u32,
             });
             self.item_array.push(unsafe { vtable::VOffset::from_raw(rt.vtable, offset) });
+            self.original_elements.push(rc_item.clone());
+            debug_assert_eq!(self.original_elements.len(), self.tree_array.len());
             self.items_types.insert(
                 item.id.clone(),
                 ItemWithinComponent { offset, rtti: rt.clone(), elem: rc_item.clone() },
@@ -887,6 +907,7 @@ pub(crate) fn generate_component<'id>(
     let mut builder = TreeBuilder {
         tree_array: vec![],
         item_array: vec![],
+        original_elements: vec![],
         items_types: HashMap::new(),
         type_builder: dynamic_type::TypeBuilder::new(guard),
         repeater: vec![],
@@ -1049,6 +1070,8 @@ pub(crate) fn generate_component<'id>(
         get_subtree_component,
         parent_node,
         subtree_index,
+        accessible_role,
+        accessible_string_property,
         drop_in_place,
         dealloc,
     };
@@ -1061,6 +1084,7 @@ pub(crate) fn generate_component<'id>(
         custom_properties,
         custom_callbacks,
         original: component.clone(),
+        original_elements: builder.original_elements,
         repeater: builder.repeater,
         repeater_names: builder.repeater_names,
         parent_component_offset,
@@ -1600,6 +1624,46 @@ unsafe extern "C" fn parent_node(component: ComponentRefPin, result: &mut ItemWe
                 parent_instance.self_weak().get().unwrap().clone().into_dyn().upgrade().unwrap();
             *result = ItemRc::new(parent_rc, parent_index).downgrade();
         };
+    }
+}
+
+extern "C" fn accessible_role(component: ComponentRefPin, item_index: usize) -> AccessibleRole {
+    generativity::make_guard!(guard);
+    let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
+    let nr = instance_ref.component_type.original_elements[item_index]
+        .borrow()
+        .accessibility_props
+        .0
+        .get("accessible-role")
+        .cloned();
+    match nr {
+        Some(nr) => crate::eval::load_property(instance_ref, &nr.element(), nr.name())
+            .unwrap()
+            .try_into()
+            .unwrap(),
+        None => AccessibleRole::default(),
+    }
+}
+extern "C" fn accessible_string_property(
+    component: ComponentRefPin,
+    item_index: usize,
+    what: AccessibleStringProperty,
+    result: &mut SharedString,
+) {
+    generativity::make_guard!(guard);
+    let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
+    let prop_name = format!("accessible-{}", what.to_string().to_lowercase());
+    let nr = instance_ref.component_type.original_elements[item_index]
+        .borrow()
+        .accessibility_props
+        .0
+        .get(&prop_name)
+        .cloned();
+    if let Some(nr) = nr {
+        *result = crate::eval::load_property(instance_ref, &nr.element(), nr.name())
+            .unwrap()
+            .try_into()
+            .unwrap();
     }
 }
 

--- a/tests/cases/accessibility/materialized.slint
+++ b/tests/cases/accessibility/materialized.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// Test the propagation of maximum and minimum size through nested grid layouts
+
+Btn := Rectangle {
+    property <string> text;
+
+    Text {
+        text: root.text;
+        width: 100%; height: 100%;
+    }
+
+    accessible-label: text;
+    accessible-role: button;
+}
+
+TestCase := Rectangle {
+    width: 300phx;
+    height: 300phx;
+
+    vl := VerticalLayout {
+        b1 := Btn {
+            text: "plus";
+        }
+
+
+        b2 := Btn {
+            text : "minus";
+        }
+    }
+
+
+    property<AccessibleRole> materialized_b1_role: b1.accessible_role;
+    property<string> materialized_b2_label: b2.accessible-label;
+    property<string> materialized_vl_label: vl.accessible-label;
+    property<AccessibleRole> materialized_vl_role: vl.accessible-role;
+
+    property <bool> test:
+        materialized_b1_role == AccessibleRole.button && materialized_b2_label == "minus"
+        && materialized_vl_label == "" && materialized_vl_role == AccessibleRole.none;
+}
+


### PR DESCRIPTION
This adds `accessible-*` property to every elements, and generate code so that the accessible properties can be queried from the component vtable with the item index.
This just start with one property, and more will be added later.

This hasn't be tested yet.

Note that this is a PR against an accessibility branch, not against master.