### PR TITLE
vscode web extension: preserve the slint preview accross restart

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -18,7 +18,8 @@
 	],
 	"preview": true,
 	"activationEvents": [
-		"onLanguage:slint"
+		"onLanguage:slint",
+		"onWebviewPanel:slint-preview"
 	],
 	"main": "./out/extension.js",
 	"browser": "./out/browser.js",


### PR DESCRIPTION
This also enable the `retainContextWhenHidden` which will make sure
the state of the preview (eg, the currently visible tab) is kept when
the preview tab is hidden.