### PR TITLE
winit: Remove unused existing_size field

### DIFF
--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -179,7 +179,9 @@ impl PlatformWindow for SimulatorWindow {
     }
 
     fn inner_size(&self) -> euclid::Size2D<u32, PhysicalPx> {
-        unimplemented!()
+        let winit_window = self.opengl_context.window();
+        let size = winit_window.inner_size();
+        euclid::Size2D::new(size.width, size.height)
     }
 
     fn set_inner_size(&self, _size: euclid::Size2D<u32, PhysicalPx>) {
@@ -315,15 +317,6 @@ impl WinitWindow for SimulatorWindow {
         self.constraints.set(constraints)
     }
 
-    fn existing_size(&self) -> winit::dpi::LogicalSize<f32> {
-        self.frame_buffer.borrow().as_ref().map_or(Default::default(), |display| {
-            let eg_size = display.size();
-            winit::dpi::LogicalSize::new(eg_size.width as f32, eg_size.height as f32)
-        })
-    }
-    fn set_existing_size(&self, _size: winit::dpi::LogicalSize<f32>) {
-        // dummy since it shouldn't be needed
-    }
     fn set_icon(&self, _icon: i_slint_core::graphics::Image) {}
 }
 

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -9,6 +9,7 @@
 */
 use copypasta::ClipboardProvider;
 use corelib::items::PointerEventButton;
+use corelib::lengths::LogicalSize;
 use i_slint_core as corelib;
 
 use corelib::api::euclid;
@@ -34,14 +35,6 @@ pub trait WinitWindow: PlatformWindow {
         &self,
         constraints: (corelib::layout::LayoutInfo, corelib::layout::LayoutInfo),
     );
-    /// Get the size of the window. Unlike [`winit::window::Window::inner_size()`], this property does not
-    /// hold the most recent window size as known by the OS but the latest size that has been processed
-    /// by [`WinitWindow::apply_window_properties()`].
-    fn existing_size(&self) -> winit::dpi::LogicalSize<f32>;
-    /// Set the size of the window. Unlike [`winit::window::Window::set_inner_size()`], this property does not
-    /// hold the most recent window size as known by the OS but the latest size that has been processed
-    /// by [`WinitWindow::apply_window_properties()`].
-    fn set_existing_size(&self, size: winit::dpi::LogicalSize<f32>);
     fn set_icon(&self, icon: corelib::graphics::Image);
 
     fn apply_constraints(
@@ -140,7 +133,8 @@ pub trait WinitWindow: PlatformWindow {
                 }
             }
 
-            let existing_size = self.existing_size();
+            let existing_size: LogicalSize =
+                self.inner_size().cast() / self.runtime_window().scale();
 
             if (existing_size.width as f32 - width).abs() > 1.
                 || (existing_size.height as f32 - height).abs() > 1.
@@ -388,7 +382,6 @@ fn process_window_event(
         WindowEvent::Resized(size) => {
             let size = size.to_logical(runtime_window.scale_factor() as f64);
             runtime_window.set_window_item_geometry(size.width, size.height);
-            window.set_existing_size(size);
         }
         WindowEvent::CloseRequested => {
             if runtime_window.request_close() {

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -33,7 +33,6 @@ pub(crate) struct GLWindow<Renderer: WinitCompatibleRenderer> {
     map_state: RefCell<GraphicsWindowBackendState<Renderer>>,
     keyboard_modifiers: std::cell::Cell<KeyboardModifiers>,
     currently_pressed_key_code: std::cell::Cell<Option<winit::event::VirtualKeyCode>>,
-    existing_size: Cell<winit::dpi::LogicalSize<f32>>,
 
     rendering_notifier: RefCell<Option<Box<dyn RenderingNotifier>>>,
 
@@ -65,7 +64,6 @@ impl<Renderer: WinitCompatibleRenderer> GLWindow<Renderer> {
             }),
             keyboard_modifiers: Default::default(),
             currently_pressed_key_code: Default::default(),
-            existing_size: Default::default(),
             rendering_notifier: Default::default(),
             renderer: Renderer::new(&window_weak),
             #[cfg(target_arch = "wasm32")]
@@ -201,14 +199,6 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Rende
         if let Some(window) = self.borrow_mapped_window() {
             window.constraints.set(constraints);
         }
-    }
-
-    fn existing_size(&self) -> winit::dpi::LogicalSize<f32> {
-        self.existing_size.get()
-    }
-
-    fn set_existing_size(&self, size: winit::dpi::LogicalSize<f32>) {
-        self.existing_size.set(size);
     }
 
     fn set_icon(&self, icon: corelib::graphics::Image) {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -163,7 +163,7 @@ impl Window {
     /// This function returns an euclid scale that allows conveniently converting between logical and
     /// physical pixels based on the window's scale factor.
     pub fn scale_factor(&self) -> euclid::Scale<f32, LogicalPx, PhysicalPx> {
-        euclid::Scale::new(self.0.scale_factor())
+        self.0.scale()
     }
 
     /// Returns the position of the window on the screen, in physical screen coordinates and including

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -6,7 +6,7 @@
 #![warn(missing_docs)]
 //! Exposed Window API
 
-use crate::api::{CloseRequestResponse, PhysicalPx, Window};
+use crate::api::{CloseRequestResponse, LogicalPx, PhysicalPx, Window};
 use crate::component::{ComponentRc, ComponentRef, ComponentVTable, ComponentWeak};
 use crate::graphics::{Point, Rect, Size};
 use crate::input::{
@@ -659,6 +659,11 @@ impl WindowInner {
     /// Sets the scale factor for the window. This is set by the backend or for testing.
     pub fn set_scale_factor(&self, factor: f32) {
         self.scale_factor.as_ref().set(factor)
+    }
+
+    /// Returns an euclid scale that can be used to convert between logical and physical pixels.
+    pub fn scale(&self) -> euclid::Scale<f32, LogicalPx, PhysicalPx> {
+        euclid::Scale::new(self.scale_factor())
     }
 
     /// Returns the window item that is the first item in the component.


### PR DESCRIPTION
… module

This field duplicates the winit window's inner size. It is set on a
WindowEvent::Resized(), after which
`winit::window::Window::inner_size()` returns the same value.