### PR TITLE
Nightly: Work around relative base path in vite config

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -307,6 +307,7 @@ jobs:
             rm -rf snapshots/$target_branch/editor
             mkdir -p snapshots/$target_branch/editor
             cp -a ../tools/online_editor/dist/* snapshots/$target_branch/editor/
+            sh -c "cd shapshots/$target_branch/editor/assets ; ln -s . assets # work around relative base set in vite"
             git add snapshots/$target_branch/editor
             git add -u snapshots/$target_branch/editor
 


### PR DESCRIPTION
The base of `.` leads to assets importing other assets from
`./assets/...`.

So add a symlink to work around that issue. The proper fix is of course
to make vite generate the correct URLs.