### PR TITLE
swrenderer: Add a renderer that operate dirrectly onh the frame buffer

### DIFF
--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -31,6 +31,11 @@ pub type TargetPixel = embedded_graphics::pixelcolor::Rgb565;
 
 pub trait Devices {
     fn screen_size(&self) -> PhysicalSize;
+    /// If the device supports it, return the target buffer where to draw the frame. Must be width * height large.
+    /// Also return the dirty area.
+    fn get_buffer(&mut self) -> Option<(&mut [TargetPixel], PhysicalRect)> {
+        None
+    }
     /// Called before the frame is being drawn, with the dirty region. Return the actual dirty region
     fn prepare_frame(&mut self, dirty_region: PhysicalRect) -> PhysicalRect {
         dirty_region
@@ -85,7 +90,7 @@ where
 }
 
 thread_local! { static DEVICES: RefCell<Option<Box<dyn Devices + 'static>>> = RefCell::new(None) }
-thread_local! { static LINE_RENDERER: RefCell<crate::renderer::LineRenderer> = RefCell::new(Default::default()) }
+thread_local! { static RENDERER: RefCell<crate::renderer::SoftwareRenderer> = RefCell::new(Default::default()) }
 
 mod the_backend {
     use super::*;
@@ -131,7 +136,7 @@ mod the_backend {
             _: i_slint_core::component::ComponentRef,
             items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'a>>>,
         ) {
-            super::LINE_RENDERER.with(|renderer| {
+            super::RENDERER.with(|renderer| {
                 renderer.borrow().free_graphics_resources(items);
             });
         }
@@ -274,8 +279,35 @@ mod the_backend {
             DEVICES.with(|devices| {
                 let mut devices = devices.borrow_mut();
                 let devices = devices.as_mut().unwrap();
-                let size = devices.screen_size().to_f32() / runtime_window.scale_factor();
+                let mut frame_profiler = profiler::Timer::new(&**devices);
+                let screen_size = devices.screen_size();
+                let scale_factor = runtime_window.scale_factor();
+                let size = screen_size.to_f32() / scale_factor;
                 runtime_window.set_window_item_geometry(size.width as _, size.height as _);
+
+                if let Some((buffer, prev_dirty)) = devices.get_buffer() {
+                    let init_dirty = PhysicalRect::from_untyped(
+                        &window
+                            .initial_dirty_region_for_next_frame
+                            .take()
+                            .to_rect()
+                            .cast::<f32>()
+                            .scale(scale_factor, scale_factor)
+                            .cast(),
+                    );
+                    let new_dirty_region = RENDERER.with(|renderer| {
+                        renderer.borrow().render(
+                            runtime_window,
+                            init_dirty.union(&prev_dirty),
+                            buffer,
+                            screen_size.width_length(),
+                        )
+                    });
+                    devices.prepare_frame(new_dirty_region.union(&init_dirty));
+                    devices.flush_frame();
+                    frame_profiler.stop_profiling(&mut **devices, "=> frame total");
+                    return;
+                }
 
                 struct BufferProvider<'a> {
                     screen_fill_profiler: profiler::Timer,
@@ -346,13 +378,14 @@ mod the_backend {
                     dirty_region: PhysicalRect::default(),
                 };
 
-                LINE_RENDERER.with(|renderer| {
-                    renderer.borrow().render(
+                RENDERER.with(|renderer| {
+                    renderer.borrow().render_by_line(
                         runtime_window,
                         window.initial_dirty_region_for_next_frame.take(),
                         buffer_provider,
                     )
                 });
+                frame_profiler.stop_profiling(&mut **devices, "=> frame total");
             });
         }
     }

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -142,7 +142,7 @@ impl PlatformWindow for SimulatorWindow {
         _: i_slint_core::component::ComponentRef,
         items: &mut dyn Iterator<Item = std::pin::Pin<i_slint_core::items::ItemRef<'a>>>,
     ) {
-        super::LINE_RENDERER.with(|cache| {
+        super::RENDERER.with(|cache| {
             cache.borrow().free_graphics_resources(items);
         });
     }
@@ -298,7 +298,7 @@ impl WinitWindow for SimulatorWindow {
                         width: size.width,
                         height: size.height,
                     }));
-                    super::LINE_RENDERER.with(|cache| {
+                    super::RENDERER.with(|cache| {
                         *cache.borrow_mut() = Default::default();
                     });
                     buffer
@@ -324,8 +324,8 @@ impl WinitWindow for SimulatorWindow {
                     );
                 }
             }
-            super::LINE_RENDERER.with(|renderer| {
-                renderer.borrow().render(
+            super::RENDERER.with(|renderer| {
+                renderer.borrow().render_by_line(
                     runtime_window,
                     self.initial_dirty_region_for_next_frame.take(),
                     BufferProvider {

--- a/internal/backends/mcu/stm32h735g.rs
+++ b/internal/backends/mcu/stm32h735g.rs
@@ -237,6 +237,10 @@ impl Devices for StmDevices {
         PhysicalSize::new(DISPLAY_WIDTH as _, DISPLAY_HEIGHT as _)
     }
 
+    fn get_buffer(&mut self) -> Option<(&mut [TargetPixel], PhysicalRect)> {
+        Some((self.work_fb, self.prev_dirty))
+    }
+
     fn prepare_frame(&mut self, dirty_region: PhysicalRect) -> PhysicalRect {
         dirty_region.union(&core::mem::replace(&mut self.prev_dirty, dirty_region))
     }

--- a/internal/backends/mcu/stm32h735g.rs
+++ b/internal/backends/mcu/stm32h735g.rs
@@ -238,6 +238,7 @@ impl Devices for StmDevices {
     }
 
     fn get_buffer(&mut self) -> Option<(&mut [TargetPixel], PhysicalRect)> {
+        while self.layer.is_swap_pending() {}
         Some((self.work_fb, self.prev_dirty))
     }
 

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -385,7 +385,8 @@ pub struct PartialRenderer<'a, T> {
     cache: &'a RefCell<PartialRenderingCache>,
     /// The region of the screen which is considered dirty and that should be repainted
     pub dirty_region: DirtyRegion,
-    actual_renderer: T,
+    /// The actual renderer which the drawing call will be forwarded to
+    pub actual_renderer: T,
 }
 
 impl<'a, T> PartialRenderer<'a, T> {

--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -372,7 +372,8 @@ fn prepare_scene(
     cache: &RefCell<PartialRenderingCache>,
 ) -> Scene {
     let factor = ScaleFactor::new(runtime_window.scale_factor());
-    let prepare_scene = PrepareScene::new(size, factor, runtime_window.default_font_properties());
+    let prepare_scene =
+        SceneBuilder::<PrepareScene>::new(size, factor, runtime_window.default_font_properties());
     let mut renderer =
         crate::item_rendering::PartialRenderer::new(cache, initial_dirty_region, prepare_scene);
 
@@ -398,29 +399,77 @@ fn prepare_scene(
 
     let prepare_scene = renderer.into_inner();
     Scene::new(
-        prepare_scene.items,
-        prepare_scene.textures,
-        prepare_scene.rounded_rectangles,
+        prepare_scene.processor.items,
+        prepare_scene.processor.textures,
+        prepare_scene.processor.rounded_rectangles,
         dirty_region,
     )
 }
 
+trait ProcessScene {
+    fn process_texture(&mut self, geometry: PhysicalRect, texture: SceneTexture);
+    fn process_rectangle(&mut self, geometry: PhysicalRect, color: Color);
+    fn process_rounded_rectangle(&mut self, geometry: PhysicalRect, data: RoundedRectangle);
+}
+
+#[derive(Default)]
 struct PrepareScene {
     items: Vec<SceneItem>,
     textures: Vec<SceneTexture>,
     rounded_rectangles: Vec<RoundedRectangle>,
+}
+
+impl ProcessScene for PrepareScene {
+    fn process_texture(&mut self, geometry: PhysicalRect, texture: SceneTexture) {
+        let size = geometry.size;
+        if !size.is_empty() {
+            let texture_index = self.textures.len() as u16;
+            self.textures.push(texture);
+            self.items.push(SceneItem {
+                pos: geometry.origin,
+                size,
+                z: self.items.len() as u16,
+                command: SceneCommand::Texture { texture_index },
+            });
+        }
+    }
+
+    fn process_rectangle(&mut self, geometry: PhysicalRect, color: Color) {
+        let size = geometry.size;
+        if !size.is_empty() {
+            let z = self.items.len() as u16;
+            let pos = geometry.origin;
+            self.items.push(SceneItem { pos, size, z, command: SceneCommand::Rectangle { color } });
+        }
+    }
+
+    fn process_rounded_rectangle(&mut self, geometry: PhysicalRect, data: RoundedRectangle) {
+        let size = geometry.size;
+        if !size.is_empty() {
+            let rectangle_index = self.rounded_rectangles.len() as u16;
+            self.rounded_rectangles.push(data);
+            self.items.push(SceneItem {
+                pos: geometry.origin,
+                size,
+                z: self.items.len() as u16,
+                command: SceneCommand::RoundedRectangle { rectangle_index },
+            });
+        }
+    }
+}
+
+struct SceneBuilder<T> {
+    processor: T,
     state_stack: Vec<RenderState>,
     current_state: RenderState,
     scale_factor: ScaleFactor,
     default_font: FontRequest,
 }
 
-impl PrepareScene {
+impl<T: ProcessScene + Default> SceneBuilder<T> {
     fn new(size: PhysicalSize, scale_factor: ScaleFactor, default_font: FontRequest) -> Self {
         Self {
-            items: vec![],
-            rounded_rectangles: vec![],
-            textures: vec![],
+            processor: Default::default(),
             state_stack: vec![],
             current_state: RenderState {
                 alpha: 1.,
@@ -439,33 +488,6 @@ impl PrepareScene {
         !rect.size.is_empty()
             && self.current_state.alpha > 0.01
             && self.current_state.clip.intersects(rect)
-    }
-
-    fn new_scene_texture(&mut self, geometry: PhysicalRect, texture: SceneTexture) {
-        let size = geometry.size;
-        if !size.is_empty() {
-            let texture_index = self.textures.len() as u16;
-            self.textures.push(texture);
-            self.items.push(SceneItem {
-                pos: geometry.origin,
-                size,
-                z: self.items.len() as u16,
-                command: SceneCommand::Texture { texture_index },
-            });
-        }
-    }
-
-    fn new_scene_item(&mut self, geometry: LogicalRect, command: SceneCommand) {
-        let geometry = (geometry.translate(self.current_state.offset.to_vector()).cast()
-            * self.scale_factor)
-            .round()
-            .cast();
-        let size = geometry.size;
-        if !size.is_empty() {
-            let z = self.items.len() as u16;
-            let pos = geometry.origin;
-            self.items.push(SceneItem { pos, size, z, command });
-        }
     }
 
     fn draw_image_impl(
@@ -549,7 +571,7 @@ impl PrepareScene {
                             + source_rect.origin.y as usize
                             - t.rect.origin.y as usize;
                         let stride = t.rect.width() as u16 * bpp(t.format);
-                        self.new_scene_texture(
+                        self.processor.process_texture(
                             target_rect.cast(),
                             SceneTexture {
                                 data: &data.as_slice()[(t.index
@@ -575,7 +597,7 @@ struct RenderState {
     clip: LogicalRect,
 }
 
-impl crate::item_rendering::ItemRenderer for PrepareScene {
+impl<T: ProcessScene + Default + 'static> crate::item_rendering::ItemRenderer for SceneBuilder<T> {
     fn draw_rectangle(&mut self, rect: Pin<&crate::items::Rectangle>, _: &ItemRc) {
         let geom = LogicalRect::new(LogicalPoint::default(), rect.logical_geometry().size_length());
         if self.should_draw(&geom) {
@@ -589,7 +611,12 @@ impl crate::item_rendering::ItemRenderer for PrepareScene {
             if color.alpha() == 0 {
                 return;
             }
-            self.new_scene_item(geom, SceneCommand::Rectangle { color: color });
+            self.processor.process_rectangle(
+                (geom.translate(self.current_state.offset.to_vector()).cast() * self.scale_factor)
+                    .round()
+                    .cast(),
+                color,
+            );
         }
     }
 
@@ -607,26 +634,31 @@ impl crate::item_rendering::ItemRenderer for PrepareScene {
                 if let Some(clipped) = geom.intersection(&self.current_state.clip) {
                     let geom2 = geom.cast() * self.scale_factor;
                     let clipped2 = clipped.cast() * self.scale_factor;
-                    let rectangle_index = self.rounded_rectangles.len() as u16;
                     // Add a small value to make sure that the clip is always positive despite floating point shenanigans
                     const E: f32 = 0.00001;
-                    self.rounded_rectangles.push(RoundedRectangle {
-                        radius: (radius.cast() * self.scale_factor).cast(),
-                        width: (LogicalLength::new(border).cast() * self.scale_factor).cast(),
-                        border_color: rect.border_color().color(),
-                        inner_color: color,
-                        top_clip: PhysicalLength::new((clipped2.min_y() - geom2.min_y() + E) as _),
-                        bottom_clip: PhysicalLength::new(
-                            (geom2.max_y() - clipped2.max_y() + E) as _,
-                        ),
-                        left_clip: PhysicalLength::new((clipped2.min_x() - geom2.min_x() + E) as _),
-                        right_clip: PhysicalLength::new(
-                            (geom2.max_x() - clipped2.max_x() + E) as _,
-                        ),
-                    });
-                    self.new_scene_item(
-                        clipped,
-                        SceneCommand::RoundedRectangle { rectangle_index },
+                    self.processor.process_rounded_rectangle(
+                        (clipped.translate(self.current_state.offset.to_vector()).cast()
+                            * self.scale_factor)
+                            .round()
+                            .cast(),
+                        RoundedRectangle {
+                            radius: (radius.cast() * self.scale_factor).cast(),
+                            width: (LogicalLength::new(border).cast() * self.scale_factor).cast(),
+                            border_color: rect.border_color().color(),
+                            inner_color: color,
+                            top_clip: PhysicalLength::new(
+                                (clipped2.min_y() - geom2.min_y() + E) as _,
+                            ),
+                            bottom_clip: PhysicalLength::new(
+                                (geom2.max_y() - clipped2.max_y() + E) as _,
+                            ),
+                            left_clip: PhysicalLength::new(
+                                (clipped2.min_x() - geom2.min_x() + E) as _,
+                            ),
+                            right_clip: PhysicalLength::new(
+                                (geom2.max_x() - clipped2.max_x() + E) as _,
+                            ),
+                        },
                     );
                 }
                 return;
@@ -636,7 +668,13 @@ impl crate::item_rendering::ItemRenderer for PrepareScene {
                 if let Some(r) =
                     geom.inflate(-border, -border).intersection(&self.current_state.clip)
                 {
-                    self.new_scene_item(r, SceneCommand::Rectangle { color });
+                    self.processor.process_rectangle(
+                        (r.translate(self.current_state.offset.to_vector()).cast()
+                            * self.scale_factor)
+                            .round()
+                            .cast(),
+                        color,
+                    );
                 }
             }
             if border > 0.01 as Coord {
@@ -646,7 +684,13 @@ impl crate::item_rendering::ItemRenderer for PrepareScene {
                 if border_color.alpha() > 0 {
                     let mut add_border = |r: LogicalRect| {
                         if let Some(r) = r.intersection(&self.current_state.clip) {
-                            self.new_scene_item(r, SceneCommand::Rectangle { color: border_color });
+                            self.processor.process_rectangle(
+                                (r.translate(self.current_state.offset.to_vector()).cast()
+                                    * self.scale_factor)
+                                    .round()
+                                    .cast(),
+                                border_color,
+                            );
                         }
                     };
                     let b = border;
@@ -756,7 +800,7 @@ impl crate::item_rendering::ItemRenderer for PrepareScene {
                     let actual_y = origin.y - src_rect.origin.y as usize;
                     let stride = positioned_glyph.platform_glyph.width().get() as u16;
                     let geometry = geometry.cast();
-                    self.new_scene_texture(
+                    self.processor.process_texture(
                         geometry,
                         SceneTexture {
                             data: &positioned_glyph.platform_glyph.data().as_slice()


### PR DESCRIPTION
It doesn't do line by line anymore, trying to avoid allocating memory for the scene

Note: currently, this is slower than the line by line renderer on STM32H735, need to investigate why.