### PR TITLE
Fix the image cache with rust generated code and debug builds

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -153,7 +153,7 @@ pub fn generate(doc: &Document) -> TokenStream {
             match &er.kind {
                 crate::embedded_resources::EmbeddedResourcesKind::RawData => {
                     let data = embedded_file_tokens(path);
-                    quote!(const #symbol: &'static [u8] = #data;)
+                    quote!(static #symbol: &'static [u8] = #data;)
                 }
                 crate::embedded_resources::EmbeddedResourcesKind::TextureData(crate::embedded_resources::Texture {
                     data, format, rect,


### PR DESCRIPTION
We use `const` for the embedded data, which doesn't guarantee a fixed location in memory.

For the image cache when embedding (encoded) image data, we rely on a fixed address.

I observed that in debug builds of the slide puzzle, the embedded data is not always
reported to be at the same address, presumably due to inlining. This makes
the theme switching a bit slower and the cache less efficient.

This patch fixes that by using static instead of const, to guarantee a fixed location in memory.

(This was not observed in release builds, but in theory it could happen there as well?)