### PR TITLE
Detect loop on the property itself

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -166,8 +166,12 @@ fn analyse_binding(
     if context.currently_analyzing.back().map_or(false, |r| r == current)
         && !element.borrow().bindings[name].borrow().two_way_bindings.is_empty()
     {
-        // This is already reported as an error by the remove_alias pass.
-        // FIXME: maybe we should report it there instead
+        let span = element.borrow().bindings[name]
+            .borrow()
+            .span
+            .clone()
+            .or_else(|| element.borrow().node.as_ref().map(|n| n.to_source_location()));
+        diag.push_error(format!("Property '{name}' cannot refer to itself"), &span);
         return depends_on_external;
     }
 

--- a/internal/compiler/tests/syntax/analysis/binding_loop2.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop2.slint
@@ -31,6 +31,10 @@ T3 := Rectangle {
     }
 }
 
+T4 := Rectangle {
+    property <length> my_property <=> x;
+}
+
 App := Rectangle {
 
 
@@ -40,5 +44,8 @@ App := Rectangle {
 //               ^error{The binding for the property 'foo' is part of a binding loop}
         T3 { hello: al; }
 //                 ^error{The binding for the property 'hello' is part of a binding loop}
+
+        T4 { my_property: my_property; }
+//                       ^error{Property 'my-property' cannot refer to itself}
     }
 }


### PR DESCRIPTION
This is the most basic loop and we wouldn't show a signal.

Turn out the comment was wrong and we do not seem to emit the error
twice for two ways binding to itself

Fixes #1407