### PR TITLE
Workaround for issue #1461

### DIFF
--- a/internal/compiler/tests/syntax/lookup/issue_1461.slint
+++ b/internal/compiler/tests/syntax/lookup/issue_1461.slint
@@ -1,0 +1,23 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import { Button, VerticalBox } from "std-widgets.slint";
+ 
+ export AppWindow := Window {
+     property<int> counter: 42;
+     callback request-increase-value();
+     VerticalBox { 
+         Button {
+             text: "Increase value";
+             clicked => { 
+                 request-increase-value();
+             }
+             states [
+                 highlight when counter > 45 : {
+                     background: red;
+//                   ^error{Internal error: The expression for the default state currently cannot be represented: https://github.com/slint-ui/slint/issues/1461}
+                 }
+             ]
+         }
+      }
+ }


### PR DESCRIPTION
Some binding can't be express with the current data structures because
they reference propertis within inner elements within a component.

The fix is a bit involved and the best is to have an error istead of a
panic, for now.