### PR TITLE
LSP: Implement a queryProperties command

### DIFF
--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -11,6 +11,8 @@ mod preview;
 mod properties;
 mod semantic_tokens;
 mod server_loop;
+#[cfg(test)]
+mod test;
 mod util;
 
 use i_slint_compiler::CompilerConfiguration;
@@ -174,8 +176,8 @@ fn main_loop(connection: &Connection, params: serde_json::Value) -> Result<(), E
                 )?;
             }
             Message::Response(_resp) => {}
-            Message::Notification(notify) => {
-                handle_notification(connection, notify, &mut document_cache)?
+            Message::Notification(notification) => {
+                handle_notification(connection, notification, &mut document_cache)?
             }
         }
     }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -8,6 +8,7 @@ mod goto;
 mod lsp_ext;
 #[cfg(feature = "preview")]
 mod preview;
+mod properties;
 mod semantic_tokens;
 mod server_loop;
 mod util;
@@ -173,8 +174,8 @@ fn main_loop(connection: &Connection, params: serde_json::Value) -> Result<(), E
                 )?;
             }
             Message::Response(_resp) => {}
-            Message::Notification(notifi) => {
-                handle_notification(connection, notifi, &mut document_cache)?
+            Message::Notification(notify) => {
+                handle_notification(connection, notify, &mut document_cache)?
             }
         }
     }

--- a/tools/lsp/properties.rs
+++ b/tools/lsp/properties.rs
@@ -52,11 +52,11 @@ fn get_element_properties(element: &Element, result: &mut Vec<PropertyInformatio
 
 fn insert_property_definition_range(
     property: &str,
-    properties: &mut Vec<PropertyInformation>,
+    properties: &mut [PropertyInformation],
     range: (u32, u32),
 ) {
     let index = properties
-        .binary_search_by(|p| (&p.name[..]).cmp(&property))
+        .binary_search_by(|p| (p.name[..]).cmp(property))
         .expect("property must be known");
     properties[index].defined_at = Some(range);
 }

--- a/tools/lsp/properties.rs
+++ b/tools/lsp/properties.rs
@@ -1,0 +1,141 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use i_slint_compiler::diagnostics::Spanned;
+use i_slint_compiler::object_tree::{Element, ElementRc};
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub(crate) struct PropertyInformation {
+    name: String,
+    type_name: String,
+    declared_at: Option<(String, u32)>,
+    defined_at: Option<(u32, u32)>, // Range in the elements source file!
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub(crate) struct QueryPropertyResponse {
+    properties: Vec<PropertyInformation>,
+    source_file: Option<String>,
+}
+
+// This gets defined accessibility properties...
+fn get_reserved_properties(result: &mut Vec<PropertyInformation>) {
+    result.extend(i_slint_compiler::typeregister::reserved_properties().map(|p| {
+        PropertyInformation {
+            name: p.0.to_string(),
+            type_name: format!("{}", p.1),
+            declared_at: None,
+            defined_at: None,
+        }
+    }))
+}
+
+fn source_file(element: &Element) -> Option<String> {
+    element.source_file().map(|sf| sf.path().to_string_lossy().to_string())
+}
+
+fn get_element_properties(element: &Element, result: &mut Vec<PropertyInformation>) {
+    let file = source_file(element);
+
+    for (name, value) in &element.property_declarations {
+        let declared_at = file.as_ref().and_then(|file| {
+            value.type_node().map(|n| n.text_range().start().into()).map(|p| (file.clone(), p))
+        });
+        result.push(PropertyInformation {
+            name: name.clone(),
+            type_name: format!("{}", value.property_type),
+            declared_at,
+            defined_at: None,
+        });
+    }
+}
+
+fn insert_property_definition_range(
+    property: &str,
+    properties: &mut Vec<PropertyInformation>,
+    range: (u32, u32),
+) {
+    let index = properties
+        .binary_search_by(|p| (&p.name[..]).cmp(&property))
+        .expect("property must be known");
+    properties[index].defined_at = Some(range);
+}
+
+fn insert_property_definitions(element: &Element, properties: &mut Vec<PropertyInformation>) {
+    let node = if let Some(node) = element.node.as_ref() {
+        node
+    } else {
+        return;
+    };
+
+    for (k, v) in &element.bindings {
+        if let Some(span) = &v.borrow().span {
+            let offset: u32 = span.span().offset.try_into().unwrap_or(u32::MAX);
+            if element.source_file().map(|sf| sf.path())
+                != span.source_file.as_ref().map(|sf| sf.path())
+                && node.text_range().contains(offset.into())
+            {
+                continue; // ignore definitions in files other than the element
+            }
+
+            if let Some(token) = node.token_at_offset(offset.into()).left_biased() {
+                let range = token.text_range();
+                insert_property_definition_range(
+                    k,
+                    properties,
+                    (range.start().into(), range.end().into()),
+                );
+            };
+        }
+    }
+}
+
+fn get_properties(element: &ElementRc) -> Vec<PropertyInformation> {
+    let mut result = vec![];
+
+    get_reserved_properties(&mut result);
+
+    let mut current_element = Some(element.clone());
+    while let Some(e) = current_element {
+        use i_slint_compiler::langtype::Type;
+
+        get_element_properties(&e.borrow(), &mut result);
+
+        // Go into base_type!
+        match &e.borrow().base_type {
+            Type::Component(c) => current_element = Some(c.root_element.clone()),
+            Type::Builtin(b) => {
+                result.extend(b.properties.iter().map(|(k, t)| PropertyInformation {
+                    name: k.clone(),
+                    type_name: format!("{}", t.ty),
+                    declared_at: None,
+                    defined_at: None,
+                }));
+                current_element = None;
+            }
+            Type::Native(n) => {
+                result.extend(n.properties.iter().map(|(k, t)| PropertyInformation {
+                    name: k.clone(),
+                    type_name: format!("{}", t.ty),
+                    declared_at: None,
+                    defined_at: None,
+                }));
+                current_element = None;
+            }
+            _ => current_element = None,
+        }
+    }
+
+    result.sort_by(|a, b| a.name.cmp(&b.name));
+
+    insert_property_definitions(&element.borrow(), &mut result);
+
+    result
+}
+
+pub(crate) fn query_properties(element: &ElementRc) -> Result<QueryPropertyResponse, crate::Error> {
+    Ok(QueryPropertyResponse {
+        properties: get_properties(&element),
+        source_file: source_file(&element.borrow()),
+    })
+}

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -410,7 +410,7 @@ fn get_document_and_offset(
 }
 
 fn element_contains(element: &i_slint_compiler::object_tree::ElementRc, offset: u32) -> bool {
-    element.borrow().node.as_ref().map(|n| n.text_range().contains(offset.into())).unwrap_or(false)
+    element.borrow().node.as_ref().map_or(false, |n| n.text_range().contains(offset.into()))
 }
 
 fn element_at_position(

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -320,7 +320,7 @@ fn maybe_goto_preview(
     let begin = text[..offset].rfind(|x: char| !x.is_ascii_alphanumeric())? + 1;
     let text = &text.as_bytes()[begin..];
     let rest = text.strip_prefix(b"preview").or_else(|| text.strip_prefix(b"PREVIEW"))?;
-    if rest.get(0).map_or(true, |x| x.is_ascii_alphanumeric()) {
+    if rest.first().map_or(true, |x| x.is_ascii_alphanumeric()) {
         return None;
     }
 

--- a/tools/lsp/test.rs
+++ b/tools/lsp/test.rs
@@ -1,0 +1,95 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+//! Code to help with writing tests for the language server
+
+use lsp_types::{Diagnostic, Url};
+
+use std::collections::HashMap;
+
+use crate::server_loop::{reload_document_impl, DocumentCache};
+
+/// Create an empty `DocumentCache`
+pub fn empty_document_cache(style: &str) -> DocumentCache {
+    let mut config = i_slint_compiler::CompilerConfiguration::new(
+        i_slint_compiler::generator::OutputFormat::Interpreter,
+    );
+    config.style = Some(style.to_string());
+    DocumentCache::new(config)
+}
+
+/// Create a `DocumentCache` with one document loaded into it.
+pub fn loaded_document_cache(
+    style: &str,
+    content: String,
+) -> (DocumentCache, Url, HashMap<Url, Vec<Diagnostic>>) {
+    let mut dc = empty_document_cache(style);
+    let dummy_absolute_path =
+        if cfg!(target_family = "windows") { "c://foo/bar.slint" } else { "/foo/bar.slint" };
+    let url = Url::from_file_path(dummy_absolute_path).unwrap();
+    let diag = spin_on::spin_on(async {
+        reload_document_impl(content, url.clone(), &mut dc)
+            .await
+            .expect("reload_document_impl failed.")
+    });
+    (dc, url, diag)
+}
+
+/// Create a `DocumentCache` with one comparatively complex test document loaded into it.
+pub fn complex_document_cache(style: &str) -> (DocumentCache, Url, HashMap<Url, Vec<Diagnostic>>) {
+    loaded_document_cache(style,
+            r#"import { LineEdit, Button, Slider, HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+MainWindow := Window {
+    property <duration> total-time: slider.value * 1s;
+    property <duration> elapsed-time;
+
+    callback tick(duration);
+    tick(passed-time) => {
+        elapsed-time += passed-time;
+        elapsed-time = min(elapsed-time, total-time);
+    }
+
+    VerticalBox {
+        HorizontalBox {
+            padding-left: 0;
+            Text { text: "Elapsed Time:"; }
+            Rectangle {
+                min-width: 200px;
+                max-height: 30px;
+                background: gray;
+                Rectangle {
+                    height: 100%;
+                    width: parent.width * (elapsed-time/total-time);
+                    background: lightblue;
+                }
+            }
+        }
+        Text{
+            text: (total-time / 1s) + "s";
+        }
+        HorizontalBox {
+            padding-left: 0;
+            Text {
+                text: "Duration:";
+                vertical-alignment: center;
+            }
+            slider := Slider {
+                maximum: 30s / 1s;
+                value: 10s / 1s;
+                changed(new-duration) => {
+                    root.total-time = new-duration * 1s;
+                    root.elapsed-time = min(root.elapsed-time, root.total-time);
+                }
+            }
+        }
+        Button {
+            text: "Reset";
+            clicked => {
+                elapsed-time = 0
+            }
+        }
+    }
+}
+            "#.to_string())
+}

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -6,6 +6,7 @@
 mod completion;
 mod goto;
 mod lsp_ext;
+mod properties;
 mod semantic_tokens;
 mod server_loop;
 mod util;


### PR DESCRIPTION
Implment a command in the LSP that can be used to query all known
properties, where those are declared and defined.

With this information we should be able to provide an property editor in
IDEs.

----

This shows how the necessary information can be extracted in our LS implementation. I would appreciate feedback on that!

The output is still very much in flux: I think it has the interesting bits it needs now, but how to best present that information depends on work on the language server client side. E.g. it will probably make sense to return proper LSP types holding `url`, `line` and `column` offsets instead of `filename` and `offset`.

I should also not break filenames by turning them into strings, but considering that URLs are used to pass file names between LS client and server this might actually be safe here.