### PR TITLE
winit: fix jitter on macos again when resizing windows

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -647,7 +647,6 @@ pub fn run(quit_behavior: i_slint_core::backend::EventLoopQuitBehavior) {
                 winit::event::Event::MainEventsCleared => {
                     for window in windows_with_pending_property_updates
                         .drain(..)
-                        .into_iter()
                         .flat_map(|window_id| window_by_id(window_id))
                     {
                         window.runtime_window().update_window_properties();


### PR DESCRIPTION
Commit 0ee361d994dd8cb0be20c8b03cc9ae459a16ce4f regressed on
https://github.com/slint-ui/slint/issues/1269 as the inner_size()
returned at the time during event processing is already the future
value, that will change again when processing the resize event.

Instead of storing the last received value, process the event at the
appropriate MainEventsCleared stage.