### PR TITLE
LSP: make the preview feature optional

### DIFF
--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -88,7 +88,7 @@
 	],
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
-		"compile": "wasm-pack build --target web --out-name index ../../tools/lsp && node ./esbuild.js",
+		"compile": "wasm-pack build --target web --out-name index ../../tools/lsp --no-default-features && node ./esbuild.js",
 		"local-package": "mkdir -p bin && cp ../../target/debug/slint-lsp bin/ && npx vsce package",
 		"watch": "tsc -watch -p ./",
 		"pretest": "npm run compile && npm run lint",

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -32,28 +32,34 @@ path = "wasm_main.rs"
 name = "slint_lsp_wasm"
 
 [features]
-backend-qt = ["slint-interpreter/backend-qt"]
-backend-gl-all = ["slint-interpreter/backend-gl-all"]
-backend-gl-wayland = ["slint-interpreter/backend-gl-wayland"]
-backend-gl-x11 = ["slint-interpreter/backend-gl-x11"]
+backend-qt = ["slint-interpreter/backend-qt", "preview"]
+backend-gl-all = ["slint-interpreter/backend-gl-all", "preview"]
+backend-gl-wayland = ["slint-interpreter/backend-gl-wayland", "preview"]
+backend-gl-x11 = ["slint-interpreter/backend-gl-x11", "preview"]
 
-default = ["backend-qt", "backend-gl-all"]
+preview = ["slint-interpreter", "i-slint-core", "i-slint-backend-selector"]
+
+default = ["backend-qt", "backend-gl-all", "preview"]
 
 [dependencies]
 i-slint-compiler = { version = "=0.2.5", path = "../../internal/compiler"}
-i-slint-core = { version = "=0.2.5", path = "../../internal/core"}
-slint-interpreter = { version = "=0.2.5", path = "../../internal/interpreter", default-features = false, features = ["compat-0-2-0"] }
-i-slint-backend-selector = { version = "=0.2.5", path="../../internal/backends/selector" }
-
 clap = { version = "3.1", features = ["derive", "wrap_help"] }
-crossbeam-channel = "0.5"  # must match the version used by lsp-server
 dunce = "1.0.1"
 euclid = "0.22"
-lsp-server = "0.6"
 lsp-types = "0.93.0"
-once_cell = "1.9.0"
 serde = "1.0.118"
 serde_json = "1.0.60"
+
+
+# for the preview
+i-slint-core = { version = "=0.2.5", path = "../../internal/core", optional = true }
+slint-interpreter = { version = "=0.2.5", path = "../../internal/interpreter", default-features = false, features = ["compat-0-2-0"], optional = true  }
+i-slint-backend-selector = { version = "=0.2.5", path="../../internal/backends/selector", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+crossbeam-channel = "0.5"  # must match the version used by lsp-server
+lsp-server = "0.6"
+once_cell = "1.9.0"
 spin_on = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use i_slint_compiler::diagnostics::Spanned;
+use i_slint_compiler::diagnostics::{DiagnosticLevel, Spanned};
 use i_slint_compiler::langtype::Type;
 use i_slint_compiler::lookup::LookupCtx;
 use i_slint_compiler::object_tree;
@@ -145,12 +145,10 @@ fn to_range(span: (usize, usize)) -> lsp_types::Range {
     lsp_types::Range::new(pos, pos)
 }
 
-fn to_lsp_diag_level(
-    level: i_slint_compiler::diagnostics::DiagnosticLevel,
-) -> lsp_types::DiagnosticSeverity {
+fn to_lsp_diag_level(level: DiagnosticLevel) -> lsp_types::DiagnosticSeverity {
     match level {
-        slint_interpreter::DiagnosticLevel::Error => lsp_types::DiagnosticSeverity::ERROR,
-        slint_interpreter::DiagnosticLevel::Warning => lsp_types::DiagnosticSeverity::WARNING,
+        DiagnosticLevel::Error => lsp_types::DiagnosticSeverity::ERROR,
+        DiagnosticLevel::Warning => lsp_types::DiagnosticSeverity::WARNING,
         _ => lsp_types::DiagnosticSeverity::INFORMATION,
     }
 }


### PR DESCRIPTION
So it can be disabled when building the web extension, and remove lots of dependencies.

This reduce the wasm size from 6M to 2M