### PR TITLE
MCU: Fix width of the text not including whitespaces

### DIFF
--- a/internal/core/textlayout/linebreaker.rs
+++ b/internal/core/textlayout/linebreaker.rs
@@ -50,6 +50,10 @@ impl<Length: Clone + Copy + Default + core::ops::AddAssign> TextLine<Length> {
         } else {
             self.glyph_range.end = fragment.glyph_range.end;
         }
+        if !fragment.byte_range.is_empty() {
+            self.text_width += self.trailing_whitespace;
+            self.trailing_whitespace = Length::default();
+        }
         self.text_width += fragment.width;
         self.trailing_whitespace += fragment.trailing_whitespace_width;
     }

--- a/internal/core/textlayout/linebreaker.rs
+++ b/internal/core/textlayout/linebreaker.rs
@@ -328,3 +328,14 @@ fn test_basic_line_break_space_v4() {
     assert_eq!(lines.len(), 1);
     assert_eq!(lines[0].line_text(&text), "H W  H");
 }
+
+#[test]
+fn test_line_width_with_whitespace() {
+    let font = FixedTestFont;
+    let text = "Hello World";
+    let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
+    let lines =
+        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(200.)).collect::<Vec<_>>();
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].text_width, text.len() as f32 * 10.);
+}


### PR DESCRIPTION
When concatenating two fragment, we should account for the trailing whitespace
in the previous fragment in the total width.

This fixes the "l" of "Ink level" not beoing drawn properly in the printer
demo with the partial renderer if the Text item (which is too small as a result
of this bug) does not overlap the dirty region, but part of the text still
need to be drawn outside before it overflows