### PR TITLE
Fix MSRV for the C++ build

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Corrosion)
 
 list(PREPEND CMAKE_MODULE_PATH ${Corrosion_SOURCE_DIR}/cmake)
-find_package(Rust 1.56 REQUIRED MODULE)
+find_package(Rust 1.59 REQUIRED MODULE)
 
 option(SLINT_FEATURE_COMPILER "Enable support for compiling .slint files to C++ ahead of time" ON)
 


### PR DESCRIPTION
Commit 452bc2a69669c76be14f6308fe7389ee2ee6c0bf bumped the version to
1.59 in the docs and the CI, but the CMake build claimed to be happy
with 1.56. Since we now have code in the repo (compiler) that requires
at least 1.58 and the CI only tests >= 1.59 *and* the docs talk about
1.59, let's check this properly in CMake as well.