### PR TITLE
Move the software renderer to core

### DIFF
--- a/internal/backends/mcu/Cargo.toml
+++ b/internal/backends/mcu/Cargo.toml
@@ -31,7 +31,7 @@ default = ["simulator"]
 
 [dependencies]
 i-slint-common = { version = "=0.2.5", path = "../../../internal/common", default-features = false }
-i-slint-core = { version = "=0.2.5", path = "../../../internal/core", default-features = false, features = ["libm", "text_layout"] }
+i-slint-core = { version = "=0.2.5", path = "../../../internal/core", default-features = false, features = ["libm", "swrenderer", "embedded-graphics"] }
 i-slint-core-macros = { version = "=0.2.5", path = "../../../internal/core-macros" }
 
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
@@ -45,7 +45,6 @@ euclid = { version = "0.22.1", default-features = false }
 femtovg = { version = "0.3.5", optional = true }
 glutin = { version = "0.28", default-features = false, optional = true, features = ["x11"] }
 imgref = { version = "1.6.1", optional = true }
-integer-sqrt = "0.1.5"
 once_cell = { version = "1.9", default-features = false, features = ["alloc", "atomic-polyfill"] }
 pin-weak = { version = "1", default-features = false }
 rgb = "0.8.27"

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -227,7 +227,7 @@ impl PlatformWindow for SimulatorWindow {
         max_width: Option<Coord>,
     ) -> i_slint_core::graphics::Size {
         let runtime_window = self.self_weak.upgrade().unwrap();
-        crate::fonts::text_size(
+        crate::renderer::fonts::text_size(
             font_request.merge(&self.self_weak.upgrade().unwrap().default_font_properties()),
             text,
             max_width,
@@ -286,9 +286,6 @@ impl WinitWindow for SimulatorWindow {
                 canvas.set_size(size.width, size.height, 1.0);
             }
 
-            let background =
-                crate::renderer::to_rgb888_color_discard_alpha(self.background_color.get());
-
             let mut frame_buffer = self.frame_buffer.borrow_mut();
             let display = match frame_buffer.as_mut() {
                 Some(buffer)
@@ -304,7 +301,6 @@ impl WinitWindow for SimulatorWindow {
                     super::LINE_RENDERER.with(|cache| {
                         *cache.borrow_mut() = Default::default();
                     });
-                    buffer.clear(background).unwrap();
                     buffer
                 }
             };
@@ -314,6 +310,8 @@ impl WinitWindow for SimulatorWindow {
                 line_buffer: Vec<crate::TargetPixel>,
             }
             impl crate::renderer::LineBufferProvider for BufferProvider<'_> {
+                type TargetPixel = crate::TargetPixel;
+
                 fn process_line(
                     &mut self,
                     line: crate::PhysicalLength,

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -31,6 +31,9 @@ unsafe_single_core = []
 
 text_layout = []
 
+## The sofwtare renderer
+swrenderer = ["integer-sqrt", "text_layout"]
+
 unicode = ["unicode-script", "unicode-linebreak"]
 
 default = ["std", "text_layout", "unicode"]
@@ -67,6 +70,8 @@ strum = { version = "0.24.0", default-features = false, features = ["derive"] }
 unicode-segmentation = "1.8.0"
 unicode-linebreak = { version = "0.1.2", optional = true }
 unicode-script = { version = "0.5.3", optional = true }
+embedded-graphics = { version = "0.7.1", optional = true }
+integer-sqrt = { version = "0.1.5", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1", features = [ "wasm-bindgen", "now" ] }

--- a/internal/core/lengths.rs
+++ b/internal/core/lengths.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use i_slint_core::Coord;
+use crate::Coord;
 pub struct PhysicalPx;
 pub type PhysicalLength = euclid::Length<i16, PhysicalPx>;
 pub type PhysicalRect = euclid::Rect<i16, PhysicalPx>;
@@ -74,7 +74,7 @@ pub trait LogicalItemGeometry {
     fn logical_geometry(self: core::pin::Pin<&Self>) -> LogicalRect;
 }
 
-impl<T: i_slint_core::items::Item> LogicalItemGeometry for T {
+impl<T: crate::items::Item> LogicalItemGeometry for T {
     fn logical_geometry(self: core::pin::Pin<&Self>) -> LogicalRect {
         LogicalRect::from_untyped(&self.geometry())
     }

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -74,11 +74,14 @@ pub mod item_rendering;
 pub mod item_tree;
 pub mod items;
 pub mod layout;
+pub mod lengths;
 pub mod model;
 pub mod properties;
 pub mod sharedvector;
 pub mod slice;
 pub mod string;
+#[cfg(feature = "swrenderer")]
+pub mod swrenderer;
 pub mod tests;
 pub mod timers;
 pub mod window;

--- a/internal/core/swrenderer/fonts.rs
+++ b/internal/core/swrenderer/fonts.rs
@@ -5,15 +5,13 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 
 #[cfg(all(not(feature = "std"), feature = "unsafe_single_core"))]
-use i_slint_core::thread_local_ as thread_local;
+use crate::thread_local_ as thread_local;
 
-use crate::{LogicalLength, LogicalSize, PhysicalLength, PhysicalSize, ScaleFactor};
-use i_slint_core::{
-    graphics::{BitmapFont, BitmapGlyph, BitmapGlyphs, FontRequest},
-    slice::Slice,
-    textlayout::{Glyph, TextLayout, TextShaper},
-    Coord,
-};
+use crate::graphics::{BitmapFont, BitmapGlyph, BitmapGlyphs, FontRequest};
+use crate::lengths::{LogicalLength, LogicalSize, PhysicalLength, PhysicalSize, ScaleFactor};
+use crate::slice::Slice;
+use crate::textlayout::{Glyph, TextLayout, TextShaper};
+use crate::Coord;
 
 thread_local! {
     static FONTS: RefCell<Vec<&'static BitmapFont>> = RefCell::default()
@@ -134,7 +132,7 @@ impl TextShaper for PixelFont {
     }
 }
 
-impl i_slint_core::textlayout::FontMetrics<PhysicalLength> for PixelFont {
+impl crate::textlayout::FontMetrics<PhysicalLength> for PixelFont {
     fn ascent(&self) -> PhysicalLength {
         self.glyphs.ascent(self.bitmap_font)
     }


### PR DESCRIPTION
Move the MCU renderer in the feature-gated swrenderer module in core. 

This also moves the lengths module to core, and it is not feature gated. I think we can make use of it for the text_layout and other stuff. 