### PR TITLE
swrenderer: clip glyphs to the text element's geometry

### DIFF
--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -733,12 +733,12 @@ impl crate::item_rendering::ItemRenderer for PrepareScene {
 
         // Clip glyphs not only against the global clip but also against the Text's geometry to avoid drawing outside
         // of its boundaries (that break partial rendering).
-        let physical_clip =
-            if let Some(logical_clip) = self.current_state.clip.cast().intersection(&geom) {
-                logical_clip * self.scale_factor
-            } else {
-                return; // This should have been caught earlier already
-            };
+        let physical_clip = if let Some(logical_clip) = self.current_state.clip.intersection(&geom)
+        {
+            logical_clip.cast() * self.scale_factor
+        } else {
+            return; // This should have been caught earlier already
+        };
         let offset = self.current_state.offset.to_vector().cast() * self.scale_factor;
 
         paragraph.layout_lines(|glyphs, line_x, line_y| {

--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -732,7 +732,8 @@ impl crate::item_rendering::ItemRenderer for PrepareScene {
         };
 
         // Clip glyphs not only against the global clip but also against the Text's geometry to avoid drawing outside
-        // of its boundaries (that break partial rendering).
+        // of its boundaries (that breaks partial rendering and the cast to usize for the item relative coordinate below).
+        // FIXME: we should allow drawing outside of the Text element's boundaries.
         let physical_clip = if let Some(logical_clip) = self.current_state.clip.intersection(&geom)
         {
             logical_clip.cast() * self.scale_factor


### PR DESCRIPTION
This ensures that the partial renderer updates correctly and this also
fixes a panic in the printer demo on the stm32h7 when opening the format
combobox in the scan page:

We would attempt to render the word "JPEG" with a font size of 12 pixels.
The letter J has a height of 12 pixels, like the font ascender reported, but it's
y coordinate is negative.
That would also result in a negative text item relative origin for the glyph (target
rect in physical pixels),
which fails to convert to an usize and panics.