### PR TITLE
Move the clipboard back from the Window to the Backend trait

### DIFF
--- a/internal/backends/gl/lib.rs
+++ b/internal/backends/gl/lib.rs
@@ -102,4 +102,16 @@ impl i_slint_core::backend::Backend for Backend {
             });
         }
     }
+
+    fn set_clipboard_text(&self, text: &str) {
+        crate::event_loop::with_window_target(|event_loop_target| {
+            event_loop_target.clipboard().set_contents(text.into()).ok()
+        });
+    }
+
+    fn clipboard_text(&self) -> Option<String> {
+        crate::event_loop::with_window_target(|event_loop_target| {
+            event_loop_target.clipboard().get_contents().ok()
+        })
+    }
 }

--- a/internal/backends/mcu/Cargo.toml
+++ b/internal/backends/mcu/Cargo.toml
@@ -17,7 +17,7 @@ links = "i_slint_backend_mcu" # just so we can pass metadata to the slint build 
 path = "lib.rs"
 
 [features]
-simulator = ["winit", "glutin", "femtovg", "embedded-graphics-simulator", "std", "imgref", "scoped-tls-hkt"]
+simulator = ["winit", "glutin", "femtovg", "embedded-graphics-simulator", "std", "imgref", "scoped-tls-hkt", "copypasta"]
 
 pico-st7789 = ["unsafe_single_core", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "display-interface", "st7789", "defmt", "defmt-rtt",  "i-slint-core/defmt", "shared-bus", "i-slint-core/libm", "embedded-dma"]
 stm32h735g = ["unsafe_single_core", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "i-slint-core/defmt", "stm32h7xx-hal/stm32h735", "defmt", "defmt-rtt", "embedded-display-controller", "ft5336", "panic-probe"]
@@ -48,6 +48,8 @@ pin-weak = { version = "1", default-features = false }
 rgb = "0.8.27"
 scoped-tls-hkt = { version = "0.1", optional = true }
 winit = { version = "0.26.0", default-features = false, optional = true, features = ["x11"] }
+copypasta = { version = "0.8.1", optional = true, default-features = false }
+cfg-if = "1"
 
 alloc-cortex-m = { version = "0.4.1", optional = true }
 cortex-m-rt = { version = "0.7", optional = true }

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -188,15 +188,6 @@ mod the_backend {
         fn set_inner_size(&self, _size: euclid::Size2D<u32, PhysicalPx>) {
             unimplemented!()
         }
-
-        fn set_clipboard_text(&self, text: &str) {
-            self.backend.with_inner(|inner| inner.clipboard = text.into())
-        }
-
-        fn clipboard_text(&self) -> Option<String> {
-            let c = self.backend.with_inner(|inner| inner.clipboard.clone());
-            c.is_empty().then(|| c)
-        }
     }
 
     enum McuEvent {
@@ -428,6 +419,15 @@ mod the_backend {
 
         fn duration_since_start(&'static self) -> core::time::Duration {
             DEVICES.with(|devices| devices.borrow_mut().as_mut().unwrap().time())
+        }
+
+        fn set_clipboard_text(&self, text: &str) {
+            self.with_inner(|inner| inner.clipboard = text.into())
+        }
+
+        fn clipboard_text(&self) -> Option<String> {
+            let c = self.with_inner(|inner| inner.clipboard.clone());
+            c.is_empty().then(|| c)
         }
     }
 }

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -255,4 +255,36 @@ impl i_slint_core::backend::Backend for Backend {
             }}
         };
     }
+
+    fn set_clipboard_text(&'static self, _text: &str) {
+        #[cfg(not(no_qt))]
+        {
+            use cpp::cpp;
+            let text: qttypes::QString = _text.into();
+            cpp! {unsafe [text as "QString"] {
+                ensure_initialized();
+                QGuiApplication::clipboard()->setText(text);
+            } }
+        }
+    }
+
+    fn clipboard_text(&'static self) -> Option<String> {
+        #[cfg(not(no_qt))]
+        {
+            use cpp::cpp;
+            let has_text = cpp! {unsafe [] -> bool as "bool" {
+                ensure_initialized();
+                return QGuiApplication::clipboard()->mimeData()->hasText();
+            } };
+            if has_text {
+                return Some(
+                    cpp! { unsafe [] -> qttypes::QString as "QString" {
+                        return QGuiApplication::clipboard()->text();
+                    }}
+                    .into(),
+                );
+            }
+        }
+        None
+    }
 }

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1591,32 +1591,6 @@ impl PlatformWindow for QtWindow {
             widget_ptr->resize(sz  / widget_ptr->devicePixelRatio());
         }};
     }
-
-    fn set_clipboard_text(&self, _text: &str) {
-        use cpp::cpp;
-        let text: qttypes::QString = _text.into();
-        cpp! {unsafe [text as "QString"] {
-            ensure_initialized();
-            QGuiApplication::clipboard()->setText(text);
-        } }
-    }
-
-    fn clipboard_text(&self) -> Option<String> {
-        use cpp::cpp;
-        let has_text = cpp! {unsafe [] -> bool as "bool" {
-            ensure_initialized();
-            return QGuiApplication::clipboard()->mimeData()->hasText();
-        } };
-        if has_text {
-            return Some(
-                cpp! { unsafe [] -> qttypes::QString as "QString" {
-                    return QGuiApplication::clipboard()->text();
-                }}
-                .into(),
-            );
-        }
-        None
-    }
 }
 
 impl Renderer for QtWindow {

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -21,7 +21,7 @@ pub struct TestingBackend {
 
 impl i_slint_core::backend::Backend for TestingBackend {
     fn create_window(&'static self) -> Window {
-        WindowInner::new(|_| Rc::new(TestingWindow { backend: self })).into()
+        WindowInner::new(|_| Rc::new(TestingWindow::default())).into()
     }
 
     fn run_event_loop(&'static self, _behavior: i_slint_core::backend::EventLoopQuitBehavior) {
@@ -52,11 +52,18 @@ impl i_slint_core::backend::Backend for TestingBackend {
         // The slint::testing::mock_elapsed_time updates the animation tick directly
         core::time::Duration::from_millis(i_slint_core::animations::current_tick().0)
     }
+
+    fn set_clipboard_text(&'static self, text: &str) {
+        *self.clipboard.lock().unwrap() = Some(text.into());
+    }
+
+    fn clipboard_text(&'static self) -> Option<String> {
+        self.clipboard.lock().unwrap().clone()
+    }
 }
 
-pub struct TestingWindow {
-    backend: &'static TestingBackend,
-}
+#[derive(Default)]
+pub struct TestingWindow {}
 
 impl PlatformWindow for TestingWindow {
     fn show(self: Rc<Self>) {
@@ -113,14 +120,6 @@ impl PlatformWindow for TestingWindow {
 
     fn set_inner_size(&self, _size: euclid::Size2D<u32, PhysicalPx>) {
         unimplemented!()
-    }
-
-    fn set_clipboard_text(&self, text: &str) {
-        *self.backend.clipboard.lock().unwrap() = Some(text.into());
-    }
-
-    fn clipboard_text(&self) -> Option<String> {
-        self.backend.clipboard.lock().unwrap().clone()
     }
 }
 

--- a/internal/core/backend.rs
+++ b/internal/core/backend.rs
@@ -6,6 +6,7 @@ The backend is the abstraction for crates that need to do the actual drawing and
 */
 
 use alloc::boxed::Box;
+use alloc::string::String;
 
 #[cfg(feature = "std")]
 use once_cell::sync::OnceCell;
@@ -77,6 +78,13 @@ pub trait Backend: Send + Sync {
         }
         #[cfg(not(feature = "std"))]
         core::time::Duration::ZERO
+    }
+
+    /// Sends the given text into the system clipboard
+    fn set_clipboard_text(&'static self, _text: &str) {}
+    /// Returns a copy of text stored in the system clipboard, if any.
+    fn clipboard_text(&'static self) -> Option<String> {
+        None
     }
 }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -19,7 +19,6 @@ use crate::renderer::Renderer;
 use crate::{Callback, Coord};
 use alloc::boxed::Box;
 use alloc::rc::{Rc, Weak};
-use alloc::string::String;
 use core::cell::{Cell, RefCell};
 use core::pin::Pin;
 use vtable::VRcMapped;
@@ -132,13 +131,6 @@ pub trait PlatformWindow {
     ///
     /// The default implementation does nothing
     fn set_inner_size(&self, _size: euclid::Size2D<u32, PhysicalPx>) {}
-
-    /// Sends the given text into the system clipboard
-    fn set_clipboard_text(&self, _text: &str) {}
-    /// Returns a copy of text stored in the system clipboard, if any.
-    fn clipboard_text(&self) -> Option<String> {
-        None
-    }
 
     /// Return the renderer
     fn renderer(&self) -> &dyn Renderer;


### PR DESCRIPTION
Found a way to connect the clipboard to the wayland display through the winit event loop target.