### PR TITLE
Button: Implement support to make the Button a toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Added
+
+ - `Button`: Add a `checkable` property that turns the button into a toggle
+   button. Use the new `checked` property to query whether the toggle button
+   is pressed down or not.
+
 ## [0.2.5] - 2022-07-06
 
 ### Changed
@@ -220,7 +226,7 @@ as well as the [Rust migration guide for the `sixtyfps` crate](api/rs/slint/migr
 ### Fixed
 
  - Fixed panic when using `TabWidget` with `Text` elements and the native style.
- - Fixed panic when caling `hide()` on a `sixtyfps::Window` from within a callback triggered by keyboard/mouse input
+ - Fixed panic when calling `hide()` on a `sixtyfps::Window` from within a callback triggered by keyboard/mouse input
    when using the GL backend.
  - Rust: The implementation of <code>ModelModel::set_row_data</code> now forward the call to the inner model
 

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -35,6 +35,7 @@ Use the following `accessible-` properties to make your items interact well with
   The  default value is empty for most elements, or is the value of the `text` property for Text
   elements.
 * **`accessible-description`** (*string*): The description for the current element.
+* **`accessible-can-check`** (*bool*): Whether the element is can be checked or not.
 * **`accessible-checked`** (*bool*): Whether the element is checked or not. This maps to the "checked" state of checkboxes, radio buttons, and other widgets.
 * **`accessible-has-focus`** (*bool*): Set to true when the current element currently has the focus.
 * **`accessible-value`** (*string*): The current value of the item.

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -35,7 +35,7 @@ Use the following `accessible-` properties to make your items interact well with
   The  default value is empty for most elements, or is the value of the `text` property for Text
   elements.
 * **`accessible-description`** (*string*): The description for the current element.
-* **`accessible-can-check`** (*bool*): Whether the element is can be checked or not.
+* **`accessible-checkable`** (*bool*): Whether the element is can be checked or not.
 * **`accessible-checked`** (*bool*): Whether the element is checked or not. This maps to the "checked" state of checkboxes, radio buttons, and other widgets.
 * **`accessible-has-focus`** (*bool*): Set to true when the current element currently has the focus.
 * **`accessible-value`** (*string*): The current value of the item.

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -79,7 +79,7 @@ import { ToggleButton, VerticalBox } from "std-widgets.slint";
 Example := Window {
   VerticalBox {
     ToggleButton {
-      text: is-checked ? "ON" : "OFF";
+      text: checked ? "ON" : "OFF";
     }
   }
 }

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -8,10 +8,12 @@ Their appearance can change depending on the style
 
 ### Properties
 
-* **`text`** (*string*): The text written in the button.
+* **`checkable`** (*bool*): Shows whether the button can be checked or not. This enables the `checked` property to possibly become `true`.
+* **`checked`** (*bool*): Shows whether the button is checked or not. Needs `checkable` to be `true` to work.
+* **`enabled`**: (*bool*): Defaults to true. When false, the button cannot be pressed
 * **`icon`** (*image*): The image to show in the button. Note that not all styles support drawing icons.
 * **`pressed`**: (*bool*): Set to true when the button is pressed.
-* **`enabled`**: (*bool*): Defaults to true. When false, the button cannot be pressed
+* **`text`** (*string*): The text written in the button.
 
 ### Callbacks
 
@@ -55,32 +57,6 @@ Example := Window {
     StandardButton { kind: ok; }
     StandardButton { kind: apply; }
     StandardButton { kind: cancel; }
-  }
-}
-```
-
-## `ToggleButton`
-
-The ToggleButton looks like a button, but will stay `pressed` when clicked and can then be toggled
-back to un-`pressed` state by clicking again.
-
-### Properties
-
-- **`checked`** (*bool*): Shows whether the button is toggled or not
-
-### Callbacks
-
-- **`clicked`**
-
-### Example
-
-```slint
-import { ToggleButton, VerticalBox } from "std-widgets.slint";
-Example := Window {
-  VerticalBox {
-    ToggleButton {
-      text: checked ? "ON" : "OFF";
-    }
   }
 }
 ```

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -66,7 +66,7 @@ back to un-`pressed` state by clicking again.
 
 ### Properties
 
-- **`checked`** (_bool_): Shows whether the button is toggled or not
+- **`checked`** (*bool*): Shows whether the button is toggled or not
 
 ### Callbacks
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -59,6 +59,32 @@ Example := Window {
 }
 ```
 
+## `ToggleButton`
+
+The ToggleButton looks like a button, but will stay `pressed` when clicked and can then be toggled
+back to un-`pressed` state by clicking again.
+
+### Properties
+
+- **`checked`** (_bool_): Shows whether the button is toggled or not
+
+### Callbacks
+
+- **`clicked`**
+
+### Example
+
+```slint
+import { ToggleButton, VerticalBox } from "std-widgets.slint";
+Example := Window {
+  VerticalBox {
+    ToggleButton {
+      text: is-checked ? "ON" : "OFF";
+    }
+  }
+}
+```
+
 ## `CheckBox`
 
 ### Properties

--- a/examples/gallery/gallery.slint
+++ b/examples/gallery/gallery.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 import { ScrollView, Button, CheckBox, SpinBox, Slider, GroupBox, LineEdit, StandardListView,
-    ComboBox, HorizontalBox, VerticalBox, GridBox, TabWidget, TextEdit, AboutSlint } from "std-widgets.slint";
+    ComboBox, HorizontalBox, VerticalBox, GridBox, TabWidget, TextEdit, ToggleButton, AboutSlint } from "std-widgets.slint";
 
 App := Window {
     preferred-width: 500px;
@@ -50,6 +50,16 @@ App := Window {
                             Button {
                                 text: "Regular Button";
                                 icon: @image-url("thumbsup.png");
+                                enabled: !disable-toggle.checked;
+                            }
+                        }
+
+                        GroupBox {
+                            title: "ToggleButton";
+                            enabled: !disable-toggle.checked;
+
+                            ToggleButton {
+                                text: checked ? "ON" : "OFF";
                                 enabled: !disable-toggle.checked;
                             }
                         }

--- a/examples/gallery/gallery.slint
+++ b/examples/gallery/gallery.slint
@@ -55,7 +55,7 @@ App := Window {
                         }
 
                         GroupBox {
-                            title: "ToggleButton";
+                            title: "Button (checkable)";
                             enabled: !disable-toggle.checked;
 
                             Button {

--- a/examples/gallery/gallery.slint
+++ b/examples/gallery/gallery.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 import { ScrollView, Button, CheckBox, SpinBox, Slider, GroupBox, LineEdit, StandardListView,
-    ComboBox, HorizontalBox, VerticalBox, GridBox, TabWidget, TextEdit, ToggleButton, AboutSlint } from "std-widgets.slint";
+    ComboBox, HorizontalBox, VerticalBox, GridBox, TabWidget, TextEdit, AboutSlint } from "std-widgets.slint";
 
 App := Window {
     preferred-width: 500px;
@@ -58,7 +58,8 @@ App := Window {
                             title: "ToggleButton";
                             enabled: !disable-toggle.checked;
 
-                            ToggleButton {
+                            Button {
+                                checkable: true;
                                 text: checked ? "ON" : "OFF";
                                 enabled: !disable-toggle.checked;
                             }

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -26,6 +26,7 @@ const CHECKED: u32 = QAccessible_Text_UserText as u32;
 const VALUE_MINIMUM: u32 = CHECKED + 1;
 const VALUE_MAXIMUM: u32 = VALUE_MINIMUM + 1;
 const VALUE_STEP: u32 = VALUE_MAXIMUM + 1;
+const CAN_CHECK: u32 = VALUE_STEP + 1;
 
 pub struct AccessibleItemPropertiesTracker {
     obj: *mut c_void,
@@ -202,6 +203,7 @@ impl SlintAccessibleItemData {
         let p = self.project_ref();
         p.state_tracker.evaluate_as_dependency_root(move || {
             if let Some(item_rc) = item.upgrade() {
+                item_rc.accessible_string_property(AccessibleStringProperty::CanCheck);
                 item_rc.accessible_string_property(AccessibleStringProperty::Checked);
             }
         });
@@ -261,6 +263,7 @@ cpp! {{
     const uint32_t VALUE_MINIMUM { CHECKED + 1 };
     const uint32_t VALUE_MAXIMUM { VALUE_MINIMUM + 1 };
     const uint32_t VALUE_STEP { VALUE_MAXIMUM + 1 };
+    const uint32_t CAN_CHECK { VALUE_STEP + 1 };
 
     // ------------------------------------------------------------------------------
     // Helper:
@@ -345,6 +348,7 @@ cpp! {{
                     VALUE_MINIMUM => item.accessible_string_property(AccessibleStringProperty::ValueMinimum),
                     VALUE_MAXIMUM => item.accessible_string_property(AccessibleStringProperty::ValueMaximum),
                     VALUE_STEP => item.accessible_string_property(AccessibleStringProperty::ValueStep),
+                    CAN_CHECK => item.accessible_string_property(AccessibleStringProperty::CanCheck),
                     _ => Default::default(),
                 };
                 QString::from(string.as_ref())
@@ -602,7 +606,7 @@ cpp! {{
             state.focusable = 1;
             state.focused = has_focus_delegation;
             state.checked = (checked == "true") ? 1 : 0;
-            state.checkable = checked.isEmpty() ? 0 : 1;
+            state.checkable = (item_string_property(m_data, CAN_CHECK) == "true") ? 1 : 0;
             return state; /* FIXME */
         }
 

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -26,7 +26,7 @@ const CHECKED: u32 = QAccessible_Text_UserText as u32;
 const VALUE_MINIMUM: u32 = CHECKED + 1;
 const VALUE_MAXIMUM: u32 = VALUE_MINIMUM + 1;
 const VALUE_STEP: u32 = VALUE_MAXIMUM + 1;
-const CAN_CHECK: u32 = VALUE_STEP + 1;
+const CHECKABLE: u32 = VALUE_STEP + 1;
 
 pub struct AccessibleItemPropertiesTracker {
     obj: *mut c_void,
@@ -203,7 +203,7 @@ impl SlintAccessibleItemData {
         let p = self.project_ref();
         p.state_tracker.evaluate_as_dependency_root(move || {
             if let Some(item_rc) = item.upgrade() {
-                item_rc.accessible_string_property(AccessibleStringProperty::CanCheck);
+                item_rc.accessible_string_property(AccessibleStringProperty::Checkable);
                 item_rc.accessible_string_property(AccessibleStringProperty::Checked);
             }
         });
@@ -263,7 +263,7 @@ cpp! {{
     const uint32_t VALUE_MINIMUM { CHECKED + 1 };
     const uint32_t VALUE_MAXIMUM { VALUE_MINIMUM + 1 };
     const uint32_t VALUE_STEP { VALUE_MAXIMUM + 1 };
-    const uint32_t CAN_CHECK { VALUE_STEP + 1 };
+    const uint32_t CHECKABLE { VALUE_STEP + 1 };
 
     // ------------------------------------------------------------------------------
     // Helper:
@@ -348,7 +348,7 @@ cpp! {{
                     VALUE_MINIMUM => item.accessible_string_property(AccessibleStringProperty::ValueMinimum),
                     VALUE_MAXIMUM => item.accessible_string_property(AccessibleStringProperty::ValueMaximum),
                     VALUE_STEP => item.accessible_string_property(AccessibleStringProperty::ValueStep),
-                    CAN_CHECK => item.accessible_string_property(AccessibleStringProperty::CanCheck),
+                    CHECKABLE => item.accessible_string_property(AccessibleStringProperty::Checkable),
                     _ => Default::default(),
                 };
                 QString::from(string.as_ref())
@@ -606,7 +606,7 @@ cpp! {{
             state.focusable = 1;
             state.focused = has_focus_delegation;
             state.checked = (checked == "true") ? 1 : 0;
-            state.checkable = (item_string_property(m_data, CAN_CHECK) == "true") ? 1 : 0;
+            state.checkable = (item_string_property(m_data, CHECKABLE) == "true") ? 1 : 0;
             return state; /* FIXME */
         }
 

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -111,7 +111,7 @@ pub struct NativeButton {
     pub text: Property<SharedString>,
     pub icon: Property<i_slint_core::graphics::Image>,
     pub pressed: Property<bool>,
-    pub can_check: Property<bool>,
+    pub checkable: Property<bool>,
     pub checked: Property<bool>,
     pub has_focus: Property<bool>,
     pub clicked: Callback<VoidArg>,
@@ -183,7 +183,7 @@ impl NativeButton {
 
     fn activate(self: Pin<&Self>) {
         Self::FIELD_OFFSETS.pressed.apply_pin(self).set(false);
-        if self.can_check() {
+        if self.checkable() {
             let checked = Self::FIELD_OFFSETS.checked.apply_pin(self);
             checked.set(!checked.get());
         }

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -300,7 +300,8 @@ impl Item for NativeButton {
     }
 
     fn_render! { this dpr size painter widget initial_state =>
-        let down: bool = this.pressed() || this.checked();
+        let down: bool = this.pressed();
+        let checked: bool = this.checked();
         let standard_button_kind = this.actual_standard_button_kind();
         let text: qttypes::QString = this.actual_text(standard_button_kind);
         let icon: qttypes::QPixmap = this.actual_icon(standard_button_kind);
@@ -315,6 +316,7 @@ impl Item for NativeButton {
             enabled as "bool",
             size as "QSize",
             down as "bool",
+            checked as "bool",
             has_focus as "bool",
             dpr as "float",
             initial_state as "int"
@@ -326,10 +328,14 @@ impl Item for NativeButton {
             auto iconSize = qApp->style()->pixelMetric(QStyle::PM_ButtonIconSize, 0, nullptr);
             option.iconSize = QSize(iconSize, iconSize);
             option.rect = QRect(QPoint(), size / dpr);
-            if (down)
+            if (down) {
                 option.state |= QStyle::State_Sunken;
-            else
+            } else {
                 option.state |= QStyle::State_Raised;
+            }
+            if (checked) {
+                option.state |= QStyle::State_On;
+            }
             if (enabled) {
                 option.state |= QStyle::State_Enabled;
             } else {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -449,13 +449,13 @@ export NativeButton := _ {
     property <string> text;
     property <image> icon;
     property <bool> pressed: native_output;
+    property <bool> checkable;
     property <bool> checked: native_output;
     property <bool> has-focus: native_output;
     callback clicked;
     property <bool> enabled: true;
     property <StandardButtonKind> standard-button-kind;
     property <bool> is-standard-button;
-    property <bool> can-check;
     //-is_internal
 }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -449,11 +449,13 @@ export NativeButton := _ {
     property <string> text;
     property <image> icon;
     property <bool> pressed: native_output;
+    property <bool> checked: native_output;
     property <bool> has-focus: native_output;
     callback clicked;
     property <bool> enabled: true;
     property <StandardButtonKind> standard-button-kind;
     property <bool> is-standard-button;
+    property <bool> can-check;
     //-is_internal
 }
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -88,7 +88,7 @@ pub(crate) const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
 
 pub(crate) const RESERVED_ACCESSIBILITY_PROPERTIES: &[(&str, Type)] = &[
     //("accessible-role", ...)
-    ("accessible-can-check", Type::Bool),
+    ("accessible-checkable", Type::Bool),
     ("accessible-checked", Type::Bool),
     ("accessible-delegate-focus", Type::Int32),
     ("accessible-description", Type::String),

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -88,6 +88,7 @@ pub(crate) const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
 
 pub(crate) const RESERVED_ACCESSIBILITY_PROPERTIES: &[(&str, Type)] = &[
     //("accessible-role", ...)
+    ("accessible-can-check", Type::Bool),
     ("accessible-checked", Type::Bool),
     ("accessible-delegate-focus", Type::Int32),
     ("accessible-description", Type::String),

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -73,7 +73,7 @@ export Button := Rectangle {
     property<bool> has-focus <=> fs.has-focus;
     property<bool> pressed: self.enabled && touch.pressed;
     property<bool> enabled <=> touch.enabled;
-    property<bool> can-check;
+    property<bool> checkable;
     property<bool> checked;
     property<image> icon;
     property<length> font-size <=> text.font-size;
@@ -113,7 +113,7 @@ export Button := Rectangle {
 
     touch := TouchArea {
         clicked => {
-            if (root.can-check) {
+            if (root.checkable) {
                 root.checked = !root.checked;
             }
             root.clicked();

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -68,11 +68,13 @@ export global StyleMetrics := {
 }
 
 export Button := Rectangle {
-    callback clicked <=> touch.clicked;
+    callback clicked;
     property<string> text <=> text.text;
     property<bool> has-focus <=> fs.has-focus;
     property<bool> pressed: self.enabled && touch.pressed;
     property<bool> enabled <=> touch.enabled;
+    property<bool> can-check;
+    property<bool> checked;
     property<image> icon;
     property<length> font-size <=> text.font-size;
 
@@ -83,7 +85,7 @@ export Button := Rectangle {
     border-radius: 2px;
     border-color: !enabled ? Palette.neutralLighter : Palette.neutralSecondaryAlt;
     background: !enabled ? Palette.neutralLighter
-        : touch.pressed ? Palette.neutralLight
+        : touch.pressed || checked ? Palette.neutralLight
         : touch.has-hover ? Palette.neutralLighter
         : Palette.white;
     horizontal-stretch: 0;
@@ -109,7 +111,14 @@ export Button := Rectangle {
         }
     }
 
-    touch := TouchArea {}
+    touch := TouchArea {
+        clicked => {
+            if (root.can-check) {
+                root.checked = !root.checked;
+            }
+            root.clicked();
+        }
+    }
 
     fs := FocusScope {
         width: 0px; // Do not react on clicks

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -85,7 +85,7 @@ export Button := Rectangle {
     border-radius: 2px;
     border-color: !enabled ? Palette.neutralLighter : Palette.neutralSecondaryAlt;
     background: !enabled ? Palette.neutralLighter
-        : touch.pressed || checked ? Palette.neutralLight
+        : (touch.pressed || checked) ? Palette.neutralLight
         : touch.has-hover ? Palette.neutralLighter
         : Palette.white;
     horizontal-stretch: 0;

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -8,10 +8,6 @@ import { StandardButton } from "../common/standardbutton.slint";
 import { StyleMetrics, ScrollView, Button, Palette  } from "std-widgets-impl.slint";
 export { StyleMetrics, ScrollView, Button, StandardButton, TextEdit, AboutSlint, AboutSlint as AboutSixtyFPS }
 
-export ToggleButton := Button {
-   checkable: true;
-}
-
 export CheckBox := Rectangle {
     callback toggled;
     property <string> text <=> text.text;

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -8,6 +8,10 @@ import { StandardButton } from "../common/standardbutton.slint";
 import { StyleMetrics, ScrollView, Button, Palette  } from "std-widgets-impl.slint";
 export { StyleMetrics, ScrollView, Button, StandardButton, TextEdit, AboutSlint, AboutSlint as AboutSixtyFPS }
 
+export ToggleButton := Button {
+   can-check: true;
+}
+
 export CheckBox := Rectangle {
     callback toggled;
     property <string> text <=> text.text;

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -9,7 +9,7 @@ import { StyleMetrics, ScrollView, Button, Palette  } from "std-widgets-impl.sli
 export { StyleMetrics, ScrollView, Button, StandardButton, TextEdit, AboutSlint, AboutSlint as AboutSixtyFPS }
 
 export ToggleButton := Button {
-   can-check: true;
+   checkable: true;
 }
 
 export CheckBox := Rectangle {
@@ -23,6 +23,7 @@ export CheckBox := Rectangle {
     vertical-stretch: 0;
 
     accessible-label <=> text.text;
+    accessible-checkable: true;
     accessible-checked <=> checked;
     accessible-role: checkbox;
 

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -10,30 +10,35 @@ export { StyleMetrics, ScrollView, TextEdit, AboutSlint, AboutSlint as AboutSixt
 // FIXME: the font-size should be removed but is required right now to compile the printer-demo
 export Button := NativeButton {
     property<length> font-size;
+    accessible-can-check <=> can-check;
+    accessible-checked <=> checked;
     accessible-label <=> text;
     accessible-role: button;
+    can-check: false;
     enabled: true;
 }
 
-export ToggleButton := NativeButton {
-    property<length> font-size;
+export ToggleButton := Button {
     accessible-label <=> text;
-    accessible-role: button;
     enabled: true;
     can-check: true;
 }
 
 export StandardButton := NativeButton {
     property<StandardButtonKind> kind <=> self.standard-button-kind;
+    accessible-can-check <=> can-check;
+    accessible-checked <=> checked;
     accessible-label <=> text;
     accessible-role: button;
     is-standard-button: true;
+    can-check: false;
 }
 
 export CheckBox := NativeCheckBox {
-    accessible-role: checkbox;
-    accessible-label <=> text;
+    accessible-can-check: true;
     accessible-checked <=> checked;
+    accessible-label <=> text;
+    accessible-role: checkbox;
 }
 export SpinBox := NativeSpinBox {
     property<length> font-size;

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -10,32 +10,32 @@ export { StyleMetrics, ScrollView, TextEdit, AboutSlint, AboutSlint as AboutSixt
 // FIXME: the font-size should be removed but is required right now to compile the printer-demo
 export Button := NativeButton {
     property<length> font-size;
-    accessible-can-check <=> can-check;
+    accessible-checkable <=> checkable;
     accessible-checked <=> checked;
     accessible-label <=> text;
     accessible-role: button;
-    can-check: false;
+    checkable: false;
     enabled: true;
 }
 
 export ToggleButton := Button {
     accessible-label <=> text;
     enabled: true;
-    can-check: true;
+    checkable: true;
 }
 
 export StandardButton := NativeButton {
     property<StandardButtonKind> kind <=> self.standard-button-kind;
-    accessible-can-check <=> can-check;
+    accessible-checkable <=> checkable;
     accessible-checked <=> checked;
     accessible-label <=> text;
     accessible-role: button;
     is-standard-button: true;
-    can-check: false;
+    checkable: false;
 }
 
 export CheckBox := NativeCheckBox {
-    accessible-can-check: true;
+    accessible-checkable: true;
     accessible-checked <=> checked;
     accessible-label <=> text;
     accessible-role: checkbox;

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -18,12 +18,6 @@ export Button := NativeButton {
     enabled: true;
 }
 
-export ToggleButton := Button {
-    accessible-label <=> text;
-    enabled: true;
-    checkable: true;
-}
-
 export StandardButton := NativeButton {
     property<StandardButtonKind> kind <=> self.standard-button-kind;
     accessible-checkable <=> checkable;

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -15,8 +15,18 @@ export Button := NativeButton {
     enabled: true;
 }
 
+export ToggleButton := NativeButton {
+    property<length> font-size;
+    accessible-label <=> text;
+    accessible-role: button;
+    enabled: true;
+    can-check: true;
+}
+
 export StandardButton := NativeButton {
     property<StandardButtonKind> kind <=> self.standard-button-kind;
+    accessible-label <=> text;
+    accessible-role: button;
     is-standard-button: true;
 }
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -5,19 +5,20 @@
 
 use crate::items::ItemRc;
 
+// The property names of the accessible-properties
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, strum::Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum AccessibleStringProperty {
-    Label,
+    Checkable,
+    Checked,
     DelegateFocus,
     Description,
-    Checked,
+    Label,
     Value,
-    ValueMinimum,
     ValueMaximum,
+    ValueMinimum,
     ValueStep,
-    CanCheck,
 }
 
 /// Find accessible descendents of `root_item`.

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -17,6 +17,7 @@ pub enum AccessibleStringProperty {
     ValueMinimum,
     ValueMaximum,
     ValueStep,
+    CanCheck,
 }
 
 /// Find accessible descendents of `root_item`.

--- a/tests/cases/elements/togglebutton.slint
+++ b/tests/cases/elements/togglebutton.slint
@@ -1,0 +1,59 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import { ToggleButton } from "std-widgets.slint";
+
+TestCase := Rectangle {
+    property <bool> checked <=> tb.checked;
+
+    tb := ToggleButton {
+        width: 100px;
+        height: 100px;
+        checked: true;
+    }
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_checked(),);
+
+// click on button
+slint::testing::send_mouse_click(&instance, 50., 50.);
+assert(!instance.get_checked(),);
+
+// click on button again
+slint::testing::send_mouse_click(&instance, 50., 50.);
+assert(instance.get_checked(),);
+
+```
+
+
+```rust
+let instance = TestCase::new();
+assert!(instance.get_checked());
+
+// click on button
+slint::testing::send_mouse_click(&instance, 50., 50.);
+assert!(!instance.get_checked());
+
+// click on button again
+slint::testing::send_mouse_click(&instance, 50., 50.);
+assert!(instance.get_checked());
+
+```
+
+```js
+var instance = new slint.TestCase();
+assert.equal(instance.checked, true);
+
+// click on button
+instance.send_mouse_click(50., 50.);
+assert.equal(instance.checked, false);
+
+// click on button
+instance.send_mouse_click(50., 50.);
+assert.equal(instance.checked, true);
+```
+*/

--- a/tests/cases/elements/togglebutton.slint
+++ b/tests/cases/elements/togglebutton.slint
@@ -1,14 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import { ToggleButton } from "std-widgets.slint";
+import { Button } from "std-widgets.slint";
 
 TestCase := Rectangle {
     property <bool> checked <=> tb.checked;
 
-    tb := ToggleButton {
+    tb := Button {
         width: 100px;
         height: 100px;
+
+        checkable: true;
         checked: true;
     }
 }

--- a/tests/cases/elements/togglebutton.slint
+++ b/tests/cases/elements/togglebutton.slint
@@ -17,15 +17,15 @@ TestCase := Rectangle {
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
-assert(instance.get_checked(),);
+assert(instance.get_checked());
 
 // click on button
 slint::testing::send_mouse_click(&instance, 50., 50.);
-assert(!instance.get_checked(),);
+assert(!instance.get_checked());
 
 // click on button again
 slint::testing::send_mouse_click(&instance, 50., 50.);
-assert(instance.get_checked(),);
+assert(instance.get_checked());
 
 ```
 


### PR DESCRIPTION
Add flags that enable the Button to be used as a Toggle, e.g. for use in toolbars or similar places.