### PR TITLE
Lsp prepare

### DIFF
--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -72,8 +72,12 @@ impl RequestHolder {
             }
         };
 
-        let result = f(param)?;
-        self.1.send(Message::Response(Response::new_ok(id, result)))?;
+        match f(param) {
+            Ok(r) => self.1.send(Message::Response(Response::new_ok(id, r)))?,
+            Err(e) => {
+                self.1.send(Message::Response(Response::new_err(id, 23, format!("{}", e))))?
+            }
+        };
 
         Ok(true)
     }


### PR DESCRIPTION
Some small patches for the LSP to prepare for adding more commands to execute.

Especially the last one in nice to have: It reports errors in the command execution back to the client instead of killing the language server.