### PR TITLE
Fix focus navigation involving repeater at the end of the chain

### DIFF
--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -293,9 +293,9 @@ impl ItemRc {
                     return step_in(item);
                 } else {
                     // Go up a level!
-                    let mut parent_node = Default::default();
                     let root_component = root.component();
                     let root_comp_ref = vtable::VRc::borrow_pin(&root_component);
+                    let mut parent_node = Default::default();
                     root_comp_ref.as_ref().parent_node(&mut parent_node);
 
                     while let Some(parent) = parent_node.upgrade() {
@@ -318,6 +318,7 @@ impl ItemRc {
                         root = ItemRc::new(parent.component(), 0);
                         let root_component = root.component();
                         let root_comp_ref = vtable::VRc::borrow_pin(&root_component);
+                        parent_node = Default::default();
                         root_comp_ref.as_ref().parent_node(&mut parent_node);
                     }
 

--- a/tests/cases/focus/keyboard_focus.slint
+++ b/tests/cases/focus/keyboard_focus.slint
@@ -66,6 +66,20 @@ TestCase := Window {
             }
         }
     }
+    for xxx in [0, 1] : FocusScope {
+        enabled: false;
+        key-pressed(event) => {
+            result += "disabledA" + xxx;
+            accept
+        }
+        if (true) :  FocusScope {
+            enabled: false;
+            key-pressed(event) => {
+                result += "disabledB" + xxx;
+                accept
+            }
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
The parent_node function doesn't reset its argument if it is already
set while calling the function