### PR TITLE
Accessibility: don't expose the properties with the MCU backend

### DIFF
--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -202,6 +202,7 @@ pub fn compile_with_config(
 
     if env::var_os("DEP_I_SLINT_BACKEND_MCU_EMBED_TEXTURES").is_some() {
         compiler_config.embed_resources = EmbedResourcesKind::EmbedTextures;
+        compiler_config.accessibility = false;
     } else if let (Ok(target), Ok(host)) = (env::var("TARGET"), env::var("HOST")) {
         if target != host {
             compiler_config.embed_resources = EmbedResourcesKind::EmbedAllResources;

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -73,6 +73,9 @@ pub struct CompilerConfiguration {
 
     /// Compile time scale factor to apply to embedded resources such as images and glyphs.
     pub scale_factor: f64,
+
+    /// expose the accessible role and properties
+    pub accessibility: bool,
 }
 
 impl CompilerConfiguration {
@@ -122,6 +125,7 @@ impl CompilerConfiguration {
             open_import_fallback: Default::default(),
             inline_all_elements,
             scale_factor,
+            accessibility: true,
         }
     }
 }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -139,7 +139,9 @@ pub async fn run_passes(
         lower_shadows::lower_shadow_properties(component, &doc.local_registry, diag);
         clip::handle_clip(component, &global_type_registry.borrow(), diag);
         visible::handle_visible(component, &global_type_registry.borrow());
-        lower_accessibility::lower_accessibility_properties(component, diag);
+        if compiler_config.accessibility {
+            lower_accessibility::lower_accessibility_properties(component, diag);
+        }
         materialize_fake_properties::materialize_fake_properties(component);
     }
     collect_globals::collect_globals(doc, diag);


### PR DESCRIPTION
No need to generate the code that expose the accessible property when we
target MCU, because they are dead code anyway on that platform