### PR TITLE
Accessibility: support for bool property

### DIFF
--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -35,7 +35,7 @@ The following `accessible-` properties are used to enable accessibility of appli
   The  default value is empty for most elements, or is the value of the `text` property for the Text
   element.
 * **`accessible-description`** (*string*) defines a string value that describes or annotates the current element.
-
+* **`accessible-checked`** (*bool*) indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
 
 ### Drop Shadows
 

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -36,6 +36,7 @@ The following `accessible-` properties are used to enable accessibility of appli
   element.
 * **`accessible-description`** (*string*) defines a string value that describes or annotates the current element.
 * **`accessible-checked`** (*bool*) indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+* **`accessible-has-focus`** (*bool*) indicates that the element currently is in the focused state.
 
 ### Drop Shadows
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -448,6 +448,7 @@ export NativeButton := _ {
     property <string> text;
     property <image> icon;
     property <bool> pressed: native_output;
+    property <bool> has-focus: native_output;
     callback clicked;
     property <bool> enabled: true;
     property <StandardButtonKind> standard-button-kind;
@@ -463,6 +464,7 @@ export NativeCheckBox := _ {
     property <bool> enabled: true;
     property <string> text;
     property <bool> checked: native_output;
+    property <bool> has-focus: native_output;
     callback toggled;
     //-is_internal
 }

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -283,13 +283,8 @@ fn lower_sub_component(
             _ => unreachable!(),
         };
         for (key, nr) in &elem.accessibility_props.0 {
-            let key_bytes = key.strip_prefix("accessible-").unwrap().as_bytes();
             // TODO: we also want to split by type (role/string/...)
-            let enum_value = format!(
-                "{}{}",
-                std::str::from_utf8(&[key_bytes[0].to_ascii_uppercase()]).unwrap(),
-                std::str::from_utf8(&key_bytes[1..]).unwrap()
-            );
+            let enum_value = to_camel_case(key.strip_prefix("accessible-").unwrap());
             accessible_prop.push((*elem.item_index.get().unwrap(), enum_value, nr.clone()));
         }
         Some(element.clone())
@@ -409,6 +404,23 @@ fn lower_sub_component(
         .collect();
 
     LoweredSubComponent { sub_component: Rc::new(sub_component), mapping }
+}
+
+// Convert a ascii kebab string to camel case
+fn to_camel_case(str: &str) -> String {
+    let mut result = Vec::with_capacity(str.len());
+    let mut next_upper = true;
+    for x in str.as_bytes() {
+        if *x == b'-' {
+            next_upper = true;
+        } else if next_upper {
+            result.push(x.to_ascii_uppercase());
+            next_upper = false;
+        } else {
+            result.push(*x);
+        }
+    }
+    String::from_utf8(result).unwrap()
 }
 
 fn get_property_analysis(elem: &ElementRc, p: &str) -> crate::object_tree::PropertyAnalysis {

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -396,10 +396,15 @@ fn lower_sub_component(
     sub_component.accessible_prop = accessible_prop
         .into_iter()
         .map(|(idx, key, nr)| {
-            (
-                (idx, key),
-                super::Expression::PropertyReference(ctx.map_property_reference(&nr)).into(),
-            )
+            let mut expr = super::Expression::PropertyReference(ctx.map_property_reference(&nr));
+            if nr.ty() == Type::Bool {
+                expr = super::Expression::Condition {
+                    condition: expr.into(),
+                    true_expr: super::Expression::StringLiteral("true".into()).into(),
+                    false_expr: super::Expression::StringLiteral("false".into()).into(),
+                };
+            }
+            ((idx, key), expr.into())
         })
         .collect();
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -89,6 +89,7 @@ pub(crate) const RESERVED_ACCESSIBILITY_PROPERTIES: &[(&str, Type)] = &[
     ("accessible-label", Type::String),
     ("accessible-description", Type::String),
     ("accessible-checked", Type::Bool),
+    ("accessible-has-focus", Type::Bool),
 ];
 
 /// list of reserved property injected in every item

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -88,6 +88,7 @@ pub(crate) const RESERVED_ACCESSIBILITY_PROPERTIES: &[(&str, Type)] = &[
     //("accessible-role", ...)
     ("accessible-label", Type::String),
     ("accessible-description", Type::String),
+    ("accessible-checked", Type::Bool),
 ];
 
 /// list of reserved property injected in every item

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -9,6 +9,7 @@ export { StyleMetrics, ScrollView, TextEdit, AboutSlint, AboutSlint as AboutSixt
 export Button := NativeButton {
     property<length> font-size;
     accessible-label <=> text;
+    accessible-has-focus <=> has-focus;
     accessible-role: button;
     enabled: true;
 }
@@ -20,6 +21,7 @@ export StandardButton := NativeButton {
 export CheckBox := NativeCheckBox {
     accessible-role: checkbox;
     accessible-label <=> text;
+    accessible-has-focus <=> has-focus;
 }
 export SpinBox := NativeSpinBox {
     property<length> font-size;

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -3,8 +3,10 @@
 
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum AccessibleStringProperty {
     Label,
     Description,
     Checked,
+    HasFocus,
 }

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -6,4 +6,5 @@
 pub enum AccessibleStringProperty {
     Label,
     Description,
+    Checked,
 }

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1661,10 +1661,12 @@ extern "C" fn accessible_string_property(
         .get(&prop_name)
         .cloned();
     if let Some(nr) = nr {
-        *result = crate::eval::load_property(instance_ref, &nr.element(), nr.name())
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let value = crate::eval::load_property(instance_ref, &nr.element(), nr.name()).unwrap();
+        match value {
+            Value::String(s) => *result = s,
+            Value::Bool(b) => *result = if b { "true" } else { "false }" }.into(),
+            _ => unimplemented!("invalid type for accessible_string_property"),
+        };
     }
 }
 

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1653,7 +1653,7 @@ extern "C" fn accessible_string_property(
 ) {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
-    let prop_name = format!("accessible-{}", what.to_string().to_lowercase());
+    let prop_name = format!("accessible-{}", what.to_string());
     let nr = instance_ref.component_type.original_elements[item_index]
         .borrow()
         .accessibility_props

--- a/tests/cases/accessibility/materialized.slint
+++ b/tests/cases/accessibility/materialized.slint
@@ -21,6 +21,7 @@ Cb := Rectangle {
     t := Text { }
     accessible-description <=> t.text;
     accessible-role: checkbox;
+    accessible-checked: true;
 }
 
 TestCase := Rectangle {
@@ -56,7 +57,8 @@ TestCase := Rectangle {
     property <bool> test:
         materialized_b1_role == AccessibleRole.button && materialized_b2_label == "minus"
         && materialized_vl_label == "" && materialized_vl_role == AccessibleRole.none
-        && materialized_txt_label == "automatic text value" && materialized_txt_role == AccessibleRole.text;
+        && materialized_txt_label == "automatic text value" && materialized_txt_role == AccessibleRole.text
+        && cb.accessible-checked && !b1.accessible-checked;
 }
 
 


### PR DESCRIPTION
Currently, bool property are mapped to string property at runtime because
we'll avoid to extand the vtable for now, we'll consider that later