### PR TITLE
Fix panic about multiple mutable borrows with the software renderer

### DIFF
--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -131,7 +131,7 @@ mod the_backend {
             items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'a>>>,
         ) {
             super::LINE_RENDERER.with(|renderer| {
-                renderer.borrow_mut().free_graphics_resources(items);
+                renderer.borrow().free_graphics_resources(items);
             });
         }
 
@@ -346,7 +346,7 @@ mod the_backend {
                 };
 
                 LINE_RENDERER.with(|renderer| {
-                    renderer.borrow_mut().render(
+                    renderer.borrow().render(
                         runtime_window,
                         window.initial_dirty_region_for_next_frame.take(),
                         buffer_provider,

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -143,7 +143,7 @@ impl PlatformWindow for SimulatorWindow {
         items: &mut dyn Iterator<Item = std::pin::Pin<i_slint_core::items::ItemRef<'a>>>,
     ) {
         super::LINE_RENDERER.with(|cache| {
-            cache.borrow_mut().free_graphics_resources(items);
+            cache.borrow().free_graphics_resources(items);
         });
     }
 
@@ -325,7 +325,7 @@ impl WinitWindow for SimulatorWindow {
                 }
             }
             super::LINE_RENDERER.with(|renderer| {
-                renderer.borrow_mut().render(
+                renderer.borrow().render(
                     runtime_window,
                     self.initial_dirty_region_for_next_frame.take(),
                     BufferProvider {


### PR DESCRIPTION
When using repeaters - like in the slide puzzle - and during renderer a component
gets deleted, we call free_graphics_resources and try to free
the dirty rectangle list in the partial renderer cache. At that point the cache is
already mutably borrowed, which causes a panic.

As remedy, apply the mutable borrow more fine grained and not right when calling
render().