### PR TITLE
Do not build node by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ members = [
 ]
 
 default-members = [
-    'api/node/native',
     'api/rs/build',
     'api/rs/slint',
     'examples/gallery',
@@ -67,7 +66,6 @@ default-members = [
     'internal/interpreter',
     'tests/doctests',
     'tests/driver/interpreter',
-    'tests/driver/nodejs',
     'tests/driver/rust',
     'tools/compiler',
     'tools/fmt',

--- a/docs/building.md
+++ b/docs/building.md
@@ -10,36 +10,45 @@ Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang
 have Rust installed, make sure that it's at least version 1.59 or newer. You can check which version you have installed
 by running `rustc --version`.
 
-Once this is done, you should have the ```rustc``` compiler and the ```cargo``` build system installed in your path.
-
+Once this is done, you should have the `rustc` compiler and the `cargo` build system installed in your path.
 
 ### Linux
 
 For Linux a few additional packages beyond the usual build essentials are needed for development and running apps:
 
-  * xcb (`libxcb-shape0-dev` `libxcb-xfixes0-dev` on debian based distributions)
-  * xkbcommon (`libxkbcommon-dev` on debian based distributions)
-  * fontconfig library (`libfontconfig-dev` on debian based distributions)
+- xcb (`libxcb-shape0-dev` `libxcb-xfixes0-dev` on debian based distributions)
+- xkbcommon (`libxkbcommon-dev` on debian based distributions)
+- fontconfig library (`libfontconfig-dev` on debian based distributions)
+- (optional) Qt will be used when `qmake` is found in `PATH`
 
 ### macOS
 
-   * Make sure the "Xcode Command Line Tools" are installed: `xcode-select --install`
-### For the NodeJS backend
+- Make sure the "Xcode Command Line Tools" are installed: `xcode-select --install`
+- (optional) Qt will be used when `qmake` is found in `PATH`
 
-For the nodejs backend, the following component are needed:
+### Windows
 
-* **node** (including npm)
-* **python**
+- Make sure the MSVC Build Tools are installed: `winget install Microsoft.VisualStudio.2019.BuildTools`
+- (optional) make sure Qt is installed and `qmake` is in the `Path`
 
-It would be nice if building the nodejs backend was optional, but right now it is part of the workspace.
-You can still not build it by doing `cargo build --workspace --exclude slint-node`. But cargo test will fail.
+### NodeJS API (optional)
 
-### For the C++ dev (optional)
+To use Slint from Node.JS, the following extra dependencies are needed.
 
-* **[cmake](https://cmake.org/download/)** (3.19 or newer)
-* A C++ compiler that can do C++20 (e.g., **MSVC 2019 16.6** on Windows)
+- **node** (including npm) At this time you will need to use the LTS version.
+- **python**
 
-## Testing
+Node.JS support is not built by default! Check below for the extra commands
+to run.
+
+### C++ API (optional)
+
+To use Slint from C++, the following extra dependencies are needed:
+
+- **[cmake](https://cmake.org/download/)** (3.19 or newer)
+- A C++ compiler that can do C++20 (e.g., **MSVC 2019 16.6** on Windows)
+
+## Building and Testing
 
 Most of the project is written in Rust, and compiling and running the test can
 done with cargo.
@@ -50,7 +59,7 @@ cargo test
 ```
 
 **Important:** Note that `cargo test` does not work without first calling `cargo build` because the
-C++ tests or the nodejs tests will not find the required dynamic library otherwise
+the required dynamic library will not be found.
 
 ### C++ test
 
@@ -65,7 +74,7 @@ cargo test --bin test-driver-cpp
 
 See [testing.md](./testing.md)
 
-## C++ Build
+## C++ API Build
 
 This is just a normal cmake build.
 
@@ -83,6 +92,18 @@ cmake --install .
 ```
 
 You can pass `-DCMAKE_INSTALL_PREFIX` in the first cmake command in order to choose the install location
+
+### Node.JS API Build
+
+Run
+
+```sh
+cargo build -p slint-node
+cargo build -p test-driver-nodejs
+```
+
+after the steps above were done as `slint-node` will need the build results
+of the default build step to function.
 
 ## Cross-Compiling
 
@@ -111,8 +132,8 @@ See the [examples](/examples) folder for examples to build, run and test.
 
 ## Running the viewer
 
-Slint also includes a viewer tool that can load `.slint`files dynamically at run-time. It is a
-cargo-integrated binary and can be run directly on the `.slint`files, for example:
+Slint also includes a viewer tool that can load `.slint` files dynamically at run-time. It is a
+cargo-integrated binary and can be run directly on the `.slint` files, for example:
 
 ```sh
 cargo run --release --bin slint-viewer -- examples/printerdemo/ui/printerdemo.slint


### PR DESCRIPTION
Having to make sure the right version of npm is installed is a hassle
for people that just want to try out slint for the first time. The
proposed way to disable node support enables basically everything else,
which opens another can of worms when Windows tries to build MCU
support.

So do not build Node.JS as part of the default build anymore, but
document how to build it.

The CI should build with `--workspace` already, so there should be no
need to change the CI build.