### PR TITLE
Enable panic-probe by default for stm32

### DIFF
--- a/internal/backends/mcu/Cargo.toml
+++ b/internal/backends/mcu/Cargo.toml
@@ -20,7 +20,7 @@ path = "lib.rs"
 simulator = ["winit", "glutin", "femtovg", "embedded-graphics-simulator", "std", "imgref", "scoped-tls-hkt"]
 
 pico-st7789 = ["unsafe_single_core", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "display-interface-spi", "st7789", "defmt", "defmt-rtt",  "i-slint-core/defmt", "shared-bus", "i-slint-core/libm" ]
-stm32h735g = ["unsafe_single_core", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "i-slint-core/defmt", "stm32h7xx-hal/stm32h735", "defmt", "defmt-rtt", "embedded-display-controller", "ft5336"]
+stm32h735g = ["unsafe_single_core", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "i-slint-core/defmt", "stm32h7xx-hal/stm32h735", "defmt", "defmt-rtt", "embedded-display-controller", "ft5336", "panic-probe"]
 
 unsafe_single_core = ["i-slint-core/unsafe_single_core"]
 
@@ -63,7 +63,8 @@ st7789 = { version = "0.6.1", optional = true }
 
 stm32h7xx-hal = { version = "0.12.1", optional = true, features = ["log-rtt", "ltdc", "xspi"] }
 embedded-display-controller = { version = "0.1.0", optional = true }
-ft5336 = { version = "0.1", optional = true }
+# Use upstream git version to enable use of panic-probe (released version enforced panic-semihosting)
+ft5336 = { version = "0.1", git = "https://github.com/bobgates/ft5336", rev = "293730a225a68b6364857602f8fb62fd0beb8a26", optional = true }
 
 defmt-rtt = { version = "0.3.0", optional = true }
 defmt = { version = "0.3.0", optional = true }


### PR DESCRIPTION
The ft5336 crate enforced the panic-semihosting for no apparent reason,
but this is fixed upstream now.