### PR TITLE
Rename `i_slint_core::window::Window` into `WindowInner` and use the public Window in the interface

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -304,7 +304,7 @@ pub mod re_exports {
     pub use i_slint_core::model::*;
     pub use i_slint_core::properties::{set_state_binding, Property, PropertyTracker, StateInfo};
     pub use i_slint_core::slice::Slice;
-    pub use i_slint_core::window::{Window, WindowHandleAccess, WindowRc};
+    pub use i_slint_core::window::{WindowHandleAccess, WindowInner, WindowRc};
     pub use i_slint_core::Color;
     pub use i_slint_core::ComponentVTable_static;
     pub use i_slint_core::Coord;

--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -23,7 +23,7 @@ use winit::event::WindowEvent;
 use winit::platform::run_return::EventLoopExtRunReturn;
 
 pub trait WinitWindow: PlatformWindow {
-    fn runtime_window(&self) -> Rc<corelib::window::Window>;
+    fn runtime_window(&self) -> Rc<corelib::window::WindowInner>;
     fn currently_pressed_key_code(&self) -> &Cell<Option<winit::event::VirtualKeyCode>>;
     fn current_keyboard_modifiers(&self) -> &Cell<KeyboardModifiers>;
     fn draw(self: Rc<Self>);

--- a/internal/backends/gl/glwindow.rs
+++ b/internal/backends/gl/glwindow.rs
@@ -31,7 +31,7 @@ pub const PASSWORD_CHARACTER: &str = "●";
 /// GraphicsWindow is an implementation of the [PlatformWindow][`crate::eventloop::PlatformWindow`] trait. This is
 /// typically instantiated by entry factory functions of the different graphics back ends.
 pub struct GLWindow {
-    self_weak: Weak<corelib::window::Window>,
+    self_weak: Weak<corelib::window::WindowInner>,
     map_state: RefCell<GraphicsWindowBackendState>,
     keyboard_modifiers: std::cell::Cell<KeyboardModifiers>,
     currently_pressed_key_code: std::cell::Cell<Option<winit::event::VirtualKeyCode>>,
@@ -54,7 +54,7 @@ impl GLWindow {
     ///   of the window changes to mapped. The event loop and window builder parameters can be used to create a
     ///   backing window.
     pub(crate) fn new(
-        window_weak: &Weak<corelib::window::Window>,
+        window_weak: &Weak<corelib::window::WindowInner>,
         #[cfg(target_arch = "wasm32")] canvas_id: String,
     ) -> Rc<Self> {
         Rc::new(Self {
@@ -153,7 +153,7 @@ impl GLWindow {
 }
 
 impl WinitWindow for GLWindow {
-    fn runtime_window(&self) -> Rc<corelib::window::Window> {
+    fn runtime_window(&self) -> Rc<corelib::window::WindowInner> {
         self.self_weak.upgrade().unwrap()
     }
 

--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 
 use std::rc::Rc;
 
-use i_slint_core::window::Window;
+use i_slint_core::window::WindowInner;
 
 mod glwindow;
 use glwindow::*;
@@ -25,8 +25,8 @@ pub(crate) mod wasm_input_helper;
 mod stylemetrics;
 
 #[cfg(target_arch = "wasm32")]
-pub fn create_gl_window_with_canvas_id(canvas_id: String) -> Rc<Window> {
-    i_slint_core::window::Window::new(|window| GLWindow::new(window, canvas_id))
+pub fn create_gl_window_with_canvas_id(canvas_id: String) -> Rc<WindowInner> {
+    i_slint_core::window::WindowInner::new(|window| GLWindow::new(window, canvas_id))
 }
 
 #[doc(hidden)]
@@ -46,8 +46,8 @@ pub use stylemetrics::native_style_metrics_init;
 
 pub struct Backend;
 impl i_slint_core::backend::Backend for Backend {
-    fn create_window(&'static self) -> Rc<Window> {
-        i_slint_core::window::Window::new(|window| {
+    fn create_window(&'static self) -> Rc<WindowInner> {
+        i_slint_core::window::WindowInner::new(|window| {
             GLWindow::new(
                 window,
                 #[cfg(target_arch = "wasm32")]

--- a/internal/backends/gl/wasm_input_helper.rs
+++ b/internal/backends/gl/wasm_input_helper.rs
@@ -66,7 +66,7 @@ impl WasmInputState {
 impl WasmInputHelper {
     #[allow(unused)]
     pub fn new(
-        window: Weak<i_slint_core::window::Window>,
+        window: Weak<i_slint_core::window::WindowInner>,
         canvas: web_sys::HtmlCanvasElement,
     ) -> Self {
         let input = web_sys::window()

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -122,7 +122,7 @@ mod the_backend {
     use core::pin::Pin;
     use i_slint_core::api::PhysicalPx;
     use i_slint_core::component::ComponentRc;
-    use i_slint_core::graphics::{Color, Point, Rect, Size};
+    use i_slint_core::graphics::{Point, Rect, Size};
     use i_slint_core::items::ItemRef;
     use i_slint_core::window::PlatformWindow;
     use i_slint_core::window::WindowInner;
@@ -133,7 +133,6 @@ mod the_backend {
     pub struct McuWindow {
         backend: &'static MCUBackend,
         self_weak: Weak<WindowInner>,
-        background_color: Cell<Color>,
         initial_dirty_region_for_next_frame: Cell<i_slint_core::item_rendering::DirtyRegion>,
     }
 
@@ -187,17 +186,6 @@ mod the_backend {
             }
         }
 
-        fn request_window_properties_update(&self) {}
-        fn apply_window_properties(&self, window_item: Pin<&i_slint_core::items::WindowItem>) {
-            self.background_color.set(window_item.background());
-        }
-        fn apply_geometry_constraint(
-            &self,
-            _constraints_horizontal: i_slint_core::layout::LayoutInfo,
-            _constraints_vertical: i_slint_core::layout::LayoutInfo,
-        ) {
-        }
-        fn set_mouse_cursor(&self, _cursor: i_slint_core::items::MouseCursor) {}
         fn text_size(
             &self,
             font_request: i_slint_core::graphics::FontRequest,
@@ -414,7 +402,6 @@ mod the_backend {
                 Rc::new(McuWindow {
                     backend: self,
                     self_weak: window.clone(),
-                    background_color: Color::from_rgb_u8(0, 0, 0).into(),
                     initial_dirty_region_for_next_frame: Default::default(),
                 })
             })

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -125,14 +125,14 @@ mod the_backend {
     use i_slint_core::graphics::{Color, Point, Rect, Size};
     use i_slint_core::items::ItemRef;
     use i_slint_core::window::PlatformWindow;
-    use i_slint_core::window::Window;
+    use i_slint_core::window::WindowInner;
     use i_slint_core::Coord;
 
     thread_local! { static WINDOWS: RefCell<Option<Rc<McuWindow>>> = RefCell::new(None) }
 
     pub struct McuWindow {
         backend: &'static MCUBackend,
-        self_weak: Weak<Window>,
+        self_weak: Weak<WindowInner>,
         background_color: Cell<Color>,
         initial_dirty_region_for_next_frame: Cell<i_slint_core::item_rendering::DirtyRegion>,
     }
@@ -409,8 +409,8 @@ mod the_backend {
     }
 
     impl i_slint_core::backend::Backend for MCUBackend {
-        fn create_window(&'static self) -> Rc<i_slint_core::window::Window> {
-            i_slint_core::window::Window::new(|window| {
+        fn create_window(&'static self) -> Rc<i_slint_core::window::WindowInner> {
+            i_slint_core::window::WindowInner::new(|window| {
                 Rc::new(McuWindow {
                     backend: self,
                     self_weak: window.clone(),

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -325,7 +325,7 @@ mod the_backend {
                     );
                     let new_dirty_region = RENDERER.with(|renderer| {
                         renderer.borrow().render(
-                            runtime_window,
+                            &runtime_window.into(),
                             init_dirty.union(&prev_dirty),
                             buffer,
                             screen_size.width_length(),
@@ -398,7 +398,7 @@ mod the_backend {
 
                 RENDERER.with(|renderer| {
                     renderer.borrow().render_by_line(
-                        runtime_window,
+                        &runtime_window.into(),
                         window.initial_dirty_region_for_next_frame.take(),
                         buffer_provider,
                     )

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -14,7 +14,7 @@ use i_slint_core::input::KeyboardModifiers;
 use i_slint_core::item_rendering::DirtyRegion;
 use i_slint_core::items::{Item, ItemRef, WindowItem};
 use i_slint_core::layout::Orientation;
-use i_slint_core::window::{PlatformWindow, Window};
+use i_slint_core::window::{PlatformWindow, WindowInner};
 use i_slint_core::{Color, Coord};
 use rgb::FromSlice;
 
@@ -30,7 +30,7 @@ mod glcontext;
 use glcontext::*;
 
 pub struct SimulatorWindow {
-    self_weak: Weak<i_slint_core::window::Window>,
+    self_weak: Weak<i_slint_core::window::WindowInner>,
     keyboard_modifiers: std::cell::Cell<KeyboardModifiers>,
     currently_pressed_key_code: std::cell::Cell<Option<winit::event::VirtualKeyCode>>,
     canvas: CanvasRc,
@@ -43,7 +43,7 @@ pub struct SimulatorWindow {
 }
 
 impl SimulatorWindow {
-    pub(crate) fn new(window_weak: &Weak<i_slint_core::window::Window>) -> Rc<Self> {
+    pub(crate) fn new(window_weak: &Weak<i_slint_core::window::WindowInner>) -> Rc<Self> {
         let window_builder = winit::window::WindowBuilder::new().with_visible(false);
 
         let opengl_context = OpenGLContext::new_context(window_builder);
@@ -257,7 +257,7 @@ impl PlatformWindow for SimulatorWindow {
 }
 
 impl WinitWindow for SimulatorWindow {
-    fn runtime_window(&self) -> Rc<i_slint_core::window::Window> {
+    fn runtime_window(&self) -> Rc<i_slint_core::window::WindowInner> {
         self.self_weak.upgrade().unwrap()
     }
 
@@ -402,8 +402,8 @@ impl WinitWindow for SimulatorWindow {
 pub struct SimulatorBackend;
 
 impl i_slint_core::backend::Backend for SimulatorBackend {
-    fn create_window(&'static self) -> Rc<Window> {
-        i_slint_core::window::Window::new(|window| SimulatorWindow::new(window))
+    fn create_window(&'static self) -> Rc<WindowInner> {
+        i_slint_core::window::WindowInner::new(|window| SimulatorWindow::new(window))
     }
 
     fn run_event_loop(&'static self, behavior: i_slint_core::backend::EventLoopQuitBehavior) {

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -329,7 +329,7 @@ impl WinitWindow for SimulatorWindow {
             }
             super::RENDERER.with(|renderer| {
                 renderer.borrow().render_by_line(
-                    runtime_window,
+                    &runtime_window.into(),
                     self.initial_dirty_region_for_next_frame.take(),
                     BufferProvider { devices: display, dirty_region: Default::default() },
                 )

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -9,7 +9,7 @@
 
 extern crate alloc;
 
-use i_slint_core::window::Window;
+use i_slint_core::window::WindowInner;
 
 #[cfg(not(no_qt))]
 mod qt_accessible;
@@ -137,12 +137,12 @@ pub fn native_style_metrics_deinit(_: core::pin::Pin<&mut native_widgets::Native
 
 pub struct Backend;
 impl i_slint_core::backend::Backend for Backend {
-    fn create_window(&'static self) -> std::rc::Rc<Window> {
+    fn create_window(&'static self) -> std::rc::Rc<WindowInner> {
         #[cfg(no_qt)]
         panic!("The Qt backend needs Qt");
         #[cfg(not(no_qt))]
         {
-            i_slint_core::window::Window::new(|window| qt_window::QtWindow::new(window))
+            i_slint_core::window::WindowInner::new(|window| qt_window::QtWindow::new(window))
         }
     }
 

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -327,7 +327,7 @@ cpp! {{
     };
 
     void *root_item_for_window(void *rustWindow) {
-        return rust!(root_item_for_window_ [rustWindow: &i_slint_core::window::Window as "void*"]
+        return rust!(root_item_for_window_ [rustWindow: &i_slint_core::window::WindowInner as "void*"]
                 -> *mut c_void as "void*" {
             let root_item = Box::new(ItemRc::new(rustWindow.component(), 0).downgrade());
             Box::into_raw(root_item) as _

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1486,7 +1486,7 @@ impl PlatformWindow for QtWindow {
         self.tree_structure_changed.replace(true);
     }
 
-    fn create_popup(&self, geometry: Rect) -> Option<Rc<i_slint_core::window::WindowInner>> {
+    fn create_popup(&self, geometry: Rect) -> Option<i_slint_core::api::Window> {
         let window = i_slint_core::window::WindowInner::new(|window| QtWindow::new(window));
         let popup_window: &QtWindow =
             <dyn std::any::Any>::downcast_ref(window.as_ref().as_any()).unwrap();
@@ -1503,7 +1503,7 @@ impl PlatformWindow for QtWindow {
             popup_ptr->setGeometry(QRect(pos + widget_ptr->mapToGlobal(QPoint(0,0)), size));
             popup_ptr->show();
         }};
-        Some(window)
+        Some(window.into())
     }
 
     fn set_mouse_cursor(&self, cursor: MouseCursor) {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1203,7 +1203,7 @@ cpp_class!(unsafe struct QWidgetPtr as "std::unique_ptr<QWidget>");
 
 pub struct QtWindow {
     widget_ptr: QWidgetPtr,
-    pub(crate) self_weak: Weak<i_slint_core::window::Window>,
+    pub(crate) self_weak: Weak<i_slint_core::window::WindowInner>,
 
     rendering_metrics_collector: RefCell<Option<Rc<RenderingMetricsCollector>>>,
 
@@ -1213,7 +1213,7 @@ pub struct QtWindow {
 }
 
 impl QtWindow {
-    pub fn new(window_weak: &Weak<i_slint_core::window::Window>) -> Rc<Self> {
+    pub fn new(window_weak: &Weak<i_slint_core::window::WindowInner>) -> Rc<Self> {
         let window_ptr = window_weak.clone().into_raw();
         let widget_ptr = cpp! {unsafe [window_ptr as "void*"] -> QWidgetPtr as "std::unique_ptr<QWidget>" {
             ensure_initialized(true);
@@ -1486,8 +1486,8 @@ impl PlatformWindow for QtWindow {
         self.tree_structure_changed.replace(true);
     }
 
-    fn create_popup(&self, geometry: Rect) -> Option<Rc<i_slint_core::window::Window>> {
-        let window = i_slint_core::window::Window::new(|window| QtWindow::new(window));
+    fn create_popup(&self, geometry: Rect) -> Option<Rc<i_slint_core::window::WindowInner>> {
+        let window = i_slint_core::window::WindowInner::new(|window| QtWindow::new(window));
         let popup_window: &QtWindow =
             <dyn std::any::Any>::downcast_ref(window.as_ref().as_any()).unwrap();
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -7,7 +7,7 @@
 use i_slint_core::api::euclid;
 use i_slint_core::api::PhysicalPx;
 use i_slint_core::graphics::{Point, Rect, Size};
-use i_slint_core::window::{PlatformWindow, Window};
+use i_slint_core::window::{PlatformWindow, WindowInner};
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Mutex;
@@ -18,8 +18,8 @@ pub struct TestingBackend {
 }
 
 impl i_slint_core::backend::Backend for TestingBackend {
-    fn create_window(&'static self) -> Rc<Window> {
-        Window::new(|_| Rc::new(TestingWindow { backend: self }))
+    fn create_window(&'static self) -> Rc<WindowInner> {
+        WindowInner::new(|_| Rc::new(TestingWindow { backend: self }))
     }
 
     fn run_event_loop(&'static self, _behavior: i_slint_core::backend::EventLoopQuitBehavior) {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1225,7 +1225,7 @@ fn generate_item_tree(
         }
 
         impl slint::re_exports::WindowHandleAccess for #inner_component_id {
-            fn window_handle(&self) -> &slint::re_exports::Rc<slint::re_exports::Window> {
+            fn window_handle(&self) -> &slint::re_exports::Rc<slint::re_exports::WindowInner> {
                 self.window.get().unwrap().window_handle()
             }
         }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -193,7 +193,7 @@ impl Window {
 }
 
 impl crate::window::WindowHandleAccess for Window {
-    fn window_handle(&self) -> &Rc<crate::window::Window> {
+    fn window_handle(&self) -> &Rc<crate::window::WindowInner> {
         &self.0
     }
 }

--- a/internal/core/backend.rs
+++ b/internal/core/backend.rs
@@ -8,7 +8,7 @@ The backend is the abstraction for crates that need to do the actual drawing and
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 
-use crate::window::Window;
+use crate::window::WindowInner;
 
 #[cfg(feature = "std")]
 use once_cell::sync::OnceCell;
@@ -29,7 +29,7 @@ pub enum EventLoopQuitBehavior {
 pub trait Backend: Send + Sync {
     /// Instantiate a window for a component.
     /// FIXME: should return a Box<dyn PlatformWindow>
-    fn create_window(&'static self) -> Rc<Window>;
+    fn create_window(&'static self) -> Rc<WindowInner>;
 
     /// Spins an event loop and renders the visible windows.
     fn run_event_loop(&'static self, behavior: EventLoopQuitBehavior);

--- a/internal/core/graphics/rendering_metrics_collector.rs
+++ b/internal/core/graphics/rendering_metrics_collector.rs
@@ -59,7 +59,7 @@ pub struct RenderingMetricsCollector {
     refresh_mode: RefreshMode,
     output_console: bool,
     output_overlay: bool,
-    window: Weak<crate::window::Window>,
+    window: Weak<crate::window::WindowInner>,
 }
 
 impl RenderingMetricsCollector {
@@ -72,7 +72,7 @@ impl RenderingMetricsCollector {
     ///
     /// If enabled, this will also print out some system information such as whether
     /// this is a debug or release build, as well as the provided winsys_info string.
-    pub fn new(window: Weak<crate::window::Window>, winsys_info: &str) -> Option<Rc<Self>> {
+    pub fn new(window: Weak<crate::window::WindowInner>, winsys_info: &str) -> Option<Rc<Self>> {
         let options = match std::env::var("SLINT_DEBUG_PERFORMANCE") {
             Ok(var) => var,
             _ => return None,

--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -4,6 +4,7 @@
 mod draw_functions;
 pub mod fonts;
 
+use crate::api::Window;
 use crate::graphics::{FontRequest, IntRect, PixelFormat, Rect as RectF};
 use crate::item_rendering::{ItemRenderer, PartialRenderingCache};
 use crate::items::{ImageFit, ItemRc};
@@ -12,6 +13,7 @@ use crate::lengths::{
     PhysicalPx, PhysicalRect, PhysicalSize, PointLengths, RectLengths, ScaleFactor, SizeLengths,
 };
 use crate::textlayout::{FontMetrics as _, TextParagraphLayout};
+use crate::window::WindowHandleAccess;
 use crate::{Color, Coord, ImageInner, StaticTextures};
 use alloc::rc::Rc;
 use alloc::{vec, vec::Vec};
@@ -51,11 +53,12 @@ impl SoftwareRenderer {
     /// returns the dirty region for this frame (not including the initial_dirty_region)
     pub fn render(
         &self,
-        window: Rc<crate::window::WindowInner>,
+        window: &Window,
         initial_dirty_region: DirtyRegion,
         buffer: &mut [impl TargetPixel],
         buffer_stride: PhysicalLength,
     ) -> DirtyRegion {
+        let window = window.window_handle().clone();
         let component_rc = window.component();
         let component = crate::component::ComponentRc::borrow_pin(&component_rc);
         let factor = ScaleFactor::new(window.scale_factor());
@@ -128,10 +131,11 @@ impl SoftwareRenderer {
     /// TODO: should `initial_dirty_region` be set from a different call?
     pub fn render_by_line(
         &self,
-        window: Rc<crate::window::WindowInner>,
+        window: &Window,
         initial_dirty_region: crate::item_rendering::DirtyRegion,
         line_buffer: impl LineBufferProvider,
     ) {
+        let window = window.window_handle().clone();
         let component_rc = window.component();
         let component = crate::component::ComponentRc::borrow_pin(&component_rc);
         if let Some(window_item) = crate::items::ItemRef::downcast_pin::<crate::items::WindowItem>(

--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -51,7 +51,7 @@ impl SoftwareRenderer {
     /// returns the dirty region for this frame (not including the initial_dirty_region)
     pub fn render(
         &self,
-        window: Rc<crate::window::Window>,
+        window: Rc<crate::window::WindowInner>,
         initial_dirty_region: DirtyRegion,
         buffer: &mut [impl TargetPixel],
         buffer_stride: PhysicalLength,
@@ -128,7 +128,7 @@ impl SoftwareRenderer {
     /// TODO: should `initial_dirty_region` be set from a different call?
     pub fn render_by_line(
         &self,
-        window: Rc<crate::window::Window>,
+        window: Rc<crate::window::WindowInner>,
         initial_dirty_region: crate::item_rendering::DirtyRegion,
         line_buffer: impl LineBufferProvider,
     ) {
@@ -163,7 +163,7 @@ impl SoftwareRenderer {
 }
 
 fn render_window_frame_by_line(
-    runtime_window: Rc<crate::window::Window>,
+    runtime_window: Rc<crate::window::WindowInner>,
     background: Color,
     size: PhysicalSize,
     initial_dirty_region: crate::item_rendering::DirtyRegion,
@@ -434,7 +434,7 @@ struct RoundedRectangle {
 }
 
 fn prepare_scene(
-    runtime_window: Rc<crate::window::Window>,
+    runtime_window: Rc<crate::window::WindowInner>,
     size: PhysicalSize,
     initial_dirty_region: crate::item_rendering::DirtyRegion,
     line_buffer: &mut impl LineBufferProvider,

--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -125,7 +125,6 @@ impl SoftwareRenderer {
     /// which are dirty. The `initial_dirty_region` is an extra dirty regin which will also
     /// be rendered.
     ///
-    /// TODO: the window should be the public slint::Window type
     /// TODO: what about async and threading.
     ///       (can we call the line_buffer function from different thread?)
     /// TODO: should `initial_dirty_region` be set from a different call?

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -78,20 +78,21 @@ pub trait PlatformWindow {
     fn close_popup(&self, _popup: &PopupWindow) {}
 
     /// Request for the event loop to wake up and call [`Window::update_window_properties()`].
-    fn request_window_properties_update(&self);
+    fn request_window_properties_update(&self) {}
     /// Request for the given title string to be set to the windowing system for use as window title.
-    fn apply_window_properties(&self, window_item: Pin<&crate::items::WindowItem>);
+    fn apply_window_properties(&self, _window_item: Pin<&crate::items::WindowItem>) {}
 
     /// Apply the given horizontal and vertical constraints to the window. This typically involves communication
     /// minimum/maximum sizes to the windowing system, for example.
     fn apply_geometry_constraint(
         &self,
-        constraints_horizontal: crate::layout::LayoutInfo,
-        constraints_vertical: crate::layout::LayoutInfo,
-    );
+        _constraints_horizontal: crate::layout::LayoutInfo,
+        _constraints_vertical: crate::layout::LayoutInfo,
+    ) {
+    }
 
     /// Set the mouse cursor
-    fn set_mouse_cursor(&self, cursor: MouseCursor);
+    fn set_mouse_cursor(&self, _cursor: MouseCursor) {}
 
     /// Returns the size of the given text in logical pixels.
     /// When set, `max_width` means that one need to wrap the text so it does not go further than that

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -6,7 +6,7 @@
 #![warn(missing_docs)]
 //! Exposed Window API
 
-use crate::api::{CloseRequestResponse, PhysicalPx};
+use crate::api::{CloseRequestResponse, PhysicalPx, Window};
 use crate::component::{ComponentRc, ComponentRef, ComponentWeak};
 use crate::graphics::{Point, Rect, Size};
 use crate::input::{
@@ -68,7 +68,7 @@ pub trait PlatformWindow {
     ///
     /// If this function return None (the default implementation), then the
     /// popup will be rendered within the window itself.
-    fn create_popup(&self, _geometry: Rect) -> Option<Rc<WindowInner>> {
+    fn create_popup(&self, _geometry: Rect) -> Option<Window> {
         None
     }
 
@@ -187,7 +187,7 @@ impl crate::properties::PropertyDirtyHandler for WindowRedrawTracker {
 /// This enum describes the different ways a popup can be rendered by the back-end.
 pub enum PopupWindowLocation {
     /// The popup is rendered in its own top-level window that is know to the windowing system.
-    TopLevel(Rc<WindowInner>),
+    TopLevel(Window),
     /// The popup is rendered as an embedded child window at the given position.
     ChildWindow(Point),
 }
@@ -646,7 +646,7 @@ impl WindowInner {
                 }
 
                 Some(window) => {
-                    window.set_component(popup_componentrc);
+                    window.window_handle().set_component(popup_componentrc);
                     PopupWindowLocation::TopLevel(window)
                 }
             };

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -577,7 +577,6 @@ impl ComponentDefinition {
     }
 
     /// Instantiate the component using an existing window.
-    /// This method is internal because the WindowRc is not a public type
     #[doc(hidden)]
     pub fn create_with_existing_window(&self, window: &Window) -> ComponentInstance {
         use i_slint_core::window::WindowHandleAccess;

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1467,7 +1467,7 @@ impl<'id> From<ComponentBox<'id>> for ErasedComponentBox {
 }
 
 impl i_slint_core::window::WindowHandleAccess for ErasedComponentBox {
-    fn window_handle(&self) -> &Rc<i_slint_core::window::Window> {
+    fn window_handle(&self) -> &Rc<i_slint_core::window::WindowInner> {
         self.window().window_handle()
     }
 }


### PR DESCRIPTION
We already have `api::Window` and also the Window element (`WindowItem`) so rename the inner part to avoid confusion.

Also use the public window more in the interfaces.