### PR TITLE
Bump system clock frequence on stm32h735

### DIFF
--- a/internal/backends/mcu/stm32h735g.rs
+++ b/internal/backends/mcu/stm32h735g.rs
@@ -47,16 +47,16 @@ pub fn init() {
     let pwrcfg = pwr.smps().freeze();
     let rcc = dp.RCC.constrain();
     let ccdr = rcc
-        .sys_ck(320.MHz())
+        .sys_ck(400.MHz())
         .pll3_p_ck(800.MHz() / 2)
         .pll3_q_ck(800.MHz() / 2)
         .pll3_r_ck(800.MHz() / 83)
         .freeze(pwrcfg, &dp.SYSCFG);
 
-    // Octospi from HCLK at 160MHz
-    assert_eq!(ccdr.clocks.hclk(), 160.MHz::<1, 1>());
+    assert_eq!(ccdr.clocks.hclk(), 200.MHz::<1, 1>());
+    // Octospi from HCLK at 200MHz
     assert_eq!(
-        ccdr.peripheral.OCTOSPI1.get_kernel_clk_mux(),
+        ccdr.peripheral.OCTOSPI2.get_kernel_clk_mux(),
         hal::rcc::rec::OctospiClkSel::RCC_HCLK3
     );
 


### PR DESCRIPTION
Up to 400 Mhz seems to work. Also fixed assert to match the octospi controller for the hyperram (1 instead of 2).

I get asserts in the stm32h7 crate above that, although https://www.st.com/resource/en/datasheet/stm32h735ag.pdf says the CPU can go up to 550Mhz.