### PR TITLE
Qt groupbox minimum size fix

### DIFF
--- a/internal/backends/qt/build.rs
+++ b/internal/backends/qt/build.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore combobox groupbox lineedit listviewitem scrollview spinbox stylemetrics
+
 fn main() {
     println!("cargo:rerun-if-env-changed=SLINT_NO_QT");
     if std::env::var("TARGET").map_or(false, |t| t.starts_with("wasm"))
@@ -37,12 +39,13 @@ fn main() {
     config.flag_if_supported("/std:c++17");
     config.include(std::env::var("DEP_QT_INCLUDE_PATH").unwrap()).build("lib.rs");
 
+    println!("cargo:rerun-if-changed=lib.rs");
     println!("cargo:rerun-if-changed=qt_accessible.rs");
-    println!("cargo:rerun-if-changed=qt_window.rs");
     println!("cargo:rerun-if-changed=qt_widgets.rs");
     println!("cargo:rerun-if-changed=qt_widgets/button.rs");
     println!("cargo:rerun-if-changed=qt_widgets/checkbox.rs");
     println!("cargo:rerun-if-changed=qt_widgets/combobox.rs");
+    println!("cargo:rerun-if-changed=qt_widgets/groupbox.rs");
     println!("cargo:rerun-if-changed=qt_widgets/lineedit.rs");
     println!("cargo:rerun-if-changed=qt_widgets/listviewitem.rs");
     println!("cargo:rerun-if-changed=qt_widgets/scrollview.rs");
@@ -50,6 +53,6 @@ fn main() {
     println!("cargo:rerun-if-changed=qt_widgets/spinbox.rs");
     println!("cargo:rerun-if-changed=qt_widgets/stylemetrics.rs");
     println!("cargo:rerun-if-changed=qt_widgets/tabwidget.rs");
-    println!("cargo:rerun-if-changed=lib.rs");
+    println!("cargo:rerun-if-changed=qt_window.rs");
     println!("cargo:SUPPORTS_NATIVE_STYLE=1");
 }

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -61,45 +61,45 @@ impl Item for NativeGroupBox {
         );
 
         shared_data.paddings.set_binding({
-        let shared_data_weak = pin_weak::rc::PinWeak::downgrade(shared_data.clone());
-        move || {
-            let shared_data = shared_data_weak.upgrade().unwrap();
+            let shared_data_weak = pin_weak::rc::PinWeak::downgrade(shared_data.clone());
+            move || {
+                let shared_data = shared_data_weak.upgrade().unwrap();
 
-            let text: qttypes::QString = GroupBoxData::FIELD_OFFSETS.title.apply_pin(shared_data.as_ref()).get().as_str().into();
+                let text: qttypes::QString = GroupBoxData::FIELD_OFFSETS.title.apply_pin(shared_data.as_ref()).get().as_str().into();
 
-            cpp!(unsafe [
-                text as "QString"
-            ] -> qttypes::QMargins as "QMargins" {
-                ensure_initialized();
-                QStyleOptionGroupBox option;
-                option.text = text;
-                option.lineWidth = 1;
-                option.midLineWidth = 0;
-                option.subControls = QStyle::SC_GroupBoxFrame;
-                if (!text.isEmpty()) {
-                    option.subControls |= QStyle::SC_GroupBoxLabel;
-                }
-                 // Just some size big enough to be sure that the frame fits in it
-                option.rect = QRect(0, 0, 10000, 10000);
-                option.textColor = QColor(qApp->style()->styleHint(
-                    QStyle::SH_GroupBox_TextLabelColor, &option));
-                QRect contentsRect = qApp->style()->subControlRect(
-                    QStyle::CC_GroupBox, &option, QStyle::SC_GroupBoxContents);
-                //QRect elementRect = qApp->style()->subElementRect(
-                //    QStyle::SE_GroupBoxLayoutItem, &option);
+                cpp!(unsafe [
+                    text as "QString"
+                ] -> qttypes::QMargins as "QMargins" {
+                    ensure_initialized();
+                    QStyleOptionGroupBox option;
+                    option.text = text;
+                    option.lineWidth = 1;
+                    option.midLineWidth = 0;
+                    option.subControls = QStyle::SC_GroupBoxFrame;
+                    if (!text.isEmpty()) {
+                        option.subControls |= QStyle::SC_GroupBoxLabel;
+                    }
+                    // Just some size big enough to be sure that the frame fits in it
+                    option.rect = QRect(0, 0, 10000, 10000);
+                    option.textColor = QColor(qApp->style()->styleHint(
+                        QStyle::SH_GroupBox_TextLabelColor, &option));
+                    QRect contentsRect = qApp->style()->subControlRect(
+                        QStyle::CC_GroupBox, &option, QStyle::SC_GroupBoxContents);
+                    //QRect elementRect = qApp->style()->subElementRect(
+                    //    QStyle::SE_GroupBoxLayoutItem, &option);
 
-                auto hs = qApp->style()->pixelMetric(QStyle::PM_LayoutHorizontalSpacing, &option);
-                auto vs = qApp->style()->pixelMetric(QStyle::PM_LayoutVerticalSpacing, &option);
+                    auto hs = qApp->style()->pixelMetric(QStyle::PM_LayoutHorizontalSpacing, &option);
+                    auto vs = qApp->style()->pixelMetric(QStyle::PM_LayoutVerticalSpacing, &option);
 
-                return {
-                    (contentsRect.left() + hs),
-                    (contentsRect.top() + vs),
-                    (option.rect.right() - contentsRect.right() + hs),
-                    (option.rect.bottom() - contentsRect.bottom() + vs)
-                };
-            })
-        }
-    });
+                    return {
+                        (contentsRect.left() + hs),
+                        (contentsRect.top() + vs),
+                        (option.rect.right() - contentsRect.right() + hs),
+                        (option.rect.bottom() - contentsRect.bottom() + vs)
+                    };
+                })
+            }
+        });
 
         self.native_padding_left.set_binding({
             let shared_data = shared_data.clone();


### PR DESCRIPTION
Take the label into account when calculating layout info for the native groupbox.

This matches the layout produced by a native Qt application much better and fixes the gallery demo with native style:

The "Button (checkable)" GroupBox is much wider with this change -- much like a similar UI looks in Qt designer.