### PR TITLE
Improvements to the vscode web extension preview

### DIFF
--- a/editor/vscode/browser-language-server/browserServerMain.ts
+++ b/editor/vscode/browser-language-server/browserServerMain.ts
@@ -31,9 +31,9 @@ slint_init(slint_wasm_data).then((_) => {
     });
 
     connection.onRequest(async (method, params, token) => {
-        if (method === "workspace/executeCommand" && (<ExecuteCommandParams>params).command === "showPreview") {
+        if (method === "workspace/executeCommand" && (params as ExecuteCommandParams).command === "showPreview") {
             // forward back to the client so it can send the command to the webview
-            return await connection.sendRequest("slint/showPreview", (<ExecuteCommandParams>params).arguments);
+            return await connection.sendRequest("slint/showPreview", (params as ExecuteCommandParams).arguments);
         }
         return await the_lsp.handle_request(token, method, params);
     });

--- a/editor/vscode/browser-language-server/browserServerMain.ts
+++ b/editor/vscode/browser-language-server/browserServerMain.ts
@@ -3,7 +3,7 @@
 
 import { createConnection, BrowserMessageReader, BrowserMessageWriter } from 'vscode-languageserver/browser';
 
-import { InitializeParams, InitializeResult } from 'vscode-languageserver';
+import { ExecuteCommandParams, InitializeParams, InitializeResult } from 'vscode-languageserver';
 
 import slint_init, * as slint_lsp from "../../../tools/lsp/pkg/index.js";
 import slint_wasm_data from "../../../tools/lsp/pkg/index_bg.wasm";
@@ -31,6 +31,10 @@ slint_init(slint_wasm_data).then((_) => {
     });
 
     connection.onRequest(async (method, params, token) => {
+        if (method === "workspace/executeCommand" && (<ExecuteCommandParams>params).command === "showPreview") {
+            // forward back to the client so it can send the command to the webview
+            return await connection.sendRequest("slint/showPreview", (<ExecuteCommandParams>params).arguments);
+        }
         return await the_lsp.handle_request(token, method, params);
     });
 

--- a/editor/vscode/src/browser.ts
+++ b/editor/vscode/src/browser.ts
@@ -191,6 +191,7 @@ function getPreviewHtml(): string {
 
     const vscode = acquireVsCodeApi();
     let promises = {};
+    let current_instance = undefined;
 
     async function load_file(url) {
         let promise = new Promise(resolve => {
@@ -211,7 +212,14 @@ function getPreviewHtml(): string {
         vscode.postMessage({ command: 'preview_ready' });
         if (component !== undefined) {
             document.getElementById("slint_error_div").innerHTML = "";
-            let instance = component.run("slint_canvas");
+            let instance = component.create("slint_canvas");
+            instance.show();
+            if (current_instance) {
+                current_instance.hide();
+            } else {
+                slint.run_event_loop();
+            }
+            current_instance = instance;
         }
     }
 

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -95,7 +95,7 @@ pub fn server_capabilities() -> ServerCapabilities {
             lsp_types::TextDocumentSyncKind::FULL,
         )),
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
-        #[cfg(feature = "preview")]
+        #[cfg(any(feature = "preview", target_arch = "wasm32"))]
         execute_command_provider: Some(lsp_types::ExecuteCommandOptions {
             commands: vec![SHOW_PREVIEW_COMMAND.into()],
             ..Default::default()
@@ -367,7 +367,7 @@ fn get_code_actions(
     _document_cache: &mut DocumentCache,
     node: SyntaxNode,
 ) -> Option<Vec<CodeActionOrCommand>> {
-    if !cfg!(feature = "preview") {
+    if !cfg!(feature = "preview") && !cfg!(target_arch = "wasm32") {
         return None;
     }
 
@@ -489,7 +489,7 @@ fn get_code_lenses(
     document_cache: &mut DocumentCache,
     text_document: &lsp_types::TextDocumentIdentifier,
 ) -> Option<Vec<CodeLens>> {
-    if !cfg!(feature = "preview") {
+    if !cfg!(feature = "preview") && !cfg!(target_arch = "wasm32") {
         return None;
     }
 


### PR DESCRIPTION

- Reload the preview when the user do changes in the imported .slint files
- Integrate with our LSP so that we add the code lense / actions to allow to preview a component.
- Only use one winit eventloop instead of always restarting one.

cc #1336