### PR TITLE
Change slint enum values to be PascalCase in rust

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -21,7 +21,7 @@ fn enums(path: &Path) -> anyhow::Result<()> {
                 writeln!(enums, "enum class {} {{", stringify!($Name))?;
                 $(
                     $(writeln!(enums, "    ///{}", $value_doc)?;)*
-                    writeln!(enums, "    {},", i_slint_common::enums::cpp_escape_keyword(stringify!($Value).trim_start_matches("r#")))?;
+                    writeln!(enums, "    {},", stringify!($Value).trim_start_matches("r#"))?;
                 )*
                 writeln!(enums, "}};")?;
              )*

--- a/docs/builtin_enums.md
+++ b/docs/builtin_enums.md
@@ -177,13 +177,6 @@ The default value of each enum type is always the first value.
 * **`end-open`**: The end of the path that remains open.
 * **`end-closed`**: The end of a path that is closed.
 
-## `KeyEventType`
-
- This enum defines the different kinds of key events that can happen.
-
-* **`key-pressed`**: A key on a keyboard was pressed.
-* **`key-released`**: A key on a keyboard was released.
-
 ## `AccessibleRole`
 
  This enum represents the different values for the `accessible-role` property, used to describe the

--- a/docs/builtin_enums.md
+++ b/docs/builtin_enums.md
@@ -181,8 +181,8 @@ The default value of each enum type is always the first value.
 
  This enum defines the different kinds of key events that can happen.
 
-* **`KeyPressed`**: A key on a keyboard was pressed.
-* **`KeyReleased`**: A key on a keyboard was released.
+* **`key-pressed`**: A key on a keyboard was pressed.
+* **`key-released`**: A key on a keyboard was released.
 
 ## `AccessibleRole`
 

--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -490,10 +490,10 @@ fn process_window_event(
         }
         WindowEvent::MouseInput { state, button, .. } => {
             let button = match button {
-                winit::event::MouseButton::Left => PointerEventButton::left,
-                winit::event::MouseButton::Right => PointerEventButton::right,
-                winit::event::MouseButton::Middle => PointerEventButton::middle,
-                winit::event::MouseButton::Other(_) => PointerEventButton::none,
+                winit::event::MouseButton::Left => PointerEventButton::Left,
+                winit::event::MouseButton::Right => PointerEventButton::Right,
+                winit::event::MouseButton::Middle => PointerEventButton::Middle,
+                winit::event::MouseButton::Other(_) => PointerEventButton::None,
             };
             let ev = match state {
                 winit::event::ElementState::Pressed => {
@@ -513,11 +513,11 @@ fn process_window_event(
             let ev = match touch.phase {
                 winit::event::TouchPhase::Started => {
                     *pressed = true;
-                    MouseEvent::MousePressed { pos, button: PointerEventButton::left }
+                    MouseEvent::MousePressed { pos, button: PointerEventButton::Left }
                 }
                 winit::event::TouchPhase::Ended | winit::event::TouchPhase::Cancelled => {
                     *pressed = false;
-                    MouseEvent::MouseReleased { pos, button: PointerEventButton::left }
+                    MouseEvent::MouseReleased { pos, button: PointerEventButton::Left }
                 }
                 winit::event::TouchPhase::Moved => MouseEvent::MouseMoved { pos },
             };

--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -556,38 +556,38 @@ impl PlatformWindow for GLWindow {
 
     fn set_mouse_cursor(&self, cursor: MouseCursor) {
         let winit_cursor = match cursor {
-            MouseCursor::default => winit::window::CursorIcon::Default,
-            MouseCursor::none => winit::window::CursorIcon::Default,
-            MouseCursor::help => winit::window::CursorIcon::Help,
-            MouseCursor::pointer => winit::window::CursorIcon::Hand,
-            MouseCursor::progress => winit::window::CursorIcon::Progress,
-            MouseCursor::wait => winit::window::CursorIcon::Wait,
-            MouseCursor::crosshair => winit::window::CursorIcon::Crosshair,
-            MouseCursor::text => winit::window::CursorIcon::Text,
-            MouseCursor::alias => winit::window::CursorIcon::Alias,
-            MouseCursor::copy => winit::window::CursorIcon::Copy,
-            MouseCursor::r#move => winit::window::CursorIcon::Move,
-            MouseCursor::no_drop => winit::window::CursorIcon::NoDrop,
-            MouseCursor::not_allowed => winit::window::CursorIcon::NotAllowed,
-            MouseCursor::grab => winit::window::CursorIcon::Grab,
-            MouseCursor::grabbing => winit::window::CursorIcon::Grabbing,
-            MouseCursor::col_resize => winit::window::CursorIcon::ColResize,
-            MouseCursor::row_resize => winit::window::CursorIcon::RowResize,
-            MouseCursor::n_resize => winit::window::CursorIcon::NResize,
-            MouseCursor::e_resize => winit::window::CursorIcon::EResize,
-            MouseCursor::s_resize => winit::window::CursorIcon::SResize,
-            MouseCursor::w_resize => winit::window::CursorIcon::WResize,
-            MouseCursor::ne_resize => winit::window::CursorIcon::NeResize,
-            MouseCursor::nw_resize => winit::window::CursorIcon::NwResize,
-            MouseCursor::se_resize => winit::window::CursorIcon::SeResize,
-            MouseCursor::sw_resize => winit::window::CursorIcon::SwResize,
-            MouseCursor::ew_resize => winit::window::CursorIcon::EwResize,
-            MouseCursor::ns_resize => winit::window::CursorIcon::NsResize,
-            MouseCursor::nesw_resize => winit::window::CursorIcon::NeswResize,
-            MouseCursor::nwse_resize => winit::window::CursorIcon::NwseResize,
+            MouseCursor::Default => winit::window::CursorIcon::Default,
+            MouseCursor::None => winit::window::CursorIcon::Default,
+            MouseCursor::Help => winit::window::CursorIcon::Help,
+            MouseCursor::Pointer => winit::window::CursorIcon::Hand,
+            MouseCursor::Progress => winit::window::CursorIcon::Progress,
+            MouseCursor::Wait => winit::window::CursorIcon::Wait,
+            MouseCursor::Crosshair => winit::window::CursorIcon::Crosshair,
+            MouseCursor::Text => winit::window::CursorIcon::Text,
+            MouseCursor::Alias => winit::window::CursorIcon::Alias,
+            MouseCursor::Copy => winit::window::CursorIcon::Copy,
+            MouseCursor::Move => winit::window::CursorIcon::Move,
+            MouseCursor::NoDrop => winit::window::CursorIcon::NoDrop,
+            MouseCursor::NotAllowed => winit::window::CursorIcon::NotAllowed,
+            MouseCursor::Grab => winit::window::CursorIcon::Grab,
+            MouseCursor::Grabbing => winit::window::CursorIcon::Grabbing,
+            MouseCursor::ColResize => winit::window::CursorIcon::ColResize,
+            MouseCursor::RowResize => winit::window::CursorIcon::RowResize,
+            MouseCursor::NResize => winit::window::CursorIcon::NResize,
+            MouseCursor::EResize => winit::window::CursorIcon::EResize,
+            MouseCursor::SResize => winit::window::CursorIcon::SResize,
+            MouseCursor::WResize => winit::window::CursorIcon::WResize,
+            MouseCursor::NeResize => winit::window::CursorIcon::NeResize,
+            MouseCursor::NwResize => winit::window::CursorIcon::NwResize,
+            MouseCursor::SeResize => winit::window::CursorIcon::SeResize,
+            MouseCursor::SwResize => winit::window::CursorIcon::SwResize,
+            MouseCursor::EwResize => winit::window::CursorIcon::EwResize,
+            MouseCursor::NsResize => winit::window::CursorIcon::NsResize,
+            MouseCursor::NeswResize => winit::window::CursorIcon::NeswResize,
+            MouseCursor::NwseResize => winit::window::CursorIcon::NwseResize,
         };
         self.with_window_handle(&mut |winit_window| {
-            winit_window.set_cursor_visible(cursor != MouseCursor::none);
+            winit_window.set_cursor_visible(cursor != MouseCursor::None);
             winit_window.set_cursor_icon(winit_cursor);
         });
     }
@@ -633,7 +633,7 @@ impl PlatformWindow for GLWindow {
             )
         });
 
-        let is_password = matches!(text_input.input_type(), corelib::items::InputType::password);
+        let is_password = matches!(text_input.input_type(), corelib::items::InputType::Password);
         let password_string;
         let actual_text = if is_password {
             password_string = PASSWORD_CHARACTER.repeat(text.chars().count());
@@ -652,7 +652,7 @@ impl PlatformWindow for GLWindow {
             Size::new(width, height),
             (text_input.horizontal_alignment(), text_input.vertical_alignment()),
             text_input.wrap(),
-            i_slint_core::items::TextOverflow::clip,
+            i_slint_core::items::TextOverflow::Clip,
             text_input.single_line(),
             paint,
             |line_text, line_pos, start, metrics| {
@@ -717,7 +717,7 @@ impl PlatformWindow for GLWindow {
             Size::new(width, height),
             (text_input.horizontal_alignment(), text_input.vertical_alignment()),
             text_input.wrap(),
-            i_slint_core::items::TextOverflow::clip,
+            i_slint_core::items::TextOverflow::Clip,
             text_input.single_line(),
             paint,
             |line_text, line_pos, start, metrics| {

--- a/internal/backends/gl/renderer/femtovg/fonts.rs
+++ b/internal/backends/gl/renderer/femtovg/fonts.rs
@@ -638,8 +638,8 @@ pub(crate) fn layout_text_lines(
     paint: femtovg::Paint,
     mut layout_line: impl FnMut(&str, Point, usize, &femtovg::TextMetrics),
 ) -> f32 {
-    let wrap = wrap == TextWrap::word_wrap;
-    let elide = overflow == TextOverflow::elide;
+    let wrap = wrap == TextWrap::WordWrap;
+    let elide = overflow == TextOverflow::Elide;
 
     let text_context = FONT_CACHE.with(|cache| cache.borrow().text_context.clone());
     let font_metrics = text_context.measure_font(paint).unwrap();
@@ -664,19 +664,19 @@ pub(crate) fn layout_text_lines(
                             start: usize,
                             line_metrics: &femtovg::TextMetrics| {
         let x = match horizontal_alignment {
-            TextHorizontalAlignment::left => 0.,
-            TextHorizontalAlignment::center => {
+            TextHorizontalAlignment::Left => 0.,
+            TextHorizontalAlignment::Center => {
                 max_width / 2. - f32::min(max_width, line_metrics.width()) / 2.
             }
-            TextHorizontalAlignment::right => max_width - f32::min(max_width, line_metrics.width()),
+            TextHorizontalAlignment::Right => max_width - f32::min(max_width, line_metrics.width()),
         };
         layout_line(text, Point::new(x, y), start, line_metrics);
     };
 
     let baseline_y = match vertical_alignment {
-        TextVerticalAlignment::top => 0.,
-        TextVerticalAlignment::center => max_height / 2. - text_height() / 2.,
-        TextVerticalAlignment::bottom => max_height - text_height(),
+        TextVerticalAlignment::Top => 0.,
+        TextVerticalAlignment::Center => max_height / 2. - text_height() / 2.,
+        TextVerticalAlignment::Bottom => max_height - text_height(),
     };
     let mut y = baseline_y;
     let mut start = 0;

--- a/internal/backends/gl/renderer/femtovg/images.rs
+++ b/internal/backends/gl/renderer/femtovg/images.rs
@@ -88,8 +88,8 @@ impl Texture {
         scaling: ImageRendering,
     ) -> Option<Rc<Self>> {
         let image_flags = match scaling {
-            ImageRendering::smooth => femtovg::ImageFlags::empty(),
-            ImageRendering::pixelated => femtovg::ImageFlags::NEAREST,
+            ImageRendering::Smooth => femtovg::ImageFlags::empty(),
+            ImageRendering::Pixelated => femtovg::ImageFlags::NEAREST,
         };
 
         let image_id = match image {

--- a/internal/backends/gl/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/gl/renderer/femtovg/itemrenderer.rs
@@ -307,7 +307,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
         let font_height = canvas.measure_font(paint).unwrap().height();
         let mut text = text_input.text();
 
-        if let InputType::password = text_input.input_type() {
+        if let InputType::Password = text_input.input_type() {
             min_select = text[..min_select].chars().count() * PASSWORD_CHARACTER.len();
             max_select = text[..max_select].chars().count() * PASSWORD_CHARACTER.len();
             cursor_pos = text[..cursor_pos].chars().count() * PASSWORD_CHARACTER.len();
@@ -322,7 +322,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
             Size::new(width, height),
             (text_input.horizontal_alignment(), text_input.vertical_alignment()),
             text_input.wrap(),
-            items::TextOverflow::clip,
+            items::TextOverflow::Clip,
             text_input.single_line(),
             paint,
             |to_draw, pos, start, metrics| {
@@ -516,8 +516,8 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
         let fill_paint =
             self.brush_to_paint(path.fill(), &mut femtovg_path).map(|mut fill_paint| {
                 fill_paint.set_fill_rule(match path.fill_rule() {
-                    FillRule::nonzero => femtovg::FillRule::NonZero,
-                    FillRule::evenodd => femtovg::FillRule::EvenOdd,
+                    FillRule::Nonzero => femtovg::FillRule::NonZero,
+                    FillRule::Evenodd => femtovg::FillRule::EvenOdd,
                 });
                 fill_paint
             });
@@ -1032,8 +1032,8 @@ impl<'a> GLItemRenderer<'a> {
         };
 
         let scaling_flags = match scaling {
-            ImageRendering::smooth => femtovg::ImageFlags::empty(),
-            ImageRendering::pixelated => {
+            ImageRendering::Smooth => femtovg::ImageFlags::empty(),
+            ImageRendering::Pixelated => {
                 femtovg::ImageFlags::empty() | femtovg::ImageFlags::NEAREST
             }
         };
@@ -1191,8 +1191,8 @@ impl<'a> GLItemRenderer<'a> {
         // The source_to_target scale is applied to the paint that holds the image as well as path
         // begin rendered.
         let (source_to_target_scale_x, source_to_target_scale_y) = match image_fit {
-            ImageFit::fill => (target_w / source_width, target_h / source_height),
-            ImageFit::cover => {
+            ImageFit::Fill => (target_w / source_width, target_h / source_height),
+            ImageFit::Cover => {
                 let ratio = f32::max(target_w / source_width, target_h / source_height);
 
                 if source_width > target_w / ratio {
@@ -1204,7 +1204,7 @@ impl<'a> GLItemRenderer<'a> {
 
                 (ratio, ratio)
             }
-            ImageFit::contain => {
+            ImageFit::Contain => {
                 let ratio = f32::min(target_w / source_width, target_h / source_height);
 
                 if source_width < target_w / ratio {

--- a/internal/backends/mcu/pico_st7789.rs
+++ b/internal/backends/mcu/pico_st7789.rs
@@ -282,7 +282,7 @@ impl<
     }
 
     fn read_touch_event(&mut self) -> Option<i_slint_core::input::MouseEvent> {
-        let button = i_slint_core::items::PointerEventButton::left;
+        let button = i_slint_core::items::PointerEventButton::Left;
         self.touch
             .read()
             .map_err(|_| ())

--- a/internal/backends/mcu/stm32h735g.rs
+++ b/internal/backends/mcu/stm32h735g.rs
@@ -364,7 +364,7 @@ impl Devices for StmDevices {
     fn read_touch_event(&mut self) -> Option<i_slint_core::input::MouseEvent> {
         let mut ft5336 = touch_device(&mut self.delay, &mut self.touch_i2c);
         let touch = ft5336.detect_touch(&mut self.touch_i2c).unwrap();
-        let button = i_slint_core::items::PointerEventButton::left;
+        let button = i_slint_core::items::PointerEventButton::Left;
 
         if touch > 0 {
             let state = ft5336.get_touch(&mut self.touch_i2c, 1).unwrap();

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -303,14 +303,14 @@ cpp! {{
                                              index: usize as "size_t"]
                     -> u32 as "QAccessible::Role" {
                 match rustDescendents[index].accessible_role() {
-                    i_slint_core::items::AccessibleRole::none => QAccessible_Role_NoRole,
-                    i_slint_core::items::AccessibleRole::button => QAccessible_Role_Button,
-                    i_slint_core::items::AccessibleRole::checkbox => QAccessible_Role_CheckBox,
-                    i_slint_core::items::AccessibleRole::combobox => QAccessible_Role_ComboBox,
-                    i_slint_core::items::AccessibleRole::slider => QAccessible_Role_Slider,
-                    i_slint_core::items::AccessibleRole::spinbox => QAccessible_Role_SpinBox,
-                    i_slint_core::items::AccessibleRole::tab => QAccessible_Role_PageTab,
-                    i_slint_core::items::AccessibleRole::text => QAccessible_Role_StaticText,
+                    i_slint_core::items::AccessibleRole::None => QAccessible_Role_NoRole,
+                    i_slint_core::items::AccessibleRole::Button => QAccessible_Role_Button,
+                    i_slint_core::items::AccessibleRole::Checkbox => QAccessible_Role_CheckBox,
+                    i_slint_core::items::AccessibleRole::Combobox => QAccessible_Role_ComboBox,
+                    i_slint_core::items::AccessibleRole::Slider => QAccessible_Role_Slider,
+                    i_slint_core::items::AccessibleRole::Spinbox => QAccessible_Role_SpinBox,
+                    i_slint_core::items::AccessibleRole::Tab => QAccessible_Role_PageTab,
+                    i_slint_core::items::AccessibleRole::Text => QAccessible_Role_StaticText,
                 }
             });
         }

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -132,17 +132,17 @@ impl NativeButton {
     ) -> qttypes::QString {
         // We would need to use the private API to get the text from QPlatformTheme
         match standard_button_kind {
-            Some(StandardButtonKind::ok) => "OK".into(),
-            Some(StandardButtonKind::cancel) => "Cancel".into(),
-            Some(StandardButtonKind::apply) => "Apply".into(),
-            Some(StandardButtonKind::close) => "Close".into(),
-            Some(StandardButtonKind::reset) => "Reset".into(),
-            Some(StandardButtonKind::help) => "Help".into(),
-            Some(StandardButtonKind::yes) => "Yes".into(),
-            Some(StandardButtonKind::no) => "No".into(),
-            Some(StandardButtonKind::abort) => "Abort".into(),
-            Some(StandardButtonKind::retry) => "Retry".into(),
-            Some(StandardButtonKind::ignore) => "Ignore".into(),
+            Some(StandardButtonKind::Ok) => "OK".into(),
+            Some(StandardButtonKind::Cancel) => "Cancel".into(),
+            Some(StandardButtonKind::Apply) => "Apply".into(),
+            Some(StandardButtonKind::Close) => "Close".into(),
+            Some(StandardButtonKind::Reset) => "Reset".into(),
+            Some(StandardButtonKind::Help) => "Help".into(),
+            Some(StandardButtonKind::Yes) => "Yes".into(),
+            Some(StandardButtonKind::No) => "No".into(),
+            Some(StandardButtonKind::Abort) => "Abort".into(),
+            Some(StandardButtonKind::Retry) => "Retry".into(),
+            Some(StandardButtonKind::Ignore) => "Ignore".into(),
             None => self.text().as_str().into(),
         }
     }
@@ -152,17 +152,17 @@ impl NativeButton {
         standard_button_kind: ActualStandardButtonKind,
     ) -> qttypes::QPixmap {
         let style_icon = match standard_button_kind {
-            Some(StandardButtonKind::ok) => QStyle_StandardPixmap_SP_DialogOkButton,
-            Some(StandardButtonKind::cancel) => QStyle_StandardPixmap_SP_DialogCancelButton,
-            Some(StandardButtonKind::apply) => QStyle_StandardPixmap_SP_DialogApplyButton,
-            Some(StandardButtonKind::close) => QStyle_StandardPixmap_SP_DialogCloseButton,
-            Some(StandardButtonKind::reset) => QStyle_StandardPixmap_SP_DialogResetButton,
-            Some(StandardButtonKind::help) => QStyle_StandardPixmap_SP_DialogHelpButton,
-            Some(StandardButtonKind::yes) => QStyle_StandardPixmap_SP_DialogYesButton,
-            Some(StandardButtonKind::no) => QStyle_StandardPixmap_SP_DialogNoButton,
-            Some(StandardButtonKind::abort) => QStyle_StandardPixmap_SP_DialogAbortButton,
-            Some(StandardButtonKind::retry) => QStyle_StandardPixmap_SP_DialogRetryButton,
-            Some(StandardButtonKind::ignore) => QStyle_StandardPixmap_SP_DialogIgnoreButton,
+            Some(StandardButtonKind::Ok) => QStyle_StandardPixmap_SP_DialogOkButton,
+            Some(StandardButtonKind::Cancel) => QStyle_StandardPixmap_SP_DialogCancelButton,
+            Some(StandardButtonKind::Apply) => QStyle_StandardPixmap_SP_DialogApplyButton,
+            Some(StandardButtonKind::Close) => QStyle_StandardPixmap_SP_DialogCloseButton,
+            Some(StandardButtonKind::Reset) => QStyle_StandardPixmap_SP_DialogResetButton,
+            Some(StandardButtonKind::Help) => QStyle_StandardPixmap_SP_DialogHelpButton,
+            Some(StandardButtonKind::Yes) => QStyle_StandardPixmap_SP_DialogYesButton,
+            Some(StandardButtonKind::No) => QStyle_StandardPixmap_SP_DialogNoButton,
+            Some(StandardButtonKind::Abort) => QStyle_StandardPixmap_SP_DialogAbortButton,
+            Some(StandardButtonKind::Retry) => QStyle_StandardPixmap_SP_DialogRetryButton,
+            Some(StandardButtonKind::Ignore) => QStyle_StandardPixmap_SP_DialogIgnoreButton,
             None => {
                 return crate::qt_window::image_to_pixmap((&self.icon()).into(), None)
                     .unwrap_or_default();

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -147,14 +147,14 @@ impl Item for NativeSlider {
                 data.pressed = 0;
                 InputEventResult::EventIgnored
             }
-            MouseEvent::MousePressed { pos, button: PointerEventButton::left } => {
+            MouseEvent::MousePressed { pos, button: PointerEventButton::Left } => {
                 data.pressed_x = pos.x as f32;
                 data.pressed = 1;
                 data.pressed_val = value;
                 InputEventResult::GrabMouse
             }
             MouseEvent::MouseExit
-            | MouseEvent::MouseReleased { button: PointerEventButton::left, .. } => {
+            | MouseEvent::MouseReleased { button: PointerEventButton::Left, .. } => {
                 data.pressed = 0;
                 InputEventResult::EventAccepted
             }
@@ -179,7 +179,7 @@ impl Item for NativeSlider {
                 InputEventResult::EventAccepted
             }
             MouseEvent::MousePressed { button, .. } | MouseEvent::MouseReleased { button, .. } => {
-                debug_assert_ne!(button, PointerEventButton::left);
+                debug_assert_ne!(button, PointerEventButton::Left);
                 InputEventResult::EventIgnored
             }
         };

--- a/internal/backends/qt/qt_widgets/stylemetrics.rs
+++ b/internal/backends/qt/qt_widgets/stylemetrics.rs
@@ -159,10 +159,10 @@ impl NativeStyleMetrics {
             }
         });
         self.tab_bar_alignment.set(match tab_bar_alignment {
-            1 => LayoutAlignment::start,
-            2 => LayoutAlignment::center,
-            3 => LayoutAlignment::end,
-            _ => LayoutAlignment::space_between, // Should not happen! If it does, it should be noticeable;-)
+            1 => LayoutAlignment::Start,
+            2 => LayoutAlignment::Center,
+            3 => LayoutAlignment::End,
+            _ => LayoutAlignment::SpaceBetween, // Should not happen! If it does, it should be noticeable;-)
         });
     }
 }

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -416,10 +416,10 @@ fn into_qbrush(
 
 fn from_qt_button(qt_button: u32) -> PointerEventButton {
     match qt_button {
-        1 => PointerEventButton::left,
-        2 => PointerEventButton::right,
-        4 => PointerEventButton::middle,
-        _ => PointerEventButton::none,
+        1 => PointerEventButton::Left,
+        2 => PointerEventButton::Right,
+        4 => PointerEventButton::Middle,
+        _ => PointerEventButton::None,
     }
 }
 
@@ -519,18 +519,18 @@ impl ItemRenderer for QtItemRenderer<'_> {
         let font: QFont =
             get_font(text.unresolved_font_request().merge(&self.default_font_properties));
         let flags = match text.horizontal_alignment() {
-            TextHorizontalAlignment::left => key_generated::Qt_AlignmentFlag_AlignLeft,
-            TextHorizontalAlignment::center => key_generated::Qt_AlignmentFlag_AlignHCenter,
-            TextHorizontalAlignment::right => key_generated::Qt_AlignmentFlag_AlignRight,
+            TextHorizontalAlignment::Left => key_generated::Qt_AlignmentFlag_AlignLeft,
+            TextHorizontalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignHCenter,
+            TextHorizontalAlignment::Right => key_generated::Qt_AlignmentFlag_AlignRight,
         } | match text.vertical_alignment() {
-            TextVerticalAlignment::top => key_generated::Qt_AlignmentFlag_AlignTop,
-            TextVerticalAlignment::center => key_generated::Qt_AlignmentFlag_AlignVCenter,
-            TextVerticalAlignment::bottom => key_generated::Qt_AlignmentFlag_AlignBottom,
+            TextVerticalAlignment::Top => key_generated::Qt_AlignmentFlag_AlignTop,
+            TextVerticalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignVCenter,
+            TextVerticalAlignment::Bottom => key_generated::Qt_AlignmentFlag_AlignBottom,
         } | match text.wrap() {
-            TextWrap::no_wrap => 0,
-            TextWrap::word_wrap => key_generated::Qt_TextFlag_TextWordWrap,
+            TextWrap::NoWrap => 0,
+            TextWrap::WordWrap => key_generated::Qt_TextFlag_TextWordWrap,
         };
-        let elide = text.overflow() == TextOverflow::elide;
+        let elide = text.overflow() == TextOverflow::Elide;
         let painter: &mut QPainterPtr = &mut self.painter;
         cpp! { unsafe [painter as "QPainterPtr*", rect as "QRectF", fill_brush as "QBrush", mut string as "QString", flags as "int", font as "QFont", elide as "bool"] {
             (*painter)->setFont(font);
@@ -602,7 +602,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
         let text = text_input.text();
         let mut string: qttypes::QString = text.as_str().into();
 
-        if let InputType::password = text_input.input_type() {
+        if let InputType::Password = text_input.input_type() {
             cpp! { unsafe [mut string as "QString"] {
                 string.fill(QChar(qApp->style()->styleHint(QStyle::SH_LineEdit_PasswordCharacter, nullptr, nullptr)));
             }}
@@ -611,16 +611,16 @@ impl ItemRenderer for QtItemRenderer<'_> {
         let font: QFont =
             get_font(text_input.unresolved_font_request().merge(&self.default_font_properties));
         let flags = match text_input.horizontal_alignment() {
-            TextHorizontalAlignment::left => key_generated::Qt_AlignmentFlag_AlignLeft,
-            TextHorizontalAlignment::center => key_generated::Qt_AlignmentFlag_AlignHCenter,
-            TextHorizontalAlignment::right => key_generated::Qt_AlignmentFlag_AlignRight,
+            TextHorizontalAlignment::Left => key_generated::Qt_AlignmentFlag_AlignLeft,
+            TextHorizontalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignHCenter,
+            TextHorizontalAlignment::Right => key_generated::Qt_AlignmentFlag_AlignRight,
         } | match text_input.vertical_alignment() {
-            TextVerticalAlignment::top => key_generated::Qt_AlignmentFlag_AlignTop,
-            TextVerticalAlignment::center => key_generated::Qt_AlignmentFlag_AlignVCenter,
-            TextVerticalAlignment::bottom => key_generated::Qt_AlignmentFlag_AlignBottom,
+            TextVerticalAlignment::Top => key_generated::Qt_AlignmentFlag_AlignTop,
+            TextVerticalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignVCenter,
+            TextVerticalAlignment::Bottom => key_generated::Qt_AlignmentFlag_AlignBottom,
         } | match text_input.wrap() {
-            TextWrap::no_wrap => 0,
-            TextWrap::word_wrap => key_generated::Qt_TextFlag_TextWordWrap,
+            TextWrap::NoWrap => 0,
+            TextWrap::WordWrap => key_generated::Qt_TextFlag_TextWordWrap,
         };
 
         // convert byte offsets to offsets in Qt UTF-16 encoded string, as that's
@@ -701,8 +701,8 @@ impl ItemRenderer for QtItemRenderer<'_> {
         let mut painter_path = QPainterPath::default();
 
         painter_path.set_fill_rule(match path.fill_rule() {
-            FillRule::nonzero => key_generated::Qt_FillRule_WindingFill,
-            FillRule::evenodd => key_generated::Qt_FillRule_OddEvenFill,
+            FillRule::Nonzero => key_generated::Qt_FillRule_WindingFill,
+            FillRule::Evenodd => key_generated::Qt_FillRule_OddEvenFill,
         });
 
         for x in path_events.iter() {
@@ -997,8 +997,8 @@ fn adjust_to_image_fit(
     dest_rect: &mut qttypes::QRectF,
 ) {
     match image_fit {
-        i_slint_core::items::ImageFit::fill => (),
-        i_slint_core::items::ImageFit::cover => {
+        i_slint_core::items::ImageFit::Fill => (),
+        i_slint_core::items::ImageFit::Cover => {
             let ratio = qttypes::qreal::max(
                 dest_rect.width / source_rect.width,
                 dest_rect.height / source_rect.height,
@@ -1012,7 +1012,7 @@ fn adjust_to_image_fit(
                 source_rect.height = dest_rect.height / ratio;
             }
         }
-        i_slint_core::items::ImageFit::contain => {
+        i_slint_core::items::ImageFit::Contain => {
             let ratio = qttypes::qreal::min(
                 dest_rect.width / source_rect.width,
                 dest_rect.height / source_rect.height,
@@ -1093,7 +1093,7 @@ impl QtItemRenderer<'_> {
         let mut dest_rect = dest_rect;
         adjust_to_image_fit(image_fit, &mut source_rect, &mut dest_rect);
         let painter: &mut QPainterPtr = &mut self.painter;
-        let smooth: bool = rendering == ImageRendering::smooth;
+        let smooth: bool = rendering == ImageRendering::Smooth;
         cpp! { unsafe [
                 painter as "QPainterPtr*",
                 pixmap as "QPixmap",
@@ -1508,35 +1508,35 @@ impl PlatformWindow for QtWindow {
         let widget_ptr = self.widget_ptr();
         //unidirectional resize cursors are replaced with bidirectional ones
         let cursor_shape = match cursor {
-            MouseCursor::default => key_generated::Qt_CursorShape_ArrowCursor,
-            MouseCursor::none => key_generated::Qt_CursorShape_BlankCursor,
-            MouseCursor::help => key_generated::Qt_CursorShape_WhatsThisCursor,
-            MouseCursor::pointer => key_generated::Qt_CursorShape_PointingHandCursor,
-            MouseCursor::progress => key_generated::Qt_CursorShape_BusyCursor,
-            MouseCursor::wait => key_generated::Qt_CursorShape_WaitCursor,
-            MouseCursor::crosshair => key_generated::Qt_CursorShape_CrossCursor,
-            MouseCursor::text => key_generated::Qt_CursorShape_IBeamCursor,
-            MouseCursor::alias => key_generated::Qt_CursorShape_DragLinkCursor,
-            MouseCursor::copy => key_generated::Qt_CursorShape_DragCopyCursor,
-            MouseCursor::r#move => key_generated::Qt_CursorShape_DragMoveCursor,
-            MouseCursor::no_drop => key_generated::Qt_CursorShape_ForbiddenCursor,
-            MouseCursor::not_allowed => key_generated::Qt_CursorShape_ForbiddenCursor,
-            MouseCursor::grab => key_generated::Qt_CursorShape_OpenHandCursor,
-            MouseCursor::grabbing => key_generated::Qt_CursorShape_ClosedHandCursor,
-            MouseCursor::col_resize => key_generated::Qt_CursorShape_SplitHCursor,
-            MouseCursor::row_resize => key_generated::Qt_CursorShape_SplitVCursor,
-            MouseCursor::n_resize => key_generated::Qt_CursorShape_SizeVerCursor,
-            MouseCursor::e_resize => key_generated::Qt_CursorShape_SizeHorCursor,
-            MouseCursor::s_resize => key_generated::Qt_CursorShape_SizeVerCursor,
-            MouseCursor::w_resize => key_generated::Qt_CursorShape_SizeHorCursor,
-            MouseCursor::ne_resize => key_generated::Qt_CursorShape_SizeBDiagCursor,
-            MouseCursor::nw_resize => key_generated::Qt_CursorShape_SizeFDiagCursor,
-            MouseCursor::se_resize => key_generated::Qt_CursorShape_SizeFDiagCursor,
-            MouseCursor::sw_resize => key_generated::Qt_CursorShape_SizeBDiagCursor,
-            MouseCursor::ew_resize => key_generated::Qt_CursorShape_SizeHorCursor,
-            MouseCursor::ns_resize => key_generated::Qt_CursorShape_SizeVerCursor,
-            MouseCursor::nesw_resize => key_generated::Qt_CursorShape_SizeBDiagCursor,
-            MouseCursor::nwse_resize => key_generated::Qt_CursorShape_SizeFDiagCursor,
+            MouseCursor::Default => key_generated::Qt_CursorShape_ArrowCursor,
+            MouseCursor::None => key_generated::Qt_CursorShape_BlankCursor,
+            MouseCursor::Help => key_generated::Qt_CursorShape_WhatsThisCursor,
+            MouseCursor::Pointer => key_generated::Qt_CursorShape_PointingHandCursor,
+            MouseCursor::Progress => key_generated::Qt_CursorShape_BusyCursor,
+            MouseCursor::Wait => key_generated::Qt_CursorShape_WaitCursor,
+            MouseCursor::Crosshair => key_generated::Qt_CursorShape_CrossCursor,
+            MouseCursor::Text => key_generated::Qt_CursorShape_IBeamCursor,
+            MouseCursor::Alias => key_generated::Qt_CursorShape_DragLinkCursor,
+            MouseCursor::Copy => key_generated::Qt_CursorShape_DragCopyCursor,
+            MouseCursor::Move => key_generated::Qt_CursorShape_DragMoveCursor,
+            MouseCursor::NoDrop => key_generated::Qt_CursorShape_ForbiddenCursor,
+            MouseCursor::NotAllowed => key_generated::Qt_CursorShape_ForbiddenCursor,
+            MouseCursor::Grab => key_generated::Qt_CursorShape_OpenHandCursor,
+            MouseCursor::Grabbing => key_generated::Qt_CursorShape_ClosedHandCursor,
+            MouseCursor::ColResize => key_generated::Qt_CursorShape_SplitHCursor,
+            MouseCursor::RowResize => key_generated::Qt_CursorShape_SplitVCursor,
+            MouseCursor::NResize => key_generated::Qt_CursorShape_SizeVerCursor,
+            MouseCursor::EResize => key_generated::Qt_CursorShape_SizeHorCursor,
+            MouseCursor::SResize => key_generated::Qt_CursorShape_SizeVerCursor,
+            MouseCursor::WResize => key_generated::Qt_CursorShape_SizeHorCursor,
+            MouseCursor::NeResize => key_generated::Qt_CursorShape_SizeBDiagCursor,
+            MouseCursor::NwResize => key_generated::Qt_CursorShape_SizeFDiagCursor,
+            MouseCursor::SeResize => key_generated::Qt_CursorShape_SizeFDiagCursor,
+            MouseCursor::SwResize => key_generated::Qt_CursorShape_SizeBDiagCursor,
+            MouseCursor::EwResize => key_generated::Qt_CursorShape_SizeHorCursor,
+            MouseCursor::NsResize => key_generated::Qt_CursorShape_SizeVerCursor,
+            MouseCursor::NeswResize => key_generated::Qt_CursorShape_SizeBDiagCursor,
+            MouseCursor::NwseResize => key_generated::Qt_CursorShape_SizeFDiagCursor,
         };
         cpp! {unsafe [widget_ptr as "QWidget*", cursor_shape as "Qt::CursorShape"] {
             widget_ptr->setCursor(QCursor{cursor_shape});
@@ -1566,19 +1566,19 @@ impl PlatformWindow for QtWindow {
             get_font(text_input.unresolved_font_request().merge(&self.default_font_properties()));
         let string = qttypes::QString::from(text_input.text().as_str());
         let flags = match text_input.horizontal_alignment() {
-            TextHorizontalAlignment::left => key_generated::Qt_AlignmentFlag_AlignLeft,
-            TextHorizontalAlignment::center => key_generated::Qt_AlignmentFlag_AlignHCenter,
-            TextHorizontalAlignment::right => key_generated::Qt_AlignmentFlag_AlignRight,
+            TextHorizontalAlignment::Left => key_generated::Qt_AlignmentFlag_AlignLeft,
+            TextHorizontalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignHCenter,
+            TextHorizontalAlignment::Right => key_generated::Qt_AlignmentFlag_AlignRight,
         } | match text_input.vertical_alignment() {
-            TextVerticalAlignment::top => key_generated::Qt_AlignmentFlag_AlignTop,
-            TextVerticalAlignment::center => key_generated::Qt_AlignmentFlag_AlignVCenter,
-            TextVerticalAlignment::bottom => key_generated::Qt_AlignmentFlag_AlignBottom,
+            TextVerticalAlignment::Top => key_generated::Qt_AlignmentFlag_AlignTop,
+            TextVerticalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignVCenter,
+            TextVerticalAlignment::Bottom => key_generated::Qt_AlignmentFlag_AlignBottom,
         } | match text_input.wrap() {
-            TextWrap::no_wrap => 0,
-            TextWrap::word_wrap => key_generated::Qt_TextFlag_TextWordWrap,
+            TextWrap::NoWrap => 0,
+            TextWrap::WordWrap => key_generated::Qt_TextFlag_TextWordWrap,
         };
         let single_line: bool = text_input.single_line();
-        let is_password: bool = matches!(text_input.input_type(), InputType::password);
+        let is_password: bool = matches!(text_input.input_type(), InputType::Password);
         cpp! { unsafe [font as "QFont", string as "QString", pos as "QPointF", flags as "int",
                 rect as "QRectF", single_line as "bool", is_password as "bool"] -> usize as "size_t" {
             // we need to do the \n replacement in a copy because the original need to be kept to know the utf8 offset
@@ -1624,16 +1624,16 @@ impl PlatformWindow for QtWindow {
         let mut string = qttypes::QString::from(text.as_str());
         let offset: u32 = utf8_byte_offset_to_utf16_units(text.as_str(), byte_offset) as _;
         let flags = match text_input.horizontal_alignment() {
-            TextHorizontalAlignment::left => key_generated::Qt_AlignmentFlag_AlignLeft,
-            TextHorizontalAlignment::center => key_generated::Qt_AlignmentFlag_AlignHCenter,
-            TextHorizontalAlignment::right => key_generated::Qt_AlignmentFlag_AlignRight,
+            TextHorizontalAlignment::Left => key_generated::Qt_AlignmentFlag_AlignLeft,
+            TextHorizontalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignHCenter,
+            TextHorizontalAlignment::Right => key_generated::Qt_AlignmentFlag_AlignRight,
         } | match text_input.vertical_alignment() {
-            TextVerticalAlignment::top => key_generated::Qt_AlignmentFlag_AlignTop,
-            TextVerticalAlignment::center => key_generated::Qt_AlignmentFlag_AlignVCenter,
-            TextVerticalAlignment::bottom => key_generated::Qt_AlignmentFlag_AlignBottom,
+            TextVerticalAlignment::Top => key_generated::Qt_AlignmentFlag_AlignTop,
+            TextVerticalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignVCenter,
+            TextVerticalAlignment::Bottom => key_generated::Qt_AlignmentFlag_AlignBottom,
         } | match text_input.wrap() {
-            TextWrap::no_wrap => 0,
-            TextWrap::word_wrap => key_generated::Qt_TextFlag_TextWordWrap,
+            TextWrap::NoWrap => 0,
+            TextWrap::WordWrap => key_generated::Qt_TextFlag_TextWordWrap,
         };
         let single_line: bool = text_input.single_line();
         let r = cpp! { unsafe [font as "QFont", mut string as "QString", offset as "int", flags as "int", rect as "QRectF", single_line as "bool"]

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -238,14 +238,6 @@ macro_rules! for_each_enums {
                 EndClosed,
             }
 
-            /// This enum defines the different kinds of key events that can happen.
-            enum KeyEventType {
-                /// A key on a keyboard was pressed.
-                KeyPressed,
-                /// A key on a keyboard was released.
-                KeyReleased,
-            }
-
             /// This enum represents the different values for the `accessible-role` property, used to describe the
             /// role of an element in the context of assistive technology such as screen readers.
             enum AccessibleRole {

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -24,67 +24,67 @@ macro_rules! for_each_enums {
             /// This enum describes the different types of alignment of text along the horizontal axis.
             enum TextHorizontalAlignment {
                 /// The text will be aligned with the left edge of the containing box.
-                left,
+                Left,
                 /// The text will be horizontally centered within the containing box.
-                center,
+                Center,
                 /// The text will be aligned to the right of the containing box.
-                right,
+                Right,
             }
 
             /// This enum describes the different types of alignment of text along the vertical axis.
             enum TextVerticalAlignment {
                 /// The text will be aligned to the top of the containing box.
-                top,
+                Top,
                 /// The text will be vertically centered within the containing box.
-                center,
+                Center,
                 /// The text will be aligned to the bottom of the containing box.
-                bottom,
+                Bottom,
             }
 
             /// This enum describes the how the text wrap if it is too wide to fit in the Text width.
             enum TextWrap {
                 /// The text will not wrap, but instead will overflow.
-                no_wrap,
+                NoWrap,
                 /// The text will be wrapped at word boundaries.
-                word_wrap,
+                WordWrap,
             }
 
             /// This enum describes the how the text appear if it is too wide to fit in the Text width.
             enum TextOverflow {
                 /// The text will simply be clipped.
-                clip,
+                Clip,
                 /// The text will be elided with `…`.
-                elide,
+                Elide,
             }
 
             /// This enum describes whether an event was rejected or accepted by an event handler.
             enum EventResult {
                 /// The event is rejected by this event handler and may then be handled by the parent item
-                reject,
+                Reject,
                 /// The event is accepted and won't be processed further
-                accept,
+                Accept,
             }
 
             /// This enum describes the different ways of deciding what the inside of a shape described by a path shall be.
             enum FillRule {
                 /// The ["nonzero" fill rule as defined in SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule#nonzero).
-                nonzero,
+                Nonzero,
                 /// The ["evenodd" fill rule as defined in SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule#evenodd)
-                evenodd,
+                Evenodd,
             }
 
             enum StandardButtonKind {
-                ok,
-                cancel,
-                apply,
-                close,
-                reset,
-                help,
-                yes,
-                no,
-                abort,
-                retry,
-                ignore,
+                Ok,
+                Cancel,
+                Apply,
+                Close,
+                Reset,
+                Help,
+                Yes,
+                No,
+                Abort,
+                Retry,
+                Ignore,
             }
 
             /// This enum represents the value of the `dialog-button-role` property which can be added to
@@ -92,32 +92,32 @@ macro_rules! for_each_enums {
             /// depends on the role and the platform.
             enum DialogButtonRole {
                 /// This is not a button means to go in the row of button of the dialog
-                none,
+                None,
                 /// This is the role of the main button to click to accept the dialog. e.g. "Ok" or "Yes"
-                accept,
+                Accept,
                 /// This is the role of the main button to click to reject the dialog. e.g. "Cancel" or "No"
-                reject,
+                Reject,
                 /// This is the role of the "Apply" button
-                apply,
+                Apply,
                 /// This is the role of the "Reset" button
-                reset,
+                Reset,
                 /// This is the role of the  "Help" button
-                help,
+                Help,
                 /// This is the role of any other button that performs another action.
-                action,
+                Action,
             }
 
             enum PointerEventKind {
-                cancel,
-                down,
-                up,
+                Cancel,
+                Down,
+                Up,
             }
 
             enum PointerEventButton {
-                none,
-                left,
-                right,
-                middle,
+                None,
+                Left,
+                Right,
+                Middle,
             }
 
             /// This enum represents different types of mouse cursors. It is a subset of the mouse cursors available in CSS.
@@ -125,80 +125,80 @@ macro_rules! for_each_enums {
             /// Depending on the backend and used OS unidirectional resize cursors may be replaced with bidirectional ones.
             enum MouseCursor {
                 /// The systems default cursor.
-                default,
+                Default,
                 /// No cursor is displayed.
-                none,
+                None,
                 //context_menu,
                 /// A cursor indicating help information.
-                help,
+                Help,
                 /// A pointing hand indicating a link.
-                pointer,
+                Pointer,
                 /// The program is busy but can still be interacted with.
-                progress,
+                Progress,
                 /// The program is busy.
-                wait,
+                Wait,
                 //cell,
                 /// A crosshair.
-                crosshair,
+                Crosshair,
                 /// A cursor indicating selectable text.
-                text,
+                Text,
                 //vertical_text,
                 /// An alias or shortcut is being created.
-                alias,
+                Alias,
                 /// A copy is being created.
-                copy,
+                Copy,
                 /// Something is to be moved.
-                r#move,
+                Move,
                 /// Something cannot be dropped here.
-                no_drop,
+                NoDrop,
                 /// An action is not allowed
-                not_allowed,
+                NotAllowed,
                 /// Something is grabbable.
-                grab,
+                Grab,
                 /// Something is being grabbed.
-                grabbing,
+                Grabbing,
                 //all_scroll,
                 /// Indicating that a column is resizable horizontally.
-                col_resize,
+                ColResize,
                 /// Indicating that a row is resizable vertically.
-                row_resize,
+                RowResize,
                 /// Unidirectional resize north.
-                n_resize,
+                NResize,
                 /// Unidirectional resize east.
-                e_resize,
+                EResize,
                 /// Unidirectional resize south.
-                s_resize,
+                SResize,
                 /// Unidirectional resize west.
-                w_resize,
+                WResize,
                 /// Unidirectional resize north-east.
-                ne_resize,
+                NeResize,
                 /// Unidirectional resize north-west.
-                nw_resize,
+                NwResize,
                 /// Unidirectional resize south-east.
-                se_resize,
+                SeResize,
                 /// Unidirectional resize south-west.
-                sw_resize,
+                SwResize,
                 /// Bidirectional resize east-west.
-                ew_resize,
+                EwResize,
                 /// Bidirectional resize north-south.
-                ns_resize,
+                NsResize,
                 /// Bidirectional resize north-east-south-west.
-                nesw_resize,
+                NeswResize,
                 /// Bidirectional resize north-west-south-east.
-                nwse_resize,
+                NwseResize,
                 //zoom_in,
                 //zoom_out,
             }
 
             enum ImageFit {
-                fill,
-                contain,
-                cover,
+                Fill,
+                Contain,
+                Cover,
             }
 
             enum ImageRendering {
-                smooth,
-                pixelated,
+                Smooth,
+                Pixelated,
             }
 
             /// This enum is used to define the type of the input field. Currently this only differentiates between
@@ -206,36 +206,36 @@ macro_rules! for_each_enums {
             /// should be shown, for example.
             enum InputType {
                 /// The default value. This will render all characters normally
-                text,
+                Text,
                 /// This will render all characters with a character that defaults to "*"
-                password,
+                Password,
             }
 
             /// Enum representing the alignment property of a BoxLayout or HorizontalLayout
             enum LayoutAlignment {
-                stretch,
-                center,
-                start,
-                end,
-                space_between,
-                space_around,
+                Stretch,
+                Center,
+                Start,
+                End,
+                SpaceBetween,
+                SpaceAround,
             }
 
             /// PathEvent is a low-level data structure describing the composition of a path. Typically it is
             /// generated at compile time from a higher-level description, such as SVG commands.
             enum PathEvent {
                 /// The beginning of the path.
-                begin,
+                Begin,
                 /// A straight line on the path.
-                line,
+                Line,
                 /// A quadratic bezier curve on the path.
-                quadratic,
+                Quadratic,
                 /// A cubic bezier curve on the path.
-                cubic,
+                Cubic,
                 /// The end of the path that remains open.
-                end_open,
+                EndOpen,
                 /// The end of a path that is closed.
-                end_closed,
+                EndClosed,
             }
 
             /// This enum defines the different kinds of key events that can happen.
@@ -250,30 +250,22 @@ macro_rules! for_each_enums {
             /// role of an element in the context of assistive technology such as screen readers.
             enum AccessibleRole {
                 /// The element is not accessible.
-                none,
+                None,
                 /// The element is a Button or behaves like one.
-                button,
+                Button,
                 /// The element is a CheckBox or behaves like one.
-                checkbox,
+                Checkbox,
                 /// The element is a ComboBox or behaves like one.
-                combobox,
+                Combobox,
                 /// The element is a Slider or behaves like one.
-                slider,
+                Slider,
                 /// The element is a SpinBox or behaves like one.
-                spinbox,
+                Spinbox,
                 /// The element is a Tab or behaves like one.
-                tab,
+                Tab,
                 /// The role for a Text element. It is automatically applied.
-                text,
+                Text,
             }
         ];
     };
-}
-
-/// add an underscore to a C++ keyword used as an enum
-pub fn cpp_escape_keyword(kw: &str) -> &str {
-    match kw {
-        "default" => "default_",
-        other => other,
-    }
 }

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -448,3 +448,42 @@ pub fn for_each_const_properties(component: &Rc<Component>, mut f: impl FnMut(&E
         }
     });
 }
+
+/// Convert a ascii kebab string to pascal case
+pub fn to_pascal_case(str: &str) -> String {
+    let mut result = Vec::with_capacity(str.len());
+    let mut next_upper = true;
+    for x in str.as_bytes() {
+        if *x == b'-' {
+            next_upper = true;
+        } else if next_upper {
+            result.push(x.to_ascii_uppercase());
+            next_upper = false;
+        } else {
+            result.push(*x);
+        }
+    }
+    String::from_utf8(result).unwrap()
+}
+
+/// Convert a ascii pascal case string to kebab case
+pub fn to_kebab_case(str: &str) -> String {
+    let mut result = Vec::with_capacity(str.len());
+    for x in str.as_bytes() {
+        if x.is_ascii_uppercase() {
+            if !result.is_empty() {
+                result.push(b'-');
+            }
+            result.push(x.to_ascii_lowercase());
+        } else {
+            result.push(*x);
+        }
+    }
+    String::from_utf8(result).unwrap()
+}
+
+#[test]
+fn case_conversions() {
+    assert_eq!(to_kebab_case("HelloWorld"), "hello-world");
+    assert_eq!(to_pascal_case("hello-world"), "HelloWorld");
+}

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2292,7 +2292,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             format!(
                 "slint::cbindgen_private::{}::{}",
                 value.enumeration.name,
-                ident(i_slint_common::enums::cpp_escape_keyword(&value.to_string())),
+                ident(&value.to_pascal_case()),
             )
         }
         Expression::ReturnStatement(Some(expr)) => format!(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1925,7 +1925,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         }
         Expression::EnumerationValue(value) => {
             let base_ident = ident(&value.enumeration.name);
-            let value_ident = ident(&value.to_string());
+            let value_ident = ident(&value.to_pascal_case());
             quote!(slint::re_exports::#base_ident::#value_ident)
         }
         Expression::ReturnStatement(expr) => {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -687,6 +687,12 @@ impl std::fmt::Display for EnumerationValue {
     }
 }
 
+impl EnumerationValue {
+    pub fn to_pascal_case(&self) -> String {
+        crate::generator::to_pascal_case(&self.enumeration.values[self.value])
+    }
+}
+
 /// If the `Type::UnitProduct(a)` can be converted to `Type::UnitProduct(a)` by multiplying
 /// by the scale factor, return that scale factor, otherwise, return None
 pub fn unit_product_length_conversion(a: &[(Unit, i8)], b: &[(Unit, i8)]) -> Option<i8> {

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -284,7 +284,8 @@ fn lower_sub_component(
         };
         for (key, nr) in &elem.accessibility_props.0 {
             // TODO: we also want to split by type (role/string/...)
-            let enum_value = to_camel_case(key.strip_prefix("accessible-").unwrap());
+            let enum_value =
+                crate::generator::to_pascal_case(key.strip_prefix("accessible-").unwrap());
             accessible_prop.push((*elem.item_index.get().unwrap(), enum_value, nr.clone()));
         }
         Some(element.clone())
@@ -413,23 +414,6 @@ fn lower_sub_component(
         .collect();
 
     LoweredSubComponent { sub_component: Rc::new(sub_component), mapping }
-}
-
-// Convert a ascii kebab string to camel case
-fn to_camel_case(str: &str) -> String {
-    let mut result = Vec::with_capacity(str.len());
-    let mut next_upper = true;
-    for x in str.as_bytes() {
-        if *x == b'-' {
-            next_upper = true;
-        } else if next_upper {
-            result.push(x.to_ascii_uppercase());
-            next_upper = false;
-        } else {
-            result.push(*x);
-        }
-    }
-    String::from_utf8(result).unwrap()
 }
 
 fn get_property_analysis(elem: &ElementRc, p: &str) -> crate::object_tree::PropertyAnalysis {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -49,7 +49,7 @@ macro_rules! declare_enums {
                 Self {
                     $($Name : Rc::new(Enumeration {
                         name: stringify!($Name).replace('_', "-"),
-                        values: vec![$(stringify!($Value).trim_start_matches("r#").replace('_', "-")),*],
+                        values: vec![$(crate::generator::to_kebab_case(stringify!($Value).trim_start_matches("r#"))),*],
                         default_value: 0,
                     })),*
                 }

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -148,26 +148,26 @@ impl<'a> Iterator for ToLyonPathEventIterator<'a> {
         use lyon_path::Event;
 
         self.events_it.next().map(|event| match event {
-            PathEvent::begin => Event::Begin { at: *self.coordinates_it.next().unwrap() },
-            PathEvent::line => Event::Line {
+            PathEvent::Begin => Event::Begin { at: *self.coordinates_it.next().unwrap() },
+            PathEvent::Line => Event::Line {
                 from: *self.coordinates_it.next().unwrap(),
                 to: *self.coordinates_it.next().unwrap(),
             },
-            PathEvent::quadratic => Event::Quadratic {
+            PathEvent::Quadratic => Event::Quadratic {
                 from: *self.coordinates_it.next().unwrap(),
                 ctrl: *self.coordinates_it.next().unwrap(),
                 to: *self.coordinates_it.next().unwrap(),
             },
-            PathEvent::cubic => Event::Cubic {
+            PathEvent::Cubic => Event::Cubic {
                 from: *self.coordinates_it.next().unwrap(),
                 ctrl1: *self.coordinates_it.next().unwrap(),
                 ctrl2: *self.coordinates_it.next().unwrap(),
                 to: *self.coordinates_it.next().unwrap(),
             },
-            PathEvent::end_open => {
+            PathEvent::EndOpen => {
                 Event::End { first: *self.first.unwrap(), last: *self.last.unwrap(), close: false }
             }
-            PathEvent::end_closed => {
+            PathEvent::EndClosed => {
                 Event::End { first: *self.first.unwrap(), last: *self.last.unwrap(), close: true }
             }
         })

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -7,8 +7,8 @@
 
 use crate::graphics::Point;
 use crate::item_tree::{ItemRc, ItemVisitorResult, ItemWeak, VisitChildrenResult};
+pub use crate::items::PointerEventButton;
 use crate::items::{ItemRef, TextCursorDirection};
-pub use crate::items::{KeyEventType, PointerEventButton};
 use crate::window::WindowRc;
 use crate::{component::ComponentRc, SharedString};
 use crate::{Coord, Property};
@@ -143,6 +143,22 @@ pub struct KeyboardModifiers {
     pub meta: bool,
     /// Indicates the shift key on a keyboard.
     pub shift: bool,
+}
+
+/// This enum defines the different kinds of key events that can happen.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C)]
+pub enum KeyEventType {
+    /// A key on a keyboard was pressed.
+    KeyPressed,
+    /// A key on a keyboard was released.
+    KeyReleased,
+}
+
+impl Default for KeyEventType {
+    fn default() -> Self {
+        KeyEventType::KeyPressed
+    }
 }
 
 /// Represents a key event sent by the windowing system.

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -383,13 +383,13 @@ impl Item for TouchArea {
     ) -> InputEventResult {
         if matches!(event, MouseEvent::MouseExit) {
             Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(false);
-            window.set_mouse_cursor(MouseCursor::default);
+            window.set_mouse_cursor(MouseCursor::Default);
         }
         if !self.enabled() {
             return InputEventResult::EventIgnored;
         }
         let result = if let MouseEvent::MouseReleased { pos, button } = event {
-            if button == PointerEventButton::left
+            if button == PointerEventButton::Left
                 && euclid::rect(0 as Coord, 0 as Coord, self.width(), self.height()).contains(pos)
             {
                 Self::FIELD_OFFSETS.clicked.apply_pin(self).call(&());
@@ -402,7 +402,7 @@ impl Item for TouchArea {
         match event {
             MouseEvent::MousePressed { pos, button } => {
                 self.grabbed.set(true);
-                if button == PointerEventButton::left {
+                if button == PointerEventButton::Left {
                     Self::FIELD_OFFSETS.pressed_x.apply_pin(self).set(pos.x);
                     Self::FIELD_OFFSETS.pressed_y.apply_pin(self).set(pos.y);
                     Self::FIELD_OFFSETS.pressed.apply_pin(self).set(true);
@@ -410,26 +410,26 @@ impl Item for TouchArea {
                 Self::FIELD_OFFSETS
                     .pointer_event
                     .apply_pin(self)
-                    .call(&(PointerEvent { button, kind: PointerEventKind::down },));
+                    .call(&(PointerEvent { button, kind: PointerEventKind::Down },));
             }
             MouseEvent::MouseExit => {
                 Self::FIELD_OFFSETS.pressed.apply_pin(self).set(false);
                 if self.grabbed.replace(false) {
                     Self::FIELD_OFFSETS.pointer_event.apply_pin(self).call(&(PointerEvent {
-                        button: PointerEventButton::none,
-                        kind: PointerEventKind::cancel,
+                        button: PointerEventButton::None,
+                        kind: PointerEventKind::Cancel,
                     },));
                 }
             }
             MouseEvent::MouseReleased { button, .. } => {
                 self.grabbed.set(false);
-                if button == PointerEventButton::left {
+                if button == PointerEventButton::Left {
                     Self::FIELD_OFFSETS.pressed.apply_pin(self).set(false);
                 }
                 Self::FIELD_OFFSETS
                     .pointer_event
                     .apply_pin(self)
-                    .call(&(PointerEvent { button, kind: PointerEventKind::up },));
+                    .call(&(PointerEvent { button, kind: PointerEventKind::Up },));
             }
             MouseEvent::MouseMoved { .. } => {
                 return if self.grabbed.get() {
@@ -537,8 +537,8 @@ impl Item for FocusScope {
             }
         };
         match r {
-            EventResult::accept => KeyEventResult::EventAccepted,
-            EventResult::reject => KeyEventResult::EventIgnored,
+            EventResult::Accept => KeyEventResult::EventAccepted,
+            EventResult::Reject => KeyEventResult::EventIgnored,
         }
     }
 
@@ -1133,7 +1133,7 @@ macro_rules! declare_enums {
         $(
             #[derive(Copy, Clone, Debug, PartialEq, Eq, strum::EnumString, strum::Display, Hash)]
             #[repr(C)]
-            #[allow(non_camel_case_types)]
+            #[strum(serialize_all = "kebab-case")]
             $(#[$enum_doc])*
             pub enum $Name {
                 $( $(#[$value_doc])* $Value),*

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -23,7 +23,7 @@ When adding an item or a property, it needs to be kept in sync with different pl
 use crate::graphics::{Brush, Color, Point, Rect};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
-    KeyEventResult, MouseEvent,
+    KeyEventResult, KeyEventType, MouseEvent,
 };
 use crate::item_rendering::CachedRenderingData;
 pub use crate::item_tree::ItemRc;

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -184,7 +184,7 @@ impl FlickableData {
     ) -> InputEventFilterResult {
         let mut inner = self.inner.borrow_mut();
         match event {
-            MouseEvent::MousePressed { pos, button: PointerEventButton::left } => {
+            MouseEvent::MousePressed { pos, button: PointerEventButton::Left } => {
                 inner.pressed_pos = pos;
                 inner.pressed_time = Some(crate::animations::current_tick());
                 inner.pressed_viewport_pos = Point::new(
@@ -202,7 +202,7 @@ impl FlickableData {
                 }
             }
             MouseEvent::MouseExit
-            | MouseEvent::MouseReleased { button: PointerEventButton::left, .. } => {
+            | MouseEvent::MouseReleased { button: PointerEventButton::Left, .. } => {
                 let was_capturing = inner.capture_events;
                 Self::mouse_released(&mut inner, flick, event);
                 if was_capturing {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -73,12 +73,12 @@ impl Item for Text {
             Orientation::Horizontal => {
                 let implicit_size = implicit_size(None);
                 let min = match self.overflow() {
-                    TextOverflow::elide => implicit_size
+                    TextOverflow::Elide => implicit_size
                         .width
                         .min(window.text_size(self.unresolved_font_request(), "…", None).width),
-                    TextOverflow::clip => match self.wrap() {
-                        TextWrap::no_wrap => implicit_size.width,
-                        TextWrap::word_wrap => 0 as Coord,
+                    TextOverflow::Clip => match self.wrap() {
+                        TextWrap::NoWrap => implicit_size.width,
+                        TextWrap::WordWrap => 0 as Coord,
                     },
                 };
                 LayoutInfo {
@@ -89,8 +89,8 @@ impl Item for Text {
             }
             Orientation::Vertical => {
                 let h = match self.wrap() {
-                    TextWrap::no_wrap => implicit_size(None).height,
-                    TextWrap::word_wrap => implicit_size(Some(self.width())).height,
+                    TextWrap::NoWrap => implicit_size(None).height,
+                    TextWrap::WordWrap => implicit_size(Some(self.width())).height,
                 }
                 .ceil();
                 LayoutInfo { min: h, preferred: h, ..LayoutInfo::default() }
@@ -241,8 +241,8 @@ impl Item for TextInput {
             Orientation::Horizontal => {
                 let implicit_size = implicit_size(None);
                 let min = match self.wrap() {
-                    TextWrap::no_wrap => implicit_size.width,
-                    TextWrap::word_wrap => 0 as Coord,
+                    TextWrap::NoWrap => implicit_size.width,
+                    TextWrap::WordWrap => 0 as Coord,
                 };
                 LayoutInfo {
                     min: min.ceil(),
@@ -252,8 +252,8 @@ impl Item for TextInput {
             }
             Orientation::Vertical => {
                 let h = match self.wrap() {
-                    TextWrap::no_wrap => implicit_size(None).height,
-                    TextWrap::word_wrap => implicit_size(Some(self.width())).height,
+                    TextWrap::NoWrap => implicit_size(None).height,
+                    TextWrap::WordWrap => implicit_size(Some(self.width())).height,
                 }
                 .ceil();
                 LayoutInfo { min: h, preferred: h, ..LayoutInfo::default() }
@@ -280,7 +280,7 @@ impl Item for TextInput {
             return InputEventResult::EventIgnored;
         }
         match event {
-            MouseEvent::MousePressed { pos, button: PointerEventButton::left } => {
+            MouseEvent::MousePressed { pos, button: PointerEventButton::Left } => {
                 let clicked_offset = window.text_input_byte_offset_for_position(self, pos) as i32;
                 self.as_ref().pressed.set(true);
                 self.as_ref().anchor_position.set(clicked_offset);
@@ -289,7 +289,7 @@ impl Item for TextInput {
                     window.clone().set_focus_item(self_rc);
                 }
             }
-            MouseEvent::MouseReleased { button: PointerEventButton::left, .. }
+            MouseEvent::MouseReleased { button: PointerEventButton::Left, .. }
             | MouseEvent::MouseExit => self.as_ref().pressed.set(false),
             MouseEvent::MouseMoved { pos } => {
                 if self.as_ref().pressed.get() {

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -485,7 +485,7 @@ pub fn solve_box_layout(data: &BoxLayoutData, repeater_indexes: Slice<u32>) -> S
     let spacings = data.spacing * num_spacings;
 
     let align = match data.alignment {
-        LayoutAlignment::stretch => {
+        LayoutAlignment::Stretch => {
             grid_internal::layout_items(
                 &mut layout_data,
                 data.padding.begin,
@@ -503,18 +503,18 @@ pub fn solve_box_layout(data: &BoxLayoutData, repeater_indexes: Slice<u32>) -> S
             );
             None
         }
-        LayoutAlignment::center => Some((
+        LayoutAlignment::Center => Some((
             data.padding.begin + (size_without_padding - pref_size - spacings) / 2 as Coord,
             data.spacing,
         )),
-        LayoutAlignment::start => Some((data.padding.begin, data.spacing)),
-        LayoutAlignment::end => {
+        LayoutAlignment::Start => Some((data.padding.begin, data.spacing)),
+        LayoutAlignment::End => {
             Some((data.padding.begin + (size_without_padding - pref_size - spacings), data.spacing))
         }
-        LayoutAlignment::space_between => {
+        LayoutAlignment::SpaceBetween => {
             Some((data.padding.begin, (size_without_padding - pref_size) / num_spacings))
         }
-        LayoutAlignment::space_around => {
+        LayoutAlignment::SpaceAround => {
             let spacing = (size_without_padding - pref_size) / (num_spacings + 1 as Coord);
             Some((data.padding.begin + spacing / 2 as Coord, spacing))
         }
@@ -575,7 +575,7 @@ pub fn box_layout_info(
     if count < 1 {
         return LayoutInfo { max: 0 as _, ..LayoutInfo::default() };
     };
-    let is_stretch = alignment == LayoutAlignment::stretch;
+    let is_stretch = alignment == LayoutAlignment::Stretch;
     let extra_w = padding.begin + padding.end + spacing * (count - 1) as Coord;
     let min = cells.iter().map(|c| c.constraint.min).sum::<Coord>() + extra_w;
     let max = if is_stretch {
@@ -756,39 +756,39 @@ pub fn reorder_dialog_button_layout(cells: &mut [GridLayoutCellData], roles: &[D
     let mut idx = 0;
 
     if cfg!(windows) {
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::reset);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Reset);
         idx += 1;
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::accept);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::action);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::reject);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::apply);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::help);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Accept);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Action);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Reject);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Apply);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Help);
     } else if cfg!(target_os = "macos") {
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::help);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::reset);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::apply);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::action);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Help);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Reset);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Apply);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Action);
         idx += 1;
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::reject);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::accept);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Reject);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Accept);
     } else if is_kde() {
         // KDE variant
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::help);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::reset);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Help);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Reset);
         idx += 1;
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::action);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::accept);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::apply);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::reject);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Action);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Accept);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Apply);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Reject);
     } else {
         // GNOME variant and fallback for WASM build
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::help);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::reset);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Help);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Reset);
         idx += 1;
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::action);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::apply);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::reject);
-        add_buttons(cells, roles, &mut idx, DialogButtonRole::accept);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Action);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Apply);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Reject);
+        add_buttons(cells, roles, &mut idx, DialogButtonRole::Accept);
     }
 }
 

--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -628,8 +628,8 @@ impl<T: ProcessScene> SceneBuilder<T> {
                 let source_to_target_y = phys_size.height / (size.height as f32);
                 let mut image_fit_offset = euclid::Vector2D::default();
                 let (source_to_target_x, source_to_target_y) = match image_fit {
-                    ImageFit::fill => (source_to_target_x, source_to_target_y),
-                    ImageFit::cover => {
+                    ImageFit::Fill => (source_to_target_x, source_to_target_y),
+                    ImageFit::Cover => {
                         let ratio = f32::max(source_to_target_x, source_to_target_y);
                         if size.width as f32 > phys_size.width / ratio {
                             let diff = (size.width as f32 - phys_size.width / ratio) as i32;
@@ -643,7 +643,7 @@ impl<T: ProcessScene> SceneBuilder<T> {
                         }
                         (ratio, ratio)
                     }
-                    ImageFit::contain => {
+                    ImageFit::Contain => {
                         let ratio = f32::min(source_to_target_x, source_to_target_y);
                         if (size.width as f32) < phys_size.width / ratio {
                             image_fit_offset.x = (phys_size.width - size.width as f32 * ratio) / 2.;

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -5,8 +5,7 @@
 #![warn(missing_docs)]
 #![allow(unsafe_code)]
 
-use crate::input::{KeyEvent, KeyboardModifiers, MouseEvent};
-use crate::items::KeyEventType;
+use crate::input::{KeyEvent, KeyEventType, KeyboardModifiers, MouseEvent};
 use crate::window::WindowRc;
 use crate::Coord;
 use crate::SharedString;

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -43,14 +43,14 @@ pub extern "C" fn slint_send_mouse_click(
     );
     state = crate::input::process_mouse_input(
         component.clone(),
-        MouseEvent::MousePressed { pos, button: crate::items::PointerEventButton::left },
+        MouseEvent::MousePressed { pos, button: crate::items::PointerEventButton::Left },
         window,
         state,
     );
     slint_mock_elapsed_time(50);
     crate::input::process_mouse_input(
         component.clone(),
-        MouseEvent::MouseReleased { pos, button: crate::items::PointerEventButton::left },
+        MouseEvent::MouseReleased { pos, button: crate::items::PointerEventButton::Left },
         window,
         state,
     );

--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -108,8 +108,8 @@ impl<'a, Font: AbstractFont> TextParagraphLayout<'a, Font> {
             Font::Length,
         ),
     ) -> Font::Length {
-        let wrap = self.wrap == TextWrap::word_wrap;
-        let elide_glyph = if self.overflow == TextOverflow::elide {
+        let wrap = self.wrap == TextWrap::WordWrap;
+        let elide_glyph = if self.overflow == TextOverflow::Elide {
             self.layout.font.glyph_for_char('…')
         } else {
             None
@@ -140,9 +140,9 @@ impl<'a, Font: AbstractFont> TextParagraphLayout<'a, Font> {
         let two = Font::LengthPrimitive::one() + Font::LengthPrimitive::one();
 
         let baseline_y = match self.vertical_alignment {
-            TextVerticalAlignment::top => Font::Length::zero(),
-            TextVerticalAlignment::center => self.max_height / two - text_height() / two,
-            TextVerticalAlignment::bottom => self.max_height - text_height(),
+            TextVerticalAlignment::Top => Font::Length::zero(),
+            TextVerticalAlignment::Center => self.max_height / two - text_height() / two,
+            TextVerticalAlignment::Bottom => self.max_height - text_height(),
         };
 
         let mut y = baseline_y;
@@ -151,12 +151,12 @@ impl<'a, Font: AbstractFont> TextParagraphLayout<'a, Font> {
             |line: &TextLine<Font::Length>,
              glyphs: &[Glyph<Font::Length, Font::PlatformGlyphData>]| {
                 let x = match self.horizontal_alignment {
-                    TextHorizontalAlignment::left => Font::Length::zero(),
-                    TextHorizontalAlignment::center => {
+                    TextHorizontalAlignment::Left => Font::Length::zero(),
+                    TextHorizontalAlignment::Center => {
                         self.max_width / two
                             - euclid::approxord::min(self.max_width, line.text_width) / two
                     }
-                    TextHorizontalAlignment::right => {
+                    TextHorizontalAlignment::Right => {
                         self.max_width - euclid::approxord::min(self.max_width, line.text_width)
                     }
                 };
@@ -285,10 +285,10 @@ fn test_elision() {
         layout: TextLayout { font: &font, letter_spacing: None },
         max_width: 13. * 10.,
         max_height: 10.,
-        horizontal_alignment: TextHorizontalAlignment::left,
-        vertical_alignment: TextVerticalAlignment::top,
-        wrap: TextWrap::no_wrap,
-        overflow: TextOverflow::elide,
+        horizontal_alignment: TextHorizontalAlignment::Left,
+        vertical_alignment: TextVerticalAlignment::Top,
+        wrap: TextWrap::NoWrap,
+        overflow: TextOverflow::Elide,
         single_line: true,
     };
     paragraph.layout_lines(|glyphs, _, _| {
@@ -317,10 +317,10 @@ fn test_exact_fit() {
         layout: TextLayout { font: &font, letter_spacing: None },
         max_width: 4. * 10.,
         max_height: 10.,
-        horizontal_alignment: TextHorizontalAlignment::left,
-        vertical_alignment: TextVerticalAlignment::top,
-        wrap: TextWrap::no_wrap,
-        overflow: TextOverflow::elide,
+        horizontal_alignment: TextHorizontalAlignment::Left,
+        vertical_alignment: TextVerticalAlignment::Top,
+        wrap: TextWrap::NoWrap,
+        overflow: TextOverflow::Elide,
         single_line: true,
     };
     paragraph.layout_lines(|glyphs, _, _| {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -9,9 +9,11 @@
 use crate::api::{CloseRequestResponse, PhysicalPx};
 use crate::component::{ComponentRc, ComponentRef, ComponentWeak};
 use crate::graphics::{Point, Rect, Size};
-use crate::input::{key_codes, KeyEvent, MouseEvent, MouseInputState, TextCursorBlinker};
+use crate::input::{
+    key_codes, KeyEvent, KeyEventType, MouseEvent, MouseInputState, TextCursorBlinker,
+};
 use crate::item_tree::ItemRc;
-use crate::items::{ItemRef, KeyEventType, MouseCursor};
+use crate::items::{ItemRef, MouseCursor};
 use crate::properties::{Property, PropertyTracker};
 use crate::{Callback, Coord};
 use alloc::boxed::Box;

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -257,7 +257,7 @@ macro_rules! declare_value_struct_conversion {
 declare_value_struct_conversion!(struct i_slint_core::model::StandardListViewItem { text });
 declare_value_struct_conversion!(struct i_slint_core::properties::StateInfo { current_state, previous_state, change_time });
 declare_value_struct_conversion!(struct i_slint_core::input::KeyboardModifiers { control, alt, shift, meta });
-declare_value_struct_conversion!(struct i_slint_core::input::KeyEvent { event_type, text, modifiers });
+declare_value_struct_conversion!(struct i_slint_core::input::KeyEvent { text, modifiers, ..Default::default() });
 declare_value_struct_conversion!(struct i_slint_core::layout::LayoutInfo { min, max, min_percent, max_percent, preferred, stretch });
 declare_value_struct_conversion!(struct i_slint_core::graphics::Point { x, y, ..Default::default()});
 declare_value_struct_conversion!(struct i_slint_core::items::PointerEvent { kind, button });

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -36,7 +36,7 @@ let instance = TestCase::new();
 let window = vtable::VRc::from(instance.clone_strong()).window_handle().clone();
 window.clone().process_mouse_input(MouseEvent::MouseMoved { pos: point2(300.0, 100.0) });
 slint::testing::mock_elapsed_time(5000);
-window.clone().process_mouse_input(MouseEvent::MousePressed { pos: point2(300.0, 100.0), button: PointerEventButton::left });
+window.clone().process_mouse_input(MouseEvent::MousePressed { pos: point2(300.0, 100.0), button: PointerEventButton::Left });
 assert_eq!(instance.get_offset_x(), 0.);
 assert_eq!(instance.get_offset_y(), 0.);
 window.clone().process_mouse_input(MouseEvent::MouseMoved { pos: point2(200.0, 50.0) });
@@ -48,7 +48,7 @@ assert_eq!(instance.get_offset_y(), 50.);
 window.clone().process_mouse_input(MouseEvent::MouseMoved { pos: point2(100.0, 50.0) });
 assert_eq!(instance.get_offset_x(), 200.);
 assert_eq!(instance.get_offset_y(), 50.);
-window.clone().process_mouse_input(MouseEvent::MouseReleased { pos: point2(100.0, 50.0), button: PointerEventButton::left });
+window.clone().process_mouse_input(MouseEvent::MouseReleased { pos: point2(100.0, 50.0), button: PointerEventButton::Left });
 // Start of the animation, the position is still unchanged
 assert_eq!(instance.get_offset_x(), 200.);
 assert_eq!(instance.get_offset_y(), 50.);

--- a/xtask/src/enumdocs.rs
+++ b/xtask/src/enumdocs.rs
@@ -32,7 +32,7 @@ The default value of each enum type is always the first value.
                 writeln!(file, "")?;
                 $(
                     let mut has_val = false;
-                    write!(file, "* **`{}`**:", stringify!($Value).trim_start_matches("r#").replace('_', "-"))?;
+                    write!(file, "* **`{}`**:", to_kebab_case(stringify!($Value)))?;
                     $(
                         if has_val {
                             write!(file, "\n   ")?;
@@ -53,4 +53,20 @@ The default value of each enum type is always the first value.
     }
 
     Ok(())
+}
+
+/// Convert a ascii pascal case string to kebab case
+fn to_kebab_case(str: &str) -> String {
+    let mut result = Vec::with_capacity(str.len());
+    for x in str.as_bytes() {
+        if x.is_ascii_uppercase() {
+            if !result.is_empty() {
+                result.push(b'-');
+            }
+            result.push(x.to_ascii_lowercase());
+        } else {
+            result.push(*x);
+        }
+    }
+    String::from_utf8(result).unwrap()
 }


### PR DESCRIPTION
... while still being kebab-case in .slint
    
Some enums might become public API and we want to have them as PascalCase to respect the rust conventions

Not the change to KeyEventType: That enum is not used in any builtin things anyway, so it shouldn't be used at all in .slint code.
