### PR TITLE
Use prettyplease crate to do the formatting

### DIFF
--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -24,3 +24,7 @@ i-slint-compiler = { version = "=0.2.5", path = "../../../internal/compiler", fe
 spin_on = "0.1"
 thiserror = "1"
 toml_edit = "0.14.2"
+prettyplease = "0.1.11"
+syn = { version = "1.0", features = ["full"] }
+proc-macro2 = "1.0.17"
+


### PR DESCRIPTION
This fixes compilation of generated Rust code when token stream contains
single-quoted semicolon.

When using glyph embedding, we generate a character map where each code
point is a literal char.  When the font contains a semicolon and we
generate an entry for that, we write ';' and the CodeFormatter would
think the semicolon is the end of a statement and produce a newline.
That breaks the build of the generated code.

Replace the hand-written formatter with the use of the prettyplease
crate.