### PR TITLE
Prospective fix for failing install-qt-action in the CI on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
         version: '5.15.2'
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         setup-python: false
+        py7zrversion: ==0.19.*
     - name: Set default style
       if: matrix.os != 'windows-2022'
       run: |
@@ -130,6 +131,7 @@ jobs:
         version: '5.15.2'
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         setup-python: false
+        py7zrversion: ==0.19.*
     - name: Set default style
       if: matrix.os != 'windows-2022'
       run: |
@@ -220,11 +222,13 @@ jobs:
       with:
         version: 5.15.2
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        py7zrversion: ==0.19.*
     - name: Install Qt (Windows, uncached)
       if: matrix.os == 'windows-2022'
       uses: jurplel/install-qt-action@v2
       with:
         version: 6.2.1
+        py7zrversion: ==0.19.*
     - name: Install Qt (cached)
       if: matrix.os != 'ubuntu-20.04' && matrix.os != 'windows-2022'
       uses: jurplel/install-qt-action@v2
@@ -232,6 +236,7 @@ jobs:
         version: 6.2.1
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         setup-python: false
+        py7zrversion: ==0.19.*
     - name: Install latest stable
       uses: actions-rs/toolchain@v1
       with:
@@ -294,6 +299,7 @@ jobs:
       with:
         version: 5.15.2
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        py7zrversion: ==0.19.*
     - uses: actions/download-artifact@v2
       with:
         name: cpp_bin-ubuntu-20.04

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -35,11 +35,13 @@ jobs:
       with:
         version: 5.15.2
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        py7zrversion: ==0.19.*
     - name: Install Qt (Windows, uncached)
       if: matrix.os == 'windows-2022'
       uses: jurplel/install-qt-action@v2
       with:
         version: 6.2.1
+        py7zrversion: ==0.19.*
     - name: Install Qt (cached)
       if: matrix.os != 'ubuntu-20.04' && matrix.os != 'windows-2022'
       uses: jurplel/install-qt-action@v2
@@ -47,6 +49,7 @@ jobs:
         version: 6.2.1
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         setup-python: false
+        py7zrversion: ==0.19.*
     - name: Install latest stable
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: jurplel/install-qt-action@v2
         with:
           version: 6.2.1
+          py7zrversion: ==0.19.*          
       - uses: Swatinem/rust-cache@v1
         with:
           key: x
@@ -91,6 +92,7 @@ jobs:
         with:
           version: 5.15.2
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          py7zrversion: ==0.19.*
       - uses: Swatinem/rust-cache@v1
         with:
           key: x
@@ -141,6 +143,7 @@ jobs:
           version: 6.2.1 # for Apple Silicon support
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
           setup-python: false
+          py7zrversion: ==0.19.*
       - uses: Swatinem/rust-cache@v1
         with:
           key: x


### PR DESCRIPTION
python3 -m pip install py7zr==0.16.1 failed with mysterious errors about package conflicts.
Upgrade to the version that the next version of the install-qt-action seems to
to going to use.