### PR TITLE
Native style: Fix crash when opening a combobox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+ - Fixed crash when opening a native (Qt) ComboBox
+
 ## [0.2.3] - 2033-05-09
 
 ### Fixed

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -197,7 +197,7 @@ impl Item for NativeComboBoxPopup {
 
     fn_render! { _this dpr size painter widget initial_state =>
         cpp!(unsafe [
-            painter as "QPainter*",
+            painter as "QPainterPtr*",
             widget as "QWidget*",
             size as "QSize",
             dpr as "float",
@@ -214,7 +214,7 @@ impl Item for NativeComboBoxPopup {
             auto style = qApp->style();
 
             if (style->styleHint(QStyle::SH_ComboBox_Popup, &option, widget)) {
-                style->drawPrimitive(QStyle::PE_PanelMenu, &option, painter, widget);
+                style->drawPrimitive(QStyle::PE_PanelMenu, &option, painter->get(), widget);
             } else {
                 option.lineWidth = 1;
             }
@@ -224,7 +224,7 @@ impl Item for NativeComboBoxPopup {
             else if ((frameStyle & QFrame::Shadow_Mask) == QFrame::Raised)
                 option.state |= QStyle::State_Raised;
             option.frameShape = QFrame::Shape(frameStyle & QFrame::Shape_Mask);
-            style->drawControl(QStyle::CE_ShapedFrame, &option, painter, widget);
+            style->drawControl(QStyle::CE_ShapedFrame, &option, painter->get(), widget);
         });
     }
 }


### PR DESCRIPTION
Bug introduced by https://github.com/slint-ui/slint/pull/1231