### PR TITLE
C++: don't force the SLINT_STYLE cmake variable

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -130,7 +130,12 @@ else()
     set(SLINT_STYLE_DEFAULT "fluent")
 endif()
 
-set(SLINT_STYLE ${SLINT_STYLE_DEFAULT} CACHE STRING "The Slint widget style" FORCE)
+set(SLINT_STYLE "" CACHE STRING "The Slint widget style")
+if (SLINT_STYLE)
+    set_property(GLOBAL PROPERTY SLINT_STYLE ${SLINT_STYLE})
+else (SLINT_STYLE)
+    set_property(GLOBAL PROPERTY SLINT_STYLE ${SLINT_STYLE_DEFAULT})
+endif(SLINT_STYLE)
 
 file(GLOB api_headers RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include/"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
@@ -213,6 +218,7 @@ foreach(prop
   endif()
 endforeach()
 
+get_property(_SLINT_STYLE GLOBAL PROPERTY SLINT_STYLE)
 configure_package_config_file("cmake/SlintConfig.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/Slint/SlintConfig.cmake" INSTALL_DESTINATION lib/cmake/Slint)
 
 write_basic_package_version_file(

--- a/api/cpp/cmake/SlintConfig.cmake.in
+++ b/api/cpp/cmake/SlintConfig.cmake.in
@@ -30,4 +30,5 @@ set(_IMPORT_PREFIX)
 
 include("${CMAKE_CURRENT_LIST_DIR}/SlintTargets.cmake")
 
-set(SLINT_STYLE @SLINT_STYLE_DEFAULT@ CACHE STRING "The Slint widget style")
+set(SLINT_STYLE @_SLINT_STYLE@ CACHE STRING "The Slint widget style")
+set_property(GLOBAL PROPERTY SLINT_STYLE ${SLINT_STYLE})

--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -5,7 +5,7 @@ function(SLINT_TARGET_SOURCES target)
     foreach (it IN ITEMS ${ARGN})
         get_filename_component(_SLINT_BASE_NAME ${it} NAME_WE)
         get_filename_component(_SLINT_ABSOLUTE ${it} REALPATH BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-
+        get_property(_SLINT_STYLE GLOBAL PROPERTY SLINT_STYLE)
         if(CMAKE_GENERATOR STREQUAL "Ninja")
             # this code is inspired from the llvm source
             # https://github.com/llvm/llvm-project/blob/a00290ed10a6b4e9f6e9be44ceec367562f270c6/llvm/cmake/modules/TableGen.cmake#L13
@@ -16,7 +16,7 @@ function(SLINT_TARGET_SOURCES target)
                 OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
                 COMMAND Slint::slint-compiler ${_SLINT_ABSOLUTE}
                     -o ${_SLINT_BASE_NAME_REL}.h  --depfile ${_SLINT_BASE_NAME_REL}.d
-                    --style ${SLINT_STYLE}
+                    --style ${_SLINT_STYLE}
                 DEPENDS Slint::slint-compiler ${_SLINT_ABSOLUTE}
                 COMMENT "Generating ${_SLINT_BASE_NAME}.h"
                 DEPFILE ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d
@@ -29,7 +29,7 @@ function(SLINT_TARGET_SOURCES target)
                 OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
                 COMMAND Slint::slint-compiler ${_SLINT_ABSOLUTE}
                     -o ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
-                    --style ${SLINT_STYLE}
+                    --style ${_SLINT_STYLE}
                 DEPENDS Slint::slint-compiler ${_SLINT_ABSOLUTE} ${ALL_SLINTS}
                 COMMENT "Generating ${_SLINT_BASE_NAME}.h"
             )


### PR DESCRIPTION
Keep the default if unset, otherwise use whatever SLINT_STYLE was passed