### PR TITLE
Fix BoxShadow property incorrectly considered const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 
  - Fixed crashes with the Qt backend in release mode.
+ - Fixed panic when drop-shadow is used in a ListView
 
 ## [0.2.2] - 2022-05-04
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1934,4 +1934,14 @@ pub fn adjust_geometry_for_injected_parent(injected_parent: &ElementRc, old_elem
             )
         }),
     ));
+    injected_parent.borrow().property_analysis.borrow_mut().extend(
+        ["x", "y", "z"].into_iter().filter_map(|x| {
+            old_elem
+                .borrow()
+                .property_analysis
+                .borrow()
+                .get_key_value(x)
+                .map(|(k, v)| (k.clone(), v.clone()))
+        }),
+    );
 }

--- a/tests/cases/crashes/issue_1233_listview_const_shadow.slint
+++ b/tests/cases/crashes/issue_1233_listview_const_shadow.slint
@@ -1,0 +1,34 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+import { ListView } from "std-widgets.slint";
+
+App := Window {
+    width: 100px;
+    height: 600px;
+
+    ListView {
+        for item in [
+            {}, {},
+        ] : Rectangle {
+            drop-shadow-blur: 5px;
+            HorizontalLayout {
+                Image {
+                    source: @image-url("../../../logo/slint-logo-square-light-128x128.png");
+                }
+            }
+        }
+    }
+}
+
+
+/*
+
+```rust
+let ui = App::new();
+// this should not panic
+slint::testing::send_mouse_click(&ui, 50., 50.);
+```
+
+*/


### PR DESCRIPTION
We steal the bindings for the geometry from the containing element,
so we should also take the analysis.

Fixes #1233