### PR TITLE
Fix debug build of wasm modules in the online editor

### DIFF
--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "build": "rimraf dist pkg && npx vite build",
-    "build:wasm_lsp": "wasm-pack build --target web ../lsp -- --no-default-features",
+    "build:wasm_lsp": "wasm-pack build --dev --target web ../lsp -- --no-default-features",
     "build:wasm_lsp-release": "wasm-pack build --release --target web ../lsp -- --no-default-features",
-    "build:wasm_preview": "wasm-pack build --target web ../../api/wasm-interpreter -- --features console_error_panic_hook",
+    "build:wasm_preview": "wasm-pack build --dev --target web ../../api/wasm-interpreter -- --features console_error_panic_hook",
     "build:wasm_preview-release": "wasm-pack build --release --target web ../../api/wasm-interpreter -- --features console_error_panic_hook",
     "lint": "eslint src",
     "start": "rimraf dist && npm run build:wasm_lsp && npm run build:wasm_preview && npm run start:vite",


### PR DESCRIPTION
wasm-pack defaults to a release build, an explicit --dev is needed.