### PR TITLE
Revive support for rotation of elements

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -64,9 +64,9 @@ export ClippedImage := ImageItem {
 export { ClippedImage as Image }
 
 export Rotate := _ {
-    property <angle> angle;
-    property <length> origin-x;
-    property <length> origin-y;
+    property <angle> rotation-angle;
+    property <length> rotation-origin-x;
+    property <length> rotation-origin-y;
     property <length> width;
     property <length> height;
     //-default_size_binding:expands_to_parent_geometry

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -139,6 +139,13 @@ pub async fn run_passes(
             diag,
         );
         lower_shadows::lower_shadow_properties(component, &doc.local_registry, diag);
+        lower_property_to_element::lower_property_to_element(
+            component,
+            "rotation-angle",
+            "Rotate",
+            &global_type_registry.borrow(),
+            diag,
+        );
         clip::handle_clip(component, &global_type_registry.borrow(), diag);
         visible::handle_visible(component, &global_type_registry.borrow());
         if compiler_config.accessibility {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -86,6 +86,12 @@ pub(crate) const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
     ("drop-shadow-color", Type::Color),
 ];
 
+pub(crate) const RESERVED_ROTATION_PROPERTIES: &[(&str, Type)] = &[
+    ("rotation-angle", Type::Angle),
+    ("rotation-origin-x", Type::LogicalLength),
+    ("rotation-origin-y", Type::LogicalLength),
+];
+
 pub(crate) const RESERVED_ACCESSIBILITY_PROPERTIES: &[(&str, Type)] = &[
     //("accessible-role", ...)
     ("accessible-checkable", Type::Bool),
@@ -106,6 +112,7 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type)> {
         .chain(RESERVED_LAYOUT_PROPERTIES.iter())
         .chain(RESERVED_OTHER_PROPERTIES.iter())
         .chain(RESERVED_DROP_SHADOW_PROPERTIES.iter())
+        .chain(RESERVED_ROTATION_PROPERTIES.iter())
         .chain(RESERVED_ACCESSIBILITY_PROPERTIES.iter())
         .map(|(k, v)| (*k, v.clone()))
         .chain(IntoIterator::into_iter([

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -832,9 +832,9 @@ declare_item_vtable! {
 #[pin]
 /// The implementation of the `Rotate` element
 pub struct Rotate {
-    pub angle: Property<f32>,
-    pub origin_x: Property<Coord>,
-    pub origin_y: Property<Coord>,
+    pub rotation_angle: Property<f32>,
+    pub rotation_origin_x: Property<Coord>,
+    pub rotation_origin_y: Property<Coord>,
     pub width: Property<Coord>,
     pub height: Property<Coord>,
     pub cached_rendering_data: CachedRenderingData,
@@ -844,7 +844,7 @@ impl Item for Rotate {
     fn init(self: Pin<&Self>, _window: &WindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
-        euclid::rect(0, 0, 0, 0).cast()
+        euclid::rect(0 as _, 0 as _, self.width(), self.height())
     }
 
     fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
@@ -882,9 +882,9 @@ impl Item for Rotate {
         backend: &mut ItemRendererRef,
         _self_rc: &ItemRc,
     ) -> RenderingResult {
-        (*backend).translate(self.origin_x(), self.origin_y());
-        (*backend).rotate(self.angle());
-        (*backend).translate(-self.origin_x(), -self.origin_y());
+        (*backend).translate(self.rotation_origin_x(), self.rotation_origin_y());
+        (*backend).rotate(self.rotation_angle());
+        (*backend).translate(-self.rotation_origin_x(), -self.rotation_origin_y());
         RenderingResult::ContinueRenderingChildren
     }
 }


### PR DESCRIPTION
The rotation-angle/rotation-origin-x/y properties are lowered to an
injected Rotate element, that we already had.

This needs further fixes for transforming input events and an
implementation of rotation in Skia.