### PR TITLE
Move the clipboard handling into the core library

### DIFF
--- a/internal/backends/gl/Cargo.toml
+++ b/internal/backends/gl/Cargo.toml
@@ -17,8 +17,8 @@ path = "lib.rs"
 # Note, these features need to be kept in sync (along with their defaults) in
 # the C++ crate's CMakeLists.txt
 [features]
-wayland = ["winit/wayland", "glutin/wayland", "copypasta/wayland"]
-x11 = ["winit/x11", "glutin/x11", "copypasta/x11"]
+wayland = ["winit/wayland", "glutin/wayland"]
+x11 = ["winit/x11", "glutin/x11"]
 rtti = ["i-slint-core/rtti"]
 default = []
 
@@ -31,7 +31,6 @@ const-field-offset = { version = "0.1", path = "../../../helper_crates/const-fie
 vtable = { version = "0.1.6", path = "../../../helper_crates/vtable" }
 
 cfg-if = "1"
-copypasta = { version = "0.8.1", default-features = false }
 derive_more = "0.99.5"
 femtovg = { version = "0.3.5" }
 fontdb = { version = "0.9.0", default-features = false }

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -117,7 +117,6 @@ mod the_backend {
     use alloc::boxed::Box;
     use alloc::collections::VecDeque;
     use alloc::rc::{Rc, Weak};
-    use alloc::string::String;
     use core::cell::{Cell, RefCell};
     use core::pin::Pin;
     use i_slint_core::api::PhysicalPx;
@@ -277,7 +276,6 @@ mod the_backend {
     #[derive(Default)]
     struct MCUBackendInner {
         event_queue: VecDeque<McuEvent>,
-        clipboard: String,
     }
 
     impl MCUBackendInner {
@@ -491,15 +489,6 @@ mod the_backend {
             font_data: &'static i_slint_core::graphics::BitmapFont,
         ) {
             crate::renderer::fonts::register_bitmap_font(font_data);
-        }
-
-        fn set_clipboard_text(&'static self, text: String) {
-            self.with_inner(|inner| inner.clipboard = text)
-        }
-
-        fn clipboard_text(&'static self) -> Option<String> {
-            let c = self.with_inner(|inner| inner.clipboard.clone());
-            c.is_empty().then(|| c)
         }
 
         fn post_event(&'static self, event: Box<dyn FnOnce() + Send>) {

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -459,14 +459,6 @@ impl i_slint_core::backend::Backend for SimulatorBackend {
         crate::renderer::fonts::register_bitmap_font(font_data);
     }
 
-    fn set_clipboard_text(&'static self, _text: String) {
-        unimplemented!()
-    }
-
-    fn clipboard_text(&'static self) -> Option<String> {
-        unimplemented!()
-    }
-
     fn post_event(&'static self, event: Box<dyn FnOnce() + Send>) {
         self::event_loop::GLOBAL_PROXY
             .get_or_init(Default::default)

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -218,38 +218,6 @@ impl i_slint_core::backend::Backend for Backend {
         Ok(())
     }
 
-    fn set_clipboard_text(&'static self, _text: String) {
-        #[cfg(not(no_qt))]
-        {
-            use cpp::cpp;
-            let text: qttypes::QString = _text.into();
-            cpp! {unsafe [text as "QString"] {
-                ensure_initialized();
-                QGuiApplication::clipboard()->setText(text);
-            } }
-        }
-    }
-
-    fn clipboard_text(&'static self) -> Option<String> {
-        #[cfg(not(no_qt))]
-        {
-            use cpp::cpp;
-            let has_text = cpp! {unsafe [] -> bool as "bool" {
-                ensure_initialized();
-                return QGuiApplication::clipboard()->mimeData()->hasText();
-            } };
-            if has_text {
-                return Some(
-                    cpp! { unsafe [] -> qttypes::QString as "QString" {
-                        return QGuiApplication::clipboard()->text();
-                    }}
-                    .into(),
-                );
-            }
-        }
-        None
-    }
-
     fn post_event(&'static self, _event: Box<dyn FnOnce() + Send>) {
         #[cfg(not(no_qt))]
         {

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -11,12 +11,9 @@ use i_slint_core::graphics::{Point, Rect, Size};
 use i_slint_core::window::{PlatformWindow, Window};
 use std::pin::Pin;
 use std::rc::Rc;
-use std::sync::Mutex;
 
 #[derive(Default)]
-pub struct TestingBackend {
-    clipboard: Mutex<Option<String>>,
-}
+pub struct TestingBackend {}
 
 impl i_slint_core::backend::Backend for TestingBackend {
     fn create_window(&'static self) -> Rc<Window> {
@@ -41,14 +38,6 @@ impl i_slint_core::backend::Backend for TestingBackend {
         _path: &std::path::Path,
     ) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
-    }
-
-    fn set_clipboard_text(&'static self, text: String) {
-        *self.clipboard.lock().unwrap() = Some(text);
-    }
-
-    fn clipboard_text(&'static self) -> Option<String> {
-        self.clipboard.lock().unwrap().clone()
     }
 
     fn post_event(&'static self, _event: Box<dyn FnOnce() + Send>) {

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -23,13 +23,15 @@ libm = ["num-traits/libm", "euclid/libm"]
 # Allow the viewer to query at runtime information about item types
 rtti = []
 # Use the standard library
-std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom", "lyon_svg", "instant", "image-decoders", "svg"]
+std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom", "lyon_svg", "instant", "image-decoders", "svg", "clipboard"]
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
 # from a single core, and not in a interrupt or signal handler.
 unsafe_single_core = []
 
 text_layout = []
+
+clipboard = ["copypasta"]
 
 ## The sofwtare renderer
 swrenderer = ["integer-sqrt", "text_layout"]
@@ -82,6 +84,8 @@ clru = { version = "0.5.0", optional = true }
 resvg = { version= "0.23", optional = true, default-features = false }
 usvg = { version= "0.23", optional = true, default-features = false, features = ["text"] }
 tiny-skia = { version= "0.6", optional = true, default-features = false }
+
+copypasta = { version = "0.8.1", optional = true, default-features = false, features = ["x11"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1", features = [ "wasm-bindgen", "now" ] }

--- a/internal/core/backend.rs
+++ b/internal/core/backend.rs
@@ -7,7 +7,6 @@ The backend is the abstraction for crates that need to do the actual drawing and
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;
-use alloc::string::String;
 
 use crate::window::Window;
 
@@ -59,9 +58,6 @@ pub trait Backend: Send + Sync {
     fn register_bitmap_font(&'static self, _font_data: &'static crate::graphics::BitmapFont) {
         unimplemented!()
     }
-
-    fn set_clipboard_text(&'static self, text: String);
-    fn clipboard_text(&'static self) -> Option<String>;
 
     /// Send an user event to from another thread that should be run in the GUI event loop
     fn post_event(&'static self, event: Box<dyn FnOnce() + Send>);

--- a/internal/core/clipboard.rs
+++ b/internal/core/clipboard.rs
@@ -1,0 +1,51 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+/*!
+This module provides access to the system clipboard.
+*/
+
+use alloc::string::String;
+
+// TODO: We can't connect to the wayland clipboard yet because
+// it requires an external connection.
+#[cfg(feature = "clipboard")]
+cfg_if::cfg_if! {
+    if #[cfg(all(
+            unix,
+            not(any(
+                target_os = "macos",
+                target_os = "android",
+                target_os = "ios",
+                target_os = "emscripten"
+            )),
+            not(feature = "x11")
+        ))] {
+        type ClipboardBackend = copypasta::nop_clipboard::NopClipboardContext;
+    } else {
+        type ClipboardBackend = copypasta::ClipboardContext;
+    }
+}
+
+#[cfg(feature = "clipboard")]
+thread_local!(pub(crate) static CLIPBOARD : core::cell::RefCell<ClipboardBackend>  = std::cell::RefCell::new(ClipboardBackend::new().unwrap()));
+
+/// Writes text into the system clipboard.
+pub fn set_clipboard_text(_text: String) {
+    #[cfg(feature = "clipboard")]
+    {
+        use copypasta::ClipboardProvider;
+        CLIPBOARD.with(|clipboard| clipboard.borrow_mut().set_contents(_text).ok());
+    }
+}
+
+/// Returns the text that is stored in the system clipboard, if any.
+pub fn clipboard_text() -> Option<String> {
+    #[cfg(feature = "clipboard")]
+    {
+        use copypasta::ClipboardProvider;
+        return CLIPBOARD.with(|clipboard| clipboard.borrow_mut().get_contents().ok());
+    }
+    #[cfg(not(feature = "clipboard"))]
+    None
+}

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -722,14 +722,11 @@ impl TextInput {
     }
 
     fn copy(self: Pin<&Self>) {
-        if let Some(backend) = crate::backend::instance() {
-            backend.set_clipboard_text(self.selected_text());
-        }
+        crate::clipboard::set_clipboard_text(self.selected_text());
     }
 
     fn paste(self: Pin<&Self>, window: &WindowRc) {
-        if let Some(text) = crate::backend::instance().and_then(|backend| backend.clipboard_text())
-        {
+        if let Some(text) = crate::clipboard::clipboard_text() {
             self.insert(&text, window);
         }
     }

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -67,6 +67,7 @@ pub mod animations;
 pub mod api;
 pub mod backend;
 pub mod callbacks;
+mod clipboard;
 pub mod component;
 pub mod graphics;
 pub mod input;


### PR DESCRIPTION
That removes two more functions from the backend interface.