### PR TITLE
Allow for the use of cache-rendering-hint in separate components

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -459,7 +459,7 @@ fn component_requires_inlining(component: &Rc<Component>) -> bool {
         let binding = binding.borrow();
         // The passes that dp the drop shadow or the opacity currently won't allow this property
         // on the top level of a component. This could be changed in the future.
-        if prop.starts_with("drop-shadow-") || prop == "opacity" {
+        if prop.starts_with("drop-shadow-") || prop == "opacity" || prop == "cache-rendering-hint" {
             return true;
         }
         if (prop == "height" || prop == "width") && binding.expression.ty() == Type::Percent {

--- a/tests/cases/examples/layer.slint
+++ b/tests/cases/examples/layer.slint
@@ -7,6 +7,22 @@ import { Button } from "std-widgets.slint";
 // output, and to have a compile-time verification that the lowering to the Layer
 // element compiles.
 
+MyLayer := Rectangle {
+    cache-rendering-hint: true;
+    background: red;
+    for i in 1000: Rectangle {
+        cache-rendering-hint: i == 8;
+        background: blue;
+        drop-shadow-blur: 10px;
+        drop-shadow-offset-x: 5px;
+        drop-shadow-offset-y: 5px;
+        drop-shadow-color: green;
+        Text {
+            text: "Many text items over each other";
+        }
+    }
+}
+
 export TestCase := Window {
     preferred-width: 800px;
     preferred-height: 600px;
@@ -24,8 +40,7 @@ export TestCase := Window {
         Rectangle {
 
             // This will be a layer
-            layered := Rectangle {
-                cache-rendering-hint: true;
+            layered := MyLayer {
                 width: 200px;
                 height: 100px;
 
@@ -42,21 +57,7 @@ export TestCase := Window {
                 animate x {
                     duration: 15s;
                 }
-
-                background: red;
-                
-                for i in 1000: Rectangle {
-                    cache-rendering-hint: i == 8;
-                    background: blue;
-                    drop-shadow-blur: 10px;
-                    drop-shadow-offset-x: 5px;
-                    drop-shadow-offset-y: 5px;
-                    drop-shadow-color: green;
-                    Text {
-                        text: "Many text items over each other";
-                    }
-                }
             }
         }
-    }    
+    }
 }


### PR DESCRIPTION
The `lower_property_to_element` pass usually disallows that because it
injects the Layer element and we can't do that for components. But we
can handle this like with opacity and inline.