### PR TITLE
GL backend: fix locating the default font in slightly atypical enviro…

### DIFF
--- a/internal/backends/gl/Cargo.toml
+++ b/internal/backends/gl/Cargo.toml
@@ -60,7 +60,7 @@ web-sys = { version = "0.3", features=["console", "WebGlContextAttributes", "Can
 wasm-bindgen = { version = "0.2" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-fontdb = { version = "0.9.0", features = ["memmap"] }
+fontdb = { version = "0.9.0", features = ["memmap", "fontconfig"] }
 glutin = { version = "0.28", default-features = false }
 usvg = { version= "0.22", optional = true, default-features = false, features = ["text", "memmap-fonts"] }
 

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -49,7 +49,7 @@ once_cell = "1"
 url = "2.2.1"
 dunce = "1.0.1"
 linked_hash_set = "0.1.4"
-fontdb = { version = "0.9.0" }
+fontdb = { version = "0.9.0", features = ["fontconfig"] }
 fontdue = { version = "0.7.1" }
 
 # for processing and embedding the rendered image (texture)


### PR DESCRIPTION
…nments

Enable fontdb's fontconfig feature to parse fontconfig files to locate
the directories where truetype fonts are located. This helps in system
setups that differ from the defaults that fontdb uses otherwise.

Fixes #1240