### PR TITLE
GL Backend: Make window.hide() respect the set EventLoopQuitBehavior

### DIFF
--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -533,6 +533,10 @@ impl PlatformWindow for GLWindow {
         if let Some(existing_blinker) = self.cursor_blinker.borrow().upgrade() {
             existing_blinker.stop();
         }*/
+        crate::event_loop::with_window_target(|event_loop| {
+            event_loop.event_loop_proxy().send_event(crate::event_loop::CustomEvent::WindowHidden)
+        })
+        .unwrap();
     }
 
     fn set_mouse_cursor(&self, cursor: MouseCursor) {


### PR DESCRIPTION
This makes the Application quit, when the windows are hidden programmatically.

Fixes #1220
