### PR TITLE
Qt: do not wrap QPainter directly, but use a unique_ptr instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Changed
+
+### Added
+
+### Fixed
+
+ - Fixed crashes with the Qt backend in release mode.
+
 ## [0.2.2] - 2022-05-04
 
 ### Changed

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -298,7 +298,7 @@ impl Item for NativeButton {
         let has_focus = this.has_focus();
 
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             text as "QString",
             icon as "QPixmap",
@@ -328,7 +328,7 @@ impl Item for NativeButton {
             if (has_focus) {
                 option.state |= QStyle::State_HasFocus | QStyle::State_KeyboardFocusChange | QStyle::State_Item;
             }
-            qApp->style()->drawControl(QStyle::CE_PushButton, &option, painter, widget);
+            qApp->style()->drawControl(QStyle::CE_PushButton, &option, painter->get(), widget);
         });
     }
 }

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -109,7 +109,7 @@ impl Item for NativeCheckBox {
         let text: qttypes::QString = this.text().as_str().into();
 
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             enabled as "bool",
             text as "QString",
@@ -132,7 +132,7 @@ impl Item for NativeCheckBox {
             if (has_focus) {
                 option.state |= QStyle::State_HasFocus | QStyle::State_KeyboardFocusChange | QStyle::State_Item;
             }
-            qApp->style()->drawControl(QStyle::CE_CheckBox, &option, painter, widget);
+            qApp->style()->drawControl(QStyle::CE_CheckBox, &option, painter->get(), widget);
         });
     }
 }

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -103,7 +103,7 @@ impl Item for NativeComboBox {
             this.current_value().as_str().into();
         let enabled = this.enabled();
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             text as "QString",
             enabled as "bool",
@@ -132,8 +132,8 @@ impl Item for NativeComboBox {
             //    option.state |= QStyle::State_On;
             }
             option.subControls = QStyle::SC_All;
-            qApp->style()->drawComplexControl(QStyle::CC_ComboBox, &option, painter, widget);
-            qApp->style()->drawControl(QStyle::CE_ComboBoxLabel, &option, painter, widget);
+            qApp->style()->drawComplexControl(QStyle::CC_ComboBox, &option, painter->get(), widget);
+            qApp->style()->drawControl(QStyle::CE_ComboBoxLabel, &option, painter->get(), widget);
         });
     }
 }

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -162,7 +162,7 @@ impl Item for NativeGroupBox {
         let enabled = this.enabled();
 
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             text as "QString",
             enabled as "bool",
@@ -187,7 +187,7 @@ impl Item for NativeGroupBox {
             }
             option.textColor = QColor(qApp->style()->styleHint(
                 QStyle::SH_GroupBox_TextLabelColor, &option));
-            qApp->style()->drawComplexControl(QStyle::CC_GroupBox, &option, painter, widget);
+            qApp->style()->drawComplexControl(QStyle::CC_GroupBox, &option, painter->get(), widget);
         });
     }
 }

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -115,7 +115,7 @@ impl Item for NativeLineEdit {
         let enabled: bool = this.enabled();
 
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             size as "QSize",
             dpr as "float",
@@ -135,7 +135,7 @@ impl Item for NativeLineEdit {
             } else {
                 option.palette.setCurrentColorGroup(QPalette::Disabled);
             }
-            qApp->style()->drawPrimitive(QStyle::PE_PanelLineEdit, &option, painter, widget);
+            qApp->style()->drawPrimitive(QStyle::PE_PanelLineEdit, &option, painter->get(), widget);
         });
     }
 }

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -90,7 +90,7 @@ impl Item for NativeStandardListViewItem {
         let item = this.item();
         let text: qttypes::QString = item.text.as_str().into();
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             size as "QSize",
             dpr as "float",
@@ -120,14 +120,14 @@ impl Item for NativeStandardListViewItem {
             option.features |= QStyleOptionViewItem::HasDisplay;
             option.text = text;
             // CE_ItemViewItem in QCommonStyle calls setClipRect on the painter and replace the clips. So we need to cheat.
-            auto engine = painter->paintEngine();
+            auto engine = (*painter)->paintEngine();
             auto old_clip = engine->systemClip();
-            auto new_clip = old_clip & (painter->clipRegion() * painter->transform());
+            auto new_clip = old_clip & ((*painter)->clipRegion() * (*painter)->transform());
             if (new_clip.isEmpty()) return;
             engine->setSystemClip(new_clip);
 
-            qApp->style()->drawPrimitive(QStyle::PE_PanelItemViewRow, &option, painter, widget);
-            qApp->style()->drawControl(QStyle::CE_ItemViewItem, &option, painter, widget);
+            qApp->style()->drawPrimitive(QStyle::PE_PanelItemViewRow, &option, painter->get(), widget);
+            qApp->style()->drawControl(QStyle::CE_ItemViewItem, &option, painter->get(), widget);
             engine->setSystemClip(old_clip);
         });
     }

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -207,7 +207,7 @@ impl Item for NativeSlider {
         let pressed = data.pressed;
 
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             enabled as "bool",
             value as "int",
@@ -224,7 +224,7 @@ impl Item for NativeSlider {
             option.rect = QRect(QPoint(), size / dpr);
             initQSliderOptions(option, pressed, enabled, active_controls, min, max, value);
             auto style = qApp->style();
-            style->drawComplexControl(QStyle::CC_Slider, &option, painter, widget);
+            style->drawComplexControl(QStyle::CC_Slider, &option, painter->get(), widget);
         });
     }
 }

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -231,7 +231,7 @@ impl Item for NativeSpinBox {
         let pressed = data.pressed;
 
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             value as "int",
             enabled as "bool",
@@ -250,7 +250,7 @@ impl Item for NativeSpinBox {
             }
             option.rect = QRect(QPoint(), size / dpr);
             initQSpinBoxOptions(option, pressed, enabled, active_controls);
-            style->drawComplexControl(QStyle::CC_SpinBox, &option, painter, widget);
+            style->drawComplexControl(QStyle::CC_SpinBox, &option, painter->get(), widget);
 
             QStyleOptionFrame frame;
             frame.state = option.state;
@@ -259,11 +259,11 @@ impl Item for NativeSpinBox {
                 : style->pixelMetric(QStyle::PM_DefaultFrameWidth, &option, widget);
             frame.midLineWidth = 0;
             frame.rect = style->subControlRect(QStyle::CC_SpinBox, &option, QStyle::SC_SpinBoxEditField, widget);
-            style->drawPrimitive(QStyle::PE_PanelLineEdit, &frame, painter, widget);
+            style->drawPrimitive(QStyle::PE_PanelLineEdit, &frame, painter->get(), widget);
             QRect text_rect = qApp->style()->subElementRect(QStyle::SE_LineEditContents, &frame, widget);
             text_rect.adjust(1, 2, 1, 2);
-            painter->setPen(option.palette.color(QPalette::Text));
-            painter->drawText(text_rect, QString::number(value));
+            (*painter)->setPen(option.palette.color(QPalette::Text));
+            (*painter)->drawText(text_rect, QString::number(value));
         });
     }
 }

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -252,7 +252,7 @@ impl Item for NativeTabWidget {
             height: this.tabbar_preferred_height() as _,
         };
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             size as "QSize",
             dpr as "float",
@@ -275,7 +275,7 @@ impl Item for NativeTabWidget {
             option.leftCornerWidgetSize = QSize(0, 0);
             option.tabBarRect = style->subElementRect(QStyle::SE_TabWidgetTabBar, &option, widget);
             option.rect = style->subElementRect(QStyle::SE_TabWidgetTabPane, &option, widget);
-            style->drawPrimitive(QStyle::PE_FrameTabWidget, &option, painter, widget);
+            style->drawPrimitive(QStyle::PE_FrameTabWidget, &option, painter->get(), widget);
 
             /* -- we don't need to draw the base since we already draw the frame
                 QStyleOptionTab tabOverlap;
@@ -290,7 +290,7 @@ impl Item for NativeTabWidget {
                 }
                 optTabBase.tabBarRect = option.tabBarRect;
                 optTabBase.selectedTabRect = option.selectedTabRect;
-                style->drawPrimitive(QStyle::PE_FrameTabBarBase, &optTabBase, painter, widget);*/
+                style->drawPrimitive(QStyle::PE_FrameTabBarBase, &optTabBase, painter->get(), widget);*/
         });
     }
 }
@@ -449,7 +449,7 @@ impl Item for NativeTab {
         let num_tabs: i32 = this.num_tabs();
 
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             text as "QString",
             icon as "QPixmap",
@@ -492,7 +492,7 @@ impl Item for NativeTab {
                 option.state |= QStyle::State_HasFocus | QStyle::State_KeyboardFocusChange | QStyle::State_Item;
             }
             option.features |= QStyleOptionTab::HasFrame;
-            qApp->style()->drawControl(QStyle::CE_TabBarTab, &option, painter, widget);
+            qApp->style()->drawControl(QStyle::CE_TabBarTab, &option, painter->get(), widget);
         });
     }
 }


### PR DESCRIPTION
Because QPainter can't be relocated.

Fixes #1230