### PR TITLE
Add missing shortcuts for delete word forward and backwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Fixed
+ - Fixed Ctrl+Backspace/Ctrl+Del not deleting words in text input elements.
+
 ### Changed
  - `mod` now works on any numeric type, not only integers.
  - Minimum rust version is now 1.60

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -276,8 +276,16 @@ impl KeyEvent {
         };
 
         match keycode {
-            key_codes::Backspace => Some(TextShortcut::DeleteBackward),
-            key_codes::Delete => Some(TextShortcut::DeleteForward),
+            key_codes::Backspace => Some(if move_mod {
+                TextShortcut::DeleteWordBackward
+            } else {
+                TextShortcut::DeleteBackward
+            }),
+            key_codes::Delete => Some(if move_mod {
+                TextShortcut::DeleteWordForward
+            } else {
+                TextShortcut::DeleteForward
+            }),
             _ => None,
         }
     }
@@ -315,6 +323,10 @@ pub enum TextShortcut {
     DeleteForward,
     /// Delete the Character to the left of the cursor (aka Backspace).
     DeleteBackward,
+    /// Delete the word to the right of the cursor
+    DeleteWordForward,
+    /// Delete the word to the left of the cursor (aka Ctrl + Backspace).
+    DeleteWordBackward,
 }
 
 /// Represents how an item's key_event handler dealt with a key event.

--- a/tests/cases/text/cursor_move.slint
+++ b/tests/cases/text/cursor_move.slint
@@ -18,6 +18,7 @@ const UP_CODE: char = '\u{F700}';
 const DOWN_CODE: char = '\u{F701}';
 const LEFT_CODE: char = '\u{F702}';
 const RIGHT_CODE: char = '\u{F703}';
+const DEL_CODE: char = '\u{007f}';
 const BACK_CODE: char = '\u{0008}'; // backspace \b
 
 let shift_modifier = slint::re_exports::KeyboardModifiers {
@@ -27,6 +28,12 @@ let shift_modifier = slint::re_exports::KeyboardModifiers {
 
 let move_mod_shift_modifier = slint::re_exports::KeyboardModifiers {
     shift: true,
+    control: cfg!(not(target_os = "macos")),
+    alt: cfg!(target_os = "macos"),
+    ..Default::default()
+};
+
+let move_mod_modifier = slint::re_exports::KeyboardModifiers {
     control: cfg!(not(target_os = "macos")),
     alt: cfg!(target_os = "macos"),
     ..Default::default()
@@ -78,5 +85,98 @@ slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::Key
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 0);
 assert_eq!(instance.get_test_anchor_pos(), 1);
+
+// Select all and start over
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers {
+    control: true,
+    ..Default::default()
+});
+slint::testing::send_keyboard_string_sequence(&instance, &"a");
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
+slint::testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+assert!(!instance.get_has_selection());
+assert_eq!(instance.get_test_text(), "");
+
+slint::testing::send_keyboard_string_sequence(&instance, "First Word Third Word Fifth");
+assert_eq!(instance.get_test_text(), "First Word Third Word Fifth");
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+assert_eq!(instance.get_test_cursor_pos(), 22);
+
+// Delete word backwards when the cursor is between the 'F' of Fifth and the leading space.
+// -> Delete "Word"
+slint::testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+slint::testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
+assert_eq!(instance.get_test_text(), "First Word Third Fifth");
+
+// Once more :-)
+slint::testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+slint::testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
+assert_eq!(instance.get_test_text(), "First Word Fifth");
+
+// Move cursor between the "d" of "Word" and the trailing space
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+
+// Delete word forwards
+slint::testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+slint::testing::send_keyboard_string_sequence(&instance, &DEL_CODE.to_string());
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
+assert_eq!(instance.get_test_text(), "First Fifth");
+
+// Select all and start over
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers {
+    control: true,
+    ..Default::default()
+});
+slint::testing::send_keyboard_string_sequence(&instance, &"a");
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
+slint::testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+assert!(!instance.get_has_selection());
+assert_eq!(instance.get_test_text(), "");
+
+slint::testing::send_keyboard_string_sequence(&instance, "First Second");
+assert_eq!(instance.get_test_text(), "First Second");
+
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+
+slint::testing::set_current_keyboard_modifiers(&instance, shift_modifier);
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
+assert!(instance.get_has_selection());
+
+// When there's an existing selection, always just delete that
+slint::testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+slint::testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
+assert_eq!(instance.get_test_text(), "First Send");
+
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+
+slint::testing::set_current_keyboard_modifiers(&instance, shift_modifier);
+slint::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
+assert!(instance.get_has_selection());
+
+// When there's an existing selection, always just delete that
+slint::testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+slint::testing::send_keyboard_string_sequence(&instance, &DEL_CODE.to_string());
+slint::testing::set_current_keyboard_modifiers(&instance, slint::re_exports::KeyboardModifiers::default());
+assert_eq!(instance.get_test_text(), "Fist Send");
 ```
 */


### PR DESCRIPTION
Fixes #1467