### PR TITLE
Sofware renderer: keep a Weak of the Window

### DIFF
--- a/examples/mcu-board-support/pico_st7789.rs
+++ b/examples/mcu-board-support/pico_st7789.rs
@@ -70,7 +70,10 @@ impl slint::platform::PlatformAbstraction for PicoBackend {
     fn create_window(&self) -> Rc<dyn slint::platform::PlatformWindow> {
         let window = Rc::new_cyclic(|self_weak: &Weak<PicoWindow>| PicoWindow {
             window: slint::Window::new(self_weak.clone()),
-            renderer: renderer::SoftwareRenderer::new(renderer::DirtyTracking::SingleBuffer),
+            renderer: renderer::SoftwareRenderer::new(
+                renderer::DirtyTracking::SingleBuffer,
+                self_weak.clone(),
+            ),
             needs_redraw: Default::default(),
         });
         self.window.replace(Some(window.clone()));
@@ -198,7 +201,7 @@ impl slint::platform::PlatformAbstraction for PicoBackend {
 
             if let Some(window) = self.window.borrow().clone() {
                 if window.needs_redraw.replace(false) {
-                    window.renderer.render_by_line(&window.window, &mut buffer_provider);
+                    window.renderer.render_by_line(&mut buffer_provider);
                     buffer_provider.flush_frame();
                 }
 

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -14,8 +14,11 @@ use std::rc::Weak;
 impl super::WinitCompatibleRenderer for SoftwareRenderer {
     type Canvas = SwCanvas;
 
-    fn new(_platform_window_weak: &Weak<dyn PlatformWindow>) -> Self {
-        SoftwareRenderer::new(i_slint_core::swrenderer::DirtyTracking::None)
+    fn new(platform_window_weak: &Weak<dyn PlatformWindow>) -> Self {
+        SoftwareRenderer::new(
+            i_slint_core::swrenderer::DirtyTracking::None,
+            platform_window_weak.clone(),
+        )
     }
 
     fn create_canvas(&self, window_builder: winit::window::WindowBuilder) -> Self::Canvas {
@@ -44,12 +47,7 @@ impl super::WinitCompatibleRenderer for SoftwareRenderer {
 
         window.draw_contents(|_component| {
             if std::env::var_os("SLINT_LINE_BY_LINE").is_none() {
-                Self::render(
-                    &self,
-                    platform_window.window(),
-                    buffer.as_mut_slice(),
-                    PhysicalLength::new(width as _),
-                );
+                Self::render(&self, buffer.as_mut_slice(), PhysicalLength::new(width as _));
             } else {
                 struct FrameBuffer<'a> {
                     buffer: &'a mut [Rgb8Pixel],
@@ -78,10 +76,10 @@ impl super::WinitCompatibleRenderer for SoftwareRenderer {
                         }
                     }
                 }
-                self.render_by_line(
-                    platform_window.window(),
-                    FrameBuffer { buffer: &mut buffer, line: vec![Default::default(); width] },
-                );
+                self.render_by_line(FrameBuffer {
+                    buffer: &mut buffer,
+                    line: vec![Default::default(); width],
+                });
             }
         });
 

--- a/internal/core/swrenderer/draw_functions.rs
+++ b/internal/core/swrenderer/draw_functions.rs
@@ -283,6 +283,7 @@ fn interpolate_color(
 /// PremultipliedRgbaColor can be constructed from a [`Color`] with
 /// the [`From`] trait. This conversion will pre-multiply the color
 /// components
+#[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct PremultipliedRgbaColor {
     pub red: u8,


### PR DESCRIPTION
Closes #1545

Not that `SoftwareRenderer::new()`  takes the Weak by value instead of
by reference, because coercing a reference to a `Weak` to a `&Weak<dyn>`
is not possible, while converting a Weak to a `Weak<dyn>` just works.