### PR TITLE
online_editor: Implement custom "slint/load_file"

### DIFF
--- a/tools/online_editor/src/index.ts
+++ b/tools/online_editor/src/index.ts
@@ -63,11 +63,11 @@ import slint_init, * as slint from "@preview/slint_wasm_interpreter.js";
     return;
   }
   const editor = monaco.editor.create(editor_element, {
-    language: "slint",
+    cursorBlinking: "smooth",
+    cursorSurroundingLines: 2,
     glyphMargin: true,
-    lightbulb: {
-      enabled: true,
-    },
+    language: "slint",
+    lightbulb: { enabled: true },
   });
   MonacoServices.install();
 

--- a/tools/online_editor/src/proxy.ts
+++ b/tools/online_editor/src/proxy.ts
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import {
+  MessageReader,
+  DataCallback,
+  Message,
+  Disposable,
+  Event,
+  PartialMessageInfo,
+} from "monaco-languageclient";
+
+export class FilterProxyReader implements MessageReader {
+  constructor(reader: MessageReader, callback: (_: Message) => boolean) {
+    this.#reader = reader;
+    this.#callback = callback;
+    this.onError = this.#reader.onError;
+    this.onClose = this.#reader.onClose;
+    this.onPartialMessage = this.#reader.onPartialMessage;
+  }
+
+  readonly #reader: MessageReader;
+  readonly #callback: (_: Message) => boolean;
+  onError: Event<Error>;
+  onClose: Event<void>;
+  onPartialMessage: Event<PartialMessageInfo>;
+
+  dispose() {
+    this.#reader.dispose();
+  }
+
+  listen(callback: DataCallback): Disposable {
+    return this.#reader.listen((data: Message) => {
+      this.#callback(data) || callback(data);
+    });
+  }
+}


### PR DESCRIPTION
The LSP running in the web worker needs to access (virtual) files in the
editor. So it can send a request to the editor for files.

Handle such requests. Also make sure to provide the editor with the
correct URLs of open files so that the base URL to request additional
data with is correct.

Also do not error out when LSP and interpreter request the same file
concurrently.