### PR TITLE
Add horizontal-alignment property from TextInput to TextEdit and LineEdit

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -220,6 +220,7 @@ export TextInput := _ {
     callback cursor_position_changed(Point);
     property <bool> enabled: true;
     property <bool> single-line: true;
+    property <bool> read-only: false;
     //-default_size_binding:expands_to_parent_geometry
     //-accepts_focus
 }

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -13,6 +13,7 @@ export LineEditInner := Rectangle {
     property enabled <=> input.enabled;
     property has-focus <=> input.has-focus;
     property input-type <=> input.input-type;
+    property horizontal-alignment <=> input.horizontal-alignment;
     min-height: input.preferred-height;
     min-width: max(50px, placeholder.min-width);
     clip: true;

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -14,6 +14,7 @@ export LineEditInner := Rectangle {
     property has-focus <=> input.has-focus;
     property input-type <=> input.input-type;
     property horizontal-alignment <=> input.horizontal-alignment;
+    property read-only <=> input.read-only;
     min-height: input.preferred-height;
     min-width: max(50px, placeholder.min-width);
     clip: true;
@@ -50,6 +51,7 @@ export TextEdit := ScrollView {
     enabled <=> input.enabled;
     property <TextWrap> wrap <=> input.wrap;
     property horizontal-alignment <=> input.horizontal-alignment;
+    property read-only <=> input.read-only;
     callback edited(string);
     forward-focus: input;
 

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -49,6 +49,7 @@ export TextEdit := ScrollView {
     has-focus <=> input.has-focus;
     enabled <=> input.enabled;
     property <TextWrap> wrap <=> input.wrap;
+    property horizontal-alignment <=> input.horizontal-alignment;
     callback edited(string);
     forward-focus: input;
 

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -414,6 +414,7 @@ export LineEdit := Rectangle {
     property <bool> has-focus: inner.has-focus;
     property <bool> enabled <=> inner.enabled;
     property input-type <=> inner.input-type;
+    property horizontal-alignment <=> inner.horizontal-alignment;
     callback accepted <=> inner.accepted;
     callback edited <=> inner.edited;
     forward-focus: inner;

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -415,6 +415,7 @@ export LineEdit := Rectangle {
     property <bool> enabled <=> inner.enabled;
     property input-type <=> inner.input-type;
     property horizontal-alignment <=> inner.horizontal-alignment;
+    property read-only <=> inner.read-only;
     callback accepted <=> inner.accepted;
     callback edited <=> inner.edited;
     forward-focus: inner;

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -35,6 +35,7 @@ export LineEdit := NativeLineEdit {
     property <string> placeholder-text <=> inner.placeholder-text;
     property input-type <=> inner.input-type;
     property horizontal-alignment <=> inner.horizontal-alignment;
+    property read-only <=> inner.read-only;
     enabled: true;
     has-focus <=> inner.has-focus;
     forward-focus: inner;

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -34,6 +34,7 @@ export LineEdit := NativeLineEdit {
     property <string> text <=> inner.text;
     property <string> placeholder-text <=> inner.placeholder-text;
     property input-type <=> inner.input-type;
+    property horizontal-alignment <=> inner.horizontal-alignment;
     enabled: true;
     has-focus <=> inner.has-focus;
     forward-focus: inner;

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -367,7 +367,7 @@ impl Item for TextInput {
                     },
                     None => (),
                 }
-                if event.modifiers.control {
+                if event.modifiers.control || self.read_only() {
                     return KeyEventResult::EventIgnored;
                 }
                 self.delete_selection(window);
@@ -634,7 +634,7 @@ impl TextInput {
     }
 
     fn delete_char(self: Pin<&Self>, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         if !self.has_selection() {
@@ -644,7 +644,7 @@ impl TextInput {
     }
 
     fn delete_previous(self: Pin<&Self>, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         if self.has_selection() {
@@ -658,7 +658,7 @@ impl TextInput {
     }
 
     fn delete_selection(self: Pin<&Self>, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         let text: String = self.text().into();
@@ -704,7 +704,7 @@ impl TextInput {
     }
 
     fn insert(self: Pin<&Self>, text_to_insert: &str, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         self.delete_selection(window);
@@ -734,7 +734,7 @@ impl TextInput {
     }
 
     fn paste(self: Pin<&Self>, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         if let Some(text) = crate::backend::instance().and_then(|backend| backend.clipboard_text())

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -203,6 +203,7 @@ pub struct TextInput {
     pub edited: Callback<VoidArg>,
     pub pressed: core::cell::Cell<bool>,
     pub single_line: Property<bool>,
+    pub read_only: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
     // The x position where the cursor wants to be.
     // It is not updated when moving up and down even when the line is shorter.
@@ -633,6 +634,9 @@ impl TextInput {
     }
 
     fn delete_char(self: Pin<&Self>, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         if !self.has_selection() {
             self.move_cursor(TextCursorDirection::Forward, AnchorMode::KeepAnchor, window);
         }
@@ -640,6 +644,9 @@ impl TextInput {
     }
 
     fn delete_previous(self: Pin<&Self>, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         if self.has_selection() {
             self.delete_selection(window);
             return;
@@ -651,6 +658,9 @@ impl TextInput {
     }
 
     fn delete_selection(self: Pin<&Self>, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         let text: String = self.text().into();
         if text.is_empty() {
             return;
@@ -694,6 +704,9 @@ impl TextInput {
     }
 
     fn insert(self: Pin<&Self>, text_to_insert: &str, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         self.delete_selection(window);
         let mut text: String = self.text().into();
         let cursor_pos = self.selection_anchor_and_cursor().1;
@@ -721,6 +734,9 @@ impl TextInput {
     }
 
     fn paste(self: Pin<&Self>, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         if let Some(text) = crate::backend::instance().and_then(|backend| backend.clipboard_text())
         {
             self.insert(&text, window);


### PR DESCRIPTION
This pr adds horizontal-alignment property from TextInput to TextEdit and LineEdit to allow for right to left text to appear properly from the right