### PR TITLE
vtable: Make VBox compatible with C++

### DIFF
--- a/api/cpp/include/slint_interpreter.h
+++ b/api/cpp/include/slint_interpreter.h
@@ -492,8 +492,7 @@ inline Value::Value(const std::shared_ptr<slint::Model<Value>> &model)
     };
 
     static const ModelAdaptorVTable vt { row_count, row_data, set_row_data, get_notify, drop };
-    vtable::VBox<ModelAdaptorVTable> wrap { &vt, wrapper.get() };
-    cbindgen_private::slint_interpreter_value_new_model(wrap, &inner);
+    cbindgen_private::slint_interpreter_value_new_model(reinterpret_cast<uint8_t *>(wrapper.get()), &vt, &inner);
 }
 
 inline Struct::Struct(std::initializer_list<std::pair<std::string_view, Value>> args)

--- a/api/cpp/include/vtable.h
+++ b/api/cpp/include/vtable.h
@@ -26,25 +26,23 @@ struct Layout {
 // For the C++'s purpose, they are all the same
 template<typename T>
 using VRef = VRefMut<T>;
-template<typename T>
-using VBox = VRefMut<T>;
 
 template<typename T>
 using Pin = T;
 
-/*
 template<typename T>
 struct VBox {
-    const T *vtable;
-    void *instance;
+    const T *vtable = nullptr;
+    void *instance = nullptr;
+    VBox(const VBox&) = delete;
+    VBox() = default;
+    VBox&operator=(const VBox&) = delete;
+    ~VBox() {
+        if (vtable && instance) {
+            vtable->drop({vtable, instance});
+        }
+    }
 };
-
-template<typename T>
-struct VRef {
-    const T *vtable;
-    const void *instance;
-};
-*/
 
 struct AllowPin;
 

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -4,6 +4,7 @@
 use crate::dynamic_component::ErasedComponentBox;
 
 use super::*;
+use core::ptr::NonNull;
 use i_slint_core::model::{Model, ModelNotify, SharedVectorModel};
 use i_slint_core::slice::Slice;
 use i_slint_core::window::{WindowHandleAccess, WindowRc};
@@ -110,10 +111,17 @@ pub unsafe extern "C" fn slint_interpreter_value_new_image(img: &Image, val: *mu
 /// Construct a new Value containing a model in the given memory location
 #[no_mangle]
 pub unsafe extern "C" fn slint_interpreter_value_new_model(
-    model: vtable::VBox<ModelAdaptorVTable>,
+    model: NonNull<u8>,
+    vtable: &ModelAdaptorVTable,
     val: *mut ValueOpaque,
 ) {
-    std::ptr::write(val as *mut Value, Value::Model(ModelRc::new(ModelAdaptorWrapper(model))))
+    std::ptr::write(
+        val as *mut Value,
+        Value::Model(ModelRc::new(ModelAdaptorWrapper(vtable::VBox::from_raw(
+            NonNull::from(vtable),
+            model,
+        )))),
+    )
 }
 
 #[no_mangle]


### PR DESCRIPTION
 - Use `NonNull` so `Option<VBox<X>>` can be represented with null pointer
 - Call the `drop` function from the C++ destructor.