### PR TITLE
Pr/api window adapter

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -135,7 +135,7 @@ fn gen_corelib(
     config.export.include = [
         "ComponentVTable",
         "Slice",
-        "PlatformWindowRcOpaque",
+        "WindowAdapterRcOpaque",
         "PropertyAnimation",
         "EasingCurve",
         "TextHorizontalAlignment",
@@ -189,7 +189,7 @@ fn gen_corelib(
         "slint_property_listener_scope_is_dirty",
         "PropertyTrackerOpaque",
         "CallbackOpaque",
-        "PlatformWindowRc",
+        "WindowAdapterRc",
         "VoidArg",
         "KeyEventArg",
         "PointerEventArg",
@@ -453,9 +453,9 @@ fn gen_corelib(
         .with_after_include(
             r"
 namespace slint {
-    namespace private_api { class PlatformWindowRc; }
+    namespace private_api { class WindowAdapterRc; }
     namespace cbindgen_private {
-        using slint::private_api::PlatformWindowRc;
+        using slint::private_api::WindowAdapterRc;
         using namespace vtable;
         struct KeyEvent; struct PointerEvent;
         using private_api::Property;

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -83,23 +83,23 @@ inline void assert_main_thread()
 #endif
 }
 
-class PlatformWindowRc
+class WindowAdapterRc
 {
 public:
-    explicit PlatformWindowRc(cbindgen_private::PlatformWindowRcOpaque adopted_inner)
+    explicit WindowAdapterRc(cbindgen_private::WindowAdapterRcOpaque adopted_inner)
         : inner(adopted_inner)
     {
     }
-    PlatformWindowRc() { cbindgen_private::slint_windowrc_init(&inner); }
-    ~PlatformWindowRc() { cbindgen_private::slint_windowrc_drop(&inner); }
-    PlatformWindowRc(const PlatformWindowRc &other)
+    WindowAdapterRc() { cbindgen_private::slint_windowrc_init(&inner); }
+    ~WindowAdapterRc() { cbindgen_private::slint_windowrc_drop(&inner); }
+    WindowAdapterRc(const WindowAdapterRc &other)
     {
         assert_main_thread();
         cbindgen_private::slint_windowrc_clone(&other.inner, &inner);
     }
-    PlatformWindowRc(PlatformWindowRc &&) = delete;
-    PlatformWindowRc &operator=(PlatformWindowRc &&) = delete;
-    PlatformWindowRc &operator=(const PlatformWindowRc &other)
+    WindowAdapterRc(WindowAdapterRc &&) = delete;
+    WindowAdapterRc &operator=(WindowAdapterRc &&) = delete;
+    WindowAdapterRc &operator=(const WindowAdapterRc &other)
     {
         assert_main_thread();
         if (this != &other) {
@@ -226,7 +226,7 @@ public:
     }
 
 private:
-    cbindgen_private::PlatformWindowRcOpaque inner;
+    cbindgen_private::WindowAdapterRcOpaque inner;
 };
 
 constexpr inline ItemTreeNode make_item_node(uint32_t child_count, uint32_t child_index,
@@ -374,7 +374,7 @@ public:
     /// \private
     /// Internal function used by the generated code to construct a new instance of this
     /// public API wrapper.
-    explicit Window(const private_api::PlatformWindowRc &windowrc) : inner(windowrc) { }
+    explicit Window(const private_api::WindowAdapterRc &windowrc) : inner(windowrc) { }
     Window(const Window &other) = delete;
     Window &operator=(const Window &other) = delete;
     Window(Window &&other) = delete;
@@ -432,12 +432,12 @@ public:
     void set_size(const slint::Size<unsigned int> &size) { inner.set_size(size); }
 
     /// \private
-    private_api::PlatformWindowRc &window_handle() { return inner; }
+    private_api::WindowAdapterRc &window_handle() { return inner; }
     /// \private
-    const private_api::PlatformWindowRc &window_handle() const { return inner; }
+    const private_api::WindowAdapterRc &window_handle() const { return inner; }
 
 private:
-    private_api::PlatformWindowRc inner;
+    private_api::WindowAdapterRc inner;
 };
 
 /// A Timer that can call a callback at repeated interval

--- a/api/cpp/include/slint_interpreter.h
+++ b/api/cpp/include/slint_interpreter.h
@@ -564,7 +564,7 @@ public:
     /// such as the position on the screen.
     const slint::Window &window()
     {
-        const cbindgen_private::PlatformWindowRcOpaque *win_ptr = nullptr;
+        const cbindgen_private::WindowAdapterRcOpaque *win_ptr = nullptr;
         cbindgen_private::slint_interpreter_component_instance_window(inner(), &win_ptr);
         return *reinterpret_cast<const slint::Window *>(win_ptr);
     }
@@ -582,10 +582,10 @@ public:
     /// it may return nullptr if the Qt backend is not used at runtime.
     QWidget *qwidget() const
     {
-        const cbindgen_private::PlatformWindowRcOpaque *win_ptr = nullptr;
+        const cbindgen_private::WindowAdapterRcOpaque *win_ptr = nullptr;
         cbindgen_private::slint_interpreter_component_instance_window(inner(), &win_ptr);
         auto wid = reinterpret_cast<QWidget *>(cbindgen_private::slint_qt_get_widget(
-                reinterpret_cast<const cbindgen_private::PlatformWindowRc *>(win_ptr)));
+                reinterpret_cast<const cbindgen_private::WindowAdapterRc *>(win_ptr)));
         return wid;
     }
 #endif
@@ -1010,10 +1010,10 @@ inline void send_keyboard_string_sequence(const slint::interpreter::ComponentIns
                                           const slint::SharedString &str,
                                           KeyboardModifiers modifiers = {})
 {
-    const cbindgen_private::PlatformWindowRcOpaque *win_ptr = nullptr;
+    const cbindgen_private::WindowAdapterRcOpaque *win_ptr = nullptr;
     cbindgen_private::slint_interpreter_component_instance_window(
             reinterpret_cast<const cbindgen_private::ErasedComponentBox *>(component), &win_ptr);
     cbindgen_private::send_keyboard_string_sequence(
-            &str, modifiers, reinterpret_cast<const cbindgen_private::PlatformWindowRc *>(win_ptr));
+            &str, modifiers, reinterpret_cast<const cbindgen_private::WindowAdapterRc *>(win_ptr));
 }
 }

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) {
         core::mem::size_of::<Rc<dyn WindowAdapter>>(),
         core::mem::size_of::<WindowAdapterRcOpaque>()
     );
-    let win = i_slint_backend_selector::with_platform_abstraction(|b| b.create_window());
+    let win = i_slint_backend_selector::with_platform_abstraction(|b| b.create_window_adapter());
     core::ptr::write(out as *mut Rc<dyn WindowAdapter>, win);
 }
 

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -4,7 +4,7 @@
 /*! This crate just expose the function used by the C++ integration */
 
 use core::ffi::c_void;
-use i_slint_core::window::{ffi::PlatformWindowRcOpaque, PlatformWindow};
+use i_slint_core::window::{ffi::WindowAdapterRcOpaque, WindowAdapter};
 use std::rc::Rc;
 
 #[doc(hidden)]
@@ -17,13 +17,13 @@ pub fn use_modules() -> usize {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn slint_windowrc_init(out: *mut PlatformWindowRcOpaque) {
+pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) {
     assert_eq!(
-        core::mem::size_of::<Rc<dyn PlatformWindow>>(),
-        core::mem::size_of::<PlatformWindowRcOpaque>()
+        core::mem::size_of::<Rc<dyn WindowAdapter>>(),
+        core::mem::size_of::<WindowAdapterRcOpaque>()
     );
     let win = i_slint_backend_selector::with_platform_abstraction(|b| b.create_window());
-    core::ptr::write(out as *mut Rc<dyn PlatformWindow>, win);
+    core::ptr::write(out as *mut Rc<dyn WindowAdapter>, win);
 }
 
 #[no_mangle]
@@ -67,16 +67,14 @@ pub unsafe extern "C" fn slint_quit_event_loop() {
 
 #[no_mangle]
 pub unsafe extern "C" fn slint_register_font_from_path(
-    win: *const PlatformWindowRcOpaque,
+    win: *const WindowAdapterRcOpaque,
     path: &i_slint_core::SharedString,
     error_str: *mut i_slint_core::SharedString,
 ) {
-    let platform_window = &*(win as *const Rc<dyn PlatformWindow>);
+    let window_adapter = &*(win as *const Rc<dyn WindowAdapter>);
     core::ptr::write(
         error_str,
-        match platform_window
-            .renderer()
-            .register_font_from_path(std::path::Path::new(path.as_str()))
+        match window_adapter.renderer().register_font_from_path(std::path::Path::new(path.as_str()))
         {
             Ok(()) => Default::default(),
             Err(err) => err.to_string().into(),
@@ -86,14 +84,14 @@ pub unsafe extern "C" fn slint_register_font_from_path(
 
 #[no_mangle]
 pub unsafe extern "C" fn slint_register_font_from_data(
-    win: *const PlatformWindowRcOpaque,
+    win: *const WindowAdapterRcOpaque,
     data: i_slint_core::slice::Slice<'static, u8>,
     error_str: *mut i_slint_core::SharedString,
 ) {
-    let platform_window = &*(win as *const Rc<dyn PlatformWindow>);
+    let window_adapter = &*(win as *const Rc<dyn WindowAdapter>);
     core::ptr::write(
         error_str,
-        match platform_window.renderer().register_font_from_memory(data.as_slice()) {
+        match window_adapter.renderer().register_font_from_memory(data.as_slice()) {
             Ok(()) => Default::default(),
             Err(err) => err.to_string().into(),
         },

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -22,13 +22,13 @@ pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) {
         core::mem::size_of::<Rc<dyn WindowAdapter>>(),
         core::mem::size_of::<WindowAdapterRcOpaque>()
     );
-    let win = i_slint_backend_selector::with_platform_abstraction(|b| b.create_window_adapter());
+    let win = i_slint_backend_selector::with_platform(|b| b.create_window_adapter());
     core::ptr::write(out as *mut Rc<dyn WindowAdapter>, win);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn slint_run_event_loop() {
-    i_slint_backend_selector::with_platform_abstraction(|b| {
+    i_slint_backend_selector::with_platform(|b| {
         b.run_event_loop(i_slint_core::platform::EventLoopQuitBehavior::QuitOnLastWindowClosed)
     });
 }

--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -15,7 +15,7 @@ mod persistent_context;
 
 struct WrappedComponentType(Option<slint_interpreter::ComponentDefinition>);
 struct WrappedComponentRc(Option<slint_interpreter::ComponentInstance>);
-struct WrappedWindow(Option<std::rc::Rc<dyn i_slint_core::window::PlatformWindow>>);
+struct WrappedWindow(Option<std::rc::Rc<dyn i_slint_core::window::WindowAdapter>>);
 
 /// We need to do some gymnastic with closures to pass the ExecuteContext with the right lifetime
 type GlobalContextCallback<'c> =
@@ -352,9 +352,9 @@ declare_types! {
             let this = cx.this();
             let component = cx.borrow(&this, |x| x.0.as_ref().map(|c| c.clone_strong()));
             let component = component.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
-            let platform_window = component.window().window_handle().platform_window();
+            let window_adapter = component.window().window_handle().window_adapter();
             let mut obj = SlintWindow::new::<_, JsValue, _>(&mut cx, std::iter::empty())?;
-            cx.borrow_mut(&mut obj, |mut obj| obj.0 = Some(platform_window));
+            cx.borrow_mut(&mut obj, |mut obj| obj.0 = Some(window_adapter));
             Ok(obj.as_value(&mut cx))
         }
         method get_property(mut cx) {
@@ -534,9 +534,9 @@ declare_types! {
 
         method get_size(mut cx) {
             let this = cx.this();
-            let platform_window = cx.borrow(&this, |x| x.0.as_ref().cloned());
-            let platform_window = platform_window.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
-            let size = platform_window.window().size();
+            let window_adapter = cx.borrow(&this, |x| x.0.as_ref().cloned());
+            let window_adapter = window_adapter.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
+            let size = window_adapter.window().size();
 
             let size_object = JsObject::new(&mut cx);
             let width_value = JsNumber::new(&mut cx, size.width).as_value(&mut cx);
@@ -548,9 +548,9 @@ declare_types! {
 
         method set_size(mut cx) {
             let this = cx.this();
-            let platform_window = cx.borrow(&this, |x| x.0.as_ref().cloned());
-            let platform_window = platform_window.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
-            let window = platform_window.window();
+            let window_adapter = cx.borrow(&this, |x| x.0.as_ref().cloned());
+            let window_adapter = window_adapter.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
+            let window = window_adapter.window();
 
             let size_object = cx.argument::<JsObject>(0)?;
             let width = size_object.get(&mut cx, "width")?.downcast_or_throw::<JsNumber, _>(&mut cx)?.value();

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -436,14 +436,14 @@ pub mod internal {
 /// Creates a new window to render components in.
 #[doc(hidden)]
 pub fn create_window_adapter() -> alloc::rc::Rc<dyn re_exports::WindowAdapter> {
-    i_slint_backend_selector::with_platform_abstraction(|b| b.create_window_adapter())
+    i_slint_backend_selector::with_platform(|b| b.create_window_adapter())
 }
 
 /// Enters the main event loop. This is necessary in order to receive
 /// events from the windowing system in order to render to the screen
 /// and react to user input.
 pub fn run_event_loop() {
-    i_slint_backend_selector::with_platform_abstraction(|b| {
+    i_slint_backend_selector::with_platform(|b| {
         b.run_event_loop(i_slint_core::platform::EventLoopQuitBehavior::QuitOnLastWindowClosed)
     })
 }

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -435,8 +435,8 @@ pub mod internal {
 
 /// Creates a new window to render components in.
 #[doc(hidden)]
-pub fn create_window() -> alloc::rc::Rc<dyn re_exports::WindowAdapter> {
-    i_slint_backend_selector::with_platform_abstraction(|b| b.create_window())
+pub fn create_window_adapter() -> alloc::rc::Rc<dyn re_exports::WindowAdapter> {
+    i_slint_backend_selector::with_platform_abstraction(|b| b.create_window_adapter())
 }
 
 /// Enters the main event loop. This is necessary in order to receive

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -284,7 +284,7 @@ pub mod re_exports {
     pub use i_slint_core::model::*;
     pub use i_slint_core::properties::{set_state_binding, Property, PropertyTracker, StateInfo};
     pub use i_slint_core::slice::Slice;
-    pub use i_slint_core::window::{PlatformWindow, WindowHandleAccess, WindowInner};
+    pub use i_slint_core::window::{WindowAdapter, WindowHandleAccess, WindowInner};
     pub use i_slint_core::Color;
     pub use i_slint_core::ComponentVTable_static;
     pub use i_slint_core::Coord;
@@ -435,7 +435,7 @@ pub mod internal {
 
 /// Creates a new window to render components in.
 #[doc(hidden)]
-pub fn create_window() -> alloc::rc::Rc<dyn re_exports::PlatformWindow> {
+pub fn create_window() -> alloc::rc::Rc<dyn re_exports::WindowAdapter> {
     i_slint_backend_selector::with_platform_abstraction(|b| b.create_window())
 }
 
@@ -474,7 +474,7 @@ pub mod testing {
             &dyn_rc,
             x,
             y,
-            &rc.window_handle().platform_window(),
+            &rc.window_handle().window_adapter(),
         );
     }
 
@@ -503,7 +503,7 @@ pub mod testing {
         i_slint_core::tests::send_keyboard_string_sequence(
             &super::SharedString::from(sequence),
             KEYBOARD_MODIFIERS.with(|x| x.get()),
-            &component.window_handle().platform_window(),
+            &component.window_handle().window_adapter(),
         )
     }
 

--- a/examples/mcu-board-support/pico_st7789.rs
+++ b/examples/mcu-board-support/pico_st7789.rs
@@ -67,7 +67,7 @@ struct PicoBackend {
     window: RefCell<Option<Rc<PicoWindow>>>,
 }
 impl slint::platform::Platform for PicoBackend {
-    fn create_window(&self) -> Rc<dyn slint::platform::PlatformWindow> {
+    fn create_window(&self) -> Rc<dyn slint::platform::WindowAdapter> {
         let window = Rc::new_cyclic(|self_weak: &Weak<PicoWindow>| PicoWindow {
             window: slint::Window::new(self_weak.clone()),
             renderer: renderer::SoftwareRenderer::new(self_weak.clone()),
@@ -285,7 +285,7 @@ struct PicoWindow {
     needs_redraw: Cell<bool>,
 }
 
-impl slint::platform::PlatformWindow for PicoWindow {
+impl slint::platform::WindowAdapter for PicoWindow {
     fn show(&self) {
         self.window.set_size(DISPLAY_SIZE.cast());
     }

--- a/examples/mcu-board-support/pico_st7789.rs
+++ b/examples/mcu-board-support/pico_st7789.rs
@@ -67,7 +67,7 @@ struct PicoBackend {
     window: RefCell<Option<Rc<PicoWindow>>>,
 }
 impl slint::platform::Platform for PicoBackend {
-    fn create_window(&self) -> Rc<dyn slint::platform::WindowAdapter> {
+    fn create_window_adapter(&self) -> Rc<dyn slint::platform::WindowAdapter> {
         let window = Rc::new_cyclic(|self_weak: &Weak<PicoWindow>| PicoWindow {
             window: slint::Window::new(self_weak.clone()),
             renderer: renderer::SoftwareRenderer::new(self_weak.clone()),

--- a/examples/mcu-board-support/stm32h735g.rs
+++ b/examples/mcu-board-support/stm32h735g.rs
@@ -51,7 +51,7 @@ struct StmBackend {
     timer: once_cell::unsync::OnceCell<hal::timer::Timer<pac::TIM2>>,
 }
 impl slint::platform::Platform for StmBackend {
-    fn create_window(&self) -> Rc<dyn slint::platform::WindowAdapter> {
+    fn create_window_adapter(&self) -> Rc<dyn slint::platform::WindowAdapter> {
         let window = Rc::new_cyclic(|self_weak: &Weak<StmWindow>| StmWindow {
             window: slint::Window::new(self_weak.clone()),
             renderer: swrenderer::SoftwareRenderer::new(self_weak.clone()),

--- a/examples/mcu-board-support/stm32h735g.rs
+++ b/examples/mcu-board-support/stm32h735g.rs
@@ -51,7 +51,7 @@ struct StmBackend {
     timer: once_cell::unsync::OnceCell<hal::timer::Timer<pac::TIM2>>,
 }
 impl slint::platform::Platform for StmBackend {
-    fn create_window(&self) -> Rc<dyn slint::platform::PlatformWindow> {
+    fn create_window(&self) -> Rc<dyn slint::platform::WindowAdapter> {
         let window = Rc::new_cyclic(|self_weak: &Weak<StmWindow>| StmWindow {
             window: slint::Window::new(self_weak.clone()),
             renderer: swrenderer::SoftwareRenderer::new(self_weak.clone()),
@@ -372,7 +372,7 @@ struct StmWindow {
     needs_redraw: core::cell::Cell<bool>,
 }
 
-impl slint::platform::PlatformWindow for StmWindow {
+impl slint::platform::WindowAdapter for StmWindow {
     fn show(&self) {
         self.window.set_size((DISPLAY_WIDTH as u32, DISPLAY_HEIGHT as u32).into());
     }

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -137,7 +137,7 @@ pub fn native_style_metrics_deinit(_: core::pin::Pin<&mut native_widgets::Native
 
 pub struct Backend;
 impl i_slint_core::platform::Platform for Backend {
-    fn create_window(&self) -> Rc<dyn i_slint_core::window::WindowAdapter> {
+    fn create_window_adapter(&self) -> Rc<dyn i_slint_core::window::WindowAdapter> {
         #[cfg(no_qt)]
         panic!("The Qt backend needs Qt");
         #[cfg(not(no_qt))]

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -40,7 +40,7 @@ pub fn use_modules() -> usize {
 mod ffi {
     #[no_mangle]
     pub extern "C" fn slint_qt_get_widget(
-        _: &i_slint_core::window::PlatformWindowRc,
+        _: &i_slint_core::window::WindowAdapterRc,
     ) -> *mut std::ffi::c_void {
         std::ptr::null_mut()
     }
@@ -137,7 +137,7 @@ pub fn native_style_metrics_deinit(_: core::pin::Pin<&mut native_widgets::Native
 
 pub struct Backend;
 impl i_slint_core::platform::Platform for Backend {
-    fn create_window(&self) -> Rc<dyn i_slint_core::window::PlatformWindow> {
+    fn create_window(&self) -> Rc<dyn i_slint_core::window::WindowAdapter> {
         #[cfg(no_qt)]
         panic!("The Qt backend needs Qt");
         #[cfg(not(no_qt))]

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -31,7 +31,7 @@ use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, RenderingResult,
 use i_slint_core::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
-use i_slint_core::window::{PlatformWindow, PlatformWindowRc, WindowHandleAccess};
+use i_slint_core::window::{WindowAdapter, WindowAdapterRc, WindowHandleAccess};
 use i_slint_core::{
     declare_item_vtable, Callback, ItemVTable_static, Property, SharedString, SharedVector,
 };

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -188,7 +188,7 @@ impl NativeButton {
 }
 
 impl Item for NativeButton {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -197,7 +197,7 @@ impl Item for NativeButton {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let standard_button_kind = self.actual_standard_button_kind();
         let mut text: qttypes::QString = self.actual_text(standard_button_kind);
@@ -233,7 +233,7 @@ impl Item for NativeButton {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -242,7 +242,7 @@ impl Item for NativeButton {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -275,7 +275,7 @@ impl Item for NativeButton {
     fn key_event(
         self: Pin<&Self>,
         event: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         match event.event_type {
             KeyEventType::KeyPressed if event.text == " " || event.text == "\n" => {
@@ -294,7 +294,7 @@ impl Item for NativeButton {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         if self.enabled() {
             Self::FIELD_OFFSETS

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -22,7 +22,7 @@ pub struct NativeCheckBox {
 }
 
 impl Item for NativeCheckBox {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -31,7 +31,7 @@ impl Item for NativeCheckBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.text().as_str().into();
         let size = cpp!(unsafe [
@@ -58,7 +58,7 @@ impl Item for NativeCheckBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -67,7 +67,7 @@ impl Item for NativeCheckBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         if !self.enabled() {
@@ -85,7 +85,7 @@ impl Item for NativeCheckBox {
     fn key_event(
         self: Pin<&Self>,
         event: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         match event.event_type {
             KeyEventType::KeyPressed if event.text == " " || event.text == "\n" => {
@@ -101,7 +101,7 @@ impl Item for NativeCheckBox {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         if self.enabled() {
             Self::FIELD_OFFSETS

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -22,7 +22,7 @@ pub struct NativeComboBox {
 }
 
 impl Item for NativeComboBox {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -31,7 +31,7 @@ impl Item for NativeComboBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let size = cpp!(unsafe [] -> qttypes::QSize as "QSize" {
             ensure_initialized();
@@ -53,7 +53,7 @@ impl Item for NativeComboBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -62,7 +62,7 @@ impl Item for NativeComboBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -95,7 +95,7 @@ impl Item for NativeComboBox {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -103,7 +103,7 @@ impl Item for NativeComboBox {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -171,7 +171,7 @@ pub struct NativeComboBoxPopup {
 }
 
 impl Item for NativeComboBoxPopup {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -180,7 +180,7 @@ impl Item for NativeComboBoxPopup {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         Default::default()
     }
@@ -188,7 +188,7 @@ impl Item for NativeComboBoxPopup {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -197,7 +197,7 @@ impl Item for NativeComboBoxPopup {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -206,7 +206,7 @@ impl Item for NativeComboBoxPopup {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -214,7 +214,7 @@ impl Item for NativeComboBoxPopup {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -62,7 +62,7 @@ fn minimum_group_box_size(title: qttypes::QString) -> qttypes::QSize {
 }
 
 impl Item for NativeGroupBox {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {
         let shared_data = Rc::pin(GroupBoxData::default());
 
         Property::link_two_way(
@@ -146,7 +146,7 @@ impl Item for NativeGroupBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
 
@@ -165,7 +165,7 @@ impl Item for NativeGroupBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -174,7 +174,7 @@ impl Item for NativeGroupBox {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -183,7 +183,7 @@ impl Item for NativeGroupBox {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -191,7 +191,7 @@ impl Item for NativeGroupBox {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -25,7 +25,7 @@ pub struct NativeLineEdit {
 }
 
 impl Item for NativeLineEdit {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {
         let paddings = Rc::pin(Property::default());
 
         paddings.as_ref().set_binding(move || {
@@ -76,7 +76,7 @@ impl Item for NativeLineEdit {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo {
             min: match orientation {
@@ -91,7 +91,7 @@ impl Item for NativeLineEdit {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -100,7 +100,7 @@ impl Item for NativeLineEdit {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -109,7 +109,7 @@ impl Item for NativeLineEdit {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -117,7 +117,7 @@ impl Item for NativeLineEdit {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -21,7 +21,7 @@ pub struct NativeStandardListViewItem {
 }
 
 impl Item for NativeStandardListViewItem {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -30,7 +30,7 @@ impl Item for NativeStandardListViewItem {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let index: i32 = self.index();
         let item = self.item();
@@ -64,7 +64,7 @@ impl Item for NativeStandardListViewItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -73,7 +73,7 @@ impl Item for NativeStandardListViewItem {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -82,7 +82,7 @@ impl Item for NativeStandardListViewItem {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -90,7 +90,7 @@ impl Item for NativeStandardListViewItem {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -30,7 +30,7 @@ pub struct NativeScrollView {
 }
 
 impl Item for NativeScrollView {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {
         let paddings = Rc::pin(Property::default());
 
         paddings.as_ref().set_binding(move || {
@@ -88,7 +88,7 @@ impl Item for NativeScrollView {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo {
             min: match orientation {
@@ -103,7 +103,7 @@ impl Item for NativeScrollView {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -112,7 +112,7 @@ impl Item for NativeScrollView {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -259,7 +259,7 @@ impl Item for NativeScrollView {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -267,7 +267,7 @@ impl Item for NativeScrollView {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -57,7 +57,7 @@ void initQSliderOptions(QStyleOptionSlider &option, bool pressed, bool enabled, 
 }}
 
 impl Item for NativeSlider {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -66,7 +66,7 @@ impl Item for NativeSlider {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let enabled = self.enabled();
         let value = self.value() as i32;
@@ -106,7 +106,7 @@ impl Item for NativeSlider {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -115,7 +115,7 @@ impl Item for NativeSlider {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -197,7 +197,7 @@ impl Item for NativeSlider {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -205,7 +205,7 @@ impl Item for NativeSlider {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -54,7 +54,7 @@ option.frame = true;
 }}
 
 impl Item for NativeSpinBox {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -63,7 +63,7 @@ impl Item for NativeSpinBox {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         //let value: i32 = self.value();
         let data = self.data();
@@ -108,7 +108,7 @@ impl Item for NativeSpinBox {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -117,7 +117,7 @@ impl Item for NativeSpinBox {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &Rc<dyn PlatformWindow>,
+        window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let size: qttypes::QSize = get_size!(self);
@@ -188,7 +188,7 @@ impl Item for NativeSpinBox {
 
         if let MouseEvent::Pressed { .. } = event {
             if !self.has_focus() {
-                platform_window.window().window_handle().set_focus_item(self_rc);
+                window_adapter.window().window_handle().set_focus_item(self_rc);
             }
         }
         InputEventResult::EventAccepted
@@ -197,7 +197,7 @@ impl Item for NativeSpinBox {
     fn key_event(
         self: Pin<&Self>,
         event: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         if !self.enabled() || event.event_type != KeyEventType::KeyPressed {
             return KeyEventResult::EventIgnored;
@@ -220,7 +220,7 @@ impl Item for NativeSpinBox {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         match event {
             FocusEvent::FocusIn => {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -35,7 +35,7 @@ pub struct NativeTabWidget {
 }
 
 impl Item for NativeTabWidget {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {
         #[derive(Default, Clone)]
         #[repr(C)]
         struct TabWidgetMetrics {
@@ -171,7 +171,7 @@ impl Item for NativeTabWidget {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let (content_size, tabbar_size) = match orientation {
             Orientation::Horizontal => (
@@ -227,7 +227,7 @@ impl Item for NativeTabWidget {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -236,7 +236,7 @@ impl Item for NativeTabWidget {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -245,7 +245,7 @@ impl Item for NativeTabWidget {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -253,7 +253,7 @@ impl Item for NativeTabWidget {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -336,7 +336,7 @@ pub struct NativeTab {
 }
 
 impl Item for NativeTab {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -345,7 +345,7 @@ impl Item for NativeTab {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
         let icon: qttypes::QPixmap =
@@ -394,7 +394,7 @@ impl Item for NativeTab {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -403,7 +403,7 @@ impl Item for NativeTab {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &Rc<dyn PlatformWindow>,
+        window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
         let enabled = self.enabled();
@@ -429,7 +429,7 @@ impl Item for NativeTab {
         if matches!(event, MouseEvent::Released { .. } if !click_on_press)
             || matches!(event, MouseEvent::Pressed { .. } if click_on_press)
         {
-            platform_window.window().window_handle().set_focus_item(self_rc);
+            window_adapter.window().window_handle().set_focus_item(self_rc);
             self.current.set(self.tab_index());
             InputEventResult::EventAccepted
         } else {
@@ -440,7 +440,7 @@ impl Item for NativeTab {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -448,7 +448,7 @@ impl Item for NativeTab {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -83,8 +83,8 @@ cfg_if::cfg_if! {
 
 /// Run the callback with the platform abstraction.
 /// Create the backend if it does not exist yet
-pub fn with_platform_abstraction<R>(f: impl FnOnce(&dyn Platform) -> R) -> R {
-    i_slint_core::with_platform_abstraction(create_backend, f)
+pub fn with_platform(f: impl FnOnce(&dyn Platform) -> R) -> R {
+    i_slint_core::with_platform(create_backend, f)
 }
 
 #[doc(hidden)]

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -83,7 +83,7 @@ cfg_if::cfg_if! {
 
 /// Run the callback with the platform abstraction.
 /// Create the backend if it does not exist yet
-pub fn with_platform(f: impl FnOnce(&dyn Platform) -> R) -> R {
+pub fn with_platform<R>(f: impl FnOnce(&dyn Platform) -> R) -> R {
     i_slint_core::with_platform(create_backend, f)
 }
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -8,7 +8,7 @@ use i_slint_core::api::euclid;
 use i_slint_core::api::PhysicalPx;
 use i_slint_core::graphics::{Point, Rect, Size};
 use i_slint_core::renderer::Renderer;
-use i_slint_core::window::PlatformWindow;
+use i_slint_core::window::WindowAdapter;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Mutex;
@@ -19,7 +19,7 @@ pub struct TestingBackend {
 }
 
 impl i_slint_core::platform::Platform for TestingBackend {
-    fn create_window(&self) -> Rc<dyn PlatformWindow> {
+    fn create_window(&self) -> Rc<dyn WindowAdapter> {
         Rc::new_cyclic(|self_weak| TestingWindow {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),
         })
@@ -43,7 +43,7 @@ pub struct TestingWindow {
     window: i_slint_core::api::Window,
 }
 
-impl PlatformWindow for TestingWindow {
+impl WindowAdapter for TestingWindow {
     fn show(&self) {
         unimplemented!("showing a testing window")
     }

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -19,7 +19,7 @@ pub struct TestingBackend {
 }
 
 impl i_slint_core::platform::Platform for TestingBackend {
-    fn create_window(&self) -> Rc<dyn WindowAdapter> {
+    fn create_window_adapter(&self) -> Rc<dyn WindowAdapter> {
         Rc::new_cyclic(|self_weak| TestingWindow {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),
         })

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs)]
 /*!
     This module contains the event loop implementation using winit, as well as the
-    [PlatformWindow] trait used by the generated code and the run-time to change
+    [WindowAdapter] trait used by the generated code and the run-time to change
     aspects of windows on the screen.
 */
 use copypasta::ClipboardProvider;
@@ -24,7 +24,7 @@ use winit::event::WindowEvent;
 #[cfg(not(target_arch = "wasm32"))]
 use winit::platform::run_return::EventLoopExtRunReturn;
 
-pub trait WinitWindow: PlatformWindow {
+pub trait WinitWindow: WindowAdapter {
     fn currently_pressed_key_code(&self) -> &Cell<Option<winit::event::VirtualKeyCode>>;
     fn current_keyboard_modifiers(&self) -> &Cell<KeyboardModifiers>;
     fn draw(&self);

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -17,13 +17,13 @@ use corelib::component::ComponentRc;
 use corelib::input::KeyboardModifiers;
 use corelib::items::{ItemRef, MouseCursor};
 use corelib::layout::Orientation;
-use corelib::window::{PlatformWindow, WindowHandleAccess};
+use corelib::window::{WindowAdapter, WindowHandleAccess};
 use corelib::Property;
 use corelib::{graphics::*, Coord};
 use i_slint_core as corelib;
 use winit::dpi::LogicalSize;
 
-/// GraphicsWindow is an implementation of the [PlatformWindow][`crate::eventloop::PlatformWindow`] trait. This is
+/// GraphicsWindow is an implementation of the [WindowAdapter][`crate::eventloopMyWindowAdapter`] trait. This is
 /// typically instantiated by entry factory functions of the different graphics back ends.
 pub(crate) struct GLWindow<Renderer: WinitCompatibleRenderer + 'static> {
     window: corelib::api::Window,
@@ -45,7 +45,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> GLWindow<Renderer> {
     /// * `graphics_backend_factory`: The factor function stored in the GraphicsWindow that's called when the state
     ///   of the window changes to mapped. The event loop and window builder parameters can be used to create a
     ///   backing window.
-    pub(crate) fn new(#[cfg(target_arch = "wasm32")] canvas_id: String) -> Rc<dyn PlatformWindow> {
+    pub(crate) fn new(#[cfg(target_arch = "wasm32")] canvas_id: String) -> Rc<dyn WindowAdapter> {
         let self_rc = Rc::new_cyclic(|self_weak| Self {
             window: corelib::api::Window::new(self_weak.clone() as _),
             self_weak: self_weak.clone(),
@@ -210,7 +210,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Rende
     }
 }
 
-impl<Renderer: WinitCompatibleRenderer + 'static> PlatformWindow for GLWindow<Renderer> {
+impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapter for GLWindow<Renderer> {
     fn request_redraw(&self) {
         self.with_window_handle(&mut |window| window.request_redraw())
     }

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -23,7 +23,7 @@ use corelib::{graphics::*, Coord};
 use i_slint_core as corelib;
 use winit::dpi::LogicalSize;
 
-/// GraphicsWindow is an implementation of the [WindowAdapter][`crate::eventloopMyWindowAdapter`] trait. This is
+/// GraphicsWindow is an implementation of the [WindowAdapter][`crate::eventloop::WindowAdapter`] trait. This is
 /// typically instantiated by entry factory functions of the different graphics back ends.
 pub(crate) struct GLWindow<Renderer: WinitCompatibleRenderer + 'static> {
     window: corelib::api::Window,

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -143,7 +143,7 @@ impl Backend {
 }
 
 impl i_slint_core::platform::Platform for Backend {
-    fn create_window(&self) -> Rc<dyn WindowAdapter> {
+    fn create_window_adapter(&self) -> Rc<dyn WindowAdapter> {
         self.window_factory_fn.lock().unwrap()()
     }
 

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -12,7 +12,7 @@ extern crate alloc;
 use std::rc::Rc;
 use std::sync::Mutex;
 
-use i_slint_core::window::PlatformWindow;
+use i_slint_core::window::WindowAdapter;
 
 mod glwindow;
 use glwindow::*;
@@ -22,7 +22,7 @@ pub(crate) mod event_loop;
 mod renderer {
     use std::rc::Weak;
 
-    use i_slint_core::window::PlatformWindow;
+    use i_slint_core::window::WindowAdapter;
 
     mod boxshadowcache;
 
@@ -30,14 +30,14 @@ mod renderer {
         type Canvas: WinitCompatibleCanvas;
 
         fn new(
-            platform_window_weak: &Weak<dyn PlatformWindow>,
+            window_adapter_weak: &Weak<dyn WindowAdapter>,
             #[cfg(target_arch = "wasm32")] canvas_id: String,
         ) -> Self;
 
         fn create_canvas(&self, window_builder: winit::window::WindowBuilder) -> Self::Canvas;
         fn release_canvas(&self, canvas: Self::Canvas);
 
-        fn render(&self, canvas: &Self::Canvas, window: &dyn PlatformWindow);
+        fn render(&self, canvas: &Self::Canvas, window: &dyn WindowAdapter);
     }
 
     pub(crate) trait WinitCompatibleCanvas {
@@ -66,7 +66,7 @@ pub(crate) mod wasm_input_helper;
 mod stylemetrics;
 
 #[cfg(target_arch = "wasm32")]
-pub fn create_gl_window_with_canvas_id(canvas_id: String) -> Rc<dyn PlatformWindow> {
+pub fn create_gl_window_with_canvas_id(canvas_id: String) -> Rc<dyn WindowAdapter> {
     GLWindow::<crate::renderer::femtovg::FemtoVGRenderer>::new(canvas_id)
 }
 
@@ -87,7 +87,7 @@ pub use stylemetrics::native_style_metrics_deinit;
 pub use stylemetrics::native_style_metrics_init;
 
 pub struct Backend {
-    window_factory_fn: Mutex<Box<dyn Fn() -> Rc<dyn PlatformWindow> + Send>>,
+    window_factory_fn: Mutex<Box<dyn Fn() -> Rc<dyn WindowAdapter> + Send>>,
 }
 
 impl Backend {
@@ -143,7 +143,7 @@ impl Backend {
 }
 
 impl i_slint_core::platform::Platform for Backend {
-    fn create_window(&self) -> Rc<dyn PlatformWindow> {
+    fn create_window(&self) -> Rc<dyn WindowAdapter> {
         self.window_factory_fn.lock().unwrap()()
     }
 

--- a/internal/backends/winit/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/winit/renderer/femtovg/itemrenderer.rs
@@ -283,7 +283,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
 
         let font = fonts::FONT_CACHE.with(|cache| {
             cache.borrow_mut().font(
-                text_input.font_request(&self.window.window_handle().platform_window()),
+                text_input.font_request(&self.window.window_handle().window_adapter()),
                 self.scale_factor,
                 &text_input.text(),
             )

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -7,7 +7,7 @@ use super::WinitCompatibleCanvas;
 use i_slint_core::graphics::Rgb8Pixel;
 use i_slint_core::lengths::PhysicalLength;
 pub use i_slint_core::swrenderer::SoftwareRenderer;
-use i_slint_core::window::{WindowAdapter, WindowHandleAccess};
+use i_slint_core::window::WindowAdapter;
 use std::cell::RefCell;
 use std::rc::Weak;
 

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-//! Delegate the rendeing to the [`i_slint_core::swrenderer::SoftwareRenderer`]
+//! Delegate the rendering to the [`i_slint_core::swrenderer::SoftwareRenderer`]
 
 use super::WinitCompatibleCanvas;
 use i_slint_core::graphics::Rgb8Pixel;

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -7,15 +7,15 @@ use super::WinitCompatibleCanvas;
 use i_slint_core::graphics::Rgb8Pixel;
 use i_slint_core::lengths::PhysicalLength;
 pub use i_slint_core::swrenderer::SoftwareRenderer;
-use i_slint_core::window::PlatformWindow;
+use i_slint_core::window::{WindowAdapter, WindowHandleAccess};
 use std::cell::RefCell;
 use std::rc::Weak;
 
 impl<const BUFFER_COUNT: usize> super::WinitCompatibleRenderer for SoftwareRenderer<BUFFER_COUNT> {
     type Canvas = SwCanvas;
 
-    fn new(platform_window_weak: &Weak<dyn PlatformWindow>) -> Self {
-        SoftwareRenderer::new(platform_window_weak.clone())
+    fn new(window_adapter_weak: &Weak<dyn WindowAdapter>) -> Self {
+        SoftwareRenderer::new(window_adapter_weak.clone())
     }
 
     fn create_canvas(&self, window_builder: winit::window::WindowBuilder) -> Self::Canvas {
@@ -33,7 +33,7 @@ impl<const BUFFER_COUNT: usize> super::WinitCompatibleRenderer for SoftwareRende
 
     fn release_canvas(&self, _canvas: Self::Canvas) {}
 
-    fn render(&self, canvas: &SwCanvas, _: &dyn PlatformWindow) {
+    fn render(&self, canvas: &SwCanvas, _: &dyn WindowAdapter) {
         let size = canvas.opengl_context.window().inner_size();
         let width = size.width as usize;
         let height = size.height as usize;

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -34,7 +34,7 @@ pub struct WasmInputHelper {
 
 #[derive(Default)]
 struct WasmInputState {
-    /// If there was a "keydown" event recieved not part of a composition
+    /// If there was a "keydown" event received that is not part of a composition
     has_key_down: bool,
     /// The current composing text
     composition: String,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -616,7 +616,7 @@ fn generate_public_component(file: &mut File, component: &llr::PublicComponent) 
         Declaration::Var(Var {
             ty: "slint::Window".into(),
             name: "m_window".into(),
-            init: Some("slint::Window{slint::private_api::PlatformWindowRc()}".into()),
+            init: Some("slint::Window{slint::private_api::WindowAdapterRc()}".into()),
             ..Default::default()
         }),
     ));
@@ -700,7 +700,7 @@ fn generate_public_component(file: &mut File, component: &llr::PublicComponent) 
         }),
     ));
 
-    component_struct.friends.push("slint::private_api::PlatformWindowRc".into());
+    component_struct.friends.push("slint::private_api::WindowAdapterRc".into());
 
     component_struct
         .friends

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1103,9 +1103,9 @@ fn generate_item_tree(
     } else {
         quote!(&self_rc)
     };
-    let (create_window, init_window) = if parent_ctx.is_none() {
+    let (create_window_adapter, init_window) = if parent_ctx.is_none() {
         (
-            Some(quote!(let window_adapter = slint::create_window();)),
+            Some(quote!(let window_adapter = slint::create_window_adapter();)),
             Some(quote! {
                 _self.window_adapter.set(window_adapter);
                 _self.window_adapter.get().unwrap().window().window_handle().set_component(&VRc::into_dyn(self_rc.clone()));
@@ -1189,7 +1189,7 @@ fn generate_item_tree(
             {
                 #![allow(unused)]
                 use slint::re_exports::*;
-                #create_window // We must create the window first to initialize the backend before using the style
+                #create_window_adapter // We must create the window first to initialize the backend before using the style
                 let mut _self = Self::default();
                 #(_self.parent = parent.clone() as #parent_component_type;)*
                 let self_rc = VRc::new(_self);

--- a/internal/core/animations.rs
+++ b/internal/core/animations.rs
@@ -206,7 +206,7 @@ impl Instant {
     }
 
     fn duration_since_start() -> core::time::Duration {
-        crate::platform::PLATFORM_ABSTRACTION_INSTANCE
+        crate::platform::PLATFORM_INSTANCE
             .with(|p| p.get().map(|p| p.duration_since_start()))
             .unwrap_or_default()
     }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -122,7 +122,7 @@ impl Window {
     ///
     /// You only need to create the window yourself when you create a
     /// [`WindowAdapter`](crate::platform::WindowAdapter) from
-    /// [`Platform::create_window`](crate::platform::Platform::create_window)
+    /// [`Platform::create_window_adapter`](crate::platform::Platform::create_window_adapter)
     ///
     /// Since the window adapter must own the Window, this function is meant to be used with
     /// [`Rc::new_cyclic`](alloc::rc::Rc::new_cyclic)
@@ -142,7 +142,7 @@ impl Window {
     /// # fn as_any(&self) -> &(dyn core::any::Any + 'static) { self }
     ///    //...
     /// }
-    /// fn create_window() -> Rc<dyn WindowAdapter> {
+    /// fn create_window_adapter() -> Rc<dyn WindowAdapter> {
     ///    Rc::<MyWindowAdapter>::new_cyclic(|weak| {
     ///        MyWindowAdapter {
     ///           window: Window::new(weak.clone()),

--- a/internal/core/graphics/rendering_metrics_collector.rs
+++ b/internal/core/graphics/rendering_metrics_collector.rs
@@ -6,7 +6,7 @@ This module contains a simple helper type to measure the average number of frame
 */
 
 use crate::timers::*;
-use crate::window::PlatformWindow;
+use crate::window::WindowAdapter;
 use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::rc::{Rc, Weak};
@@ -60,7 +60,7 @@ pub struct RenderingMetricsCollector {
     refresh_mode: RefreshMode,
     output_console: bool,
     output_overlay: bool,
-    platform_window: Weak<dyn PlatformWindow>,
+    window_adapter: Weak<dyn WindowAdapter>,
 }
 
 impl RenderingMetricsCollector {
@@ -73,7 +73,7 @@ impl RenderingMetricsCollector {
     ///
     /// If enabled, this will also print out some system information such as whether
     /// this is a debug or release build, as well as the provided winsys_info string.
-    pub fn new(platform_window: Weak<dyn PlatformWindow>, winsys_info: &str) -> Option<Rc<Self>> {
+    pub fn new(window_adapter: Weak<dyn WindowAdapter>, winsys_info: &str) -> Option<Rc<Self>> {
         let options = match std::env::var("SLINT_DEBUG_PERFORMANCE") {
             Ok(var) => var,
             _ => return None,
@@ -102,7 +102,7 @@ impl RenderingMetricsCollector {
             refresh_mode,
             output_console,
             output_overlay,
-            platform_window,
+            window_adapter,
         });
 
         #[cfg(debug_assertions)]
@@ -171,7 +171,7 @@ impl RenderingMetricsCollector {
             .borrow_mut()
             .push(FrameData { timestamp: instant::Instant::now(), metrics: renderer.metrics() });
         if matches!(self.refresh_mode, RefreshMode::FullSpeed) {
-            if let Some(window) = self.platform_window.upgrade() {
+            if let Some(window) = self.window_adapter.upgrade() {
                 window.request_redraw();
             }
             crate::animations::CURRENT_ANIMATION_DRIVER

--- a/internal/core/graphics/rendering_metrics_collector.rs
+++ b/internal/core/graphics/rendering_metrics_collector.rs
@@ -161,7 +161,7 @@ impl RenderingMetricsCollector {
         }
     }
 
-    /// Call this function every time you've completed the rendering of a frame. The rendere parameter
+    /// Call this function every time you've completed the rendering of a frame. The `renderer` parameter
     /// is used to collect additional data and is used to render an overlay if enabled.
     pub fn measure_frame_rendered(
         self: &Rc<Self>,

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -558,7 +558,7 @@ pub fn process_mouse_input(
                     InputEventResult::EventAccepted => {
                         if result.item_stack.is_empty() {
                             // In case the item stack is set already, it shouldn't
-                            // be overriden as we have to keep the deepest stack
+                            // be overridden as we have to keep the deepest stack
                             // for `send_exit_events` to work properly.
                             result.item_stack = mouse_grabber_stack;
                             result.grabbed = false;

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -136,7 +136,7 @@ impl<T: Clone> ItemCache<T> {
 
     /// Function that must be called when a component is destroyed.
     ///
-    /// Usually can be called from [`crate::window::PlatformWindow::unregister_component`]
+    /// Usually can be called from [`crate::window::WindowAdapter::unregister_component`]
     pub fn component_destroyed(&self, component: crate::component::ComponentRef) {
         let component_ptr: *const _ =
             crate::component::ComponentRef::as_ptr(component).cast().as_ptr();

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -30,7 +30,7 @@ pub use crate::item_tree::ItemRc;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::{PlatformWindow, PlatformWindowRc, WindowHandleAccess};
+use crate::window::{WindowAdapter, WindowAdapterRc, WindowHandleAccess};
 use crate::{Callback, Coord, Property, SharedString};
 use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
@@ -108,7 +108,7 @@ pub struct ItemVTable {
     /// This function is called by the run-time after the memory for the item
     /// has been allocated and initialized. It will be called before any user specified
     /// bindings are set.
-    pub init: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>, platform_window: &PlatformWindowRc),
+    pub init: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>, window_adapter: &WindowAdapterRc),
 
     /// Returns the geometry of this item (relative to its parent item)
     pub geometry: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>) -> Rect,
@@ -123,7 +123,7 @@ pub struct ItemVTable {
     pub layout_info: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         orientation: Orientation,
-        platform_window: &PlatformWindowRc,
+        window_adapter: &WindowAdapterRc,
     ) -> LayoutInfo,
 
     /// Event handler for mouse and touch event. This function is called before being called on children.
@@ -133,7 +133,7 @@ pub struct ItemVTable {
     pub input_event_filter_before_children: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
-        platform_window: &PlatformWindowRc,
+        window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> InputEventFilterResult,
 
@@ -141,20 +141,20 @@ pub struct ItemVTable {
     pub input_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
-        platform_window: &PlatformWindowRc,
+        window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> InputEventResult,
 
     pub focus_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &FocusEvent,
-        platform_window: &PlatformWindowRc,
+        window_adapter: &WindowAdapterRc,
     ) -> FocusEventResult,
 
     pub key_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &KeyEvent,
-        platform_window: &PlatformWindowRc,
+        window_adapter: &WindowAdapterRc,
     ) -> KeyEventResult,
 
     pub render: extern "C" fn(
@@ -182,7 +182,7 @@ pub struct Rectangle {
 }
 
 impl Item for Rectangle {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -191,7 +191,7 @@ impl Item for Rectangle {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -199,7 +199,7 @@ impl Item for Rectangle {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -208,7 +208,7 @@ impl Item for Rectangle {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -217,7 +217,7 @@ impl Item for Rectangle {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -225,7 +225,7 @@ impl Item for Rectangle {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -268,7 +268,7 @@ pub struct BorderRectangle {
 }
 
 impl Item for BorderRectangle {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -277,7 +277,7 @@ impl Item for BorderRectangle {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -285,7 +285,7 @@ impl Item for BorderRectangle {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -294,7 +294,7 @@ impl Item for BorderRectangle {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -303,7 +303,7 @@ impl Item for BorderRectangle {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -311,7 +311,7 @@ impl Item for BorderRectangle {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -369,7 +369,7 @@ pub struct TouchArea {
 }
 
 impl Item for TouchArea {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -378,7 +378,7 @@ impl Item for TouchArea {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -386,7 +386,7 @@ impl Item for TouchArea {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &Rc<dyn PlatformWindow>,
+        window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if !self.enabled() {
@@ -399,7 +399,7 @@ impl Item for TouchArea {
         let hovering = !matches!(event, MouseEvent::Exit);
         Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(hovering);
         if hovering {
-            platform_window.set_mouse_cursor(self.mouse_cursor());
+            window_adapter.set_mouse_cursor(self.mouse_cursor());
         }
         InputEventFilterResult::ForwardAndInterceptGrab
     }
@@ -407,12 +407,12 @@ impl Item for TouchArea {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &Rc<dyn PlatformWindow>,
+        window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         if matches!(event, MouseEvent::Exit) {
             Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(false);
-            platform_window.set_mouse_cursor(MouseCursor::Default);
+            window_adapter.set_mouse_cursor(MouseCursor::Default);
         }
         if !self.enabled() {
             return InputEventResult::EventIgnored;
@@ -483,7 +483,7 @@ impl Item for TouchArea {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -491,7 +491,7 @@ impl Item for TouchArea {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -534,7 +534,7 @@ pub struct FocusScope {
 }
 
 impl Item for FocusScope {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -543,7 +543,7 @@ impl Item for FocusScope {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -551,7 +551,7 @@ impl Item for FocusScope {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardEvent
@@ -560,11 +560,11 @@ impl Item for FocusScope {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        platform_window: &Rc<dyn PlatformWindow>,
+        window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> InputEventResult {
         if self.enabled() && matches!(event, MouseEvent::Pressed { .. }) && !self.has_focus() {
-            platform_window.window().window_handle().set_focus_item(self_rc);
+            window_adapter.window().window_handle().set_focus_item(self_rc);
         }
         InputEventResult::EventIgnored
     }
@@ -572,7 +572,7 @@ impl Item for FocusScope {
     fn key_event(
         self: Pin<&Self>,
         event: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         let r = match event.event_type {
             KeyEventType::KeyPressed => {
@@ -591,7 +591,7 @@ impl Item for FocusScope {
     fn focus_event(
         self: Pin<&Self>,
         event: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         if !self.enabled() {
             return FocusEventResult::FocusIgnored;
@@ -644,7 +644,7 @@ pub struct Clip {
 }
 
 impl Item for Clip {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -653,7 +653,7 @@ impl Item for Clip {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -661,7 +661,7 @@ impl Item for Clip {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -680,7 +680,7 @@ impl Item for Clip {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -689,7 +689,7 @@ impl Item for Clip {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -697,7 +697,7 @@ impl Item for Clip {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -735,7 +735,7 @@ pub struct Opacity {
 }
 
 impl Item for Opacity {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -744,7 +744,7 @@ impl Item for Opacity {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -752,7 +752,7 @@ impl Item for Opacity {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -761,7 +761,7 @@ impl Item for Opacity {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -770,7 +770,7 @@ impl Item for Opacity {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -778,7 +778,7 @@ impl Item for Opacity {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -845,7 +845,7 @@ pub struct Layer {
 }
 
 impl Item for Layer {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -854,7 +854,7 @@ impl Item for Layer {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -862,7 +862,7 @@ impl Item for Layer {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -871,7 +871,7 @@ impl Item for Layer {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -880,7 +880,7 @@ impl Item for Layer {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -888,7 +888,7 @@ impl Item for Layer {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -927,7 +927,7 @@ pub struct Rotate {
 }
 
 impl Item for Rotate {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(0 as _, 0 as _, self.width(), self.height())
@@ -936,7 +936,7 @@ impl Item for Rotate {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -944,7 +944,7 @@ impl Item for Rotate {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -953,7 +953,7 @@ impl Item for Rotate {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -962,7 +962,7 @@ impl Item for Rotate {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -970,7 +970,7 @@ impl Item for Rotate {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -1043,7 +1043,7 @@ pub struct WindowItem {
 }
 
 impl Item for WindowItem {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(0 as _, 0 as _, self.width(), self.height())
@@ -1052,7 +1052,7 @@ impl Item for WindowItem {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -1060,7 +1060,7 @@ impl Item for WindowItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -1069,7 +1069,7 @@ impl Item for WindowItem {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -1078,7 +1078,7 @@ impl Item for WindowItem {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -1086,7 +1086,7 @@ impl Item for WindowItem {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -1158,7 +1158,7 @@ pub struct BoxShadow {
 }
 
 impl Item for BoxShadow {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -1167,7 +1167,7 @@ impl Item for BoxShadow {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -1175,7 +1175,7 @@ impl Item for BoxShadow {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -1184,7 +1184,7 @@ impl Item for BoxShadow {
     fn input_event(
         self: Pin<&Self>,
         _event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -1193,7 +1193,7 @@ impl Item for BoxShadow {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -1201,7 +1201,7 @@ impl Item for BoxShadow {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -21,7 +21,7 @@ use crate::items::{PropertyAnimation, Rectangle};
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::PlatformWindow;
+use crate::window::WindowAdapter;
 use crate::Coord;
 use crate::Property;
 use alloc::boxed::Box;
@@ -55,7 +55,7 @@ pub struct Flickable {
 }
 
 impl Item for Flickable {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -64,7 +64,7 @@ impl Item for Flickable {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -72,7 +72,7 @@ impl Item for Flickable {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -89,7 +89,7 @@ impl Item for Flickable {
     fn input_event(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         if !self.interactive() && !matches!(event, MouseEvent::Wheel { .. }) {
@@ -112,7 +112,7 @@ impl Item for Flickable {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -120,7 +120,7 @@ impl Item for Flickable {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -18,7 +18,7 @@ use crate::item_rendering::ItemRenderer;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::PlatformWindow;
+use crate::window::WindowAdapter;
 use crate::{Brush, Coord, Property};
 use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
@@ -41,7 +41,7 @@ pub struct ImageItem {
 }
 
 impl Item for ImageItem {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -50,7 +50,7 @@ impl Item for ImageItem {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let natural_size = self.source().size();
         LayoutInfo {
@@ -68,7 +68,7 @@ impl Item for ImageItem {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -77,7 +77,7 @@ impl Item for ImageItem {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -86,7 +86,7 @@ impl Item for ImageItem {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -94,7 +94,7 @@ impl Item for ImageItem {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }
@@ -137,7 +137,7 @@ pub struct ClippedImage {
 }
 
 impl Item for ClippedImage {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -146,7 +146,7 @@ impl Item for ClippedImage {
     fn layout_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let natural_size = self.source().size();
         LayoutInfo {
@@ -164,7 +164,7 @@ impl Item for ClippedImage {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         InputEventFilterResult::ForwardAndIgnore
@@ -173,7 +173,7 @@ impl Item for ClippedImage {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -182,7 +182,7 @@ impl Item for ClippedImage {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -190,7 +190,7 @@ impl Item for ClippedImage {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -19,7 +19,7 @@ use crate::item_rendering::CachedRenderingData;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::PlatformWindow;
+use crate::window::WindowAdapter;
 use crate::{Coord, Property};
 use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
@@ -49,7 +49,7 @@ pub struct Path {
 }
 
 impl Item for Path {
-    fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
+    fn init(self: Pin<&Self>, _window_adapter: &Rc<dyn WindowAdapter>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
         euclid::rect(self.x(), self.y(), self.width(), self.height())
@@ -58,7 +58,7 @@ impl Item for Path {
     fn layout_info(
         self: Pin<&Self>,
         _orientation: Orientation,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -66,7 +66,7 @@ impl Item for Path {
     fn input_event_filter_before_children(
         self: Pin<&Self>,
         event: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
         if let Some(pos) = event.position() {
@@ -85,7 +85,7 @@ impl Item for Path {
     fn input_event(
         self: Pin<&Self>,
         _: MouseEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
         InputEventResult::EventIgnored
@@ -94,7 +94,7 @@ impl Item for Path {
     fn key_event(
         self: Pin<&Self>,
         _: &KeyEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> KeyEventResult {
         KeyEventResult::EventIgnored
     }
@@ -102,7 +102,7 @@ impl Item for Path {
     fn focus_event(
         self: Pin<&Self>,
         _: &FocusEvent,
-        _platform_window: &Rc<dyn PlatformWindow>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> FocusEventResult {
         FocusEventResult::FocusIgnored
     }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -798,7 +798,7 @@ impl TextInput {
             return;
         }
         let text = self.text();
-        crate::platform::PLATFORM_ABSTRACTION_INSTANCE.with(|p| {
+        crate::platform::PLATFORM_INSTANCE.with(|p| {
             if let Some(backend) = p.get() {
                 backend.set_clipboard_text(&text[anchor..cursor]);
             }
@@ -806,8 +806,8 @@ impl TextInput {
     }
 
     fn paste(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>) {
-        if let Some(text) = crate::platform::PLATFORM_ABSTRACTION_INSTANCE
-            .with(|p| p.get().and_then(|p| p.clipboard_text()))
+        if let Some(text) =
+            crate::platform::PLATFORM_INSTANCE.with(|p| p.get().and_then(|p| p.clipboard_text()))
         {
             self.insert(&text, window_adapter);
         }

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -85,7 +85,7 @@ pub type Coord = i32;
 /// Internal function to access the platform abstraction.
 /// The factory function is called if the platform abstraction is not yet
 /// initialized, and should be given by the platform_selector
-pub fn with_platform(
+pub fn with_platform<R>(
     factory: impl FnOnce() -> alloc::boxed::Box<dyn Platform + 'static>,
     f: impl FnOnce(&dyn Platform) -> R,
 ) -> R {

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -85,11 +85,11 @@ pub type Coord = i32;
 /// Internal function to access the platform abstraction.
 /// The factory function is called if the platform abstraction is not yet
 /// initialized, and should be given by the platform_selector
-pub fn with_platform_abstraction<R>(
+pub fn with_platform(
     factory: impl FnOnce() -> alloc::boxed::Box<dyn Platform + 'static>,
     f: impl FnOnce(&dyn Platform) -> R,
 ) -> R {
-    platform::PLATFORM_ABSTRACTION_INSTANCE.with(|p| match p.get() {
+    platform::PLATFORM_INSTANCE.with(|p| match p.get() {
         Some(p) => f(&**p),
         None => {
             platform::set_platform(factory())

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -106,7 +106,7 @@ impl std::convert::From<crate::animations::Instant> for instant::Instant {
 }
 
 thread_local! {
-    pub(crate) static PLATFORM_ABSTRACTION_INSTANCE : once_cell::unsync::OnceCell<Box<dyn Platform>>
+    pub(crate) static PLATFORM_INSTANCE : once_cell::unsync::OnceCell<Box<dyn Platform>>
         = once_cell::unsync::OnceCell::new()
 }
 static EVENTLOOP_PROXY: OnceCell<Box<dyn EventLoopProxy + 'static>> = OnceCell::new();
@@ -119,7 +119,7 @@ pub(crate) fn event_loop_proxy() -> Option<&'static dyn EventLoopProxy> {
 ///
 /// If the platform abstraction was already set this will return `Err`
 pub fn set_platform(platform: Box<dyn Platform + 'static>) -> Result<(), ()> {
-    PLATFORM_ABSTRACTION_INSTANCE.with(|instance| {
+    PLATFORM_INSTANCE.with(|instance| {
         if instance.get().is_some() {
             return Err(());
         }
@@ -150,7 +150,7 @@ pub fn update_timers_and_animations() {
 /// can be called to know if a window has running animation
 pub fn duration_until_next_timer_update() -> Option<core::time::Duration> {
     crate::timers::TimerList::next_timeout().map(|timeout| {
-        let duration_since_start = crate::platform::PLATFORM_ABSTRACTION_INSTANCE
+        let duration_since_start = crate::platform::PLATFORM_INSTANCE
             .with(|p| p.get().map(|p| p.duration_since_start()))
             .unwrap_or_default();
         core::time::Duration::from_millis(

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -35,7 +35,7 @@ pub enum EventLoopQuitBehavior {
 /// Interface implemented by back-ends
 pub trait Platform {
     /// Instantiate a window for a component.
-    fn create_window(&self) -> Rc<dyn WindowAdapter>;
+    fn create_window_adapter(&self) -> Rc<dyn WindowAdapter>;
 
     /// Spins an event loop and renders the visible windows.
     fn run_event_loop(&self, _behavior: EventLoopQuitBehavior) {

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -21,7 +21,7 @@ pub use crate::lengths::{PhysicalLength, PhysicalPoint};
 pub use crate::renderer::Renderer;
 #[cfg(feature = "swrenderer")]
 pub use crate::swrenderer;
-pub use crate::window::PlatformWindow;
+pub use crate::window::WindowAdapter;
 
 #[derive(Copy, Clone)]
 /// Behavior describing how the event loop should terminate.
@@ -35,7 +35,7 @@ pub enum EventLoopQuitBehavior {
 /// Interface implemented by back-ends
 pub trait Platform {
     /// Instantiate a window for a component.
-    fn create_window(&self) -> Rc<dyn PlatformWindow>;
+    fn create_window(&self) -> Rc<dyn WindowAdapter>;
 
     /// Spins an event loop and renders the visible windows.
     fn run_event_loop(&self, _behavior: EventLoopQuitBehavior) {

--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore swrenderer
+
 //! This module contains the [`SoftwareRenderer`] and related types.
 //!
 //! It is only available with the `renderer-software` feature.
@@ -59,7 +61,7 @@ pub trait LineBufferProvider {
 /// There are two kind of possible rendering
 ///  1. Using [`render()`](Self::render()) to render the window in a buffer
 ///  2. Using [`render_by_line()`](Self::render()) to render the window line by line. This
-///     is only usefull if the device does not have enough memory to render the whole window
+///     is only useful if the device does not have enough memory to render the whole window
 ///     in one single buffer
 ///
 /// The `BUFFER_COUNT` parameter specifies how many buffers are being re-used.
@@ -79,15 +81,15 @@ pub struct SoftwareRenderer<const BUFFER_COUNT: usize = 0> {
     /// We really only need BUFFER_COUNT - 1 but that's not allowed because we cannot do operations with
     /// generic parameters
     prev_frame_dirty: [Cell<DirtyRegion>; BUFFER_COUNT],
-    window: Weak<dyn crate::window::PlatformWindow>,
+    window: Weak<dyn crate::window::WindowAdapter>,
 }
 
 impl<const BUFFER_COUNT: usize> SoftwareRenderer<BUFFER_COUNT> {
     /// Create a new Renderer for a given window.
     ///
-    /// The `window` parametter can be comming from [`Rc::new_cyclic()`](alloc::rc::Rc::new_cyclic())
-    /// since the `PlatformWindow` most likely owd the Renderer
-    pub fn new(window: Weak<dyn crate::window::PlatformWindow>) -> Self {
+    /// The `window` parameter can be coming from [`Rc::new_cyclic()`](alloc::rc::Rc::new_cyclic())
+    /// since the `WindowAdapter` most likely owd the Renderer
+    pub fn new(window: Weak<dyn crate::window::WindowAdapter>) -> Self {
         Self {
             window: window.clone(),
             partial_cache: Default::default(),
@@ -193,7 +195,7 @@ impl<const BUFFER_COUNT: usize> SoftwareRenderer<BUFFER_COUNT> {
     /// The line callback will be called for each line and should provide a buffer to draw into.
     ///
     /// As an example, let's imagine we want to render into a plain buffer.
-    /// (You wouldn't normaly use `render_by_line` for that because the [`Self::render`] would
+    /// (You wouldn't normally use `render_by_line` for that because the [`Self::render`] would
     /// then be more efficient)
     ///
     /// ```rust

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -29,7 +29,7 @@ pub extern "C" fn slint_send_mouse_click(
     component: &crate::component::ComponentRc,
     x: Coord,
     y: Coord,
-    platform_window: &crate::window::PlatformWindowRc,
+    window_adapter: &crate::window::WindowAdapterRc,
 ) {
     let mut state = crate::input::MouseInputState::default();
     let position = euclid::point2(x, y);
@@ -37,20 +37,20 @@ pub extern "C" fn slint_send_mouse_click(
     state = crate::input::process_mouse_input(
         component.clone(),
         MouseEvent::Moved { position },
-        platform_window,
+        window_adapter,
         state,
     );
     state = crate::input::process_mouse_input(
         component.clone(),
         MouseEvent::Pressed { position, button: crate::items::PointerEventButton::Left },
-        platform_window,
+        window_adapter,
         state,
     );
     slint_mock_elapsed_time(50);
     crate::input::process_mouse_input(
         component.clone(),
         MouseEvent::Released { position, button: crate::items::PointerEventButton::Left },
-        platform_window,
+        window_adapter,
         state,
     );
 }
@@ -60,7 +60,7 @@ pub extern "C" fn slint_send_mouse_click(
 pub extern "C" fn send_keyboard_string_sequence(
     sequence: &crate::SharedString,
     modifiers: KeyboardModifiers,
-    platform_window: &crate::window::PlatformWindowRc,
+    window_adapter: &crate::window::WindowAdapterRc,
 ) {
     for ch in sequence.chars() {
         let mut modifiers = modifiers;
@@ -70,12 +70,12 @@ pub extern "C" fn send_keyboard_string_sequence(
         let mut buffer = [0; 6];
         let text = SharedString::from(ch.encode_utf8(&mut buffer) as &str);
 
-        platform_window.window().window_handle().process_key_input(&KeyEvent {
+        window_adapter.window().window_handle().process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyPressed,
             text: text.clone(),
             modifiers,
         });
-        platform_window.window().window_handle().process_key_input(&KeyEvent {
+        window_adapter.window().window_handle().process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyReleased,
             text,
             modifiers,

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -586,7 +586,7 @@ impl ComponentDefinition {
                 .inner
                 .unerase(guard)
                 .clone()
-                .create_with_existing_window(&window.window_handle().platform_window()),
+                .create_with_existing_window(&window.window_handle().window_adapter()),
         }
     }
 
@@ -964,13 +964,13 @@ impl ComponentHandle for ComponentInstance {
     fn show(&self) {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.borrow_instance().platform_window().show();
+        comp.borrow_instance().window_adapter().show();
     }
 
     fn hide(&self) {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.borrow_instance().platform_window().hide();
+        comp.borrow_instance().window_adapter().hide();
     }
 
     fn run(&self) {
@@ -980,7 +980,7 @@ impl ComponentHandle for ComponentInstance {
     }
 
     fn window(&self) -> &Window {
-        self.inner.platform_window().window()
+        self.inner.window_adapter().window()
     }
 
     fn global<'a, T: Global<'a, Self>>(&'a self) -> T
@@ -1058,7 +1058,7 @@ pub mod testing {
             &vtable::VRc::into_dyn(comp.inner.clone()),
             x,
             y,
-            &comp.window().window_handle().platform_window(),
+            &comp.window().window_handle().window_adapter(),
         );
     }
     /// Wrapper around [`i_slint_core::tests::send_keyboard_string_sequence`]
@@ -1069,7 +1069,7 @@ pub mod testing {
         i_slint_core::tests::send_keyboard_string_sequence(
             &string,
             Default::default(),
-            &comp.window().window_handle().platform_window(),
+            &comp.window().window_handle().window_adapter(),
         );
     }
 }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1042,7 +1042,7 @@ pub enum InvokeCallbackError {
 /// events from the windowing system in order to render to the screen
 /// and react to user input.
 pub fn run_event_loop() {
-    i_slint_backend_selector::with_platform_abstraction(|b| {
+    i_slint_backend_selector::with_platform(|b| {
         b.run_event_loop(i_slint_core::platform::EventLoopQuitBehavior::QuitOnLastWindowClosed)
     });
 }

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -389,7 +389,7 @@ impl<'id> ComponentDescription<'id> {
         self: Rc<Self>,
         #[cfg(target_arch = "wasm32")] canvas_id: String,
     ) -> vtable::VRc<ComponentVTable, ErasedComponentBox> {
-        let window_adapter = i_slint_backend_selector::with_platform_abstraction(|_b| {
+        let window_adapter = i_slint_backend_selector::with_platform(|_b| {
             #[cfg(not(target_arch = "wasm32"))]
             return _b.create_window_adapter();
             #[cfg(target_arch = "wasm32")]

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -391,7 +391,7 @@ impl<'id> ComponentDescription<'id> {
     ) -> vtable::VRc<ComponentVTable, ErasedComponentBox> {
         let window_adapter = i_slint_backend_selector::with_platform_abstraction(|_b| {
             #[cfg(not(target_arch = "wasm32"))]
-            return _b.create_window();
+            return _b.create_window_adapter();
             #[cfg(target_arch = "wasm32")]
             i_slint_backend_winit::create_gl_window_with_canvas_id(canvas_id)
         });

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1124,7 +1124,7 @@ pub fn convert_path(path: &ExprPath, local_context: &mut EvalLocalContext) -> Pa
             if let Value::String(commands) = eval_expression(commands, local_context) {
                 PathData::Commands(commands)
             } else {
-                panic!("binding to path commands does not evalutate to string");
+                panic!("binding to path commands does not evaluate to string");
             }
         }
     }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -341,7 +341,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                         popup,
                         i_slint_core::graphics::Point::new(x.try_into().unwrap(), y.try_into().unwrap()),
                         component.borrow(),
-                        platform_window_ref(component).unwrap(),
+                        window_adapter_ref(component).unwrap(),
                         &parent_item);
                     Value::Void
                 } else {
@@ -451,8 +451,8 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     let item_info = &component_type.items[item.borrow().id.as_str()];
                     let item_ref = unsafe { item_info.item_from_component(enclosing_component.as_ptr()) };
 
-                    let platform_window = platform_window_ref(component).unwrap();
-                    item_ref.as_ref().layout_info(crate::eval_layout::to_runtime(*orient), platform_window).into()
+                    let window_adapter = window_adapter_ref(component).unwrap();
+                    item_ref.as_ref().layout_info(crate::eval_layout::to_runtime(*orient), window_adapter).into()
                 } else {
                     panic!("internal error: incorrect arguments to ImplicitLayoutInfo {:?}", arguments);
                 }
@@ -466,7 +466,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     ComponentInstance::GlobalComponent(_) => panic!("Cannot access the implicit item size from a global component")
                 };
                 if let Value::String(s) = eval_expression(&arguments[0], local_context) {
-                    if let Some(err) = platform_window_ref(component).unwrap().renderer().register_font_from_path(&std::path::PathBuf::from(s.as_str())).err() {
+                    if let Some(err) = window_adapter_ref(component).unwrap().renderer().register_font_from_path(&std::path::PathBuf::from(s.as_str())).err() {
                         corelib::debug_log!("Error loading custom font {}: {}", s.as_str(), err);
                     }
                     Value::Void
@@ -993,16 +993,16 @@ fn root_component_instance<'a, 'old_id, 'new_id>(
     }
 }
 
-pub fn platform_window_ref<'a>(
+pub fn window_adapter_ref<'a>(
     component: InstanceRef<'a, '_>,
-) -> Option<&'a Rc<dyn i_slint_core::window::PlatformWindow>> {
-    component.component_type.platform_window_offset.apply(component.instance.get_ref()).as_ref()
+) -> Option<&'a Rc<dyn i_slint_core::window::WindowAdapter>> {
+    component.component_type.window_adapter_offset.apply(component.instance.get_ref()).as_ref()
 }
 
 pub fn window_ref<'a>(
     component: InstanceRef<'a, '_>,
 ) -> Option<&'a i_slint_core::window::WindowInner> {
-    platform_window_ref(component).map(|platform_window| platform_window.window().window_handle())
+    window_adapter_ref(component).map(|window_adapter| window_adapter.window().window_handle())
 }
 
 /// Return the component instance which hold the given element.

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -13,7 +13,7 @@ use i_slint_core::items::DialogButtonRole;
 use i_slint_core::layout::{self as core_layout};
 use i_slint_core::model::RepeatedComponent;
 use i_slint_core::slice::Slice;
-use i_slint_core::window::PlatformWindow;
+use i_slint_core::window::WindowAdapter;
 use std::convert::TryInto;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -187,7 +187,7 @@ fn grid_layout_data(
             let mut layout_info = get_layout_info(
                 &cell.item.element,
                 component,
-                eval::platform_window_ref(component).unwrap(),
+                eval::window_adapter_ref(component).unwrap(),
                 orientation,
             );
             fill_layout_info_constraints(
@@ -210,7 +210,7 @@ fn box_layout_data(
     expr_eval: &impl Fn(&NamedReference) -> f32,
     mut repeater_indices: Option<&mut Vec<u32>>,
 ) -> (Vec<core_layout::BoxLayoutCellData>, i_slint_core::items::LayoutAlignment) {
-    let platform_window = eval::platform_window_ref(component).unwrap();
+    let window_adapter = eval::window_adapter_ref(component).unwrap();
     let mut cells = Vec::with_capacity(box_layout.elems.len());
     for cell in &box_layout.elems {
         if cell.element.borrow().repeated.is_some() {
@@ -224,7 +224,7 @@ fn box_layout_data(
                 let instance = crate::dynamic_component::instantiate(
                     rep.1.clone(),
                     Some(component.borrow()),
-                    Some(platform_window),
+                    Some(window_adapter),
                     Default::default(),
                 );
                 instance.run_setup_code();
@@ -242,7 +242,7 @@ fn box_layout_data(
             );
         } else {
             let mut layout_info =
-                get_layout_info(&cell.element, component, platform_window, orientation);
+                get_layout_info(&cell.element, component, window_adapter, orientation);
             fill_layout_info_constraints(
                 &mut layout_info,
                 &cell.constraints,
@@ -267,7 +267,7 @@ fn box_layout_data(
 }
 
 fn repeater_indices(children: &[ElementRc], component: InstanceRef) -> Vec<u32> {
-    let platform_window = eval::platform_window_ref(component).unwrap();
+    let window_adapter = eval::window_adapter_ref(component).unwrap();
 
     let mut idx = 0;
     let mut ri = Vec::new();
@@ -283,7 +283,7 @@ fn repeater_indices(children: &[ElementRc], component: InstanceRef) -> Vec<u32> 
                 let instance = crate::dynamic_component::instantiate(
                     rep.1.clone(),
                     Some(component.borrow()),
-                    Some(platform_window),
+                    Some(window_adapter),
                     Default::default(),
                 );
                 instance.run_setup_code();
@@ -361,7 +361,7 @@ pub(crate) fn fill_layout_info_constraints(
 pub(crate) fn get_layout_info(
     elem: &ElementRc,
     component: InstanceRef,
-    platform_window: &Rc<dyn PlatformWindow>,
+    window_adapter: &Rc<dyn WindowAdapter>,
     orientation: Orientation,
 ) -> core_layout::LayoutInfo {
     let elem = elem.borrow();
@@ -376,7 +376,7 @@ pub(crate) fn get_layout_info(
         unsafe {
             item.item_from_component(component.as_ptr())
                 .as_ref()
-                .layout_info(to_runtime(orientation), platform_window)
+                .layout_info(to_runtime(orientation), window_adapter)
         }
     }
 }

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -7,7 +7,7 @@ use super::*;
 use core::ptr::NonNull;
 use i_slint_core::model::{Model, ModelNotify, SharedVectorModel};
 use i_slint_core::slice::Slice;
-use i_slint_core::window::PlatformWindow;
+use i_slint_core::window::WindowAdapter;
 use std::ffi::c_void;
 use vtable::VRef;
 
@@ -547,9 +547,9 @@ pub extern "C" fn slint_interpreter_component_instance_show(
     generativity::make_guard!(guard);
     let comp = inst.unerase(guard);
     if is_visible {
-        comp.borrow_instance().platform_window().show();
+        comp.borrow_instance().window_adapter().show();
     } else {
-        comp.borrow_instance().platform_window().hide();
+        comp.borrow_instance().window_adapter().hide();
     }
 }
 
@@ -560,13 +560,13 @@ pub extern "C" fn slint_interpreter_component_instance_show(
 #[no_mangle]
 pub unsafe extern "C" fn slint_interpreter_component_instance_window(
     inst: &ErasedComponentBox,
-    out: *mut *const i_slint_core::window::ffi::PlatformWindowRcOpaque,
+    out: *mut *const i_slint_core::window::ffi::WindowAdapterRcOpaque,
 ) {
     assert_eq!(
-        core::mem::size_of::<Rc<dyn PlatformWindow>>(),
-        core::mem::size_of::<i_slint_core::window::ffi::PlatformWindowRcOpaque>()
+        core::mem::size_of::<Rc<dyn WindowAdapter>>(),
+        core::mem::size_of::<i_slint_core::window::ffi::WindowAdapterRcOpaque>()
     );
-    core::ptr::write(out as *mut *const Rc<dyn PlatformWindow>, inst.platform_window() as *const _)
+    core::ptr::write(out as *mut *const Rc<dyn WindowAdapter>, inst.window_adapter() as *const _)
 }
 
 /// Instantiate an instance from a definition.

--- a/tests/cases/bindings/two_way_binding.slint
+++ b/tests/cases/bindings/two_way_binding.slint
@@ -5,7 +5,7 @@ OtherComp := Rectangle {
     property <string> t <=> text.text;
     property <string> get_text <=> text.text;
     text := Text {
-        text: "to be overriden";
+        text: "to be overridden";
     }
     property <int> some_value: 42;
     property <int> some_value_alias <=> some_value;

--- a/tests/cases/bindings/two_way_binding2.slint
+++ b/tests/cases/bindings/two_way_binding2.slint
@@ -5,7 +5,7 @@ OtherComp := Rectangle {
     property t <=> text.text;
     property get_text <=> text.text;
     text := Text {
-        text: "to be overriden";
+        text: "to be overridden";
     }
     property <int> some_value: 42;
     property some_value_alias <=> some_value;

--- a/tests/cases/bindings/two_way_priority_default.slint
+++ b/tests/cases/bindings/two_way_priority_default.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 // The visible and enabled property are set by default by Slint to true.
-// But when overriden by an alias, the overriden value should take precedence.
+// But when overridden by an alias, the overridden value should take precedence.
 
 export Button := Rectangle {
     property<bool> the_enabled <=> touch.enabled;

--- a/tests/cases/focus/event_propagation.slint
+++ b/tests/cases/focus/event_propagation.slint
@@ -13,7 +13,7 @@ TestCase := Rectangle {
             FocusScope {
                 width: 75%;
                 key-pressed(event) => {
-                    recieved += event.text;
+                    received += event.text;
                     accept
                 }
 
@@ -35,7 +35,7 @@ TestCase := Rectangle {
     property<string> input1_text: input1.text;
     property<bool> input2_focused: input2.has_focus;
     property<string> input2_text: input2.text;
-    property<string> recieved;
+    property<string> received;
 }
 
 /*
@@ -53,13 +53,13 @@ assert!(instance.get_input2_focused());
 slint::testing::send_keyboard_string_sequence(&instance, "Hello");
 assert_eq!(instance.get_input2_text(), "Hello");
 assert_eq!(instance.get_input1_text(), "");
-assert_eq!(instance.get_recieved(), "");
+assert_eq!(instance.get_received(), "");
 
 slint::testing::set_current_keyboard_modifiers(&instance, ctrl_modifier);
 slint::testing::send_keyboard_string_sequence(&instance, "ß");
 assert_eq!(instance.get_input2_text(), "Hello");
 assert_eq!(instance.get_input1_text(), "");
-assert_eq!(instance.get_recieved(), "ß");
+assert_eq!(instance.get_received(), "ß");
 ```
 
 ```cpp
@@ -75,11 +75,11 @@ assert(instance.get_input2_focused());
 slint::testing::send_keyboard_string_sequence(&instance, "Hello");
 assert_eq(instance.get_input2_text(), "Hello");
 assert_eq(instance.get_input1_text(), "");
-assert_eq(instance.get_recieved(), "");
+assert_eq(instance.get_received(), "");
 
 slint::testing::send_keyboard_string_sequence(&instance, "ß", ctrl_modifier);
 assert_eq(instance.get_input2_text(), "Hello");
 assert_eq(instance.get_input1_text(), "");
-assert_eq(instance.get_recieved(), "ß");
+assert_eq(instance.get_received(), "ß");
 ```
 */

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -85,7 +85,7 @@ pub fn start_ui_event_loop() {
 
         if *state_requested == RequestedGuiEventLoopState::StartLoop {
             // make sure the backend is initialized
-            i_slint_backend_selector::with_platform_abstraction(|_| {});
+            i_slint_backend_selector::with_platform(|_| {});
             // Send an event so that once the loop is started, we notify the LSP thread that it can send more events
             i_slint_core::api::invoke_from_event_loop(|| {
                 let mut state_request = GUI_EVENT_LOOP_STATE_REQUEST.lock().unwrap();
@@ -97,7 +97,7 @@ pub fn start_ui_event_loop() {
         }
     }
 
-    i_slint_backend_selector::with_platform_abstraction(|b| {
+    i_slint_backend_selector::with_platform(|b| {
         b.run_event_loop(i_slint_core::platform::EventLoopQuitBehavior::QuitOnlyExplicitly)
     });
 }

--- a/tools/viewer/README.md
+++ b/tools/viewer/README.md
@@ -42,7 +42,7 @@ Instead of a path to a file, one can use `-` for the standard input or the stand
 
 ## Callback handler
 
-It is possible to tell the viewer to execute some shell commands when a callback is recieved.
+It is possible to tell the viewer to execute some shell commands when a callback is received.
 You can use the `--on` command line argument, followed by the callback name, followed by the command.
 Within the command arguments, `$1`, `$2`, ... will be replaced by the first, second, ... argument of the
 callback. These will be shell escaped.


### PR DESCRIPTION
Replace `PlatformWindow` with `WindowAdapter`.

Replace `create_window` with `create_window_adapter`.

Replace remaining `Platform Abstraction` to plain `Platform`.

Fixes: #1536 (what remained of that after the first PR).