### PR TITLE
Change `set_clipboard_set` to take a `&str` instead of a `String`

### DIFF
--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -817,9 +817,9 @@ impl PlatformWindow for GLWindow {
         }
     }
 
-    fn set_clipboard_text(&self, text: String) {
+    fn set_clipboard_text(&self, text: &str) {
         if let Some(mapped_window) = self.borrow_mapped_window() {
-            mapped_window.clipboard.borrow_mut().set_contents(text).ok();
+            mapped_window.clipboard.borrow_mut().set_contents(text.into()).ok();
         }
     }
 

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -248,8 +248,8 @@ mod the_backend {
             unimplemented!()
         }
 
-        fn set_clipboard_text(&self, text: String) {
-            self.backend.with_inner(|inner| inner.clipboard = text)
+        fn set_clipboard_text(&self, text: &str) {
+            self.backend.with_inner(|inner| inner.clipboard = text.into())
         }
 
         fn clipboard_text(&self) -> Option<String> {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1708,7 +1708,7 @@ impl PlatformWindow for QtWindow {
         }};
     }
 
-    fn set_clipboard_text(&self, _text: String) {
+    fn set_clipboard_text(&self, _text: &str) {
         use cpp::cpp;
         let text: qttypes::QString = _text.into();
         cpp! {unsafe [text as "QString"] {

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -134,8 +134,8 @@ impl PlatformWindow for TestingWindow {
         unimplemented!()
     }
 
-    fn set_clipboard_text(&self, text: String) {
-        *self.backend.clipboard.lock().unwrap() = Some(text);
+    fn set_clipboard_text(&self, text: &str) {
+        *self.backend.clipboard.lock().unwrap() = Some(text.into());
     }
 
     fn clipboard_text(&self) -> Option<String> {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -697,7 +697,7 @@ impl TextInput {
     fn with_selected_text<T>(self: Pin<&Self>, cb: impl FnOnce(&str) -> T) -> T {
         let (anchor, cursor) = self.selection_anchor_and_cursor();
         let text: String = self.text().into();
-        cb(text.split_at(anchor).1.split_at(cursor - anchor).0)
+        cb(&text[anchor..cursor])
     }
 
     fn insert(self: Pin<&Self>, text_to_insert: &str, window: &WindowRc) {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -694,12 +694,6 @@ impl TextInput {
         anchor_pos != cursor_pos
     }
 
-    fn with_selected_text<T>(self: Pin<&Self>, cb: impl FnOnce(&str) -> T) -> T {
-        let (anchor, cursor) = self.selection_anchor_and_cursor();
-        let text: String = self.text().into();
-        cb(&text[anchor..cursor])
-    }
-
     fn insert(self: Pin<&Self>, text_to_insert: &str, window: &WindowRc) {
         self.delete_selection(window);
         let mut text: String = self.text().into();
@@ -722,7 +716,12 @@ impl TextInput {
     }
 
     fn copy(self: Pin<&Self>, window: &WindowRc) {
-        self.with_selected_text(|text| window.set_clipboard_text(text));
+        let (anchor, cursor) = self.selection_anchor_and_cursor();
+        if anchor == cursor {
+            return;
+        }
+        let text = self.text();
+        window.set_clipboard_text(&text[anchor..cursor]);
     }
 
     fn paste(self: Pin<&Self>, window: &WindowRc) {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -694,10 +694,10 @@ impl TextInput {
         anchor_pos != cursor_pos
     }
 
-    fn selected_text(self: Pin<&Self>) -> String {
+    fn with_selected_text<T>(self: Pin<&Self>, cb: impl FnOnce(&str) -> T) -> T {
         let (anchor, cursor) = self.selection_anchor_and_cursor();
         let text: String = self.text().into();
-        text.split_at(anchor).1.split_at(cursor - anchor).0.into()
+        cb(text.split_at(anchor).1.split_at(cursor - anchor).0)
     }
 
     fn insert(self: Pin<&Self>, text_to_insert: &str, window: &WindowRc) {
@@ -722,7 +722,7 @@ impl TextInput {
     }
 
     fn copy(self: Pin<&Self>, window: &WindowRc) {
-        window.set_clipboard_text(self.selected_text());
+        self.with_selected_text(|text| window.set_clipboard_text(text));
     }
 
     fn paste(self: Pin<&Self>, window: &WindowRc) {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -147,7 +147,7 @@ pub trait PlatformWindow {
     fn set_inner_size(&self, size: euclid::Size2D<u32, PhysicalPx>);
 
     /// Sends the given text into the system clipboard
-    fn set_clipboard_text(&self, _text: String) {}
+    fn set_clipboard_text(&self, _text: &str) {}
     /// Returns a copy of text stored in the system clipboard, if any.
     fn clipboard_text(&self) -> Option<String> {
         None


### PR DESCRIPTION
Every backend will do something different with the string that needs to go into the clipboard.

Qt will convert it to a QString, copypasta to a String, in theory it could be written
directly to a socket.

Given that we don't know what the perfect representation on the backend side is, passing
a string slice avoids any immediate conversions.