### PR TITLE
GL backend: reduce memory allocations for text rendering

### DIFF
--- a/internal/backends/gl/fonts.rs
+++ b/internal/backends/gl/fonts.rs
@@ -610,12 +610,12 @@ impl FontCache {
         let remaining_required_script_coverage = scripts_without_coverage.len();
         let remaining_required_char_coverage = chars_without_coverage.len();
 
-        if remaining_required_script_coverage < old_uncovered_scripts_count
+        if scripts_without_coverage.is_empty() && chars_without_coverage.is_empty() {
+            GlyphCoverageCheckResult::Complete
+        } else if remaining_required_script_coverage < old_uncovered_scripts_count
             || remaining_required_char_coverage < old_uncovered_chars_count
         {
             GlyphCoverageCheckResult::Improved
-        } else if scripts_without_coverage.is_empty() && chars_without_coverage.is_empty() {
-            GlyphCoverageCheckResult::Complete
         } else {
             GlyphCoverageCheckResult::Incomplete
         }


### PR DESCRIPTION
Fix a logic bug in the function to determine if we need to fall back to
other fonts or if the font we selected provides complete coverage.

In the common case where coverage is given, we start with some unknown
coverage (in old_uncovered_*) and end up with empty
remaining_required_*_coverage. That also happens to be less than
old_uncovered_*. Since that check came first, we always returned
"Improved", which meant we still built up the font fallback list, even
though we didn't need to. Fix the order of checks to avoid that.