### PR TITLE
Clean up the background color handling in the GL backend

### DIFF
--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -13,7 +13,7 @@ use i_slint_core as corelib;
 use corelib::api::euclid;
 use corelib::graphics::Point;
 use corelib::input::{KeyEvent, KeyEventType, KeyboardModifiers, MouseEvent};
-use corelib::{window::*, Color};
+use corelib::window::*;
 use corelib::{Coord, SharedString};
 use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
@@ -41,7 +41,6 @@ pub trait WinitWindow: PlatformWindow {
     /// hold the most recent window size as known by the OS but the latest size that has been processed
     /// by [`WinitWindow::apply_window_properties()`].
     fn set_existing_size(&self, size: winit::dpi::LogicalSize<f32>);
-    fn set_background_color(&self, color: Color);
     fn set_icon(&self, icon: corelib::graphics::Image);
 
     fn apply_constraints(
@@ -107,14 +106,12 @@ pub trait WinitWindow: PlatformWindow {
         &self,
         window_item: core::pin::Pin<&i_slint_core::items::WindowItem>,
     ) {
-        let background = window_item.background();
         let title = window_item.title();
         let no_frame = window_item.no_frame();
         let icon = window_item.icon();
         let mut width = window_item.width() as f32;
         let mut height = window_item.height() as f32;
 
-        self.set_background_color(background);
         self.set_icon(icon);
 
         let mut must_resize = false;

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -15,7 +15,7 @@ use i_slint_core::item_rendering::DirtyRegion;
 use i_slint_core::items::{Item, ItemRef, WindowItem};
 use i_slint_core::layout::Orientation;
 use i_slint_core::window::{PlatformWindow, WindowInner};
-use i_slint_core::{Color, Coord};
+use i_slint_core::Coord;
 use rgb::FromSlice;
 
 use crate::PhysicalRect;
@@ -37,7 +37,6 @@ pub struct SimulatorWindow {
     opengl_context: OpenGLContext,
     constraints: Cell<(i_slint_core::layout::LayoutInfo, i_slint_core::layout::LayoutInfo)>,
     visible: Cell<bool>,
-    background_color: Cell<Color>,
     frame_buffer: RefCell<Option<SimulatorDisplay<embedded_graphics::pixelcolor::Rgb888>>>,
     initial_dirty_region_for_next_frame: Cell<DirtyRegion>,
 }
@@ -66,7 +65,6 @@ impl SimulatorWindow {
             opengl_context,
             constraints: Default::default(),
             visible: Default::default(),
-            background_color: Color::from_rgb_u8(0, 0, 0).into(),
             frame_buffer: RefCell::default(),
             initial_dirty_region_for_next_frame: Default::default(),
         });
@@ -392,9 +390,6 @@ impl WinitWindow for SimulatorWindow {
     }
     fn set_existing_size(&self, _size: winit::dpi::LogicalSize<f32>) {
         // dummy since it shouldn't be needed
-    }
-    fn set_background_color(&self, color: Color) {
-        self.background_color.set(color);
     }
     fn set_icon(&self, _icon: i_slint_core::graphics::Image) {}
 }


### PR DESCRIPTION
Just like the software renderer, query the background color when rendering
and use it as clear color.

In the simulator this was an unused field (because the sw renderer already does the right thing).