### PR TITLE
Fix Node tests in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
           command: test
-          args: --verbose
+          args: --verbose --workspace ${{ matrix.extra_args }} --exclude test-driver-cpp --exclude i-slint-backend-mcu --exclude printerdemo_mcu   # mcu backend requires nightly
   cpp_test_driver:
     env:
       DYLD_FRAMEWORK_PATH: /Users/runner/work/slint/Qt/5.15.2/clang_64/lib


### PR DESCRIPTION
After commit 894ee5aa9118d9eb72cb4c66907c8cf5c0242dc4 we weren't running the nodejs tests,
because we don't pass --workspace to cargo test.

This patch fixes that and also ends up running the other previously non-run unit
tests such as for the vtable crate.