### PR TITLE
Fix compilation of generated Rust code when token stream contains sin…

### DIFF
--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -24,7 +24,3 @@ i-slint-compiler = { version = "=0.2.5", path = "../../../internal/compiler", fe
 spin_on = "0.1"
 thiserror = "1"
 toml_edit = "0.14.2"
-prettyplease = "0.1.11"
-syn = { version = "1.0", features = ["full"] }
-proc-macro2 = "1.0.17"
-

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -111,6 +111,52 @@ pub enum CompileError {
     SaveError(std::io::Error),
 }
 
+struct CodeFormatter<Sink> {
+    indentation: usize,
+    in_string: bool,
+    sink: Sink,
+}
+
+impl<Sink: Write> Write for CodeFormatter<Sink> {
+    fn write(&mut self, mut s: &[u8]) -> std::io::Result<usize> {
+        let len = s.len();
+        while let Some(idx) = s.iter().position(|c| match c {
+            b'{' if !self.in_string => {
+                self.indentation += 1;
+                true
+            }
+            b'}' if !self.in_string => {
+                self.indentation -= 1;
+                true
+            }
+            b';' if !self.in_string => true,
+            b'"' if !self.in_string => {
+                self.in_string = true;
+                false
+            }
+            b'"' if self.in_string => {
+                // FIXME! escape character
+                self.in_string = false;
+                false
+            }
+            _ => false,
+        }) {
+            let idx = idx + 1;
+            self.sink.write_all(&s[..idx])?;
+            self.sink.write_all(b"\n")?;
+            for _ in 0..self.indentation {
+                self.sink.write_all(b"    ")?;
+            }
+            s = &s[idx..];
+        }
+        self.sink.write_all(s)?;
+        Ok(len)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.sink.flush()
+    }
+}
+
 /// Compile the `.slint` file and generate rust code for it.
 ///
 /// The generated code code will be created in the directory specified by
@@ -202,7 +248,8 @@ pub fn compile_with_config(
                 .with_extension("rs"),
         );
 
-    let mut file = std::fs::File::create(&output_file_path).map_err(CompileError::SaveError)?;
+    let file = std::fs::File::create(&output_file_path).map_err(CompileError::SaveError)?;
+    let mut code_formatter = CodeFormatter { indentation: 0, in_string: false, sink: file };
     let generated = i_slint_compiler::generator::rust::generate(&doc);
 
     for x in &diag.all_loaded_files {
@@ -218,14 +265,7 @@ pub fn compile_with_config(
         }
     });
 
-    if let Ok(formatted_code) =
-        syn::parse2(generated.clone()).and_then(|syn_file| Ok(prettyplease::unparse(&syn_file)))
-    {
-        write!(file, "{}", formatted_code).map_err(CompileError::SaveError)?;
-    } else {
-        write!(file, "{}", generated).map_err(CompileError::SaveError)?;
-    }
-
+    write!(code_formatter, "{}", generated).map_err(CompileError::SaveError)?;
     println!("{}\ncargo:rerun-if-changed={}", rerun_if_changed, path.display());
 
     for resource in doc.root_component.embedded_file_resources.borrow().keys() {


### PR DESCRIPTION
…gle-quoted semicolon

When using glyph embedding, we generate a character map where each code
point is a literal char.  When the font contains a semicolon and we
generate an entry for that, we write ';' and the CodeFormatter would
think the semicolon is the end of a statement and produce a newline.
That breaks the build of the generated code. Instead teach the formatter
also about single-quoted string literals.