### PR TITLE
Separate the OpenGL specific Skia code from the generic Skia code

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -36,6 +36,8 @@ pub trait WinitWindow: PlatformWindow {
         constraints: (corelib::layout::LayoutInfo, corelib::layout::LayoutInfo),
     );
     fn set_icon(&self, icon: corelib::graphics::Image);
+    /// Called by the event loop when a WindowEvent::Resized is received.
+    fn resize_event(&self) {}
 
     fn apply_constraints(
         &self,
@@ -382,6 +384,7 @@ fn process_window_event(
         WindowEvent::Resized(size) => {
             let size = size.to_logical(runtime_window.scale_factor() as f64);
             runtime_window.set_window_item_geometry(size.width, size.height);
+            window.resize_event();
         }
         WindowEvent::CloseRequested => {
             if runtime_window.request_close() {

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -215,6 +215,12 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Rende
             Err(_) => true,
         }
     }
+
+    fn resize_event(&self) {
+        if let Some(mapped_window) = self.borrow_mapped_window() {
+            mapped_window.canvas.resize_event()
+        }
+    }
 }
 
 impl<Renderer: WinitCompatibleRenderer + 'static> PlatformWindow for GLWindow<Renderer> {

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -49,6 +49,8 @@ mod renderer {
 
         fn with_window_handle<T>(&self, callback: impl FnOnce(&winit::window::Window) -> T) -> T;
 
+        fn resize_event(&self);
+
         #[cfg(target_arch = "wasm32")]
         fn html_canvas_element(&self) -> std::cell::Ref<web_sys::HtmlCanvasElement>;
     }

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -122,7 +122,6 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
         let height = size.height;
 
         canvas.opengl_context.make_current();
-        canvas.opengl_context.ensure_resized();
 
         window.clone().draw_contents(|components| {
             {
@@ -385,6 +384,10 @@ impl super::WinitCompatibleCanvas for FemtoVGCanvas {
 
     fn with_window_handle<T>(&self, callback: impl FnOnce(&winit::window::Window) -> T) -> T {
         callback(&*self.opengl_context.window())
+    }
+
+    fn resize_event(&self) {
+        self.opengl_context.ensure_resized()
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -150,6 +150,7 @@ pub trait Surface {
         &self,
         callback: impl FnOnce(&mut skia_safe::Canvas, &RefCell<skia_safe::gpu::DirectContext>),
     );
+    fn resize_event(&self);
 }
 
 pub struct SkiaCanvas<SurfaceType: Surface> {
@@ -173,5 +174,9 @@ impl<SurfaceType: Surface> super::WinitCompatibleCanvas for SkiaCanvas<SurfaceTy
 
     fn with_window_handle<T>(&self, callback: impl FnOnce(&winit::window::Window) -> T) -> T {
         self.surface.with_window_handle(callback)
+    }
+
+    fn resize_event(&self) {
+        self.surface.resize_event()
     }
 }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -16,19 +16,21 @@ use crate::WindowSystemName;
 mod itemrenderer;
 mod textlayout;
 
+mod opengl_surface;
+
 pub struct SkiaRenderer {
     window_weak: Weak<i_slint_core::window::WindowInner>,
 }
 
 impl super::WinitCompatibleRenderer for SkiaRenderer {
-    type Canvas = SkiaCanvas;
+    type Canvas = SkiaCanvas<opengl_surface::OpenGLSurface>;
 
     fn new(window_weak: &std::rc::Weak<i_slint_core::window::WindowInner>) -> Self {
         Self { window_weak: window_weak.clone() }
     }
 
     fn create_canvas(&self, window_builder: winit::window::WindowBuilder) -> Self::Canvas {
-        let surface = OpenGLSurface::new(window_builder);
+        let surface = opengl_surface::OpenGLSurface::new(window_builder);
 
         let rendering_metrics_collector = RenderingMetricsCollector::new(
             self.window_weak.clone(),
@@ -140,114 +142,23 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
     }
 }
 
-struct OpenGLSurface {
-    surface: RefCell<skia_safe::Surface>,
-    gr_context: RefCell<skia_safe::gpu::DirectContext>,
-    opengl_context: crate::OpenGLContext,
-}
-
-impl OpenGLSurface {
-    fn new(window_builder: winit::window::WindowBuilder) -> Self {
-        let opengl_context = crate::OpenGLContext::new_context(window_builder);
-
-        let gl_interface = skia_safe::gpu::gl::Interface::new_load_with(|symbol| {
-            opengl_context.get_proc_address(symbol)
-        });
-
-        let mut gr_context = skia_safe::gpu::DirectContext::new_gl(gl_interface, None).unwrap();
-
-        let surface =
-            Self::create_internal_surface(&opengl_context.glutin_context(), &mut gr_context).into();
-
-        Self { surface, gr_context: RefCell::new(gr_context), opengl_context }
-    }
-
-    fn with_graphics_api(&self, callback: impl FnOnce(GraphicsAPI<'_>)) {
-        let api = GraphicsAPI::NativeOpenGL {
-            get_proc_address: &|name| self.opengl_context.get_proc_address(name),
-        };
-        callback(api)
-    }
-
-    fn with_window_handle<T>(&self, callback: impl FnOnce(&winit::window::Window) -> T) -> T {
-        callback(&*self.opengl_context.window())
-    }
-
-    fn create_internal_surface(
-        gl_context: &glutin::WindowedContext<glutin::PossiblyCurrent>,
-        gr_context: &mut skia_safe::gpu::DirectContext,
-    ) -> skia_safe::Surface {
-        use glow::HasContext;
-
-        let fb_info = {
-            let gl = unsafe {
-                glow::Context::from_loader_function(|s| gl_context.get_proc_address(s) as *const _)
-            };
-            let fboid = unsafe { gl.get_parameter_i32(glow::FRAMEBUFFER_BINDING) };
-
-            skia_safe::gpu::gl::FramebufferInfo {
-                fboid: fboid.try_into().unwrap(),
-                format: skia_safe::gpu::gl::Format::RGBA8.into(),
-            }
-        };
-
-        let pixel_format = gl_context.get_pixel_format();
-        let size = gl_context.window().inner_size();
-        let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_gl(
-            (size.width.try_into().unwrap(), size.height.try_into().unwrap()),
-            pixel_format.multisampling.map(|s| s.try_into().unwrap()),
-            pixel_format.stencil_bits.try_into().unwrap(),
-            fb_info,
-        );
-        let surface = skia_safe::Surface::from_backend_render_target(
-            gr_context,
-            &backend_render_target,
-            skia_safe::gpu::SurfaceOrigin::BottomLeft,
-            skia_safe::ColorType::RGBA8888,
-            None,
-            None,
-        )
-        .unwrap();
-        surface
-    }
-
-    fn render<T>(
+pub trait Surface {
+    fn new(window_builder: winit::window::WindowBuilder) -> Self;
+    fn with_graphics_api(&self, callback: impl FnOnce(GraphicsAPI<'_>));
+    fn with_window_handle<T>(&self, callback: impl FnOnce(&winit::window::Window) -> T) -> T;
+    fn render(
         &self,
-        callback: impl FnOnce(&mut skia_safe::Canvas, &RefCell<skia_safe::gpu::DirectContext>) -> T,
-    ) -> T {
-        let size = self.opengl_context.window().inner_size();
-        let width = size.width;
-        let height = size.height;
-
-        self.opengl_context.make_current();
-        self.opengl_context.ensure_resized();
-
-        let mut surface = self.surface.borrow_mut();
-        if width != surface.width() as u32 || height != surface.height() as u32 {
-            *surface = Self::create_internal_surface(
-                &self.opengl_context.glutin_context(),
-                &mut self.gr_context.borrow_mut(),
-            );
-        }
-
-        let skia_canvas = surface.canvas();
-
-        let result = callback(skia_canvas, &self.gr_context);
-
-        self.opengl_context.swap_buffers();
-        self.opengl_context.make_not_current();
-
-        result
-    }
+        callback: impl FnOnce(&mut skia_safe::Canvas, &RefCell<skia_safe::gpu::DirectContext>),
+    );
 }
 
-pub struct SkiaCanvas {
+pub struct SkiaCanvas<SurfaceType: Surface> {
     image_cache: ItemCache<Option<skia_safe::Image>>,
     rendering_metrics_collector: Option<Rc<RenderingMetricsCollector>>,
-    surface: OpenGLSurface,
+    surface: SurfaceType,
 }
 
-impl super::WinitCompatibleCanvas for SkiaCanvas {
+impl<SurfaceType: Surface> super::WinitCompatibleCanvas for SkiaCanvas<SurfaceType> {
     fn release_graphics_resources(&self) {
         self.image_cache.clear_all();
     }

--- a/internal/backends/winit/renderer/skia/opengl_surface.rs
+++ b/internal/backends/winit/renderer/skia/opengl_surface.rs
@@ -1,0 +1,107 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use std::cell::RefCell;
+
+use i_slint_core::api::GraphicsAPI;
+
+pub struct OpenGLSurface {
+    surface: RefCell<skia_safe::Surface>,
+    gr_context: RefCell<skia_safe::gpu::DirectContext>,
+    opengl_context: crate::OpenGLContext,
+}
+
+impl super::Surface for OpenGLSurface {
+    fn new(window_builder: winit::window::WindowBuilder) -> Self {
+        let opengl_context = crate::OpenGLContext::new_context(window_builder);
+
+        let gl_interface = skia_safe::gpu::gl::Interface::new_load_with(|symbol| {
+            opengl_context.get_proc_address(symbol)
+        });
+
+        let mut gr_context = skia_safe::gpu::DirectContext::new_gl(gl_interface, None).unwrap();
+
+        let surface =
+            Self::create_internal_surface(&opengl_context.glutin_context(), &mut gr_context).into();
+
+        Self { surface, gr_context: RefCell::new(gr_context), opengl_context }
+    }
+
+    fn with_graphics_api(&self, callback: impl FnOnce(GraphicsAPI<'_>)) {
+        let api = GraphicsAPI::NativeOpenGL {
+            get_proc_address: &|name| self.opengl_context.get_proc_address(name),
+        };
+        callback(api)
+    }
+
+    fn with_window_handle<T>(&self, callback: impl FnOnce(&winit::window::Window) -> T) -> T {
+        callback(&*self.opengl_context.window())
+    }
+
+    fn render(
+        &self,
+        callback: impl FnOnce(&mut skia_safe::Canvas, &RefCell<skia_safe::gpu::DirectContext>),
+    ) {
+        let size = self.opengl_context.window().inner_size();
+        let width = size.width;
+        let height = size.height;
+
+        self.opengl_context.make_current();
+        self.opengl_context.ensure_resized();
+
+        let mut surface = self.surface.borrow_mut();
+        if width != surface.width() as u32 || height != surface.height() as u32 {
+            *surface = Self::create_internal_surface(
+                &self.opengl_context.glutin_context(),
+                &mut self.gr_context.borrow_mut(),
+            );
+        }
+
+        let skia_canvas = surface.canvas();
+
+        callback(skia_canvas, &self.gr_context);
+
+        self.opengl_context.swap_buffers();
+        self.opengl_context.make_not_current();
+    }
+}
+
+impl OpenGLSurface {
+    fn create_internal_surface(
+        gl_context: &glutin::WindowedContext<glutin::PossiblyCurrent>,
+        gr_context: &mut skia_safe::gpu::DirectContext,
+    ) -> skia_safe::Surface {
+        use glow::HasContext;
+
+        let fb_info = {
+            let gl = unsafe {
+                glow::Context::from_loader_function(|s| gl_context.get_proc_address(s) as *const _)
+            };
+            let fboid = unsafe { gl.get_parameter_i32(glow::FRAMEBUFFER_BINDING) };
+
+            skia_safe::gpu::gl::FramebufferInfo {
+                fboid: fboid.try_into().unwrap(),
+                format: skia_safe::gpu::gl::Format::RGBA8.into(),
+            }
+        };
+
+        let pixel_format = gl_context.get_pixel_format();
+        let size = gl_context.window().inner_size();
+        let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_gl(
+            (size.width.try_into().unwrap(), size.height.try_into().unwrap()),
+            pixel_format.multisampling.map(|s| s.try_into().unwrap()),
+            pixel_format.stencil_bits.try_into().unwrap(),
+            fb_info,
+        );
+        let surface = skia_safe::Surface::from_backend_render_target(
+            gr_context,
+            &backend_render_target,
+            skia_safe::gpu::SurfaceOrigin::BottomLeft,
+            skia_safe::ColorType::RGBA8888,
+            None,
+            None,
+        )
+        .unwrap();
+        surface
+    }
+}

--- a/internal/backends/winit/renderer/skia/opengl_surface.rs
+++ b/internal/backends/winit/renderer/skia/opengl_surface.rs
@@ -47,7 +47,6 @@ impl super::Surface for OpenGLSurface {
         let height = size.height;
 
         self.opengl_context.make_current();
-        self.opengl_context.ensure_resized();
 
         let mut surface = self.surface.borrow_mut();
         if width != surface.width() as u32 || height != surface.height() as u32 {
@@ -63,6 +62,10 @@ impl super::Surface for OpenGLSurface {
 
         self.opengl_context.swap_buffers();
         self.opengl_context.make_not_current();
+    }
+
+    fn resize_event(&self) {
+        self.opengl_context.ensure_resized();
     }
 }
 


### PR DESCRIPTION
This merge request introduces a Surface abstraction behind which we can hide the OpenGL code and in the future Metal, Direct3D and Vulkan.