### PR TITLE
Remove unnecessary character in tutorial

### DIFF
--- a/docs/tutorial/rust/src/creating_the_tiles_from_rust.md
+++ b/docs/tutorial/rust/src/creating_the_tiles_from_rust.md
@@ -1,6 +1,6 @@
 # Creating The Tiles From Rust
 
-The tiles in the game should have a random placement. We'll need to add the <`rand` dependency to
+The tiles in the game should have a random placement. We'll need to add the `rand` dependency to
 `Cargo.toml` for the randomization.
 
 ```toml


### PR DESCRIPTION
Seems like a typo.