### PR TITLE
Fix the AboutSlint in fluent style with dark style desktop

### DIFF
--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -99,7 +99,7 @@ export AboutSlint := Rectangle {
             horizontal-alignment: center;
         }
         Image {
-            source: NativeStyleMetrics.dark-style ? @image-url("slint-logo-dark.svg") : @image-url("slint-logo-light.svg");
+            source: StyleMetrics.dark-style ? @image-url("slint-logo-dark.svg") : @image-url("slint-logo-light.svg");
             preferred-width: 256px;
         }
         Text {

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -65,6 +65,7 @@ export global StyleMetrics := {
     property<color> textedit-text-color: Palette.neutralPrimary;
     property<brush> textedit-background-disabled: Palette.neutralLighter;
     property<color> textedit-text-color-disabled: Palette.neutralTertiary;
+    property<bool> dark-style: false;
 }
 
 export Button := Rectangle {


### PR DESCRIPTION
The widget should not reach into the NativeStyleMetrics directly,
it should get the information from the StyleMetrics which return
the right value (which is not dark style, for the fluent style)