### PR TITLE
Perform resolution of font properties against the window defaults in …

### DIFF
--- a/helper_crates/vtable/CHANGELOG.md
+++ b/helper_crates/vtable/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this crate will be documented in this file.
 
+## [0.1.9] - Unreleased
+
+ - Added `VRc::map_dyn`, the equivalent of `VRc::map` to create a `VRcMapped`
+   when the VRc is already type erased
+
 ## [0.1.8] - 2022-07-05
 
  - Changed the representation of the different types to use NonNull

--- a/helper_crates/vtable/Cargo.toml
+++ b/helper_crates/vtable/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "vtable"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Slint Developers <info@slint-ui.com>"]
 edition = "2021"
 license = "GPL-3.0-only OR LicenseRef-Slint-commercial"

--- a/helper_crates/vtable/src/vrc.rs
+++ b/helper_crates/vtable/src/vrc.rs
@@ -200,7 +200,7 @@ impl<VTable: VTableMetaDropInPlace + 'static> VRc<VTable, Dyn> {
     /// that, you need to provide a mapping function `map_fn` in which you need to provide and return a
     /// pinned reference to the object you would like to map. The returned `VRcMapped` allows obtaining
     /// that pinned reference again using [`VRcMapped::as_pin_ref`].
-    /// This works similar to `VRc::map` except that it works on a type-erased VRc.
+    /// This works similar to [`VRc::map`] except that it works on a type-erased VRc.
     pub fn map_dyn<MappedType: ?Sized>(
         this: Self,
         map_fn: impl for<'r> FnOnce(Pin<VRef<'r, VTable>>) -> Pin<&'r MappedType>,

--- a/helper_crates/vtable/tests/test_vrc.rs
+++ b/helper_crates/vtable/tests/test_vrc.rs
@@ -234,6 +234,24 @@ fn rc_map_test() {
 }
 
 #[test]
+fn rc_map_dyn_test() {
+    fn get_struct_value(instance: &VRcMapped<AppVTable, SomeStruct>) -> u8 {
+        let field_ref = SomeStruct::FIELD_OFFSETS.e.apply_pin(instance.as_pin_ref());
+        *field_ref
+    }
+
+    let app_rc = AppStruct::new();
+    let app_dyn = VRc::into_dyn(app_rc);
+
+    let some_struct_ref = VRc::map_dyn(app_dyn.clone(), |app_dyn| {
+        let app_ref = VRef::downcast_pin(app_dyn).unwrap();
+        AppStruct::FIELD_OFFSETS.some.apply_pin(app_ref)
+    });
+
+    assert_eq!(get_struct_value(&some_struct_ref), 55);
+}
+
+#[test]
 fn rc_map_origin() {
     let app_rc = AppStruct::new();
 

--- a/internal/backends/gl/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/gl/renderer/femtovg/itemrenderer.rs
@@ -241,8 +241,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
         let string = string.as_str();
         let font = fonts::FONT_CACHE.with(|cache| {
             cache.borrow_mut().font(
-                text.unresolved_font_request()
-                    .merge(&self.graphics_window.default_font_properties()),
+                text.font_request(&self.graphics_window.runtime_window()),
                 self.scale_factor,
                 &text.text(),
             )
@@ -280,9 +279,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
 
         let font = fonts::FONT_CACHE.with(|cache| {
             cache.borrow_mut().font(
-                text_input
-                    .unresolved_font_request()
-                    .merge(&self.graphics_window.default_font_properties()),
+                text_input.font_request(&self.graphics_window.runtime_window()),
                 self.scale_factor,
                 &text_input.text(),
             )
@@ -811,13 +808,8 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
     }
 
     fn draw_string(&mut self, string: &str, color: Color) {
-        let font = fonts::FONT_CACHE.with(|cache| {
-            cache.borrow_mut().font(
-                self.graphics_window.default_font_properties(),
-                self.scale_factor,
-                string,
-            )
-        });
+        let font = fonts::FONT_CACHE
+            .with(|cache| cache.borrow_mut().font(Default::default(), self.scale_factor, string));
         let paint = font.init_paint(0.0, femtovg::Paint::color(to_femtovg_color(&color)));
         let mut canvas = self.canvas.borrow_mut();
         canvas.fill_text(0., 0., string, paint).unwrap();

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -194,7 +194,7 @@ mod the_backend {
         ) -> Size {
             let runtime_window = self.self_weak.upgrade().unwrap();
             renderer::fonts::text_size(
-                font_request.merge(&runtime_window.default_font_properties()),
+                font_request,
                 text,
                 max_width,
                 ScaleFactor::new(runtime_window.scale_factor()),

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -211,7 +211,7 @@ impl PlatformWindow for SimulatorWindow {
     ) -> i_slint_core::graphics::Size {
         let runtime_window = self.self_weak.upgrade().unwrap();
         crate::renderer::fonts::text_size(
-            font_request.merge(&self.self_weak.upgrade().unwrap().default_font_properties()),
+            font_request,
             text,
             max_width,
             crate::ScaleFactor::new(runtime_window.scale_factor()),

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -143,20 +143,6 @@ pub struct FontRequest {
     pub letter_spacing: Option<Coord>,
 }
 
-impl FontRequest {
-    /// Consumes the FontRequest, replaces any missing fields from the specified other request and
-    /// returns the new request.
-    #[must_use]
-    pub fn merge(self, other: &FontRequest) -> Self {
-        Self {
-            family: self.family.or_else(|| other.family.clone()),
-            weight: self.weight.or(other.weight),
-            pixel_size: self.pixel_size.or(other.pixel_size),
-            letter_spacing: self.letter_spacing.or(other.letter_spacing),
-        }
-    }
-}
-
 #[cfg(feature = "ffi")]
 pub(crate) mod ffi {
     #![allow(unsafe_code)]

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1000,7 +1000,7 @@ impl WindowItem {
         }
     }
 
-    pub fn font_size(self: Pin<&Self>) -> Option<f32> {
+    pub fn font_size(self: Pin<&Self>) -> Option<Coord> {
         let font_size = self.default_font_size();
         if font_size <= 0 as Coord {
             None

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -991,34 +991,30 @@ impl Item for WindowItem {
 }
 
 impl WindowItem {
-    /// Returns the font properties that can be used as defaults for child items
-    pub fn default_font_properties(self: Pin<&Self>) -> crate::graphics::FontRequest {
-        crate::graphics::FontRequest {
-            family: {
-                let maybe_family = self.default_font_family();
-                if !maybe_family.is_empty() {
-                    Some(maybe_family)
-                } else {
-                    None
-                }
-            },
-            pixel_size: {
-                let font_size = self.default_font_size();
-                if font_size <= 0 as Coord {
-                    None
-                } else {
-                    Some(font_size)
-                }
-            },
-            weight: {
-                let font_weight = self.default_font_weight();
-                if font_weight == 0 {
-                    None
-                } else {
-                    Some(font_weight)
-                }
-            },
-            ..Default::default()
+    pub fn font_family(self: Pin<&Self>) -> Option<SharedString> {
+        let maybe_family = self.default_font_family();
+        if !maybe_family.is_empty() {
+            Some(maybe_family)
+        } else {
+            None
+        }
+    }
+
+    pub fn font_size(self: Pin<&Self>) -> Option<f32> {
+        let font_size = self.default_font_size();
+        if font_size <= 0 as Coord {
+            None
+        } else {
+            Some(font_size)
+        }
+    }
+
+    pub fn font_weight(self: Pin<&Self>) -> Option<i32> {
+        let font_weight = self.default_font_weight();
+        if font_weight == 0 {
+            None
+        } else {
+            Some(font_weight)
         }
     }
 }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -9,7 +9,7 @@ Lookup the [`crate::items`] module documentation.
 */
 
 use super::{
-    InputType, Item, ItemConsts, ItemRc, ItemRef, KeyEventResult, KeyEventType, PointArg,
+    InputType, Item, ItemConsts, ItemRc, KeyEventResult, KeyEventType, PointArg,
     PointerEventButton, RenderingResult, TextHorizontalAlignment, TextOverflow,
     TextVerticalAlignment, TextWrap, VoidArg,
 };
@@ -142,9 +142,6 @@ impl ItemConsts for Text {
 impl Text {
     pub fn font_request(self: Pin<&Self>, window: &WindowRc) -> FontRequest {
         let window_item = window.window_item();
-        let window_item = window_item.as_ref().map(|window_item| ItemRc::borrow(window_item));
-        let window_item = window_item
-            .and_then(|window_item| ItemRef::downcast_pin::<crate::items::WindowItem>(window_item));
 
         FontRequest {
             family: {
@@ -152,13 +149,13 @@ impl Text {
                 if !maybe_family.is_empty() {
                     Some(maybe_family)
                 } else {
-                    window_item.and_then(|item| item.font_family())
+                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_family())
                 }
             },
             weight: {
                 let weight = self.font_weight();
                 if weight == 0 {
-                    window_item.and_then(|item| item.font_weight())
+                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_weight())
                 } else {
                     Some(weight)
                 }
@@ -166,7 +163,7 @@ impl Text {
             pixel_size: {
                 let font_size = self.font_size();
                 if font_size == 0 as Coord {
-                    window_item.and_then(|item| item.font_size())
+                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_size())
                 } else {
                     Some(font_size)
                 }
@@ -737,9 +734,6 @@ impl TextInput {
 
     pub fn font_request(self: Pin<&Self>, window: &WindowRc) -> FontRequest {
         let window_item = window.window_item();
-        let window_item = window_item.as_ref().map(|window_item| ItemRc::borrow(window_item));
-        let window_item = window_item
-            .and_then(|window_item| ItemRef::downcast_pin::<crate::items::WindowItem>(window_item));
 
         FontRequest {
             family: {
@@ -747,13 +741,13 @@ impl TextInput {
                 if !maybe_family.is_empty() {
                     Some(maybe_family)
                 } else {
-                    window_item.and_then(|item| item.font_family())
+                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_family())
                 }
             },
             weight: {
                 let weight = self.font_weight();
                 if weight == 0 {
-                    window_item.and_then(|item| item.font_weight())
+                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_weight())
                 } else {
                     Some(weight)
                 }
@@ -761,7 +755,7 @@ impl TextInput {
             pixel_size: {
                 let font_size = self.font_size();
                 if font_size == 0 as Coord {
-                    window_item.and_then(|item| item.font_size())
+                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_size())
                 } else {
                     Some(font_size)
                 }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -684,19 +684,15 @@ impl WindowInner {
         self.scale_factor.as_ref().set(factor)
     }
 
-    /// Returns the font properties that are set on the root item if it's a Window item.
-    pub fn default_font_properties(&self) -> crate::graphics::FontRequest {
-        self.try_component()
-            .and_then(|component_rc| {
-                let component = ComponentRc::borrow_pin(&component_rc);
-                let root_item = component.as_ref().get_item_ref(0);
-                ItemRef::downcast_pin(root_item).map(
-                    |window_item: Pin<&crate::items::WindowItem>| {
-                        window_item.default_font_properties()
-                    },
-                )
-            })
-            .unwrap_or_default()
+    /// Returns the window item that is the first item in the component.
+    pub fn window_item(&self) -> Option<ItemRc> {
+        self.try_component().map(|component_rc| {
+            debug_assert!(ItemRef::downcast_pin::<crate::items::WindowItem>(
+                ComponentRc::borrow_pin(&component_rc).as_ref().get_item_ref(0)
+            )
+            .is_some());
+            ItemRc::new(component_rc, 0)
+        })
     }
 
     /// Sets the size of the window item. This method is typically called in response to receiving a

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -7,7 +7,7 @@
 //! Exposed Window API
 
 use crate::api::{CloseRequestResponse, PhysicalPx, Window};
-use crate::component::{ComponentRc, ComponentRef, ComponentWeak};
+use crate::component::{ComponentRc, ComponentRef, ComponentVTable, ComponentWeak};
 use crate::graphics::{Point, Rect, Size};
 use crate::input::{
     key_codes, KeyEvent, KeyEventType, MouseEvent, MouseInputState, TextCursorBlinker,
@@ -21,6 +21,7 @@ use alloc::rc::{Rc, Weak};
 use alloc::string::String;
 use core::cell::{Cell, RefCell};
 use core::pin::Pin;
+use vtable::VRcMapped;
 
 fn next_focus_item(item: ItemRc) -> ItemRc {
     item.next_focus_item()
@@ -685,13 +686,9 @@ impl WindowInner {
     }
 
     /// Returns the window item that is the first item in the component.
-    pub fn window_item(&self) -> Option<ItemRc> {
-        self.try_component().map(|component_rc| {
-            debug_assert!(ItemRef::downcast_pin::<crate::items::WindowItem>(
-                ComponentRc::borrow_pin(&component_rc).as_ref().get_item_ref(0)
-            )
-            .is_some());
-            ItemRc::new(component_rc, 0)
+    pub fn window_item(&self) -> Option<VRcMapped<ComponentVTable, crate::items::WindowItem>> {
+        self.try_component().and_then(|component_rc| {
+            ItemRc::new(component_rc, 0).downcast::<crate::items::WindowItem>()
         })
     }
 


### PR DESCRIPTION
…the core library

This simplifies the renderer handling - the FontRequest arriving there
will always be resolved.

And this reduces the amount of property dependencies: If a Text elements
specifies a font-family, no dependency to the window's
default-font-family is created.