### PR TITLE
Skia: Cache the Skia image in the core image cache

### DIFF
--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -256,7 +256,8 @@ fn to_js_value<'cx>(
             &ImageInner::None => JsUndefined::new().as_value(cx),
             &ImageInner::EmbeddedImage { .. }
             | &ImageInner::StaticTextures { .. }
-            | &ImageInner::Svg(..) => JsNull::new().as_value(cx), // TODO: maybe pass around node buffers?
+            | &ImageInner::Svg(..)
+            | &ImageInner::BackendStorage(..) => JsNull::new().as_value(cx), // TODO: maybe pass around node buffers?
         },
         Value::Model(model) => {
             if let Some(js_model) = model.as_any().downcast_ref::<js_model::JsModel>() {

--- a/helper_crates/vtable/macro/macro.rs
+++ b/helper_crates/vtable/macro/macro.rs
@@ -501,6 +501,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 block: parse2(if has_self {
                     quote!({
                         // Safety: this rely on the vtable being valid, and the ptr being a valid instance for this vtable
+                        #[allow(unsafe_code)]
                         unsafe {
                             let vtable = self.vtable.as_ref();
                             if let #some(func) = vtable.#ident {
@@ -536,6 +537,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     block: parse2(quote!({
                         let vtable = self;
                         // Safety: this rely on the vtable being valid, and the ptr being a valid instance for this vtable
+                        #[allow(unsafe_code)]
                         unsafe { (self.#ident)(#call_code) }
                     }))
                     .unwrap(),
@@ -545,6 +547,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     #sig_extern {
                         // This is safe since the self must be a instance of our type
                         #[allow(unused)]
+                        #[allow(unsafe_code)]
                         let vtable = unsafe { core::ptr::NonNull::from(&*_0) };
                         #wrap_trait_call(T::#ident(#self_call #forward_code))
                     }
@@ -560,6 +563,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 vtable_ctor.push(quote!(#ident: {
                     #sig_extern {
                         // This is safe since the self must be a instance of our type
+                        #[allow(unsafe_code)]
                         unsafe { #erase_return_type_lifetime(T::#ident(#self_call #forward_code)) }
                     }
                     #ident::<T>

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -14,6 +14,7 @@ use i_slint_core::{
 
 use crate::WindowSystemName;
 
+mod cached_image;
 mod itemrenderer;
 mod textlayout;
 

--- a/internal/backends/winit/renderer/skia/cached_image.rs
+++ b/internal/backends/winit/renderer/skia/cached_image.rs
@@ -1,0 +1,118 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use i_slint_core::graphics::{
+    cache as core_cache, Image, ImageCacheKey, ImageInner, IntSize, OpaqueImage, OpaqueImageVTable,
+    SharedImageBuffer,
+};
+
+struct SkiaCachedImage {
+    image: skia_safe::Image,
+    cache_key: ImageCacheKey,
+}
+
+i_slint_core::OpaqueImageVTable_static! {
+    static SKIA_CACHED_IMAGE_VT for SkiaCachedImage
+}
+
+impl OpaqueImage for SkiaCachedImage {
+    fn size(&self) -> IntSize {
+        IntSize::new(self.image.width() as u32, self.image.height() as u32)
+    }
+
+    fn cache_key(&self) -> ImageCacheKey {
+        self.cache_key.clone()
+    }
+}
+
+pub(crate) fn as_skia_image(
+    image: Image,
+    target_width: std::pin::Pin<&i_slint_core::Property<f32>>,
+    target_height: std::pin::Pin<&i_slint_core::Property<f32>>,
+) -> Option<skia_safe::Image> {
+    let image_inner: &ImageInner = (&image).into();
+    match image_inner {
+        ImageInner::None => None,
+        ImageInner::EmbeddedImage { buffer, cache_key } => {
+            let result = image_buffer_to_skia_image(buffer);
+            if let Some(img) = result.as_ref() {
+                core_cache::replace_cached_image(
+                    cache_key.clone(),
+                    ImageInner::BackendStorage(vtable::VRc::into_dyn(vtable::VRc::new(
+                        SkiaCachedImage { image: img.clone(), cache_key: cache_key.clone() },
+                    ))),
+                )
+            }
+            result
+        }
+        ImageInner::Svg(svg) => {
+            // Query target_width/height here again to ensure that changes will invalidate the item rendering cache.
+            let target_width = target_width.get();
+            let target_height = target_height.get();
+            let pixels =
+                match svg.render(IntSize::new(target_width as u32, target_height as u32)).ok()? {
+                    SharedImageBuffer::RGB8(_) => unreachable!(),
+                    SharedImageBuffer::RGBA8(_) => unreachable!(),
+                    SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels,
+                };
+
+            let image_info = skia_safe::ImageInfo::new(
+                skia_safe::ISize::new(pixels.width() as i32, pixels.height() as i32),
+                skia_safe::ColorType::RGBA8888,
+                skia_safe::AlphaType::Premul,
+                None,
+            );
+
+            skia_safe::image::Image::from_raster_data(
+                &image_info,
+                skia_safe::Data::new_copy(pixels.as_bytes()),
+                pixels.stride() as usize * 4,
+            )
+        }
+        ImageInner::StaticTextures(_) => todo!(),
+        ImageInner::BackendStorage(x) => {
+            vtable::VRc::borrow(x).downcast::<SkiaCachedImage>().map(|x| x.image.clone())
+        }
+    }
+}
+
+fn image_buffer_to_skia_image(buffer: &SharedImageBuffer) -> Option<skia_safe::Image> {
+    let (data, bpl, size, color_type, alpha_type) = match buffer {
+        SharedImageBuffer::RGB8(pixels) => {
+            // RGB888 with one byte per component is not supported by Skia right now. Convert once to RGBA8 :-(
+            let rgba = pixels
+                .as_bytes()
+                .chunks(3)
+                .flat_map(|rgb| IntoIterator::into_iter([rgb[0], rgb[1], rgb[2], 255]))
+                .collect::<Vec<u8>>();
+            (
+                skia_safe::Data::new_copy(&*rgba),
+                pixels.stride() as usize * 4,
+                pixels.size(),
+                skia_safe::ColorType::RGBA8888,
+                skia_safe::AlphaType::Unpremul,
+            )
+        }
+        SharedImageBuffer::RGBA8(pixels) => (
+            skia_safe::Data::new_copy(pixels.as_bytes()),
+            pixels.stride() as usize * 4,
+            pixels.size(),
+            skia_safe::ColorType::RGBA8888,
+            skia_safe::AlphaType::Unpremul,
+        ),
+        SharedImageBuffer::RGBA8Premultiplied(pixels) => (
+            skia_safe::Data::new_copy(pixels.as_bytes()),
+            pixels.stride() as usize * 4,
+            pixels.size(),
+            skia_safe::ColorType::RGBA8888,
+            skia_safe::AlphaType::Premul,
+        ),
+    };
+    let image_info = skia_safe::ImageInfo::new(
+        skia_safe::ISize::new(size.width as i32, size.height as i32),
+        color_type,
+        alpha_type,
+        None,
+    );
+    skia_safe::image::Image::from_raster_data(&image_info, data, bpl)
+}

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -46,7 +46,7 @@ i-slint-common = { version = "=0.2.6", path = "../common" }
 i-slint-core-macros = { version = "=0.2.6", path = "../core-macros" }
 
 const-field-offset = { version = "0.1", path = "../../helper_crates/const-field-offset" }
-vtable = { version="0.1.8", path = "../../helper_crates/vtable" }
+vtable = { version="0.1.9", path = "../../helper_crates/vtable" }
 
 atomic-polyfill = { version = "0.1.5" }
 auto_enums = "0.7"

--- a/internal/core/graphics/image/htmlimage.rs
+++ b/internal/core/graphics/image/htmlimage.rs
@@ -3,6 +3,7 @@
 
 use alloc::rc::Rc;
 
+use super::ImageCacheKey;
 use crate::graphics::IntSize;
 use crate::Property;
 
@@ -56,4 +57,11 @@ impl HTMLImage {
     }
 }
 
-impl super::OpaqueRc for HTMLImage {}
+impl super::OpaqueImage for HTMLImage {
+    fn size(&self) -> IntSize {
+        self.size().unwrap_or_default()
+    }
+    fn cache_key(&self) -> ImageCacheKey {
+        ImageCacheKey::URL(self.source().into())
+    }
+}

--- a/internal/core/graphics/image/svg.rs
+++ b/internal/core/graphics/image/svg.rs
@@ -13,7 +13,14 @@ pub struct ParsedSVG {
     cache_key: ImageCacheKey,
 }
 
-impl super::OpaqueRc for ParsedSVG {}
+impl super::OpaqueImage for ParsedSVG {
+    fn size(&self) -> crate::graphics::IntSize {
+        self.size()
+    }
+    fn cache_key(&self) -> ImageCacheKey {
+        self.cache_key.clone()
+    }
+}
 
 impl core::fmt::Debug for ParsedSVG {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
Because re-generating the Skia image is slow and there is no point
storing both the image buffer and the SkiaImage in the cache as it
is basically the same information.

This speeds up the switching to the berlin theme in the slide_puzzle 
CC  #1445
