### PR TITLE
Make the property to element lowering a little less magic

### DIFF
--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -126,14 +126,14 @@ pub async fn run_passes(
         z_order::reorder_by_z_order(component, diag);
         lower_property_to_element::lower_property_to_element(
             component,
-            "opacity",
+            &[("opacity", Type::Float32)],
             "Opacity",
             &global_type_registry.borrow(),
             diag,
         );
         lower_property_to_element::lower_property_to_element(
             component,
-            "cache-rendering-hint",
+            &[("cache-rendering-hint", Type::Bool)],
             "Layer",
             &global_type_registry.borrow(),
             diag,
@@ -141,7 +141,7 @@ pub async fn run_passes(
         lower_shadows::lower_shadow_properties(component, &doc.local_registry, diag);
         lower_property_to_element::lower_property_to_element(
             component,
-            "rotation-angle",
+            crate::typeregister::RESERVED_ROTATION_PROPERTIES,
             "Rotate",
             &global_type_registry.borrow(),
             diag,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -127,7 +127,7 @@ pub async fn run_passes(
         lower_property_to_element::lower_property_to_element(
             component,
             "opacity",
-            &[],
+            core::iter::empty(),
             "Opacity",
             &global_type_registry.borrow(),
             diag,
@@ -135,7 +135,7 @@ pub async fn run_passes(
         lower_property_to_element::lower_property_to_element(
             component,
             "cache-rendering-hint",
-            &[],
+            core::iter::empty(),
             "Layer",
             &global_type_registry.borrow(),
             diag,
@@ -146,9 +146,7 @@ pub async fn run_passes(
             crate::typeregister::RESERVED_ROTATION_PROPERTIES[0].0,
             crate::typeregister::RESERVED_ROTATION_PROPERTIES[1..]
                 .iter()
-                .map(|(prop_name, _)| *prop_name)
-                .collect::<Vec<_>>()
-                .as_slice(),
+                .map(|(prop_name, _)| *prop_name),
             "Rotate",
             &global_type_registry.borrow(),
             diag,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -126,14 +126,16 @@ pub async fn run_passes(
         z_order::reorder_by_z_order(component, diag);
         lower_property_to_element::lower_property_to_element(
             component,
-            &[("opacity", Type::Float32)],
+            "opacity",
+            &[],
             "Opacity",
             &global_type_registry.borrow(),
             diag,
         );
         lower_property_to_element::lower_property_to_element(
             component,
-            &[("cache-rendering-hint", Type::Bool)],
+            "cache-rendering-hint",
+            &[],
             "Layer",
             &global_type_registry.borrow(),
             diag,
@@ -141,7 +143,12 @@ pub async fn run_passes(
         lower_shadows::lower_shadow_properties(component, &doc.local_registry, diag);
         lower_property_to_element::lower_property_to_element(
             component,
-            crate::typeregister::RESERVED_ROTATION_PROPERTIES,
+            crate::typeregister::RESERVED_ROTATION_PROPERTIES[0].0,
+            crate::typeregister::RESERVED_ROTATION_PROPERTIES[1..]
+                .iter()
+                .map(|(prop_name, _)| *prop_name)
+                .collect::<Vec<_>>()
+                .as_slice(),
             "Rotate",
             &global_type_registry.borrow(),
             diag,

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -20,8 +20,8 @@ use crate::typeregister::TypeRegister;
 // `Rotate` element.
 pub(crate) fn lower_property_to_element(
     component: &Rc<Component>,
-    property_name: &str,
-    extra_properties: &[&str],
+    property_name: &'static str,
+    extra_properties: impl Iterator<Item = &'static str> + Clone,
     element_name: &str,
     type_register: &TypeRegister,
     diag: &mut BuildDiagnostics,
@@ -66,7 +66,7 @@ pub(crate) fn lower_property_to_element(
                         create_property_element(
                             &root_elem,
                             property_name,
-                            extra_properties,
+                            extra_properties.clone(),
                             element_name,
                             type_register,
                         ),
@@ -76,7 +76,7 @@ pub(crate) fn lower_property_to_element(
                 let new_child = create_property_element(
                     &child,
                     property_name,
-                    extra_properties,
+                    extra_properties.clone(),
                     element_name,
                     type_register,
                 );
@@ -92,15 +92,15 @@ pub(crate) fn lower_property_to_element(
 
 fn create_property_element(
     child: &ElementRc,
-    property_name: &str,
-    extra_properties: &[&str],
+    property_name: &'static str,
+    extra_properties: impl Iterator<Item = &'static str>,
     element_name: &str,
     type_register: &TypeRegister,
 ) -> ElementRc {
-    let bindings = core::iter::once(&property_name)
-        .chain(extra_properties.iter())
+    let bindings = core::iter::once(property_name)
+        .chain(extra_properties)
         .filter_map(|property_name| {
-            if child.borrow().bindings.contains_key(*property_name) {
+            if child.borrow().bindings.contains_key(property_name) {
                 Some((
                     property_name.to_string(),
                     BindingExpression::new_two_way(NamedReference::new(child, property_name))


### PR DESCRIPTION
Instead of automatically mapping property bindings if the initial property has a `-` infix,
supply the list of all properties as a parameter.