### PR TITLE
Merge initial Skia renderer

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -85,6 +85,7 @@ define_cargo_feature(eventloop-winit-x11 "Enable support for the winit create to
 define_cargo_feature(eventloop-winit-wayland "Enable support for the winit create to interact only with the wayland windowing system on Unix. Enable this option and turn off SLINT_FEATURE_EVENTLOOP_WINIT_ALL for a smaller build with just wayland support." OFF)
 
 define_cargo_feature(renderer-femtovg "Enable support for the OpenGL ES 2.0 based FemtoVG rendering engine." ON)
+define_cargo_feature(renderer-skia "Enable support for the Skia based rendering engine." ON)
 
 define_cargo_feature(backend-qt "Enable Qt based rendering backend" ON)
 

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -31,6 +31,7 @@ eventloop-winit = ["i-slint-backend-selector/eventloop-winit"]
 eventloop-winit-x11 = ["i-slint-backend-selector/eventloop-winit-x11"]
 eventloop-winit-wayland = ["i-slint-backend-selector/eventloop-winit-wayland"]
 renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg"]
+renderer-skia = ["i-slint-backend-selector/renderer-skia"]
 
 default = ["eventloop-winit", "renderer-femtovg", "backend-qt"]
 

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -62,6 +62,9 @@ eventloop-qt = ["backend-qt"]
 ## The `femtovg` crate is available for rendering. 
 renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "std"]
 
+## The Skia based rendering engine.
+renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
+
 ## This feature is an alias for `backend-qt`
 renderer-qt = ["backend-qt"]
 

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -20,6 +20,7 @@ eventloop-winit-x11 = ["i-slint-backend-winit/x11"]
 eventloop-winit-wayland = ["i-slint-backend-winit/wayland"]
 
 renderer-femtovg = ["i-slint-backend-winit/renderer-femtovg"]
+renderer-skia = ["i-slint-backend-winit/renderer-skia"]
 
 rtti = ["i-slint-backend-winit?/rtti", "i-slint-backend-qt?/rtti"]
 

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -41,6 +41,7 @@ cfg_if::cfg_if! {
                 if let Some((event_loop, _renderer)) = backend_config.split_once('-').or_else(|| match backend_config.as_str() {
                     "qt" => Some(("qt", "qpainter")),
                     "gl" => Some(("winit", "femtovg")),
+                    "skia" => Some(("winit", "skia")),
                     _ => None,
                 }) {
                     match event_loop {

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -49,7 +49,7 @@ winit = { version = "0.26", default-features = false }
 dark-light = "0.2.2"
 
 # For the Skia renderer
-skia-safe = { version = "0", optional = true, features = ["gl"] }
+skia-safe = { version = "0", optional = true, features = ["gl", "textlayout"] }
 glow = { version = "0.11", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -20,6 +20,7 @@ path = "lib.rs"
 wayland = ["winit/wayland", "glutin/wayland", "copypasta/wayland"]
 x11 = ["winit/x11", "glutin/x11", "copypasta/x11"]
 renderer-femtovg = []
+renderer-skia = ["skia-safe", "glow"]
 rtti = ["i-slint-core/rtti"]
 default = []
 
@@ -46,6 +47,10 @@ ttf-parser = "0.15.0" # Use the same version was femtovg's rustybuzz, to avoid d
 unicode-script = "0.5.4" # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
 winit = { version = "0.26", default-features = false }
 dark-light = "0.2.2"
+
+# For the Skia renderer
+skia-safe = { version = "0", optional = true, features = ["gl"] }
+glow = { version = "0.11", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["console", "WebGlContextAttributes", "CanvasRenderingContext2d", "HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "CssStyleDeclaration", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent"] }

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -162,14 +162,21 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Rende
         window.opengl_context.make_current();
         window.opengl_context.ensure_resized();
 
-        self.renderer.render(&window.canvas, size.width, size.height, || {
-            if self.has_rendering_notifier() {
-                self.invoke_rendering_notifier(
-                    RenderingState::BeforeRendering,
-                    &window.opengl_context,
-                );
-            }
-        });
+        self.renderer.render(
+            &window.canvas,
+            size.width,
+            size.height,
+            #[cfg(not(target_arch = "wasm32"))]
+            &window.opengl_context.glutin_context(),
+            || {
+                if self.has_rendering_notifier() {
+                    self.invoke_rendering_notifier(
+                        RenderingState::BeforeRendering,
+                        &window.opengl_context,
+                    );
+                }
+            },
+        );
 
         self.invoke_rendering_notifier(RenderingState::AfterRendering, &window.opengl_context);
 

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -87,6 +87,9 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
         canvas: &FemtoVGCanvas,
         width: u32,
         height: u32,
+        #[cfg(not(target_arch = "wasm32"))] _gl_context: &glutin::WindowedContext<
+            glutin::PossiblyCurrent,
+        >,
         before_rendering_callback: impl FnOnce(),
     ) {
         let window = match self.window_weak.upgrade() {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -118,7 +118,10 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
             scale_factor,
             text,
             None,
-            max_width.map(|w| w * scale_factor),
+            (max_width.map(|w| w * scale_factor), None),
+            Default::default(),
+            Default::default(),
+            Default::default(),
         );
 
         [layout.max_intrinsic_width() / scale_factor, layout.height() / scale_factor].into()

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -129,16 +129,16 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
 
     fn text_input_byte_offset_for_position(
         &self,
-        text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
-        pos: i_slint_core::graphics::Point,
+        _text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
+        _pos: i_slint_core::graphics::Point,
     ) -> usize {
         todo!()
     }
 
     fn text_input_cursor_rect_for_byte_offset(
         &self,
-        text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
-        byte_offset: usize,
+        _text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
+        _byte_offset: usize,
     ) -> i_slint_core::graphics::Rect {
         todo!()
     }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -105,7 +105,13 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
         max_width: Option<i_slint_core::Coord>,
         scale_factor: f32,
     ) -> i_slint_core::graphics::Size {
-        let layout = textlayout::create_layout(font_request, scale_factor, text, None, max_width);
+        let layout = textlayout::create_layout(
+            font_request,
+            scale_factor,
+            text,
+            None,
+            max_width.map(|w| w * scale_factor),
+        );
 
         [layout.max_width() / scale_factor, layout.height() / scale_factor].into()
     }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -80,7 +80,7 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
                     .clear(itemrenderer::to_skia_color(&window_item.as_pin_ref().background()));
             }
 
-            skia_canvas.flush();
+            canvas.gr_context.borrow_mut().flush(None);
 
             let mut item_renderer =
                 itemrenderer::SkiaRenderer::new(skia_canvas, &window, &canvas.image_cache);
@@ -100,7 +100,7 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
             }
 
             drop(item_renderer);
-            skia_canvas.flush();
+            canvas.gr_context.borrow_mut().flush(None);
         });
     }
 }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -123,7 +123,8 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
             Default::default(),
         );
 
-        [layout.max_intrinsic_width() / scale_factor, layout.height() / scale_factor].into()
+        [layout.max_intrinsic_width().ceil() / scale_factor, layout.height().ceil() / scale_factor]
+            .into()
     }
 
     fn text_input_byte_offset_for_position(

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -142,6 +142,20 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
     ) -> i_slint_core::graphics::Rect {
         todo!()
     }
+
+    fn register_font_from_memory(
+        &self,
+        data: &'static [u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        textlayout::register_font_from_memory(data)
+    }
+
+    fn register_font_from_path(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        textlayout::register_font_from_path(path)
+    }
 }
 
 pub struct SkiaCanvas {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -1,0 +1,179 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use std::{
+    cell::RefCell,
+    rc::{Rc, Weak},
+};
+
+use i_slint_core::graphics::rendering_metrics_collector::RenderingMetricsCollector;
+
+mod itemrenderer;
+
+pub struct SkiaRenderer {
+    window_weak: Weak<i_slint_core::window::WindowInner>,
+}
+
+impl super::WinitCompatibleRenderer for SkiaRenderer {
+    type Canvas = SkiaCanvas;
+
+    fn new(window_weak: &std::rc::Weak<i_slint_core::window::WindowInner>) -> Self {
+        Self { window_weak: window_weak.clone() }
+    }
+
+    fn create_canvas_from_glutin_context(
+        &self,
+        gl_context: &glutin::WindowedContext<glutin::PossiblyCurrent>,
+        winsys_name: Option<&str>,
+    ) -> Self::Canvas {
+        let _platform_window = gl_context.window();
+
+        let rendering_metrics_collector = winsys_name.and_then(|winsys_name| {
+            RenderingMetricsCollector::new(
+                self.window_weak.clone(),
+                &format!("Skia renderer (windowing system: {})", winsys_name),
+            )
+        });
+
+        let gl_interface = skia_safe::gpu::gl::Interface::new_load_with(|symbol| {
+            gl_context.get_proc_address(symbol)
+        });
+
+        let mut gr_context = skia_safe::gpu::DirectContext::new_gl(gl_interface, None).unwrap();
+
+        let surface = create_surface(&gl_context, &mut gr_context).into();
+
+        SkiaCanvas { surface, gr_context: RefCell::new(gr_context), rendering_metrics_collector }
+    }
+
+    fn render(
+        &self,
+        canvas: &Self::Canvas,
+        width: u32,
+        height: u32,
+        gl_context: &glutin::WindowedContext<glutin::PossiblyCurrent>,
+        before_rendering_callback: impl FnOnce(),
+    ) {
+        let window = match self.window_weak.upgrade() {
+            Some(window) => window,
+            None => return,
+        };
+
+        window.clone().draw_contents(|components| {
+            let mut surface = canvas.surface.borrow_mut();
+            if width != surface.width() as u32 || height != surface.height() as u32 {
+                *surface = create_surface(gl_context, &mut canvas.gr_context.borrow_mut());
+            }
+
+            let skia_canvas = surface.canvas();
+
+            if let Some(window_item) = window.window_item() {
+                skia_canvas
+                    .clear(itemrenderer::to_skia_color(&window_item.as_pin_ref().background()));
+            }
+
+            skia_canvas.flush();
+
+            let mut item_renderer = itemrenderer::SkiaRenderer::new(skia_canvas, &window);
+
+            before_rendering_callback();
+
+            for (component, origin) in components {
+                i_slint_core::item_rendering::render_component_items(
+                    component,
+                    &mut item_renderer,
+                    *origin,
+                );
+            }
+
+            if let Some(collector) = &canvas.rendering_metrics_collector {
+                collector.measure_frame_rendered(&mut item_renderer);
+            }
+
+            drop(item_renderer);
+            skia_canvas.flush();
+        });
+    }
+}
+
+impl i_slint_core::renderer::Renderer for SkiaRenderer {
+    fn text_size(
+        &self,
+        font_request: i_slint_core::graphics::FontRequest,
+        text: &str,
+        max_width: Option<i_slint_core::Coord>,
+        scale_factor: f32,
+    ) -> i_slint_core::graphics::Size {
+        todo!()
+    }
+
+    fn text_input_byte_offset_for_position(
+        &self,
+        text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
+        pos: i_slint_core::graphics::Point,
+    ) -> usize {
+        todo!()
+    }
+
+    fn text_input_cursor_rect_for_byte_offset(
+        &self,
+        text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
+        byte_offset: usize,
+    ) -> i_slint_core::graphics::Rect {
+        todo!()
+    }
+}
+
+pub struct SkiaCanvas {
+    surface: RefCell<skia_safe::Surface>,
+    gr_context: RefCell<skia_safe::gpu::DirectContext>,
+    rendering_metrics_collector: Option<Rc<RenderingMetricsCollector>>,
+}
+
+impl super::WinitCompatibleCanvas for SkiaCanvas {
+    fn release_graphics_resources(&self) {
+        todo!()
+    }
+
+    fn component_destroyed(&self, component: i_slint_core::component::ComponentRef) {
+        todo!()
+    }
+}
+
+fn create_surface(
+    gl_context: &glutin::WindowedContext<glutin::PossiblyCurrent>,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+) -> skia_safe::Surface {
+    use glow::HasContext;
+
+    let fb_info = {
+        let gl = unsafe {
+            glow::Context::from_loader_function(|s| gl_context.get_proc_address(s) as *const _)
+        };
+        let fboid = unsafe { gl.get_parameter_i32(glow::FRAMEBUFFER_BINDING) };
+
+        skia_safe::gpu::gl::FramebufferInfo {
+            fboid: fboid.try_into().unwrap(),
+            format: skia_safe::gpu::gl::Format::RGBA8.into(),
+        }
+    };
+
+    let pixel_format = gl_context.get_pixel_format();
+    let size = gl_context.window().inner_size();
+    let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_gl(
+        (size.width.try_into().unwrap(), size.height.try_into().unwrap()),
+        pixel_format.multisampling.map(|s| s.try_into().unwrap()),
+        pixel_format.stencil_bits.try_into().unwrap(),
+        fb_info,
+    );
+    let surface = skia_safe::Surface::from_backend_render_target(
+        gr_context,
+        &backend_render_target,
+        skia_safe::gpu::SurfaceOrigin::BottomLeft,
+        skia_safe::ColorType::RGBA8888,
+        None,
+        None,
+    )
+    .unwrap();
+    surface
+}

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -29,8 +29,6 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
         gl_context: &glutin::WindowedContext<glutin::PossiblyCurrent>,
         winsys_name: Option<&str>,
     ) -> Self::Canvas {
-        let _platform_window = gl_context.window();
-
         let rendering_metrics_collector = winsys_name.and_then(|winsys_name| {
             RenderingMetricsCollector::new(
                 self.window_weak.clone(),

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -118,8 +118,7 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
             scale_factor,
             text,
             None,
-            (max_width.map(|w| w * scale_factor), None),
-            Default::default(),
+            max_width.map(|w| w * scale_factor),
             Default::default(),
             Default::default(),
         );

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -113,7 +113,7 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
             max_width.map(|w| w * scale_factor),
         );
 
-        [layout.max_width() / scale_factor, layout.height() / scale_factor].into()
+        [layout.max_intrinsic_width() / scale_factor, layout.height() / scale_factor].into()
     }
 
     fn text_input_byte_offset_for_position(

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -167,7 +167,7 @@ pub struct SkiaCanvas {
 
 impl super::WinitCompatibleCanvas for SkiaCanvas {
     fn release_graphics_resources(&self) {
-        todo!()
+        self.image_cache.clear_all();
     }
 
     fn component_destroyed(&self, component: i_slint_core::component::ComponentRef) {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -9,6 +9,7 @@ use std::{
 use i_slint_core::graphics::rendering_metrics_collector::RenderingMetricsCollector;
 
 mod itemrenderer;
+mod textlayout;
 
 pub struct SkiaRenderer {
     window_weak: Weak<i_slint_core::window::WindowInner>,
@@ -104,7 +105,9 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
         max_width: Option<i_slint_core::Coord>,
         scale_factor: f32,
     ) -> i_slint_core::graphics::Size {
-        todo!()
+        let layout = textlayout::create_layout(font_request, scale_factor, text, None, max_width);
+
+        [layout.max_width() / scale_factor, layout.height() / scale_factor].into()
     }
 
     fn text_input_byte_offset_for_position(

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -93,7 +93,7 @@ impl<'a> SkiaRenderer<'a> {
         target_width: std::pin::Pin<&Property<f32>>,
         target_height: std::pin::Pin<&Property<f32>>,
         image_fit: ImageFit,
-        rendering: ImageRendering,
+        _rendering: ImageRendering, // TODO
         colorize_property: Option<Pin<&Property<Brush>>>,
     ) {
         // TODO: avoid doing creating an SkImage multiple times when the same source is used in multiple image elements
@@ -434,7 +434,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
 
     fn draw_text_input(
         &mut self,
-        text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
+        _text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) {
         //todo!()
@@ -589,7 +589,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
             .translate(skia_safe::Vector::from((x * self.scale_factor, y * self.scale_factor)));
     }
 
-    fn rotate(&mut self, angle_in_degrees: f32) {
+    fn rotate(&mut self, _angle_in_degrees: f32) {
         //todo!()
     }
 
@@ -613,8 +613,8 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
 
     fn draw_cached_pixmap(
         &mut self,
-        item_cache: &i_slint_core::items::ItemRc,
-        update_fn: &dyn Fn(&mut dyn FnMut(u32, u32, &[u8])),
+        _item_cache: &i_slint_core::items::ItemRc,
+        _update_fn: &dyn Fn(&mut dyn FnMut(u32, u32, &[u8])),
     ) {
         //todo!()
     }

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -338,13 +338,15 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
             self.canvas.draw_rrect(rounded_rect, &fill_paint);
         }
 
-        if let Some(mut border_paint) =
-            self.brush_to_paint(rect.border_color(), geometry.width(), geometry.height())
-        {
-            border_paint.set_style(skia_safe::PaintStyle::Stroke);
-            border_paint.set_stroke_width(border_width);
-            self.canvas.draw_rrect(rounded_rect, &border_paint);
-        };
+        if border_width > 0.0 {
+            if let Some(mut border_paint) =
+                self.brush_to_paint(rect.border_color(), geometry.width(), geometry.height())
+            {
+                border_paint.set_style(skia_safe::PaintStyle::Stroke);
+                border_paint.set_stroke_width(border_width);
+                self.canvas.draw_rrect(rounded_rect, &border_paint);
+            }
+        }
     }
 
     fn draw_image(

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -232,7 +232,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
     }
 
     fn get_current_clip(&self) -> i_slint_core::graphics::Rect {
-        from_skia_rect(&self.canvas.local_clip_bounds().unwrap())
+        from_skia_rect(&self.canvas.local_clip_bounds().unwrap_or_default())
             .scale(1. / self.scale_factor, 1. / self.scale_factor)
     }
 

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -365,13 +365,18 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
             self.scale_factor,
             string,
             Some(text_style),
-            (Some(max_width), Some(max_height)),
-            (text.horizontal_alignment(), text.vertical_alignment()),
+            Some(max_width),
+            text.horizontal_alignment(),
             text.overflow(),
-            text.wrap(),
         );
 
-        layout.paint(&mut self.canvas, skia_safe::Point::default());
+        let y = match text.vertical_alignment() {
+            items::TextVerticalAlignment::Top => 0.,
+            items::TextVerticalAlignment::Center => (max_height - layout.height()) / 2.,
+            items::TextVerticalAlignment::Bottom => (max_height - layout.height()),
+        };
+
+        layout.paint(&mut self.canvas, skia_safe::Point::new(0., y));
     }
 
     fn draw_text_input(

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -449,37 +449,61 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
     fn draw_box_shadow(
         &mut self,
         box_shadow: std::pin::Pin<&i_slint_core::items::BoxShadow>,
-        _self_rc: &i_slint_core::items::ItemRc,
+        self_rc: &i_slint_core::items::ItemRc,
     ) {
-        let mut geometry = item_rect(box_shadow, self.scale_factor);
-
-        let color = box_shadow.color();
-        if color.alpha() == 0 {
-            return;
-        }
-        let blur = box_shadow.blur();
         let ox = box_shadow.offset_x() * self.scale_factor;
         let oy = box_shadow.offset_y() * self.scale_factor;
 
-        if blur == 0.0 && ox == 0. && oy == 0. {
+        if ox == 0. && oy == 0. && box_shadow.blur() == 0.0 {
             return;
         }
 
-        let radius = box_shadow.border_radius() * self.scale_factor;
+        let cached_shadow_image = self.image_cache.get_or_update_cache_entry(self_rc, || {
+            let geometry = item_rect(box_shadow, self.scale_factor);
 
-        geometry.offset((ox, oy));
+            let color = box_shadow.color();
+            if color.alpha() == 0 {
+                return None;
+            }
+            let blur = box_shadow.blur();
 
-        let rounded_rect = skia_safe::RRect::new_rect_xy(geometry, radius, radius);
+            let mut shadow_size = geometry.size();
+            shadow_size.width += 2. * blur;
+            shadow_size.height += 2. * blur;
 
-        let mut paint = skia_safe::Paint::default();
-        paint.set_color(to_skia_color(&color));
-        paint.set_anti_alias(true);
-        paint.set_mask_filter(skia_safe::MaskFilter::blur(
-            skia_safe::BlurStyle::Normal,
-            blur / 2.,
-            None,
-        ));
-        self.canvas.draw_rrect(rounded_rect, &paint);
+            let image_info = skia_safe::ImageInfo::new(
+                shadow_size.to_ceil(),
+                skia_safe::ColorType::RGBA8888,
+                skia_safe::AlphaType::Premul,
+                None,
+            );
+
+            let radius = box_shadow.border_radius() * self.scale_factor;
+
+            let rounded_rect = skia_safe::RRect::new_rect_xy(geometry, radius, radius);
+
+            let mut paint = skia_safe::Paint::default();
+            paint.set_color(to_skia_color(&color));
+            paint.set_anti_alias(true);
+            paint.set_mask_filter(skia_safe::MaskFilter::blur(
+                skia_safe::BlurStyle::Normal,
+                blur / 2.,
+                None,
+            ));
+
+            let mut surface = self.canvas.new_surface(&image_info, None)?;
+            let canvas = surface.canvas();
+            canvas.clear(skia_safe::Color::TRANSPARENT);
+            canvas.draw_rrect(rounded_rect, &paint);
+            Some(surface.image_snapshot())
+        });
+
+        let cached_shadow_image = match cached_shadow_image {
+            Some(img) => img,
+            None => return,
+        };
+
+        self.canvas.draw_image(cached_shadow_image, skia_safe::Point::from((ox, oy)), None);
     }
 
     fn combine_clip(

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -240,7 +240,14 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
     }
 
     fn draw_string(&mut self, string: &str, color: i_slint_core::Color) {
-        //todo!()
+        let mut paint = skia_safe::Paint::default();
+        paint.set_color(to_skia_color(&color));
+        self.canvas.draw_str(
+            string,
+            skia_safe::Point::new(0., 12.), // Default text size is 12 pixels
+            &skia_safe::Font::default(),
+            &paint,
+        );
     }
 
     fn window(&self) -> i_slint_core::window::WindowRc {

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use i_slint_core::graphics::{euclid, SharedImageBuffer};
 use i_slint_core::item_rendering::{ItemCache, ItemRenderer};
-use i_slint_core::items::{ImageFit, ImageRendering, ItemRc, Opacity, RenderingResult, TextWrap};
+use i_slint_core::items::{ImageFit, ImageRendering, ItemRc, Opacity, RenderingResult};
 use i_slint_core::{items, Brush, Color, ImageInner, Property};
 
 #[derive(Clone, Copy)]
@@ -303,7 +303,10 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
             self.scale_factor,
             string,
             Some(text_style),
-            if text.wrap() == TextWrap::WordWrap { Some(max_width) } else { None },
+            (Some(max_width), Some(max_height)),
+            (text.horizontal_alignment(), text.vertical_alignment()),
+            text.overflow(),
+            text.wrap(),
         );
 
         layout.paint(&mut self.canvas, skia_safe::Point::default());

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -1,0 +1,193 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use std::pin::Pin;
+use std::rc::Rc;
+
+use i_slint_core::graphics::euclid;
+use i_slint_core::item_rendering::ItemRenderer;
+use i_slint_core::{items, Brush, Color};
+
+pub struct SkiaRenderer<'a> {
+    pub canvas: &'a mut skia_safe::Canvas,
+    pub window: Rc<i_slint_core::window::WindowInner>,
+    pub scale_factor: f32,
+}
+
+impl<'a> SkiaRenderer<'a> {
+    pub fn new(
+        canvas: &'a mut skia_safe::Canvas,
+        window: &Rc<i_slint_core::window::WindowInner>,
+    ) -> Self {
+        Self { canvas, window: window.clone(), scale_factor: window.scale_factor() }
+    }
+}
+
+impl<'a> ItemRenderer for SkiaRenderer<'a> {
+    fn draw_rectangle(
+        &mut self,
+        rect: std::pin::Pin<&i_slint_core::items::Rectangle>,
+        _self_rc: &i_slint_core::items::ItemRc,
+    ) {
+        let geometry = item_rect(rect, self.scale_factor);
+        if geometry.is_empty() {
+            return;
+        }
+
+        let paint = match self.brush_to_paint(rect.background()) {
+            Some(paint) => paint,
+            None => return,
+        };
+        self.canvas.draw_rect(geometry, &paint);
+    }
+
+    fn draw_border_rectangle(
+        &mut self,
+        rect: std::pin::Pin<&i_slint_core::items::BorderRectangle>,
+        _self_rc: &i_slint_core::items::ItemRc,
+    ) {
+        //todo!()
+    }
+
+    fn draw_image(
+        &mut self,
+        image: std::pin::Pin<&i_slint_core::items::ImageItem>,
+        _self_rc: &i_slint_core::items::ItemRc,
+    ) {
+        //todo!()
+    }
+
+    fn draw_clipped_image(
+        &mut self,
+        image: std::pin::Pin<&i_slint_core::items::ClippedImage>,
+        _self_rc: &i_slint_core::items::ItemRc,
+    ) {
+        //todo!()
+    }
+
+    fn draw_text(
+        &mut self,
+        text: std::pin::Pin<&i_slint_core::items::Text>,
+        _self_rc: &i_slint_core::items::ItemRc,
+    ) {
+        //todo!()
+    }
+
+    fn draw_text_input(
+        &mut self,
+        text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
+        _self_rc: &i_slint_core::items::ItemRc,
+    ) {
+        //todo!()
+    }
+
+    fn draw_path(
+        &mut self,
+        path: std::pin::Pin<&i_slint_core::items::Path>,
+        _self_rc: &i_slint_core::items::ItemRc,
+    ) {
+        //todo!()
+    }
+
+    fn draw_box_shadow(
+        &mut self,
+        box_shadow: std::pin::Pin<&i_slint_core::items::BoxShadow>,
+        _self_rc: &i_slint_core::items::ItemRc,
+    ) {
+        //todo!()
+    }
+
+    fn combine_clip(
+        &mut self,
+        rect: i_slint_core::graphics::Rect,
+        radius: i_slint_core::Coord,
+        border_width: i_slint_core::Coord,
+    ) -> bool {
+        //todo!()
+        true // clip region is valid and not empty
+    }
+
+    fn get_current_clip(&self) -> i_slint_core::graphics::Rect {
+        from_skia_rect(&self.canvas.local_clip_bounds().unwrap())
+    }
+
+    fn translate(&mut self, x: i_slint_core::Coord, y: i_slint_core::Coord) {
+        //todo!()
+    }
+
+    fn rotate(&mut self, angle_in_degrees: f32) {
+        //todo!()
+    }
+
+    fn apply_opacity(&mut self, opacity: f32) {
+        //todo!()
+    }
+
+    fn save_state(&mut self) {
+        self.canvas.save();
+    }
+
+    fn restore_state(&mut self) {
+        self.canvas.restore();
+    }
+
+    fn scale_factor(&self) -> f32 {
+        self.scale_factor
+    }
+
+    fn draw_cached_pixmap(
+        &mut self,
+        item_cache: &i_slint_core::items::ItemRc,
+        update_fn: &dyn Fn(&mut dyn FnMut(u32, u32, &[u8])),
+    ) {
+        //todo!()
+    }
+
+    fn draw_string(&mut self, string: &str, color: i_slint_core::Color) {
+        //todo!()
+    }
+
+    fn window(&self) -> i_slint_core::window::WindowRc {
+        self.window.clone()
+    }
+
+    fn as_any(&mut self) -> Option<&mut dyn core::any::Any> {
+        None
+    }
+}
+
+impl<'a> SkiaRenderer<'a> {
+    fn brush_to_paint(&self, brush: Brush) -> Option<skia_safe::Paint> {
+        if brush.is_transparent() {
+            return None;
+        }
+        let mut paint = skia_safe::Paint::default();
+        match brush {
+            Brush::SolidColor(color) => paint.set_color(to_skia_color(&color)),
+            Brush::LinearGradient(_) => todo!(),
+            Brush::RadialGradient(_) => todo!(),
+            _ => return None,
+        };
+        Some(paint)
+    }
+}
+
+pub fn from_skia_rect(rect: &skia_safe::Rect) -> i_slint_core::graphics::Rect {
+    let top_left = euclid::Point2D::new(rect.left, rect.top);
+    let bottom_right = euclid::Point2D::new(rect.right, rect.bottom);
+    euclid::Box2D::new(top_left, bottom_right).to_rect()
+}
+
+fn item_rect<Item: items::Item>(item: Pin<&Item>, scale_factor: f32) -> skia_safe::Rect {
+    let geometry = item.geometry();
+    skia_safe::Rect::from_xywh(
+        0.,
+        0.,
+        geometry.width() * scale_factor,
+        geometry.height() * scale_factor,
+    )
+}
+
+pub fn to_skia_color(col: &Color) -> skia_safe::Color {
+    skia_safe::Color::from_argb(col.alpha(), col.red(), col.green(), col.blue())
+}

--- a/internal/backends/winit/renderer/skia/textlayout.rs
+++ b/internal/backends/winit/renderer/skia/textlayout.rs
@@ -19,10 +19,9 @@ pub fn create_layout(
     scale_factor: f32,
     text: &str,
     text_style: Option<skia_safe::textlayout::TextStyle>,
-    (max_width, max_height): (Option<Coord>, Option<Coord>),
-    (h_align, v_align): (items::TextHorizontalAlignment, items::TextVerticalAlignment),
+    max_width: Option<Coord>,
+    h_align: items::TextHorizontalAlignment,
     overflow: items::TextOverflow,
-    wrap: items::TextWrap,
 ) -> skia_safe::textlayout::Paragraph {
     let mut text_style = text_style.unwrap_or_default();
 
@@ -43,9 +42,7 @@ pub fn create_layout(
     ));
 
     let mut style = skia_safe::textlayout::ParagraphStyle::new();
-    if let Some(h) = max_height {
-        style.set_height(h);
-    }
+
     if overflow == items::TextOverflow::Elide {
         style.set_ellipsis("…");
     }
@@ -62,10 +59,6 @@ pub fn create_layout(
     builder.push_style(&text_style);
     builder.add_text(text);
     let mut paragraph = builder.build();
-    paragraph.layout(
-        max_width
-            .filter(|_| overflow == items::TextOverflow::Elide || wrap != items::TextWrap::NoWrap)
-            .unwrap_or(core::f32::MAX),
-    );
+    paragraph.layout(max_width.unwrap_or(core::f32::MAX));
     paragraph
 }

--- a/internal/backends/winit/renderer/skia/textlayout.rs
+++ b/internal/backends/winit/renderer/skia/textlayout.rs
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use i_slint_core::{graphics::FontRequest, Coord};
+
+pub const DEFAULT_FONT_SIZE: f32 = 12.;
+
+pub fn create_layout(
+    font_request: FontRequest,
+    scale_factor: f32,
+    text: &str,
+    text_style: Option<skia_safe::textlayout::TextStyle>,
+    max_width: Option<Coord>,
+) -> skia_safe::textlayout::Paragraph {
+    // TODO: don't create the font collection, etc. every time
+    let mut font_collection = skia_safe::textlayout::FontCollection::new();
+    font_collection.set_default_font_manager(skia_safe::FontMgr::new(), None);
+
+    let mut text_style = text_style.unwrap_or_default();
+
+    if let Some(family_name) = font_request.family {
+        text_style.set_font_families(&[family_name.as_str()]);
+    }
+
+    let pixel_size = font_request.pixel_size.unwrap_or(DEFAULT_FONT_SIZE) * scale_factor;
+
+    // TODO: add more font properties
+    text_style.set_font_size(pixel_size);
+
+    let style = skia_safe::textlayout::ParagraphStyle::new();
+    let mut builder = skia_safe::textlayout::ParagraphBuilder::new(&style, font_collection);
+    builder.push_style(&text_style);
+    builder.add_text(text);
+    let mut paragraph = builder.build();
+    paragraph.layout(max_width.unwrap_or(core::f32::MAX));
+    paragraph
+}

--- a/internal/backends/winit/renderer/skia/textlayout.rs
+++ b/internal/backends/winit/renderer/skia/textlayout.rs
@@ -28,8 +28,15 @@ pub fn create_layout(
 
     let pixel_size = font_request.pixel_size.unwrap_or(DEFAULT_FONT_SIZE) * scale_factor;
 
-    // TODO: add more font properties
+    if let Some(letter_spacing) = font_request.letter_spacing {
+        text_style.set_letter_spacing(letter_spacing * scale_factor);
+    }
     text_style.set_font_size(pixel_size);
+    text_style.set_font_style(skia_safe::FontStyle::new(
+        font_request.weight.map_or(skia_safe::font_style::Weight::NORMAL, |w| w.into()),
+        skia_safe::font_style::Width::NORMAL,
+        skia_safe::font_style::Slant::Upright,
+    ));
 
     let style = skia_safe::textlayout::ParagraphStyle::new();
 

--- a/internal/backends/winit/renderer/skia/textlayout.rs
+++ b/internal/backends/winit/renderer/skia/textlayout.rs
@@ -27,8 +27,12 @@ thread_local! {
         let font_mgr = skia_safe::FontMgr::new();
         let type_face_font_provider = skia_safe::textlayout::TypefaceFontProvider::new();
         let mut font_collection = skia_safe::textlayout::FontCollection::new();
+        // FontCollection first looks up in the dynamic font manager and then the asset font manager. If the
+        // family is empty, the default font manager will match against the system default. We want that behavior,
+        // and only if the family is not present in the system, then we want to fall back to the assert font manager
+        // to pick up the custom font.
         font_collection.set_asset_font_manager(Some(type_face_font_provider.clone().into()));
-        font_collection.set_default_font_manager(font_mgr.clone(), None);
+        font_collection.set_dynamic_font_manager(font_mgr.clone());
         FontCache { font_collection, font_mgr, type_face_font_provider: RefCell::new(type_face_font_provider), custom_fonts: Default::default() }
     }
 }

--- a/internal/backends/winit/renderer/skia/textlayout.rs
+++ b/internal/backends/winit/renderer/skia/textlayout.rs
@@ -1,8 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use std::cell::RefCell;
-
 use i_slint_core::{graphics::FontRequest, Coord};
 
 pub const DEFAULT_FONT_SIZE: f32 = 12.;

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -68,6 +68,9 @@ eventloop-qt = ["backend-qt"]
 ## The `femtovg` crate is available for rendering. 
 renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "std"]
 
+## The Skia based rendering engine.
+renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
+
 ## This feature is an alias for `backend-qt`
 renderer-qt = ["backend-qt"]
 

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -41,6 +41,7 @@ eventloop-winit-x11 = ["slint-interpreter/eventloop-winit-x11", "preview"]
 eventloop-winit-wayland = ["slint-interpreter/eventloop-winit-wayland", "preview"]
 
 renderer-femtovg = ["slint-interpreter/renderer-femtovg", "preview"]
+renderer-skia = ["slint-interpreter/renderer-skia", "preview"]
 
 # Compat
 backend-gl-all = ["eventloop-winit", "renderer-femtovg"]

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -23,6 +23,7 @@ eventloop-winit-wayland = ["slint-interpreter/eventloop-winit-wayland"]
 eventloop-winit-x11 = ["slint-interpreter/eventloop-winit-x11"]
 
 renderer-femtovg = ["slint-interpreter/renderer-femtovg"]
+renderer-skia = ["slint-interpreter/renderer-skia"]
 
 # Compat
 backend-gl-all = ["eventloop-winit", "renderer-femtovg"]


### PR DESCRIPTION
As part of #1445, this merges the initial Skia renderer into the winit backend. It's not enabled by default.

In the CI this is built on macOS, Windows and Linux, but as per #1445 there are some caveats left, feature and build system wise.