### PR TITLE
Add read only TextInput and propagate horizontal-alignment property from TextInput to TextEdit and LineEdit

### DIFF
--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -651,6 +651,8 @@ When not part of a layout, its width or height defaults to 100% of the parent el
 * **`letter-spacing`** (*length*): The letter spacing allows changing the spacing between the glyphs. A positive value increases the spacing
   and a negative value decreases the distance. The default value is 0.
 * **`single-line`** (bool): When set to `true`, no newlines are allowed (default value: `true`)
+* **`read-only`** (bool): When set to `true`, text editing via keyboard and mouse is disabled but selecting text is still enabled as well as 
+  editing text programatically (default value: `false`)
 * **`wrap`** (*enum [`TextWrap`](builtin_enums.md#textwrap)*): The way the text input wraps.  Only makes sense when `single-line` is false. (default: no-wrap)
 * **`input-type`** (*enum [`InputType`](builtin_enums.md#InputType)*): The way to allow special input viewing properties such as password fields (default value: `text`).
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -172,6 +172,7 @@ A widget used to enter a single line of text
 * **`read-only`** (bool): When set to `true`, text editing via keyboard and mouse is disabled but selecting text is still enabled as well as 
   editing text programatically (default value: `false`)
 * **`input-type`** (*enum [`InputType`](#InputType)*): The way to allow special input viewing properties such as password fields (default value: `text`).
+* **`horizontal-alignment`** (*enum [`TextHorizontalAlignment`](builtin_enums.md#texthorizontalalignment)*): The horizontal alignment of the text.
 
 ### Callbacks
 
@@ -210,6 +211,7 @@ shortcut will be implemented in a future version: <https://github.com/slint-ui/s
 * **`read-only`** (bool): When set to `true`, text editing via keyboard and mouse is disabled but selecting text is still enabled as well as 
   editing text programatically (default value: `false`)
 * **`wrap`** (*enum [`TextWrap`](builtin_enums.md#textwrap)*): The way the text wraps (default: word-wrap).
+* **`horizontal-alignment`** (*enum [`TextHorizontalAlignment`](builtin_enums.md#texthorizontalalignment)*): The horizontal alignment of the text.
 
 ### Callbacks
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -169,6 +169,8 @@ A widget used to enter a single line of text
 * **`has-focus`**: (*bool*): Set to true when the line edit currently has the focus
 * **`placeholder-text`**: (*string*): A placeholder text being shown when there is no text in the edit field
 * **`enabled`**: (*bool*): Defaults to true. When false, nothing can be entered
+* **`read-only`** (bool): When set to `true`, text editing via keyboard and mouse is disabled but selecting text is still enabled as well as 
+  editing text programatically (default value: `false`)
 * **`input-type`** (*enum [`InputType`](#InputType)*): The way to allow special input viewing properties such as password fields (default value: `text`).
 
 ### Callbacks
@@ -205,6 +207,8 @@ shortcut will be implemented in a future version: <https://github.com/slint-ui/s
 * **`font-size`** (*length*): the size of the font of the input text
 * **`has-focus`**: (*bool*): Set to true when the widget currently has the focus
 * **`enabled`**: (*bool*): Defaults to true. When false, nothing can be entered
+* **`read-only`** (bool): When set to `true`, text editing via keyboard and mouse is disabled but selecting text is still enabled as well as 
+  editing text programatically (default value: `false`)
 * **`wrap`** (*enum [`TextWrap`](builtin_enums.md#textwrap)*): The way the text wraps (default: word-wrap).
 
 ### Callbacks

--- a/internal/backends/gl/glrenderer.rs
+++ b/internal/backends/gl/glrenderer.rs
@@ -295,7 +295,7 @@ impl ItemRenderer for GLItemRenderer {
 
         let (mut min_select, mut max_select) = text_input.selection_anchor_and_cursor();
         let cursor_pos = text_input.cursor_position();
-        let cursor_visible = cursor_pos >= 0 && text_input.cursor_visible() && text_input.enabled();
+        let cursor_visible = cursor_pos >= 0 && text_input.cursor_visible() && text_input.enabled() && !text_input.read_only();
         let mut cursor_pos = cursor_pos as usize;
         let mut canvas = self.canvas.borrow_mut();
         let font_height = canvas.measure_font(paint).unwrap().height();

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -636,7 +636,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
             0
         };
 
-        let text_cursor_width: f32 = if text_input.cursor_visible() && text_input.enabled() {
+        let text_cursor_width: f32 = if text_input.cursor_visible() && text_input.enabled() && !text_input.read_only() {
             text_input.text_cursor_width()
         } else {
             0.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -220,6 +220,7 @@ export TextInput := _ {
     callback cursor_position_changed(Point);
     property <bool> enabled: true;
     property <bool> single-line: true;
+    property <bool> read-only: false;
     //-default_size_binding:expands_to_parent_geometry
     //-accepts_focus
 }

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -13,6 +13,7 @@ export LineEditInner := Rectangle {
     property enabled <=> input.enabled;
     property has-focus <=> input.has-focus;
     property input-type <=> input.input-type;
+    property horizontal-alignment <=> input.horizontal-alignment;
     min-height: input.preferred-height;
     min-width: max(50px, placeholder.min-width);
     clip: true;

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -14,6 +14,7 @@ export LineEditInner := Rectangle {
     property has-focus <=> input.has-focus;
     property input-type <=> input.input-type;
     property horizontal-alignment <=> input.horizontal-alignment;
+    property read-only <=> input.read-only;
     min-height: input.preferred-height;
     min-width: max(50px, placeholder.min-width);
     clip: true;
@@ -50,6 +51,7 @@ export TextEdit := ScrollView {
     enabled <=> input.enabled;
     property <TextWrap> wrap <=> input.wrap;
     property horizontal-alignment <=> input.horizontal-alignment;
+    property read-only <=> input.read-only;
     callback edited(string);
     forward-focus: input;
 

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -49,6 +49,7 @@ export TextEdit := ScrollView {
     has-focus <=> input.has-focus;
     enabled <=> input.enabled;
     property <TextWrap> wrap <=> input.wrap;
+    property horizontal-alignment <=> input.horizontal-alignment;
     callback edited(string);
     forward-focus: input;
 

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -414,6 +414,7 @@ export LineEdit := Rectangle {
     property <bool> has-focus: inner.has-focus;
     property <bool> enabled <=> inner.enabled;
     property input-type <=> inner.input-type;
+    property horizontal-alignment <=> inner.horizontal-alignment;
     callback accepted <=> inner.accepted;
     callback edited <=> inner.edited;
     forward-focus: inner;

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -415,6 +415,7 @@ export LineEdit := Rectangle {
     property <bool> enabled <=> inner.enabled;
     property input-type <=> inner.input-type;
     property horizontal-alignment <=> inner.horizontal-alignment;
+    property read-only <=> inner.read-only;
     callback accepted <=> inner.accepted;
     callback edited <=> inner.edited;
     forward-focus: inner;

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -35,6 +35,7 @@ export LineEdit := NativeLineEdit {
     property <string> placeholder-text <=> inner.placeholder-text;
     property input-type <=> inner.input-type;
     property horizontal-alignment <=> inner.horizontal-alignment;
+    property read-only <=> inner.read-only;
     enabled: true;
     has-focus <=> inner.has-focus;
     forward-focus: inner;

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -34,6 +34,7 @@ export LineEdit := NativeLineEdit {
     property <string> text <=> inner.text;
     property <string> placeholder-text <=> inner.placeholder-text;
     property input-type <=> inner.input-type;
+    property horizontal-alignment <=> inner.horizontal-alignment;
     enabled: true;
     has-focus <=> inner.has-focus;
     forward-focus: inner;

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -312,7 +312,7 @@ impl Item for TextInput {
             KeyEventType::KeyPressed => {
                 match event.text_shortcut() {
                     Some(text_shortcut) => match text_shortcut {
-                        TextShortcut::Move(direction) if !self.read_only() => {
+                        TextShortcut::Move(direction) => {
                             TextInput::move_cursor(self, direction, event.modifiers.into(), window);
                             return KeyEventResult::EventAccepted;
                         }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -484,9 +484,6 @@ impl From<KeyboardModifiers> for AnchorMode {
 
 impl TextInput {
     fn show_cursor(&self, window: &WindowRc) {
-        if self.read_only() {
-            return;
-        }
         window.set_cursor_blink_binding(&self.cursor_visible);
     }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -211,7 +211,13 @@ pub struct TextInput {
 }
 
 impl Item for TextInput {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowRc) {
+        self.cursor_visible.set_binding({
+            let cursor_visible = self.cursor_visible.clone();
+            let read_only = self.read_only.clone();
+            move || cursor_visible.get() && !read_only.get()
+        });
+    }
 
     // FIXME: width / height.  or maybe it doesn't matter?  (
     fn geometry(self: Pin<&Self>) -> Rect {
@@ -484,7 +490,6 @@ impl From<KeyboardModifiers> for AnchorMode {
 
 impl TextInput {
     fn show_cursor(self: Pin<&Self>, window: &WindowRc) {
-	self.cursor_visible.set(self.read_only());
         window.set_cursor_blink_binding(&self.cursor_visible);
     }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -367,7 +367,7 @@ impl Item for TextInput {
                     },
                     None => (),
                 }
-                if event.modifiers.control {
+                if event.modifiers.control || self.read_only() {
                     return KeyEventResult::EventIgnored;
                 }
                 self.delete_selection(window);
@@ -634,7 +634,7 @@ impl TextInput {
     }
 
     fn delete_char(self: Pin<&Self>, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         if !self.has_selection() {
@@ -644,7 +644,7 @@ impl TextInput {
     }
 
     fn delete_previous(self: Pin<&Self>, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         if self.has_selection() {
@@ -658,7 +658,7 @@ impl TextInput {
     }
 
     fn delete_selection(self: Pin<&Self>, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         let text: String = self.text().into();
@@ -704,7 +704,7 @@ impl TextInput {
     }
 
     fn insert(self: Pin<&Self>, text_to_insert: &str, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         self.delete_selection(window);
@@ -734,7 +734,7 @@ impl TextInput {
     }
 
     fn paste(self: Pin<&Self>, window: &WindowRc) {
-        if self.read_only {
+        if self.read_only() {
             return;
         }
         if let Some(text) = crate::backend::instance().and_then(|backend| backend.clipboard_text())

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -483,7 +483,10 @@ impl From<KeyboardModifiers> for AnchorMode {
 }
 
 impl TextInput {
-    fn show_cursor(&self, window: &WindowRc) {
+    fn show_cursor(self: Pin<&Self>, window: &WindowRc) {
+        if self.read_only() {
+			return;
+		}
         window.set_cursor_blink_binding(&self.cursor_visible);
     }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -203,6 +203,7 @@ pub struct TextInput {
     pub edited: Callback<VoidArg>,
     pub pressed: core::cell::Cell<bool>,
     pub single_line: Property<bool>,
+    pub read_only: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
     // The x position where the cursor wants to be.
     // It is not updated when moving up and down even when the line is shorter.
@@ -633,6 +634,9 @@ impl TextInput {
     }
 
     fn delete_char(self: Pin<&Self>, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         if !self.has_selection() {
             self.move_cursor(TextCursorDirection::Forward, AnchorMode::KeepAnchor, window);
         }
@@ -640,6 +644,9 @@ impl TextInput {
     }
 
     fn delete_previous(self: Pin<&Self>, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         if self.has_selection() {
             self.delete_selection(window);
             return;
@@ -651,6 +658,9 @@ impl TextInput {
     }
 
     fn delete_selection(self: Pin<&Self>, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         let text: String = self.text().into();
         if text.is_empty() {
             return;
@@ -694,6 +704,9 @@ impl TextInput {
     }
 
     fn insert(self: Pin<&Self>, text_to_insert: &str, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         self.delete_selection(window);
         let mut text: String = self.text().into();
         let cursor_pos = self.selection_anchor_and_cursor().1;
@@ -721,6 +734,9 @@ impl TextInput {
     }
 
     fn paste(self: Pin<&Self>, window: &WindowRc) {
+        if self.read_only {
+            return;
+        }
         if let Some(text) = crate::backend::instance().and_then(|backend| backend.clipboard_text())
         {
             self.insert(&text, window);

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -484,7 +484,6 @@ impl From<KeyboardModifiers> for AnchorMode {
 
 impl TextInput {
     fn show_cursor(self: Pin<&Self>, window: &WindowRc) {
-        self.cursor_visible.set(!self.read_only());
         window.set_cursor_blink_binding(&self.cursor_visible);
     }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -211,13 +211,7 @@ pub struct TextInput {
 }
 
 impl Item for TextInput {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {
-        self.cursor_visible.set_binding({
-            let cursor_visible = self.cursor_visible.clone();
-            let read_only = self.read_only.clone();
-            move || cursor_visible.get() && !read_only.get()
-        });
-    }
+    fn init(self: Pin<&Self>, _window: &WindowRc) {}
 
     // FIXME: width / height.  or maybe it doesn't matter?  (
     fn geometry(self: Pin<&Self>) -> Rect {
@@ -490,6 +484,7 @@ impl From<KeyboardModifiers> for AnchorMode {
 
 impl TextInput {
     fn show_cursor(self: Pin<&Self>, window: &WindowRc) {
+        self.cursor_visible.set(!self.read_only());
         window.set_cursor_blink_binding(&self.cursor_visible);
     }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -484,9 +484,7 @@ impl From<KeyboardModifiers> for AnchorMode {
 
 impl TextInput {
     fn show_cursor(self: Pin<&Self>, window: &WindowRc) {
-        if self.read_only() {
-			return;
-		}
+	self.cursor_visible.set(self.read_only());
         window.set_cursor_blink_binding(&self.cursor_visible);
     }
 


### PR DESCRIPTION
This adds read only TextInput and its derivatives (TextEdit and LineEdit) and propagate horizontal-alignment property from TextInput to TextEdit and LineEdit