### PR TITLE
Don't optimize const state property

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -426,7 +426,7 @@ fn handle_property_init(
         let init_expr =
             compile_expression_wrap_return(&binding_expression.expression.borrow(), ctx);
 
-        init.push(if binding_expression.is_constant {
+        init.push(if binding_expression.is_constant && !binding_expression.is_state_info {
             format!("{}.set({});", prop_access, init_expr)
         } else {
             let binding_code = format!(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -419,7 +419,7 @@ fn handle_property_init(
     } else {
         let tokens_for_expression =
             compile_expression(&binding_expression.expression.borrow(), ctx);
-        init.push(if binding_expression.is_constant {
+        init.push(if binding_expression.is_constant && !binding_expression.is_state_info {
             let t = rust_type(prop_type).unwrap_or(quote!(_));
 
             // When there is a `return` statement, we must use a lambda expression in the generated code so that the

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -398,12 +398,18 @@ pub trait TypeResolutionContext {
     }
 }
 
-#[derive(Clone, Copy)]
 pub struct ParentCtx<'a, T = ()> {
     pub ctx: &'a EvaluationContext<'a, T>,
     // Index of the repeater within the ctx.current_sub_component
     pub repeater_index: Option<usize>,
 }
+
+impl<'a, T> Clone for ParentCtx<'a, T> {
+    fn clone(&self) -> Self {
+        Self { ctx: self.ctx, repeater_index: self.repeater_index }
+    }
+}
+impl<'a, T> Copy for ParentCtx<'a, T> {}
 
 impl<'a, T> ParentCtx<'a, T> {
     pub fn new(ctx: &'a EvaluationContext<'a, T>, repeater_index: Option<usize>) -> Self {

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -86,8 +86,8 @@ impl<'a> PrettyPrinter<'a> {
     }
 }
 
-pub struct DisplayPropertyRef<'a>(pub &'a PropertyReference, pub &'a EvaluationContext<'a>);
-impl Display for DisplayPropertyRef<'_> {
+pub struct DisplayPropertyRef<'a, T>(pub &'a PropertyReference, pub &'a EvaluationContext<'a, T>);
+impl<T> Display for DisplayPropertyRef<'_, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result {
         let mut ctx = self.1;
         match &self.0 {
@@ -126,8 +126,8 @@ impl Display for DisplayPropertyRef<'_> {
     }
 }
 
-pub struct DisplayExpression<'a>(pub &'a Expression, pub &'a EvaluationContext<'a>);
-impl<'a> Display for DisplayExpression<'a> {
+pub struct DisplayExpression<'a, T>(pub &'a Expression, pub &'a EvaluationContext<'a, T>);
+impl<'a, T> Display for DisplayExpression<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result {
         let ctx = self.1;
         let e = |e: &'a Expression| DisplayExpression(e, ctx);

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -20,7 +20,9 @@ pub fn const_propagation(component: &Component) {
 fn simplify_expression(expr: &mut Expression) -> bool {
     match expr {
         Expression::PropertyReference(nr) => {
-            if nr.is_constant() {
+            if nr.is_constant()
+                && !matches!(nr.ty(), Type::Struct { name: Some(name), .. } if name.ends_with("::StateInfo"))
+            {
                 // Inline the constant value
                 if let Some(result) = extract_constant_property_reference(nr) {
                     *expr = result;

--- a/tests/cases/crashes/issue1327_inlined_state_property.slint
+++ b/tests/cases/crashes/issue1327_inlined_state_property.slint
@@ -1,0 +1,68 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+// based on https://github.com/slint-ui/slint/issues/1327#issuecomment-1151244049
+
+export RipplCircle := Rectangle {
+    property <length> radius: 0;
+    property <length> mx: 0;
+    property <length> my: 0;
+    property <float> fwidth: 0;
+    property <float> fheight: 0;
+    property <bool> running: false;
+    width: radius * 2;
+    height: radius * 2;
+    x: mx - width / 2;
+    y: my - height / 2;
+    background: rgba(0,0,0, 0.5);
+    border-radius: width / 2;
+
+    property <float> counter: 0;
+    animate counter { duration: 800ms; }
+
+    states [
+        ripple when counter > 0 && counter < 0.1 : {
+            radius: 100px;
+            opacity: 0.;
+            running: true;
+        }
+    ]
+
+    transitions [
+        in ripple: {
+            animate radius { duration: 800ms; }
+            animate opacity { duration: 800ms; }
+        }
+    ]
+}
+
+export InkEffect := Rectangle {
+
+    preferred-width: 200px;
+    preferred-height: 200px;
+    background: white;
+    clip: true;
+
+    circle1 := RipplCircle {}
+    // un commenting the next line causes macro proc panick
+    circle2 := RipplCircle { background: green; }
+
+
+    tch := TouchArea {
+        width: parent.width;
+        height: parent.height;
+        pointer-event(ev) => {
+            if (ev.kind == PointerEventKind.down && ev.button == PointerEventButton.left) {
+                if (!circle1.running) {
+                    circle1.mx = mouse-x;
+                    circle1.my = mouse-y;
+                    circle1.fwidth = parent.width / 1px;
+                    circle1.fheight = parent.height / 1px;
+                    circle1.counter = circle1.counter == 0 ? 0.1 : 0;
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
state info properties are special and cannot simply be inlined or set
(because we need to record the time it was changed and stuff)
So disable the optimization for now.

In fact, what could be done is to remove the state entirely if the state property
is constant. But that change is a bit more involved

This patch does:
 - Don't inline const state property
 - Don't generate a call to .set in the generated code
 - Also allowed to debug the expression with a context from the generator
   (added T generic parameter to the pretty printer)

Fix panic reported in https://github.com/slint-ui/slint/issues/1327#issuecomment-1151244049