### PR TITLE
Invert and simplify Window and PlatformWindow ownership

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -135,7 +135,7 @@ fn gen_corelib(
     config.export.include = [
         "ComponentVTable",
         "Slice",
-        "WindowRcOpaque",
+        "PlatformWindowRcOpaque",
         "PropertyAnimation",
         "EasingCurve",
         "TextHorizontalAlignment",

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -189,7 +189,7 @@ fn gen_corelib(
         "slint_property_listener_scope_is_dirty",
         "PropertyTrackerOpaque",
         "CallbackOpaque",
-        "WindowRc",
+        "PlatformWindowRc",
         "VoidArg",
         "KeyEventArg",
         "PointerEventArg",
@@ -453,9 +453,9 @@ fn gen_corelib(
         .with_after_include(
             r"
 namespace slint {
-    namespace private_api { class WindowRc; }
+    namespace private_api { class PlatformWindowRc; }
     namespace cbindgen_private {
-        using slint::private_api::WindowRc;
+        using slint::private_api::PlatformWindowRc;
         using namespace vtable;
         struct KeyEvent; struct PointerEvent;
         using private_api::Property;

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -86,7 +86,9 @@ inline void assert_main_thread()
 class WindowRc
 {
 public:
-    explicit WindowRc(cbindgen_private::WindowRcOpaque adopted_inner) : inner(adopted_inner) { }
+    explicit WindowRc(cbindgen_private::PlatformWindowRcOpaque adopted_inner) : inner(adopted_inner)
+    {
+    }
     WindowRc() { cbindgen_private::slint_windowrc_init(&inner); }
     ~WindowRc() { cbindgen_private::slint_windowrc_drop(&inner); }
     WindowRc(const WindowRc &other)
@@ -223,7 +225,7 @@ public:
     }
 
 private:
-    cbindgen_private::WindowRcOpaque inner;
+    cbindgen_private::PlatformWindowRcOpaque inner;
 };
 
 constexpr inline ItemTreeNode make_item_node(uint32_t child_count, uint32_t child_index,

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -83,22 +83,23 @@ inline void assert_main_thread()
 #endif
 }
 
-class WindowRc
+class PlatformWindowRc
 {
 public:
-    explicit WindowRc(cbindgen_private::PlatformWindowRcOpaque adopted_inner) : inner(adopted_inner)
+    explicit PlatformWindowRc(cbindgen_private::PlatformWindowRcOpaque adopted_inner)
+        : inner(adopted_inner)
     {
     }
-    WindowRc() { cbindgen_private::slint_windowrc_init(&inner); }
-    ~WindowRc() { cbindgen_private::slint_windowrc_drop(&inner); }
-    WindowRc(const WindowRc &other)
+    PlatformWindowRc() { cbindgen_private::slint_windowrc_init(&inner); }
+    ~PlatformWindowRc() { cbindgen_private::slint_windowrc_drop(&inner); }
+    PlatformWindowRc(const PlatformWindowRc &other)
     {
         assert_main_thread();
         cbindgen_private::slint_windowrc_clone(&other.inner, &inner);
     }
-    WindowRc(WindowRc &&) = delete;
-    WindowRc &operator=(WindowRc &&) = delete;
-    WindowRc &operator=(const WindowRc &other)
+    PlatformWindowRc(PlatformWindowRc &&) = delete;
+    PlatformWindowRc &operator=(PlatformWindowRc &&) = delete;
+    PlatformWindowRc &operator=(const PlatformWindowRc &other)
     {
         assert_main_thread();
         if (this != &other) {
@@ -373,7 +374,7 @@ public:
     /// \private
     /// Internal function used by the generated code to construct a new instance of this
     /// public API wrapper.
-    explicit Window(const private_api::WindowRc &windowrc) : inner(windowrc) { }
+    explicit Window(const private_api::PlatformWindowRc &windowrc) : inner(windowrc) { }
     Window(const Window &other) = delete;
     Window &operator=(const Window &other) = delete;
     Window(Window &&other) = delete;
@@ -431,12 +432,12 @@ public:
     void set_size(const slint::Size<unsigned int> &size) { inner.set_size(size); }
 
     /// \private
-    private_api::WindowRc &window_handle() { return inner; }
+    private_api::PlatformWindowRc &window_handle() { return inner; }
     /// \private
-    const private_api::WindowRc &window_handle() const { return inner; }
+    const private_api::PlatformWindowRc &window_handle() const { return inner; }
 
 private:
-    private_api::WindowRc inner;
+    private_api::PlatformWindowRc inner;
 };
 
 /// A Timer that can call a callback at repeated interval

--- a/api/cpp/include/slint_interpreter.h
+++ b/api/cpp/include/slint_interpreter.h
@@ -585,7 +585,7 @@ public:
         const cbindgen_private::PlatformWindowRcOpaque *win_ptr = nullptr;
         cbindgen_private::slint_interpreter_component_instance_window(inner(), &win_ptr);
         auto wid = reinterpret_cast<QWidget *>(cbindgen_private::slint_qt_get_widget(
-                reinterpret_cast<const cbindgen_private::WindowRc *>(win_ptr)));
+                reinterpret_cast<const cbindgen_private::PlatformWindowRc *>(win_ptr)));
         return wid;
     }
 #endif
@@ -1014,6 +1014,6 @@ inline void send_keyboard_string_sequence(const slint::interpreter::ComponentIns
     cbindgen_private::slint_interpreter_component_instance_window(
             reinterpret_cast<const cbindgen_private::ErasedComponentBox *>(component), &win_ptr);
     cbindgen_private::send_keyboard_string_sequence(
-            &str, modifiers, reinterpret_cast<const cbindgen_private::WindowRc *>(win_ptr));
+            &str, modifiers, reinterpret_cast<const cbindgen_private::PlatformWindowRc *>(win_ptr));
 }
 }

--- a/api/cpp/include/slint_interpreter.h
+++ b/api/cpp/include/slint_interpreter.h
@@ -564,7 +564,7 @@ public:
     /// such as the position on the screen.
     const slint::Window &window()
     {
-        const cbindgen_private::WindowRcOpaque *win_ptr = nullptr;
+        const cbindgen_private::PlatformWindowRcOpaque *win_ptr = nullptr;
         cbindgen_private::slint_interpreter_component_instance_window(inner(), &win_ptr);
         return *reinterpret_cast<const slint::Window *>(win_ptr);
     }
@@ -582,7 +582,7 @@ public:
     /// it may return nullptr if the Qt backend is not used at runtime.
     QWidget *qwidget() const
     {
-        const cbindgen_private::WindowRcOpaque *win_ptr = nullptr;
+        const cbindgen_private::PlatformWindowRcOpaque *win_ptr = nullptr;
         cbindgen_private::slint_interpreter_component_instance_window(inner(), &win_ptr);
         auto wid = reinterpret_cast<QWidget *>(cbindgen_private::slint_qt_get_widget(
                 reinterpret_cast<const cbindgen_private::WindowRc *>(win_ptr)));
@@ -1010,7 +1010,7 @@ inline void send_keyboard_string_sequence(const slint::interpreter::ComponentIns
                                           const slint::SharedString &str,
                                           KeyboardModifiers modifiers = {})
 {
-    const cbindgen_private::WindowRcOpaque *win_ptr = nullptr;
+    const cbindgen_private::PlatformWindowRcOpaque *win_ptr = nullptr;
     cbindgen_private::slint_interpreter_component_instance_window(
             reinterpret_cast<const cbindgen_private::ErasedComponentBox *>(component), &win_ptr);
     cbindgen_private::send_keyboard_string_sequence(

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -5,7 +5,8 @@
 
 use core::ffi::c_void;
 use i_slint_backend_selector::backend;
-use i_slint_core::window::{ffi::PlatformWindowRcOpaque, PlatformWindowRc};
+use i_slint_core::window::{ffi::PlatformWindowRcOpaque, PlatformWindow};
+use std::rc::Rc;
 
 #[doc(hidden)]
 #[cold]
@@ -19,10 +20,10 @@ pub fn use_modules() -> usize {
 #[no_mangle]
 pub unsafe extern "C" fn slint_windowrc_init(out: *mut PlatformWindowRcOpaque) {
     assert_eq!(
-        core::mem::size_of::<PlatformWindowRc>(),
+        core::mem::size_of::<Rc<dyn PlatformWindow>>(),
         core::mem::size_of::<PlatformWindowRcOpaque>()
     );
-    core::ptr::write(out as *mut PlatformWindowRc, crate::backend().create_window());
+    core::ptr::write(out as *mut Rc<dyn PlatformWindow>, crate::backend().create_window());
 }
 
 #[no_mangle]
@@ -69,7 +70,7 @@ pub unsafe extern "C" fn slint_register_font_from_path(
     path: &i_slint_core::SharedString,
     error_str: *mut i_slint_core::SharedString,
 ) {
-    let platform_window = &*(win as *const PlatformWindowRc);
+    let platform_window = &*(win as *const Rc<dyn PlatformWindow>);
     core::ptr::write(
         error_str,
         match platform_window
@@ -88,7 +89,7 @@ pub unsafe extern "C" fn slint_register_font_from_data(
     data: i_slint_core::slice::Slice<'static, u8>,
     error_str: *mut i_slint_core::SharedString,
 ) {
-    let platform_window = &*(win as *const PlatformWindowRc);
+    let platform_window = &*(win as *const Rc<dyn PlatformWindow>);
     core::ptr::write(
         error_str,
         match platform_window.renderer().register_font_from_memory(data.as_slice()) {

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -5,8 +5,7 @@
 
 use core::ffi::c_void;
 use i_slint_backend_selector::backend;
-use i_slint_core::api::Window;
-use i_slint_core::window::{ffi::WindowRcOpaque, WindowRc};
+use i_slint_core::window::{ffi::PlatformWindowRcOpaque, PlatformWindowRc};
 
 #[doc(hidden)]
 #[cold]
@@ -18,9 +17,12 @@ pub fn use_modules() -> usize {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowRcOpaque) {
-    assert_eq!(core::mem::size_of::<Window>(), core::mem::size_of::<WindowRcOpaque>());
-    core::ptr::write(out as *mut Window, crate::backend().create_window());
+pub unsafe extern "C" fn slint_windowrc_init(out: *mut PlatformWindowRcOpaque) {
+    assert_eq!(
+        core::mem::size_of::<PlatformWindowRc>(),
+        core::mem::size_of::<PlatformWindowRcOpaque>()
+    );
+    core::ptr::write(out as *mut PlatformWindowRc, crate::backend().create_window());
 }
 
 #[no_mangle]
@@ -63,14 +65,17 @@ pub unsafe extern "C" fn slint_quit_event_loop() {
 
 #[no_mangle]
 pub unsafe extern "C" fn slint_register_font_from_path(
-    win: *const WindowRcOpaque,
+    win: *const PlatformWindowRcOpaque,
     path: &i_slint_core::SharedString,
     error_str: *mut i_slint_core::SharedString,
 ) {
-    let window = &*(win as *const WindowRc);
+    let platform_window = &*(win as *const PlatformWindowRc);
     core::ptr::write(
         error_str,
-        match window.renderer().register_font_from_path(std::path::Path::new(path.as_str())) {
+        match platform_window
+            .renderer()
+            .register_font_from_path(std::path::Path::new(path.as_str()))
+        {
             Ok(()) => Default::default(),
             Err(err) => err.to_string().into(),
         },
@@ -79,14 +84,14 @@ pub unsafe extern "C" fn slint_register_font_from_path(
 
 #[no_mangle]
 pub unsafe extern "C" fn slint_register_font_from_data(
-    win: *const WindowRcOpaque,
+    win: *const PlatformWindowRcOpaque,
     data: i_slint_core::slice::Slice<'static, u8>,
     error_str: *mut i_slint_core::SharedString,
 ) {
-    let window = &*(win as *const WindowRc);
+    let platform_window = &*(win as *const PlatformWindowRc);
     core::ptr::write(
         error_str,
-        match window.renderer().register_font_from_memory(data.as_slice()) {
+        match platform_window.renderer().register_font_from_memory(data.as_slice()) {
             Ok(()) => Default::default(),
             Err(err) => err.to_string().into(),
         },

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -151,9 +151,6 @@ TEST_CASE("Image")
 {
     using namespace slint;
 
-    // ensure a backend exists, using private api
-    private_api::WindowRc wnd;
-
     Image img;
     {
         auto size = img.size();

--- a/api/cpp/tests/interpreter.cpp
+++ b/api/cpp/tests/interpreter.cpp
@@ -95,9 +95,6 @@ SCENARIO("Value API")
 
     SECTION("Construct an image")
     {
-        // ensure a backend exists, using private api
-        slint::private_api::WindowRc wnd;
-
         REQUIRE(!value.to_image().has_value());
         slint::Image image = slint::Image::load_from_path(
                 SOURCE_DIR "/../../logo/slint-logo-square-light-128x128.png");

--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -15,7 +15,7 @@ mod persistent_context;
 
 struct WrappedComponentType(Option<slint_interpreter::ComponentDefinition>);
 struct WrappedComponentRc(Option<slint_interpreter::ComponentInstance>);
-struct WrappedWindow(Option<i_slint_core::window::PlatformWindowRc>);
+struct WrappedWindow(Option<std::rc::Rc<dyn i_slint_core::window::PlatformWindow>>);
 
 /// We need to do some gymnastic with closures to pass the ExecuteContext with the right lifetime
 type GlobalContextCallback<'c> =

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -284,7 +284,7 @@ pub mod re_exports {
     pub use i_slint_core::model::*;
     pub use i_slint_core::properties::{set_state_binding, Property, PropertyTracker, StateInfo};
     pub use i_slint_core::slice::Slice;
-    pub use i_slint_core::window::{WindowHandleAccess, WindowInner, WindowRc};
+    pub use i_slint_core::window::{PlatformWindowRc, WindowHandleAccess, WindowInner};
     pub use i_slint_core::Color;
     pub use i_slint_core::ComponentVTable_static;
     pub use i_slint_core::Coord;
@@ -435,9 +435,8 @@ pub mod internal {
 
 /// Creates a new window to render components in.
 #[doc(hidden)]
-pub fn create_window() -> re_exports::WindowRc {
-    use i_slint_core::window::WindowHandleAccess;
-    i_slint_backend_selector::backend().create_window().window_handle().clone()
+pub fn create_window() -> re_exports::PlatformWindowRc {
+    i_slint_backend_selector::backend().create_window()
 }
 
 /// Enters the main event loop. This is necessary in order to receive
@@ -478,7 +477,7 @@ pub mod testing {
     ) {
         let rc = component.clone_strong().into();
         let dyn_rc = vtable::VRc::into_dyn(rc.clone());
-        i_slint_core::tests::slint_send_mouse_click(&dyn_rc, x, y, &rc.window_handle().clone());
+        i_slint_core::tests::slint_send_mouse_click(&dyn_rc, x, y, rc.window_handle());
     }
 
     /// Simulate a change in keyboard modifiers being pressed
@@ -506,7 +505,7 @@ pub mod testing {
         i_slint_core::tests::send_keyboard_string_sequence(
             &super::SharedString::from(sequence),
             KEYBOARD_MODIFIERS.with(|x| x.get()),
-            &component.window_handle().clone(),
+            component.window_handle(),
         )
     }
 

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -510,7 +510,7 @@ pub mod testing {
         i_slint_core::tests::send_keyboard_string_sequence(
             &super::SharedString::from(sequence),
             KEYBOARD_MODIFIERS.with(|x| x.get()),
-            component.window_handle(),
+            &component.window_handle().platform_window(),
         )
     }
 

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -477,7 +477,12 @@ pub mod testing {
     ) {
         let rc = component.clone_strong().into();
         let dyn_rc = vtable::VRc::into_dyn(rc.clone());
-        i_slint_core::tests::slint_send_mouse_click(&dyn_rc, x, y, rc.window_handle());
+        i_slint_core::tests::slint_send_mouse_click(
+            &dyn_rc,
+            x,
+            y,
+            &rc.window_handle().platform_window(),
+        );
     }
 
     /// Simulate a change in keyboard modifiers being pressed

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -284,7 +284,7 @@ pub mod re_exports {
     pub use i_slint_core::model::*;
     pub use i_slint_core::properties::{set_state_binding, Property, PropertyTracker, StateInfo};
     pub use i_slint_core::slice::Slice;
-    pub use i_slint_core::window::{PlatformWindowRc, WindowHandleAccess, WindowInner};
+    pub use i_slint_core::window::{PlatformWindow, WindowHandleAccess, WindowInner};
     pub use i_slint_core::Color;
     pub use i_slint_core::ComponentVTable_static;
     pub use i_slint_core::Coord;
@@ -435,7 +435,7 @@ pub mod internal {
 
 /// Creates a new window to render components in.
 #[doc(hidden)]
-pub fn create_window() -> re_exports::PlatformWindowRc {
+pub fn create_window() -> alloc::rc::Rc<dyn re_exports::PlatformWindow> {
     i_slint_backend_selector::backend().create_window()
 }
 

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -114,7 +114,7 @@ mod the_backend {
     use alloc::string::String;
     use core::cell::RefCell;
     use i_slint_core::api::Window;
-    use i_slint_core::window::{PlatformWindow, PlatformWindowRc, WindowHandleAccess};
+    use i_slint_core::window::{PlatformWindow, WindowHandleAccess};
 
     thread_local! { static WINDOWS: RefCell<Option<Rc<McuWindow>>> = RefCell::new(None) }
     thread_local! { static EVENT_QUEUE: RefCell<VecDeque<McuEvent>> = Default::default() }
@@ -266,7 +266,7 @@ mod the_backend {
     }
 
     impl i_slint_core::backend::Backend for MCUBackend {
-        fn create_window(&self) -> PlatformWindowRc {
+        fn create_window(&self) -> Rc<dyn i_slint_core::window::PlatformWindow> {
             Rc::new_cyclic(|self_weak| McuWindow {
                 window: Window::new(self_weak.clone() as _),
                 self_weak: self_weak.clone(),

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -113,8 +113,8 @@ mod the_backend {
     use alloc::rc::{Rc, Weak};
     use alloc::string::String;
     use core::cell::RefCell;
-    use i_slint_core::window::PlatformWindow;
     use i_slint_core::window::WindowInner;
+    use i_slint_core::window::{PlatformWindow, WindowRc};
 
     thread_local! { static WINDOWS: RefCell<Option<Rc<McuWindow>>> = RefCell::new(None) }
     thread_local! { static EVENT_QUEUE: RefCell<VecDeque<McuEvent>> = Default::default() }
@@ -146,6 +146,10 @@ mod the_backend {
 
         fn as_any(&self) -> &dyn core::any::Any {
             self
+        }
+
+        fn window(&self) -> WindowRc {
+            self.self_weak.upgrade().unwrap()
         }
     }
 

--- a/internal/backends/mcu/pico_st7789.rs
+++ b/internal/backends/mcu/pico_st7789.rs
@@ -311,6 +311,10 @@ impl i_slint_core::window::PlatformWindow for PicoWindow {
     fn as_any(&self) -> &dyn core::any::Any {
         self
     }
+
+    fn window(&self) -> i_slint_core::window::WindowRc {
+        self.self_weak.upgrade().unwrap()
+    }
 }
 
 struct DrawBuffer<Display, PioTransfer, Stolen> {

--- a/internal/backends/mcu/pico_st7789.rs
+++ b/internal/backends/mcu/pico_st7789.rs
@@ -65,7 +65,7 @@ thread_local! { static WINDOW: RefCell<Option<Rc<PicoWindow>>> = RefCell::new(No
 
 struct PicoBackend;
 impl i_slint_core::backend::Backend for PicoBackend {
-    fn create_window(&self) -> i_slint_core::window::PlatformWindowRc {
+    fn create_window(&self) -> Rc<dyn i_slint_core::window::PlatformWindow> {
         Rc::new_cyclic(|self_weak| PicoWindow {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),
             self_weak: self_weak.clone(),

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -12,7 +12,7 @@ use i_slint_core::api::{euclid, PhysicalPx};
 use i_slint_core::component::ComponentRc;
 use i_slint_core::input::KeyboardModifiers;
 use i_slint_core::layout::Orientation;
-use i_slint_core::window::{PlatformWindow, PlatformWindowRc, WindowHandleAccess};
+use i_slint_core::window::{PlatformWindow, WindowHandleAccess};
 use i_slint_core::Coord;
 use rgb::FromSlice;
 
@@ -298,7 +298,7 @@ impl WinitWindow for SimulatorWindow {
 pub struct SimulatorBackend;
 
 impl i_slint_core::backend::Backend for SimulatorBackend {
-    fn create_window(&self) -> PlatformWindowRc {
+    fn create_window(&self) -> Rc<dyn PlatformWindow> {
         SimulatorWindow::new()
     }
 

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -12,7 +12,7 @@ use i_slint_core::api::{euclid, PhysicalPx};
 use i_slint_core::component::ComponentRc;
 use i_slint_core::input::KeyboardModifiers;
 use i_slint_core::layout::Orientation;
-use i_slint_core::window::PlatformWindow;
+use i_slint_core::window::{PlatformWindow, WindowRc};
 use i_slint_core::Coord;
 use rgb::FromSlice;
 
@@ -87,7 +87,7 @@ impl PlatformWindow for SimulatorWindow {
 
         self.visible.set(true);
 
-        let runtime_window = self.runtime_window();
+        let runtime_window = self.window();
         let component_rc = runtime_window.component();
         let component = ComponentRc::borrow_pin(&component_rc);
 
@@ -175,13 +175,13 @@ impl PlatformWindow for SimulatorWindow {
     fn set_position(&self, _position: euclid::Point2D<i32, PhysicalPx>) {
         unimplemented!()
     }
+
+    fn window(&self) -> WindowRc {
+        self.self_weak.upgrade().unwrap()
+    }
 }
 
 impl WinitWindow for SimulatorWindow {
-    fn runtime_window(&self) -> Rc<i_slint_core::window::WindowInner> {
-        self.self_weak.upgrade().unwrap()
-    }
-
     fn currently_pressed_key_code(&self) -> &Cell<Option<winit::event::VirtualKeyCode>> {
         &self.currently_pressed_key_code
     }

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -38,7 +38,7 @@ pub fn use_modules() -> usize {
 mod ffi {
     #[no_mangle]
     pub extern "C" fn slint_qt_get_widget(
-        _: &i_slint_core::window::WindowRc,
+        _: &i_slint_core::window::PlatformWindowRc,
     ) -> *mut std::ffi::c_void {
         std::ptr::null_mut()
     }
@@ -122,6 +122,7 @@ pub type NativeGlobals = ();
 
 pub const HAS_NATIVE_STYLE: bool = cfg!(not(no_qt));
 
+use i_slint_core::window::PlatformWindowRc;
 #[cfg(not(no_qt))]
 pub use qt_widgets::{native_style_metrics_deinit, native_style_metrics_init};
 #[cfg(no_qt)]
@@ -135,12 +136,12 @@ pub fn native_style_metrics_deinit(_: core::pin::Pin<&mut native_widgets::Native
 
 pub struct Backend;
 impl i_slint_core::backend::Backend for Backend {
-    fn create_window(&self) -> i_slint_core::api::Window {
+    fn create_window(&self) -> PlatformWindowRc {
         #[cfg(no_qt)]
         panic!("The Qt backend needs Qt");
         #[cfg(not(no_qt))]
         {
-            i_slint_core::window::WindowInner::new(|window| qt_window::QtWindow::new(window)).into()
+            qt_window::QtWindow::new()
         }
     }
 

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -122,7 +122,8 @@ pub type NativeGlobals = ();
 
 pub const HAS_NATIVE_STYLE: bool = cfg!(not(no_qt));
 
-use i_slint_core::window::PlatformWindowRc;
+use std::rc::Rc;
+
 #[cfg(not(no_qt))]
 pub use qt_widgets::{native_style_metrics_deinit, native_style_metrics_init};
 #[cfg(no_qt)]
@@ -136,7 +137,7 @@ pub fn native_style_metrics_deinit(_: core::pin::Pin<&mut native_widgets::Native
 
 pub struct Backend;
 impl i_slint_core::backend::Backend for Backend {
-    fn create_window(&self) -> PlatformWindowRc {
+    fn create_window(&self) -> Rc<dyn i_slint_core::window::PlatformWindow> {
         #[cfg(no_qt)]
         panic!("The Qt backend needs Qt");
         #[cfg(not(no_qt))]

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -328,9 +328,9 @@ cpp! {{
     };
 
     void *root_item_for_window(void *rustWindow) {
-        return rust!(root_item_for_window_ [rustWindow: &std::rc::Weak<crate::qt_window::QtWindow> as "void*"]
+        return rust!(root_item_for_window_ [rustWindow: &crate::qt_window::QtWindow as "void*"]
                 -> *mut c_void as "void*" {
-            let root_item = Box::new(ItemRc::new(rustWindow.upgrade().unwrap().window.window_handle().component(), 0).downgrade());
+            let root_item = Box::new(ItemRc::new(rustWindow.window.window_handle().component(), 0).downgrade());
             Box::into_raw(root_item) as _
         });
     }
@@ -708,7 +708,7 @@ cpp! {{
 
     private:
         QWidget *m_widget;
-        void *m_rustWindow;
+        void *m_rustWindow; // *const QtWindow
         mutable bool is_used = false;
     };
 

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -8,6 +8,7 @@ use crate::accessible_generated::*;
 use i_slint_core::accessibility::AccessibleStringProperty;
 use i_slint_core::item_tree::{ItemRc, ItemWeak};
 use i_slint_core::properties::{PropertyDirtyHandler, PropertyTracker};
+use i_slint_core::window::WindowHandleAccess;
 use i_slint_core::SharedVector;
 
 use cpp::*;
@@ -327,9 +328,9 @@ cpp! {{
     };
 
     void *root_item_for_window(void *rustWindow) {
-        return rust!(root_item_for_window_ [rustWindow: &i_slint_core::window::WindowInner as "void*"]
+        return rust!(root_item_for_window_ [rustWindow: &std::rc::Weak<crate::qt_window::QtWindow> as "void*"]
                 -> *mut c_void as "void*" {
-            let root_item = Box::new(ItemRc::new(rustWindow.component(), 0).downgrade());
+            let root_item = Box::new(ItemRc::new(rustWindow.upgrade().unwrap().window.window_handle().component(), 0).downgrade());
             Box::into_raw(root_item) as _
         });
     }

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -31,7 +31,7 @@ use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, RenderingResult,
 use i_slint_core::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
-use i_slint_core::window::WindowRc;
+use i_slint_core::window::WindowInner;
 use i_slint_core::{
     declare_item_vtable, Callback, ItemVTable_static, Property, SharedString, SharedVector,
 };

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -31,7 +31,7 @@ use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, RenderingResult,
 use i_slint_core::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
-use i_slint_core::window::{WindowHandleAccess, WindowInner};
+use i_slint_core::window::{PlatformWindowRc, WindowHandleAccess};
 use i_slint_core::{
     declare_item_vtable, Callback, ItemVTable_static, Property, SharedString, SharedVector,
 };

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -31,7 +31,7 @@ use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, RenderingResult,
 use i_slint_core::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
-use i_slint_core::window::WindowInner;
+use i_slint_core::window::{WindowHandleAccess, WindowInner};
 use i_slint_core::{
     declare_item_vtable, Callback, ItemVTable_static, Property, SharedString, SharedVector,
 };
@@ -59,7 +59,7 @@ macro_rules! fn_render {
             let $dpr: f32 = backend.scale_factor();
 
             let window = backend.window();
-            let active: bool = window.active();
+            let active: bool = window.window_handle().active();
             // This should include self.enabled() as well, but not every native widget
             // has that property right now.
             let $initial_state = cpp!(unsafe [ active as "bool" ] -> i32 as "int" {

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -31,7 +31,7 @@ use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, RenderingResult,
 use i_slint_core::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
-use i_slint_core::window::{PlatformWindowRc, WindowHandleAccess};
+use i_slint_core::window::{PlatformWindow, PlatformWindowRc, WindowHandleAccess};
 use i_slint_core::{
     declare_item_vtable, Callback, ItemVTable_static, Property, SharedString, SharedVector,
 };

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -188,13 +188,17 @@ impl NativeButton {
 }
 
 impl Item for NativeButton {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let standard_button_kind = self.actual_standard_button_kind();
         let mut text: qttypes::QString = self.actual_text(standard_button_kind);
         let icon: qttypes::QPixmap = self.actual_icon(standard_button_kind);
@@ -229,7 +233,7 @@ impl Item for NativeButton {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -238,7 +242,7 @@ impl Item for NativeButton {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -268,7 +272,7 @@ impl Item for NativeButton {
         }
     }
 
-    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         match event.event_type {
             KeyEventType::KeyPressed if event.text == " " || event.text == "\n" => {
                 Self::FIELD_OFFSETS.pressed.apply_pin(self).set(true);
@@ -283,7 +287,11 @@ impl Item for NativeButton {
         }
     }
 
-    fn focus_event(self: Pin<&Self>, event: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        event: &FocusEvent,
+        _window: &WindowInner,
+    ) -> FocusEventResult {
         if self.enabled() {
             Self::FIELD_OFFSETS
                 .has_focus

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -188,7 +188,7 @@ impl NativeButton {
 }
 
 impl Item for NativeButton {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -197,7 +197,7 @@ impl Item for NativeButton {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let standard_button_kind = self.actual_standard_button_kind();
         let mut text: qttypes::QString = self.actual_text(standard_button_kind);
@@ -233,7 +233,7 @@ impl Item for NativeButton {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -242,7 +242,7 @@ impl Item for NativeButton {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -275,7 +275,7 @@ impl Item for NativeButton {
     fn key_event(
         self: Pin<&Self>,
         event: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         match event.event_type {
             KeyEventType::KeyPressed if event.text == " " || event.text == "\n" => {
@@ -294,7 +294,7 @@ impl Item for NativeButton {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         if self.enabled() {
             Self::FIELD_OFFSETS

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -188,7 +188,7 @@ impl NativeButton {
 }
 
 impl Item for NativeButton {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -197,7 +197,7 @@ impl Item for NativeButton {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let standard_button_kind = self.actual_standard_button_kind();
         let mut text: qttypes::QString = self.actual_text(standard_button_kind);
@@ -233,7 +233,7 @@ impl Item for NativeButton {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -242,7 +242,7 @@ impl Item for NativeButton {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -272,7 +272,11 @@ impl Item for NativeButton {
         }
     }
 
-    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        event: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         match event.event_type {
             KeyEventType::KeyPressed if event.text == " " || event.text == "\n" => {
                 Self::FIELD_OFFSETS.pressed.apply_pin(self).set(true);
@@ -290,7 +294,7 @@ impl Item for NativeButton {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> FocusEventResult {
         if self.enabled() {
             Self::FIELD_OFFSETS

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -22,7 +22,7 @@ pub struct NativeCheckBox {
 }
 
 impl Item for NativeCheckBox {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -31,7 +31,7 @@ impl Item for NativeCheckBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.text().as_str().into();
         let size = cpp!(unsafe [
@@ -58,7 +58,7 @@ impl Item for NativeCheckBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -67,7 +67,7 @@ impl Item for NativeCheckBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         if !self.enabled() {
@@ -85,7 +85,7 @@ impl Item for NativeCheckBox {
     fn key_event(
         self: Pin<&Self>,
         event: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         match event.event_type {
             KeyEventType::KeyPressed if event.text == " " || event.text == "\n" => {
@@ -101,7 +101,7 @@ impl Item for NativeCheckBox {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         if self.enabled() {
             Self::FIELD_OFFSETS

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -22,7 +22,7 @@ pub struct NativeCheckBox {
 }
 
 impl Item for NativeCheckBox {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -31,7 +31,7 @@ impl Item for NativeCheckBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.text().as_str().into();
         let size = cpp!(unsafe [
@@ -58,7 +58,7 @@ impl Item for NativeCheckBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -67,7 +67,7 @@ impl Item for NativeCheckBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         if !self.enabled() {
@@ -82,7 +82,11 @@ impl Item for NativeCheckBox {
         InputEventResult::EventAccepted
     }
 
-    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        event: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         match event.event_type {
             KeyEventType::KeyPressed if event.text == " " || event.text == "\n" => {
                 Self::FIELD_OFFSETS.checked.apply_pin(self).set(!self.checked());
@@ -97,7 +101,7 @@ impl Item for NativeCheckBox {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> FocusEventResult {
         if self.enabled() {
             Self::FIELD_OFFSETS

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -22,13 +22,17 @@ pub struct NativeCheckBox {
 }
 
 impl Item for NativeCheckBox {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let text: qttypes::QString = self.text().as_str().into();
         let size = cpp!(unsafe [
             text as "QString"
@@ -54,7 +58,7 @@ impl Item for NativeCheckBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -63,7 +67,7 @@ impl Item for NativeCheckBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         if !self.enabled() {
@@ -78,7 +82,7 @@ impl Item for NativeCheckBox {
         InputEventResult::EventAccepted
     }
 
-    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         match event.event_type {
             KeyEventType::KeyPressed if event.text == " " || event.text == "\n" => {
                 Self::FIELD_OFFSETS.checked.apply_pin(self).set(!self.checked());
@@ -90,7 +94,11 @@ impl Item for NativeCheckBox {
         }
     }
 
-    fn focus_event(self: Pin<&Self>, event: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        event: &FocusEvent,
+        _window: &WindowInner,
+    ) -> FocusEventResult {
         if self.enabled() {
             Self::FIELD_OFFSETS
                 .has_focus

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -22,13 +22,17 @@ pub struct NativeComboBox {
 }
 
 impl Item for NativeComboBox {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let size = cpp!(unsafe [] -> qttypes::QSize as "QSize" {
             ensure_initialized();
             QStyleOptionComboBox option;
@@ -49,7 +53,7 @@ impl Item for NativeComboBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -58,7 +62,7 @@ impl Item for NativeComboBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -88,11 +92,11 @@ impl Item for NativeComboBox {
         }
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -159,20 +163,24 @@ pub struct NativeComboBoxPopup {
 }
 
 impl Item for NativeComboBoxPopup {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         Default::default()
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -181,17 +189,17 @@ impl Item for NativeComboBoxPopup {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -22,7 +22,7 @@ pub struct NativeComboBox {
 }
 
 impl Item for NativeComboBox {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -31,7 +31,7 @@ impl Item for NativeComboBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let size = cpp!(unsafe [] -> qttypes::QSize as "QSize" {
             ensure_initialized();
@@ -53,7 +53,7 @@ impl Item for NativeComboBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -62,7 +62,7 @@ impl Item for NativeComboBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -95,7 +95,7 @@ impl Item for NativeComboBox {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -103,7 +103,7 @@ impl Item for NativeComboBox {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -171,7 +171,7 @@ pub struct NativeComboBoxPopup {
 }
 
 impl Item for NativeComboBoxPopup {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -180,7 +180,7 @@ impl Item for NativeComboBoxPopup {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         Default::default()
     }
@@ -188,7 +188,7 @@ impl Item for NativeComboBoxPopup {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -197,7 +197,7 @@ impl Item for NativeComboBoxPopup {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -206,7 +206,7 @@ impl Item for NativeComboBoxPopup {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -214,7 +214,7 @@ impl Item for NativeComboBoxPopup {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -22,7 +22,7 @@ pub struct NativeComboBox {
 }
 
 impl Item for NativeComboBox {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -31,7 +31,7 @@ impl Item for NativeComboBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let size = cpp!(unsafe [] -> qttypes::QSize as "QSize" {
             ensure_initialized();
@@ -53,7 +53,7 @@ impl Item for NativeComboBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -62,7 +62,7 @@ impl Item for NativeComboBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -92,11 +92,19 @@ impl Item for NativeComboBox {
         }
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -163,7 +171,7 @@ pub struct NativeComboBoxPopup {
 }
 
 impl Item for NativeComboBoxPopup {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -172,7 +180,7 @@ impl Item for NativeComboBoxPopup {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         Default::default()
     }
@@ -180,7 +188,7 @@ impl Item for NativeComboBoxPopup {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -189,17 +197,25 @@ impl Item for NativeComboBoxPopup {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -62,7 +62,7 @@ fn minimum_group_box_size(title: qttypes::QString) -> qttypes::QSize {
 }
 
 impl Item for NativeGroupBox {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {
         let shared_data = Rc::pin(GroupBoxData::default());
 
         Property::link_two_way(
@@ -146,7 +146,7 @@ impl Item for NativeGroupBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
 
@@ -165,7 +165,7 @@ impl Item for NativeGroupBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -174,17 +174,25 @@ impl Item for NativeGroupBox {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -62,7 +62,7 @@ fn minimum_group_box_size(title: qttypes::QString) -> qttypes::QSize {
 }
 
 impl Item for NativeGroupBox {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {
+    fn init(self: Pin<&Self>, _window: &WindowInner) {
         let shared_data = Rc::pin(GroupBoxData::default());
 
         Property::link_two_way(
@@ -143,7 +143,11 @@ impl Item for NativeGroupBox {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
 
         let size = minimum_group_box_size(text);
@@ -161,7 +165,7 @@ impl Item for NativeGroupBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -170,17 +174,17 @@ impl Item for NativeGroupBox {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -62,7 +62,7 @@ fn minimum_group_box_size(title: qttypes::QString) -> qttypes::QSize {
 }
 
 impl Item for NativeGroupBox {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {
         let shared_data = Rc::pin(GroupBoxData::default());
 
         Property::link_two_way(
@@ -146,7 +146,7 @@ impl Item for NativeGroupBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
 
@@ -165,7 +165,7 @@ impl Item for NativeGroupBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -174,7 +174,7 @@ impl Item for NativeGroupBox {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -183,7 +183,7 @@ impl Item for NativeGroupBox {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -191,7 +191,7 @@ impl Item for NativeGroupBox {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -25,7 +25,7 @@ pub struct NativeLineEdit {
 }
 
 impl Item for NativeLineEdit {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {
+    fn init(self: Pin<&Self>, _window: &WindowInner) {
         let paddings = Rc::pin(Property::default());
 
         paddings.as_ref().set_binding(move || {
@@ -73,7 +73,11 @@ impl Item for NativeLineEdit {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo {
             min: match orientation {
                 Orientation::Horizontal => self.native_padding_left() + self.native_padding_right(),
@@ -87,7 +91,7 @@ impl Item for NativeLineEdit {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -96,17 +100,17 @@ impl Item for NativeLineEdit {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -25,7 +25,7 @@ pub struct NativeLineEdit {
 }
 
 impl Item for NativeLineEdit {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {
         let paddings = Rc::pin(Property::default());
 
         paddings.as_ref().set_binding(move || {
@@ -76,7 +76,7 @@ impl Item for NativeLineEdit {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo {
             min: match orientation {
@@ -91,7 +91,7 @@ impl Item for NativeLineEdit {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -100,7 +100,7 @@ impl Item for NativeLineEdit {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -109,7 +109,7 @@ impl Item for NativeLineEdit {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -117,7 +117,7 @@ impl Item for NativeLineEdit {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -25,7 +25,7 @@ pub struct NativeLineEdit {
 }
 
 impl Item for NativeLineEdit {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {
         let paddings = Rc::pin(Property::default());
 
         paddings.as_ref().set_binding(move || {
@@ -76,7 +76,7 @@ impl Item for NativeLineEdit {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo {
             min: match orientation {
@@ -91,7 +91,7 @@ impl Item for NativeLineEdit {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -100,17 +100,25 @@ impl Item for NativeLineEdit {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -21,13 +21,17 @@ pub struct NativeStandardListViewItem {
 }
 
 impl Item for NativeStandardListViewItem {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let index: i32 = self.index();
         let item = self.item();
         let text: qttypes::QString = item.text.as_str().into();
@@ -60,7 +64,7 @@ impl Item for NativeStandardListViewItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -69,17 +73,17 @@ impl Item for NativeStandardListViewItem {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -21,7 +21,7 @@ pub struct NativeStandardListViewItem {
 }
 
 impl Item for NativeStandardListViewItem {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -30,7 +30,7 @@ impl Item for NativeStandardListViewItem {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let index: i32 = self.index();
         let item = self.item();
@@ -64,7 +64,7 @@ impl Item for NativeStandardListViewItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -73,7 +73,7 @@ impl Item for NativeStandardListViewItem {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -82,7 +82,7 @@ impl Item for NativeStandardListViewItem {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -90,7 +90,7 @@ impl Item for NativeStandardListViewItem {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -21,7 +21,7 @@ pub struct NativeStandardListViewItem {
 }
 
 impl Item for NativeStandardListViewItem {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -30,7 +30,7 @@ impl Item for NativeStandardListViewItem {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let index: i32 = self.index();
         let item = self.item();
@@ -64,7 +64,7 @@ impl Item for NativeStandardListViewItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -73,17 +73,25 @@ impl Item for NativeStandardListViewItem {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -30,7 +30,7 @@ pub struct NativeScrollView {
 }
 
 impl Item for NativeScrollView {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {
         let paddings = Rc::pin(Property::default());
 
         paddings.as_ref().set_binding(move || {
@@ -88,7 +88,7 @@ impl Item for NativeScrollView {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo {
             min: match orientation {
@@ -103,7 +103,7 @@ impl Item for NativeScrollView {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -112,7 +112,7 @@ impl Item for NativeScrollView {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -259,7 +259,7 @@ impl Item for NativeScrollView {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -267,7 +267,7 @@ impl Item for NativeScrollView {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -30,7 +30,7 @@ pub struct NativeScrollView {
 }
 
 impl Item for NativeScrollView {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {
+    fn init(self: Pin<&Self>, _window: &WindowInner) {
         let paddings = Rc::pin(Property::default());
 
         paddings.as_ref().set_binding(move || {
@@ -85,7 +85,11 @@ impl Item for NativeScrollView {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo {
             min: match orientation {
                 Orientation::Horizontal => self.native_padding_left() + self.native_padding_right(),
@@ -99,7 +103,7 @@ impl Item for NativeScrollView {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -108,7 +112,7 @@ impl Item for NativeScrollView {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -252,11 +256,11 @@ impl Item for NativeScrollView {
         }
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -30,7 +30,7 @@ pub struct NativeScrollView {
 }
 
 impl Item for NativeScrollView {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {
         let paddings = Rc::pin(Property::default());
 
         paddings.as_ref().set_binding(move || {
@@ -88,7 +88,7 @@ impl Item for NativeScrollView {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo {
             min: match orientation {
@@ -103,7 +103,7 @@ impl Item for NativeScrollView {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -112,7 +112,7 @@ impl Item for NativeScrollView {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -256,11 +256,19 @@ impl Item for NativeScrollView {
         }
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -57,7 +57,7 @@ void initQSliderOptions(QStyleOptionSlider &option, bool pressed, bool enabled, 
 }}
 
 impl Item for NativeSlider {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -66,7 +66,7 @@ impl Item for NativeSlider {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let enabled = self.enabled();
         let value = self.value() as i32;
@@ -106,7 +106,7 @@ impl Item for NativeSlider {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -115,7 +115,7 @@ impl Item for NativeSlider {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -197,7 +197,7 @@ impl Item for NativeSlider {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -205,7 +205,7 @@ impl Item for NativeSlider {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -57,7 +57,7 @@ void initQSliderOptions(QStyleOptionSlider &option, bool pressed, bool enabled, 
 }}
 
 impl Item for NativeSlider {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -66,7 +66,7 @@ impl Item for NativeSlider {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let enabled = self.enabled();
         let value = self.value() as i32;
@@ -106,7 +106,7 @@ impl Item for NativeSlider {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -115,7 +115,7 @@ impl Item for NativeSlider {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -194,11 +194,19 @@ impl Item for NativeSlider {
         result
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -57,13 +57,17 @@ void initQSliderOptions(QStyleOptionSlider &option, bool pressed, bool enabled, 
 }}
 
 impl Item for NativeSlider {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let enabled = self.enabled();
         let value = self.value() as i32;
         let min = self.minimum() as i32;
@@ -102,7 +106,7 @@ impl Item for NativeSlider {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -111,7 +115,7 @@ impl Item for NativeSlider {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -190,11 +194,11 @@ impl Item for NativeSlider {
         result
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -184,7 +184,7 @@ impl Item for NativeSpinBox {
 
         if let MouseEvent::Pressed { .. } = event {
             if !self.has_focus() {
-                window.clone().set_focus_item(self_rc);
+                window.set_focus_item(self_rc);
             }
         }
         InputEventResult::EventAccepted

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -54,7 +54,7 @@ option.frame = true;
 }}
 
 impl Item for NativeSpinBox {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -63,7 +63,7 @@ impl Item for NativeSpinBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         //let value: i32 = self.value();
         let data = self.data();
@@ -108,7 +108,7 @@ impl Item for NativeSpinBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -117,7 +117,7 @@ impl Item for NativeSpinBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -188,13 +188,17 @@ impl Item for NativeSpinBox {
 
         if let MouseEvent::Pressed { .. } = event {
             if !self.has_focus() {
-                window.set_focus_item(self_rc);
+                platform_window.window().window_handle().set_focus_item(self_rc);
             }
         }
         InputEventResult::EventAccepted
     }
 
-    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        event: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         if !self.enabled() || event.event_type != KeyEventType::KeyPressed {
             return KeyEventResult::EventIgnored;
         }
@@ -216,7 +220,7 @@ impl Item for NativeSpinBox {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> FocusEventResult {
         match event {
             FocusEvent::FocusIn => {

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -54,7 +54,7 @@ option.frame = true;
 }}
 
 impl Item for NativeSpinBox {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -63,7 +63,7 @@ impl Item for NativeSpinBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         //let value: i32 = self.value();
         let data = self.data();
@@ -108,7 +108,7 @@ impl Item for NativeSpinBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -117,7 +117,7 @@ impl Item for NativeSpinBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &PlatformWindowRc,
+        platform_window: &Rc<dyn PlatformWindow>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -197,7 +197,7 @@ impl Item for NativeSpinBox {
     fn key_event(
         self: Pin<&Self>,
         event: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         if !self.enabled() || event.event_type != KeyEventType::KeyPressed {
             return KeyEventResult::EventIgnored;
@@ -220,7 +220,7 @@ impl Item for NativeSpinBox {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         match event {
             FocusEvent::FocusIn => {

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -54,13 +54,17 @@ option.frame = true;
 }}
 
 impl Item for NativeSpinBox {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         //let value: i32 = self.value();
         let data = self.data();
         let active_controls = data.active_controls;
@@ -104,7 +108,7 @@ impl Item for NativeSpinBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -113,7 +117,7 @@ impl Item for NativeSpinBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowRc,
+        window: &WindowInner,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -190,7 +194,7 @@ impl Item for NativeSpinBox {
         InputEventResult::EventAccepted
     }
 
-    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         if !self.enabled() || event.event_type != KeyEventType::KeyPressed {
             return KeyEventResult::EventIgnored;
         }
@@ -209,7 +213,11 @@ impl Item for NativeSpinBox {
         }
     }
 
-    fn focus_event(self: Pin<&Self>, event: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        event: &FocusEvent,
+        _window: &WindowInner,
+    ) -> FocusEventResult {
         match event {
             FocusEvent::FocusIn => {
                 if self.enabled() {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -35,7 +35,7 @@ pub struct NativeTabWidget {
 }
 
 impl Item for NativeTabWidget {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {
         #[derive(Default, Clone)]
         #[repr(C)]
         struct TabWidgetMetrics {
@@ -171,7 +171,7 @@ impl Item for NativeTabWidget {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let (content_size, tabbar_size) = match orientation {
             Orientation::Horizontal => (
@@ -227,7 +227,7 @@ impl Item for NativeTabWidget {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -236,7 +236,7 @@ impl Item for NativeTabWidget {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -245,7 +245,7 @@ impl Item for NativeTabWidget {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -253,7 +253,7 @@ impl Item for NativeTabWidget {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -336,7 +336,7 @@ pub struct NativeTab {
 }
 
 impl Item for NativeTab {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -345,7 +345,7 @@ impl Item for NativeTab {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
         let icon: qttypes::QPixmap =
@@ -394,7 +394,7 @@ impl Item for NativeTab {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -403,7 +403,7 @@ impl Item for NativeTab {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &PlatformWindowRc,
+        platform_window: &Rc<dyn PlatformWindow>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -440,7 +440,7 @@ impl Item for NativeTab {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -448,7 +448,7 @@ impl Item for NativeTab {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -413,7 +413,7 @@ impl Item for NativeTab {
         if matches!(event, MouseEvent::Released { .. } if !click_on_press)
             || matches!(event, MouseEvent::Pressed { .. } if click_on_press)
         {
-            window.clone().set_focus_item(self_rc);
+            window.set_focus_item(self_rc);
             self.current.set(self.tab_index());
             InputEventResult::EventAccepted
         } else {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -35,7 +35,7 @@ pub struct NativeTabWidget {
 }
 
 impl Item for NativeTabWidget {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {
+    fn init(self: Pin<&Self>, _window: &WindowInner) {
         #[derive(Default, Clone)]
         #[repr(C)]
         struct TabWidgetMetrics {
@@ -168,7 +168,11 @@ impl Item for NativeTabWidget {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let (content_size, tabbar_size) = match orientation {
             Orientation::Horizontal => (
                 qttypes::QSizeF {
@@ -223,7 +227,7 @@ impl Item for NativeTabWidget {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -232,17 +236,17 @@ impl Item for NativeTabWidget {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -324,13 +328,17 @@ pub struct NativeTab {
 }
 
 impl Item for NativeTab {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
         let icon: qttypes::QPixmap =
             crate::qt_window::image_to_pixmap((&self.icon()).into(), None).unwrap_or_default();
@@ -378,7 +386,7 @@ impl Item for NativeTab {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -387,7 +395,7 @@ impl Item for NativeTab {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowRc,
+        window: &WindowInner,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -421,11 +429,11 @@ impl Item for NativeTab {
         }
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -35,7 +35,7 @@ pub struct NativeTabWidget {
 }
 
 impl Item for NativeTabWidget {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {
         #[derive(Default, Clone)]
         #[repr(C)]
         struct TabWidgetMetrics {
@@ -171,7 +171,7 @@ impl Item for NativeTabWidget {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let (content_size, tabbar_size) = match orientation {
             Orientation::Horizontal => (
@@ -227,7 +227,7 @@ impl Item for NativeTabWidget {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -236,17 +236,25 @@ impl Item for NativeTabWidget {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -328,7 +336,7 @@ pub struct NativeTab {
 }
 
 impl Item for NativeTab {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -337,7 +345,7 @@ impl Item for NativeTab {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
         let icon: qttypes::QPixmap =
@@ -386,7 +394,7 @@ impl Item for NativeTab {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -395,7 +403,7 @@ impl Item for NativeTab {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -421,7 +429,7 @@ impl Item for NativeTab {
         if matches!(event, MouseEvent::Released { .. } if !click_on_press)
             || matches!(event, MouseEvent::Pressed { .. } if click_on_press)
         {
-            window.set_focus_item(self_rc);
+            platform_window.window().window_handle().set_focus_item(self_rc);
             self.current.set(self.tab_index());
             InputEventResult::EventAccepted
         } else {
@@ -429,11 +437,19 @@ impl Item for NativeTab {
         }
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1338,7 +1338,7 @@ impl QtWindow {
 
 #[allow(unused)]
 impl PlatformWindow for QtWindow {
-    fn show(self: Rc<Self>) {
+    fn show(&self) {
         let component_rc = self.self_weak.upgrade().unwrap().component();
         let component = ComponentRc::borrow_pin(&component_rc);
         let root_item = component.as_ref().get_item_ref(0);
@@ -1359,7 +1359,7 @@ impl PlatformWindow for QtWindow {
         );
     }
 
-    fn hide(self: Rc<Self>) {
+    fn hide(&self) {
         self.rendering_metrics_collector.take();
         let widget_ptr = self.widget_ptr();
         cpp! {unsafe [widget_ptr as "QWidget*"] {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -20,7 +20,7 @@ use i_slint_core::items::{
     PointerEventButton, RenderingResult, TextOverflow, TextWrap,
 };
 use i_slint_core::layout::Orientation;
-use i_slint_core::window::{PlatformWindow, PlatformWindowRc, WindowHandleAccess};
+use i_slint_core::window::{PlatformWindow, WindowHandleAccess};
 use i_slint_core::{ImageInner, PathData, Property, SharedString};
 use items::{ImageFit, TextHorizontalAlignment, TextVerticalAlignment};
 
@@ -1479,7 +1479,7 @@ impl PlatformWindow for QtWindow {
         self.tree_structure_changed.replace(true);
     }
 
-    fn create_popup(&self, geometry: Rect) -> Option<PlatformWindowRc> {
+    fn create_popup(&self, geometry: Rect) -> Option<Rc<dyn PlatformWindow>> {
         let popup_window = QtWindow::new();
 
         let size = qttypes::QSize { width: geometry.width() as _, height: geometry.height() as _ };

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -604,7 +604,8 @@ impl ItemRenderer for QtItemRenderer<'_> {
             }}
         }
 
-        let font: QFont = get_font(text_input.font_request(self.window.window_handle()));
+        let font: QFont =
+            get_font(text_input.font_request(&self.window.window_handle().platform_window()));
         let flags = match text_input.horizontal_alignment() {
             TextHorizontalAlignment::Left => key_generated::Qt_AlignmentFlag_AlignLeft,
             TextHorizontalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignHCenter,
@@ -1605,7 +1606,8 @@ impl Renderer for QtWindow {
         }
         let rect: qttypes::QRectF = get_geometry!(items::TextInput, text_input);
         let pos = qttypes::QPointF { x: pos.x as _, y: pos.y as _ };
-        let font: QFont = get_font(text_input.font_request(self.window.window_handle()));
+        let font: QFont =
+            get_font(text_input.font_request(&self.window.window_handle().platform_window()));
         let string = qttypes::QString::from(text_input.text().as_str());
         let flags = match text_input.horizontal_alignment() {
             TextHorizontalAlignment::Left => key_generated::Qt_AlignmentFlag_AlignLeft,
@@ -1660,7 +1662,8 @@ impl Renderer for QtWindow {
         byte_offset: usize,
     ) -> Rect {
         let rect: qttypes::QRectF = get_geometry!(items::TextInput, text_input);
-        let font: QFont = get_font(text_input.font_request(self.window.window_handle()));
+        let font: QFont =
+            get_font(text_input.font_request(&self.window.window_handle().platform_window()));
         let text = text_input.text();
         let mut string = qttypes::QString::from(text.as_str());
         let offset: u32 = utf8_byte_offset_to_utf16_units(text.as_str(), byte_offset) as _;

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1582,6 +1582,10 @@ impl PlatformWindow for QtWindow {
             widget_ptr->resize(sz);
         }};
     }
+
+    fn window(&self) -> WindowRc {
+        self.self_weak.upgrade().unwrap()
+    }
 }
 
 impl Renderer for QtWindow {

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -56,11 +56,11 @@ pub struct TestingWindow {
 }
 
 impl PlatformWindow for TestingWindow {
-    fn show(self: Rc<Self>) {
+    fn show(&self) {
         unimplemented!("showing a testing window")
     }
 
-    fn hide(self: Rc<Self>) {}
+    fn hide(&self) {}
 
     fn request_redraw(&self) {}
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -9,7 +9,6 @@ use i_slint_core::api::PhysicalPx;
 use i_slint_core::graphics::{Point, Rect, Size};
 use i_slint_core::renderer::Renderer;
 use i_slint_core::window::PlatformWindow;
-use i_slint_core::window::PlatformWindowRc;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Mutex;
@@ -20,7 +19,7 @@ pub struct TestingBackend {
 }
 
 impl i_slint_core::backend::Backend for TestingBackend {
-    fn create_window(&self) -> PlatformWindowRc {
+    fn create_window(&self) -> Rc<dyn PlatformWindow> {
         Rc::new_cyclic(|self_weak| TestingWindow {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),
         })

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -25,7 +25,6 @@ use winit::event::WindowEvent;
 use winit::platform::run_return::EventLoopExtRunReturn;
 
 pub trait WinitWindow: PlatformWindow {
-    fn runtime_window(&self) -> Rc<corelib::window::WindowInner>;
     fn currently_pressed_key_code(&self) -> &Cell<Option<winit::event::VirtualKeyCode>>;
     fn current_keyboard_modifiers(&self) -> &Cell<KeyboardModifiers>;
     fn draw(self: Rc<Self>);
@@ -58,7 +57,7 @@ pub trait WinitWindow: PlatformWindow {
                 let max_width = constraints_horizontal.max.max(constraints_horizontal.min) as f32;
                 let max_height = constraints_vertical.max.max(constraints_vertical.min) as f32;
 
-                let sf = self.runtime_window().scale_factor();
+                let sf = self.window().scale_factor();
 
                 winit_window.set_resizable(true);
                 winit_window.set_min_inner_size(if min_width > 0. || min_height > 0. {
@@ -123,9 +122,8 @@ pub trait WinitWindow: PlatformWindow {
             if width <= 0. || height <= 0. {
                 must_resize = true;
 
-                let winit_size = winit_window
-                    .inner_size()
-                    .to_logical(self.runtime_window().scale_factor() as f64);
+                let winit_size =
+                    winit_window.inner_size().to_logical(self.window().scale_factor() as f64);
 
                 if width <= 0. {
                     width = winit_size.width;
@@ -135,8 +133,7 @@ pub trait WinitWindow: PlatformWindow {
                 }
             }
 
-            let existing_size: LogicalSize =
-                self.inner_size().cast() / self.runtime_window().scale();
+            let existing_size: LogicalSize = self.inner_size().cast() / self.window().scale();
 
             if (existing_size.width as f32 - width).abs() > 1.
                 || (existing_size.height as f32 - height).abs() > 1.
@@ -151,7 +148,7 @@ pub trait WinitWindow: PlatformWindow {
         });
 
         if must_resize {
-            let win = i_slint_core::api::Window::from(self.runtime_window());
+            let win = i_slint_core::api::Window::from(self.window());
             let f = win.scale_factor().0;
             win.set_size(euclid::size2((width as f32 * f) as _, (height as f32 * f) as _));
         }
@@ -383,7 +380,7 @@ fn process_window_event(
         event
     }
 
-    let runtime_window = window.runtime_window();
+    let runtime_window = window.window();
     match event {
         WindowEvent::Resized(size) => {
             window.resize_event(size);
@@ -654,7 +651,7 @@ pub fn run(quit_behavior: i_slint_core::backend::EventLoopQuitBehavior) {
                         .drain(..)
                         .flat_map(|window_id| window_by_id(window_id))
                     {
-                        window.runtime_window().update_window_properties();
+                        window.window().update_window_properties();
                     }
                 }
 

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -27,7 +27,7 @@ use winit::platform::run_return::EventLoopExtRunReturn;
 pub trait WinitWindow: PlatformWindow {
     fn currently_pressed_key_code(&self) -> &Cell<Option<winit::event::VirtualKeyCode>>;
     fn current_keyboard_modifiers(&self) -> &Cell<KeyboardModifiers>;
-    fn draw(self: Rc<Self>);
+    fn draw(&self);
     fn with_window_handle(&self, callback: &mut dyn FnMut(&winit::window::Window));
     fn constraints(&self) -> (corelib::layout::LayoutInfo, corelib::layout::LayoutInfo);
     fn set_constraints(

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -418,7 +418,7 @@ fn process_window_event(
 
             let mut event = key_event(KeyEventType::KeyPressed, text, modifiers);
 
-            runtime_window.clone().process_key_input(&event);
+            runtime_window.process_key_input(&event);
             event.event_type = KeyEventType::KeyReleased;
             runtime_window.process_key_input(&event);
         }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -57,7 +57,7 @@ pub trait WinitWindow: PlatformWindow {
                 let max_width = constraints_horizontal.max.max(constraints_horizontal.min) as f32;
                 let max_height = constraints_vertical.max.max(constraints_vertical.min) as f32;
 
-                let sf = self.window().scale_factor();
+                let sf = self.window().scale_factor().get();
 
                 winit_window.set_resizable(true);
                 winit_window.set_min_inner_size(if min_width > 0. || min_height > 0. {
@@ -123,7 +123,7 @@ pub trait WinitWindow: PlatformWindow {
                 must_resize = true;
 
                 let winit_size =
-                    winit_window.inner_size().to_logical(self.window().scale_factor() as f64);
+                    winit_window.inner_size().to_logical(self.window().scale_factor().get() as f64);
 
                 if width <= 0. {
                     width = winit_size.width;
@@ -133,7 +133,8 @@ pub trait WinitWindow: PlatformWindow {
                 }
             }
 
-            let existing_size: LogicalSize = self.inner_size().cast() / self.window().scale();
+            let existing_size: LogicalSize =
+                self.inner_size().cast() / self.window().scale_factor();
 
             if (existing_size.width as f32 - width).abs() > 1.
                 || (existing_size.height as f32 - height).abs() > 1.
@@ -148,7 +149,7 @@ pub trait WinitWindow: PlatformWindow {
         });
 
         if must_resize {
-            let win = i_slint_core::api::Window::from(self.window());
+            let win = self.window();
             let f = win.scale_factor().0;
             win.set_size(euclid::size2((width as f32 * f) as _, (height as f32 * f) as _));
         }
@@ -380,7 +381,7 @@ fn process_window_event(
         event
     }
 
-    let runtime_window = window.window();
+    let runtime_window = window.window().window_handle();
     match event {
         WindowEvent::Resized(size) => {
             window.resize_event(size);
@@ -651,7 +652,7 @@ pub fn run(quit_behavior: i_slint_core::backend::EventLoopQuitBehavior) {
                         .drain(..)
                         .flat_map(|window_id| window_by_id(window_id))
                     {
-                        window.window().update_window_properties();
+                        window.window().window_handle().update_window_properties();
                     }
                 }
 

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -17,7 +17,7 @@ use corelib::component::ComponentRc;
 use corelib::input::KeyboardModifiers;
 use corelib::items::{ItemRef, MouseCursor};
 use corelib::layout::Orientation;
-use corelib::window::{PlatformWindow, PlatformWindowRc, WindowHandleAccess};
+use corelib::window::{PlatformWindow, WindowHandleAccess};
 use corelib::Property;
 use corelib::{graphics::*, Coord};
 use i_slint_core as corelib;
@@ -45,7 +45,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> GLWindow<Renderer> {
     /// * `graphics_backend_factory`: The factor function stored in the GraphicsWindow that's called when the state
     ///   of the window changes to mapped. The event loop and window builder parameters can be used to create a
     ///   backing window.
-    pub(crate) fn new(#[cfg(target_arch = "wasm32")] canvas_id: String) -> PlatformWindowRc {
+    pub(crate) fn new(#[cfg(target_arch = "wasm32")] canvas_id: String) -> Rc<dyn PlatformWindow> {
         let self_rc = Rc::new_cyclic(|self_weak| Self {
             window: corelib::api::Window::new(self_weak.clone() as _),
             self_weak: self_weak.clone(),

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -17,7 +17,7 @@ use corelib::component::ComponentRc;
 use corelib::input::KeyboardModifiers;
 use corelib::items::{ItemRef, MouseCursor};
 use corelib::layout::Orientation;
-use corelib::window::PlatformWindow;
+use corelib::window::{PlatformWindow, WindowRc};
 use corelib::Property;
 use corelib::{graphics::*, Coord};
 use i_slint_core as corelib;
@@ -101,10 +101,6 @@ impl<Renderer: WinitCompatibleRenderer> GLWindow<Renderer> {
 }
 
 impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Renderer> {
-    fn runtime_window(&self) -> Rc<corelib::window::WindowInner> {
-        self.self_weak.upgrade().unwrap()
-    }
-
     fn currently_pressed_key_code(&self) -> &Cell<Option<winit::event::VirtualKeyCode>> {
         &self.currently_pressed_key_code
     }
@@ -194,7 +190,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Rende
 
     fn resize_event(&self, size: winit::dpi::PhysicalSize<u32>) {
         if let Some(mapped_window) = self.borrow_mapped_window() {
-            i_slint_core::api::Window::from(self.runtime_window())
+            i_slint_core::api::Window::from(self.window())
                 .set_size(euclid::size2(size.width, size.height));
             mapped_window.canvas.resize_event()
         }
@@ -272,7 +268,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> PlatformWindow for GLWindow<Re
             GraphicsWindowBackendState::Mapped(_) => return,
         };
 
-        let runtime_window = self.runtime_window();
+        let runtime_window = self.window();
         let component_rc = runtime_window.component();
         let component = ComponentRc::borrow_pin(&component_rc);
 
@@ -483,6 +479,10 @@ impl<Renderer: WinitCompatibleRenderer + 'static> PlatformWindow for GLWindow<Re
                 }
             }
         }
+    }
+
+    fn window(&self) -> WindowRc {
+        self.self_weak.upgrade().unwrap()
     }
 }
 

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -12,6 +12,8 @@ extern crate alloc;
 use std::rc::Rc;
 use std::sync::Mutex;
 
+use i_slint_core::window::PlatformWindow;
+
 mod glwindow;
 use glwindow::*;
 mod glcontext;
@@ -59,7 +61,7 @@ pub(crate) mod wasm_input_helper;
 mod stylemetrics;
 
 #[cfg(target_arch = "wasm32")]
-pub fn create_gl_window_with_canvas_id(canvas_id: String) -> PlatformWindowRc {
+pub fn create_gl_window_with_canvas_id(canvas_id: String) -> Rc<dyn PlatformWindow> {
     GLWindow::<crate::renderer::femtovg::FemtoVGRenderer>::new(canvas_id)
 }
 
@@ -75,12 +77,11 @@ pub mod native_widgets {
 }
 pub const HAS_NATIVE_STYLE: bool = false;
 
-use i_slint_core::window::PlatformWindowRc;
 pub use stylemetrics::native_style_metrics_deinit;
 pub use stylemetrics::native_style_metrics_init;
 
 pub struct Backend {
-    window_factory_fn: Mutex<Box<dyn Fn() -> PlatformWindowRc + Send>>,
+    window_factory_fn: Mutex<Box<dyn Fn() -> Rc<dyn PlatformWindow> + Send>>,
 }
 
 impl Backend {
@@ -129,7 +130,7 @@ impl Backend {
 }
 
 impl i_slint_core::backend::Backend for Backend {
-    fn create_window(&self) -> PlatformWindowRc {
+    fn create_window(&self) -> Rc<dyn PlatformWindow> {
         self.window_factory_fn.lock().unwrap()()
     }
 

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -18,14 +18,15 @@ mod glcontext;
 use glcontext::*;
 pub(crate) mod event_loop;
 mod renderer {
+    use std::rc::Weak;
 
-    use i_slint_core::window::PlatformWindowWeak;
+    use i_slint_core::window::PlatformWindow;
 
     pub(crate) trait WinitCompatibleRenderer: i_slint_core::renderer::Renderer {
         type Canvas: WinitCompatibleCanvas;
 
         fn new(
-            platform_window_weak: &PlatformWindowWeak,
+            platform_window_weak: &Weak<dyn PlatformWindow>,
             #[cfg(target_arch = "wasm32")] canvas_id: String,
         ) -> Self;
 

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -1,7 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use std::{cell::RefCell, pin::Pin, rc::Rc};
+use std::cell::RefCell;
+use std::pin::Pin;
+use std::rc::{Rc, Weak};
 
 use i_slint_core::api::{
     euclid, GraphicsAPI, RenderingNotifier, RenderingState, SetRenderingNotifierError,
@@ -10,7 +12,7 @@ use i_slint_core::graphics::{
     rendering_metrics_collector::RenderingMetricsCollector, Point, Rect, Size,
 };
 use i_slint_core::renderer::Renderer;
-use i_slint_core::window::{PlatformWindowWeak, WindowHandleAccess};
+use i_slint_core::window::{PlatformWindow, WindowHandleAccess};
 use i_slint_core::Coord;
 
 use crate::WindowSystemName;
@@ -24,7 +26,7 @@ mod itemrenderer;
 const PASSWORD_CHARACTER: &str = "●";
 
 pub struct FemtoVGRenderer {
-    platform_window_weak: PlatformWindowWeak,
+    platform_window_weak: Weak<dyn PlatformWindow>,
     #[cfg(target_arch = "wasm32")]
     canvas_id: String,
     rendering_notifier: RefCell<Option<Box<dyn RenderingNotifier>>>,
@@ -34,7 +36,7 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
     type Canvas = FemtoVGCanvas;
 
     fn new(
-        platform_window_weak: &PlatformWindowWeak,
+        platform_window_weak: &Weak<dyn PlatformWindow>,
         #[cfg(target_arch = "wasm32")] canvas_id: String,
     ) -> Self {
         Self {

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -136,7 +136,7 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
 
         canvas.opengl_context.make_current();
 
-        window.clone().draw_contents(|components| {
+        window.draw_contents(|components| {
             {
                 let mut femtovg_canvas = canvas.canvas.as_ref().borrow_mut();
                 // We pass 1.0 as dpi / device pixel ratio as femtovg only uses this factor to scale

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -243,7 +243,7 @@ impl Renderer for FemtoVGRenderer {
 
         let font = crate::renderer::femtovg::fonts::FONT_CACHE.with(|cache| {
             cache.borrow_mut().font(
-                text_input.font_request(&window),
+                text_input.font_request(&platform_window),
                 scale_factor,
                 &text_input.text(),
             )
@@ -311,8 +311,10 @@ impl Renderer for FemtoVGRenderer {
         let text = text_input.text();
         let scale_factor = window.scale_factor();
 
-        let font_size =
-            text_input.font_request(&window).pixel_size.unwrap_or(fonts::DEFAULT_FONT_SIZE);
+        let font_size = text_input
+            .font_request(&platform_window)
+            .pixel_size
+            .unwrap_or(fonts::DEFAULT_FONT_SIZE);
 
         let mut result = Point::default();
 
@@ -324,7 +326,7 @@ impl Renderer for FemtoVGRenderer {
 
         let font = crate::renderer::femtovg::fonts::FONT_CACHE.with(|cache| {
             cache.borrow_mut().font(
-                text_input.font_request(&window),
+                text_input.font_request(&platform_window),
                 scale_factor,
                 &text_input.text(),
             )

--- a/internal/backends/winit/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/winit/renderer/femtovg/itemrenderer.rs
@@ -278,7 +278,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
 
         let font = fonts::FONT_CACHE.with(|cache| {
             cache.borrow_mut().font(
-                text_input.font_request(self.window.window_handle()),
+                text_input.font_request(&self.window.window_handle().platform_window()),
                 self.scale_factor,
                 &text_input.text(),
             )

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -88,7 +88,7 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
         };
 
         canvas.surface.render(|skia_canvas, gr_context| {
-            window.clone().draw_contents(|components| {
+            window.draw_contents(|components| {
                 if let Some(window_item) = window.window_item() {
                     skia_canvas
                         .clear(itemrenderer::to_skia_color(&window_item.as_pin_ref().background()));

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -1,14 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use std::{cell::RefCell, rc::Rc};
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
 
 use i_slint_core::api::{
     GraphicsAPI, RenderingNotifier, RenderingState, SetRenderingNotifierError,
 };
 use i_slint_core::graphics::rendering_metrics_collector::RenderingMetricsCollector;
 use i_slint_core::item_rendering::ItemCache;
-use i_slint_core::window::{PlatformWindowWeak, WindowHandleAccess};
+use i_slint_core::window::{PlatformWindow, WindowHandleAccess};
 
 use crate::WindowSystemName;
 
@@ -36,14 +37,14 @@ cfg_if::cfg_if! {
 }
 
 pub struct SkiaRenderer {
-    platform_window_weak: PlatformWindowWeak,
+    platform_window_weak: Weak<dyn PlatformWindow>,
     rendering_notifier: RefCell<Option<Box<dyn RenderingNotifier>>>,
 }
 
 impl super::WinitCompatibleRenderer for SkiaRenderer {
     type Canvas = SkiaCanvas<DefaultSurface>;
 
-    fn new(platform_window_weak: &PlatformWindowWeak) -> Self {
+    fn new(platform_window_weak: &Weak<dyn PlatformWindow>) -> Self {
         Self {
             platform_window_weak: platform_window_weak.clone(),
             rendering_notifier: Default::default(),

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -137,7 +137,7 @@ impl WasmInputHelper {
                 if !e.is_composing() && e.input_type() != "insertCompositionText" {
                     if !shared_state2.borrow_mut().has_key_down {
                         let text = SharedString::from(data.as_str());
-                        window.clone().process_key_input(&KeyEvent {
+                        window.process_key_input(&KeyEvent {
                             modifiers: Default::default(),
                             text: text.clone(),
                             event_type: KeyEventType::KeyPressed,
@@ -170,14 +170,14 @@ impl WasmInputHelper {
                                 as &str,
                         );
                         for _ in 0..to_delete {
-                            window.clone().process_key_input(&KeyEvent {
+                            window.process_key_input(&KeyEvent {
                                 modifiers: Default::default(),
                                 text: backspace.clone(),
                                 event_type: KeyEventType::KeyPressed,
                             });
                         }
                     }
-                    window.clone().process_key_input(&KeyEvent {
+                    window.process_key_input(&KeyEvent {
                         modifiers: Default::default(),
                         text: text.clone(),
                         event_type: KeyEventType::KeyPressed,

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -18,10 +18,10 @@
 //! we just simulate a few backspaces.
 
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 use i_slint_core::input::{KeyEvent, KeyEventType, KeyboardModifiers};
-use i_slint_core::window::{PlatformWindowWeak, WindowHandleAccess};
+use i_slint_core::window::{PlatformWindow, WindowHandleAccess};
 use i_slint_core::SharedString;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::convert::FromWasmAbi;
@@ -66,7 +66,10 @@ impl WasmInputState {
 
 impl WasmInputHelper {
     #[allow(unused)]
-    pub fn new(platform_window: PlatformWindowWeak, canvas: web_sys::HtmlCanvasElement) -> Self {
+    pub fn new(
+        platform_window: Weak<dyn PlatformWindow>,
+        canvas: web_sys::HtmlCanvasElement,
+    ) -> Self {
         let input = web_sys::window()
             .unwrap()
             .document()

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -616,7 +616,7 @@ fn generate_public_component(file: &mut File, component: &llr::PublicComponent) 
         Declaration::Var(Var {
             ty: "slint::Window".into(),
             name: "m_window".into(),
-            init: Some("slint::Window{slint::private_api::WindowRc()}".into()),
+            init: Some("slint::Window{slint::private_api::PlatformWindowRc()}".into()),
             ..Default::default()
         }),
     ));
@@ -700,7 +700,7 @@ fn generate_public_component(file: &mut File, component: &llr::PublicComponent) 
         }),
     ));
 
-    component_struct.friends.push("slint::private_api::WindowRc".into());
+    component_struct.friends.push("slint::private_api::PlatformWindowRc".into());
 
     component_struct
         .friends

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1988,7 +1988,7 @@ fn compile_builtin_function_call(
                 let window_tokens = access_window_field(ctx);
                 let focus_item = access_item_rc(pr, ctx);
                 quote!(
-                    #window_tokens.clone().set_focus_item(#focus_item);
+                    #window_tokens.set_focus_item(#focus_item);
                 )
             } else {
                 panic!("internal error: invalid args to SetFocusItem {:?}", arguments)

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2031,7 +2031,7 @@ fn compile_builtin_function_call(
                 let item = access_member(pr, ctx);
                 let platform_window_tokens = access_platform_window_field(ctx);
                 quote!(
-                    #item.layout_info(#orient, #platform_window_tokens.window().window_handle())
+                    #item.layout_info(#orient, #platform_window_tokens)
                 )
             } else {
                 panic!("internal error: invalid args to ImplicitLayoutInfo {:?}", arguments)

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -347,7 +347,7 @@ fn generate_public_component(llr: &llr::PublicComponent) -> TokenStream {
             }
 
             fn window(&self) -> &slint::Window {
-                vtable::VRc::as_pin_ref(&self.0).get_ref().window.get().unwrap()
+                vtable::VRc::as_pin_ref(&self.0).get_ref().platform_window.get().unwrap().window()
             }
 
             fn global<'a, T: slint::Global<'a, Self>>(&'a self) -> T {
@@ -859,7 +859,7 @@ fn generate_sub_component(
             self_weak : slint::re_exports::OnceCell<slint::re_exports::VWeakMapped<slint::re_exports::ComponentVTable, #inner_component_id>>,
             #(parent : #parent_component_type,)*
             // FIXME: Do we really need a window all the time?
-            window: slint::re_exports::OnceCell<slint::Window>,
+            platform_window: slint::re_exports::OnceCell<slint::re_exports::PlatformWindowRc>,
             root : slint::re_exports::OnceCell<slint::re_exports::VWeak<slint::re_exports::ComponentVTable, #root_component_id>>,
             tree_index: ::core::cell::Cell<u32>,
             tree_index_of_first_child: ::core::cell::Cell<u32>,
@@ -874,7 +874,7 @@ fn generate_sub_component(
                 let _self = self_rc.as_pin_ref();
                 _self.self_weak.set(VRcMapped::downgrade(&self_rc));
                 _self.root.set(VRc::downgrade(root));
-                _self.window.set(root.window.get().unwrap().window_handle().clone().into());
+                _self.platform_window.set(root.platform_window.get().unwrap().clone());
                 _self.tree_index.set(tree_index);
                 _self.tree_index_of_first_child.set(tree_index_of_first_child);
                 #(#init)*
@@ -1105,10 +1105,10 @@ fn generate_item_tree(
     };
     let (create_window, init_window) = if parent_ctx.is_none() {
         (
-            Some(quote!(let window = slint::create_window().into();)),
+            Some(quote!(let platform_window = slint::create_window();)),
             Some(quote! {
-                _self.window.set(window);
-                _self.window.get().unwrap().window_handle().set_component(&VRc::into_dyn(self_rc.clone()));
+                _self.platform_window.set(platform_window);
+                _self.platform_window.get().unwrap().window().window_handle().set_component(&VRc::into_dyn(self_rc.clone()));
             }),
         )
     } else {
@@ -1195,7 +1195,7 @@ fn generate_item_tree(
                 let self_rc = VRc::new(_self);
                 let _self = self_rc.as_pin_ref();
                 #init_window
-                slint::re_exports::register_component(_self, Self::item_array(), #root_token.window.get().unwrap().window_handle());
+                slint::re_exports::register_component(_self, Self::item_array(), #root_token.platform_window.get().unwrap());
                 Self::init(slint::re_exports::VRc::map(self_rc.clone(), |x| x), #root_token, 0, 1);
                 self_rc
             }
@@ -1220,13 +1220,13 @@ fn generate_item_tree(
             fn drop(self: core::pin::Pin<&mut #inner_component_id>) {
                 use slint::re_exports::*;
                 new_vref!(let vref : VRef<ComponentVTable> for Component = self.as_ref().get_ref());
-                slint::re_exports::unregister_component(self.as_ref(), vref, Self::item_array(), self.window.get().unwrap().window_handle());
+                slint::re_exports::unregister_component(self.as_ref(), vref, Self::item_array(), self.platform_window.get().unwrap());
             }
         }
 
         impl slint::re_exports::WindowHandleAccess for #inner_component_id {
-            fn window_handle(&self) -> &slint::re_exports::Rc<slint::re_exports::WindowInner> {
-                self.window.get().unwrap().window_handle()
+            fn window_handle(&self) -> &slint::re_exports::WindowInner {
+                self.platform_window.get().unwrap().window().window_handle()
             }
         }
 
@@ -1533,9 +1533,9 @@ fn follow_sub_component_path<'a>(
     (compo_path, sub_component)
 }
 
-fn access_window_field(ctx: &EvaluationContext) -> TokenStream {
+fn access_platform_window_field(ctx: &EvaluationContext) -> TokenStream {
     let root = &ctx.generator_state;
-    quote!(#root.window.get().unwrap().window_handle())
+    quote!(#root.platform_window.get().unwrap())
 }
 
 /// Given a property reference to a native item (eg, the property name is empty)
@@ -1985,10 +1985,10 @@ fn compile_builtin_function_call(
     match function {
         BuiltinFunction::SetFocusItem => {
             if let [Expression::PropertyReference(pr)] = arguments {
-                let window_tokens = access_window_field(ctx);
+                let window_tokens = access_platform_window_field(ctx);
                 let focus_item = access_item_rc(pr, ctx);
                 quote!(
-                    #window_tokens.set_focus_item(#focus_item);
+                    #window_tokens.window().window_handle().set_focus_item(#focus_item);
                 )
             } else {
                 panic!("internal error: invalid args to SetFocusItem {:?}", arguments)
@@ -2014,9 +2014,9 @@ fn compile_builtin_function_call(
                 let parent_component = access_item_rc(parent_ref, ctx);
                 let x = compile_expression(x, ctx);
                 let y = compile_expression(y, ctx);
-                let window_tokens = access_window_field(ctx);
+                let platform_window_tokens = access_platform_window_field(ctx);
                 quote!(
-                    #window_tokens.show_popup(
+                    #platform_window_tokens.window().window_handle().show_popup(
                         &VRc::into_dyn(#popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone()).into()),
                         Point::new(#x as slint::re_exports::Coord, #y as slint::re_exports::Coord),
                         #parent_component
@@ -2029,9 +2029,9 @@ fn compile_builtin_function_call(
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
             if let [Expression::PropertyReference(pr)] = arguments {
                 let item = access_member(pr, ctx);
-                let window_tokens = access_window_field(ctx);
+                let platform_window_tokens = access_platform_window_field(ctx);
                 quote!(
-                    #item.layout_info(#orient, #window_tokens)
+                    #item.layout_info(#orient, #platform_window_tokens.window().window_handle())
                 )
             } else {
                 panic!("internal error: invalid args to ImplicitLayoutInfo {:?}", arguments)
@@ -2039,8 +2039,8 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::RegisterCustomFontByPath => {
             if let [Expression::StringLiteral(path)] = arguments {
-                let window_tokens = access_window_field(ctx);
-                quote!(#window_tokens.renderer().register_font_from_path(&std::path::PathBuf::from(#path));)
+                let platform_window_tokens = access_platform_window_field(ctx);
+                quote!(#platform_window_tokens.renderer().register_font_from_path(&std::path::PathBuf::from(#path));)
             } else {
                 panic!("internal error: invalid args to RegisterCustomFontByPath {:?}", arguments)
             }
@@ -2049,8 +2049,8 @@ fn compile_builtin_function_call(
             if let [Expression::NumberLiteral(resource_id)] = &arguments {
                 let resource_id: usize = *resource_id as _;
                 let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id);
-                let window_tokens = access_window_field(ctx);
-                quote!(#window_tokens.renderer().register_font_from_memory(#symbol.into());)
+                let platform_window_tokens = access_platform_window_field(ctx);
+                quote!(#platform_window_tokens.renderer().register_font_from_memory(#symbol.into());)
             } else {
                 panic!("internal error: invalid args to RegisterCustomFontByMemory {:?}", arguments)
             }
@@ -2059,15 +2059,15 @@ fn compile_builtin_function_call(
             if let [Expression::NumberLiteral(resource_id)] = &arguments {
                 let resource_id: usize = *resource_id as _;
                 let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id);
-                let window_tokens = access_window_field(ctx);
-                quote!(#window_tokens.renderer().register_bitmap_font(&#symbol);)
+                let platform_window_tokens = access_platform_window_field(ctx);
+                quote!(#platform_window_tokens.renderer().register_bitmap_font(&#symbol);)
             } else {
                 panic!("internal error: invalid args to RegisterBitmapFont must be a number")
             }
         }
         BuiltinFunction::GetWindowScaleFactor => {
-            let window_tokens = access_window_field(ctx);
-            quote!(#window_tokens.scale_factor())
+            let platform_window_tokens = access_platform_window_field(ctx);
+            quote!(#platform_window_tokens.window().window_handle().scale_factor())
         }
         BuiltinFunction::AnimationTick => quote!(slint::re_exports::animation_tick()),
         BuiltinFunction::Debug => quote!(slint::internal::debug(#(#a)*)),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -859,7 +859,7 @@ fn generate_sub_component(
             self_weak : slint::re_exports::OnceCell<slint::re_exports::VWeakMapped<slint::re_exports::ComponentVTable, #inner_component_id>>,
             #(parent : #parent_component_type,)*
             // FIXME: Do we really need a window all the time?
-            platform_window: slint::re_exports::OnceCell<slint::re_exports::PlatformWindowRc>,
+            platform_window: slint::re_exports::OnceCell<slint::re_exports::Rc<dyn slint::re_exports::PlatformWindow>>,
             root : slint::re_exports::OnceCell<slint::re_exports::VWeak<slint::re_exports::ComponentVTable, #root_component_id>>,
             tree_index: ::core::cell::Cell<u32>,
             tree_index_of_first_child: ::core::cell::Cell<u32>,

--- a/internal/core/backend.rs
+++ b/internal/core/backend.rs
@@ -6,6 +6,7 @@ The backend is the abstraction for crates that need to do the actual drawing and
 */
 
 use alloc::boxed::Box;
+use alloc::rc::Rc;
 use alloc::string::String;
 
 #[cfg(feature = "std")]
@@ -13,7 +14,7 @@ use once_cell::sync::OnceCell;
 
 #[cfg(all(not(feature = "std"), feature = "unsafe_single_core"))]
 use crate::unsafe_single_core::OnceCell;
-use crate::window::PlatformWindowRc;
+use crate::window::PlatformWindow;
 
 #[derive(Copy, Clone)]
 /// Behavior describing how the event loop should terminate.
@@ -27,7 +28,7 @@ pub enum EventLoopQuitBehavior {
 /// Interface implemented by back-ends
 pub trait Backend: Send + Sync {
     /// Instantiate a window for a component.
-    fn create_window(&self) -> PlatformWindowRc;
+    fn create_window(&self) -> Rc<dyn PlatformWindow>;
 
     /// Spins an event loop and renders the visible windows.
     fn run_event_loop(&self, _behavior: EventLoopQuitBehavior) {

--- a/internal/core/backend.rs
+++ b/internal/core/backend.rs
@@ -13,6 +13,7 @@ use once_cell::sync::OnceCell;
 
 #[cfg(all(not(feature = "std"), feature = "unsafe_single_core"))]
 use crate::unsafe_single_core::OnceCell;
+use crate::window::PlatformWindowRc;
 
 #[derive(Copy, Clone)]
 /// Behavior describing how the event loop should terminate.
@@ -26,7 +27,7 @@ pub enum EventLoopQuitBehavior {
 /// Interface implemented by back-ends
 pub trait Backend: Send + Sync {
     /// Instantiate a window for a component.
-    fn create_window(&self) -> crate::api::Window;
+    fn create_window(&self) -> PlatformWindowRc;
 
     /// Spins an event loop and renders the visible windows.
     fn run_event_loop(&self, _behavior: EventLoopQuitBehavior) {

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -12,7 +12,7 @@ use crate::item_tree::{
 use crate::items::{AccessibleRole, ItemVTable};
 use crate::layout::{LayoutInfo, Orientation};
 use crate::slice::Slice;
-use crate::window::WindowRc;
+use crate::window::WindowInner;
 use crate::SharedString;
 use vtable::*;
 
@@ -114,7 +114,7 @@ pub type ComponentWeak = vtable::VWeak<ComponentVTable, Dyn>;
 pub fn register_component<Base>(
     base: core::pin::Pin<&Base>,
     item_array: &[vtable::VOffset<Base, ItemVTable, vtable::AllowPin>],
-    window: &WindowRc,
+    window: &WindowInner,
 ) {
     item_array.iter().for_each(|item| item.apply_pin(base).as_ref().init(window));
     window.register_component();
@@ -125,7 +125,7 @@ pub fn unregister_component<Base>(
     base: core::pin::Pin<&Base>,
     component: ComponentRef,
     item_array: &[vtable::VOffset<Base, ItemVTable, vtable::AllowPin>],
-    window: &WindowRc,
+    window: &WindowInner,
 ) {
     window.unregister_component(component, &mut item_array.iter().map(|item| item.apply_pin(base)));
 }
@@ -135,6 +135,7 @@ pub(crate) mod ffi {
     #![allow(unsafe_code)]
 
     use super::*;
+    use crate::window::WindowRc;
 
     /// Call init() on the ItemVTable of each item in the item array.
     #[no_mangle]

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -12,7 +12,7 @@ use crate::item_tree::{
 use crate::items::{AccessibleRole, ItemVTable};
 use crate::layout::{LayoutInfo, Orientation};
 use crate::slice::Slice;
-use crate::window::{PlatformWindowRc, WindowHandleAccess};
+use crate::window::PlatformWindowRc;
 use crate::SharedString;
 use vtable::*;
 
@@ -116,9 +116,7 @@ pub fn register_component<Base>(
     item_array: &[vtable::VOffset<Base, ItemVTable, vtable::AllowPin>],
     platform_window: &PlatformWindowRc,
 ) {
-    item_array.iter().for_each(|item| {
-        item.apply_pin(base).as_ref().init(platform_window.window().window_handle())
-    });
+    item_array.iter().for_each(|item| item.apply_pin(base).as_ref().init(platform_window));
     platform_window.register_component();
 }
 

--- a/internal/core/graphics/rendering_metrics_collector.rs
+++ b/internal/core/graphics/rendering_metrics_collector.rs
@@ -6,10 +6,10 @@ This module contains a simple helper type to measure the average number of frame
 */
 
 use crate::timers::*;
-use crate::window::PlatformWindowWeak;
+use crate::window::PlatformWindow;
 use std::cell::RefCell;
 use std::convert::TryFrom;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 enum RefreshMode {
     Lazy,      // render only when necessary (default)
@@ -60,7 +60,7 @@ pub struct RenderingMetricsCollector {
     refresh_mode: RefreshMode,
     output_console: bool,
     output_overlay: bool,
-    platform_window: PlatformWindowWeak,
+    platform_window: Weak<dyn PlatformWindow>,
 }
 
 impl RenderingMetricsCollector {
@@ -73,7 +73,7 @@ impl RenderingMetricsCollector {
     ///
     /// If enabled, this will also print out some system information such as whether
     /// this is a debug or release build, as well as the provided winsys_info string.
-    pub fn new(platform_window: PlatformWindowWeak, winsys_info: &str) -> Option<Rc<Self>> {
+    pub fn new(platform_window: Weak<dyn PlatformWindow>, winsys_info: &str) -> Option<Rc<Self>> {
         let options = match std::env::var("SLINT_DEBUG_PERFORMANCE") {
             Ok(var) => var,
             _ => return None,

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -9,7 +9,7 @@ use crate::graphics::Point;
 use crate::item_tree::{ItemRc, ItemVisitorResult, ItemWeak, VisitChildrenResult};
 pub use crate::items::PointerEventButton;
 use crate::items::{ItemRef, TextCursorDirection};
-use crate::window::WindowRc;
+use crate::window::WindowInner;
 use crate::{component::ComponentRc, SharedString};
 use crate::{Coord, Property};
 use alloc::rc::Rc;
@@ -403,7 +403,7 @@ pub struct MouseInputState {
 /// Try to handle the mouse grabber. Return true if the event has handled, or false otherwise
 fn handle_mouse_grab(
     mouse_event: &MouseEvent,
-    window: &WindowRc,
+    window: &WindowInner,
     mouse_input_state: &mut MouseInputState,
 ) -> bool {
     if !mouse_input_state.grabbed || mouse_input_state.item_stack.is_empty() {
@@ -456,7 +456,7 @@ fn handle_mouse_grab(
 fn send_exit_events(
     mouse_input_state: &MouseInputState,
     mut pos: Option<Point>,
-    window: &WindowRc,
+    window: &WindowInner,
 ) {
     for it in mouse_input_state.item_stack.iter() {
         let item = if let Some(item) = it.0.upgrade() { item } else { break };
@@ -477,7 +477,7 @@ fn send_exit_events(
 pub fn process_mouse_input(
     component: ComponentRc,
     mouse_event: MouseEvent,
-    window: &WindowRc,
+    window: &WindowInner,
     mut mouse_input_state: MouseInputState,
 ) -> MouseInputState {
     if handle_mouse_grab(&mouse_event, window, &mut mouse_input_state) {

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -9,7 +9,7 @@ use crate::graphics::Point;
 use crate::item_tree::{ItemRc, ItemVisitorResult, ItemWeak, VisitChildrenResult};
 pub use crate::items::PointerEventButton;
 use crate::items::{ItemRef, TextCursorDirection};
-use crate::window::PlatformWindowRc;
+use crate::window::PlatformWindow;
 use crate::{component::ComponentRc, SharedString};
 use crate::{Coord, Property};
 use alloc::rc::Rc;
@@ -403,7 +403,7 @@ pub struct MouseInputState {
 /// Try to handle the mouse grabber. Return true if the event has handled, or false otherwise
 fn handle_mouse_grab(
     mouse_event: &MouseEvent,
-    platform_window: &PlatformWindowRc,
+    platform_window: &Rc<dyn PlatformWindow>,
     mouse_input_state: &mut MouseInputState,
 ) -> bool {
     if !mouse_input_state.grabbed || mouse_input_state.item_stack.is_empty() {
@@ -459,7 +459,7 @@ fn handle_mouse_grab(
 fn send_exit_events(
     mouse_input_state: &MouseInputState,
     mut pos: Option<Point>,
-    platform_window: &PlatformWindowRc,
+    platform_window: &Rc<dyn PlatformWindow>,
 ) {
     for it in mouse_input_state.item_stack.iter() {
         let item = if let Some(item) = it.0.upgrade() { item } else { break };
@@ -480,7 +480,7 @@ fn send_exit_events(
 pub fn process_mouse_input(
     component: ComponentRc,
     mouse_event: MouseEvent,
-    platform_window: &PlatformWindowRc,
+    platform_window: &Rc<dyn PlatformWindow>,
     mut mouse_input_state: MouseInputState,
 ) -> MouseInputState {
     if handle_mouse_grab(&mouse_event, platform_window, &mut mouse_input_state) {

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -345,7 +345,7 @@ pub trait ItemRenderer {
         (self.get_current_clip().intersects(&item_geometry), item_geometry)
     }
 
-    fn window(&self) -> crate::window::WindowRc;
+    fn window(&self) -> &crate::api::Window;
 
     /// Return the internal renderer
     fn as_any(&mut self) -> Option<&mut dyn core::any::Any>;
@@ -547,7 +547,7 @@ impl<'a, T: ItemRenderer> ItemRenderer for PartialRenderer<'a, T> {
         self.actual_renderer.draw_string(string, color)
     }
 
-    fn window(&self) -> crate::window::WindowRc {
+    fn window(&self) -> &crate::api::Window {
         self.actual_renderer.window()
     }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -30,7 +30,7 @@ pub use crate::item_tree::ItemRc;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::WindowRc;
+use crate::window::WindowInner;
 use crate::{Callback, Coord, Property, SharedString};
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
@@ -107,7 +107,7 @@ pub struct ItemVTable {
     /// This function is called by the run-time after the memory for the item
     /// has been allocated and initialized. It will be called before any user specified
     /// bindings are set.
-    pub init: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>, window: &WindowRc),
+    pub init: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>, window: &WindowInner),
 
     /// Returns the geometry of this item (relative to its parent item)
     pub geometry: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>) -> Rect,
@@ -122,7 +122,7 @@ pub struct ItemVTable {
     pub layout_info: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         orientation: Orientation,
-        window: &WindowRc,
+        window: &WindowInner,
     ) -> LayoutInfo,
 
     /// Event handler for mouse and touch event. This function is called before being called on children.
@@ -132,7 +132,7 @@ pub struct ItemVTable {
     pub input_event_filter_before_children: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
-        window: &WindowRc,
+        window: &WindowInner,
         self_rc: &ItemRc,
     ) -> InputEventFilterResult,
 
@@ -140,20 +140,20 @@ pub struct ItemVTable {
     pub input_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
-        window: &WindowRc,
+        window: &WindowInner,
         self_rc: &ItemRc,
     ) -> InputEventResult,
 
     pub focus_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &FocusEvent,
-        window: &WindowRc,
+        window: &WindowInner,
     ) -> FocusEventResult,
 
     pub key_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &KeyEvent,
-        window: &WindowRc,
+        window: &WindowInner,
     ) -> KeyEventResult,
 
     pub render: extern "C" fn(
@@ -181,20 +181,24 @@ pub struct Rectangle {
 }
 
 impl Item for Rectangle {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -203,17 +207,17 @@ impl Item for Rectangle {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -255,20 +259,24 @@ pub struct BorderRectangle {
 }
 
 impl Item for BorderRectangle {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -277,17 +285,17 @@ impl Item for BorderRectangle {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -344,20 +352,24 @@ pub struct TouchArea {
 }
 
 impl Item for TouchArea {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo::default()
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowRc,
+        window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if !self.enabled() {
@@ -378,7 +390,7 @@ impl Item for TouchArea {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowRc,
+        window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         if matches!(event, MouseEvent::Exit) {
@@ -451,11 +463,11 @@ impl Item for TouchArea {
         result
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -497,20 +509,24 @@ pub struct FocusScope {
 }
 
 impl Item for FocusScope {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo::default()
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -519,7 +535,7 @@ impl Item for FocusScope {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowRc,
+        window: &WindowInner,
         self_rc: &ItemRc,
     ) -> InputEventResult {
         if self.enabled() && matches!(event, MouseEvent::Pressed { .. }) && !self.has_focus() {
@@ -528,7 +544,7 @@ impl Item for FocusScope {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         let r = match event.event_type {
             KeyEventType::KeyPressed => {
                 Self::FIELD_OFFSETS.key_pressed.apply_pin(self).call(&(event.clone(),))
@@ -543,7 +559,11 @@ impl Item for FocusScope {
         }
     }
 
-    fn focus_event(self: Pin<&Self>, event: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        event: &FocusEvent,
+        _window: &WindowInner,
+    ) -> FocusEventResult {
         if !self.enabled() {
             return FocusEventResult::FocusIgnored;
         }
@@ -595,20 +615,24 @@ pub struct Clip {
 }
 
 impl Item for Clip {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -627,17 +651,17 @@ impl Item for Clip {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -674,20 +698,24 @@ pub struct Opacity {
 }
 
 impl Item for Opacity {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -696,17 +724,17 @@ impl Item for Opacity {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -772,20 +800,24 @@ pub struct Layer {
 }
 
 impl Item for Layer {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -794,17 +826,17 @@ impl Item for Layer {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -842,20 +874,24 @@ pub struct Rotate {
 }
 
 impl Item for Rotate {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(0 as _, 0 as _, self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -864,17 +900,17 @@ impl Item for Rotate {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -946,20 +982,24 @@ pub struct WindowItem {
 }
 
 impl Item for WindowItem {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(0 as _, 0 as _, self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo::default()
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -968,17 +1008,17 @@ impl Item for WindowItem {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -1049,20 +1089,24 @@ pub struct BoxShadow {
 }
 
 impl Item for BoxShadow {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -1071,17 +1115,17 @@ impl Item for BoxShadow {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -523,7 +523,7 @@ impl Item for FocusScope {
         self_rc: &ItemRc,
     ) -> InputEventResult {
         if self.enabled() && matches!(event, MouseEvent::Pressed { .. }) && !self.has_focus() {
-            window.clone().set_focus_item(self_rc);
+            window.set_focus_item(self_rc);
         }
         InputEventResult::EventIgnored
     }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -30,7 +30,7 @@ pub use crate::item_tree::ItemRc;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::WindowInner;
+use crate::window::{PlatformWindowRc, WindowHandleAccess};
 use crate::{Callback, Coord, Property, SharedString};
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
@@ -107,7 +107,7 @@ pub struct ItemVTable {
     /// This function is called by the run-time after the memory for the item
     /// has been allocated and initialized. It will be called before any user specified
     /// bindings are set.
-    pub init: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>, window: &WindowInner),
+    pub init: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>, platform_window: &PlatformWindowRc),
 
     /// Returns the geometry of this item (relative to its parent item)
     pub geometry: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>) -> Rect,
@@ -122,7 +122,7 @@ pub struct ItemVTable {
     pub layout_info: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         orientation: Orientation,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
     ) -> LayoutInfo,
 
     /// Event handler for mouse and touch event. This function is called before being called on children.
@@ -132,7 +132,7 @@ pub struct ItemVTable {
     pub input_event_filter_before_children: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
         self_rc: &ItemRc,
     ) -> InputEventFilterResult,
 
@@ -140,20 +140,20 @@ pub struct ItemVTable {
     pub input_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
         self_rc: &ItemRc,
     ) -> InputEventResult,
 
     pub focus_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &FocusEvent,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
     ) -> FocusEventResult,
 
     pub key_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &KeyEvent,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
     ) -> KeyEventResult,
 
     pub render: extern "C" fn(
@@ -181,7 +181,7 @@ pub struct Rectangle {
 }
 
 impl Item for Rectangle {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -190,7 +190,7 @@ impl Item for Rectangle {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -198,7 +198,7 @@ impl Item for Rectangle {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -207,17 +207,25 @@ impl Item for Rectangle {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -259,7 +267,7 @@ pub struct BorderRectangle {
 }
 
 impl Item for BorderRectangle {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -268,7 +276,7 @@ impl Item for BorderRectangle {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -276,7 +284,7 @@ impl Item for BorderRectangle {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -285,17 +293,25 @@ impl Item for BorderRectangle {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -352,7 +368,7 @@ pub struct TouchArea {
 }
 
 impl Item for TouchArea {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -361,7 +377,7 @@ impl Item for TouchArea {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -369,7 +385,7 @@ impl Item for TouchArea {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if !self.enabled() {
@@ -382,7 +398,7 @@ impl Item for TouchArea {
         let hovering = !matches!(event, MouseEvent::Exit);
         Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(hovering);
         if hovering {
-            window.platform_window().set_mouse_cursor(self.mouse_cursor());
+            platform_window.set_mouse_cursor(self.mouse_cursor());
         }
         InputEventFilterResult::ForwardAndInterceptGrab
     }
@@ -390,12 +406,12 @@ impl Item for TouchArea {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         if matches!(event, MouseEvent::Exit) {
             Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(false);
-            window.platform_window().set_mouse_cursor(MouseCursor::Default);
+            platform_window.set_mouse_cursor(MouseCursor::Default);
         }
         if !self.enabled() {
             return InputEventResult::EventIgnored;
@@ -463,11 +479,19 @@ impl Item for TouchArea {
         result
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -509,7 +533,7 @@ pub struct FocusScope {
 }
 
 impl Item for FocusScope {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -518,7 +542,7 @@ impl Item for FocusScope {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -526,7 +550,7 @@ impl Item for FocusScope {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -535,16 +559,20 @@ impl Item for FocusScope {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowInner,
+        platform_window: &PlatformWindowRc,
         self_rc: &ItemRc,
     ) -> InputEventResult {
         if self.enabled() && matches!(event, MouseEvent::Pressed { .. }) && !self.has_focus() {
-            window.set_focus_item(self_rc);
+            platform_window.window().window_handle().set_focus_item(self_rc);
         }
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, event: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        event: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         let r = match event.event_type {
             KeyEventType::KeyPressed => {
                 Self::FIELD_OFFSETS.key_pressed.apply_pin(self).call(&(event.clone(),))
@@ -562,7 +590,7 @@ impl Item for FocusScope {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> FocusEventResult {
         if !self.enabled() {
             return FocusEventResult::FocusIgnored;
@@ -615,7 +643,7 @@ pub struct Clip {
 }
 
 impl Item for Clip {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -624,7 +652,7 @@ impl Item for Clip {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -632,7 +660,7 @@ impl Item for Clip {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -651,17 +679,25 @@ impl Item for Clip {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -698,7 +734,7 @@ pub struct Opacity {
 }
 
 impl Item for Opacity {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -707,7 +743,7 @@ impl Item for Opacity {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -715,7 +751,7 @@ impl Item for Opacity {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -724,17 +760,25 @@ impl Item for Opacity {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -800,7 +844,7 @@ pub struct Layer {
 }
 
 impl Item for Layer {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -809,7 +853,7 @@ impl Item for Layer {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -817,7 +861,7 @@ impl Item for Layer {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -826,17 +870,25 @@ impl Item for Layer {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -874,7 +926,7 @@ pub struct Rotate {
 }
 
 impl Item for Rotate {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(0 as _, 0 as _, self.width(), self.height())
@@ -883,7 +935,7 @@ impl Item for Rotate {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -891,7 +943,7 @@ impl Item for Rotate {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -900,17 +952,25 @@ impl Item for Rotate {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -982,7 +1042,7 @@ pub struct WindowItem {
 }
 
 impl Item for WindowItem {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(0 as _, 0 as _, self.width(), self.height())
@@ -991,7 +1051,7 @@ impl Item for WindowItem {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -999,7 +1059,7 @@ impl Item for WindowItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -1008,17 +1068,25 @@ impl Item for WindowItem {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -1089,7 +1157,7 @@ pub struct BoxShadow {
 }
 
 impl Item for BoxShadow {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -1098,7 +1166,7 @@ impl Item for BoxShadow {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -1106,7 +1174,7 @@ impl Item for BoxShadow {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -1115,17 +1183,25 @@ impl Item for BoxShadow {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -382,7 +382,7 @@ impl Item for TouchArea {
         let hovering = !matches!(event, MouseEvent::Exit);
         Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(hovering);
         if hovering {
-            window.set_mouse_cursor(self.mouse_cursor());
+            window.platform_window().set_mouse_cursor(self.mouse_cursor());
         }
         InputEventFilterResult::ForwardAndInterceptGrab
     }
@@ -395,7 +395,7 @@ impl Item for TouchArea {
     ) -> InputEventResult {
         if matches!(event, MouseEvent::Exit) {
             Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(false);
-            window.set_mouse_cursor(MouseCursor::Default);
+            window.platform_window().set_mouse_cursor(MouseCursor::Default);
         }
         if !self.enabled() {
             return InputEventResult::EventIgnored;

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -30,8 +30,9 @@ pub use crate::item_tree::ItemRc;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::{PlatformWindowRc, WindowHandleAccess};
+use crate::window::{PlatformWindow, PlatformWindowRc, WindowHandleAccess};
 use crate::{Callback, Coord, Property, SharedString};
+use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
 use core::pin::Pin;
@@ -181,7 +182,7 @@ pub struct Rectangle {
 }
 
 impl Item for Rectangle {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -190,7 +191,7 @@ impl Item for Rectangle {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -198,7 +199,7 @@ impl Item for Rectangle {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -207,7 +208,7 @@ impl Item for Rectangle {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -216,7 +217,7 @@ impl Item for Rectangle {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -224,7 +225,7 @@ impl Item for Rectangle {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -267,7 +268,7 @@ pub struct BorderRectangle {
 }
 
 impl Item for BorderRectangle {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -276,7 +277,7 @@ impl Item for BorderRectangle {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -284,7 +285,7 @@ impl Item for BorderRectangle {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -293,7 +294,7 @@ impl Item for BorderRectangle {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -302,7 +303,7 @@ impl Item for BorderRectangle {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -310,7 +311,7 @@ impl Item for BorderRectangle {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -368,7 +369,7 @@ pub struct TouchArea {
 }
 
 impl Item for TouchArea {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -377,7 +378,7 @@ impl Item for TouchArea {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -385,7 +386,7 @@ impl Item for TouchArea {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &PlatformWindowRc,
+        platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if !self.enabled() {
@@ -406,7 +407,7 @@ impl Item for TouchArea {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &PlatformWindowRc,
+        platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         if matches!(event, MouseEvent::Exit) {
@@ -482,7 +483,7 @@ impl Item for TouchArea {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -490,7 +491,7 @@ impl Item for TouchArea {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -533,7 +534,7 @@ pub struct FocusScope {
 }
 
 impl Item for FocusScope {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -542,7 +543,7 @@ impl Item for FocusScope {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -550,7 +551,7 @@ impl Item for FocusScope {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -559,7 +560,7 @@ impl Item for FocusScope {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &PlatformWindowRc,
+        platform_window: &Rc<dyn PlatformWindow>,
         self_rc: &ItemRc,
     ) -> InputEventResult {
         if self.enabled() && matches!(event, MouseEvent::Pressed { .. }) && !self.has_focus() {
@@ -571,7 +572,7 @@ impl Item for FocusScope {
     fn key_event(
         self: Pin<&Self>,
         event: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         let r = match event.event_type {
             KeyEventType::KeyPressed => {
@@ -590,7 +591,7 @@ impl Item for FocusScope {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         if !self.enabled() {
             return FocusEventResult::FocusIgnored;
@@ -643,7 +644,7 @@ pub struct Clip {
 }
 
 impl Item for Clip {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -652,7 +653,7 @@ impl Item for Clip {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -660,7 +661,7 @@ impl Item for Clip {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -679,7 +680,7 @@ impl Item for Clip {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -688,7 +689,7 @@ impl Item for Clip {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -696,7 +697,7 @@ impl Item for Clip {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -734,7 +735,7 @@ pub struct Opacity {
 }
 
 impl Item for Opacity {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -743,7 +744,7 @@ impl Item for Opacity {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -751,7 +752,7 @@ impl Item for Opacity {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -760,7 +761,7 @@ impl Item for Opacity {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -769,7 +770,7 @@ impl Item for Opacity {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -777,7 +778,7 @@ impl Item for Opacity {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -844,7 +845,7 @@ pub struct Layer {
 }
 
 impl Item for Layer {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -853,7 +854,7 @@ impl Item for Layer {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -861,7 +862,7 @@ impl Item for Layer {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -870,7 +871,7 @@ impl Item for Layer {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -879,7 +880,7 @@ impl Item for Layer {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -887,7 +888,7 @@ impl Item for Layer {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -926,7 +927,7 @@ pub struct Rotate {
 }
 
 impl Item for Rotate {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(0 as _, 0 as _, self.width(), self.height())
@@ -935,7 +936,7 @@ impl Item for Rotate {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -943,7 +944,7 @@ impl Item for Rotate {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -952,7 +953,7 @@ impl Item for Rotate {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -961,7 +962,7 @@ impl Item for Rotate {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -969,7 +970,7 @@ impl Item for Rotate {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -1042,7 +1043,7 @@ pub struct WindowItem {
 }
 
 impl Item for WindowItem {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(0 as _, 0 as _, self.width(), self.height())
@@ -1051,7 +1052,7 @@ impl Item for WindowItem {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -1059,7 +1060,7 @@ impl Item for WindowItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -1068,7 +1069,7 @@ impl Item for WindowItem {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -1077,7 +1078,7 @@ impl Item for WindowItem {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -1085,7 +1086,7 @@ impl Item for WindowItem {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -1157,7 +1158,7 @@ pub struct BoxShadow {
 }
 
 impl Item for BoxShadow {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -1166,7 +1167,7 @@ impl Item for BoxShadow {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -1174,7 +1175,7 @@ impl Item for BoxShadow {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -1183,7 +1184,7 @@ impl Item for BoxShadow {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -1192,7 +1193,7 @@ impl Item for BoxShadow {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -1200,7 +1201,7 @@ impl Item for BoxShadow {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -21,7 +21,7 @@ use crate::items::{PropertyAnimation, Rectangle};
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::WindowRc;
+use crate::window::WindowInner;
 use crate::Coord;
 use crate::Property;
 use alloc::boxed::Box;
@@ -54,20 +54,24 @@ pub struct Flickable {
 }
 
 impl Item for Flickable {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -84,7 +88,7 @@ impl Item for Flickable {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         if !self.interactive() && !matches!(event, MouseEvent::Wheel { .. }) {
@@ -104,11 +108,11 @@ impl Item for Flickable {
         self.data.handle_mouse(self, event)
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -21,7 +21,7 @@ use crate::items::{PropertyAnimation, Rectangle};
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::WindowInner;
+use crate::window::PlatformWindowRc;
 use crate::Coord;
 use crate::Property;
 use alloc::boxed::Box;
@@ -54,7 +54,7 @@ pub struct Flickable {
 }
 
 impl Item for Flickable {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -63,7 +63,7 @@ impl Item for Flickable {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -71,7 +71,7 @@ impl Item for Flickable {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -88,7 +88,7 @@ impl Item for Flickable {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         if !self.interactive() && !matches!(event, MouseEvent::Wheel { .. }) {
@@ -108,11 +108,19 @@ impl Item for Flickable {
         self.data.handle_mouse(self, event)
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -21,10 +21,11 @@ use crate::items::{PropertyAnimation, Rectangle};
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::PlatformWindowRc;
+use crate::window::PlatformWindow;
 use crate::Coord;
 use crate::Property;
 use alloc::boxed::Box;
+use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
 use core::cell::RefCell;
 use core::pin::Pin;
@@ -54,7 +55,7 @@ pub struct Flickable {
 }
 
 impl Item for Flickable {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -63,7 +64,7 @@ impl Item for Flickable {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -71,7 +72,7 @@ impl Item for Flickable {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -88,7 +89,7 @@ impl Item for Flickable {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         if !self.interactive() && !matches!(event, MouseEvent::Wheel { .. }) {
@@ -111,7 +112,7 @@ impl Item for Flickable {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -119,7 +120,7 @@ impl Item for Flickable {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -18,7 +18,7 @@ use crate::item_rendering::ItemRenderer;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::WindowRc;
+use crate::window::WindowInner;
 use crate::{Brush, Coord, Property};
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
@@ -40,13 +40,17 @@ pub struct ImageItem {
 }
 
 impl Item for ImageItem {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let natural_size = self.source().size();
         LayoutInfo {
             preferred: match orientation {
@@ -63,7 +67,7 @@ impl Item for ImageItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -72,17 +76,17 @@ impl Item for ImageItem {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -124,13 +128,17 @@ pub struct ClippedImage {
 }
 
 impl Item for ClippedImage {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         let natural_size = self.source().size();
         LayoutInfo {
             preferred: match orientation {
@@ -147,7 +155,7 @@ impl Item for ClippedImage {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -156,17 +164,17 @@ impl Item for ClippedImage {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -18,8 +18,9 @@ use crate::item_rendering::ItemRenderer;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::PlatformWindowRc;
+use crate::window::PlatformWindow;
 use crate::{Brush, Coord, Property};
+use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
 use i_slint_core_macros::*;
@@ -40,7 +41,7 @@ pub struct ImageItem {
 }
 
 impl Item for ImageItem {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -49,7 +50,7 @@ impl Item for ImageItem {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let natural_size = self.source().size();
         LayoutInfo {
@@ -67,7 +68,7 @@ impl Item for ImageItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -76,7 +77,7 @@ impl Item for ImageItem {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -85,7 +86,7 @@ impl Item for ImageItem {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -93,7 +94,7 @@ impl Item for ImageItem {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -136,7 +137,7 @@ pub struct ClippedImage {
 }
 
 impl Item for ClippedImage {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -145,7 +146,7 @@ impl Item for ClippedImage {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         let natural_size = self.source().size();
         LayoutInfo {
@@ -163,7 +164,7 @@ impl Item for ClippedImage {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -172,7 +173,7 @@ impl Item for ClippedImage {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -181,7 +182,7 @@ impl Item for ClippedImage {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -189,7 +190,7 @@ impl Item for ClippedImage {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -18,7 +18,7 @@ use crate::item_rendering::ItemRenderer;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::WindowInner;
+use crate::window::PlatformWindowRc;
 use crate::{Brush, Coord, Property};
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
@@ -40,7 +40,7 @@ pub struct ImageItem {
 }
 
 impl Item for ImageItem {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -49,7 +49,7 @@ impl Item for ImageItem {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let natural_size = self.source().size();
         LayoutInfo {
@@ -67,7 +67,7 @@ impl Item for ImageItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -76,17 +76,25 @@ impl Item for ImageItem {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -128,7 +136,7 @@ pub struct ClippedImage {
 }
 
 impl Item for ClippedImage {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -137,7 +145,7 @@ impl Item for ClippedImage {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         let natural_size = self.source().size();
         LayoutInfo {
@@ -155,7 +163,7 @@ impl Item for ClippedImage {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -164,17 +172,25 @@ impl Item for ClippedImage {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -19,7 +19,7 @@ use crate::item_rendering::CachedRenderingData;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::WindowInner;
+use crate::window::PlatformWindowRc;
 use crate::{Coord, Property};
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
@@ -48,7 +48,7 @@ pub struct Path {
 }
 
 impl Item for Path {
-    fn init(self: Pin<&Self>, _window: &WindowInner) {}
+    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -57,7 +57,7 @@ impl Item for Path {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -65,7 +65,7 @@ impl Item for Path {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -84,17 +84,25 @@ impl Item for Path {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowInner,
+        _platform_window: &PlatformWindowRc,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _platform_window: &PlatformWindowRc,
+    ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -19,8 +19,9 @@ use crate::item_rendering::CachedRenderingData;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::PlatformWindowRc;
+use crate::window::PlatformWindow;
 use crate::{Coord, Property};
+use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
 use i_slint_core_macros::*;
@@ -48,7 +49,7 @@ pub struct Path {
 }
 
 impl Item for Path {
-    fn init(self: Pin<&Self>, _platform_window: &PlatformWindowRc) {}
+    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -57,7 +58,7 @@ impl Item for Path {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -65,7 +66,7 @@ impl Item for Path {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -84,7 +85,7 @@ impl Item for Path {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -93,7 +94,7 @@ impl Item for Path {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -101,7 +102,7 @@ impl Item for Path {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &PlatformWindowRc,
+        _platform_window: &Rc<dyn PlatformWindow>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -19,7 +19,7 @@ use crate::item_rendering::CachedRenderingData;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::WindowRc;
+use crate::window::WindowInner;
 use crate::{Coord, Property};
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
@@ -48,20 +48,24 @@ pub struct Path {
 }
 
 impl Item for Path {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, _orientation: Orientation, _window: &WindowRc) -> LayoutInfo {
+    fn layout_info(
+        self: Pin<&Self>,
+        _orientation: Orientation,
+        _window: &WindowInner,
+    ) -> LayoutInfo {
         LayoutInfo::default()
     }
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -80,17 +84,17 @@ impl Item for Path {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -298,7 +298,7 @@ impl Item for TextInput {
                 self.as_ref().anchor_position.set(clicked_offset);
                 self.set_cursor_position(clicked_offset, true, window);
                 if !self.has_focus() {
-                    window.clone().set_focus_item(self_rc);
+                    window.set_focus_item(self_rc);
                 }
             }
             MouseEvent::Released { button: PointerEventButton::Left, .. } | MouseEvent::Exit => {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -22,7 +22,7 @@ use crate::item_rendering::{CachedRenderingData, ItemRenderer};
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::WindowRc;
+use crate::window::WindowInner;
 use crate::{Callback, Coord, Property, SharedString};
 use alloc::string::String;
 use const_field_offset::FieldOffsets;
@@ -55,13 +55,13 @@ pub struct Text {
 }
 
 impl Item for Text {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, window: &WindowRc) -> LayoutInfo {
+    fn layout_info(self: Pin<&Self>, orientation: Orientation, window: &WindowInner) -> LayoutInfo {
         let implicit_size = |max_width| {
             window.renderer().text_size(
                 self.font_request(window),
@@ -109,7 +109,7 @@ impl Item for Text {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -118,17 +118,17 @@ impl Item for Text {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
     }
 
-    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, _: &KeyEvent, _window: &WindowInner) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
 
-    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, _: &FocusEvent, _window: &WindowInner) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
 
@@ -148,7 +148,7 @@ impl ItemConsts for Text {
 }
 
 impl Text {
-    pub fn font_request(self: Pin<&Self>, window: &WindowRc) -> FontRequest {
+    pub fn font_request(self: Pin<&Self>, window: &WindowInner) -> FontRequest {
         let window_item = window.window_item();
 
         FontRequest {
@@ -221,14 +221,14 @@ pub struct TextInput {
 }
 
 impl Item for TextInput {
-    fn init(self: Pin<&Self>, _window: &WindowRc) {}
+    fn init(self: Pin<&Self>, _window: &WindowInner) {}
 
     // FIXME: width / height.  or maybe it doesn't matter?  (
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
-    fn layout_info(self: Pin<&Self>, orientation: Orientation, window: &WindowRc) -> LayoutInfo {
+    fn layout_info(self: Pin<&Self>, orientation: Orientation, window: &WindowInner) -> LayoutInfo {
         let text = self.text();
         let implicit_size = |max_width| {
             window.renderer().text_size(
@@ -275,7 +275,7 @@ impl Item for TextInput {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _window: &WindowRc,
+        _window: &WindowInner,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -284,7 +284,7 @@ impl Item for TextInput {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        window: &WindowRc,
+        window: &WindowInner,
         self_rc: &ItemRc,
     ) -> InputEventResult {
         if !self.enabled() {
@@ -317,7 +317,7 @@ impl Item for TextInput {
         InputEventResult::EventAccepted
     }
 
-    fn key_event(self: Pin<&Self>, event: &KeyEvent, window: &WindowRc) -> KeyEventResult {
+    fn key_event(self: Pin<&Self>, event: &KeyEvent, window: &WindowInner) -> KeyEventResult {
         if !self.enabled() {
             return KeyEventResult::EventIgnored;
         }
@@ -440,7 +440,7 @@ impl Item for TextInput {
         }
     }
 
-    fn focus_event(self: Pin<&Self>, event: &FocusEvent, window: &WindowRc) -> FocusEventResult {
+    fn focus_event(self: Pin<&Self>, event: &FocusEvent, window: &WindowInner) -> FocusEventResult {
         match event {
             FocusEvent::FocusIn | FocusEvent::WindowReceivedFocus => {
                 self.has_focus.set(true);
@@ -524,7 +524,7 @@ impl From<KeyboardModifiers> for AnchorMode {
 }
 
 impl TextInput {
-    fn show_cursor(&self, window: &WindowRc) {
+    fn show_cursor(&self, window: &WindowInner) {
         window.set_cursor_blink_binding(&self.cursor_visible);
     }
 
@@ -537,7 +537,7 @@ impl TextInput {
         self: Pin<&Self>,
         direction: TextCursorDirection,
         anchor_mode: AnchorMode,
-        window: &WindowRc,
+        window: &WindowInner,
     ) -> bool {
         let text = self.text();
         if text.is_empty() {
@@ -669,7 +669,7 @@ impl TextInput {
         self: Pin<&Self>,
         new_position: i32,
         reset_preferred_x_pos: bool,
-        window: &WindowRc,
+        window: &WindowInner,
     ) {
         self.cursor_position.set(new_position);
         if new_position >= 0 {
@@ -684,14 +684,14 @@ impl TextInput {
         }
     }
 
-    fn select_and_delete(self: Pin<&Self>, step: TextCursorDirection, window: &WindowRc) {
+    fn select_and_delete(self: Pin<&Self>, step: TextCursorDirection, window: &WindowInner) {
         if !self.has_selection() {
             self.move_cursor(step, AnchorMode::KeepAnchor, window);
         }
         self.delete_selection(window);
     }
 
-    fn delete_selection(self: Pin<&Self>, window: &WindowRc) {
+    fn delete_selection(self: Pin<&Self>, window: &WindowInner) {
         let text: String = self.text().into();
         if text.is_empty() {
             return;
@@ -728,7 +728,7 @@ impl TextInput {
         anchor_pos != cursor_pos
     }
 
-    fn insert(self: Pin<&Self>, text_to_insert: &str, window: &WindowRc) {
+    fn insert(self: Pin<&Self>, text_to_insert: &str, window: &WindowInner) {
         self.delete_selection(window);
         let mut text: String = self.text().into();
         let cursor_pos = self.selection_anchor_and_cursor().1;
@@ -744,7 +744,7 @@ impl TextInput {
         Self::FIELD_OFFSETS.edited.apply_pin(self).call(&());
     }
 
-    fn select_all(self: Pin<&Self>, window: &WindowRc) {
+    fn select_all(self: Pin<&Self>, window: &WindowInner) {
         self.move_cursor(TextCursorDirection::StartOfText, AnchorMode::MoveAnchor, window);
         self.move_cursor(TextCursorDirection::EndOfText, AnchorMode::KeepAnchor, window);
     }
@@ -760,14 +760,14 @@ impl TextInput {
         }
     }
 
-    fn paste(self: Pin<&Self>, window: &WindowRc) {
+    fn paste(self: Pin<&Self>, window: &WindowInner) {
         if let Some(text) = crate::backend::instance().and_then(|backend| backend.clipboard_text())
         {
             self.insert(&text, window);
         }
     }
 
-    pub fn font_request(self: Pin<&Self>, window: &WindowRc) -> FontRequest {
+    pub fn font_request(self: Pin<&Self>, window: &WindowInner) -> FontRequest {
         let window_item = window.window_item();
 
         FontRequest {

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -28,7 +28,7 @@ pub extern "C" fn slint_send_mouse_click(
     component: &crate::component::ComponentRc,
     x: Coord,
     y: Coord,
-    window: &crate::window::WindowInner,
+    platform_window: &crate::window::PlatformWindowRc,
 ) {
     let mut state = crate::input::MouseInputState::default();
     let position = euclid::point2(x, y);
@@ -36,20 +36,20 @@ pub extern "C" fn slint_send_mouse_click(
     state = crate::input::process_mouse_input(
         component.clone(),
         MouseEvent::Moved { position },
-        window,
+        platform_window,
         state,
     );
     state = crate::input::process_mouse_input(
         component.clone(),
         MouseEvent::Pressed { position, button: crate::items::PointerEventButton::Left },
-        window,
+        platform_window,
         state,
     );
     slint_mock_elapsed_time(50);
     crate::input::process_mouse_input(
         component.clone(),
         MouseEvent::Released { position, button: crate::items::PointerEventButton::Left },
-        window,
+        platform_window,
         state,
     );
 }

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -6,7 +6,6 @@
 #![allow(unsafe_code)]
 
 use crate::input::{KeyEvent, KeyEventType, KeyboardModifiers, MouseEvent};
-use crate::window::WindowRc;
 use crate::Coord;
 use crate::SharedString;
 
@@ -29,7 +28,7 @@ pub extern "C" fn slint_send_mouse_click(
     component: &crate::component::ComponentRc,
     x: Coord,
     y: Coord,
-    window: &WindowRc,
+    window: &crate::window::WindowInner,
 ) {
     let mut state = crate::input::MouseInputState::default();
     let position = euclid::point2(x, y);
@@ -60,7 +59,7 @@ pub extern "C" fn slint_send_mouse_click(
 pub extern "C" fn send_keyboard_string_sequence(
     sequence: &crate::SharedString,
     modifiers: KeyboardModifiers,
-    window: &WindowRc,
+    window: &crate::window::WindowInner,
 ) {
     for ch in sequence.chars() {
         let mut modifiers = modifiers;

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -70,12 +70,12 @@ pub extern "C" fn send_keyboard_string_sequence(
         let mut buffer = [0; 6];
         let text = SharedString::from(ch.encode_utf8(&mut buffer) as &str);
 
-        window.clone().process_key_input(&KeyEvent {
+        window.process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyPressed,
             text: text.clone(),
             modifiers,
         });
-        window.clone().process_key_input(&KeyEvent {
+        window.process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyReleased,
             text,
             modifiers,

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -6,6 +6,7 @@
 #![allow(unsafe_code)]
 
 use crate::input::{KeyEvent, KeyEventType, KeyboardModifiers, MouseEvent};
+use crate::window::WindowHandleAccess;
 use crate::Coord;
 use crate::SharedString;
 
@@ -59,7 +60,7 @@ pub extern "C" fn slint_send_mouse_click(
 pub extern "C" fn send_keyboard_string_sequence(
     sequence: &crate::SharedString,
     modifiers: KeyboardModifiers,
-    window: &crate::window::WindowInner,
+    platform_window: &crate::window::PlatformWindowRc,
 ) {
     for ch in sequence.chars() {
         let mut modifiers = modifiers;
@@ -69,12 +70,12 @@ pub extern "C" fn send_keyboard_string_sequence(
         let mut buffer = [0; 6];
         let text = SharedString::from(ch.encode_utf8(&mut buffer) as &str);
 
-        window.process_key_input(&KeyEvent {
+        platform_window.window().window_handle().process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyPressed,
             text: text.clone(),
             modifiers,
         });
-        window.process_key_input(&KeyEvent {
+        platform_window.window().window_handle().process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyReleased,
             text,
             modifiers,

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -304,7 +304,7 @@ impl WindowInner {
         self.mouse_input_state.set(crate::input::process_mouse_input(
             component,
             event,
-            self,
+            &self.platform_window(),
             self.mouse_input_state.take(),
         ));
 
@@ -329,7 +329,7 @@ impl WindowInner {
                 // Reset the focus... not great, but better than keeping it.
                 self.take_focus_item();
             } else {
-                if focus_item.borrow().as_ref().key_event(event, self)
+                if focus_item.borrow().as_ref().key_event(event, &self.platform_window())
                     == crate::input::KeyEventResult::EventAccepted
                 {
                     return;
@@ -380,7 +380,7 @@ impl WindowInner {
         };
 
         if let Some(focus_item) = self.focus_item.borrow().upgrade() {
-            focus_item.borrow().as_ref().focus_event(&event, self);
+            focus_item.borrow().as_ref().focus_event(&event, &self.platform_window());
         }
     }
 
@@ -391,7 +391,10 @@ impl WindowInner {
         let focus_item = self.focus_item.take();
 
         if let Some(focus_item_rc) = focus_item.upgrade() {
-            focus_item_rc.borrow().as_ref().focus_event(&crate::input::FocusEvent::FocusOut, self);
+            focus_item_rc
+                .borrow()
+                .as_ref()
+                .focus_event(&crate::input::FocusEvent::FocusOut, &self.platform_window());
             Some(focus_item_rc)
         } else {
             None
@@ -405,7 +408,9 @@ impl WindowInner {
         match item {
             Some(item) => {
                 *self.focus_item.borrow_mut() = item.downgrade();
-                item.borrow().as_ref().focus_event(&crate::input::FocusEvent::FocusIn, self)
+                item.borrow()
+                    .as_ref()
+                    .focus_event(&crate::input::FocusEvent::FocusIn, &self.platform_window())
             }
             None => {
                 *self.focus_item.borrow_mut() = Default::default();

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -691,8 +691,6 @@ pub trait WindowHandleAccess {
 
 /// Internal alias for Rc<dyn PlatformWindow>.
 pub type PlatformWindowRc = Rc<dyn PlatformWindow>;
-/// Internal convenience alias for Weak<dyn PlatformWindow>.
-pub type PlatformWindowWeak = Weak<dyn PlatformWindow>;
 
 /// This module contains the functions needed to interface with the event loop and window traits
 /// from outside the Rust language.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -36,9 +36,9 @@ fn previous_focus_item(item: ItemRc) -> ItemRc {
 /// window resizing and other typically windowing system related tasks.
 pub trait PlatformWindow {
     /// Registers the window with the windowing system.
-    fn show(self: Rc<Self>) {}
+    fn show(&self) {}
     /// De-registers the window from the windowing system.
-    fn hide(self: Rc<Self>) {}
+    fn hide(&self) {}
     /// Issue a request to the windowing system to re-render the contents of the window. This is typically an asynchronous
     /// request.
     fn request_redraw(&self) {}

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -5,6 +5,7 @@ use core::convert::TryFrom;
 use i_slint_compiler::langtype::Type as LangType;
 use i_slint_core::graphics::Image;
 use i_slint_core::model::{Model, ModelRc};
+use i_slint_core::window::WindowHandleAccess;
 use i_slint_core::{Brush, PathData, SharedString, SharedVector};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -581,7 +582,11 @@ impl ComponentDefinition {
     pub fn create_with_existing_window(&self, window: &Window) -> ComponentInstance {
         generativity::make_guard!(guard);
         ComponentInstance {
-            inner: self.inner.unerase(guard).clone().create_with_existing_window(window),
+            inner: self
+                .inner
+                .unerase(guard)
+                .clone()
+                .create_with_existing_window(&window.window_handle().platform_window()),
         }
     }
 
@@ -959,13 +964,13 @@ impl ComponentHandle for ComponentInstance {
     fn show(&self) {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.borrow_instance().window().show();
+        comp.borrow_instance().platform_window().show();
     }
 
     fn hide(&self) {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.borrow_instance().window().hide();
+        comp.borrow_instance().platform_window().hide();
     }
 
     fn run(&self) {
@@ -976,7 +981,7 @@ impl ComponentHandle for ComponentInstance {
     }
 
     fn window(&self) -> &Window {
-        self.inner.window()
+        self.inner.platform_window().window()
     }
 
     fn global<'a, T: Global<'a, Self>>(&'a self) -> T

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1069,7 +1069,7 @@ pub mod testing {
         i_slint_core::tests::send_keyboard_string_sequence(
             &string,
             Default::default(),
-            comp.window().window_handle(),
+            &comp.window().window_handle().platform_window(),
         );
     }
 }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1058,7 +1058,7 @@ pub mod testing {
             &vtable::VRc::into_dyn(comp.inner.clone()),
             x,
             y,
-            comp.window().window_handle(),
+            &comp.window().window_handle().platform_window(),
         );
     }
     /// Wrapper around [`i_slint_core::tests::send_keyboard_string_sequence`]

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -29,7 +29,7 @@ use i_slint_core::model::Repeater;
 use i_slint_core::properties::InterpolatedPropertyValue;
 use i_slint_core::rtti::{self, AnimatedBindingKind, FieldOffset, PropertyInfo};
 use i_slint_core::slice::Slice;
-use i_slint_core::window::{WindowHandleAccess, WindowRc};
+use i_slint_core::window::{WindowHandleAccess, WindowInner};
 use i_slint_core::{Brush, Color, Property, SharedString, SharedVector};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -1193,7 +1193,7 @@ fn make_binding_eval_closure(
 pub fn instantiate(
     component_type: Rc<ComponentDescription>,
     parent_ctx: Option<ComponentRefPin>,
-    window: Option<&i_slint_core::window::WindowRc>,
+    window: Option<&i_slint_core::window::WindowInner>,
     mut globals: crate::global_component::GlobalStorage,
 ) -> vtable::VRc<ComponentVTable, ErasedComponentBox> {
     let mut instance = component_type.dynamic_type.clone().create_instance();
@@ -1217,7 +1217,7 @@ pub fn instantiate(
             .collect();
     }
     *component_type.window_offset.apply_mut(instance.as_mut()) =
-        window.map(|window| window.clone().into());
+        window.map(|window| window.window_rc().into());
 
     let component_box = ComponentBox { instance, component_type: component_type.clone() };
     let instance_ref = component_box.borrow_instance();
@@ -1730,7 +1730,7 @@ pub fn show_popup(
     popup: &object_tree::PopupWindow,
     pos: i_slint_core::graphics::Point,
     parent_comp: ComponentRefPin,
-    parent_window: &WindowRc,
+    parent_window: &WindowInner,
     parent_item: &ItemRc,
 ) {
     generativity::make_guard!(guard);

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1490,7 +1490,7 @@ extern "C" fn layout_info(component: ComponentRefPin, orientation: Orientation) 
     let mut result = crate::eval_layout::get_layout_info(
         &instance_ref.component_type.original.root_element,
         instance_ref,
-        eval::window_ref(instance_ref).unwrap(),
+        eval::platform_window_ref(instance_ref).unwrap(),
         orientation,
     );
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -9,7 +9,7 @@ use corelib::graphics::{GradientStop, LinearGradientBrush, PathElement, RadialGr
 use corelib::items::{ItemRef, PropertyAnimation};
 use corelib::model::{Model, ModelRc};
 use corelib::rtti::AnimatedBindingKind;
-use corelib::window::{WindowHandleAccess, WindowRc};
+use corelib::window::{WindowHandleAccess, WindowInner};
 use corelib::{Brush, Color, PathData, SharedString, SharedVector};
 use i_slint_compiler::expression_tree::{
     BuiltinFunction, EasingCurve, Expression, Path as ExprPath, PathElement as ExprPathElement,
@@ -993,13 +993,13 @@ fn root_component_instance<'a, 'old_id, 'new_id>(
     }
 }
 
-pub fn window_ref<'a>(component: InstanceRef<'a, '_>) -> Option<&'a WindowRc> {
+pub fn window_ref<'a>(component: InstanceRef<'a, '_>) -> Option<&'a WindowInner> {
     component
         .component_type
         .window_offset
         .apply(component.instance.get_ref())
         .as_ref()
-        .map(|window| window.window_handle())
+        .map(|window| window.window_handle().as_ref())
 }
 
 /// Return the component instance which hold the given element.

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -307,7 +307,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
 
                     let focus_item_comp = enclosing_component.self_weak().get().unwrap().upgrade().unwrap();
 
-                    window_ref(component).unwrap().clone().set_focus_item(&corelib::items::ItemRc::new(vtable::VRc::into_dyn(focus_item_comp), item_info.item_index()));
+                    window_ref(component).unwrap().set_focus_item(&corelib::items::ItemRc::new(vtable::VRc::into_dyn(focus_item_comp), item_info.item_index()));
                     Value::Void
                 } else {
                     panic!("internal error: argument to SetFocusItem must be an element")

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -9,7 +9,7 @@ use corelib::graphics::{GradientStop, LinearGradientBrush, PathElement, RadialGr
 use corelib::items::{ItemRef, PropertyAnimation};
 use corelib::model::{Model, ModelRc};
 use corelib::rtti::AnimatedBindingKind;
-use corelib::window::{PlatformWindowRc, WindowHandleAccess};
+use corelib::window::WindowHandleAccess;
 use corelib::{Brush, Color, PathData, SharedString, SharedVector};
 use i_slint_compiler::expression_tree::{
     BuiltinFunction, EasingCurve, Expression, Path as ExprPath, PathElement as ExprPathElement,
@@ -993,7 +993,9 @@ fn root_component_instance<'a, 'old_id, 'new_id>(
     }
 }
 
-pub fn platform_window_ref<'a>(component: InstanceRef<'a, '_>) -> Option<&'a PlatformWindowRc> {
+pub fn platform_window_ref<'a>(
+    component: InstanceRef<'a, '_>,
+) -> Option<&'a Rc<dyn i_slint_core::window::PlatformWindow>> {
     component.component_type.platform_window_offset.apply(component.instance.get_ref()).as_ref()
 }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -451,8 +451,8 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     let item_info = &component_type.items[item.borrow().id.as_str()];
                     let item_ref = unsafe { item_info.item_from_component(enclosing_component.as_ptr()) };
 
-                    let window = window_ref(component).unwrap();
-                    item_ref.as_ref().layout_info(crate::eval_layout::to_runtime(*orient), window).into()
+                    let platform_window = platform_window_ref(component).unwrap();
+                    item_ref.as_ref().layout_info(crate::eval_layout::to_runtime(*orient), platform_window).into()
                 } else {
                     panic!("internal error: incorrect arguments to ImplicitLayoutInfo {:?}", arguments);
                 }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -13,8 +13,9 @@ use i_slint_core::items::DialogButtonRole;
 use i_slint_core::layout::{self as core_layout};
 use i_slint_core::model::RepeatedComponent;
 use i_slint_core::slice::Slice;
-use i_slint_core::window::PlatformWindowRc;
+use i_slint_core::window::PlatformWindow;
 use std::convert::TryInto;
+use std::rc::Rc;
 use std::str::FromStr;
 
 pub(crate) fn to_runtime(o: Orientation) -> core_layout::Orientation {
@@ -360,7 +361,7 @@ pub(crate) fn fill_layout_info_constraints(
 pub(crate) fn get_layout_info(
     elem: &ElementRc,
     component: InstanceRef,
-    platform_window: &PlatformWindowRc,
+    platform_window: &Rc<dyn PlatformWindow>,
     orientation: Orientation,
 ) -> core_layout::LayoutInfo {
     let elem = elem.borrow();

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -13,7 +13,7 @@ use i_slint_core::items::DialogButtonRole;
 use i_slint_core::layout::{self as core_layout};
 use i_slint_core::model::RepeatedComponent;
 use i_slint_core::slice::Slice;
-use i_slint_core::window::{WindowHandleAccess, WindowInner};
+use i_slint_core::window::PlatformWindowRc;
 use std::convert::TryInto;
 use std::str::FromStr;
 
@@ -186,7 +186,7 @@ fn grid_layout_data(
             let mut layout_info = get_layout_info(
                 &cell.item.element,
                 component,
-                eval::window_ref(component).unwrap(),
+                eval::platform_window_ref(component).unwrap(),
                 orientation,
             );
             fill_layout_info_constraints(
@@ -240,12 +240,8 @@ fn box_layout_data(
                     .map(|x| x.as_pin_ref().box_layout_data(to_runtime(orientation))),
             );
         } else {
-            let mut layout_info = get_layout_info(
-                &cell.element,
-                component,
-                platform_window.window().window_handle(),
-                orientation,
-            );
+            let mut layout_info =
+                get_layout_info(&cell.element, component, platform_window, orientation);
             fill_layout_info_constraints(
                 &mut layout_info,
                 &cell.constraints,
@@ -364,7 +360,7 @@ pub(crate) fn fill_layout_info_constraints(
 pub(crate) fn get_layout_info(
     elem: &ElementRc,
     component: InstanceRef,
-    window: &WindowInner,
+    platform_window: &PlatformWindowRc,
     orientation: Orientation,
 ) -> core_layout::LayoutInfo {
     let elem = elem.borrow();
@@ -379,7 +375,7 @@ pub(crate) fn get_layout_info(
         unsafe {
             item.item_from_component(component.as_ptr())
                 .as_ref()
-                .layout_info(to_runtime(orientation), window)
+                .layout_info(to_runtime(orientation), platform_window)
         }
     }
 }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -13,7 +13,7 @@ use i_slint_core::items::DialogButtonRole;
 use i_slint_core::layout::{self as core_layout};
 use i_slint_core::model::RepeatedComponent;
 use i_slint_core::slice::Slice;
-use i_slint_core::window::WindowRc;
+use i_slint_core::window::WindowInner;
 use std::convert::TryInto;
 use std::str::FromStr;
 
@@ -360,7 +360,7 @@ pub(crate) fn fill_layout_info_constraints(
 pub(crate) fn get_layout_info(
     elem: &ElementRc,
     component: InstanceRef,
-    window: &WindowRc,
+    window: &WindowInner,
     orientation: Orientation,
 ) -> core_layout::LayoutInfo {
     let elem = elem.borrow();

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -560,11 +560,11 @@ pub extern "C" fn slint_interpreter_component_instance_show(
 #[no_mangle]
 pub unsafe extern "C" fn slint_interpreter_component_instance_window(
     inst: &ErasedComponentBox,
-    out: *mut *const i_slint_core::window::ffi::WindowRcOpaque,
+    out: *mut *const i_slint_core::window::ffi::PlatformWindowRcOpaque,
 ) {
     assert_eq!(
         core::mem::size_of::<WindowRc>(),
-        core::mem::size_of::<i_slint_core::window::ffi::WindowRcOpaque>()
+        core::mem::size_of::<i_slint_core::window::ffi::PlatformWindowRcOpaque>()
     );
     core::ptr::write(out as *mut *const WindowRc, inst.window().window_handle() as *const _)
 }

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -7,7 +7,7 @@ use super::*;
 use core::ptr::NonNull;
 use i_slint_core::model::{Model, ModelNotify, SharedVectorModel};
 use i_slint_core::slice::Slice;
-use i_slint_core::window::PlatformWindowRc;
+use i_slint_core::window::PlatformWindow;
 use std::ffi::c_void;
 use vtable::VRef;
 
@@ -563,10 +563,10 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_window(
     out: *mut *const i_slint_core::window::ffi::PlatformWindowRcOpaque,
 ) {
     assert_eq!(
-        core::mem::size_of::<PlatformWindowRc>(),
+        core::mem::size_of::<Rc<dyn PlatformWindow>>(),
         core::mem::size_of::<i_slint_core::window::ffi::PlatformWindowRcOpaque>()
     );
-    core::ptr::write(out as *mut *const PlatformWindowRc, inst.platform_window() as *const _)
+    core::ptr::write(out as *mut *const Rc<dyn PlatformWindow>, inst.platform_window() as *const _)
 }
 
 /// Instantiate an instance from a definition.

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -7,7 +7,7 @@ use super::*;
 use core::ptr::NonNull;
 use i_slint_core::model::{Model, ModelNotify, SharedVectorModel};
 use i_slint_core::slice::Slice;
-use i_slint_core::window::{WindowHandleAccess, WindowRc};
+use i_slint_core::window::PlatformWindowRc;
 use std::ffi::c_void;
 use vtable::VRef;
 
@@ -547,9 +547,9 @@ pub extern "C" fn slint_interpreter_component_instance_show(
     generativity::make_guard!(guard);
     let comp = inst.unerase(guard);
     if is_visible {
-        comp.borrow_instance().window().show();
+        comp.borrow_instance().platform_window().show();
     } else {
-        comp.borrow_instance().window().hide();
+        comp.borrow_instance().platform_window().hide();
     }
 }
 
@@ -563,10 +563,10 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_window(
     out: *mut *const i_slint_core::window::ffi::PlatformWindowRcOpaque,
 ) {
     assert_eq!(
-        core::mem::size_of::<WindowRc>(),
+        core::mem::size_of::<PlatformWindowRc>(),
         core::mem::size_of::<i_slint_core::window::ffi::PlatformWindowRcOpaque>()
     );
-    core::ptr::write(out as *mut *const WindowRc, inst.window().window_handle() as *const _)
+    core::ptr::write(out as *mut *const PlatformWindowRc, inst.platform_window() as *const _)
 }
 
 /// Instantiate an instance from a definition.


### PR DESCRIPTION
This inverts the ownership model between the internal Window (sometimes dubbed runtime window) and the PlatformWindow impl.

The objective is to reduce complexity, remove an intermediate Rc and make it easier to implement PlatformWindow.

The old model was:

    Component -> Rc<WindowInner> -> Rc<dyn PlatformWindow>

and the PlatformWindow impl has a Weak to itself and back.

With the new model this is:

    Component -> Rc<dyn PlatformWindow> -> has slint::Window, which wraps WindowInner