### PR TITLE
Add app_id property to Window

### DIFF
--- a/examples/gallery/gallery.slint
+++ b/examples/gallery/gallery.slint
@@ -8,6 +8,7 @@ App := Window {
     preferred-width: 500px;
     preferred-height: 600px;
     title: "Slint Gallery";
+    app_id: "com.slint-ui.gallery";
     icon: @image-url("../../logo/slint-logo-small-light-128x128.png");
 
     VerticalBox {

--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -390,20 +390,23 @@ impl PlatformWindow for GLWindow {
         let component = ComponentRc::borrow_pin(&component_rc);
         let root_item = component.as_ref().get_item_ref(0);
 
-        let (window_title, no_frame, is_resizable) = if let Some(window_item) =
+        let (window_title, no_frame, is_resizable, app_id) = if let Some(window_item) =
             ItemRef::downcast_pin::<corelib::items::WindowItem>(root_item)
         {
             (
                 window_item.title().to_string(),
                 window_item.no_frame(),
                 window_item.height() <= 0 as _ && window_item.width() <= 0 as _,
+                window_item.app_id().to_string(),
             )
         } else {
-            ("Slint Window".to_string(), false, true)
+            ("Slint Window".to_string(), false, true, "".to_string())
         };
 
+        use winit::platform::unix::WindowBuilderExtUnix;
         let window_builder = winit::window::WindowBuilder::new()
             .with_title(window_title)
+            .with_app_id(app_id)
             .with_resizable(is_resizable);
 
         let scale_factor_override = runtime_window.scale_factor();

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -167,6 +167,10 @@ cpp! {{
         // (because the QGuiApplication destructor access some Q_GLOBAL_STATIC which are already gone)
         new QApplication(argc, argv2);
     }
+
+    void setDesktopFileName(const QString &name) {
+        QGuiApplication::setDesktopFileName(name);
+    }
 }}
 
 mod button;

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -54,6 +54,7 @@ cpp! {{
     #include <memory>
 
     void ensure_initialized(bool from_qt_backend);
+    void setDesktopFileName(const QString &name);
 
     using QPainterPtr = std::unique_ptr<QPainter>;
 
@@ -1300,6 +1301,7 @@ impl QtWindow {
         cpp! {unsafe [widget_ptr as "SlintWidget*", rust_window as "void*"]  {
             widget_ptr->rust_window = rust_window;
         }};
+
         ALL_WINDOWS.with(|aw| aw.borrow_mut().push(self_weak));
         rc
     }
@@ -1443,6 +1445,8 @@ impl PlatformWindow for QtWindow {
     fn apply_window_properties(&self, window_item: Pin<&items::WindowItem>) {
         let widget_ptr = self.widget_ptr();
         let title: qttypes::QString = window_item.title().as_str().into();
+        let app_id: qttypes::QString = window_item.app_id().as_str().into();
+
         let no_frame = window_item.no_frame();
         let mut size = qttypes::QSize {
             width: window_item.width().ceil() as _,
@@ -1501,6 +1505,10 @@ impl PlatformWindow for QtWindow {
             #endif
             pal.setColor(QPalette::Window, QColor::fromRgba(background));
             widget_ptr->setPalette(pal);
+        }};
+
+        cpp! {unsafe [app_id as "QString"] {
+            setDesktopFileName(app_id);
         }};
     }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -170,6 +170,7 @@ WindowItem := _ {
     property <length> default-font-size;
     property <int> default-font-weight;
     property <image> icon;
+    property <string> app_id;
 }
 
 export Window := WindowItem {}

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -942,6 +942,7 @@ pub struct WindowItem {
     pub default_font_size: Property<Coord>,
     pub default_font_weight: Property<i32>,
     pub cached_rendering_data: CachedRenderingData,
+    pub app_id: Property<SharedString>,
 }
 
 impl Item for WindowItem {


### PR DESCRIPTION
On Wayland this will be passed to set_app_id in xdg-shell

On X11 this will be passed to wmclass

It is used by desktop environments to identify the application

Fixes #1332