### PR TITLE
Revert #1049

### DIFF
--- a/examples/7guis/crud.rs
+++ b/examples/7guis/crud.rs
@@ -108,6 +108,10 @@ impl FilteredStringModel {
     fn remove(&self, index: usize) {
         let mut inner = self.inner.borrow_mut();
 
+        if index > inner.filtered_array.len() {
+            return;
+        }
+
         let id = inner.filtered_array.remove(index).id;
         self.notify.row_removed(index, 1);
         inner.filtered_ids.remove(&id);

--- a/examples/7guis/crud.slint
+++ b/examples/7guis/crud.slint
@@ -33,12 +33,12 @@ MainWindow := Window {
             }
             Button {
                 text: "Update";
-                enabled: list.current-item != -1;
+                enabled: list.current-item != -1 && list.current-item < names-list.length;
                 clicked => { root.updateClicked() }
             }
             Button {
                 text: "Delete";
-                enabled: list.current-item != -1;
+                enabled: list.current-item != -1 && list.current-item < names-list.length;
                 clicked => { root.deleteClicked() }
             }
         }

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -447,7 +447,7 @@ export ListView := ScrollView {
 
 export StandardListView := ListView {
     property<[StandardListViewItem]> model;
-    property<int> current-item: min(fs.actual-current-item, model.length - 1);
+    property<int> current-item: -1;
     for item[idx] in model : Rectangle {
         l := HorizontalLayout {
             padding: 8px;
@@ -462,17 +462,16 @@ export StandardListView := ListView {
         touch := TouchArea {
             width: parent.width;
             height: parent.height;
-            clicked => { fs.actual-current-item = idx; }
+            clicked => { current-item = idx; }
         }
     }
-    fs := FocusScope {
-        property<int> actual-current-item: -1;
+    FocusScope {
         key-pressed(event) => {
             if (event.text == Keys.UpArrow && current-item > 0) {
-                actual-current-item -= 1;
+                current-item -= 1;
                 return accept;
             } else if (event.text == Keys.DownArrow && current-item + 1 < model.length) {
-                actual-current-item += 1;
+                current-item += 1;
                 return accept;
             }
             reject

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -60,24 +60,23 @@ export ListView := ScrollView {
 
 export StandardListView := ListView {
     property<[StandardListViewItem]> model;
-    property<int> current-item: min(fs.actual-current-item, model.length - 1);
+    property<int> current-item: -1;
     for item[i] in model : NativeStandardListViewItem {
         item: item;
         index: i;
         is-selected: current-item == i;
         TouchArea {
-            clicked => { fs.actual-current-item = i; }
+            clicked => { current-item = i; }
             has-hover <=> parent.has-hover;
         }
     }
-    fs := FocusScope {
-        property<int> actual-current-item: -1;
+    FocusScope {
         key-pressed(event) => {
             if (event.text == Keys.UpArrow && current-item > 0) {
-                actual-current-item -= 1;
+                current-item -= 1;
                 accept
             } else if (event.text == Keys.DownArrow && current-item + 1 < model.length) {
-                actual-current-item += 1;
+                current-item += 1;
                 accept
             } else {
                 reject


### PR DESCRIPTION
This breaks the printer demo USB page, it makes it impossible to
change the current item.
That's because the printer demo do `current-item: 1;` to preselect the cat.
But that breaks the property binding that makes current-item follow the
actual-current-item.

 * Revert "move actual-current-item to FocusScope"
   This reverts commit 8240531e6ef4f706d86dbb41802856e7a631ccc1.

 * Revert "reset StandardListView's current-item if it is out of bounds"
   This reverts commit 9d18882f9da026ef58871facaf25894608027208.