### PR TITLE
Make the PlatformAbstraction not Send using a EventLoopProxy trait

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -436,24 +436,17 @@ pub mod internal {
 /// Creates a new window to render components in.
 #[doc(hidden)]
 pub fn create_window() -> alloc::rc::Rc<dyn re_exports::PlatformWindow> {
-    i_slint_backend_selector::backend().create_window()
+    i_slint_backend_selector::with_platform_abstraction(|b| b.create_window())
 }
 
 /// Enters the main event loop. This is necessary in order to receive
 /// events from the windowing system in order to render to the screen
 /// and react to user input.
 pub fn run_event_loop() {
-    i_slint_backend_selector::backend()
-        .run_event_loop(i_slint_core::platform::EventLoopQuitBehavior::QuitOnLastWindowClosed);
+    i_slint_backend_selector::with_platform_abstraction(|b| {
+        b.run_event_loop(i_slint_core::platform::EventLoopQuitBehavior::QuitOnLastWindowClosed)
+    })
 }
-/// Schedules the main event loop for termination. This function is meant
-/// to be called from callbacks triggered by the UI. After calling the function,
-/// it will return immediately and once control is passed back to the event loop,
-/// the initial call to [`run_event_loop()`] will return.
-pub fn quit_event_loop() {
-    i_slint_backend_selector::backend().quit_event_loop();
-}
-
 /// This module contains functions useful for unit tests
 #[cfg(feature = "std")]
 pub mod testing {

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -324,7 +324,7 @@ mod the_backend {
             }
         }
 
-        fn event_loop_proxy(&self) -> Option<Box<dyn i_slint_core::platform::EventLoopProxy>> {
+        fn new_event_loop_proxy(&self) -> Option<Box<dyn i_slint_core::platform::EventLoopProxy>> {
             struct Proxy;
             impl i_slint_core::platform::EventLoopProxy for Proxy {
                 fn quit_event_loop(&self) {

--- a/internal/backends/mcu/pico_st7789.rs
+++ b/internal/backends/mcu/pico_st7789.rs
@@ -58,7 +58,8 @@ const DISPLAY_SIZE: PhysicalSize = PhysicalSize::new(320, 240);
 
 pub fn init() {
     unsafe { ALLOCATOR.init(&mut HEAP as *const u8 as usize, core::mem::size_of_val(&HEAP)) }
-    i_slint_core::platform::instance_or_init(|| alloc::boxed::Box::new(PicoBackend));
+    i_slint_core::platform::set_platform_abstraction(alloc::boxed::Box::new(PicoBackend))
+        .expect("backend already initialized");
 }
 
 thread_local! { static WINDOW: RefCell<Option<Rc<PicoWindow>>> = RefCell::new(None) }

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -165,7 +165,7 @@ impl i_slint_core::platform::PlatformAbstraction for Backend {
     }
 
     #[cfg(not(no_qt))]
-    fn event_loop_proxy(&self) -> Option<Box<dyn i_slint_core::platform::EventLoopProxy>> {
+    fn new_event_loop_proxy(&self) -> Option<Box<dyn i_slint_core::platform::EventLoopProxy>> {
         struct Proxy;
         impl i_slint_core::platform::EventLoopProxy for Proxy {
             fn quit_event_loop(&self) {

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -5,20 +5,26 @@
 #![doc(html_logo_url = "https://slint-ui.com/logo/slint-logo-square-light.svg")]
 #![cfg_attr(not(any(feature = "i-slint-backend-qt", feature = "i-slint-backend-winit")), no_std)]
 
+extern crate alloc;
+
+use alloc::boxed::Box;
 use core::pin::Pin;
+use i_slint_core::platform::PlatformAbstraction;
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "i-slint-backend-qt", not(no_qt)))] {
         use i_slint_backend_qt as default_backend;
 
-        fn create_default_backend() -> Box<dyn i_slint_core::platform::PlatformAbstraction + 'static> {
+        fn create_default_backend() -> Box<dyn PlatformAbstraction + 'static> {
             Box::new(default_backend::Backend)
         }
     } else if #[cfg(feature = "i-slint-backend-winit")] {
         use i_slint_backend_winit as default_backend;
-        fn create_default_backend() -> Box<dyn i_slint_core::platform::PlatformAbstraction + 'static> {
+        fn create_default_backend() -> Box<dyn PlatformAbstraction + 'static> {
             Box::new(i_slint_backend_winit::Backend::new(None))
         }
+    } else {
+
     }
 }
 
@@ -27,52 +33,45 @@ cfg_if::cfg_if! {
             all(feature = "i-slint-backend-qt", not(no_qt)),
             feature = "i-slint-backend-winit"
         ))] {
-        pub fn backend() -> &'static dyn i_slint_core::platform::PlatformAbstraction {
-            i_slint_core::platform::instance_or_init(|| {
-                let backend_config = std::env::var("SLINT_BACKEND").or_else(|_| {
-                    let legacy_fallback = std::env::var("SIXTYFPS_BACKEND");
-                    if legacy_fallback.is_ok() {
-                        eprintln!("Using `SIXTYFPS_BACKEND` environment variable for dynamic backend selection. This is deprecated, use `SLINT_BACKEND` instead.")
-                    }
-                    legacy_fallback
-                }).unwrap_or_default();
+        pub fn create_backend() -> Box<dyn PlatformAbstraction + 'static>  {
 
-                let backend_config = backend_config.to_lowercase();
-                if let Some((event_loop, _renderer)) = backend_config.split_once('-').or_else(|| match backend_config.as_str() {
-                    "qt" => Some(("qt", "qpainter")),
-                    "gl" => Some(("winit", "femtovg")),
-                    "skia" => Some(("winit", "skia")),
-                    "sw" | "software" => Some(("winit", "software")),
-                    _ => None,
-                }) {
-                    match event_loop {
-                        #[cfg(all(feature = "i-slint-backend-qt", not(no_qt)))]
-                        "qt" => return Box::new(i_slint_backend_qt::Backend),
-                        #[cfg(feature = "i-slint-backend-winit")]
-                        "winit" => return Box::new(i_slint_backend_winit::Backend::new(Some(_renderer))),
-                        _ => {},
-                    }
-                };
-
-                #[cfg(any(
-                    feature = "i-slint-backend-qt",
-                    feature = "i-slint-backend-winit"
-                ))]
-                if !backend_config.is_empty() {
-                    eprintln!("Could not load rendering backend {}, fallback to default", backend_config)
+            let backend_config = std::env::var("SLINT_BACKEND").or_else(|_| {
+                let legacy_fallback = std::env::var("SIXTYFPS_BACKEND");
+                if legacy_fallback.is_ok() {
+                    eprintln!("Using `SIXTYFPS_BACKEND` environment variable for dynamic backend selection. This is deprecated, use `SLINT_BACKEND` instead.")
                 }
+                legacy_fallback
+            }).unwrap_or_default();
 
-                create_default_backend()
-            })
+            let backend_config = backend_config.to_lowercase();
+            if let Some((event_loop, _renderer)) = backend_config.split_once('-').or_else(|| match backend_config.as_str() {
+                "qt" => Some(("qt", "qpainter")),
+                "gl" => Some(("winit", "femtovg")),
+                "skia" => Some(("winit", "skia")),
+                "sw" | "software" => Some(("winit", "software")),
+                _ => None,
+            }) {
+                match event_loop {
+                    #[cfg(all(feature = "i-slint-backend-qt", not(no_qt)))]
+                    "qt" => return Box::new(i_slint_backend_qt::Backend),
+                    #[cfg(feature = "i-slint-backend-winit")]
+                    "winit" => return Box::new(i_slint_backend_winit::Backend::new(Some(_renderer))),
+                    _ => {},
+                }
+            };
+
+            if !backend_config.is_empty() {
+                eprintln!("Could not load rendering backend {}, fallback to default", backend_config)
+            }
+            create_default_backend()
         }
         pub use default_backend::{
             native_widgets, Backend, NativeGlobals, NativeWidgets, HAS_NATIVE_STYLE,
         };
     } else {
-        pub fn backend() -> &'static dyn i_slint_core::platform::PlatformAbstraction {
-            i_slint_core::platform::instance().expect("no default backend configured, the backend must be initialized manually")
+        pub fn create_backend() -> Box<dyn PlatformAbstraction + 'static> {
+            panic!("no default backend configured, the backend must be initialized manually")
         }
-
         pub type NativeWidgets = ();
         pub type NativeGlobals = ();
         pub mod native_widgets {
@@ -80,6 +79,12 @@ cfg_if::cfg_if! {
         }
         pub const HAS_NATIVE_STYLE: bool = false;
     }
+}
+
+/// Run the callback with the platform abstraction.
+/// Create the backend if it does not exist yet
+pub fn with_platform_abstraction<R>(f: impl FnOnce(&dyn PlatformAbstraction) -> R) -> R {
+    i_slint_core::with_platform_abstraction(create_backend, f)
 }
 
 #[doc(hidden)]

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -25,16 +25,6 @@ impl i_slint_core::platform::PlatformAbstraction for TestingBackend {
         })
     }
 
-    fn run_event_loop(&self, _behavior: i_slint_core::platform::EventLoopQuitBehavior) {
-        unimplemented!("running an event loop with the testing backend");
-    }
-
-    fn quit_event_loop(&self) {}
-
-    fn post_event(&self, _event: Box<dyn FnOnce() + Send>) {
-        // The event will never be invoked
-    }
-
     fn duration_since_start(&self) -> core::time::Duration {
         // The slint::testing::mock_elapsed_time updates the animation tick directly
         core::time::Duration::from_millis(i_slint_core::animations::current_tick().0)
@@ -153,5 +143,6 @@ impl Renderer for TestingWindow {
 /// Must be called before any call that would otherwise initialize the rendering backend.
 /// Calling it when the rendering backend is already initialized will have no effects
 pub fn init() {
-    i_slint_core::platform::instance_or_init(|| Box::new(TestingBackend::default()));
+    i_slint_core::platform::set_platform_abstraction(Box::new(TestingBackend::default()))
+        .expect("platform already initialized");
 }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -151,7 +151,7 @@ impl i_slint_core::platform::PlatformAbstraction for Backend {
         crate::event_loop::run(behavior);
     }
 
-    fn event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>> {
+    fn new_event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>> {
         struct Proxy;
         impl EventLoopProxy for Proxy {
             fn quit_event_loop(&self) {

--- a/internal/core/animations.rs
+++ b/internal/core/animations.rs
@@ -206,8 +206,8 @@ impl Instant {
     }
 
     fn duration_since_start() -> core::time::Duration {
-        crate::platform::instance()
-            .map(|backend| backend.duration_since_start())
+        crate::platform::PLAFTORM_ABSTRACTION_INSTANCE
+            .with(|p| p.get().map(|p| p.duration_since_start()))
             .unwrap_or_default()
     }
 }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -480,9 +480,17 @@ pub use weak_handle::*;
 /// handle.run();
 /// ```
 pub fn invoke_from_event_loop(func: impl FnOnce() + Send + 'static) {
-    if let Some(backend) = crate::platform::instance() {
-        backend.post_event(alloc::boxed::Box::new(func))
-    } else {
-        panic!("slint::invoke_from_event_loop() must be called after the Slint backend is initialized.")
-    }
+    crate::platform::event_loop_proxy()
+        .expect("quit_event_loop() called before the slint platform abstraction was initialized, or the platform does not support event loop")
+        .invoke_from_event_loop(alloc::boxed::Box::new(func))
+}
+
+/// Schedules the main event loop for termination. This function is meant
+/// to be called from callbacks triggered by the UI. After calling the function,
+/// it will return immediately and once control is passed back to the event loop,
+/// the initial call to `slint::run_event_loop()` will return.
+pub fn quit_event_loop() {
+    crate::platform::event_loop_proxy()
+        .expect("quit_event_loop() called before the slint platform abstraction was initialized, or the platform does not support event loop")
+        .quit_event_loop()
 }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -422,6 +422,7 @@ mod weak_handle {
         ///     // ... Do some computation in the thread
         ///     let foo = 42;
         ///     # assert!(handle_weak.upgrade().is_none()); // note that upgrade fails in a thread
+        ///     # return; // don't upgrade_in_event_loop in our examples
         ///     // now forward the data to the main thread using upgrade_in_event_loop
         ///     handle_weak.upgrade_in_event_loop(move |handle| handle.set_foo(foo));
         /// });
@@ -469,6 +470,7 @@ pub use weak_handle::*;
 /// # i_slint_backend_testing::init();
 /// let handle = MyApp::new();
 /// let handle_weak = handle.as_weak();
+/// # return; // don't run the event loop in examples
 /// let thread = std::thread::spawn(move || {
 ///     // ... Do some computation in the thread
 ///     let foo = 42;
@@ -476,7 +478,6 @@ pub use weak_handle::*;
 ///     let handle_copy = handle_weak.clone();
 ///     slint::invoke_from_event_loop(move || handle_copy.unwrap().set_foo(foo));
 /// });
-/// # thread.join().unwrap(); return; // don't run the event loop in examples
 /// handle.run();
 /// ```
 pub fn invoke_from_event_loop(func: impl FnOnce() + Send + 'static) {

--- a/internal/core/graphics/image/htmlimage.rs
+++ b/internal/core/graphics/image/htmlimage.rs
@@ -33,9 +33,7 @@ impl HTMLImage {
                     // on a winit window only queues an additional internal event, that'll be
                     // be dispatched as the next event. We are however not in an event loop
                     // call, so we also need to wake up the event loop and redraw then.
-                    if let Some(backend) = crate::platform::instance() {
-                        backend.post_event(Box::new(|| {}))
-                    }
+                    crate::api::invoke_from_event_loop(|| {});
                 }
             })
             .into(),

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -797,14 +797,17 @@ impl TextInput {
         if anchor == cursor {
             return;
         }
-        if let Some(backend) = crate::platform::instance() {
-            let text = self.text();
-            backend.set_clipboard_text(&text[anchor..cursor]);
-        }
+        let text = self.text();
+        crate::platform::PLAFTORM_ABSTRACTION_INSTANCE.with(|p| {
+            if let Some(backend) = p.get() {
+                backend.set_clipboard_text(&text[anchor..cursor]);
+            }
+        });
     }
 
     fn paste(self: Pin<&Self>, platform_window: &Rc<dyn PlatformWindow>) {
-        if let Some(text) = crate::platform::instance().and_then(|backend| backend.clipboard_text())
+        if let Some(text) = crate::platform::PLAFTORM_ABSTRACTION_INSTANCE
+            .with(|p| p.get().and_then(|p| p.clipboard_text()))
         {
             self.insert(&text, platform_window);
         }

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -43,7 +43,7 @@ pub trait PlatformAbstraction {
     /// not be possible to send event to the event loop and the function
     /// [`slint::invoke_from_event_loop()`](crate::api::invoke_from_event_loop) and
     /// [`slint::quit_event_loop()`](crate::api::quit_event_loop) will panic
-    fn event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>> {
+    fn new_event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>> {
         None
     }
 
@@ -72,7 +72,7 @@ pub trait PlatformAbstraction {
     }
 }
 
-/// Trait that is returned by the [`PlatformAbstraction::event_loop_proxy`]
+/// Trait that is returned by the [`PlatformAbstraction::new_event_loop_proxy`]
 ///
 /// This are the implementation details for the function that may need to
 /// communicate with the eventloop from different thread
@@ -120,7 +120,7 @@ pub fn set_platform_abstraction(
         if instance.get().is_some() {
             return Err(());
         }
-        if let Some(proxy) = platform.event_loop_proxy() {
+        if let Some(proxy) = platform.new_event_loop_proxy() {
             EVENTLOOP_PROXY.set(proxy).map_err(drop)?
         }
         instance.set(platform.into()).map_err(drop).unwrap();

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -975,8 +975,7 @@ impl ComponentHandle for ComponentInstance {
 
     fn run(&self) {
         self.show();
-        i_slint_backend_selector::backend()
-            .run_event_loop(i_slint_core::platform::EventLoopQuitBehavior::QuitOnLastWindowClosed);
+        run_event_loop();
         self.hide();
     }
 
@@ -1043,8 +1042,9 @@ pub enum InvokeCallbackError {
 /// events from the windowing system in order to render to the screen
 /// and react to user input.
 pub fn run_event_loop() {
-    i_slint_backend_selector::backend()
-        .run_event_loop(i_slint_core::platform::EventLoopQuitBehavior::QuitOnLastWindowClosed);
+    i_slint_backend_selector::with_platform_abstraction(|b| {
+        b.run_event_loop(i_slint_core::platform::EventLoopQuitBehavior::QuitOnLastWindowClosed)
+    });
 }
 
 /// This module contains a few function use by tests

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -389,14 +389,13 @@ impl<'id> ComponentDescription<'id> {
         self: Rc<Self>,
         #[cfg(target_arch = "wasm32")] canvas_id: String,
     ) -> vtable::VRc<ComponentVTable, ErasedComponentBox> {
-        #[cfg(not(target_arch = "wasm32"))]
-        let platform_window = i_slint_backend_selector::backend().create_window();
-        #[cfg(target_arch = "wasm32")]
-        let platform_window = {
-            // Ensure that the backend is initialized
-            i_slint_backend_selector::backend();
+        let platform_window = i_slint_backend_selector::with_platform_abstraction(|_b| {
+            #[cfg(not(target_arch = "wasm32"))]
+            return _b.create_window();
+            #[cfg(target_arch = "wasm32")]
             i_slint_backend_winit::create_gl_window_with_canvas_id(canvas_id)
-        };
+        });
+
         self.create_with_existing_window(&platform_window)
     }
 

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -195,7 +195,7 @@ fn init_dialog(instance: &ComponentInstance) {
         instance
             .set_callback(&cb, move |_| {
                 EXIT_CODE.store(exit_code, std::sync::atomic::Ordering::Relaxed);
-                i_slint_backend_selector::backend().quit_event_loop();
+                i_slint_core::api::quit_event_loop();
                 Default::default()
             })
             .unwrap();
@@ -350,7 +350,7 @@ unsafe impl Sync for FutureRunner {}
 
 impl Wake for FutureRunner {
     fn wake(self: Arc<Self>) {
-        i_slint_backend_selector::backend().post_event(Box::new(move || {
+        i_slint_core::api::invoke_from_event_loop(move || {
             let waker = self.clone().into();
             let mut cx = std::task::Context::from_waker(&waker);
             let mut fut_opt = self.fut.lock().unwrap();
@@ -360,7 +360,7 @@ impl Wake for FutureRunner {
                     std::task::Poll::Pending => {}
                 }
             }
-        }));
+        });
     }
 }
 


### PR DESCRIPTION
This changes the way the platform abstraction is initialized