### PR TITLE
Simplify time handling in the backend

### DIFF
--- a/docs/debugging_techniques.md
+++ b/docs/debugging_techniques.md
@@ -2,12 +2,6 @@
 
 On this page we're presenting different techniques and tools we've built into Slint that may help you track down different issues you may be running into, during the design and development.
 
-## Slow Motion Animations
-
-Animations in the user interface need to be carefully designed to have the correct duration and changes in element positioning or size need to follow a suitable curve.
-
-In order to inspect the animations in your application, you can can set the `SLINT_SLOW_ANIMATIONS` environment variable before running the program. The variable accepts an unsigned integer value that is interpreted as a factor to globally slow down the steps of all animations, without having to make any changes to the `.slint` markup and recompiling. For example `SLINT_SLOW_ANIMATIONS=4` will slow down animations by a factor of four.
-
 ## User Interface Scaling
 
 The use of logical pixel lengths throughout `.slint` files allows Slint to dynamically compute the correct size of physical pixels, depending on the device-pixel ratio of the screen that is reported by the windowing system. If you want to get an impression of how the individual elements look like when rendered on a screen with a different device-pixel ratio, then you can set the `SLINT_SCALE_FACTOR` environment variable before running the program. The variable accepts a floating pointer number that is used to convert logical pixel lengths to physical pixel lengths by multiplication. For example `SLINT_SCALE_FACTOR=2` will render the user interface in a way where every logical pixel will have twice the width and height.

--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -637,7 +637,7 @@ pub fn run(quit_behavior: i_slint_core::backend::EventLoopQuitBehavior) {
                 }
 
                 winit::event::Event::NewEvents(_) => {
-                    corelib::timers::update_timers();
+                    i_slint_core::timers::update_timers(i_slint_core::timers::Instant::now());
                 }
                 _ => (),
             }

--- a/internal/backends/gl/event_loop.rs
+++ b/internal/backends/gl/event_loop.rs
@@ -637,8 +637,7 @@ pub fn run(quit_behavior: i_slint_core::backend::EventLoopQuitBehavior) {
                 }
 
                 winit::event::Event::NewEvents(_) => {
-                    corelib::timers::TimerList::maybe_activate_timers();
-                    corelib::animations::update_animations();
+                    corelib::timers::update_timers();
                 }
                 _ => (),
             }

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -310,8 +310,7 @@ mod the_backend {
 
         fn run_event_loop(&'static self, behavior: i_slint_core::backend::EventLoopQuitBehavior) {
             loop {
-                i_slint_core::timers::TimerList::maybe_activate_timers();
-                i_slint_core::animations::update_animations();
+                i_slint_core::timers::update_timers();
                 match self.with_inner(|inner| inner.event_queue.pop_front()) {
                     Some(McuEvent::Quit) => break,
                     Some(McuEvent::Custom(e)) => e(),

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1247,7 +1247,7 @@ impl QtWindow {
     fn paint_event(&self, painter: QPainterPtr) {
         let runtime_window = self.self_weak.upgrade().unwrap();
         runtime_window.clone().draw_contents(|components| {
-            i_slint_core::animations::update_animations();
+            i_slint_core::timers::update_timers(i_slint_core::timers::Instant::now());
             let mut renderer = QtItemRenderer {
                 painter,
                 cache: &self.cache,
@@ -1301,12 +1301,12 @@ impl QtWindow {
     }
 
     fn mouse_event(&self, event: MouseEvent) {
+        i_slint_core::timers::update_timers(i_slint_core::timers::Instant::now());
         self.self_weak.upgrade().unwrap().process_mouse_input(event);
-        timer_event();
     }
 
     fn key_event(&self, key: i32, text: qttypes::QString, qt_modifiers: u32, released: bool) {
-        i_slint_core::animations::update_animations();
+        i_slint_core::timers::update_timers(i_slint_core::timers::Instant::now());
         let text: String = text.into();
         let modifiers = i_slint_core::input::KeyboardModifiers {
             control: (qt_modifiers & key_generated::Qt_KeyboardModifier_ControlModifier) != 0,
@@ -1780,7 +1780,7 @@ thread_local! {
 
 /// Called by C++'s TimerHandler::timerEvent, or every time a timer might have been started
 pub(crate) fn timer_event() {
-    i_slint_core::timers::update_timers();
+    i_slint_core::timers::update_timers(i_slint_core::timers::Instant::now());
 
     let timeout = i_slint_core::timers::TimerList::next_timeout().map(|instant| {
         let now = std::time::Instant::now();

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -48,11 +48,6 @@ impl i_slint_core::backend::Backend for TestingBackend {
         // The event will never be invoked
     }
 
-    fn duration_since_start(&'static self) -> core::time::Duration {
-        // The slint::testing::mock_elapsed_time updates the animation tick directly
-        core::time::Duration::from_millis(i_slint_core::animations::current_tick().0)
-    }
-
     fn set_clipboard_text(&'static self, text: &str) {
         *self.clipboard.lock().unwrap() = Some(text.into());
     }

--- a/internal/core/backend.rs
+++ b/internal/core/backend.rs
@@ -70,33 +70,11 @@ pub trait Backend: Send + Sync {
         unimplemented!()
     }
 
-    fn duration_since_start(&'static self) -> core::time::Duration {
-        #[cfg(feature = "std")]
-        {
-            let the_beginning = *INITIAL_INSTANT.get_or_init(instant::Instant::now);
-            instant::Instant::now() - the_beginning
-        }
-        #[cfg(not(feature = "std"))]
-        core::time::Duration::ZERO
-    }
-
     /// Sends the given text into the system clipboard
     fn set_clipboard_text(&'static self, _text: &str) {}
     /// Returns a copy of text stored in the system clipboard, if any.
     fn clipboard_text(&'static self) -> Option<String> {
         None
-    }
-}
-
-#[cfg(feature = "std")]
-static INITIAL_INSTANT: once_cell::sync::OnceCell<instant::Instant> =
-    once_cell::sync::OnceCell::new();
-
-#[cfg(feature = "std")]
-impl std::convert::From<crate::animations::Instant> for instant::Instant {
-    fn from(our_instant: crate::animations::Instant) -> Self {
-        let the_beginning = *INITIAL_INSTANT.get_or_init(instant::Instant::now);
-        the_beginning + core::time::Duration::from_millis(our_instant.0)
     }
 }
 

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -1098,7 +1098,7 @@ pub use properties_animations::*;
 ///
 /// A state is just the current state, but also has information about the previous state and the moment it changed
 #[repr(C)]
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct StateInfo {
     /// The current state value
     pub current_state: i32,
@@ -1106,6 +1106,16 @@ pub struct StateInfo {
     pub previous_state: i32,
     /// The instant in which the state changed last
     pub change_time: crate::animations::Instant,
+}
+
+impl Default for StateInfo {
+    fn default() -> Self {
+        Self {
+            current_state: 0,
+            previous_state: 0,
+            change_time: crate::animations::Instant::from_duration_since_start(Default::default()),
+        }
+    }
 }
 
 struct StateInfoBinding<F> {

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -259,7 +259,12 @@ unsafe fn c_set_animated_binding<T: InterpolatedPropertyValue + Clone>(
             compute_animation_details: move || -> properties_animations::AnimationDetail {
                 let mut start_instant = 0;
                 let anim = transition_data(user_data, &mut start_instant);
-                Some((anim, crate::animations::Instant(start_instant)))
+                Some((
+                    anim,
+                    crate::animations::Instant::from_duration_since_start(
+                        core::time::Duration::from_millis(start_instant),
+                    ),
+                ))
             },
         });
     } else {

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -12,7 +12,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
 
-use crate::animations::Instant;
+pub use crate::animations::Instant;
 
 type TimerCallback = Box<dyn FnMut()>;
 type SingleShotTimerCallback = Box<dyn FnOnce()>;
@@ -215,8 +215,7 @@ impl TimerList {
 
     /// Activates any expired timers by calling their callback function. Returns true if any timers were
     /// activated; false otherwise.
-    pub fn maybe_activate_timers() -> bool {
-        let now = Instant::now();
+    pub fn maybe_activate_timers(now: Instant) -> bool {
         // Shortcut: Is there any timer worth activating?
         if TimerList::next_timeout().map(|timeout| now < timeout).unwrap_or(false) {
             return false;
@@ -339,9 +338,9 @@ fn lower_bound<T>(vec: &[T], mut less_than: impl FnMut(&T) -> bool) -> usize {
 }
 
 /// Fire timer events and update animations
-pub fn update_timers() {
-    TimerList::maybe_activate_timers();
-    crate::animations::update_animations();
+pub fn update_timers(instant: Instant) {
+    crate::animations::update_animations(instant);
+    TimerList::maybe_activate_timers(instant);
 }
 
 #[cfg(feature = "ffi")]

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -338,6 +338,12 @@ fn lower_bound<T>(vec: &[T], mut less_than: impl FnMut(&T) -> bool) -> usize {
     left
 }
 
+/// Fire timer events and update animations
+pub fn update_timers() {
+    TimerList::maybe_activate_timers();
+    crate::animations::update_animations();
+}
+
 #[cfg(feature = "ffi")]
 pub(crate) mod ffi {
     #![allow(unsafe_code)]

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -282,8 +282,6 @@ impl WindowInner {
     /// * `what`: The type of mouse event.
     /// * `component`: The Slint compiled component that provides the tree of items.
     pub fn process_mouse_input(self: Rc<Self>, mut event: MouseEvent) {
-        crate::animations::update_animations();
-
         let embedded_popup_component =
             self.active_popup.borrow().as_ref().and_then(|popup| match popup.location {
                 PopupWindowLocation::TopLevel(_) => None,

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -305,14 +305,16 @@ i_slint_common::for_each_enums!(declare_value_enum_conversion);
 
 impl From<i_slint_core::animations::Instant> for Value {
     fn from(value: i_slint_core::animations::Instant) -> Self {
-        Value::Number(value.0 as _)
+        Value::Number(value.as_duration_since_start().as_secs_f64() as _)
     }
 }
 impl TryFrom<Value> for i_slint_core::animations::Instant {
     type Error = ();
     fn try_from(v: Value) -> Result<i_slint_core::animations::Instant, Self::Error> {
         match v {
-            Value::Number(x) => Ok(i_slint_core::animations::Instant(x as _)),
+            Value::Number(x) => Ok(i_slint_core::animations::Instant::from_duration_since_start(
+                core::time::Duration::from_secs_f64(x),
+            )),
             _ => Err(()),
         }
     }

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1149,7 +1149,7 @@ pub fn animation_for_property(
                             );
                         }
                     }
-                    Default::default()
+                    (Default::default(), state_info.change_time)
                 },
             ))
         }


### PR DESCRIPTION
The idea is that `update_timers(Instant)` will be used by the event loop to set the time, so that function and the `Instant` type will become public
