### PR TITLE
Skia/FemtoVG: implement re-use of box shadow textures

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -24,6 +24,8 @@ mod renderer {
 
     use i_slint_core::window::PlatformWindow;
 
+    mod boxshadowcache;
+
     pub(crate) trait WinitCompatibleRenderer: i_slint_core::renderer::Renderer {
         type Canvas: WinitCompatibleCanvas;
 

--- a/internal/backends/winit/renderer/boxshadowcache.rs
+++ b/internal/backends/winit/renderer/boxshadowcache.rs
@@ -1,0 +1,86 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use std::{cell::RefCell, collections::BTreeMap};
+
+use i_slint_core::{items::ItemRc, Color};
+
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct BoxShadowOptions {
+    pub width: f32,
+    pub height: f32,
+    pub color: Color,
+    pub blur: f32,
+    pub radius: f32,
+}
+
+impl Eq for BoxShadowOptions {}
+impl Ord for BoxShadowOptions {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if (other.width, other.height, other.color, other.blur, other.radius)
+            < (self.width, self.height, self.color, self.blur, self.radius)
+        {
+            std::cmp::Ordering::Less
+        } else if (self.width, self.height, self.color, self.blur, self.radius)
+            < (other.width, other.height, other.color, other.blur, other.radius)
+        {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    }
+}
+
+impl PartialOrd for BoxShadowOptions {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl BoxShadowOptions {
+    fn new(
+        box_shadow: std::pin::Pin<&i_slint_core::items::BoxShadow>,
+        scale_factor: f32,
+    ) -> Option<Self> {
+        let color = box_shadow.color();
+        if color.alpha() == 0 {
+            return None;
+        }
+        Some(Self {
+            width: box_shadow.width() * scale_factor,
+            height: box_shadow.height() * scale_factor,
+            color,
+            blur: box_shadow.blur(),
+            radius: box_shadow.border_radius() * scale_factor,
+        })
+    }
+}
+
+pub struct BoxShadowCache<ImageType>(RefCell<BTreeMap<BoxShadowOptions, ImageType>>);
+
+impl<ImageType> Default for BoxShadowCache<ImageType> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<ImageType: Clone> BoxShadowCache<ImageType> {
+    pub fn get_box_shadow(
+        &self,
+        item_rc: &ItemRc,
+        item_cache: &i_slint_core::item_rendering::ItemCache<Option<ImageType>>,
+        box_shadow: std::pin::Pin<&i_slint_core::items::BoxShadow>,
+        scale_factor: f32,
+        shadow_render_fn: impl FnOnce(&BoxShadowOptions) -> ImageType,
+    ) -> Option<ImageType> {
+        item_cache.get_or_update_cache_entry(item_rc, || {
+            let shadow_options = BoxShadowOptions::new(box_shadow, scale_factor)?;
+            self.0
+                .borrow_mut()
+                .entry(shadow_options.clone())
+                .or_insert_with(|| shadow_render_fn(&shadow_options))
+                .clone()
+                .into()
+        })
+    }
+}

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -109,10 +109,13 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
                     })
                 }
 
+                let mut box_shadow_cache = Default::default();
+
                 let mut item_renderer = itemrenderer::SkiaRenderer::new(
                     skia_canvas,
                     platform_window.window(),
                     &canvas.image_cache,
+                    &mut box_shadow_cache,
                 );
 
                 for (component, origin) in components {

--- a/internal/core/graphics/color.rs
+++ b/internal/core/graphics/color.rs
@@ -43,7 +43,7 @@ pub struct RgbaColor<T> {
 ///
 /// let new_col = Color::from(RgbaColor{ red: 0.5, green: 0.65, blue: 0.32, alpha: 1.});
 /// ```
-#[derive(Copy, Clone, PartialEq, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
 #[repr(C)]
 pub struct Color {
     red: u8,


### PR DESCRIPTION
When using box shadows in repeaters, we end up creating multiple
distinct textures of the drop shadow. That's a waste of precious texture
memory if they have the same properties.

Instead, when creating box shadows in a frame, see if they can be
re-used across images.  The texture still persistent in the image_cache,
via the explicitly shared skia_safe::Image and Rc<Texture>.

This works well when rendering repeated elements new top-down, but it's
not perfect.  For example if a bunch of repeated elements are in a
flickable, only a portion of them are visible and the view is scroll up,
then the top-down rendering will not find a cache hit for the newly
visible element with drop shadows. Yet this is simple enough to help
with sharing in many cases.