### PR TITLE
Upgrade the CI to Github's windows-2022 image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,9 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macOS-11, windows-2022]
         rust_version: [stable, "1.60"]
+        include:
+          - os: windows-2022
+            extra_args: "--exclude slint-node --exclude test-driver-nodejs"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-11, windows-2019]
+        os: [ubuntu-20.04, macOS-11, windows-2022]
         rust_version: [stable, "1.60"]
 
     runs-on: ${{ matrix.os }}
@@ -31,25 +31,25 @@ jobs:
       if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
     - name: Cache Qt
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       id: cache-qt
       uses: actions/cache@v2
       with:
         path: ~/work/slint/Qt
         key: ${{ runner.os }}-${{ github.job }}-qt5.15.2
     - name: Install Qt
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       uses: jurplel/install-qt-action@v2
       with:
         version: '5.15.2'
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         setup-python: false
     - name: Set default style
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       run: |
           echo "SLINT_STYLE=native" >> $GITHUB_ENV
     - name: Set default style
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       run: |
           echo "SLINT_STYLE=fluent" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "SLINT_NO_QT=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -62,12 +62,12 @@ jobs:
           echo "::set-output name=node-version::$(node --version)"
     - name: Cache native node libraries
       uses: actions/cache@v2
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       with:
         path: ~/node-gyp/cache
         key: ${{ runner.os }}-${{ github.job }}-${{ steps.nodeversion.outputs.node-version }}
     - name: Ensure node-gyp cache is populated
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       run: |
           npm install -g node-gyp
           node-gyp install
@@ -99,7 +99,7 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-11, windows-2019]
+        os: [ubuntu-20.04, macOS-11, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -110,25 +110,25 @@ jobs:
           sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev gcc-10 g++-10
           echo "CXX=g++-10" >> $GITHUB_ENV
     - name: Cache Qt
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       id: cache-qt
       uses: actions/cache@v2
       with:
         path: ~/work/slint/Qt
         key: ${{ runner.os }}-${{ github.job }}-qt5.15.2
     - name: Install Qt
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       uses: jurplel/install-qt-action@v2
       with:
         version: '5.15.2'
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         setup-python: false
     - name: Set default style
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       run: |
           echo "SLINT_STYLE=native" >> $GITHUB_ENV
     - name: Set default style
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       run: |
           echo "SLINT_STYLE=fluent" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "SLINT_NO_QT=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -174,7 +174,7 @@ jobs:
           rm -rf target/*/*test*
           du -hs target
     - name: Clean cache # Otherwise the cache is much too big
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       run: |
           du -hs target
           rm -Recurse -Force target/*/incremental
@@ -191,7 +191,7 @@ jobs:
       CARGO_INCREMENTAL: false
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-11, windows-2019]
+        os: [ubuntu-20.04, macOS-11, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -201,7 +201,7 @@ jobs:
           sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev gcc-10 g++-10
           echo "CXX=g++-10" >> $GITHUB_ENV
     - name: Cache Qt
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       id: cache-qt
       uses: actions/cache@v2
       with:
@@ -214,12 +214,12 @@ jobs:
         version: 5.15.2
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
     - name: Install Qt (Windows, uncached)
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       uses: jurplel/install-qt-action@v2
       with:
         version: 6.2.1
     - name: Install Qt (cached)
-      if: matrix.os != 'ubuntu-20.04' && matrix.os != 'windows-2019'
+      if: matrix.os != 'ubuntu-20.04' && matrix.os != 'windows-2022'
       uses: jurplel/install-qt-action@v2
       with:
         version: 6.2.1
@@ -238,7 +238,7 @@ jobs:
       run: |
         echo "CC=cl.exe" >> $GITHUB_ENV
         echo "CXX=cl.exe" >> $GITHUB_ENV
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
     - name: Enable test coverage for resource embedding in C++ when building examples
       if: matrix.os == 'ubuntu-20.04'
       run: |

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -15,7 +15,7 @@ jobs:
       CARGO_INCREMENTAL: false
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-11, windows-2019]
+        os: [ubuntu-20.04, macOS-11, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
       if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
     - name: Cache Qt
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       id: cache-qt
       uses: actions/cache@v2
       with:
@@ -36,12 +36,12 @@ jobs:
         version: 5.15.2
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
     - name: Install Qt (Windows, uncached)
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       uses: jurplel/install-qt-action@v2
       with:
         version: 6.2.1
     - name: Install Qt (cached)
-      if: matrix.os != 'ubuntu-20.04' && matrix.os != 'windows-2019'
+      if: matrix.os != 'ubuntu-20.04' && matrix.os != 'windows-2022'
       uses: jurplel/install-qt-action@v2
       with:
         version: 6.2.1
@@ -57,17 +57,17 @@ jobs:
       with:
         crate: cargo-about
     - name: Prepare licenses (with Qt)
-      if: matrix.os == 'windows-2019' || matrix.os == 'macOS-11'
+      if: matrix.os == 'windows-2022' || matrix.os == 'macOS-11'
       run: bash -x ./scripts/prepare_binary_package.sh . --with-qt
     - name: Prepare licenses (without Qt)
-      if: matrix.os != 'windows-2019' && matrix.os != 'macOS-11'
+      if: matrix.os != 'windows-2022' && matrix.os != 'macOS-11'
       run: bash -x ./scripts/prepare_binary_package.sh .
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Select MSVC (windows)
       run: |
         echo "CC=cl.exe" >> $GITHUB_ENV
         echo "CXX=cl.exe" >> $GITHUB_ENV
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
     - name: C++ Build
       uses: lukka/run-cmake@v3.4
       with:

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -50,7 +50,7 @@ jobs:
             binary_built: slint-lsp
             target_dir:
             artifact_name: slint-lsp-x86_64-unknown-linux-gnu
-          - os: windows-2019
+          - os: windows-2022
             toolchain: x86_64-pc-windows-gnu
             binary_built: slint-lsp.exe
             target_dir:

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - name: Install latest stable Rust


### PR DESCRIPTION
This includes a newer version of Visual Studio.

This is needed for #1447.

Unfortunately this disables the NodeJS bindings build on Windows - see also #961.