### PR TITLE
LSP: fetch the file content from cache instead of from disk to compute the line number

### DIFF
--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -104,6 +104,10 @@ impl SourceFileInner {
                 .unwrap_or_default()
         })
     }
+
+    pub fn source(&self) -> Option<&str> {
+        self.source.as_ref().map(|s| s.as_str())
+    }
 }
 
 pub type SourceFile = Rc<SourceFileInner>;


### PR DESCRIPTION
Otherwise it doesn't work with the web extension. And the file must anyway be in the cache