### PR TITLE
WIP: Repeater: Report changes to the model up to the window

### DIFF
--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -55,6 +55,10 @@ pub struct ComponentVTable {
         result: &mut vtable::VWeak<ComponentVTable, Dyn>,
     ),
 
+    /// Request notification about a change in the subtree below `index`
+    pub notify_about_subtree_change:
+        extern "C" fn(core::pin::Pin<VRef<ComponentVTable>>, index: usize),
+
     /// Return the item tree that is defined by this `Component`.
     /// The return value is an item weak because it can be null if there is no parent.
     /// And the return value is passed by &mut because ItemWeak has a destructor

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -112,6 +112,17 @@ impl ItemRc {
         r.upgrade()?.parent_item()
     }
 
+    pub fn has_ancestor(&self, ancestor: &ItemRc) -> bool {
+        let mut this = Some(self.clone());
+        while let Some(item) = this {
+            if item == *ancestor {
+                return true;
+            }
+            this = item.parent_item();
+        }
+        false
+    }
+
     // FIXME: This should be nicer/done elsewhere?
     pub fn is_visible(&self) -> bool {
         let item = self.borrow();


### PR DESCRIPTION
The a11y branch would need to get notification on tree changes as those happen in the "real" item tree. So I spent some time playing and this seems to work to get those updates aggregated in the window. Would something like this make sense to have?

I am probably missing something critical in this implementation.

It is currently just an experiment: So I only bothered to implement the rust generator and only aggregate the information.

The a11y branch could hook into this via rendering notifiers: If at the end of the rendering some item is set as having changes below it, it needs to rebuild the accessible tree below that item and reset the item changed item.