### PR TITLE
Fix resize jitter bug on macOS with GL Backend

### DIFF
--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -32,7 +32,13 @@ pub trait WinitWindow: PlatformWindow {
         &self,
         constraints: (corelib::layout::LayoutInfo, corelib::layout::LayoutInfo),
     );
+    /// Get the size of the window. Unlike [`winit::window::Window::inner_size()`], this property does not
+    /// hold the most recent window size as known by the OS but the latest size that has been processed
+    /// as a [`WindowEvent::Resized`] by [`process_window_event()`].
     fn size(&self) -> winit::dpi::LogicalSize<f32>;
+    /// Set the size of the window. Unlike [`winit::window::Window::set_inner_size()`], this property does not
+    /// hold the most recent window size as known by the OS but the latest size that has been processed
+    /// as a [`WindowEvent::Resized`] by [`process_window_event()`].
     fn set_size(&self, size: winit::dpi::LogicalSize<f32>);
     fn set_background_color(&self, color: Color);
     fn set_icon(&self, icon: corelib::graphics::Image);

--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -32,6 +32,8 @@ pub trait WinitWindow: PlatformWindow {
         &self,
         constraints: (corelib::layout::LayoutInfo, corelib::layout::LayoutInfo),
     );
+    fn size(&self) -> winit::dpi::LogicalSize<f32>;
+    fn set_size(&self, size: winit::dpi::LogicalSize<f32>);
     fn set_background_color(&self, color: Color);
     fn set_icon(&self, icon: corelib::graphics::Image);
 
@@ -118,8 +120,7 @@ pub trait WinitWindow: PlatformWindow {
                 winit_window.set_decorations(true);
             }
 
-            let existing_size =
-                winit_window.inner_size().to_logical(self.runtime_window().scale_factor() as f64);
+            let existing_size = self.size();
 
             if width <= 0. {
                 width = existing_size.width;
@@ -364,6 +365,7 @@ fn process_window_event(
         WindowEvent::Resized(size) => {
             let size = size.to_logical(runtime_window.scale_factor() as f64);
             runtime_window.set_window_item_geometry(size.width, size.height);
+            window.set_size(size);
         }
         WindowEvent::CloseRequested => {
             if runtime_window.request_close() {

--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -258,6 +258,22 @@ impl WinitWindow for GLWindow {
         }
     }
 
+    fn size(&self) -> winit::dpi::LogicalSize<f32> {
+        match &*self.map_state.borrow() {
+            GraphicsWindowBackendState::Unmapped => Default::default(),
+            GraphicsWindowBackendState::Mapped(mapped_window) => mapped_window.size,
+        }
+    }
+
+    fn set_size(&self, size: winit::dpi::LogicalSize<f32>) {
+        match &mut *self.map_state.borrow_mut() {
+            GraphicsWindowBackendState::Unmapped => {
+                panic!("Cannot set window_size of Unmapped Window");
+            }
+            GraphicsWindowBackendState::Mapped(mapped_window) => mapped_window.size = size,
+        }
+    }
+
     fn set_background_color(&self, color: Color) {
         if let Some(mut window) = self.borrow_mapped_window_mut() {
             window.clear_color = color;
@@ -513,6 +529,7 @@ impl PlatformWindow for GLWindow {
             opengl_context,
             clear_color: RgbaColor { red: 255_u8, green: 255, blue: 255, alpha: 255 }.into(),
             constraints: Default::default(),
+            size: Default::default(),
         }));
 
         crate::event_loop::register_window(id, self);
@@ -750,6 +767,7 @@ struct MappedWindow {
     opengl_context: crate::OpenGLContext,
     clear_color: Color,
     constraints: Cell<(corelib::layout::LayoutInfo, corelib::layout::LayoutInfo)>,
+    size: winit::dpi::LogicalSize<f32>,
 }
 
 impl Drop for MappedWindow {

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -384,6 +384,15 @@ impl WinitWindow for SimulatorWindow {
         self.constraints.set(constraints)
     }
 
+    fn size(&self) -> winit::dpi::LogicalSize<f32> {
+        self.frame_buffer.borrow().as_ref().map_or(Default::default(), |display| {
+            let eg_size = display.size();
+            winit::dpi::LogicalSize::new(eg_size.width as f32, eg_size.height as f32)
+        })
+    }
+    fn set_size(&self, _size: winit::dpi::LogicalSize<f32>) {
+        // dummy since it shouldn't be needed
+    }
     fn set_background_color(&self, color: Color) {
         self.background_color.set(color);
     }


### PR DESCRIPTION
This fixes #1269.
It introduces a size property to WinitWindow, that in contrast to winit::Window::inner_size() represents the sizes that are actually already processed by slint's event handling.
The problem did occur since the inner_size() value was returning the latest window size even if a previous Resize event (resizing to an earlier size) was still being processed. This discrepancy caused the jittering.