### PR TITLE
Printerdemo_mcu: Polish settings page

### DIFF
--- a/examples/printerdemo_mcu/ui/settings_page.slint
+++ b/examples/printerdemo_mcu/ui/settings_page.slint
@@ -55,7 +55,7 @@ export SettingsPage := Page {
             Label { text: "Color"; }
             ComboBox {
                 value: "Grayscale";
-                choices: ["Grayscale", "RGB", "YCMB"];
+                choices: ["Grayscale", "Color"];
                 horizontal-stretch: 2;
             }
         }


### PR DESCRIPTION
Only list Greyscale/Color. That is a more realistic set of options and it has the added benefit to fit on the small screen.