### PR TITLE
API: seal the WindowAdaptor trait

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -20,7 +20,7 @@ use i_slint_core::items::{
     PointerEventButton, RenderingResult, TextOverflow, TextWrap,
 };
 use i_slint_core::layout::Orientation;
-use i_slint_core::window::{WindowAdapter, WindowHandleAccess};
+use i_slint_core::window::{WindowAdapter, WindowAdapterSealed, WindowHandleAccess};
 use i_slint_core::{ImageInner, PathData, Property, SharedString};
 use items::{ImageFit, TextHorizontalAlignment, TextVerticalAlignment};
 
@@ -1337,8 +1337,13 @@ impl QtWindow {
     }
 }
 
-#[allow(unused)]
 impl WindowAdapter for QtWindow {
+    fn window(&self) -> &i_slint_core::api::Window {
+        &self.window
+    }
+}
+
+impl WindowAdapterSealed for QtWindow {
     fn show(&self) {
         let component_rc = self.window.window_handle().component();
         let component = ComponentRc::borrow_pin(&component_rc);
@@ -1542,7 +1547,7 @@ impl WindowAdapter for QtWindow {
         self
     }
 
-    fn handle_focus_change(&self, old: Option<ItemRc>, new: Option<ItemRc>) {
+    fn handle_focus_change(&self, _old: Option<ItemRc>, new: Option<ItemRc>) {
         let widget_ptr = self.widget_ptr();
         if let Some(ai) = accessible_item(new) {
             let item = &ai;
@@ -1578,10 +1583,6 @@ impl WindowAdapter for QtWindow {
         cpp! {unsafe [widget_ptr as "QWidget*", sz as "QSize"] {
             widget_ptr->resize(sz);
         }};
-    }
-
-    fn window(&self) -> &i_slint_core::api::Window {
-        &self.window
     }
 }
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -9,6 +9,7 @@ use i_slint_core::api::PhysicalPx;
 use i_slint_core::graphics::{Point, Rect, Size};
 use i_slint_core::renderer::Renderer;
 use i_slint_core::window::WindowAdapter;
+use i_slint_core::window::WindowAdapterSealed;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Mutex;
@@ -43,38 +44,10 @@ pub struct TestingWindow {
     window: i_slint_core::api::Window,
 }
 
-impl WindowAdapter for TestingWindow {
+impl WindowAdapterSealed for TestingWindow {
     fn show(&self) {
         unimplemented!("showing a testing window")
     }
-
-    fn hide(&self) {}
-
-    fn request_redraw(&self) {}
-
-    fn register_component(&self) {}
-
-    fn unregister_component<'a>(
-        &self,
-        _: i_slint_core::component::ComponentRef,
-        _items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'a>>>,
-    ) {
-    }
-
-    fn request_window_properties_update(&self) {}
-
-    fn apply_window_properties(&self, _window_item: Pin<&i_slint_core::items::WindowItem>) {
-        todo!()
-    }
-
-    fn apply_geometry_constraint(
-        &self,
-        _constraints_horizontal: i_slint_core::layout::LayoutInfo,
-        _constraints_vertical: i_slint_core::layout::LayoutInfo,
-    ) {
-    }
-
-    fn set_mouse_cursor(&self, _cursor: i_slint_core::items::MouseCursor) {}
 
     fn renderer(&self) -> &dyn Renderer {
         self
@@ -91,7 +64,9 @@ impl WindowAdapter for TestingWindow {
     fn set_position(&self, _position: euclid::Point2D<i32, PhysicalPx>) {
         unimplemented!()
     }
+}
 
+impl WindowAdapter for TestingWindow {
     fn window(&self) -> &i_slint_core::api::Window {
         &self.window
     }

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -17,7 +17,7 @@ use corelib::component::ComponentRc;
 use corelib::input::KeyboardModifiers;
 use corelib::items::{ItemRef, MouseCursor};
 use corelib::layout::Orientation;
-use corelib::window::{WindowAdapter, WindowHandleAccess};
+use corelib::window::{WindowAdapter, WindowAdapterSealed, WindowHandleAccess};
 use corelib::Property;
 use corelib::{graphics::*, Coord};
 use i_slint_core as corelib;
@@ -309,11 +309,15 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Rende
 }
 
 impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapter for GLWindow<Renderer> {
+    fn window(&self) -> &corelib::api::Window {
+        &self.window
+    }
+}
+
+impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWindow<Renderer> {
     fn request_redraw(&self) {
         self.with_window_handle(&mut |window| window.request_redraw())
     }
-
-    fn register_component(&self) {}
 
     fn unregister_component<'a>(
         &self,
@@ -495,10 +499,6 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapter for GLWindow<Ren
                 }
             }
         }
-    }
-
-    fn window(&self) -> &corelib::api::Window {
-        &self.window
     }
 }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -138,10 +138,12 @@ impl Window {
     /// }
     /// impl WindowAdapter for MyWindowAdapter {
     ///    fn window(&self) -> &Window { &self.window }
-    /// # fn renderer(&self) -> &dyn i_slint_core::renderer::Renderer { unimplemented!() }
-    /// # fn as_any(&self) -> &(dyn core::any::Any + 'static) { self }
     ///    //...
     /// }
+    /// # impl i_slint_core::window::WindowAdapterSealed for MyWindowAdapter {
+    /// #   fn renderer(&self) -> &dyn i_slint_core::renderer::Renderer { unimplemented!() }
+    /// # }
+    ///
     /// fn create_window_adapter() -> Rc<dyn WindowAdapter> {
     ///    Rc::<MyWindowAdapter>::new_cyclic(|weak| {
     ///        MyWindowAdapter {
@@ -151,6 +153,7 @@ impl Window {
     ///    })
     /// }
     /// ```
+    #[doc(hidden)]
     pub fn new(window_adapter_weak: alloc::rc::Weak<dyn WindowAdapter>) -> Self {
         Self(WindowInner::new(window_adapter_weak))
     }

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -7,7 +7,6 @@ The backend is the abstraction for crates that need to do the actual drawing and
 
 #![warn(missing_docs)]
 
-pub use crate::items::{InputType, MouseCursor};
 pub use crate::lengths::{PhysicalLength, PhysicalPoint};
 pub use crate::renderer::Renderer;
 #[cfg(feature = "swrenderer")]

--- a/internal/core/swrenderer.rs
+++ b/internal/core/swrenderer.rs
@@ -89,7 +89,7 @@ impl<const BUFFER_COUNT: usize> SoftwareRenderer<BUFFER_COUNT> {
     /// Create a new Renderer for a given window.
     ///
     /// The `window` parameter can be coming from [`Rc::new_cyclic()`](alloc::rc::Rc::new_cyclic())
-    /// since the `WindowAdapter` most likely owd the Renderer
+    /// since the `WindowAdapter` most likely own the Renderer
     pub fn new(window: Weak<dyn crate::window::WindowAdapter>) -> Self {
         Self {
             window: window.clone(),
@@ -1334,13 +1334,18 @@ impl<const BUFFER_COUNT: usize> MinimalSoftwareWindow<BUFFER_COUNT> {
     }
 }
 
-impl<const BUFFER_COUNT: usize> WindowAdapter for MinimalSoftwareWindow<BUFFER_COUNT> {
+impl<const BUFFER_COUNT: usize> crate::window::WindowAdapterSealed
+    for MinimalSoftwareWindow<BUFFER_COUNT>
+{
     fn request_redraw(&self) {
         self.needs_redraw.set(true);
     }
     fn renderer(&self) -> &dyn Renderer {
         &self.renderer
     }
+}
+
+impl<const BUFFER_COUNT: usize> WindowAdapter for MinimalSoftwareWindow<BUFFER_COUNT> {
     fn window(&self) -> &Window {
         &self.window
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -31,10 +31,24 @@ fn previous_focus_item(item: ItemRc) -> ItemRc {
     item.previous_focus_item()
 }
 
-/// This trait represents the interface that the generated code and the run-time
-/// require in order to implement functionality such as device-independent pixels,
+/// This trait represents the adapter layer between the [`Window`] API, and the
+/// internal type from the backend that provides functionality such as device-independent pixels,
 /// window resizing and other typically windowing system related tasks.
-pub trait WindowAdapter {
+///
+/// This trait is Sealed, meaning that you are not expected to implement this trait
+/// yourself, but you should use the provided window adapter. Currently only
+/// [`MinimalSoftwareWindow`](crate::swrenderer::MinimalSoftwareWindow) is available
+///  for [`platform`](crate::platform) implementer
+pub trait WindowAdapter: WindowAdapterSealed {
+    /// Returns the window API.
+    fn window(&self) -> &Window;
+}
+
+/// Implementation details behind [`WindowAdapter`],  but since this
+/// trait is not exported in the public API, it is not possible for the
+/// users to call or re-implement these function
+#[doc(hidden)]
+pub trait WindowAdapterSealed {
     /// Registers the window with the windowing system.
     fn show(&self) {}
     /// De-registers the window from the windowing system.
@@ -118,9 +132,6 @@ pub trait WindowAdapter {
 
     /// Return the renderer
     fn renderer(&self) -> &dyn Renderer;
-
-    /// Returns the window API.
-    fn window(&self) -> &Window;
 }
 
 struct WindowPropertiesTracker {


### PR DESCRIPTION
And hide most of its functions in the sealed trait.

Closes #1535