### PR TITLE
GL backend: process timing event before processing input events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Added
+
  - Added the Model Adapters `FilterModel` and `MapModel`.
+
+### Fixed
+
+ - GL backend: Fixed animation sometimes not starting from input event (#1255)
 
 ## [0.2.4] - 2022-05-09
 

--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -600,7 +600,7 @@ pub fn run(quit_behavior: i_slint_core::backend::EventLoopQuitBehavior) {
                     *control_flow = winit::event_loop::ControlFlow::Poll;
                 }
 
-                winit::event::Event::MainEventsCleared => {
+                winit::event::Event::NewEvents(_) => {
                     corelib::timers::TimerList::maybe_activate_timers();
                     corelib::animations::update_animations();
                 }


### PR DESCRIPTION
Otherwise the timing code might think at the time of an event (eg key press)
that the starting point of an animation that starts in this event is
earlier in time than it really is. Causing the animation to appear as it
had started earlier or literaly be finished before it starts.

Fixes #1255