### PR TITLE
Clipboard refactoring

### DIFF
--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -857,6 +857,16 @@ impl PlatformWindow for GLWindow {
             }
         }
     }
+
+    fn set_clipboard_text(&self, text: String) {
+        use copypasta::ClipboardProvider;
+        crate::CLIPBOARD.with(|clipboard| clipboard.borrow_mut().set_contents(text).ok());
+    }
+
+    fn clipboard_text(&self) -> Option<String> {
+        use copypasta::ClipboardProvider;
+        crate::CLIPBOARD.with(|clipboard| clipboard.borrow_mut().get_contents().ok())
+    }
 }
 
 impl Drop for GLWindow {

--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -566,8 +566,7 @@ impl PlatformWindow for GLWindow {
             collector.start(&format!("GL backend (windowing system: {})", winsys));
         }
 
-        let clipboard =
-            crate::ClipboardBackend::new().expect("internal error: unable to access clipboard");
+        let clipboard = create_clipboard(&platform_window);
 
         drop(platform_window);
 
@@ -864,16 +863,13 @@ impl PlatformWindow for GLWindow {
 
     fn set_clipboard_text(&self, text: String) {
         if let Some(mapped_window) = self.borrow_mapped_window() {
-            use copypasta::ClipboardProvider;
             mapped_window.clipboard.borrow_mut().set_contents(text).ok();
         }
     }
 
     fn clipboard_text(&self) -> Option<String> {
-        self.borrow_mapped_window().and_then(|mapped_window| {
-            use copypasta::ClipboardProvider;
-            mapped_window.clipboard.borrow_mut().get_contents().ok()
-        })
+        self.borrow_mapped_window()
+            .and_then(|mapped_window| mapped_window.clipboard.borrow_mut().get_contents().ok())
     }
 }
 
@@ -888,7 +884,7 @@ struct MappedWindow {
     opengl_context: crate::OpenGLContext,
     clear_color: Color,
     constraints: Cell<(corelib::layout::LayoutInfo, corelib::layout::LayoutInfo)>,
-    clipboard: RefCell<crate::ClipboardBackend>,
+    clipboard: RefCell<Box<dyn copypasta::ClipboardProvider>>,
 }
 
 impl Drop for MappedWindow {
@@ -925,4 +921,44 @@ impl Default for WindowProperties {
     fn default() -> Self {
         Self { scale_factor: Property::new(1.0) }
     }
+}
+
+fn create_clipboard(window: &winit::window::Window) -> Box<dyn copypasta::ClipboardProvider> {
+    let mut clipboard: Option<Box<dyn copypasta::ClipboardProvider>> = None;
+
+    cfg_if::cfg_if! {
+        if #[cfg(all(any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ), feature = "wayland", not(feature = "x11")))] {
+            type DefaultClipboard = copypasta::nop_clipboard::NopClipboardContext;
+        } else {
+            type DefaultClipboard = copypasta::ClipboardContext;
+        }
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    if cfg!(feature = "wayland") {
+        use winit::platform::unix::WindowExtUnix;
+        #[cfg(feature = "wayland")]
+        if let Some(wayland_display) = window.wayland_display() {
+            clipboard = unsafe {
+                Some(Box::new(
+                    copypasta::wayland_clipboard::create_clipboards_from_external(wayland_display)
+                        .1,
+                ))
+            };
+        }
+    }
+
+    clipboard.unwrap_or_else(|| Box::new(DefaultClipboard::new().unwrap()))
 }

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -47,29 +47,6 @@ pub const HAS_NATIVE_STYLE: bool = false;
 pub use stylemetrics::native_style_metrics_deinit;
 pub use stylemetrics::native_style_metrics_init;
 
-// TODO: We can't connect to the wayland clipboard yet because
-// it requires an external connection.
-cfg_if::cfg_if! {
-    if #[cfg(all(
-             unix,
-             not(any(
-                 target_os = "macos",
-                 target_os = "android",
-                 target_os = "ios",
-                 target_os = "emscripten"
-            )),
-            not(feature = "x11")
-        ))] {
-        if #[cfg(feature = "wayland")] {
-            type ClipboardBackend = copypasta::wayland_clipboard::Clipboard;
-        } else {
-            type ClipboardBackend = copypasta::nop_clipboard::NopClipboardContext;
-        }
-    } else {
-        type ClipboardBackend = copypasta::ClipboardContext;
-    }
-}
-
 pub struct Backend;
 impl i_slint_core::backend::Backend for Backend {
     fn create_window(&'static self) -> Rc<Window> {

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -105,16 +105,6 @@ impl i_slint_core::backend::Backend for Backend {
         self::fonts::register_font_from_path(path)
     }
 
-    fn set_clipboard_text(&'static self, text: String) {
-        use copypasta::ClipboardProvider;
-        CLIPBOARD.with(|clipboard| clipboard.borrow_mut().set_contents(text).ok());
-    }
-
-    fn clipboard_text(&'static self) -> Option<String> {
-        use copypasta::ClipboardProvider;
-        CLIPBOARD.with(|clipboard| clipboard.borrow_mut().get_contents().ok())
-    }
-
     fn post_event(&'static self, event: Box<dyn FnOnce() + Send>) {
         let e = crate::event_loop::CustomEvent::UserEvent(event);
         #[cfg(not(target_arch = "wasm32"))]

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -6,7 +6,6 @@
 
 extern crate alloc;
 
-use std::cell::RefCell;
 use std::rc::Rc;
 
 use i_slint_core::window::Window;
@@ -61,13 +60,15 @@ cfg_if::cfg_if! {
             )),
             not(feature = "x11")
         ))] {
-        type ClipboardBackend = copypasta::nop_clipboard::NopClipboardContext;
+        if #[cfg(feature = "wayland")] {
+            type ClipboardBackend = copypasta::wayland_clipboard::Clipboard;
+        } else {
+            type ClipboardBackend = copypasta::nop_clipboard::NopClipboardContext;
+        }
     } else {
         type ClipboardBackend = copypasta::ClipboardContext;
     }
 }
-
-thread_local!(pub(crate) static CLIPBOARD : RefCell<ClipboardBackend> = std::cell::RefCell::new(ClipboardBackend::new().unwrap()));
 
 pub struct Backend;
 impl i_slint_core::backend::Backend for Backend {

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -266,6 +266,15 @@ mod the_backend {
         fn set_inner_size(&self, _size: euclid::Size2D<u32, PhysicalPx>) {
             unimplemented!()
         }
+
+        fn set_clipboard_text(&self, text: String) {
+            self.backend.with_inner(|inner| inner.clipboard = text)
+        }
+
+        fn clipboard_text(&self) -> Option<String> {
+            let c = self.backend.with_inner(|inner| inner.clipboard.clone());
+            c.is_empty().then(|| c)
+        }
     }
 
     enum McuEvent {
@@ -491,15 +500,6 @@ mod the_backend {
             font_data: &'static i_slint_core::graphics::BitmapFont,
         ) {
             crate::renderer::fonts::register_bitmap_font(font_data);
-        }
-
-        fn set_clipboard_text(&'static self, text: String) {
-            self.with_inner(|inner| inner.clipboard = text)
-        }
-
-        fn clipboard_text(&'static self) -> Option<String> {
-            let c = self.with_inner(|inner| inner.clipboard.clone());
-            c.is_empty().then(|| c)
         }
 
         fn post_event(&'static self, event: Box<dyn FnOnce() + Send>) {

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -459,14 +459,6 @@ impl i_slint_core::backend::Backend for SimulatorBackend {
         crate::renderer::fonts::register_bitmap_font(font_data);
     }
 
-    fn set_clipboard_text(&'static self, _text: String) {
-        unimplemented!()
-    }
-
-    fn clipboard_text(&'static self) -> Option<String> {
-        unimplemented!()
-    }
-
     fn post_event(&'static self, event: Box<dyn FnOnce() + Send>) {
         self::event_loop::GLOBAL_PROXY
             .get_or_init(Default::default)

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -218,38 +218,6 @@ impl i_slint_core::backend::Backend for Backend {
         Ok(())
     }
 
-    fn set_clipboard_text(&'static self, _text: String) {
-        #[cfg(not(no_qt))]
-        {
-            use cpp::cpp;
-            let text: qttypes::QString = _text.into();
-            cpp! {unsafe [text as "QString"] {
-                ensure_initialized();
-                QGuiApplication::clipboard()->setText(text);
-            } }
-        }
-    }
-
-    fn clipboard_text(&'static self) -> Option<String> {
-        #[cfg(not(no_qt))]
-        {
-            use cpp::cpp;
-            let has_text = cpp! {unsafe [] -> bool as "bool" {
-                ensure_initialized();
-                return QGuiApplication::clipboard()->mimeData()->hasText();
-            } };
-            if has_text {
-                return Some(
-                    cpp! { unsafe [] -> qttypes::QString as "QString" {
-                        return QGuiApplication::clipboard()->text();
-                    }}
-                    .into(),
-                );
-            }
-        }
-        None
-    }
-
     fn post_event(&'static self, _event: Box<dyn FnOnce() + Send>) {
         #[cfg(not(no_qt))]
         {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1711,6 +1711,38 @@ impl PlatformWindow for QtWindow {
             widget_ptr->resize(sz  / widget_ptr->devicePixelRatio());
         }};
     }
+
+    fn set_clipboard_text(&self, _text: String) {
+        #[cfg(not(no_qt))]
+        {
+            use cpp::cpp;
+            let text: qttypes::QString = _text.into();
+            cpp! {unsafe [text as "QString"] {
+                ensure_initialized();
+                QGuiApplication::clipboard()->setText(text);
+            } }
+        }
+    }
+
+    fn clipboard_text(&self) -> Option<String> {
+        #[cfg(not(no_qt))]
+        {
+            use cpp::cpp;
+            let has_text = cpp! {unsafe [] -> bool as "bool" {
+                ensure_initialized();
+                return QGuiApplication::clipboard()->mimeData()->hasText();
+            } };
+            if has_text {
+                return Some(
+                    cpp! { unsafe [] -> qttypes::QString as "QString" {
+                        return QGuiApplication::clipboard()->text();
+                    }}
+                    .into(),
+                );
+            }
+        }
+        None
+    }
 }
 
 fn accessible_item(item: Option<ItemRc>) -> Option<ItemRc> {

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -20,7 +20,7 @@ pub struct TestingBackend {
 
 impl i_slint_core::backend::Backend for TestingBackend {
     fn create_window(&'static self) -> Rc<Window> {
-        Window::new(|_| Rc::new(TestingWindow::default()))
+        Window::new(|_| Rc::new(TestingWindow { backend: self }))
     }
 
     fn run_event_loop(&'static self, _behavior: i_slint_core::backend::EventLoopQuitBehavior) {
@@ -43,14 +43,6 @@ impl i_slint_core::backend::Backend for TestingBackend {
         Ok(())
     }
 
-    fn set_clipboard_text(&'static self, text: String) {
-        *self.clipboard.lock().unwrap() = Some(text);
-    }
-
-    fn clipboard_text(&'static self) -> Option<String> {
-        self.clipboard.lock().unwrap().clone()
-    }
-
     fn post_event(&'static self, _event: Box<dyn FnOnce() + Send>) {
         // The event will never be invoked
     }
@@ -61,8 +53,9 @@ impl i_slint_core::backend::Backend for TestingBackend {
     }
 }
 
-#[derive(Default)]
-pub struct TestingWindow {}
+pub struct TestingWindow {
+    backend: &'static TestingBackend,
+}
 
 impl PlatformWindow for TestingWindow {
     fn show(self: Rc<Self>) {
@@ -144,6 +137,14 @@ impl PlatformWindow for TestingWindow {
 
     fn set_inner_size(&self, _size: euclid::Size2D<u32, PhysicalPx>) {
         unimplemented!()
+    }
+
+    fn set_clipboard_text(&self, text: String) {
+        *self.backend.clipboard.lock().unwrap() = Some(text);
+    }
+
+    fn clipboard_text(&self) -> Option<String> {
+        self.backend.clipboard.lock().unwrap().clone()
     }
 }
 

--- a/internal/core/backend.rs
+++ b/internal/core/backend.rs
@@ -7,7 +7,6 @@ The backend is the abstraction for crates that need to do the actual drawing and
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;
-use alloc::string::String;
 
 use crate::window::Window;
 
@@ -59,9 +58,6 @@ pub trait Backend: Send + Sync {
     fn register_bitmap_font(&'static self, _font_data: &'static crate::graphics::BitmapFont) {
         unimplemented!()
     }
-
-    fn set_clipboard_text(&'static self, text: String);
-    fn clipboard_text(&'static self) -> Option<String>;
 
     /// Send an user event to from another thread that should be run in the GUI event loop
     fn post_event(&'static self, event: Box<dyn FnOnce() + Send>);

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -354,7 +354,7 @@ impl Item for TextInput {
                             return KeyEventResult::EventAccepted;
                         }
                         StandardShortcut::Copy => {
-                            self.copy();
+                            self.copy(window);
                             return KeyEventResult::EventAccepted;
                         }
                         StandardShortcut::Paste if !self.read_only() => {
@@ -362,7 +362,7 @@ impl Item for TextInput {
                             return KeyEventResult::EventAccepted;
                         }
                         StandardShortcut::Cut if !self.read_only() => {
-                            self.copy();
+                            self.copy(window);
                             self.delete_selection(window);
                             return KeyEventResult::EventAccepted;
                         }
@@ -721,15 +721,12 @@ impl TextInput {
         self.move_cursor(TextCursorDirection::EndOfText, AnchorMode::KeepAnchor, window);
     }
 
-    fn copy(self: Pin<&Self>) {
-        if let Some(backend) = crate::backend::instance() {
-            backend.set_clipboard_text(self.selected_text());
-        }
+    fn copy(self: Pin<&Self>, window: &WindowRc) {
+        window.set_clipboard_text(self.selected_text());
     }
 
     fn paste(self: Pin<&Self>, window: &WindowRc) {
-        if let Some(text) = crate::backend::instance().and_then(|backend| backend.clipboard_text())
-        {
+        if let Some(text) = window.clipboard_text() {
             self.insert(&text, window);
         }
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -16,6 +16,7 @@ use crate::properties::{Property, PropertyTracker};
 use crate::{Callback, Coord};
 use alloc::boxed::Box;
 use alloc::rc::{Rc, Weak};
+use alloc::string::String;
 use core::cell::{Cell, RefCell};
 use core::pin::Pin;
 
@@ -135,6 +136,13 @@ pub trait PlatformWindow {
     /// Resizes the window to the specified size on the screen, in physical pixels and excluding
     /// a window frame (if present).
     fn set_inner_size(&self, size: euclid::Size2D<u32, PhysicalPx>);
+
+    /// Sends the given text into the system clipboard
+    fn set_clipboard_text(&self, _text: String) {}
+    /// Returns a copy of text stored in the system clipboard, if any.
+    fn clipboard_text(&self) -> Option<String> {
+        None
+    }
 }
 
 struct WindowPropertiesTracker {


### PR DESCRIPTION
This moves the clipboard functionality from the Backend to the Window, due to the inherent connection of access to the system clipboard with the windowing system. In theory this could be part of an event loop interface (which maintains the display connection), but in the absence of that it's in the Window now.

This also adds support for the clipboard on wayland, in consequence.