### PR TITLE
7guis example: add logic to the cells

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,10 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macOS-11, windows-2019]
         rust_version: [stable, 1.59]
+        include:
+          - rust_version: 1.59
+            extra_args: --exclude _7guis
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -83,7 +87,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
           command: build
-          args: --verbose --all-features --workspace --exclude i-slint-backend-mcu --exclude printerdemo_mcu # mcu backend requires nightly
+          args: --verbose --all-features --workspace ${{ matrix.extra_args }} --exclude i-slint-backend-mcu --exclude printerdemo_mcu  # mcu backend requires nightly
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 
  - GL backend: Fixed animation sometimes not starting from input event (#1255)
+ - C++ fix compilation when writing to the model data
 
 ## [0.2.4] - 2022-05-09
 

--- a/examples/7guis/Cargo.toml
+++ b/examples/7guis/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Slint Developers <info@slint-ui.com>"]
 edition = "2021"
 publish = false
 license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
+rust-version = "1.60"
 
 [[bin]]
 path = "booker.rs"

--- a/examples/7guis/Cargo.toml
+++ b/examples/7guis/Cargo.toml
@@ -14,16 +14,21 @@ path = "booker.rs"
 name = "booker"
 
 [[bin]]
-path = "circledraw.rs"
-name = "circledraw"
+path = "timer.rs"
+name = "timer"
 
 [[bin]]
 path = "crud.rs"
 name = "crud"
 
 [[bin]]
-path = "timer.rs"
-name = "timer"
+path = "circledraw.rs"
+name = "circledraw"
+
+[[bin]]
+path = "cells.rs"
+name = "cells"
+
 
 [dependencies]
 slint = { path = "../../api/rs/slint" }

--- a/examples/7guis/cells.rs
+++ b/examples/7guis/cells.rs
@@ -1,0 +1,245 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+use slint::{Model, ModelRc, SharedString};
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::rc::{Rc, Weak};
+
+slint::slint!(import { MainWindow } from "cells.slint";);
+
+const ROW_COUNT: usize = 100;
+const COL_COUNT: usize = 26;
+
+/// Graph of dependences so that node B depends on node A.
+/// So when node A is updated, node B also need to re updated.
+#[derive(Default)]
+struct DepGraph<A, B> {
+    index1: HashMap<A, HashSet<B>>,
+    index2: HashMap<B, HashSet<A>>,
+}
+
+impl<A: Clone + Eq + Hash, B: Clone + Eq + Hash> DepGraph<A, B> {
+    pub fn add_dep(&mut self, a: A, b: B) {
+        self.index1.entry(a.clone()).or_default().insert(b.clone());
+        self.index2.entry(b).or_default().insert(a);
+    }
+
+    pub fn deps<'a>(&'a self, a: &A) -> impl Iterator<Item = &B> + 'a {
+        self.index1.get(a).into_iter().flat_map(|x| x.iter())
+    }
+
+    pub fn remove_rev_deps(&mut self, b: &B) {
+        if let Some(h) = self.index2.remove(b) {
+            for a in h {
+                self.index1.get_mut(&a).map(|x| x.remove(b));
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Expr {
+    Value(f32),
+    Cell(usize, usize),
+    Add(Box<(Expr, Expr)>),
+    Sub(Box<(Expr, Expr)>),
+}
+
+fn parse_formula(formula: &str) -> Option<Expr> {
+    let formula = formula.trim();
+    let alpha_n = formula.find(|c: char| !c.is_ascii_alphabetic()).unwrap_or(formula.len());
+    let num_n = formula[alpha_n..]
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .map_or(formula.len(), |x| x + alpha_n);
+
+    let e = if alpha_n > 0 {
+        if alpha_n != 1 {
+            return None;
+        };
+        let col = formula.as_bytes()[0].to_ascii_lowercase() - b'a';
+        let row = formula[alpha_n..num_n].parse().ok()?;
+        Expr::Cell(row, col as usize)
+    } else if num_n > 0 {
+        Expr::Value(formula[alpha_n..num_n].parse().ok()?)
+    } else {
+        return None;
+    };
+
+    let rest = formula[num_n..].trim();
+
+    if rest.is_empty() {
+        Some(e)
+    } else if let Some(x) = rest.strip_prefix("+") {
+        Some(Expr::Add(Box::new((e, parse_formula(x)?))))
+    } else if let Some(x) = rest.strip_prefix("-") {
+        Some(Expr::Sub(Box::new((e, parse_formula(x)?))))
+    } else {
+        None
+    }
+}
+
+#[test]
+fn test_parse_formula() {
+    assert_eq!(parse_formula("42"), Some(Expr::Value(42.0)));
+    assert_eq!(parse_formula(" 49.5 "), Some(Expr::Value(49.5)));
+    assert_eq!(parse_formula("B4"), Some(Expr::Cell(4, 1)));
+    assert_eq!(parse_formula("B 4"), None);
+    assert_eq!(parse_formula("B4.2"), None);
+    assert_eq!(parse_formula("AB5"), None);
+    assert_eq!(parse_formula("4B"), None);
+    assert_eq!(
+        parse_formula("8 + C6"),
+        Some(Expr::Add(Box::new((Expr::Value(8.), Expr::Cell(6, 2)))))
+    );
+    assert_eq!(
+        parse_formula(" a9-b2 "),
+        Some(Expr::Sub(Box::new((Expr::Cell(9, 0), Expr::Cell(2, 1)))))
+    );
+    assert_eq!(
+        parse_formula("D22+B12+85.5"),
+        Some(Expr::Add(Box::new((
+            Expr::Cell(22, 3),
+            Expr::Add(Box::new((Expr::Cell(12, 1), Expr::Value(85.5))))
+        ))))
+    );
+}
+
+struct RowModel {
+    row: usize,
+    row_data: RefCell<Vec<CellContent>>,
+    base_model: Weak<CellsModel>,
+    notify: slint::ModelNotify,
+}
+
+impl slint::Model for RowModel {
+    type Data = CellContent;
+
+    fn row_count(&self) -> usize {
+        self.row_data.borrow().len()
+    }
+
+    fn row_data(&self, row: usize) -> Option<Self::Data> {
+        self.row_data.borrow().get(row).cloned()
+    }
+
+    fn model_tracker(&self) -> &dyn slint::ModelTracker {
+        &self.notify
+    }
+
+    fn set_row_data(&self, index: usize, data: CellContent) {
+        if let Some(cells) = self.base_model.upgrade() {
+            cells.update_cell(self.row, index, Some(data.formula));
+        }
+    }
+}
+
+struct CellsModel {
+    rows: Vec<Rc<RowModel>>,
+    dep_graph: RefCell<DepGraph<(usize, usize), (usize, usize)>>,
+}
+
+impl CellsModel {
+    fn new() -> Rc<Self> {
+        Rc::new_cyclic(|w| Self {
+            rows: (0..ROW_COUNT)
+                .map(|row| {
+                    Rc::new(RowModel {
+                        row,
+                        row_data: vec![CellContent::default(); COL_COUNT].into(),
+                        base_model: w.clone(),
+                        notify: Default::default(),
+                    })
+                })
+                .collect(),
+            dep_graph: Default::default(),
+        })
+    }
+
+    fn get_cell_value(&self, row: usize, col: usize) -> Option<f32> {
+        self.rows.get(row)?.row_data.borrow().get(col)?.value.into()
+    }
+
+    /// Update a cell to a new formula, or re_avaluate the current formula of that cell
+    fn update_cell(&self, row: usize, col: usize, new_formula: Option<SharedString>) -> Option<()> {
+        let r_model = self.rows.get(row)?;
+        let mut r = r_model.row_data.borrow_mut();
+        let data = r.get_mut(col)?;
+        let new_form = new_formula.is_some();
+        if let Some(new_formula) = new_formula {
+            data.formula = new_formula;
+        };
+        let exp = parse_formula(&data.formula).unwrap_or(Expr::Value(0.));
+
+        drop(r);
+        self.dep_graph.borrow_mut().remove_rev_deps(&(row, col));
+        let new = self.eval(&exp);
+        let mut r = r_model.row_data.borrow_mut();
+        let data = r.get_mut(col)?;
+        if data.value != new {
+            data.value = new;
+            drop(r);
+            r_model.notify.row_changed(col);
+            let deps = self.dep_graph.borrow().deps(&(row, col)).cloned().collect::<Vec<_>>();
+            for (r, c) in deps {
+                self.update_cell(r, c, None);
+            }
+        } else if new_form {
+            r_model.notify.row_changed(col);
+        }
+
+        make_deps(&mut *self.dep_graph.borrow_mut(), (row, col), &exp);
+
+        Some(())
+    }
+
+    /// Evaluate an expression recursively
+    fn eval(&self, exp: &Expr) -> f32 {
+        match exp {
+            Expr::Value(x) => *x,
+            Expr::Cell(row, col) => self.get_cell_value(*row, *col).unwrap_or(0.),
+            Expr::Add(x) => self.eval(&x.0) + self.eval(&x.1),
+            Expr::Sub(x) => self.eval(&x.0) - self.eval(&x.1),
+        }
+    }
+}
+
+/// Traverse a given expression to register the dependencies
+fn make_deps(
+    graph: &mut DepGraph<(usize, usize), (usize, usize)>,
+    orig: (usize, usize),
+    exp: &Expr,
+) {
+    match exp {
+        Expr::Value(_) => {}
+        Expr::Cell(row, col) => graph.add_dep((*row, *col), orig),
+        Expr::Add(x) | Expr::Sub(x) => {
+            make_deps(graph, orig, &x.0);
+            make_deps(graph, orig, &x.1)
+        }
+    }
+}
+
+impl Model for CellsModel {
+    type Data = ModelRc<CellContent>;
+
+    fn row_count(&self) -> usize {
+        ROW_COUNT
+    }
+
+    fn row_data(&self, row: usize) -> Option<Self::Data> {
+        self.rows.get(row).map(|x| x.clone().into())
+    }
+
+    fn model_tracker(&self) -> &dyn slint::ModelTracker {
+        &()
+    }
+}
+
+pub fn main() {
+    let main_window = MainWindow::new();
+    let cells_model = CellsModel::new();
+    main_window.set_cells(ModelRc::from(cells_model));
+    main_window.run();
+}

--- a/examples/7guis/cells.slint
+++ b/examples/7guis/cells.slint
@@ -15,7 +15,7 @@ export MainWindow := Window {
 
     property <{r: int, c: int}> active-cell: { r: -1, c: -1 };
 
-        ScrollView {
+    ScrollView {
         width: 100%;
         height: 100%;
         viewport-width: 20px + 26 * cell-width;

--- a/examples/7guis/cells.slint
+++ b/examples/7guis/cells.slint
@@ -3,13 +3,19 @@
 
 import { LineEdit, ScrollView} from "std-widgets.slint";
 
+struct CellContent := { value: float, formula: string }
 
-Cells := Window {
+
+export MainWindow := Window {
 
     property<length> cell-height: 32px;
-    property<length> cell-width: 80px;
+    property<length> cell-width: 100px;
 
-    ScrollView {
+    property <[[CellContent]]> cells;
+
+    property <{r: int, c: int}> active-cell: { r: -1, c: -1 };
+
+        ScrollView {
         width: 100%;
         height: 100%;
         viewport-width: 20px + 26 * cell-width;
@@ -21,18 +27,58 @@ Cells := Window {
             width: cell-width;
             Text { text: letter; }
         }
-        for __[idx] in 100 : Rectangle {
-            y: cell-height + idx * cell-height;
+        for row[row-idx] in cells : Rectangle {
+            y: cell-height + row-idx * cell-height;
             height: cell-height;
-            Text { text: idx; }
-            for ___[idx-x] in 26 :   LineEdit {
-                height: cell-height - 1px;
-                width: cell-width - 2px;
-                x: 20px + idx-x * cell-width;
+            Text { text: row_idx; }
+            for cell[col-idx] in row: Rectangle {
+                height: cell-height;
+                width: cell-width;
+                border-color: gray;
+                border-width: 1px;
+                x: 20px + col-idx * cell-width;
+                property <bool> is-active: root.active-cell.r == row-idx && root.active-cell.c == col-idx;
+
+                Text {
+                    visible: !is-active && cell.formula != "";
+                    text: " " + cell.value;
+                    vertical-alignment: center;
+                    width: 100%;
+                    height: 100%;
+                }
+
+                TouchArea {
+                    clicked => {
+                        l.text = cell.formula;
+                        active-cell = {r: row-idx, c: col-idx};
+                        l.focus();
+                    }
+                }
+
+                l := LineEdit {
+                    visible: is-active;
+                    width: 100%;
+                    height: 100%;
+                    edited => {
+                        cell = { value: self.text.to-float(), formula: self.text };
+                    }
+                    accepted => {
+                        root.active-cell = { r: -1, c: -1};
+                    }
+                }
             }
-
         }
-
     }
+}
 
+Cell := MainWindow {
+    // initialize the cells with demy value to be viewed in the preview
+    property <[CellContent]> _row: [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}];
+    cells: [
+        _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row,
+        _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row,
+        _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row,
+        _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row,
+        _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row, _row,
+    ];
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1401,7 +1401,7 @@ fn generate_sub_component(
         ));
 
         target_struct.members.push((
-            Access::Private,
+            field_access,
             Declaration::Var(Var {
                 ty: format!(
                     "slint::private_api::Repeater<class {}, {}>",

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1565,7 +1565,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         Expression::CallBackCall { callback, arguments } => {
             let f = access_member(callback, ctx);
             let a = arguments.iter().map(|a| compile_expression(a, ctx));
-            quote! { #f.call(&(#(#a.clone() as _,)*).into())}
+            quote! { #f.call(&(#(#a as _,)*).into())}
         }
         Expression::ExtraBuiltinFunctionCall { function, arguments, return_ty: _ } => {
             let f = ident(function);
@@ -1787,7 +1787,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         }
         Expression::ReadLocalVariable { name, .. } => {
             let name = ident(name);
-            quote!(#name)
+            quote!(#name.clone())
         }
         Expression::EasingCurve(EasingCurve::Linear) => {
             quote!(slint::re_exports::EasingCurve::Linear)

--- a/tests/cases/expr/string_concatenation.slint
+++ b/tests/cases/expr/string_concatenation.slint
@@ -14,6 +14,8 @@
         s3 += s3;
         obj.a += "yo";
     }
+
+    property <bool> test: (s1 + s1 + obj.a + obj.a) == "hello1212hello1212aa";
 }
 /*
 ```cpp

--- a/tests/cases/models/array.slint
+++ b/tests/cases/models/array.slint
@@ -7,8 +7,11 @@ export TestCase := Rectangle {
     property<int> n: ints[ints[4] - ints[1]];
     property<int> operations: ints.length < 1 ? ints.length : ints.length + ints.length;
     property<[{a: [int]}]> empty_model;
+    property<[[int]]> array_of_array: [ints, ints, ints];
+
     property<bool> test: num_ints == 5 && operations == 10
-        && hello_world == (["", "world"])[1] && empty_model.length == 0 && empty_model[45].a.length == 0;
+        && hello_world == (["", "world"])[1] && empty_model.length == 0 && empty_model[45].a.length == 0
+        && array_of_array[1][1] == 2;
     property<int> third_int: ints[2];
     property<string> hello_world: [{t: "hello"}, {t: "world"}][1].t;
 }

--- a/tests/cases/models/model_in_struct.slint
+++ b/tests/cases/models/model_in_struct.slint
@@ -14,4 +14,9 @@ struct Bar := {
 
 TestCase := Rectangle {
     property <[Bar]> bars: [];
+
+    // make sure the generated code compiles (that we generate .clone() properly)
+    property <Foo> foo: {ok: true};
+    property <Bar> bar: {foos: [foo, foo]};
+    property <[Bar]> bars2: [bar, bar];
 }

--- a/tests/cases/models/write_to_model_sub_component.slint
+++ b/tests/cases/models/write_to_model_sub_component.slint
@@ -1,0 +1,56 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+SubComponent := Rectangle {
+    property <[int]> m;
+    HorizontalLayout {
+        for foo in m: Rectangle {
+            if foo < 100 : TouchArea {
+                clicked => { foo += 8; }
+            }
+        }
+    }
+}
+
+TestCase := Rectangle {
+    width: 100px;
+    height: 100px;
+    property <[int]> mod;
+    SubComponent {
+        m: mod;
+    }
+}
+
+/*
+```rust
+use slint::Model;
+let instance = TestCase::new();
+
+let the_model = std::rc::Rc::new(slint::VecModel::<i32>::from(vec![1, 2, 3]));
+instance.set_mod(the_model.clone().into());
+slint::testing::send_mouse_click(&instance, 50., 50.);
+assert_eq!(the_model.row_data(1).unwrap() , 2+8);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+std::vector<int> array { 1 , 2 ,  3 };
+auto the_model = std::make_shared<slint::VectorModel<int>>(std::move(array));
+instance.set_mod(the_model);
+
+slint::testing::send_mouse_click(&instance, 50., 50.);
+assert_eq(*the_model->row_data(1) , 2+8);
+```
+
+
+```js
+var instance = new slint.TestCase({});
+instance.mod = [1, 2, 3];
+instance.send_mouse_click(50., 50.);
+assert.equal(instance.mod[1], 2+8);
+```
+
+
+*/

--- a/tests/cases/types/structs2.slint
+++ b/tests/cases/types/structs2.slint
@@ -10,6 +10,10 @@ struct Foo3 := { b: int }
 TestCase := Rectangle {
     callback cb1(Foo2) -> Foo3;
     cb1(foo) => { return { b: foo.a.member+1 }; }
+
+    property<Foo2> xx;
+    callback cb2(Foo2, Foo2)->Foo2;
+    property<Foo2> xx2: cb2(xx, xx);
 }
 
 /*


### PR DESCRIPTION
I think that's more or less what is required by https://eugenkiss.github.io/7guis/tasks#cells

Some notes:
 - The line edit aprears on click instead of double click since we don't yet have double click events in slint
 -  the parsing is evaluated once the user edits the text instead of "finish editing" because we don't have this concept in slint yet.
 - The dependency tracking was re-implmented. Would have been nice to be able to re-use the `properties` if it was exposed in public API.  That said, that would panic on cycles instead of returning some random value like we do now.
 
I've had to use Model of Model. Mapping from a big vector in more row model is not currently possible because one cannot implement a filter model ourselves, as the ModelChangeListenerContainer is not public.

But well, i think it works pretty well still.