### PR TITLE
Pr/api set platform

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -19,7 +19,13 @@ path = "lib.rs"
 
 [features]
 
-default = ["std", "eventloop-winit", "renderer-femtovg", "backend-qt", "compat-0-2-0"]
+default = [
+  "std",
+  "eventloop-winit",
+  "renderer-femtovg",
+  "backend-qt",
+  "compat-0-2-0",
+]
 
 ## Mandatory feature:
 ## This feature is required to keep the compatibility with Slint 0.2.0
@@ -54,22 +60,28 @@ eventloop-winit-x11 = ["i-slint-backend-selector/eventloop-winit-x11", "std"]
 
 ## Simliar to `eventloop-winit` this enables the winit based event loop but only
 ## with support for the Wayland window system on Unix.
-eventloop-winit-wayland = ["i-slint-backend-selector/eventloop-winit-wayland", "std"]
+eventloop-winit-wayland = [
+  "i-slint-backend-selector/eventloop-winit-wayland",
+  "std",
+]
 
 ## This feature is an alias for `backend-qt`
 eventloop-qt = ["backend-qt"]
 
-## The `femtovg` crate is available for rendering. 
+## The `femtovg` crate is available for rendering.
 renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "std"]
 
 ## The Skia based rendering engine.
 renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
 
 ## This feature makes the `slint::platform::swrenderer` module available in the public API.
-## Use this to render with Slint for example on MCUs, when you provide you own `slint::platform::PlatformAbstraction`.
+## Use this to render with Slint for example on MCUs, when you provide you own `slint::platform::Platform`.
 ## Alternatively, enabling this feature alongside `eventloop-winit` enables selecting the software
 ## renderer at run-time when using winit, via the `SLINT_BACKEND=software` environment variable.
-renderer-software = ["i-slint-core/swrenderer", "i-slint-backend-selector/renderer-software"]
+renderer-software = [
+  "i-slint-core/swrenderer",
+  "i-slint-backend-selector/renderer-software",
+]
 
 ## This feature is an alias for `backend-qt`
 renderer-qt = ["backend-qt"]
@@ -85,16 +97,16 @@ libm = ["i-slint-core/libm"]
 ## Slint uses internally some `thread_local` state.
 ##
 ## When the `std` feature is enabled, Slint can use [`std::thread_local!`], but when in a `#![no_std]`
-## environment, we need a replacement. Using this feature, Slint will just use static variable 
+## environment, we need a replacement. Using this feature, Slint will just use static variable
 ## disregarding Rust's Send and Sync safety
 ##
 ## **Safety** : You must ensure that there is only one single thread that call into the Slint API
 unsafe-single-threaded = ["i-slint-core/unsafe-single-threaded"]
 
 [dependencies]
-i-slint-core = { version = "=0.2.6", path="../../../internal/core", default-features = false }
+i-slint-core = { version = "=0.2.6", path = "../../../internal/core", default-features = false }
 slint-macros = { version = "=0.2.6", path = "../macros" }
-i-slint-backend-selector = { version = "=0.2.6", path="../../../internal/backends/selector" }
+i-slint-backend-selector = { version = "=0.2.6", path = "../../../internal/backends/selector" }
 
 const-field-offset = { version = "0.1.2", path = "../../../helper_crates/const-field-offset" }
 document-features = { version = "0.2.0", optional = true }
@@ -112,5 +124,10 @@ log = { version = "0.4.17", optional = true }
 slint-build = { path = "../build" }
 
 [package.metadata.docs.rs]
-rustdoc-args = [ "--html-in-header", "docs/resources/slint-docs-preview.html", "--html-in-header", "docs/resources/slint-docs-highlight.html" ]
+rustdoc-args = [
+  "--html-in-header",
+  "docs/resources/slint-docs-preview.html",
+  "--html-in-header",
+  "docs/resources/slint-docs-highlight.html",
+]
 features = ["document-features", "renderer-software"]

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -538,8 +538,8 @@ macro_rules! include_modules {
 ///
 /// By default, slint comes with a platform abstraction as part of the backend (winit or qt).
 /// You may want to write your own backend.
-/// To do so, you need to call [`platform::set_platform_abstraction()`] with your own
-/// implementation of the [`platform::PlatformAbstraction`] trait.
+/// To do so, you need to call [`platform::set_platform()`] with your own
+/// implementation of the [`platform::Platform`] trait.
 pub mod platform {
     pub use i_slint_core::platform::*;
 }

--- a/examples/mcu-board-support/pico_st7789.rs
+++ b/examples/mcu-board-support/pico_st7789.rs
@@ -58,7 +58,7 @@ pub type TargetPixel = Rgb565Pixel;
 
 pub fn init() {
     unsafe { ALLOCATOR.init(&mut HEAP as *const u8 as usize, core::mem::size_of_val(&HEAP)) }
-    slint::platform::set_platform_abstraction(Box::new(PicoBackend::default()))
+    slint::platform::set_platform(Box::new(PicoBackend::default()))
         .expect("backend already initialized");
 }
 
@@ -66,7 +66,7 @@ pub fn init() {
 struct PicoBackend {
     window: RefCell<Option<Rc<PicoWindow>>>,
 }
-impl slint::platform::PlatformAbstraction for PicoBackend {
+impl slint::platform::Platform for PicoBackend {
     fn create_window(&self) -> Rc<dyn slint::platform::PlatformWindow> {
         let window = Rc::new_cyclic(|self_weak: &Weak<PicoWindow>| PicoWindow {
             window: slint::Window::new(self_weak.clone()),

--- a/examples/mcu-board-support/stm32h735g.rs
+++ b/examples/mcu-board-support/stm32h735g.rs
@@ -41,7 +41,7 @@ static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
 
 pub fn init() {
     unsafe { ALLOCATOR.init(&mut HEAP as *const u8 as usize, core::mem::size_of_val(&HEAP)) }
-    slint::platform::set_platform_abstraction(Box::new(StmBackend::default()))
+    slint::platform::set_platform(Box::new(StmBackend::default()))
         .expect("backend already initialized");
 }
 
@@ -50,7 +50,7 @@ struct StmBackend {
     window: core::cell::RefCell<Option<Rc<StmWindow>>>,
     timer: once_cell::unsync::OnceCell<hal::timer::Timer<pac::TIM2>>,
 }
-impl slint::platform::PlatformAbstraction for StmBackend {
+impl slint::platform::Platform for StmBackend {
     fn create_window(&self) -> Rc<dyn slint::platform::PlatformWindow> {
         let window = Rc::new_cyclic(|self_weak: &Weak<StmWindow>| StmWindow {
             window: slint::Window::new(self_weak.clone()),

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -136,7 +136,7 @@ pub fn native_style_metrics_deinit(_: core::pin::Pin<&mut native_widgets::Native
 }
 
 pub struct Backend;
-impl i_slint_core::platform::PlatformAbstraction for Backend {
+impl i_slint_core::platform::Platform for Backend {
     fn create_window(&self) -> Rc<dyn i_slint_core::window::PlatformWindow> {
         #[cfg(no_qt)]
         panic!("The Qt backend needs Qt");

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -9,18 +9,18 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use core::pin::Pin;
-use i_slint_core::platform::PlatformAbstraction;
+use i_slint_core::platform::Platform;
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "i-slint-backend-qt", not(no_qt)))] {
         use i_slint_backend_qt as default_backend;
 
-        fn create_default_backend() -> Box<dyn PlatformAbstraction + 'static> {
+        fn create_default_backend() -> Box<dyn Platform + 'static> {
             Box::new(default_backend::Backend)
         }
     } else if #[cfg(feature = "i-slint-backend-winit")] {
         use i_slint_backend_winit as default_backend;
-        fn create_default_backend() -> Box<dyn PlatformAbstraction + 'static> {
+        fn create_default_backend() -> Box<dyn Platform + 'static> {
             Box::new(i_slint_backend_winit::Backend::new(None))
         }
     } else {
@@ -33,7 +33,7 @@ cfg_if::cfg_if! {
             all(feature = "i-slint-backend-qt", not(no_qt)),
             feature = "i-slint-backend-winit"
         ))] {
-        pub fn create_backend() -> Box<dyn PlatformAbstraction + 'static>  {
+        pub fn create_backend() -> Box<dyn Platform + 'static>  {
 
             let backend_config = std::env::var("SLINT_BACKEND").or_else(|_| {
                 let legacy_fallback = std::env::var("SIXTYFPS_BACKEND");
@@ -69,7 +69,7 @@ cfg_if::cfg_if! {
             native_widgets, Backend, NativeGlobals, NativeWidgets, HAS_NATIVE_STYLE,
         };
     } else {
-        pub fn create_backend() -> Box<dyn PlatformAbstraction + 'static> {
+        pub fn create_backend() -> Box<dyn Platform + 'static> {
             panic!("no default backend configured, the backend must be initialized manually")
         }
         pub type NativeWidgets = ();
@@ -83,7 +83,7 @@ cfg_if::cfg_if! {
 
 /// Run the callback with the platform abstraction.
 /// Create the backend if it does not exist yet
-pub fn with_platform_abstraction<R>(f: impl FnOnce(&dyn PlatformAbstraction) -> R) -> R {
+pub fn with_platform_abstraction<R>(f: impl FnOnce(&dyn Platform) -> R) -> R {
     i_slint_core::with_platform_abstraction(create_backend, f)
 }
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -18,7 +18,7 @@ pub struct TestingBackend {
     clipboard: Mutex<Option<String>>,
 }
 
-impl i_slint_core::platform::PlatformAbstraction for TestingBackend {
+impl i_slint_core::platform::Platform for TestingBackend {
     fn create_window(&self) -> Rc<dyn PlatformWindow> {
         Rc::new_cyclic(|self_weak| TestingWindow {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -143,6 +143,6 @@ impl Renderer for TestingWindow {
 /// Must be called before any call that would otherwise initialize the rendering backend.
 /// Calling it when the rendering backend is already initialized will have no effects
 pub fn init() {
-    i_slint_core::platform::set_platform_abstraction(Box::new(TestingBackend::default()))
+    i_slint_core::platform::set_platform(Box::new(TestingBackend::default()))
         .expect("platform already initialized");
 }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -142,7 +142,7 @@ impl Backend {
     }
 }
 
-impl i_slint_core::platform::PlatformAbstraction for Backend {
+impl i_slint_core::platform::Platform for Backend {
     fn create_window(&self) -> Rc<dyn PlatformWindow> {
         self.window_factory_fn.lock().unwrap()()
     }

--- a/internal/core/animations.rs
+++ b/internal/core/animations.rs
@@ -206,7 +206,7 @@ impl Instant {
     }
 
     fn duration_since_start() -> core::time::Duration {
-        crate::platform::PLAFTORM_ABSTRACTION_INSTANCE
+        crate::platform::PLATFORM_ABSTRACTION_INSTANCE
             .with(|p| p.get().map(|p| p.duration_since_start()))
             .unwrap_or_default()
     }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -82,7 +82,7 @@ impl<F: FnMut(RenderingState, &GraphicsAPI)> RenderingNotifier for F {
     }
 }
 
-/// This enum describes the different error scenarios that may occur when the applicaton
+/// This enum describes the different error scenarios that may occur when the application
 /// registers a rendering notifier on a [`crate::Window`](struct.Window.html).
 #[derive(Debug, Clone)]
 #[repr(C)]
@@ -133,7 +133,7 @@ impl Window {
     /// use slint::platform::PlatformWindow;
     /// use slint::Window;
     /// struct MyPlatformWindow {
-    ///     window: Window,  
+    ///     window: Window,
     ///     //...
     /// }
     /// impl PlatformWindow for MyPlatformWindow {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -122,7 +122,7 @@ impl Window {
     ///
     /// You only need to create the window yourself when you create a
     /// [`PlatformWindow`](crate::platform::PlatformWindow) from
-    /// [`PlatformAbstraction::create_window`](crate::platform::PlatformAbstraction::create_window)
+    /// [`Platform::create_window`](crate::platform::Platform::create_window)
     ///
     /// Since the platform window must own the Window, this function is meant to be used with
     /// [`Rc::new_cyclic`](alloc::rc::Rc::new_cyclic)

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -798,7 +798,7 @@ impl TextInput {
             return;
         }
         let text = self.text();
-        crate::platform::PLAFTORM_ABSTRACTION_INSTANCE.with(|p| {
+        crate::platform::PLATFORM_ABSTRACTION_INSTANCE.with(|p| {
             if let Some(backend) = p.get() {
                 backend.set_clipboard_text(&text[anchor..cursor]);
             }
@@ -806,7 +806,7 @@ impl TextInput {
     }
 
     fn paste(self: Pin<&Self>, platform_window: &Rc<dyn PlatformWindow>) {
-        if let Some(text) = crate::platform::PLAFTORM_ABSTRACTION_INSTANCE
+        if let Some(text) = crate::platform::PLATFORM_ABSTRACTION_INSTANCE
             .with(|p| p.get().and_then(|p| p.clipboard_text()))
         {
             self.insert(&text, platform_window);

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -89,7 +89,7 @@ pub fn with_platform_abstraction<R>(
     factory: impl FnOnce() -> alloc::boxed::Box<dyn PlatformAbstraction + 'static>,
     f: impl FnOnce(&dyn PlatformAbstraction) -> R,
 ) -> R {
-    platform::PLAFTORM_ABSTRACTION_INSTANCE.with(|p| match p.get() {
+    platform::PLATFORM_ABSTRACTION_INSTANCE.with(|p| match p.get() {
         Some(p) => f(&**p),
         None => {
             platform::set_platform(factory())

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -92,7 +92,7 @@ pub fn with_platform_abstraction<R>(
     platform::PLAFTORM_ABSTRACTION_INSTANCE.with(|p| match p.get() {
         Some(p) => f(&**p),
         None => {
-            platform::set_platform_abstraction(factory())
+            platform::set_platform(factory())
                 .expect("platform already initialized in another thread");
             f(&**p.get().unwrap())
         }

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -75,7 +75,7 @@ pub use graphics::RgbaColor;
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use graphics::PathData;
-use platform::PlatformAbstraction;
+use platform::Platform;
 
 #[cfg(not(slint_int_coord))]
 pub type Coord = f32;
@@ -86,8 +86,8 @@ pub type Coord = i32;
 /// The factory function is called if the platform abstraction is not yet
 /// initialized, and should be given by the platform_selector
 pub fn with_platform_abstraction<R>(
-    factory: impl FnOnce() -> alloc::boxed::Box<dyn PlatformAbstraction + 'static>,
-    f: impl FnOnce(&dyn PlatformAbstraction) -> R,
+    factory: impl FnOnce() -> alloc::boxed::Box<dyn Platform + 'static>,
+    f: impl FnOnce(&dyn Platform) -> R,
 ) -> R {
     platform::PLATFORM_ABSTRACTION_INSTANCE.with(|p| match p.get() {
         Some(p) => f(&**p),

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -106,7 +106,7 @@ impl std::convert::From<crate::animations::Instant> for instant::Instant {
 }
 
 thread_local! {
-    pub(crate) static PLAFTORM_ABSTRACTION_INSTANCE : once_cell::unsync::OnceCell<Box<dyn PlatformAbstraction>>
+    pub(crate) static PLATFORM_ABSTRACTION_INSTANCE : once_cell::unsync::OnceCell<Box<dyn PlatformAbstraction>>
         = once_cell::unsync::OnceCell::new()
 }
 static EVENTLOOP_PROXY: OnceCell<Box<dyn EventLoopProxy + 'static>> = OnceCell::new();
@@ -119,7 +119,7 @@ pub(crate) fn event_loop_proxy() -> Option<&'static dyn EventLoopProxy> {
 ///
 /// If the platform abastraction was already set this will return `Err`
 pub fn set_platform(platform: Box<dyn PlatformAbstraction + 'static>) -> Result<(), ()> {
-    PLAFTORM_ABSTRACTION_INSTANCE.with(|instance| {
+    PLATFORM_ABSTRACTION_INSTANCE.with(|instance| {
         if instance.get().is_some() {
             return Err(());
         }
@@ -150,7 +150,7 @@ pub fn update_timers_and_animations() {
 /// can be called to know if a window has running animation
 pub fn duration_until_next_timer_update() -> Option<core::time::Duration> {
     crate::timers::TimerList::next_timeout().map(|timeout| {
-        let duration_since_start = crate::platform::PLAFTORM_ABSTRACTION_INSTANCE
+        let duration_since_start = crate::platform::PLATFORM_ABSTRACTION_INSTANCE
             .with(|p| p.get().map(|p| p.duration_since_start()))
             .unwrap_or_default();
         core::time::Duration::from_millis(

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -118,9 +118,7 @@ pub(crate) fn event_loop_proxy() -> Option<&'static dyn EventLoopProxy> {
 /// Set the slint platform abstraction.
 ///
 /// If the platform abastraction was already set this will return `Err`
-pub fn set_platform_abstraction(
-    platform: Box<dyn PlatformAbstraction + 'static>,
-) -> Result<(), ()> {
+pub fn set_platform(platform: Box<dyn PlatformAbstraction + 'static>) -> Result<(), ()> {
     PLAFTORM_ABSTRACTION_INSTANCE.with(|instance| {
         if instance.get().is_some() {
             return Err(());

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -57,7 +57,7 @@ pub trait PlatformAbstraction {
     /// This is used by the animations and timer to compute the elapsed time.
     ///
     /// When the `std` feature is enabled, this function is implemented in terms of
-    /// [`std::time::Instant::now()`], but on `#![no_std]` platform, this funciton must
+    /// [`std::time::Instant::now()`], but on `#![no_std]` platform, this function must
     /// be implemented.
     fn duration_since_start(&self) -> core::time::Duration {
         #[cfg(feature = "std")]
@@ -117,7 +117,7 @@ pub(crate) fn event_loop_proxy() -> Option<&'static dyn EventLoopProxy> {
 
 /// Set the slint platform abstraction.
 ///
-/// If the platform abastraction was already set this will return `Err`
+/// If the platform abstraction was already set this will return `Err`
 pub fn set_platform(platform: Box<dyn PlatformAbstraction + 'static>) -> Result<(), ()> {
     PLATFORM_ABSTRACTION_INSTANCE.with(|instance| {
         if instance.get().is_some() {
@@ -141,7 +141,7 @@ pub fn update_timers_and_animations() {
 }
 
 /// Return the duration before the next timer should be activated. This is basically the
-/// maximum time before calling [`upate_timers_and_animation()`].
+/// maximum time before calling [`update_timers_and_animation()`].
 ///
 /// That is typically called by the implementation of the event loop to know how long the
 /// thread can go to sleep before the next event.

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -33,7 +33,7 @@ pub enum EventLoopQuitBehavior {
 }
 
 /// Interface implemented by back-ends
-pub trait PlatformAbstraction {
+pub trait Platform {
     /// Instantiate a window for a component.
     fn create_window(&self) -> Rc<dyn PlatformWindow>;
 
@@ -77,7 +77,7 @@ pub trait PlatformAbstraction {
     }
 }
 
-/// Trait that is returned by the [`PlatformAbstraction::new_event_loop_proxy`]
+/// Trait that is returned by the [`Platform::new_event_loop_proxy`]
 ///
 /// This are the implementation details for the function that may need to
 /// communicate with the eventloop from different thread
@@ -106,7 +106,7 @@ impl std::convert::From<crate::animations::Instant> for instant::Instant {
 }
 
 thread_local! {
-    pub(crate) static PLATFORM_ABSTRACTION_INSTANCE : once_cell::unsync::OnceCell<Box<dyn PlatformAbstraction>>
+    pub(crate) static PLATFORM_ABSTRACTION_INSTANCE : once_cell::unsync::OnceCell<Box<dyn Platform>>
         = once_cell::unsync::OnceCell::new()
 }
 static EVENTLOOP_PROXY: OnceCell<Box<dyn EventLoopProxy + 'static>> = OnceCell::new();
@@ -118,7 +118,7 @@ pub(crate) fn event_loop_proxy() -> Option<&'static dyn EventLoopProxy> {
 /// Set the slint platform abstraction.
 ///
 /// If the platform abstraction was already set this will return `Err`
-pub fn set_platform(platform: Box<dyn PlatformAbstraction + 'static>) -> Result<(), ()> {
+pub fn set_platform(platform: Box<dyn Platform + 'static>) -> Result<(), ()> {
     PLATFORM_ABSTRACTION_INSTANCE.with(|instance| {
         if instance.get().is_some() {
             return Err(());

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -677,7 +677,7 @@ impl WindowInner {
         }
     }
 
-    /// Returns the upgraded rlatform window.
+    /// Returns the upgraded platform window.
     pub fn platform_window(&self) -> Rc<dyn PlatformWindow> {
         self.platform_window_weak.upgrade().unwrap()
     }


### PR DESCRIPTION
Rename `set_platform_abstraction` to `set_platform` and `PlatformAbstraction` to `Platform`.

Fix some typos reported by cspell in follow up patches.

Fixes: #1503, #1536