### PR TITLE
Fix compiler panic when optimizing child of layout

### DIFF
--- a/internal/compiler/passes/optimize_useless_rectangles.rs
+++ b/internal/compiler/passes/optimize_useless_rectangles.rs
@@ -40,6 +40,11 @@ fn can_optimize(elem: &ElementRc) -> bool {
         return false;
     };
 
+    if e.child_of_layout {
+        // The `LayoutItem` still has reference to this component, so we cannot remove it
+        return false;
+    }
+
     let base_type = match &e.base_type {
         Type::Builtin(base_type) if base_type.name == "Rectangle" => base_type,
         _ => return false,

--- a/tests/cases/crashes/issue1267_opacity_in_layout.slint
+++ b/tests/cases/crashes/issue1267_opacity_in_layout.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+MainWindow := Window {
+    VerticalLayout {
+        Rectangle {
+            opacity: 0.5;
+        }
+    }
+}
+


### PR DESCRIPTION
Normally, child of layout don't get optimized anyway because
the layout sets their `x` and `y` prop, preventing the optimization.
But if the rectangle has an opacity, its `x` and `y` property are
stolen by the opacity element, and then it can get optimized anyway

Fixes #1267