### PR TITLE
GL backend: speed up updates to layer content

### DIFF
--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -126,8 +126,7 @@ impl<T: Clone> ItemCache<T> {
             .borrow()
             .get(&component)
             .and_then(|per_component_entries| per_component_entries.get(&item_rc.index()))
-            .map(|entry| callback(&entry.data))
-            .flatten()
+            .and_then(|entry| callback(&entry.data))
     }
 
     /// free the whole cache

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -114,6 +114,22 @@ impl<T: Clone> ItemCache<T> {
         }
     }
 
+    /// Returns the cached value associated with the `item_rc` if it is in the cache
+    /// and still valid.
+    pub fn with_entry<U>(
+        &self,
+        item_rc: &ItemRc,
+        callback: impl FnOnce(&T) -> Option<U>,
+    ) -> Option<U> {
+        let component = &(*item_rc.component()) as *const _;
+        self.map
+            .borrow()
+            .get(&component)
+            .and_then(|per_component_entries| per_component_entries.get(&item_rc.index()))
+            .map(|entry| callback(&entry.data))
+            .flatten()
+    }
+
     /// free the whole cache
     pub fn clear_all(&self) {
         self.map.borrow_mut().clear();


### PR DESCRIPTION
Now that we store the layer textures as Rc<Texture>, before rendering a
layer we can take a clone of a possibly existing layer texture and if if
the layer's tracker is dirty, we can re-use the existing layer texture
if it's the same size.

This avoids unnecessary texture allocations.