### PR TITLE
wasm: Prevent wasted redraws with multiple post_events

### DIFF
--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -552,7 +552,14 @@ pub fn run(quit_behavior: i_slint_core::backend::EventLoopQuitBehavior) {
         let running_instance =
             RunningEventLoop { event_loop_target, event_loop_proxy: &event_loop_proxy };
         CURRENT_WINDOW_TARGET.set(&running_instance, || {
-            *control_flow = ControlFlow::Wait;
+            // MainEventsCleared and RedrawEventsCleared are passed after flush of the event loop
+            // by winit. Make sure not to overwrite a previously set ControlFlow::Poll in that process.
+            if !matches!(
+                event,
+                winit::event::Event::MainEventsCleared | winit::event::Event::RedrawEventsCleared
+            ) {
+                *control_flow = ControlFlow::Wait;
+            }
 
             match event {
                 winit::event::Event::WindowEvent { event, window_id } => {


### PR DESCRIPTION
The previous approach of calling send_event on a timer has the disadvantage
or re-entering the event loop for every queued event. Any requested redraw
after one of those events will end up actually drawing, even if that frame could be
replaced by the next event's redraw without being shown to the user.

winit also doesn't expose publicly its web Runner send_events method that would
allow us to queue the events outside and pass them all together.

We can however queue the events inside winit by putting the event loop in
ControlFlow::Poll mode so that winit batches them itself.
This has the side effect of processing and painting those events using
requestAnimationFrame.

To achieve this we take advantage of winit processing send_event calls
synchronously, possibly while on a native event handler, by entering the
event loop just to send WakeEventLoopWorkaround, set the event loop in
Poll mode, exit, and call send_events again with our event which then
ends up being queue in the web event loop's Runner until the next animation
frame where all queued events are processed and redrawn together.