### PR TITLE
Online editor: Cleanup TS setup

### DIFF
--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -40,6 +40,8 @@ jobs:
     - name: Compile online editor
       run: |
           npm install
+          npm run syntax_check
+          npm run lint
           npm run build
       working-directory: tools/online_editor
     - name: Clean wasm build artefacts from previous editor build

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -14,46 +14,50 @@ jobs:
       CARGO_INCREMENTAL: false
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12'
-    - id: nodeversion
-      run: |
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+      - id: nodeversion
+        run: |
           echo "::set-output name=node-version::$(node --version)"
-    - uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-${{ github.job }}-node-${{ hashFiles('examples/**/package.json', 'api/**/package.json') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.job }}-node-
-    - name: Install latest stable
-      uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ github.job }}-node-${{ hashFiles('examples/**/package.json', 'api/**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-node-
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
           toolchain: stable
           profile: minimal
           target: wasm32-unknown-unknown
-    - uses: Swatinem/rust-cache@v1
-    - name: Install wasm-pack
-      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-    - name: Compile online editor
-      run: |
-          npm install
-          npm run syntax_check
-          npm run lint
-          npm run build
-      working-directory: tools/online_editor
-    - name: Clean wasm build artefacts from previous editor build
-      run: rm -rf pkg
-      working-directory: api/wasm-interpreter
-    - name: Compile slint-wasm-interpreter
-      run: wasm-pack build --release --target web -- --features console_error_panic_hook
-      working-directory: api/wasm-interpreter
-    - name: "Upload wasm Artifacts"
-      uses: actions/upload-artifact@v2
-      with:
+      - uses: Swatinem/rust-cache@v1
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install NPM dependencies
+        run: npm install
+        working-directory: tools/online_editor
+      - name: Compile online editor
+        run: npm run build
+        working-directory: tools/online_editor
+      - name: Clean wasm build artefacts from previous editor build
+        run: rm -rf pkg
+        working-directory: api/wasm-interpreter
+      - name: Compile slint-wasm-interpreter
+        run: wasm-pack build --release --target web -- --features console_error_panic_hook
+        working-directory: api/wasm-interpreter
+      - name: "Upload wasm Artifacts"
+        uses: actions/upload-artifact@v2
+        with:
           name: wasm
           path: |
-              api/wasm-interpreter/pkg/
-              tools/online_editor/dist/
+            api/wasm-interpreter/pkg/
+            tools/online_editor/dist/
+      - name: Lint online editor # This needs the slint-wasm-interpreter!
+        run: |
+          npm run syntax_check
+          npm run lint
+        working-directory: tools/online_editor

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -14,50 +14,50 @@ jobs:
       CARGO_INCREMENTAL: false
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12"
-      - id: nodeversion
-        run: |
+    - uses: actions/checkout@v2
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+    - id: nodeversion
+      run: |
           echo "::set-output name=node-version::$(node --version)"
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-${{ github.job }}-node-${{ hashFiles('examples/**/package.json', 'api/**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-node-
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-${{ github.job }}-node-${{ hashFiles('examples/**/package.json', 'api/**/package.json') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ github.job }}-node-
+    - name: Install latest stable
+      uses: actions-rs/toolchain@v1
+      with:
           toolchain: stable
           profile: minimal
           target: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v1
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Install NPM dependencies
-        run: npm install
-        working-directory: tools/online_editor
-      - name: Compile online editor
-        run: npm run build
-        working-directory: tools/online_editor
-      - name: Clean wasm build artefacts from previous editor build
-        run: rm -rf pkg
-        working-directory: api/wasm-interpreter
-      - name: Compile slint-wasm-interpreter
-        run: wasm-pack build --release --target web -- --features console_error_panic_hook
-        working-directory: api/wasm-interpreter
-      - name: "Upload wasm Artifacts"
-        uses: actions/upload-artifact@v2
-        with:
+    - uses: Swatinem/rust-cache@v1
+    - name: Install wasm-pack
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+    - name: Install NPM dependencies
+      run: npm install
+      working-directory: tools/online_editor
+    - name: Compile online editor
+      run: npm run build
+      working-directory: tools/online_editor
+    - name: Clean wasm build artefacts from previous editor build
+      run: rm -rf pkg
+      working-directory: api/wasm-interpreter
+    - name: Compile slint-wasm-interpreter
+      run: wasm-pack build --release --target web -- --features console_error_panic_hook
+      working-directory: api/wasm-interpreter
+    - name: "Upload wasm Artifacts"
+      uses: actions/upload-artifact@v2
+      with:
           name: wasm
           path: |
-            api/wasm-interpreter/pkg/
-            tools/online_editor/dist/
-      - name: Lint online editor # This needs the slint-wasm-interpreter!
-        run: |
+              api/wasm-interpreter/pkg/
+              tools/online_editor/dist/
+    - name: Lint online editor # This needs the slint-wasm-interpreter!
+      run: |
           npm run syntax_check
           npm run lint
-        working-directory: tools/online_editor
+      working-directory: tools/online_editor

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,7 +7,7 @@ Files: */slint-logo-*.svg */slint-logo-*.png
 Copyright: Copyright © SixtyFPS GmbH <info@slint-ui.com>
 License: CC-BY-ND-4.0
 
-Files: .clang-format .gitattributes .gitignore */.gitignore .pre-commit-config.yaml .vscode/* cspell.json rustfmt.toml .mailmap
+Files: .clang-format .gitattributes .gitignore */.gitignore .pre-commit-config.yaml .vscode/* cspell.json rustfmt.toml .mailmap */.eslintrc.yml
 Copyright: Copyright © SixtyFPS GmbH <info@slint-ui.com>
 License: GPL-3.0-only OR LicenseRef-Slint-commercial
 

--- a/tools/online_editor/.eslintrc.yml
+++ b/tools/online_editor/.eslintrc.yml
@@ -1,0 +1,9 @@
+env:
+  browser: true
+  es2021: true
+extends: standard-with-typescript
+overrides: []
+parserOptions:
+  ecmaVersion: latest
+  sourceType: module
+rules: {}

--- a/tools/online_editor/.eslintrc.yml
+++ b/tools/online_editor/.eslintrc.yml
@@ -1,11 +1,24 @@
 env:
   browser: true
   es2021: true
-extends: standard-with-typescript
+extends:
+  - eslint:recommended
+  - plugin:@typescript-eslint/recommended
 overrides: []
+parser: "@typescript-eslint/parser"
 parserOptions:
-  project:
-    - "./tsconfig.json"
   ecmaVersion: latest
   sourceType: module
-rules: {}
+plugins:
+  - "@typescript-eslint"
+rules:
+  "no-unused-vars":
+    - error
+    - "argsIgnorePattern": "^_"
+      "destructuredArrayIgnorePattern": "^_"
+      "varsIgnorePattern": "^_"
+  "@typescript-eslint/no-unused-vars":
+    - error
+    - "argsIgnorePattern": "^_"
+      "destructuredArrayIgnorePattern": "^_"
+      "varsIgnorePattern": "^_"

--- a/tools/online_editor/.eslintrc.yml
+++ b/tools/online_editor/.eslintrc.yml
@@ -4,6 +4,8 @@ env:
 extends: standard-with-typescript
 overrides: []
 parserOptions:
+  project:
+    - "./tsconfig.json"
   ecmaVersion: latest
   sourceType: module
 rules: {}

--- a/tools/online_editor/highlighting.ts
+++ b/tools/online_editor/highlighting.ts
@@ -30,7 +30,7 @@ export const slint_language = <monaco.languages.IMonarchLanguage>{
   escapes:
     /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
 
-  symbols: /[\#\!\%\&\*\+\-\.\/\:\;\<\=\>\@\^\|_\?,()]+/,
+  symbols: /[#!%&*+\-./:;<=>@^|_?,()]+/,
 
   tokenizer: {
     root: [
@@ -50,11 +50,11 @@ export const slint_language = <monaco.languages.IMonarchLanguage>{
       [/@symbols/, ""],
     ],
     inner: [
-      [/[a-zA-Z_][a-zA-Z0-9_\-]*\s*:=/, "variable.parameter"],
-      [/[a-zA-Z_][a-zA-Z0-9_\-]*\s*:\s*\{/, "variable.parameter", "@binding_1"],
-      [/[a-zA-Z_][a-zA-Z0-9_\-]*\s*:/, "variable.parameter", "@binding_0"],
+      [/[a-zA-Z_][a-zA-Z0-9_-]*\s*:=/, "variable.parameter"],
+      [/[a-zA-Z_][a-zA-Z0-9_-]*\s*:\s*\{/, "variable.parameter", "@binding_1"],
+      [/[a-zA-Z_][a-zA-Z0-9_-]*\s*:/, "variable.parameter", "@binding_0"],
       [
-        /[a-zA-Z_][a-zA-Z0-9_\-]*/,
+        /[a-zA-Z_][a-zA-Z0-9_-]*/,
         {
           cases: {
             "@inner_keywords": { token: "keyword" },
@@ -70,7 +70,7 @@ export const slint_language = <monaco.languages.IMonarchLanguage>{
       [/:=/, ""],
       [/<=>/, "", "@binding_0"],
       [/=>\s*{/, "", "@binding_1"],
-      [/\</, "", "@type"],
+      [/</, "", "@type"],
       [/\[/, "", "binding_1"],
       [/@symbols/, ""],
     ],
@@ -88,8 +88,8 @@ export const slint_language = <monaco.languages.IMonarchLanguage>{
       { include: "@whitespace" },
       { include: "@numbers" },
       [/"/, "string", "@string"],
-      [/\</, "", "@push"],
-      [/\>/, "", "@pop"],
+      [/</, "", "@push"],
+      [/>/, "", "@pop"],
       [/@symbols/, ""],
     ],
 
@@ -146,10 +146,10 @@ export const slint_language = <monaco.languages.IMonarchLanguage>{
       [/"/, "string", "@pop"],
     ],
     comment: [
-      [/[^\/*]+/, "comment"],
+      [/[^/*]+/, "comment"],
       [/\/\*/, "comment", "@push"],
       ["\\*/", "comment", "@pop"],
-      [/[\/*]/, "comment"],
+      [/[/*]/, "comment"],
     ],
 
     numbers: [

--- a/tools/online_editor/highlighting.ts
+++ b/tools/online_editor/highlighting.ts
@@ -1,135 +1,160 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import * as monaco from 'monaco-editor';
+// cSpell: ignore abfnrtv
 
+import * as monaco from "monaco-editor";
 
 export const slint_language = <monaco.languages.IMonarchLanguage>{
-    defaultToken: 'invalid',
+  defaultToken: "invalid",
 
-    root_keywords: [
-        'import', 'from', 'export'
+  root_keywords: ["import", "from", "export"],
+  inner_keywords: [
+    "property",
+    "callback",
+    "animate",
+    "states",
+    "transitions",
+    "if",
+    "for",
+  ],
+  lang_keywords: ["root", "parent", "this", "if"],
+  type_keywords: [
+    "int",
+    "string",
+    "float",
+    "length",
+    "physical_length",
+    "duration",
+  ],
+  escapes:
+    /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
+  symbols: /[\#\!\%\&\*\+\-\.\/\:\;\<\=\>\@\^\|_\?,()]+/,
+
+  tokenizer: {
+    root: [
+      [
+        /[a-zA-Z_][a-zA-Z0-9_]*/,
+        {
+          cases: {
+            "@root_keywords": { token: "keyword" },
+            "@default": "identifier",
+          },
+        },
+      ],
+      { include: "@whitespace" },
+      { include: "@numbers" },
+      [/"/, "string", "@string"],
+      [/\{/, "", "@inner"],
+      [/@symbols/, ""],
     ],
-    inner_keywords: [
-        'property', 'callback', 'animate', 'states', 'transitions', 'if', 'for'
+    inner: [
+      [/[a-zA-Z_][a-zA-Z0-9_\-]*\s*:=/, "variable.parameter"],
+      [/[a-zA-Z_][a-zA-Z0-9_\-]*\s*:\s*\{/, "variable.parameter", "@binding_1"],
+      [/[a-zA-Z_][a-zA-Z0-9_\-]*\s*:/, "variable.parameter", "@binding_0"],
+      [
+        /[a-zA-Z_][a-zA-Z0-9_\-]*/,
+        {
+          cases: {
+            "@inner_keywords": { token: "keyword" },
+            "@default": "identifier",
+          },
+        },
+      ],
+      { include: "@whitespace" },
+      { include: "@numbers" },
+      [/"/, "string", "@string"],
+      [/\{/, "", "@push"],
+      [/\}/, "", "@pop"],
+      [/:=/, ""],
+      [/<=>/, "", "@binding_0"],
+      [/=>\s*{/, "", "@binding_1"],
+      [/\</, "", "@type"],
+      [/\[/, "", "binding_1"],
+      [/@symbols/, ""],
     ],
-    lang_keywords: [
-        'root', 'parent', 'this', 'if'
+
+    type: [
+      [
+        /[a-zA-Z_][a-zA-Z0-9_]*/,
+        {
+          cases: {
+            "@type_keywords": { token: "keyword.type" },
+            "@default": "identifier",
+          },
+        },
+      ],
+      { include: "@whitespace" },
+      { include: "@numbers" },
+      [/"/, "string", "@string"],
+      [/\</, "", "@push"],
+      [/\>/, "", "@pop"],
+      [/@symbols/, ""],
     ],
-    type_keywords: ['int', 'string', 'float', 'length', 'physical_length', 'duration'],
-    escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
 
-    symbols: /[\#\!\%\&\*\+\-\.\/\:\;\<\=\>\@\^\|_\?,()]+/,
+    binding_0: [
+      { include: "@whitespace" },
+      [/\{/, "", "@binding_1"],
+      [/;/, "", "@pop"],
+      // that should not be needed, but ends recovering after a for
+      [/\}/, "", "@pop"],
+      [
+        /[a-zA-Z_][a-zA-Z0-9_]*/,
+        {
+          cases: {
+            "@lang_keywords": { token: "keyword.type" },
+            "@default": "identifier",
+          },
+        },
+      ],
+      { include: "@numbers" },
+      [/"/, "string", "@string"],
+      [/@symbols/, ""],
+    ],
 
-    tokenizer: {
-        root: [
-            [/[a-zA-Z_][a-zA-Z0-9_]*/, {
-                cases: {
-                    '@root_keywords': { token: 'keyword' },
-                    '@default': 'identifier'
-                }
-            }],
-            { include: '@whitespace' },
-            { include: '@numbers' },
-            [/"/, 'string', '@string'],
-            [/\{/, '', '@inner'],
-            [/@symbols/, ''],
-        ],
-        inner: [
-            [/[a-zA-Z_][a-zA-Z0-9_\-]*\s*:=/, 'variable.parameter'],
-            [/[a-zA-Z_][a-zA-Z0-9_\-]*\s*:\s*\{/, 'variable.parameter', '@binding_1'],
-            [/[a-zA-Z_][a-zA-Z0-9_\-]*\s*:/, 'variable.parameter', '@binding_0'],
-            [/[a-zA-Z_][a-zA-Z0-9_\-]*/, {
-                cases: {
-                    '@inner_keywords': { token: 'keyword' },
-                    '@default': 'identifier'
-                }
-            }],
-            { include: '@whitespace' },
-            { include: '@numbers' },
-            [/"/, 'string', '@string'],
-            [/\{/, '', '@push'],
-            [/\}/, '', '@pop'],
-            [/:=/, ''],
-            [/<=>/, '', '@binding_0'],
-            [/=>\s*{/, '', '@binding_1'],
-            [/\</, '', '@type'],
-            [/\[/, '', 'binding_1'],
-            [/@symbols/, ''],
-        ],
+    // inside a '{'
+    binding_1: [
+      [
+        /[a-zA-Z_][a-zA-Z0-9_]*/,
+        {
+          cases: {
+            "@lang_keywords": { token: "keyword.type" },
+            "@default": "identifier",
+          },
+        },
+      ],
+      { include: "@whitespace" },
+      { include: "@numbers" },
+      [/"/, "string", "@string"],
+      [/\{/, "", "@push"],
+      [/\}/, "", "@pop"],
+      [/\[/, "", "@push"],
+      [/\]/, "", "@pop"],
+      [/@symbols/, ""],
+    ],
 
+    whitespace: [
+      [/[ \t\r\n]+/, "white"],
+      [/\/\*/, "comment", "@comment"],
+      [/\/\/.*$/, "comment"],
+    ],
+    string: [
+      [/[^\\"]+/, "string"],
+      [/@escapes/, "string.escape"],
+      [/\\./, "string.escape.invalid"],
+      [/"/, "string", "@pop"],
+    ],
+    comment: [
+      [/[^\/*]+/, "comment"],
+      [/\/\*/, "comment", "@push"],
+      ["\\*/", "comment", "@pop"],
+      [/[\/*]/, "comment"],
+    ],
 
-        type: [
-            [/[a-zA-Z_][a-zA-Z0-9_]*/, {
-                cases: {
-                    '@type_keywords': { token: 'keyword.type' },
-                    '@default': 'identifier'
-                }
-            }],
-            { include: '@whitespace' },
-            { include: '@numbers' },
-            [/"/, 'string', '@string'],
-            [/\</, '', '@push'],
-            [/\>/, '', '@pop'],
-            [/@symbols/, ''],
-        ],
-
-        binding_0: [
-            { include: '@whitespace' },
-            [/\{/, '', '@binding_1'],
-            [/;/, '', '@pop'],
-            // that should not be needed, but ends recovering after a for
-            [/\}/, '', '@pop'],
-            [/[a-zA-Z_][a-zA-Z0-9_]*/, {
-                cases: {
-                    '@lang_keywords': { token: 'keyword.type' },
-                    '@default': 'identifier'
-                }
-            }],
-            { include: '@numbers' },
-            [/"/, 'string', '@string'],
-            [/@symbols/, ''],
-        ],
-
-        // inside a '{'
-        binding_1: [
-            [/[a-zA-Z_][a-zA-Z0-9_]*/, {
-                cases: {
-                    '@lang_keywords': { token: 'keyword.type' },
-                    '@default': 'identifier'
-                }
-            }],
-            { include: '@whitespace' },
-            { include: '@numbers' },
-            [/"/, 'string', '@string'],
-            [/\{/, '', '@push'],
-            [/\}/, '', '@pop'],
-            [/\[/, '', '@push'],
-            [/\]/, '', '@pop'],
-            [/@symbols/, ''],
-        ],
-
-        whitespace: [
-            [/[ \t\r\n]+/, 'white'],
-            [/\/\*/, 'comment', '@comment'],
-            [/\/\/.*$/, 'comment']
-        ],
-        string: [
-            [/[^\\"]+/, 'string'],
-            [/@escapes/, 'string.escape'],
-            [/\\./, 'string.escape.invalid'],
-            [/"/, 'string', '@pop']
-        ],
-        comment: [
-            [/[^\/*]+/, 'comment'],
-            [/\/\*/, 'comment', '@push'],
-            ['\\*/', 'comment', '@pop'],
-            [/[\/*]/, 'comment']
-        ],
-
-        numbers: [
-            [/\d+(\.\d+)?\w*/, { token: 'number' }],
-            [/#[0-9a-fA-F]+/, { token: 'number' }],
-        ]
-    },
-}
+    numbers: [
+      [/\d+(\.\d+)?\w*/, { token: "number" }],
+      [/#[0-9a-fA-F]+/, { token: "number" }],
+    ],
+  },
+};

--- a/tools/online_editor/index.ts
+++ b/tools/online_editor/index.ts
@@ -17,10 +17,9 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 (self as any).MonacoEnvironment = {
   getWorker(_: any, _label: any) {
-    return new Worker(
-      new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url),
-      { type: "module" }
-    );
+    return new Worker(new URL("monaco_worker.js", import.meta.url), {
+      type: "module",
+    });
   },
 };
 

--- a/tools/online_editor/index.ts
+++ b/tools/online_editor/index.ts
@@ -16,9 +16,9 @@ import "monaco-editor/esm/vs/editor/standalone/browser/referenceSearch/standalon
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 (self as any).MonacoEnvironment = {
-  getWorker(_: any, label: any) {
+  getWorker(_: any, _label: any) {
     return new Worker(
-      new URL("monaco-editor/esm/vs/editor/editor.worker", import.meta.url),
+      new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url),
       { type: "module" }
     );
   },
@@ -169,7 +169,7 @@ export Demo := Window {
     editor_documents.clear();
   }
 
-  function addTab(model: monaco.editor.ITextModel, url: string = "") {
+  function addTab(_model: monaco.editor.ITextModel, url: string = "") {
     let tab_bar = document.getElementById("tabs") as HTMLUListElement;
     let tab = document.createElement("li");
     tab.setAttribute("class", "nav-item");
@@ -238,7 +238,7 @@ export Demo := Window {
       (<HTMLInputElement>document.getElementById("style_combo"))?.value ??
       "fluent";
 
-    let canvas_id = "canvas_" + Math.random().toString(36).substr(2, 9);
+    let canvas_id = "canvas_" + Math.random().toString(36).slice(2, 11);
     let canvas = document.createElement("canvas");
     canvas.width = 800;
     canvas.height = 600;

--- a/tools/online_editor/index.ts
+++ b/tools/online_editor/index.ts
@@ -169,7 +169,7 @@ export Demo := Window {
     tab.dataset["url"] = url;
     tab.innerHTML = `<span class="nav-link">${tabTitleFromURL(url)}</span>`;
     tab_bar.appendChild(tab);
-    $(tab).on("click", (e) => {
+    tab.addEventListener("click", (e) => {
       e.preventDefault();
       setCurrentTab(url);
     });

--- a/tools/online_editor/index.ts
+++ b/tools/online_editor/index.ts
@@ -78,11 +78,13 @@ export Demo := Window {
   function select_combo_changed() {
     if (select.value) {
       let tag = "master";
-      var found;
-      if (
-        (found = window.location.pathname.match(/releases\/([^\/]*)\/editor/))
-      ) {
-        tag = "v" + found[1];
+      {
+        let found;
+        if (
+          (found = window.location.pathname.match(/releases\/([^\/]*)\/editor/))
+        ) {
+          tag = "v" + found[1];
+        }
       }
       load_from_url(
         `https://raw.githubusercontent.com/slint-ui/slint/${tag}/${select.value}`

--- a/tools/online_editor/index.ts
+++ b/tools/online_editor/index.ts
@@ -3,53 +3,51 @@
 
 import { slint_language } from "./highlighting";
 
-import 'monaco-editor/esm/vs/editor/editor.all.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/inspectTokens/inspectTokens.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneHelpQuickAccess.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoSymbolQuickAccess.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/referenceSearch/standaloneReferenceSearch.js';
+import "monaco-editor/esm/vs/editor/editor.all.js";
+import "monaco-editor/esm/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.js";
+import "monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js";
+import "monaco-editor/esm/vs/editor/standalone/browser/inspectTokens/inspectTokens.js";
+import "monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneHelpQuickAccess.js";
+import "monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess.js";
+import "monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoSymbolQuickAccess.js";
+import "monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess.js";
+import "monaco-editor/esm/vs/editor/standalone/browser/referenceSearch/standaloneReferenceSearch.js";
 
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
-
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 
 self.MonacoEnvironment = {
-    getWorker(_, label) {
-        return new editorWorker();
-    }
+  getWorker(_, label) {
+    return new editorWorker();
+  },
 };
 
 import slint_init, * as slint from "../../../wasm-interpreter/slint_wasm_interpreter.js";
 
-
 (async function () {
-    await slint_init();
+  await slint_init();
 
-    monaco.languages.register({
-        id: 'slint'
-    });
-    monaco.languages.onLanguage('slint', () => {
-        monaco.languages.setMonarchTokensProvider('slint', slint_language);
-    });
-    var editor = monaco.editor.create(document.getElementById("editor"), {
-        language: 'slint'
-    });
-    var base_url = "";
+  monaco.languages.register({
+    id: "slint",
+  });
+  monaco.languages.onLanguage("slint", () => {
+    monaco.languages.setMonarchTokensProvider("slint", slint_language);
+  });
+  var editor = monaco.editor.create(document.getElementById("editor"), {
+    language: "slint",
+  });
+  var base_url = "";
 
-    interface ModelAndViewState {
-        model: monaco.editor.ITextModel,
-        view_state: monaco.editor.ICodeEditorViewState
-    }
+  interface ModelAndViewState {
+    model: monaco.editor.ITextModel;
+    view_state: monaco.editor.ICodeEditorViewState;
+  }
 
-    /// Index by url. Inline documents will use the empty string.
-    var editor_documents: Map<string, ModelAndViewState> = new Map;
+  /// Index by url. Inline documents will use the empty string.
+  var editor_documents: Map<string, ModelAndViewState> = new Map();
 
-    let hello_world = `import { Button, VerticalBox } from "std-widgets.slint";
+  let hello_world = `import { Button, VerticalBox } from "std-widgets.slint";
 export Demo := Window {
     VerticalBox {
         Text {
@@ -63,220 +61,247 @@ export Demo := Window {
         Button { text: "OK!"; }
     }
 }
-`
+`;
 
-    function load_from_url(url: string) {
-        clearTabs();
-        fetch(url).then(
-            x => x.text().then(y => {
-                base_url = url;
-                let model = createMainModel(y, url);
-                addTab(model, url);
-            })
-        );
-    }
+  function load_from_url(url: string) {
+    clearTabs();
+    fetch(url).then((x) =>
+      x.text().then((y) => {
+        base_url = url;
+        let model = createMainModel(y, url);
+        addTab(model, url);
+      })
+    );
+  }
 
-    let select = (<HTMLInputElement>document.getElementById("select_combo"));
-    function select_combo_changed() {
-        if (select.value) {
-            let tag = "master";
-            var found;
-            if (found = window.location.pathname.match(/releases\/([^\/]*)\/editor/)) {
-                tag = "v" + found[1];
-            }
-            load_from_url(`https://raw.githubusercontent.com/slint-ui/slint/${tag}/${select.value}`);
-        } else {
-            clearTabs();
-            base_url = "";
-            let model = createMainModel(hello_world, "");
-            addTab(model);
-        }
-    }
-    select.onchange = select_combo_changed;
-
-    let style_combo = (<HTMLInputElement>document.getElementById("style_combo"));
-    if (style_combo) {
-        style_combo.onchange = update_preview;
-    }
-
-    let compile_button = (<HTMLButtonElement>document.getElementById("compile_button"));
-    compile_button.onclick = function () {
-        update_preview();
-    };
-
-    let auto_compile = (<HTMLInputElement>document.getElementById("auto_compile"));
-    auto_compile.onchange = function () {
-        if (auto_compile.checked) {
-            update_preview()
-        }
-    };
-
-    function tabTitleFromURL(url: string): string {
-        if (url === "") {
-            return "unnamed.slint";
-        }
-        try {
-            let parsed_url = new URL(url);
-            let path = parsed_url.pathname;
-            return path.substring(path.lastIndexOf('/') + 1);
-        } catch (e) {
-            return url;
-        }
-    }
-
-    function maybe_update_preview_automatically() {
-        if (auto_compile.checked) {
-            if (keystroke_timeout_handle) {
-                clearTimeout(keystroke_timeout_handle);
-            }
-            keystroke_timeout_handle = setTimeout(update_preview, 500);
-        }
-    }
-
-    function createMainModel(source: string, url: string): monaco.editor.ITextModel {
-        let model = monaco.editor.createModel(source, "slint");
-        model.onDidChangeContent(function () {
-            let permalink = (<HTMLAnchorElement>document.getElementById("permalink"));
-            let params = new URLSearchParams();
-            params.set("snippet", editor.getModel().getValue());
-            let this_url = new URL(window.location.toString());
-            this_url.search = params.toString();
-            permalink.href = this_url.toString();
-            maybe_update_preview_automatically();
-        });
-        editor_documents.set(url, { model, view_state: null });
-        update_preview();
-        return model;
-    }
-
-    function clearTabs() {
-        let tab_bar = document.getElementById("tabs") as HTMLUListElement;
-        tab_bar.innerHTML = "";
-        editor_documents.clear();
-    }
-
-    function addTab(model: monaco.editor.ITextModel, url: string = "") {
-        let tab_bar = document.getElementById("tabs") as HTMLUListElement;
-        let tab = document.createElement("li");
-        tab.setAttribute("class", "nav-item");
-        tab.dataset["url"] = url;
-        tab.innerHTML = `<span class="nav-link">${tabTitleFromURL(url)}</span>`;
-        tab_bar.appendChild(tab);
-        $(tab).on("click", (e) => {
-            e.preventDefault();
-            setCurrentTab(url);
-        });
-        if (tab_bar.childElementCount == 1) {
-            setCurrentTab(url);
-        }
-    }
-
-    function setCurrentTab(url: string) {
-        let current_tab = document.querySelector(`#tabs li[class~="nav-item"] span[class~="nav-link"][class~="active"]`);
-        if (current_tab != undefined) {
-            current_tab.className = "nav-link";
-            let url = current_tab.parentElement.dataset.url;
-            if (url != undefined) {
-                let model_and_state = editor_documents.get(url);
-                model_and_state.view_state = editor.saveViewState();
-                editor_documents.set(url, model_and_state);
-            }
-        }
-        let new_current = document.querySelector(`#tabs li[class~="nav-item"][data-url="${url}"] span[class~="nav-link"]`);
-        if (new_current != undefined) {
-            new_current.className = "nav-link active";
-        }
-        let model_and_state = editor_documents.get(url);
-        if (model_and_state != undefined) {
-            editor.setModel(model_and_state.model);
-            if (model_and_state.view_state != null) {
-                editor.restoreViewState(model_and_state.view_state);
-            }
-            editor.focus();
-        }
-    }
-
-    function update_preview() {
-        let main_model_and_state = editor_documents.get(base_url);
-        if (main_model_and_state === undefined) {
-            return;
-        }
-        let source = main_model_and_state.model.getValue();
-        let div = document.getElementById("preview") as HTMLDivElement;
-        setTimeout(function () { render_or_error(source, base_url, div); }, 1);
-    }
-
-    async function render_or_error(source: string, base_url: string, div: HTMLDivElement) {
-
-        let style = (<HTMLInputElement>document.getElementById("style_combo"))?.value ?? "fluent";
-
-        let canvas_id = 'canvas_' + Math.random().toString(36).substr(2, 9);
-        let canvas = document.createElement("canvas");
-        canvas.width = 800;
-        canvas.height = 600;
-        canvas.id = canvas_id;
-        div.innerHTML = "";
-        div.appendChild(canvas);
-        var markers = [];
-        let { component, diagnostics, error_string } = await slint.compile_from_string_with_style(source, base_url, style, async (url: string): Promise<string> => {
-            let model_and_state = editor_documents.get(url);
-            if (model_and_state === undefined) {
-                const response = await fetch(url);
-                let doc = await response.text();
-                let model = monaco.editor.createModel(doc, "slint");
-                model.onDidChangeContent(function () {
-                    maybe_update_preview_automatically();
-                });
-                editor_documents.set(url, { model, view_state: null });
-                addTab(model, url);
-                return doc;
-            }
-            return model_and_state.model.getValue();
-        });
-
-        if (error_string != "") {
-            let text = document.createTextNode(error_string);
-            let p = document.createElement('pre');
-            p.appendChild(text);
-            div.innerHTML = "<pre style='color: red; background-color:#fee; margin:0'>" + p.innerHTML + "</pre>";
-        }
-
-
-        markers = diagnostics.map(function (x) {
-            return {
-                severity: 3 - x.level,
-                message: x.message,
-                source: x.fileName,
-                startLineNumber: x.lineNumber,
-                startColumn: x.columnNumber,
-                endLineNumber: x.lineNumber,
-                endColumn: -1,
-            }
-        });
-        monaco.editor.setModelMarkers(editor.getModel(), "slint", markers);
-
-        if (component !== undefined) {
-            component.run(canvas_id)
-        }
-    }
-
-    let keystroke_timeout_handle: number;
-
-    const params = new URLSearchParams(window.location.search);
-    const code = params.get("snippet");
-    const load_url = params.get("load_url");
-
-    if (code) {
-        clearTabs();
-        let model = createMainModel(code, "");
-        addTab(model);
-    } else if (load_url) {
-        load_from_url(load_url);
+  let select = <HTMLInputElement>document.getElementById("select_combo");
+  function select_combo_changed() {
+    if (select.value) {
+      let tag = "master";
+      var found;
+      if (
+        (found = window.location.pathname.match(/releases\/([^\/]*)\/editor/))
+      ) {
+        tag = "v" + found[1];
+      }
+      load_from_url(
+        `https://raw.githubusercontent.com/slint-ui/slint/${tag}/${select.value}`
+      );
     } else {
-        clearTabs();
-        base_url = "";
-        let model = createMainModel(hello_world, "");
-        addTab(model);
+      clearTabs();
+      base_url = "";
+      let model = createMainModel(hello_world, "");
+      addTab(model);
+    }
+  }
+  select.onchange = select_combo_changed;
+
+  let style_combo = <HTMLInputElement>document.getElementById("style_combo");
+  if (style_combo) {
+    style_combo.onchange = update_preview;
+  }
+
+  let compile_button = <HTMLButtonElement>(
+    document.getElementById("compile_button")
+  );
+  compile_button.onclick = function () {
+    update_preview();
+  };
+
+  let auto_compile = <HTMLInputElement>document.getElementById("auto_compile");
+  auto_compile.onchange = function () {
+    if (auto_compile.checked) {
+      update_preview();
+    }
+  };
+
+  function tabTitleFromURL(url: string): string {
+    if (url === "") {
+      return "unnamed.slint";
+    }
+    try {
+      let parsed_url = new URL(url);
+      let path = parsed_url.pathname;
+      return path.substring(path.lastIndexOf("/") + 1);
+    } catch (e) {
+      return url;
+    }
+  }
+
+  function maybe_update_preview_automatically() {
+    if (auto_compile.checked) {
+      if (keystroke_timeout_handle) {
+        clearTimeout(keystroke_timeout_handle);
+      }
+      keystroke_timeout_handle = setTimeout(update_preview, 500);
+    }
+  }
+
+  function createMainModel(
+    source: string,
+    url: string
+  ): monaco.editor.ITextModel {
+    let model = monaco.editor.createModel(source, "slint");
+    model.onDidChangeContent(function () {
+      let permalink = <HTMLAnchorElement>document.getElementById("permalink");
+      let params = new URLSearchParams();
+      params.set("snippet", editor.getModel().getValue());
+      let this_url = new URL(window.location.toString());
+      this_url.search = params.toString();
+      permalink.href = this_url.toString();
+      maybe_update_preview_automatically();
+    });
+    editor_documents.set(url, { model, view_state: null });
+    update_preview();
+    return model;
+  }
+
+  function clearTabs() {
+    let tab_bar = document.getElementById("tabs") as HTMLUListElement;
+    tab_bar.innerHTML = "";
+    editor_documents.clear();
+  }
+
+  function addTab(model: monaco.editor.ITextModel, url: string = "") {
+    let tab_bar = document.getElementById("tabs") as HTMLUListElement;
+    let tab = document.createElement("li");
+    tab.setAttribute("class", "nav-item");
+    tab.dataset["url"] = url;
+    tab.innerHTML = `<span class="nav-link">${tabTitleFromURL(url)}</span>`;
+    tab_bar.appendChild(tab);
+    $(tab).on("click", (e) => {
+      e.preventDefault();
+      setCurrentTab(url);
+    });
+    if (tab_bar.childElementCount == 1) {
+      setCurrentTab(url);
+    }
+  }
+
+  function setCurrentTab(url: string) {
+    let current_tab = document.querySelector(
+      `#tabs li[class~="nav-item"] span[class~="nav-link"][class~="active"]`
+    );
+    if (current_tab != undefined) {
+      current_tab.className = "nav-link";
+      let url = current_tab.parentElement.dataset.url;
+      if (url != undefined) {
+        let model_and_state = editor_documents.get(url);
+        model_and_state.view_state = editor.saveViewState();
+        editor_documents.set(url, model_and_state);
+      }
+    }
+    let new_current = document.querySelector(
+      `#tabs li[class~="nav-item"][data-url="${url}"] span[class~="nav-link"]`
+    );
+    if (new_current != undefined) {
+      new_current.className = "nav-link active";
+    }
+    let model_and_state = editor_documents.get(url);
+    if (model_and_state != undefined) {
+      editor.setModel(model_and_state.model);
+      if (model_and_state.view_state != null) {
+        editor.restoreViewState(model_and_state.view_state);
+      }
+      editor.focus();
+    }
+  }
+
+  function update_preview() {
+    let main_model_and_state = editor_documents.get(base_url);
+    if (main_model_and_state === undefined) {
+      return;
+    }
+    let source = main_model_and_state.model.getValue();
+    let div = document.getElementById("preview") as HTMLDivElement;
+    setTimeout(function () {
+      render_or_error(source, base_url, div);
+    }, 1);
+  }
+
+  async function render_or_error(
+    source: string,
+    base_url: string,
+    div: HTMLDivElement
+  ) {
+    let style =
+      (<HTMLInputElement>document.getElementById("style_combo"))?.value ??
+      "fluent";
+
+    let canvas_id = "canvas_" + Math.random().toString(36).substr(2, 9);
+    let canvas = document.createElement("canvas");
+    canvas.width = 800;
+    canvas.height = 600;
+    canvas.id = canvas_id;
+    div.innerHTML = "";
+    div.appendChild(canvas);
+    var markers = [];
+    let { component, diagnostics, error_string } =
+      await slint.compile_from_string_with_style(
+        source,
+        base_url,
+        style,
+        async (url: string): Promise<string> => {
+          let model_and_state = editor_documents.get(url);
+          if (model_and_state === undefined) {
+            const response = await fetch(url);
+            let doc = await response.text();
+            let model = monaco.editor.createModel(doc, "slint");
+            model.onDidChangeContent(function () {
+              maybe_update_preview_automatically();
+            });
+            editor_documents.set(url, { model, view_state: null });
+            addTab(model, url);
+            return doc;
+          }
+          return model_and_state.model.getValue();
+        }
+      );
+
+    if (error_string != "") {
+      let text = document.createTextNode(error_string);
+      let p = document.createElement("pre");
+      p.appendChild(text);
+      div.innerHTML =
+        "<pre style='color: red; background-color:#fee; margin:0'>" +
+        p.innerHTML +
+        "</pre>";
     }
 
+    markers = diagnostics.map(function (x) {
+      return {
+        severity: 3 - x.level,
+        message: x.message,
+        source: x.fileName,
+        startLineNumber: x.lineNumber,
+        startColumn: x.columnNumber,
+        endLineNumber: x.lineNumber,
+        endColumn: -1,
+      };
+    });
+    monaco.editor.setModelMarkers(editor.getModel(), "slint", markers);
+
+    if (component !== undefined) {
+      component.run(canvas_id);
+    }
+  }
+
+  let keystroke_timeout_handle: number;
+
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("snippet");
+  const load_url = params.get("load_url");
+
+  if (code) {
+    clearTabs();
+    let model = createMainModel(code, "");
+    addTab(model);
+  } else if (load_url) {
+    load_from_url(load_url);
+  } else {
+    clearTabs();
+    base_url = "";
+    let model = createMainModel(hello_world, "");
+    addTab(model);
+  }
 })();

--- a/tools/online_editor/index.ts
+++ b/tools/online_editor/index.ts
@@ -15,8 +15,9 @@ import "monaco-editor/esm/vs/editor/standalone/browser/referenceSearch/standalon
 
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 (self as any).MonacoEnvironment = {
-  getWorker(_: any, _label: any) {
+  getWorker(_: unknown, _label: unknown) {
     return new Worker(new URL("monaco_worker.js", import.meta.url), {
       type: "module",
     });
@@ -51,7 +52,7 @@ import slint_init, * as slint from "@preview/slint_wasm_interpreter.js";
   /// Index by url. Inline documents will use the empty string.
   const editor_documents: Map<string, ModelAndViewState> = new Map();
 
-  let hello_world = `import { Button, VerticalBox } from "std-widgets.slint";
+  const hello_world = `import { Button, VerticalBox } from "std-widgets.slint";
 export Demo := Window {
     VerticalBox {
         Text {
@@ -72,20 +73,20 @@ export Demo := Window {
     fetch(url).then((x) =>
       x.text().then((y) => {
         base_url = url;
-        let model = createMainModel(y, url);
+        const model = createMainModel(y, url);
         addTab(model, url);
       })
     );
   }
 
-  let select = <HTMLInputElement>document.getElementById("select_combo");
+  const select = <HTMLInputElement>document.getElementById("select_combo");
   function select_combo_changed() {
     if (select.value) {
       let tag = "master";
       {
         let found;
         if (
-          (found = window.location.pathname.match(/releases\/([^\/]*)\/editor/))
+          (found = window.location.pathname.match(/releases\/([^/]*)\/editor/))
         ) {
           tag = "v" + found[1];
         }
@@ -96,25 +97,27 @@ export Demo := Window {
     } else {
       clearTabs();
       base_url = "";
-      let model = createMainModel(hello_world, "");
+      const model = createMainModel(hello_world, "");
       addTab(model);
     }
   }
   select.onchange = select_combo_changed;
 
-  let style_combo = <HTMLInputElement>document.getElementById("style_combo");
+  const style_combo = <HTMLInputElement>document.getElementById("style_combo");
   if (style_combo) {
     style_combo.onchange = update_preview;
   }
 
-  let compile_button = <HTMLButtonElement>(
+  const compile_button = <HTMLButtonElement>(
     document.getElementById("compile_button")
   );
   compile_button.onclick = function () {
     update_preview();
   };
 
-  let auto_compile = <HTMLInputElement>document.getElementById("auto_compile");
+  const auto_compile = <HTMLInputElement>(
+    document.getElementById("auto_compile")
+  );
   auto_compile.onchange = function () {
     if (auto_compile.checked) {
       update_preview();
@@ -126,8 +129,8 @@ export Demo := Window {
       return "unnamed.slint";
     }
     try {
-      let parsed_url = new URL(url);
-      let path = parsed_url.pathname;
+      const parsed_url = new URL(url);
+      const path = parsed_url.pathname;
       return path.substring(path.lastIndexOf("/") + 1);
     } catch (e) {
       return url;
@@ -147,10 +150,10 @@ export Demo := Window {
     source: string,
     url: string
   ): monaco.editor.ITextModel {
-    let model = monaco.editor.createModel(source, "slint");
+    const model = monaco.editor.createModel(source, "slint");
     model.onDidChangeContent(function () {
-      let permalink = <HTMLAnchorElement>document.getElementById("permalink");
-      let params = new URLSearchParams();
+      const permalink = <HTMLAnchorElement>document.getElementById("permalink");
+      const params = new URLSearchParams();
       params.set("snippet", editor.getModel()?.getValue() || "");
       const this_url = new URL(window.location.toString());
       this_url.search = params.toString();
@@ -163,14 +166,14 @@ export Demo := Window {
   }
 
   function clearTabs() {
-    let tab_bar = document.getElementById("tabs") as HTMLUListElement;
+    const tab_bar = document.getElementById("tabs") as HTMLUListElement;
     tab_bar.innerHTML = "";
     editor_documents.clear();
   }
 
-  function addTab(_model: monaco.editor.ITextModel, url: string = "") {
-    let tab_bar = document.getElementById("tabs") as HTMLUListElement;
-    let tab = document.createElement("li");
+  function addTab(_model: monaco.editor.ITextModel, url = "") {
+    const tab_bar = document.getElementById("tabs") as HTMLUListElement;
+    const tab = document.createElement("li");
     tab.setAttribute("class", "nav-item");
     tab.dataset["url"] = url;
     tab.innerHTML = `<span class="nav-link">${tabTitleFromURL(url)}</span>`;
@@ -185,13 +188,13 @@ export Demo := Window {
   }
 
   function setCurrentTab(url: string) {
-    let current_tab = document.querySelector(
+    const current_tab = document.querySelector(
       `#tabs li[class~="nav-item"] span[class~="nav-link"][class~="active"]`
     );
     if (current_tab != undefined) {
       current_tab.className = "nav-link";
 
-      let url = current_tab.parentElement?.dataset.url;
+      const url = current_tab.parentElement?.dataset.url;
       if (url != undefined) {
         const model_and_state = editor_documents.get(url);
         if (model_and_state !== undefined) {
@@ -200,13 +203,13 @@ export Demo := Window {
         }
       }
     }
-    let new_current = document.querySelector(
+    const new_current = document.querySelector(
       `#tabs li[class~="nav-item"][data-url="${url}"] span[class~="nav-link"]`
     );
     if (new_current != undefined) {
       new_current.className = "nav-link active";
     }
-    let model_and_state = editor_documents.get(url);
+    const model_and_state = editor_documents.get(url);
     if (model_and_state != undefined) {
       editor.setModel(model_and_state.model);
       if (model_and_state.view_state != null) {
@@ -217,12 +220,12 @@ export Demo := Window {
   }
 
   function update_preview() {
-    let main_model_and_state = editor_documents.get(base_url);
+    const main_model_and_state = editor_documents.get(base_url);
     if (main_model_and_state === undefined) {
       return;
     }
-    let source = main_model_and_state.model.getValue();
-    let div = document.getElementById("preview") as HTMLDivElement;
+    const source = main_model_and_state.model.getValue();
+    const div = document.getElementById("preview") as HTMLDivElement;
     setTimeout(function () {
       render_or_error(source, base_url, div);
     }, 1);
@@ -233,29 +236,29 @@ export Demo := Window {
     base_url: string,
     div: HTMLDivElement
   ) {
-    let style =
+    const style =
       (<HTMLInputElement>document.getElementById("style_combo"))?.value ??
       "fluent";
 
-    let canvas_id = "canvas_" + Math.random().toString(36).slice(2, 11);
-    let canvas = document.createElement("canvas");
+    const canvas_id = "canvas_" + Math.random().toString(36).slice(2, 11);
+    const canvas = document.createElement("canvas");
     canvas.width = 800;
     canvas.height = 600;
     canvas.id = canvas_id;
     div.innerHTML = "";
     div.appendChild(canvas);
-    var markers = [];
-    let { component, diagnostics, error_string } =
+    let markers = [];
+    const { component, diagnostics, error_string } =
       await slint.compile_from_string_with_style(
         source,
         base_url,
         style,
         async (url: string): Promise<string> => {
-          let model_and_state = editor_documents.get(url);
+          const model_and_state = editor_documents.get(url);
           if (model_and_state === undefined) {
             const response = await fetch(url);
-            let doc = await response.text();
-            let model = monaco.editor.createModel(doc, "slint");
+            const doc = await response.text();
+            const model = monaco.editor.createModel(doc, "slint");
             model.onDidChangeContent(function () {
               maybe_update_preview_automatically();
             });
@@ -268,8 +271,8 @@ export Demo := Window {
       );
 
     if (error_string != "") {
-      let text = document.createTextNode(error_string);
-      let p = document.createElement("pre");
+      const text = document.createTextNode(error_string);
+      const p = document.createElement("pre");
       p.appendChild(text);
       div.innerHTML =
         "<pre style='color: red; background-color:#fee; margin:0'>" +
@@ -306,14 +309,14 @@ export Demo := Window {
 
   if (code) {
     clearTabs();
-    let model = createMainModel(code, "");
+    const model = createMainModel(code, "");
     addTab(model);
   } else if (load_url) {
     load_from_url(load_url);
   } else {
     clearTabs();
     base_url = "";
-    let model = createMainModel(hello_world, "");
+    const model = createMainModel(hello_world, "");
     addTab(model);
   }
 })();

--- a/tools/online_editor/index.ts
+++ b/tools/online_editor/index.ts
@@ -23,7 +23,7 @@ self.MonacoEnvironment = {
   },
 };
 
-import slint_init, * as slint from "../../../wasm-interpreter/slint_wasm_interpreter.js";
+import slint_init, * as slint from "@preview/slint_wasm_interpreter.js";
 
 (async function () {
   await slint_init();

--- a/tools/online_editor/monaco_worker.js
+++ b/tools/online_editor/monaco_worker.js
@@ -1,0 +1,4 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+export * from "monaco-editor/esm/vs/editor/editor.worker.js";

--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -17,6 +17,7 @@
     "npm": "^8.9.0"
   },
   "devDependencies": {
+    "eslint": "^8.22.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.7.4",
     "vite": "^2.9.8"

--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "syntax_check": "tsc --noemit",
     "start": "rimraf dist && wasm-pack build --target web ../../api/wasm-interpreter && vite --open",
     "build": "rimraf dist pkg && npx vite build"
   },

--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "typescript": "^4.0.3",
+    "typescript": "^4.7.4",
     "vite": "^2.9.8"
   }
 }

--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -10,7 +10,6 @@
   "keywords": [],
   "author": "",
   "dependencies": {
-    "@types/jquery": "^3.5.4",
     "install": "^0.13.0",
     "monaco-editor": "^0.33",
     "npm": "^8.9.0"

--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rimraf dist pkg && npx vite build",
     "build:wasm_preview": "wasm-pack build --target web ../../api/wasm-interpreter",
-    "lint": "eslint .",
+    "lint": "eslint *.ts",
     "start": "rimraf dist && npm run build:wasm_preview && npn start:vite",
     "start:vite": "vite --open",
     "syntax_check": "tsc --noemit"
@@ -19,8 +19,9 @@
     "npm": "^8.9.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.33.0",
+    "@typescript-eslint/parser": "^5.33.0",
     "eslint": "^8.22.0",
-    "eslint-config-standard-with-typescript": "^22.0.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.7.4",
     "vite": "^2.9.8"

--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "syntax_check": "tsc --noemit",
-    "start": "rimraf dist && wasm-pack build --target web ../../api/wasm-interpreter && vite --open",
+    "build:wasm_preview": "wasm-pack build --target web ../../api/wasm-interpreter",
+    "start": "rimraf dist && npm run build:wasm_preview && vite --open",
     "build": "rimraf dist pkg && npx vite build"
   },
   "keywords": [],

--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -4,10 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "syntax_check": "tsc --noemit",
+    "build": "rimraf dist pkg && npx vite build",
     "build:wasm_preview": "wasm-pack build --target web ../../api/wasm-interpreter",
-    "start": "rimraf dist && npm run build:wasm_preview && vite --open",
-    "build": "rimraf dist pkg && npx vite build"
+    "lint": "eslint .",
+    "start": "rimraf dist && npm run build:wasm_preview && npn start:vite",
+    "start:vite": "vite --open",
+    "syntax_check": "tsc --noemit"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +20,7 @@
   },
   "devDependencies": {
     "eslint": "^8.22.0",
+    "eslint-config-standard-with-typescript": "^22.0.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.7.4",
     "vite": "^2.9.8"

--- a/tools/online_editor/preview.ts
+++ b/tools/online_editor/preview.ts
@@ -73,7 +73,10 @@ export Demo := Window {
         p.innerHTML +
         "</pre>";
     } else {
-      document.getElementById("spinner").remove();
+      const spinner = document.getElementById("spinner");
+      if (spinner !== null) {
+        spinner.remove();
+      }
     }
 
     if (component !== undefined) {

--- a/tools/online_editor/preview.ts
+++ b/tools/online_editor/preview.ts
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import slint_init, * as slint from "../../../wasm-interpreter/slint_wasm_interpreter.js";
+import slint_init, * as slint from "@preview/slint_wasm_interpreter.js";
 
 (async function () {
   await slint_init();

--- a/tools/online_editor/preview.ts
+++ b/tools/online_editor/preview.ts
@@ -39,7 +39,7 @@ export Demo := Window {
     base_url: string,
     div: HTMLDivElement
   ) {
-    let canvas_id = "canvas_" + Math.random().toString(36).substr(2, 9);
+    let canvas_id = "canvas_" + Math.random().toString(36).slice(2, 11);
     let canvas = document.createElement("canvas");
     canvas.width = 800;
     canvas.height = 600;

--- a/tools/online_editor/preview.ts
+++ b/tools/online_editor/preview.ts
@@ -4,14 +4,14 @@
 import slint_init, * as slint from "../../../wasm-interpreter/slint_wasm_interpreter.js";
 
 (async function () {
-    await slint_init();
+  await slint_init();
 
-    var base_url = "";
+  var base_url = "";
 
-    /// Index by url. Inline documents will use the empty string.
-    var loaded_documents: Map<string, string> = new Map;
+  /// Index by url. Inline documents will use the empty string.
+  var loaded_documents: Map<string, string> = new Map();
 
-    let main_source = `
+  let main_source = `
 import { SpinBox, Button, CheckBox, Slider, GroupBox } from "std-widgets.slint";
 export Demo := Window {
     width:  300px;   // Width in logical pixels. All 'px' units are automatically scaled with screen resolution.
@@ -25,58 +25,73 @@ export Demo := Window {
         source: @image-url("https://slint-ui.com/logo/slint-logo-full-light.svg");
     }
 }
-`
+`;
 
-    function update_preview() {
-        let div = document.getElementById("preview") as HTMLDivElement;
-        setTimeout(function () { render_or_error(main_source, base_url, div); }, 1);
-    }
+  function update_preview() {
+    let div = document.getElementById("preview") as HTMLDivElement;
+    setTimeout(function () {
+      render_or_error(main_source, base_url, div);
+    }, 1);
+  }
 
-    async function render_or_error(source: string, base_url: string, div: HTMLDivElement) {
-        let canvas_id = 'canvas_' + Math.random().toString(36).substr(2, 9);
-        let canvas = document.createElement("canvas");
-        canvas.width = 800;
-        canvas.height = 600;
-        canvas.id = canvas_id;
-        div.innerHTML = "";
-        div.appendChild(canvas);
+  async function render_or_error(
+    source: string,
+    base_url: string,
+    div: HTMLDivElement
+  ) {
+    let canvas_id = "canvas_" + Math.random().toString(36).substr(2, 9);
+    let canvas = document.createElement("canvas");
+    canvas.width = 800;
+    canvas.height = 600;
+    canvas.id = canvas_id;
+    div.innerHTML = "";
+    div.appendChild(canvas);
 
-        let { component, error_string } = await slint.compile_from_string_with_style(source, base_url, style, async (url: string): Promise<string> => {
-            let file_source = loaded_documents.get(url);
-            if (file_source === undefined) {
-                const response = await fetch(url);
-                let doc = await response.text();
-                loaded_documents.set(url, doc);
-                return doc;
-            }
-            return file_source;
-        });
-
-        if (error_string != "") {
-            let text = document.createTextNode(error_string);
-            let p = document.createElement('pre');
-            p.appendChild(text);
-            div.innerHTML = "<pre style='color: red; background-color:#fee; margin:0'>" + p.innerHTML + "</pre>";
-        } else {
-            document.getElementById("spinner").remove()
+    let { component, error_string } =
+      await slint.compile_from_string_with_style(
+        source,
+        base_url,
+        style,
+        async (url: string): Promise<string> => {
+          let file_source = loaded_documents.get(url);
+          if (file_source === undefined) {
+            const response = await fetch(url);
+            let doc = await response.text();
+            loaded_documents.set(url, doc);
+            return doc;
+          }
+          return file_source;
         }
+      );
 
-        if (component !== undefined) {
-            component.run(canvas_id)
-        }
+    if (error_string != "") {
+      let text = document.createTextNode(error_string);
+      let p = document.createElement("pre");
+      p.appendChild(text);
+      div.innerHTML =
+        "<pre style='color: red; background-color:#fee; margin:0'>" +
+        p.innerHTML +
+        "</pre>";
+    } else {
+      document.getElementById("spinner").remove();
     }
 
-    const params = new URLSearchParams(window.location.search);
-    const code = params.get("snippet");
-    const load_url = params.get("load_url");
-    const style = params.get("style") || "";
-
-    if (code) {
-        main_source = code;
-    } else if (load_url) {
-        base_url = load_url;
-        const response = await fetch(load_url);
-        main_source = await response.text();
+    if (component !== undefined) {
+      component.run(canvas_id);
     }
-    update_preview();
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("snippet");
+  const load_url = params.get("load_url");
+  const style = params.get("style") || "";
+
+  if (code) {
+    main_source = code;
+  } else if (load_url) {
+    base_url = load_url;
+    const response = await fetch(load_url);
+    main_source = await response.text();
+  }
+  update_preview();
 })();

--- a/tools/online_editor/preview.ts
+++ b/tools/online_editor/preview.ts
@@ -6,10 +6,10 @@ import slint_init, * as slint from "@preview/slint_wasm_interpreter.js";
 (async function () {
   await slint_init();
 
-  var base_url = "";
+  let base_url = "";
 
   /// Index by url. Inline documents will use the empty string.
-  var loaded_documents: Map<string, string> = new Map();
+  const loaded_documents: Map<string, string> = new Map();
 
   let main_source = `
 import { SpinBox, Button, CheckBox, Slider, GroupBox } from "std-widgets.slint";
@@ -28,7 +28,7 @@ export Demo := Window {
 `;
 
   function update_preview() {
-    let div = document.getElementById("preview") as HTMLDivElement;
+    const div = document.getElementById("preview") as HTMLDivElement;
     setTimeout(function () {
       render_or_error(main_source, base_url, div);
     }, 1);
@@ -39,24 +39,24 @@ export Demo := Window {
     base_url: string,
     div: HTMLDivElement
   ) {
-    let canvas_id = "canvas_" + Math.random().toString(36).slice(2, 11);
-    let canvas = document.createElement("canvas");
+    const canvas_id = "canvas_" + Math.random().toString(36).slice(2, 11);
+    const canvas = document.createElement("canvas");
     canvas.width = 800;
     canvas.height = 600;
     canvas.id = canvas_id;
     div.innerHTML = "";
     div.appendChild(canvas);
 
-    let { component, error_string } =
+    const { component, error_string } =
       await slint.compile_from_string_with_style(
         source,
         base_url,
         style,
         async (url: string): Promise<string> => {
-          let file_source = loaded_documents.get(url);
+          const file_source = loaded_documents.get(url);
           if (file_source === undefined) {
             const response = await fetch(url);
-            let doc = await response.text();
+            const doc = await response.text();
             loaded_documents.set(url, doc);
             return doc;
           }
@@ -65,8 +65,8 @@ export Demo := Window {
       );
 
     if (error_string != "") {
-      let text = document.createTextNode(error_string);
-      let p = document.createElement("pre");
+      const text = document.createTextNode(error_string);
+      const p = document.createElement("pre");
       p.appendChild(text);
       div.innerHTML =
         "<pre style='color: red; background-color:#fee; margin:0'>" +

--- a/tools/online_editor/tsconfig.json
+++ b/tools/online_editor/tsconfig.json
@@ -3,9 +3,10 @@
     "sourceMap": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "strict": true,
     "target": "es2020",
     "outDir": "./dist",
-    "lib": ["dom", "es6", "es2015.collection", "es2015.promise"],
+    "lib": ["dom", "es6"],
     "baseUrl": "./node_modules",
     "jsx": "preserve",
     "paths": {

--- a/tools/online_editor/tsconfig.json
+++ b/tools/online_editor/tsconfig.json
@@ -1,29 +1,16 @@
 {
-    "compilerOptions": {
-        "sourceMap": true,
-        "module": "esnext",
-        "moduleResolution": "node",
-        "target": "es2020",
-        "outDir": "./dist",
-        "lib": [
-            "dom",
-            "es6",
-            "es2015.collection",
-            "es2015.promise"
-        ],
-        "types": [
-            "jquery"
-        ],
-        "baseUrl": "./node_modules",
-        "jsx": "preserve",
-        "typeRoots": [
-            "node_modules/@types"
-        ]
-    },
-    "include": [
-        "./*.ts"
-    ],
-    "exclude": [
-        "node_modules"
-    ]
+  "compilerOptions": {
+    "sourceMap": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "es2020",
+    "outDir": "./dist",
+    "lib": ["dom", "es6", "es2015.collection", "es2015.promise"],
+    "types": ["jquery"],
+    "baseUrl": "./node_modules",
+    "jsx": "preserve",
+    "typeRoots": ["node_modules/@types"]
+  },
+  "include": ["./*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/tools/online_editor/tsconfig.json
+++ b/tools/online_editor/tsconfig.json
@@ -8,6 +8,9 @@
     "lib": ["dom", "es6", "es2015.collection", "es2015.promise"],
     "baseUrl": "./node_modules",
     "jsx": "preserve",
+    "paths": {
+      "@preview/*": ["../../../api/wasm-interpreter/pkg/*"]
+    },
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["./*.ts"],

--- a/tools/online_editor/tsconfig.json
+++ b/tools/online_editor/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "es2020",
     "outDir": "./dist",
     "lib": ["dom", "es6", "es2015.collection", "es2015.promise"],
-    "types": ["jquery"],
     "baseUrl": "./node_modules",
     "jsx": "preserve",
     "typeRoots": ["node_modules/@types"]

--- a/tools/online_editor/vite.config.js
+++ b/tools/online_editor/vite.config.js
@@ -1,35 +1,36 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import { defineConfig } from 'vite'
+import { defineConfig } from "vite";
 export default defineConfig(({ command, mode }) => {
   let base_config = {
     server: {
       fs: {
         // Allow serving files from the project root
-        allow: ['../../']
-      }
+        allow: ["../../"],
+      },
     },
-    base: '',
+    base: "",
   };
 
   if (command === "serve") {
     // For development builds, serve the wasm interpreter straight out of the local file system.
     base_config.resolve = {
       alias: {
-        '../../../wasm-interpreter/slint_wasm_interpreter.js': "../../api/wasm-interpreter/pkg/slint_wasm_interpreter.js"
-      }
-    }
+        "../../../wasm-interpreter/slint_wasm_interpreter.js":
+          "../../api/wasm-interpreter/pkg/slint_wasm_interpreter.js",
+      },
+    };
   } else {
     // For distribution builds,
     // assume deployment on the main website where the loading file (index.js) is in the assets/ sub-directory and the
     // relative path to the interpreter is as below.
-    base_config.build = {}
+    base_config.build = {};
     base_config.build.rollupOptions = {
-      external: ['../../../wasm-interpreter/slint_wasm_interpreter.js'],
+      external: ["../../../wasm-interpreter/slint_wasm_interpreter.js"],
       input: ["index.html", "preview.html"],
-    }
+    };
   }
 
   return base_config;
-})
+});

--- a/tools/online_editor/vite.config.js
+++ b/tools/online_editor/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ command, _mode }) => {
     base_config.build = {};
     base_config.build.rollupOptions = {
       external: ["../../../wasm-interpreter/slint_wasm_interpreter.js"],
-      input: ["index.html", "preview.html"],
+      input: ["index.html", "preview.html", "monaco_worker.js"],
     };
     base_config.resolve = {
       alias: {

--- a/tools/online_editor/vite.config.js
+++ b/tools/online_editor/vite.config.js
@@ -17,8 +17,7 @@ export default defineConfig(({ command, mode }) => {
     // For development builds, serve the wasm interpreter straight out of the local file system.
     base_config.resolve = {
       alias: {
-        "../../../wasm-interpreter/slint_wasm_interpreter.js":
-          "../../api/wasm-interpreter/pkg/slint_wasm_interpreter.js",
+        "@preview/": "../../api/wasm-interpreter/pkg/",
       },
     };
   } else {
@@ -29,6 +28,11 @@ export default defineConfig(({ command, mode }) => {
     base_config.build.rollupOptions = {
       external: ["../../../wasm-interpreter/slint_wasm_interpreter.js"],
       input: ["index.html", "preview.html"],
+    };
+    base_config.resolve = {
+      alias: {
+        "@preview/": "../../../wasm-interpreter/pkg/",
+      },
     };
   }
 

--- a/tools/online_editor/vite.config.js
+++ b/tools/online_editor/vite.config.js
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 import { defineConfig } from "vite";
-export default defineConfig(({ command, mode }) => {
-  let base_config = {
+export default defineConfig(({ command, _mode }) => {
+  const base_config = {
     server: {
       fs: {
         // Allow serving files from the project root

--- a/tools/online_editor/vite.config.js
+++ b/tools/online_editor/vite.config.js
@@ -27,11 +27,11 @@ export default defineConfig(({ command, _mode }) => {
     base_config.build = {};
     base_config.build.rollupOptions = {
       external: ["../../../wasm-interpreter/slint_wasm_interpreter.js"],
-      input: ["index.html", "preview.html", "monaco_worker.js"],
+      input: ["index.html", "preview.html"],
     };
     base_config.resolve = {
       alias: {
-        "@preview/": "../../../wasm-interpreter/pkg/",
+        "@preview/": "../../../wasm-interpreter/",
       },
     };
   }

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore datetime dotdot
+
 use anyhow::Context;
 use anyhow::Result;
 use lazy_static::lazy_static;
@@ -293,6 +295,7 @@ lazy_static! {
         (".+\\.sublime-commands$", LicenseLocation::NoLicense),
         (".+\\.sublime-syntax$", LicenseLocation::Tag(LicenseTagStyle::shell_comment_style())),
         (".+\\.tmPreferences$", LicenseLocation::NoLicense),
+        ("\\.eslintrc.yml$", LicenseLocation::NoLicense),
         ("\\.clang-format$", LicenseLocation::NoLicense),
         (".+Dockerfile.*$", LicenseLocation::Tag(LicenseTagStyle::shell_comment_style())),
         ("^api/cpp/docs/Pipfile$", LicenseLocation::NoLicense),


### PR DESCRIPTION
Reformat the code and config files, set up linting, update typescript version, set up TS to find all the modules, enable `strict` mode in TS, fix all issues reported by tsc in strict mode, have a npm script to run `tsc --noemit` as recommended by vite.

I do not expect any of this to cause problems in CI as these changes.