### PR TITLE
Generate the enum documentation based of the common/enums.rs

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -15,7 +15,7 @@ jobs:
       # Allow deprecated warning because we are using nightly and some things might be deprecated in nightly
       # for which the stable alternative is not yet available.
       # Allow suspicious-auto-trait-impls to work around https://github.com/Diggsey/scoped-tls-hkt/issues/2
-      # RUSTFLAGS: -D warnings -W deprecated 
+      # RUSTFLAGS: -D warnings -W deprecated
       RUSTDOCFLAGS: --html-in-header=/home/runner/work/slint/slint/docs/resources/slint-docs-preview.html --html-in-header=/home/runner/work/slint/slint/docs/resources/slint-docs-highlight.html -D warnings -W deprecated -W suspicious-auto-trait-impls
       SLINT_NO_QT: 1
       CARGO_INCREMENTAL: false
@@ -71,6 +71,11 @@ jobs:
           args: -- --check
     - name: Check license headers
       run: cargo xtask check_license_headers --show-all
+    - name: Check Enum docs
+      run: |
+        cargo xtask enumdocs
+        echo "Check that the docs were actual. If there is a diff you need co call 'cargo xtask enumdocs'"
+        git diff --exit-code
     - name: Check reuse compliance
       run: cargo xtask check_reuse_compliance
     - name: Build Cpp docs

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -74,7 +74,7 @@ jobs:
     - name: Check Enum docs
       run: |
         cargo xtask enumdocs
-        echo "Check that the docs were actual. If there is a diff you need co call 'cargo xtask enumdocs'"
+        echo "Check that the docs were actual. If there is a diff you need to run 'cargo xtask enumdocs'"
         git diff --exit-code
     - name: Check reuse compliance
       run: cargo xtask check_reuse_compliance

--- a/api/cpp/docs/language.rst
+++ b/api/cpp/docs/language.rst
@@ -8,5 +8,6 @@ The .slint UI Design Language
 
     Language Reference<markdown/langref.md>
     markdown/builtin_elements.md
+    markdown/builtin_enums.md
     markdown/widgets.md
     markdown/layouting.md

--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -35,6 +35,13 @@ pub mod builtin_elements {
     #![doc = include_str!("docs/builtin_elements.md")]
     //!
     //! #
+    //! Next: [Builtin Enums](super::builtin_enums)
+}
+
+pub mod builtin_enums {
+    #![doc = include_str!("docs/builtin_enums.md")]
+    //!
+    //! #
     //! Next: [Widgets](super::widgets)
 }
 

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -17,6 +17,7 @@ If you are already familiar with Slint, the following topics provide related inf
  * [Examples and Recipes](docs::recipes)
  * [The `.slint` language reference](docs::langref)
  * [Builtin Elements](docs::builtin_elements)
+ * [Builtin Enums](docs::builtin_enums)
  * [Widgets](docs::widgets)
  * [Positioning and Layout of Elements](docs::layouting)
  * [Debugging Techniques](docs::debugging_techniques)

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -210,10 +210,10 @@ and the text itself.
 * **`font-size`** (*length*): The font size of the text
 * **`font-weight`** (*int*): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
 * **`color`** (*brush*): The color of the text (default value: depends on the style)
-* **`horizontal-alignment`** (*enum [`TextHorizontalAlignment`](#texthorizontalalignment)*): The horizontal alignment of the text.
-* **`vertical-alignment`** (*enum [`TextVerticalAlignment`](#textverticalalignment)*): The vertical alignment of the text.
-* **`wrap`** (*enum [`TextWrap`](#textwrap)*): The way the text wraps (default: no-wrap).
-* **`overflow`** (*enum [`TextOverflow`](#textoverflow)*): What happens when the text overflows (default: clip).
+* **`horizontal-alignment`** (*enum [`TextHorizontalAlignment`](builtin_enums.md#texthorizontalalignment)*): The horizontal alignment of the text.
+* **`vertical-alignment`** (*enum [`TextVerticalAlignment`](builtin_enums.md#textverticalalignment)*): The vertical alignment of the text.
+* **`wrap`** (*enum [`TextWrap`](builtin_enums.md#textwrap)*): The way the text wraps (default: no-wrap).
+* **`overflow`** (*enum [`TextOverflow`](builtin_enums.md#textoverflow)*): What happens when the text overflows (default: clip).
 * **`letter-spacing`** (*length*): The letter spacing allows changing the spacing between the glyphs. A positive value increases the spacing
   and a negative value decreases the distance. The default value is 0.
 
@@ -270,7 +270,7 @@ accordingly.
 ### Common Path Properties
 
 * **`fill`** (*brush*): The color for filling the shape of the path.
-* **`fill-rule`** (enum *[`FillRule`](#fillrule)*): The fill rule to use for the path. (default value: `nonzero`)
+* **`fill-rule`** (enum *[`FillRule`](builtin_enums.md#fillrule)*): The fill rule to use for the path. (default value: `nonzero`)
 * **`stroke`** (*brush*): The color for drawing the outline of the path.
 * **`stroke-width`** (*length*): The width of the outline.
 * **`width`** (*length*): If non-zero, the path will be scaled to fit into the specified width.
@@ -432,7 +432,7 @@ When not part of a layout, its width or height default to 100% of the parent ele
 * **`has-hover`** (*bool*): Set to `true` by the TouchArea when the mouse is over it.
 * **`mouse-x`**, **`mouse-y`** (*length*): Set by the TouchArea to the position of the mouse within it.
 * **`pressed-x`**, **`pressed-y`** (*length*): Set to `true` by the TouchArea to the position of the mouse at the moment it was last pressed.
-* **`mouse-cursor`** (enum *[`MouseCursor`](#mousecursor)*): The mouse cursor type when the mouse is hovering the TouchArea.
+* **`mouse-cursor`** (enum *[`MouseCursor`](builtin_enums.md#mousecursor)*): The mouse cursor type when the mouse is hovering the TouchArea.
 
 ### Callbacks
 
@@ -645,14 +645,14 @@ When not part of a layout, its width or height defaults to 100% of the parent el
 * **`font-size`** (*length*): The font size of the text
 * **`font-weight`** (*int*): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
 * **`color`** (*brush*): The color of the text (default value: depends on the style)
-* **`horizontal-alignment`** (enum *[`TextHorizontalAlignment`](#texthorizontalalignment)*): The horizontal alignment of the text.
-* **`vertical-alignment`** (enum *[`TextVerticalAlignment`](#textverticalalignment)*): The vertical alignment of the text.
+* **`horizontal-alignment`** (enum *[`TextHorizontalAlignment`](builtin_enums.md#texthorizontalalignment)*): The horizontal alignment of the text.
+* **`vertical-alignment`** (enum *[`TextVerticalAlignment`](builtin_enums.md#textverticalalignment)*): The vertical alignment of the text.
 * **`has-focus`** (*bool*): Set to `true` when item is focused and receives keyboard events.
 * **`letter-spacing`** (*length*): The letter spacing allows changing the spacing between the glyphs. A positive value increases the spacing
   and a negative value decreases the distance. The default value is 0.
 * **`single-line`** (bool): When set to `true`, no newlines are allowed (default value: `true`)
-* **`wrap`** (*enum [`TextWrap`](#textwrap)*): The way the text input wraps.  Only makes sense when `single-line` is false. (default: no-wrap)
-* **`input-type`** (*enum [`InputType`](#InputType)*): The way to allow special input viewing properties such as password fields (default value: `text`).
+* **`wrap`** (*enum [`TextWrap`](builtin_enums.md#textwrap)*): The way the text input wraps.  Only makes sense when `single-line` is false. (default: no-wrap)
+* **`input-type`** (*enum [`InputType`](builtin_enums.md#InputType)*): The way to allow special input viewing properties such as password fields (default value: `text`).
 
 ### Methods
 
@@ -791,131 +791,6 @@ This structure is generated and passed to the `pointer-event` callback of the `T
    - `up`: The button was released.
    - `cancel`: Another element or window took hold of the grab. This applies to all pressed button and the `button` is not relevent.
 * **`button`** (*enum PointerEventButton*): The button that was pressed or released. `left`, `right`, `middle`, or `none`.
-
-# Builtin Enums
-
-The default value of each enum type is always the first value.
-
-## `TextHorizontalAlignment`
-
-This enum describes the different types of alignment of text along the horizontal axis.
-
-### Values
-
-* **`TextHorizontalAlignment.left`**: The text will be aligned with the left edge of the containing box.
-* **`TextHorizontalAlignment.center`**: The text will be horizontally centered within the containing box.
-* **`TextHorizontalAlignment.right`** The text will be aligned to the right of the containing box.
-
-## `TextVerticalAlignment`
-
-This enum describes the different types of alignment of text along the vertical axis.
-
-### Values
-
-* **`TextVerticalAlignment.top`**: The text will be aligned to the top of the containing box.
-* **`TextVerticalAlignment.center`**: The text will be vertically centered within the containing box.
-* **`TextVerticalAlignment.bottom`** The text will be alignt to the bottom of the containing box.
-
-## `TextWrap`
-
-This enum describes the how the text wrap if it is too wide to fit in the Text width.
-
-### Values
-
-* **`TextWrap.no-wrap`**: The text will not wrap, but instead will overflow.
-* **`TextWrap.word-wrap`**: The text will be wrapped at word boundaries.
-
-## `TextOverflow`
-
-This enum describes the how the text appear if it is too wide to fit in the Text width.
-
-### Values
-
-* **`TextOverflow.clip`**: The text will simply be clipped.
-* **`TextOverflow.elide`**: The text will be elided with `…`.
-
-## `EventResult`
-
-This enum describes whether an event was rejected or accepted by an event handler.
-
-### Values
-
-* **`EventResult.reject`**: The event is rejected by this event handler and may then be handled by the parent item
-* **`EventResult.accept`**: The event is accepted and won't be processed further
-
-## `FillRule`
-
-This enum describes the different ways of deciding what the inside of a shape described by a path shall be.
-
-### Values
-
-* **`FillRule.nonzero`**: The ["nonzero" fill rule as defined in SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule#nonzero).
-* **`FillRule.evenodd`**: The ["evenodd" fill rule as defined in SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule#evenodd).
-
-## `DialogButtonRole`
-
-This enum represent the value of the `dialog-button-role` property which can be added to
-any element within a `Dialog` to put that item in the button row, and its exact position
-depends on the role and the platform.
-
-### Values
-
-* **`none`**: This is not a button means to go in the row of button of the dialog
-* **`accept`**: This is the role of the main button to click to accept the dialog. e.g. "Ok" or "Yes"
-* **`reject`**: This is the role of the main button to click to reject the dialog. e.g. "Cancel" or "No"
-* **`apply`**: This is the role of the "Apply" button
-* **`reset`**: This is the role of the "Reset" button
-* **`help`**: This is the role of the  "Help" button
-* **`action`**: This is the role of any other button that perform another action.
-
-## `MouseCursor`
-
-This enum represents different types of mouse cursors. It is a subset of the mouse cursors available in CSS.
-For details and pictograms see the [MDN Documentation for cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values).
-Depending on the backend and used OS unidirectional resize cursors may be replaced with bidirectional ones.
-
-### Values
-
-* **`default`**: The systems default cursor.
-* **`none`**: No cursor is displayed.
-* **`help`**: A cursor indicating help information.
-* **`pointer`**: A pointing hand indicating a link.
-* **`progress`**: The program is busy but can still be interacted with.
-* **`wait`**: The program is busy.
-* **`crosshair`**: A crosshair.
-* **`text`**: A cursor indicating selectable text.
-* **`alias`**: An alias or shortcut is being created.
-* **`copy`**: A copy is being created.
-* **`move`**: Something is to be moved.
-* **`no-drop`**: Something cannot be dropped here.
-* **`not-allowed`**: An action is not allowed
-* **`grab`**: Something is grabbable.
-* **`grabbing`**: Something is being grabbed.
-* **`col-resize`**: Indicating that a column is resizable horizontally.
-* **`row-resize`**: Indicating that a row is resizable vertically.
-* **`n-resize`**: Unidirectional resize north.
-* **`e-resize`**: Unidirectional resize east.
-* **`s-resize`**: Unidirectional resize south.
-* **`w-resize`**: Unidirectional resize west.
-* **`ne-resize`**: Unidirectional resize north-east.
-* **`nw-resize`**: Unidirectional resize north-west.
-* **`se-resize`**: Unidirectional resize south-east.
-* **`sw-resize`**: Unidirectional resize south-west.
-* **`ew-resize`**: Bidirectional resize east-west.
-* **`ns-resize`**: Bidirectional resize north-south.
-* **`nesw-resize`**: Bidirectional resize north-east-south-west.
-* **`nwse-resize`**: Bidirectional resize north-west-south-east.
-
-## `InputType`
-
-This enum is used to define the type of the input field. Currently this only differentiates between
-text and password inputs but in the future it could be expanded to also define what type of virtual keyboard
-should be shown, for example.
-
-### Values
-
-* **`text`**: The default value. This will render all characters normally
-* **`password`**: This will render all characters with a character that defaults to "*"
 
 # Namespaces
 

--- a/docs/builtin_enums.md
+++ b/docs/builtin_enums.md
@@ -1,0 +1,186 @@
+<!-- Generated with `cargo xtask enumdocs` from internal/commons/enums.rs -->
+# Builtin Enums
+
+Enum value can be referenced by using the name of the enum and the name of the value
+separated by a dot. (eg: `TextHorizontalAlignment.left`)
+
+The name of the enum can be omitted in bindings of the type of that enum, or if the
+return value of a callback is of that enum.
+
+The default value of each enum type is always the first value.
+## `TextHorizontalAlignment`
+
+ This enum describes the different types of alignment of text along the horizontal axis.
+
+* **`left`**: The text will be aligned with the left edge of the containing box.
+* **`center`**: The text will be horizontally centered within the containing box.
+* **`right`**: The text will be aligned to the right of the containing box.
+
+## `TextVerticalAlignment`
+
+ This enum describes the different types of alignment of text along the vertical axis.
+
+* **`top`**: The text will be aligned to the top of the containing box.
+* **`center`**: The text will be vertically centered within the containing box.
+* **`bottom`**: The text will be alignt to the bottom of the containing box.
+
+## `TextWrap`
+
+ This enum describes the how the text wrap if it is too wide to fit in the Text width.
+
+* **`no-wrap`**: The text will not wrap, but instead will overflow.
+* **`word-wrap`**: The text will be wrapped at word boundaries.
+
+## `TextOverflow`
+
+ This enum describes the how the text appear if it is too wide to fit in the Text width.
+
+* **`clip`**: The text will simply be clipped.
+* **`elide`**: The text will be elided with `…`.
+
+## `EventResult`
+
+ This enum describes whether an event was rejected or accepted by an event handler.
+
+* **`reject`**: The event is rejected by this event handler and may then be handled by the parent item
+* **`accept`**: The event is accepted and won't be processed further
+
+## `FillRule`
+
+ This enum describes the different ways of deciding what the inside of a shape described by a path shall be.
+
+* **`nonzero`**: The ["nonzero" fill rule as defined in SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule#nonzero).
+* **`evenodd`**: The ["evenodd" fill rule as defined in SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule#evenodd)
+
+## `StandardButtonKind`
+
+
+* **`ok`**:
+* **`cancel`**:
+* **`apply`**:
+* **`close`**:
+* **`reset`**:
+* **`help`**:
+* **`yes`**:
+* **`no`**:
+* **`abort`**:
+* **`retry`**:
+* **`ignore`**:
+
+## `DialogButtonRole`
+
+ This enum represent the value of the `dialog-button-role` property which can be added to
+ any element within a `Dialog` to put that item in the button row, and its exact position
+ depends on the role and the platform.
+
+* **`none`**: This is not a button means to go in the row of button of the dialog
+* **`accept`**: This is the role of the main button to click to accept the dialog. e.g. "Ok" or "Yes"
+* **`reject`**: This is the role of the main button to click to reject the dialog. e.g. "Cancel" or "No"
+* **`apply`**: This is the role of the "Apply" button
+* **`reset`**: This is the role of the "Reset" button
+* **`help`**: This is the role of the  "Help" button
+* **`action`**: This is the role of any other button that perform another action.
+
+## `PointerEventKind`
+
+
+* **`cancel`**:
+* **`down`**:
+* **`up`**:
+
+## `PointerEventButton`
+
+
+* **`none`**:
+* **`left`**:
+* **`right`**:
+* **`middle`**:
+
+## `MouseCursor`
+
+ This enum represents different types of mouse cursors. It is a subset of the mouse cursors available in CSS.
+ For details and pictograms see the [MDN Documentation for cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values).
+ Depending on the backend and used OS unidirectional resize cursors may be replaced with bidirectional ones.
+
+* **`default`**: The systems default cursor.
+* **`none`**: No cursor is displayed.
+* **`help`**: A cursor indicating help information.
+* **`pointer`**: A pointing hand indicating a link.
+* **`progress`**: The program is busy but can still be interacted with.
+* **`wait`**: The program is busy.
+* **`crosshair`**: A crosshair.
+* **`text`**: A cursor indicating selectable text.
+* **`alias`**: An alias or shortcut is being created.
+* **`copy`**: A copy is being created.
+* **`move`**: Something is to be moved.
+* **`no-drop`**: Something cannot be dropped here.
+* **`not-allowed`**: An action is not allowed
+* **`grab`**: Something is grabbable.
+* **`grabbing`**: Something is being grabbed.
+* **`col-resize`**: Indicating that a column is resizable horizontally.
+* **`row-resize`**: Indicating that a row is resizable vertically.
+* **`n-resize`**: Unidirectional resize north.
+* **`e-resize`**: Unidirectional resize east.
+* **`s-resize`**: Unidirectional resize south.
+* **`w-resize`**: Unidirectional resize west.
+* **`ne-resize`**: Unidirectional resize north-east.
+* **`nw-resize`**: Unidirectional resize north-west.
+* **`se-resize`**: Unidirectional resize south-east.
+* **`sw-resize`**: Unidirectional resize south-west.
+* **`ew-resize`**: Bidirectional resize east-west.
+* **`ns-resize`**: Bidirectional resize north-south.
+* **`nesw-resize`**: Bidirectional resize north-east-south-west.
+* **`nwse-resize`**: Bidirectional resize north-west-south-east.
+
+## `ImageFit`
+
+
+* **`fill`**:
+* **`contain`**:
+* **`cover`**:
+
+## `ImageRendering`
+
+
+* **`smooth`**:
+* **`pixelated`**:
+
+## `InputType`
+
+ This enum is used to define the type of the input field. Currently this only differentiates between
+ text and password inputs but in the future it could be expanded to also define what type of virtual keyboard
+ should be shown, for example.
+
+* **`text`**: The default value. This will render all characters normally
+* **`password`**: This will render all characters with a character that defaults to "*"
+
+## `LayoutAlignment`
+
+ Enum representing the alignment property of a BoxLayout or HorizontalLayout
+
+* **`stretch`**:
+* **`center`**:
+* **`start`**:
+* **`end`**:
+* **`space-between`**:
+* **`space-around`**:
+
+## `PathEvent`
+
+ PathEvent is a low-level data structure describing the composition of a path. Typically it is
+ generated at compile time from a higher-level description, such as SVG commands.
+
+* **`begin`**: The beginning of the path.
+* **`line`**: A straight line on the path.
+* **`quadratic`**: A quadratic bezier curve on the path.
+* **`cubic`**: A cubic bezier curve on the path.
+* **`end-open`**: The end of the path that remains open.
+* **`end-closed`**: The end of a path that is closed.
+
+## `KeyEventType`
+
+ This enum defines the different kinds of key events that can happen.
+
+* **`KeyPressed`**: A key on a keyboard was pressed.
+* **`KeyReleased`**: A key on a keyboard was released.
+

--- a/docs/builtin_enums.md
+++ b/docs/builtin_enums.md
@@ -69,7 +69,7 @@ The default value of each enum type is always the first value.
 
 ## `DialogButtonRole`
 
- This enum represent the value of the `dialog-button-role` property which can be added to
+ This enum represents the value of the `dialog-button-role` property which can be added to
  any element within a `Dialog` to put that item in the button row, and its exact position
  depends on the role and the platform.
 
@@ -79,7 +79,7 @@ The default value of each enum type is always the first value.
 * **`apply`**: This is the role of the "Apply" button
 * **`reset`**: This is the role of the "Reset" button
 * **`help`**: This is the role of the  "Help" button
-* **`action`**: This is the role of any other button that perform another action.
+* **`action`**: This is the role of any other button that performs another action.
 
 ## `PointerEventKind`
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -205,7 +205,7 @@ shortcut will be implemented in a future version: <https://github.com/slint-ui/s
 * **`font-size`** (*length*): the size of the font of the input text
 * **`has-focus`**: (*bool*): Set to true when the widget currently has the focus
 * **`enabled`**: (*bool*): Defaults to true. When false, nothing can be entered
-* **`wrap`** (*enum [`TextWrap`](builtin_elements.md#textwrap)*): The way the text wraps (default: word-wrap).
+* **`wrap`** (*enum [`TextWrap`](builtin_enums.md#textwrap)*): The way the text wraps (default: word-wrap).
 
 ### Callbacks
 

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -3,6 +3,9 @@
 
 //! This module contains all enums exposed in the .slint language.
 
+// NOTE: when changing the documentation of enums, you need to update
+// the markdown file with `cargo xtask enumdocs`
+
 /// Call a macro with every enum exposed in the .slint language
 ///
 /// ## Example
@@ -14,11 +17,62 @@
 /// }
 /// i_slint_common::for_each_enums!(print_enums);
 /// ```
-// NOTE: the documentation for .slint enum is in builtin_elements.md
 #[macro_export]
 macro_rules! for_each_enums {
     ($macro:ident) => {
         $macro![
+            /// This enum describes the different types of alignment of text along the horizontal axis.
+            enum TextHorizontalAlignment {
+                /// The text will be aligned with the left edge of the containing box.
+                left,
+                /// The text will be horizontally centered within the containing box.
+                center,
+                /// The text will be aligned to the right of the containing box.
+                right,
+            }
+
+            /// This enum describes the different types of alignment of text along the vertical axis.
+            enum TextVerticalAlignment {
+                /// The text will be aligned to the top of the containing box.
+                top,
+                /// The text will be vertically centered within the containing box.
+                center,
+                /// The text will be alignt to the bottom of the containing box.
+                bottom,
+            }
+
+            /// This enum describes the how the text wrap if it is too wide to fit in the Text width.
+            enum TextWrap {
+                /// The text will not wrap, but instead will overflow.
+                no_wrap,
+                /// The text will be wrapped at word boundaries.
+                word_wrap,
+            }
+
+            /// This enum describes the how the text appear if it is too wide to fit in the Text width.
+            enum TextOverflow {
+                /// The text will simply be clipped.
+                clip,
+                /// The text will be elided with `…`.
+                elide,
+            }
+
+            /// This enum describes whether an event was rejected or accepted by an event handler.
+            enum EventResult {
+                /// The event is rejected by this event handler and may then be handled by the parent item
+                reject,
+                /// The event is accepted and won't be processed further
+                accept,
+            }
+
+            /// This enum describes the different ways of deciding what the inside of a shape described by a path shall be.
+            enum FillRule {
+                /// The ["nonzero" fill rule as defined in SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule#nonzero).
+                nonzero,
+                /// The ["evenodd" fill rule as defined in SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule#evenodd)
+                evenodd,
+            }
+
             enum StandardButtonKind {
                 ok,
                 cancel,
@@ -32,14 +86,25 @@ macro_rules! for_each_enums {
                 retry,
                 ignore,
             }
+
+            /// This enum represent the value of the `dialog-button-role` property which can be added to
+            /// any element within a `Dialog` to put that item in the button row, and its exact position
+            /// depends on the role and the platform.
             enum DialogButtonRole {
+                /// This is not a button means to go in the row of button of the dialog
                 none,
+                /// This is the role of the main button to click to accept the dialog. e.g. "Ok" or "Yes"
                 accept,
+                /// This is the role of the main button to click to reject the dialog. e.g. "Cancel" or "No"
                 reject,
+                /// This is the role of the "Apply" button
                 apply,
+                /// This is the role of the "Reset" button
                 reset,
-                action,
+                /// This is the role of the  "Help" button
                 help,
+                /// This is the role of any other button that perform another action.
+                action,
             }
 
             enum PointerEventKind {
@@ -55,39 +120,71 @@ macro_rules! for_each_enums {
                 middle,
             }
 
+            /// This enum represents different types of mouse cursors. It is a subset of the mouse cursors available in CSS.
+            /// For details and pictograms see the [MDN Documentation for cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values).
+            /// Depending on the backend and used OS unidirectional resize cursors may be replaced with bidirectional ones.
             enum MouseCursor {
+                /// The systems default cursor.
                 default,
+                /// No cursor is displayed.
                 none,
                 //context_menu,
+                /// A cursor indicating help information.
                 help,
+                /// A pointing hand indicating a link.
                 pointer,
+                /// The program is busy but can still be interacted with.
                 progress,
+                /// The program is busy.
                 wait,
                 //cell,
+                /// A crosshair.
                 crosshair,
+                /// A cursor indicating selectable text.
                 text,
                 //vertical_text,
+                /// An alias or shortcut is being created.
                 alias,
+                /// A copy is being created.
                 copy,
+                /// Something is to be moved.
                 r#move,
+                /// Something cannot be dropped here.
                 no_drop,
+                /// An action is not allowed
                 not_allowed,
+                /// Something is grabbable.
                 grab,
+                /// Something is being grabbed.
                 grabbing,
                 //all_scroll,
+                /// Indicating that a column is resizable horizontally.
                 col_resize,
+                /// Indicating that a row is resizable vertically.
                 row_resize,
+                /// Unidirectional resize north.
                 n_resize,
+                /// Unidirectional resize east.
                 e_resize,
+                /// Unidirectional resize south.
                 s_resize,
+                /// Unidirectional resize west.
                 w_resize,
+                /// Unidirectional resize north-east.
                 ne_resize,
+                /// Unidirectional resize north-west.
                 nw_resize,
+                /// Unidirectional resize south-east.
                 se_resize,
+                /// Unidirectional resize south-west.
                 sw_resize,
+                /// Bidirectional resize east-west.
                 ew_resize,
+                /// Bidirectional resize north-south.
                 ns_resize,
+                /// Bidirectional resize north-east-south-west.
                 nesw_resize,
+                /// Bidirectional resize north-west-south-east.
                 nwse_resize,
                 //zoom_in,
                 //zoom_out,
@@ -104,36 +201,14 @@ macro_rules! for_each_enums {
                 pixelated,
             }
 
-            enum FillRule {
-                nonzero,
-                evenodd,
-            }
-
-            /// This enum defines the input type in a text input which for now only distinguishes a normal
-            /// input from a password input
+            /// This enum is used to define the type of the input field. Currently this only differentiates between
+            /// text and password inputs but in the future it could be expanded to also define what type of virtual keyboard
+            /// should be shown, for example.
             enum InputType {
-                /// This type is used for a normal text input
+                /// The default value. This will render all characters normally
                 text,
-                /// This type is used for password inputs where the characters are represented as *'s
+                /// This will render all characters with a character that defaults to "*"
                 password,
-            }
-            enum TextHorizontalAlignment {
-                left,
-                center,
-                right,
-            }
-            enum TextVerticalAlignment {
-                top,
-                center,
-                bottom,
-            }
-            enum TextWrap {
-                no_wrap,
-                word_wrap,
-            }
-            enum TextOverflow {
-                clip,
-                elide,
             }
 
             /// Enum representing the alignment property of a BoxLayout or HorizontalLayout
@@ -161,12 +236,6 @@ macro_rules! for_each_enums {
                 end_open,
                 /// The end of a path that is closed.
                 end_closed,
-            }
-
-            /// What is returned from the event handler
-            enum EventResult {
-                reject,
-                accept,
             }
 
             /// This enum defines the different kinds of key events that can happen.

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -87,7 +87,7 @@ macro_rules! for_each_enums {
                 ignore,
             }
 
-            /// This enum represent the value of the `dialog-button-role` property which can be added to
+            /// This enum represents the value of the `dialog-button-role` property which can be added to
             /// any element within a `Dialog` to put that item in the button row, and its exact position
             /// depends on the role and the platform.
             enum DialogButtonRole {
@@ -103,7 +103,7 @@ macro_rules! for_each_enums {
                 reset,
                 /// This is the role of the  "Help" button
                 help,
-                /// This is the role of any other button that perform another action.
+                /// This is the role of any other button that performs another action.
                 action,
             }
 

--- a/xtask/src/enumdocs.rs
+++ b/xtask/src/enumdocs.rs
@@ -1,0 +1,56 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use anyhow::Context;
+use std::io::Write;
+
+pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
+    let root = super::root_dir();
+
+    let mut file = std::fs::File::create(root.join("docs/builtin_enums.md"))
+        .context("error creating docs/builtin_enums.md")?;
+
+    file.write_all(
+        br#"<!-- Generated with `cargo xtask enumdocs` from internal/commons/enums.rs -->
+# Builtin Enums
+
+Enum value can be referenced by using the name of the enum and the name of the value
+separated by a dot. (eg: `TextHorizontalAlignment.left`)
+
+The name of the enum can be omitted in bindings of the type of that enum, or if the
+return value of a callback is of that enum.
+
+The default value of each enum type is always the first value.
+"#,
+    )?;
+
+    macro_rules! gen_enums {
+        ($( $(#[doc = $enum_doc:literal])* enum $Name:ident { $( $(#[doc = $value_doc:literal])* $Value:ident,)* })*) => {
+            $(
+                writeln!(file, "## `{}`\n", stringify!($Name))?;
+                $(writeln!(file, "{}", $enum_doc)?;)*
+                writeln!(file, "")?;
+                $(
+                    let mut has_val = false;
+                    write!(file, "* **`{}`**:", stringify!($Value).trim_start_matches("r#").replace('_', "-"))?;
+                    $(
+                        if has_val {
+                            write!(file, "\n   ")?;
+                        }
+                        write!(file, "{}", $value_doc)?;
+                        has_val = true;
+                    )*
+                    writeln!(file, "")?;
+                )*
+                writeln!(file, "")?;
+            )*
+        }
+    }
+
+    #[allow(unused)] // for 'has_val'
+    {
+        i_slint_common::for_each_enums!(gen_enums);
+    }
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::path::PathBuf;
 
 mod cppdocs;
+mod enumdocs;
 mod license_headers_check;
 mod nodepackage;
 mod reuse_compliance_check;
@@ -22,6 +23,8 @@ pub enum TaskCommand {
     NodePackage,
     #[clap(name = "check_reuse_compliance")]
     ReuseComplianceCheck(reuse_compliance_check::ReuseComplianceCheck),
+    #[clap(name = "enumdocs")]
+    EnumDocs,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -85,6 +88,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         TaskCommand::CppDocs(cmd) => cppdocs::generate(cmd.show_warnings)?,
         TaskCommand::NodePackage => nodepackage::generate()?,
         TaskCommand::ReuseComplianceCheck(cmd) => cmd.check_reuse_compliance()?,
+        TaskCommand::EnumDocs => enumdocs::generate()?,
     };
 
     Ok(())


### PR DESCRIPTION
So that makes it harder to forget to update the docs

Note that the new builtin_enums.md does not contain a `### Values`
section header anymore. Also some enum where documented with the full
enum value (such as `TextHorizontalAlignment.left`) while now this
is omitted

The CI should fail if one forget to run `cargo xtask enumdocs` after
adding an enum or changing the docs