### PR TITLE
mcu pico: fix the screen artifacts by re-implementing display-interface-spi

### DIFF
--- a/internal/backends/mcu/Cargo.toml
+++ b/internal/backends/mcu/Cargo.toml
@@ -19,7 +19,7 @@ path = "lib.rs"
 [features]
 simulator = ["winit", "glutin", "femtovg", "embedded-graphics-simulator", "std", "imgref", "scoped-tls-hkt"]
 
-pico-st7789 = ["unsafe_single_core", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "display-interface-spi", "st7789", "defmt", "defmt-rtt",  "i-slint-core/defmt", "shared-bus", "i-slint-core/libm" ]
+pico-st7789 = ["unsafe_single_core", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "display-interface", "st7789", "defmt", "defmt-rtt",  "i-slint-core/defmt", "shared-bus", "i-slint-core/libm" ]
 stm32h735g = ["unsafe_single_core", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "i-slint-core/defmt", "stm32h7xx-hal/stm32h735", "defmt", "defmt-rtt", "embedded-display-controller", "ft5336", "panic-probe"]
 
 unsafe_single_core = ["i-slint-core/unsafe_single_core"]
@@ -54,7 +54,7 @@ winit = { version = "0.26.0", default-features = false, optional = true, feature
 alloc-cortex-m = { version = "0.4.1", optional = true }
 cortex-m-rt = { version = "0.7", optional = true }
 cortex-m = { version = "0.7.2", optional = true }
-display-interface-spi = { version = "0.4.1", optional = true }
+display-interface = { version = "0.4.1", optional = true }
 embedded-hal = { version = "0.2.5", optional = true }
 embedded-time = { version = "0.12.0", optional = true }
 rp-pico = { version = "0.4.0", optional = true }

--- a/internal/backends/mcu/pico_st7789.rs
+++ b/internal/backends/mcu/pico_st7789.rs
@@ -29,6 +29,8 @@ use alloc_cortex_m::CortexMHeap;
 
 use crate::{Devices, PhysicalRect, PhysicalSize};
 
+mod display_interface_spi;
+
 const HEAP_SIZE: usize = 200 * 1024;
 static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
 

--- a/internal/backends/mcu/pico_st7789/display_interface_spi.rs
+++ b/internal/backends/mcu/pico_st7789/display_interface_spi.rs
@@ -1,0 +1,115 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+//! The `display-interface-spi` crate cannot be used because it doesn't "flush" the spi between
+//! the write and the changes in the CS and DC pin. This results in artifacts being shown on the
+//! screen
+//!
+//! Work-around the problem by using `transfer` instead of write.
+
+use embedded_hal as hal;
+use hal::digital::v2::OutputPin;
+
+use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
+
+fn send_u8<SPI: hal::blocking::spi::Transfer<u8>>(
+    spi: &mut SPI,
+    words: DataFormat<'_>,
+) -> Result<(), DisplayError> {
+    match words {
+        DataFormat::U8Iter(iter) => {
+            let mut buf = [0; 32];
+            let mut i = 0;
+
+            for v in iter.into_iter() {
+                buf[i] = v;
+                i += 1;
+
+                if i == buf.len() {
+                    spi.transfer(&mut buf).map_err(|_| DisplayError::BusWriteError)?;
+                    i = 0;
+                }
+            }
+
+            if i > 0 {
+                spi.transfer(&mut buf[..i]).map_err(|_| DisplayError::BusWriteError)?;
+            }
+
+            Ok(())
+        }
+        DataFormat::U16BEIter(iter) => {
+            for mut v in iter.map(u16::to_be_bytes) {
+                spi.transfer(&mut v).map_err(|_| DisplayError::BusWriteError)?;
+            }
+
+            Ok(())
+        }
+        _ => Err(DisplayError::DataFormatNotImplemented),
+    }
+}
+
+/// SPI display interface.
+///
+/// This combines the SPI peripheral and a data/command as well as a chip-select pin
+pub struct SPIInterface<SPI, DC, CS> {
+    spi: SPI,
+    dc: DC,
+    cs: CS,
+}
+
+impl<SPI, DC, CS> SPIInterface<SPI, DC, CS>
+where
+    SPI: hal::blocking::spi::Transfer<u8>,
+    DC: OutputPin,
+    CS: OutputPin,
+{
+    /// Create new SPI interface for communication with a display driver
+    pub fn new(spi: SPI, dc: DC, cs: CS) -> Self {
+        Self { spi, dc, cs }
+    }
+}
+
+impl<SPI, DC, CS> WriteOnlyDataCommand for SPIInterface<SPI, DC, CS>
+where
+    SPI: hal::blocking::spi::Transfer<u8>,
+    DC: OutputPin,
+    CS: OutputPin,
+{
+    fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result<(), DisplayError> {
+        // Assert chip select pin
+        self.cs.set_low().map_err(|_| DisplayError::CSError)?;
+
+        // 1 = data, 0 = command
+        self.dc.set_low().map_err(|_| DisplayError::DCError)?;
+
+        // Send words over SPI
+        let err = send_u8(&mut self.spi, cmds);
+
+        // ---
+        // for _ in 0..70 {
+        //     self.cs.set_low().map_err(|_| DisplayError::CSError)?;
+        // }
+        // ---
+
+        // Deassert chip select pin
+        self.cs.set_high().ok();
+
+        err
+    }
+
+    fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
+        // Assert chip select pin
+        self.cs.set_low().map_err(|_| DisplayError::CSError)?;
+
+        // 1 = data, 0 = command
+        self.dc.set_high().map_err(|_| DisplayError::DCError)?;
+
+        // Send words over SPI
+        let err = send_u8(&mut self.spi, buf);
+
+        // Deassert chip select pin
+        self.cs.set_high().ok();
+
+        err
+    }
+}


### PR DESCRIPTION
The display-interface-spi crate the not flush the internal fifo between the write
and the changes of the CS and DC pins, which result of changing these pins before
the screen recieve all the data over the spi and causes artifacts on the screen.

So re-implement the logic in our crate and use `transfer` instead of `write`
which flushes the fifo correctly.