### PR TITLE
Fix mouse exit events not triggered by scrolling a Flickable

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -99,12 +99,12 @@ pub enum InputEventFilterResult {
     /// going to be called for this item
     ForwardAndIgnore,
     /// Just like `ForwardEvent`, but even in the case the children grabs the mouse, this function
-    /// Will still be called for further event.
+    /// will still be called for further event
     ForwardAndInterceptGrab,
-    /// The Event will not be forwarded to children, if a children already had the grab, the
+    /// The event will not be forwarded to children, if a children already had the grab, the
     /// grab will be cancelled with a [`MouseEvent::MouseExit`] event
     Intercept,
-    // TODO: add docs
+    /// Similar to `Intercept` but the contained [`MouseEvent`] will be forwarded to children
     InterceptAndDispatch(MouseEvent),
 }
 

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -104,6 +104,8 @@ pub enum InputEventFilterResult {
     /// The Event will not be forwarded to children, if a children already had the grab, the
     /// grab will be cancelled with a [`MouseEvent::MouseExit`] event
     Intercept,
+    // TODO: add docs
+    ForwardAndIntercept,
 }
 
 impl Default for InputEventFilterResult {
@@ -430,8 +432,6 @@ pub fn process_mouse_input(
         return mouse_input_state;
     }
 
-    send_exit_events(&mouse_input_state, mouse_event.pos(), window);
-
     let mut result = MouseInputState::default();
     type State = (Vector2D<Coord>, Vec<(ItemWeak, InputEventFilterResult)>);
     crate::item_tree::visit_items_with_post_visit(
@@ -460,6 +460,9 @@ pub fn process_mouse_input(
                     InputEventFilterResult::ForwardAndIgnore => None,
                     InputEventFilterResult::ForwardEvent => {
                         Some((event2, mouse_grabber_stack.clone(), item_rc, false))
+                    }
+                    InputEventFilterResult::ForwardAndIntercept => {
+                        Some((event2, mouse_grabber_stack.clone(), item_rc, true))
                     }
                     InputEventFilterResult::ForwardAndInterceptGrab => {
                         Some((event2, mouse_grabber_stack.clone(), item_rc, false))
@@ -509,6 +512,9 @@ pub fn process_mouse_input(
         },
         (Vector2D::new(0 as Coord, 0 as Coord), Vec::new()),
     );
+
+    send_exit_events(&mouse_input_state, mouse_event.pos(), window);
+
     result
 }
 

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -500,8 +500,13 @@ pub fn process_mouse_input(
                 }
                 match item.as_ref().input_event(event2, window, &item_rc) {
                     InputEventResult::EventAccepted => {
-                        result.item_stack = mouse_grabber_stack;
-                        result.grabbed = false;
+                        if result.item_stack.len() == 0 {
+                            // In case the item stack is set already, it shouldn't
+                            // be overriden as we have to keep the deepest stack
+                            // for `send_exit_events` to work properly.
+                            result.item_stack = mouse_grabber_stack;
+                            result.grabbed = false;
+                        }
                         return VisitChildrenResult::abort(item_rc.index(), 0);
                     }
                     InputEventResult::EventIgnored => {

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -241,7 +241,7 @@ impl FlickableData {
                     InputEventFilterResult::ForwardEvent
                 }
             }
-            MouseEvent::MouseWheel { .. } => InputEventFilterResult::Intercept,
+            MouseEvent::MouseWheel { .. } => InputEventFilterResult::ForwardAndIntercept,
             // Not the left button
             MouseEvent::MousePressed { .. } | MouseEvent::MouseReleased { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
@@ -295,7 +295,8 @@ impl FlickableData {
                 (Flickable::FIELD_OFFSETS.viewport + Rectangle::FIELD_OFFSETS.y)
                     .apply_pin(flick)
                     .set(new_pos.y);
-                InputEventResult::EventAccepted
+                // Although the event was handled, child items also have to handle it
+                InputEventResult::EventIgnored
             }
         }
     }

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -241,7 +241,9 @@ impl FlickableData {
                     InputEventFilterResult::ForwardEvent
                 }
             }
-            MouseEvent::MouseWheel { .. } => InputEventFilterResult::ForwardAndIntercept,
+            MouseEvent::MouseWheel { pos, .. } => {
+                InputEventFilterResult::InterceptAndDispatch(MouseEvent::MouseMoved { pos })
+            }
             // Not the left button
             MouseEvent::MousePressed { .. } | MouseEvent::MouseReleased { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
@@ -295,7 +297,8 @@ impl FlickableData {
                 (Flickable::FIELD_OFFSETS.viewport + Rectangle::FIELD_OFFSETS.y)
                     .apply_pin(flick)
                     .set(new_pos.y);
-                // Although the event was handled, child items also have to handle it
+                // Although the event was handled, the mouse grabber stack
+                // should extend into child items and don't end at this point
                 InputEventResult::EventIgnored
             }
         }

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -297,9 +297,7 @@ impl FlickableData {
                 (Flickable::FIELD_OFFSETS.viewport + Rectangle::FIELD_OFFSETS.y)
                     .apply_pin(flick)
                     .set(new_pos.y);
-                // Although the event was handled, the mouse grabber stack
-                // should extend into child items and don't end at this point
-                InputEventResult::EventIgnored
+                InputEventResult::EventAccepted
             }
         }
     }

--- a/tests/cases/elements/flickable3.slint
+++ b/tests/cases/elements/flickable3.slint
@@ -1,0 +1,52 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+TestCase := Window {
+  width: 500phx;
+  height: 500phx;
+
+  Flickable {
+    x: 0phx;
+    width: 250phx;
+    viewport-height: 800phx;
+
+    t1 := TouchArea {
+      height: 50phx;
+    }
+  }
+
+  Flickable {
+    x: 250phx;
+    width: 250phx;
+    viewport-width: 800phx;
+
+    t2 := TouchArea {
+      width: 50phx;
+    }
+  }
+
+  property<bool> t1-has-hover: t1.has-hover;
+  property<bool> t2-has-hover: t2.has-hover;
+}
+
+/*
+```rust
+// Test that mouse exit events are dispatched while scrolling
+use slint::re_exports::{MouseEvent, euclid::point2, vtable, WindowHandleAccess};
+let instance = TestCase::new();
+let window = vtable::VRc::from(instance.clone_strong()).window_handle().clone();
+// Vertical
+assert_eq!(instance.get_t1_has_hover(), false);
+window.clone().process_mouse_input(MouseEvent::MouseMoved { pos: point2(25.0, 25.0) });
+assert_eq!(instance.get_t1_has_hover(), true);
+window.clone().process_mouse_input(MouseEvent::MouseWheel { pos: point2(25.0, 25.0), delta: point2(0.0, -30.0) });
+assert_eq!(instance.get_t1_has_hover(), false);
+// Horizontal
+assert_eq!(instance.get_t2_has_hover(), false);
+window.clone().process_mouse_input(MouseEvent::MouseMoved { pos: point2(275.0, 25.0) });
+assert_eq!(instance.get_t2_has_hover(), true);
+window.clone().process_mouse_input(MouseEvent::MouseWheel { pos: point2(275.0, 25.0), delta: point2(-30.0, 0.0) });
+assert_eq!(instance.get_t2_has_hover(), false);
+```
+*/


### PR DESCRIPTION
This is more of an POC of a fix to #1107. Basically the main idea here is to make sure that mouse events are handled as usual by child items in case of a mouse scroll event on a flickable, so they are part of the previous mouse grabber stack which is required to be included in the exit event dispatching. This works for the case shown on the video at the bottom (mouse leave) but I think it's not the most complete solution here. Probably a better solution would be to convert the scroll event to a move event as this would be more correct for the child items. I also had to move the call to `send_exit_events` after the actual event handling to be able to catch the updated scroll position in the frame it was changed and not 1 frame later. While this wasn't a huge issue when scrolling slowly, scrolling fast could easily trigger a wrong hovering state as the jump in a single frame was greater than a single item in height.

Open questions:
- Is introducing a new input event filter result the best option here?
- Using `EventIgnore` as result of the flickable event handler feels a bit hacky.
- Could there be any regressions or unintended side effects caused by sending exit events at the end of event handling?
- While the mouse event should be forwarded to child items only, it is also forwarded to siblings if I'm not mistaken, which is not desired

https://user-images.githubusercontent.com/9491603/168012405-f40b14e6-e074-4f7c-a4ba-afe12130872b.mp4

Fixes #1107
Fixes #1278