### PR TITLE
Fix element rotation when the element is translated

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -64,6 +64,8 @@ export ClippedImage := ImageItem {
 export { ClippedImage as Image }
 
 export Rotate := _ {
+    property <length> x;
+    property <length> y;
     property <angle> rotation-angle;
     property <length> rotation-origin-x;
     property <length> rotation-origin-y;

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -918,6 +918,8 @@ declare_item_vtable! {
 #[pin]
 /// The implementation of the `Rotate` element
 pub struct Rotate {
+    pub x: Property<Coord>,
+    pub y: Property<Coord>,
     pub rotation_angle: Property<f32>,
     pub rotation_origin_x: Property<Coord>,
     pub rotation_origin_y: Property<Coord>,
@@ -930,7 +932,7 @@ impl Item for Rotate {
     fn init(self: Pin<&Self>, _platform_window: &Rc<dyn PlatformWindow>) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
-        euclid::rect(0 as _, 0 as _, self.width(), self.height())
+        euclid::rect(self.x(), self.y(), self.width(), self.height())
     }
 
     fn layout_info(


### PR DESCRIPTION
For example

    Image {
        x: 150px;
        y: 50px;
        rotation-angle: 45deg;
    }

will end up rendering as if x and y are zero. This is because during
the injection we "move" x and y to the Rotate
element as bindings, but due to the lack of built-in
x/y properties, dummy properties are materialized
and they are not applied for the regular per-item translation.

Add x/y to the Rotate element and then it works.