### PR TITLE
Online editor: Add link to Slint language reference

### DIFF
--- a/tools/online_editor/index.html
+++ b/tools/online_editor/index.html
@@ -35,6 +35,8 @@
             <option value="fluent">fluent</option>
         </select>
         -->
+        &nbsp; &nbsp; &nbsp; &nbsp;
+        <a href="../docs/rust/slint/docs/langref/index.html">Slint Language Reference</a>
     </p>
 
     <div id="preview" style="max-width: 48%; float: right"></div>


### PR DESCRIPTION
This link works on the slint web site, but not when run locally. We do
not expect this to have users outside of the Slint site, so we are
willing to accept this limitation.

Please open a bug report if you indeed use the online editor elsewhere
and are bothered by the link.