### PR TITLE
Speed up rendering of clipped children

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -853,7 +853,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
         }
     }
 
-    fn combine_clip(&mut self, rect: Rect, radius: f32, mut border_width: f32) {
+    fn combine_clip(&mut self, rect: Rect, radius: f32, mut border_width: f32) -> bool {
         let mut clip_rect = qttypes::QRectF {
             x: rect.min_x() as _,
             y: rect.min_y() as _,
@@ -862,7 +862,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
         };
         adjust_rect_and_border_for_inner_drawing(&mut clip_rect, &mut border_width);
         let painter: &mut QPainterPtr = &mut self.painter;
-        cpp! { unsafe [painter as "QPainterPtr*", clip_rect as "QRectF", radius as "float"] {
+        cpp! { unsafe [painter as "QPainterPtr*", clip_rect as "QRectF", radius as "float"] -> bool as "bool" {
             if (radius <= 0) {
                 (*painter)->setClipRect(clip_rect, Qt::IntersectClip);
             } else {
@@ -870,6 +870,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
                 path.addRoundedRect(clip_rect, radius, radius);
                 (*painter)->setClipPath(path, Qt::IntersectClip);
             }
+            return !(*painter)->clipBoundingRect().isEmpty();
         }}
     }
 

--- a/internal/backends/winit/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/winit/renderer/femtovg/itemrenderer.rs
@@ -724,14 +724,16 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
         }
     }
 
-    fn combine_clip(&mut self, clip_rect: Rect, radius: f32, border_width: f32) {
+    fn combine_clip(&mut self, clip_rect: Rect, radius: f32, border_width: f32) -> bool {
         let clip = &mut self.state.last_mut().unwrap().scissor;
-        match clip.intersection(&clip_rect) {
+        let clip_region_valid = match clip.intersection(&clip_rect) {
             Some(r) => {
                 *clip = r;
+                true
             }
             None => {
                 *clip = Rect::default();
+                false
             }
         };
 
@@ -750,6 +752,8 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
         // femtovg only supports rectangular clipping. Non-rectangular clips must be handled via `apply_clip`,
         // which can render children into a layer.
         debug_assert!(radius == 0.);
+
+        clip_region_valid
     }
 
     fn get_current_clip(&self) -> Rect {

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -102,7 +102,7 @@ impl Item for Path {
         let clip = self.clip();
         if clip {
             (*backend).save_state();
-            (*backend).combine_clip(self.geometry(), 0 as _, 0 as _)
+            (*backend).combine_clip(self.geometry(), 0 as _, 0 as _);
         }
         (*backend).draw_path(self, self_rc);
         if clip {

--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -1111,15 +1111,17 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<T> {
         // TODO
     }
 
-    fn combine_clip(&mut self, other: RectF, _radius: Coord, _border_width: Coord) {
+    fn combine_clip(&mut self, other: RectF, _radius: Coord, _border_width: Coord) -> bool {
         match self.current_state.clip.intersection(&LogicalRect::from_untyped(&other)) {
             Some(r) => {
                 self.current_state.clip = r;
+                true
             }
             None => {
                 self.current_state.clip = LogicalRect::default();
+                false
             }
-        };
+        }
         // TODO: handle radius and border
     }
 


### PR DESCRIPTION
When the renderer does not re-implement visit_clip, we call combine_clip.
Then we're missing out on an optimization the GL renderer does: When the resulting clip region
is empty, we do not need to recurse into children for rendering.

That itself reduces the property dependency chain and avoids unnecessary
updates when invisible (clipped) children change properties.