### PR TITLE
Enable the simple env logger on slint-viewer

### DIFF
--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -35,6 +35,7 @@ notify = "4.0.15"
 serde_json = "1"
 shlex = "1"
 spin_on = "0.1"
+env_logger = "0.9.0"
 
 [[bin]]
 name = "slint-viewer"

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -64,6 +64,7 @@ thread_local! {static CURRENT_INSTANCE: std::cell::RefCell<Option<ComponentInsta
 static EXIT_CODE: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
 
 fn main() -> Result<()> {
+    env_logger::init();
     let args = Cli::parse();
 
     if args.auto_reload && args.save_data.is_some() {


### PR DESCRIPTION
This makes it possible to see the output from the log facade in any
crates that Slint uses, using the RUST_LOG environment variable..