### PR TITLE
Make the Pico use interrupts and make it sleep

### DIFF
--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -45,7 +45,7 @@ pub trait Devices {
         core::time::Duration::ZERO
     }
     fn set_timer_interrupt(&mut self, _duration: core::time::Duration) {}
-    fn wait_for_interrupt(&self) {}
+    fn sleep(&self) {}
 }
 
 impl<T: embedded_graphics::draw_target::DrawTarget> crate::Devices for T
@@ -409,7 +409,7 @@ mod the_backend {
                                 time_to_sleep.0,
                             ));
                         }
-                        devices.borrow_mut().as_mut().unwrap().wait_for_interrupt();
+                        devices.borrow_mut().as_mut().unwrap().sleep();
                     }
                 });
                 match behavior {

--- a/internal/backends/mcu/pico_st7789.rs
+++ b/internal/backends/mcu/pico_st7789.rs
@@ -13,7 +13,7 @@ use embedded_time::rate::*;
 use rp_pico::hal::gpio::{self, Interrupt as GpioInterrupt};
 use rp_pico::hal::pac::{self, interrupt};
 use rp_pico::hal::prelude::*;
-use rp_pico::hal::timer::Alarm0;
+use rp_pico::hal::timer::{Alarm, Alarm0};
 use rp_pico::hal::{self, Timer};
 
 use defmt_rtt as _; // global logger

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -18,7 +18,7 @@ pub mod unsafe_single_core {
     macro_rules! thread_local_ {
         ($(#[$($meta:tt)*])* $vis:vis static $ident:ident : $ty:ty = $expr:expr) => {
             $(#[$($meta)*])*
-            pub(crate) static $ident: crate::unsafe_single_core::FakeThreadStorage<$ty> = {
+            $vis static $ident: crate::unsafe_single_core::FakeThreadStorage<$ty> = {
                 fn init() -> $ty { $expr }
                 crate::unsafe_single_core::FakeThreadStorage::new(init)
             };


### PR DESCRIPTION
This makes the the Raspberry Pi Pico sleep when nothing happens and wake it with interrupts/events.

I cannot compare the performance to the previous code since I only own one pico with the display.
Perhaps you can check it for (visible) performance/responsiveness regressions by comparing it side by side with the old polling code?