### PR TITLE
Add a warning when setting a two way binding for which the rhs does not declare a default value

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1262,7 +1262,6 @@ fn generate_sub_component(
     let mut subtrees_ranges_cases = Vec::new();
     let mut subtrees_components_cases = Vec::new();
 
-    let mut subcomponent_init_code = Vec::new();
     for sub in &component.sub_components {
         let field_name = ident(&sub.name);
         let local_tree_index: u32 = sub.index_in_tree as _;
@@ -1281,7 +1280,7 @@ fn generate_sub_component(
             format!("tree_index_of_first_child + {} - 1", local_index_of_first_child)
         };
 
-        subcomponent_init_code.push(format!(
+        init.push(format!(
             "this->{}.init(root, self_weak.into_dyn(), {}, {});",
             field_name, global_index, global_children
         ));
@@ -1452,7 +1451,6 @@ fn generate_sub_component(
         ));
     }
 
-    init.extend(subcomponent_init_code);
     init.extend(properties_init_code);
     init.extend(component.init_code.iter().map(|e| compile_expression(&e.borrow(), &ctx)));
 

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -3,6 +3,7 @@
 
 mod apply_default_properties_from_style;
 mod binding_analysis;
+mod check_aliases;
 mod check_expressions;
 mod check_public_api;
 mod clip;
@@ -89,6 +90,7 @@ pub async fn run_passes(
             diag,
         );
         lower_states::lower_states(component, &doc.local_registry, diag);
+        check_aliases::check_aliases(component, diag)
     }
 
     inlining::inline(doc, inlining::InlineSelection::InlineOnlyRequiredComponents);

--- a/internal/compiler/passes/check_aliases.rs
+++ b/internal/compiler/passes/check_aliases.rs
@@ -1,0 +1,60 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+//! Verify that aliases have proper default values
+
+use crate::diagnostics::BuildDiagnostics;
+use crate::expression_tree::Expression;
+use crate::langtype::Type;
+use crate::object_tree::{Component, ElementRc};
+use std::rc::Rc;
+
+pub fn check_aliases(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
+    crate::object_tree::recurse_elem_including_sub_components(&component, &(), &mut |elem, _| {
+        let base = if let Type::Component(base) = &elem.borrow().base_type {
+            base.clone()
+        } else {
+            return;
+        };
+        for (prop, b) in &elem.borrow().bindings {
+            if b.borrow().two_way_bindings.is_empty() {
+                continue;
+            }
+            if !has_default_binding(&base.root_element, prop) {
+                continue;
+            }
+            for nr in &b.borrow().two_way_bindings {
+                if !has_default_binding(&nr.element(), nr.name()) {
+                    diag.push_warning(
+                        format!(
+r#"Two way binding between the property '{prop}' with a default value to the property '{nr:?}' without value.
+The current behavior is to keep the value from the left-hand-side, but this behavior will change in the next version to always keep the right-hand-side value.
+This may cause panic at runtime. See https://github.com/slint-ui/slint/issues/1394
+To fix this warning, add a default value to the property '{nr:?}'"#,
+            ),
+             &b.borrow().span);
+                }
+            }
+        }
+    });
+}
+
+/// return whether the property has an actual default binding value set
+fn has_default_binding(elem: &ElementRc, name: &str) -> bool {
+    if let Some(b) = elem.borrow().bindings.get(name) {
+        if !matches!(b.borrow().expression, Expression::Invalid) {
+            true
+        } else {
+            for nr in &b.borrow().two_way_bindings {
+                if has_default_binding(&nr.element(), nr.name()) {
+                    return true;
+                }
+            }
+            false
+        }
+    } else if let Type::Component(base) = &elem.borrow().base_type {
+        has_default_binding(&base.root_element, name)
+    } else {
+        false
+    }
+}

--- a/internal/compiler/passes/check_aliases.rs
+++ b/internal/compiler/passes/check_aliases.rs
@@ -45,11 +45,11 @@ To fix this warning, add a default value to the property '{nr:?}'"#,
 fn explicit_binding_priority(elem: &ElementRc, name: &str) -> Option<i32> {
     if let Some(b) = elem.borrow().bindings.get(name) {
         if !matches!(b.borrow().expression, Expression::Invalid) {
-            Some(b.borrow().priority.max(1))
+            Some(b.borrow().priority)
         } else {
             for nr in &b.borrow().two_way_bindings {
                 if let Some(p) = explicit_binding_priority(&nr.element(), nr.name()) {
-                    return Some(p.saturating_add(b.borrow().priority.max(1)) - 1);
+                    return Some(p.saturating_add(b.borrow().priority) - 1);
                 }
             }
             None

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -84,7 +84,9 @@ fn lower_state_in_element(
                     e.get_mut().get_mut().expression = new_expr
                 }
                 std::collections::btree_map::Entry::Vacant(e) => {
-                    e.insert(RefCell::new(new_expr.into()));
+                    let mut r = BindingExpression::from(new_expr);
+                    r.priority = 1;
+                    e.insert(r.into());
                 }
             };
         }

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -143,13 +143,13 @@ fn process_tabwidget(
         "num-tabs".to_owned(),
         RefCell::new(Expression::NumberLiteral(num_tabs as _, Unit::None).into()),
     );
-    tabbar.borrow_mut().bindings.insert(
-        "current".to_owned(),
-        BindingExpression::new_two_way(NamedReference::new(elem, "current-index")).into(),
+    elem.borrow_mut().bindings.insert(
+        "current-index".to_owned(),
+        BindingExpression::new_two_way(NamedReference::new(&tabbar, "current")).into(),
     );
-    tabbar.borrow_mut().bindings.insert(
+    elem.borrow_mut().bindings.insert(
         "current-focused".to_owned(),
-        BindingExpression::new_two_way(NamedReference::new(elem, "current-focused")).into(),
+        BindingExpression::new_two_way(NamedReference::new(&tabbar, "current-focused")).into(),
     );
     elem.borrow_mut().bindings.insert(
         "tabbar-preferred-width".to_owned(),

--- a/internal/compiler/tests/syntax/lookup/two_way_binding_warning_compat.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding_warning_compat.slint
@@ -1,0 +1,59 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+
+Sub := Rectangle {
+    property <string> no_default;
+    property <string> alias_no_default <=> t1.text;
+    property <string> alias_default <=> t2.text;
+    property <string> default: "Def";
+    property <string> state_prop;
+
+    t1 := Text {     }
+    t2 := Text { text: "Hello"; }
+
+    states [
+        X when false : { state_prop: "state"; }
+    ]
+
+}
+
+X := Rectangle {
+    property <string> some_value: "Hello";
+
+    property <string> b1;
+
+    Sub {  no_default <=> b1;  }
+    property <string> b2;
+    Sub {  alias_no_default <=> b2;  }
+
+    property <string> b3;
+    Sub {  alias_default <=> b3;  }
+    //     ^warning{Two way binding between the property 'alias-default' with a default value to the property 'root.b3' without value.}
+
+    property <string> b4;
+    Sub {  default <=> b4;  }
+    //     ^warning{Two way binding between the property 'default' with a default value to the property 'root.b4' without value.}
+
+    property <string> b5: "Val";
+    Sub {  default <=> b5;  }
+    property <string> b6 <=> s6.default;
+    s6 := Sub { }
+
+    s7 := Sub {}
+    Sub {
+        default <=> s7.no-default;
+//      ^warning{Two way binding between the property 'default' with a default value to the property 's7.no-default' without value.}
+        no-default <=> s7.default;
+    }
+
+    property <string> b8;
+    property <string> b9 <=> some_value;
+    if false: Sub {
+        state_prop <=> b8; // warn
+//      ^warning{Two way binding between the property 'state-prop' with a default value to the property 'root.b8' without value.}
+        Sub {  state_prop <=> b9; }
+    }
+
+}

--- a/internal/compiler/tests/syntax/lookup/two_way_binding_warning_compat.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding_warning_compat.slint
@@ -19,6 +19,8 @@ Sub := Rectangle {
 
 }
 
+Interm := Sub {}
+
 X := Rectangle {
     property <string> some_value: "Hello";
 
@@ -51,9 +53,24 @@ X := Rectangle {
     property <string> b8;
     property <string> b9 <=> some_value;
     if false: Sub {
-        state_prop <=> b8; // warn
+        state_prop <=> b8;
 //      ^warning{Two way binding between the property 'state-prop' with a default value to the property 'root.b8' without value.}
         Sub {  state_prop <=> b9; }
     }
+
+    s10 := Interm {}
+    s11 := Interm {
+        default: "";
+        state_prop <=> s10.default;
+        alias_default <=> s10.alias-no-default;
+//      ^warning{Two way binding between the property 'alias-default' with a default value to the property 's10.alias-no-default' without value.}
+
+        Sub {
+            alias-default <=> s10.default;
+//          ^warning{Two way binding between the property 'alias-default' with a default value to the property 's10.default' without value.}
+            default <=> s11.default;
+        }
+    }
+
 
 }

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -70,7 +70,12 @@ fn process_diagnostics(
 
     let mut diags = compile_diagnostics
         .iter()
-        .filter(|d| canonical(d.source_file().unwrap()) == path)
+        .filter(|d| {
+            canonical(
+                d.source_file()
+                    .unwrap_or_else(|| panic!("{path:?}: Error without a source file {d:?}",)),
+            ) == path
+        })
         .collect::<Vec<_>>();
 
     let lines = source

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1308,10 +1308,6 @@ pub fn instantiate(
                 let maybe_animation = animation_for_property(instance_ref, &binding.animation);
                 let item = Pin::new_unchecked(&*instance_ref.as_ptr().add(*offset));
 
-                for nr in &binding.two_way_bindings {
-                    // Safety: The compiler must have ensured that the properties exist and are of the same type
-                    prop_info.link_two_ways(item, get_property_ptr(nr, instance_ref));
-                }
                 if !matches!(binding.expression, Expression::Invalid) {
                     if is_const {
                         let v = eval::eval_expression(
@@ -1329,6 +1325,10 @@ pub fn instantiate(
                             )
                             .unwrap();
                     }
+                }
+                for nr in &binding.two_way_bindings {
+                    // Safety: The compiler must have ensured that the properties exist and are of the same type
+                    prop_info.link_two_ways(item, get_property_ptr(nr, instance_ref));
                 }
             } else {
                 let item_within_component = &component_type.items[&elem.id];

--- a/tests/cases/bindings/two_way_priority.slint
+++ b/tests/cases/bindings/two_way_priority.slint
@@ -9,6 +9,7 @@ export OpacityTwoWay := Rectangle {
 }
 
 export Compo := Rectangle {
+    preferred-height: 10px;
     property<int> foo <=> self.bar;
     property<int> bar: 120;
 }
@@ -23,11 +24,18 @@ TestCase := Window {
         otw2 := OpacityTwoWay { sub_opacity: 0.5; }
     }
 
+    property <int> override_bar: 22;
+    force_instance := VerticalLayout {
+        if true : Compo { bar <=> override_bar; }
+    }
+
     property <int> compo0_foo: compo0.foo;
     property <int> compo2_foo: compo2.foo;
     property <float> otw_opacity <=> otw.sub_opacity;
 
-    property <bool> test: compo0_foo == 140 && compo2_foo == 130 && otw_opacity == 0.5 && otw2.sub_opacity == 0.5;
+    property <bool> test_override_bar: force_instance.preferred-height == 10px && override_bar == 22;
+
+    property <bool> test: compo0_foo == 140 && compo2_foo == 130 && otw_opacity == 0.5 && otw2.sub_opacity == 0.5 && test_override_bar;
 }
 
 /*
@@ -37,6 +45,8 @@ let instance = TestCase::new();
 assert_eq!(instance.get_compo0_foo(), 140);
 assert_eq!(instance.get_compo2_foo(), 130);
 assert_eq!(instance.get_otw_opacity(), 0.5);
+assert!(instance.get_test_override_bar(), "override_bar = {}", instance.get_override_bar());
+assert!(instance.get_test());
 ```
 
 
@@ -47,6 +57,7 @@ const TestCase &instance = *handle;
 assert_eq(instance.get_compo0_foo(), 140);
 assert_eq(instance.get_compo2_foo(), 130);
 assert_eq(instance.get_otw_opacity(), 0.5);
+assert(instance.get_test());
 ```
 
 
@@ -55,6 +66,7 @@ let instance = new slint.TestCase({});
 assert.equal(instance.compo0_foo, 140);
 assert.equal(instance.compo2_foo, 130);
 assert.equal(instance.otw_opacity, 0.5);
+assert(instance.test);
 ```
 
 */

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -116,6 +116,8 @@ fn generate_source(
             std::io::ErrorKind::Other,
             format!("build error in {:?}", testcase.absolute_path),
         ));
+    } else {
+        diag.print();
     }
 
     generator::generate(generator::OutputFormat::Rust, output, &root_component)?;


### PR DESCRIPTION
Because of issue #1394 and because the semantic are not properly defined
currently, we decided that future version of slint should always and only
take the binding from the right hand side, even if it has no bindings.

Since we can't change the behavior in 0.2, just add a warning instead for now.
The warning can be silenced by setting a default binding for the property on the rhs.

Ignoring the warning can still lead to panic (the one in #1394)