### PR TITLE
MCU: Refactor the renderer in a LineRenderer

### DIFF
--- a/internal/backends/mcu/profiler.rs
+++ b/internal/backends/mcu/profiler.rs
@@ -54,7 +54,7 @@ impl Timer {
         }
     }
 
-    pub fn stop_profiling(self, _devices: &dyn Devices, _context: &'static str) {
+    pub fn stop_profiling(&mut self, _devices: &dyn Devices, _context: &'static str) {
         #[cfg(slint_debug_performance)]
         i_slint_core::debug_log!("{} took: {}ms", _context, self.elapsed(_devices).as_millis())
     }


### PR DESCRIPTION
The LineRenderer is going to be a public type which can be used
by the MCU board support to draw.
Right now, it is used by the old code