### PR TITLE
Box shadow rendering fixes

### DIFF
--- a/internal/backends/winit/renderer/boxshadowcache.rs
+++ b/internal/backends/winit/renderer/boxshadowcache.rs
@@ -50,7 +50,7 @@ impl BoxShadowOptions {
             width: box_shadow.width() * scale_factor,
             height: box_shadow.height() * scale_factor,
             color,
-            blur: box_shadow.blur(),
+            blur: box_shadow.blur() * scale_factor, // This effectively becomes the blur radius, so scale to physical pixels
             radius: box_shadow.border_radius() * scale_factor,
         })
     }

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -487,7 +487,12 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
                 );
 
                 let rounded_rect = skia_safe::RRect::new_rect_xy(
-                    skia_safe::Rect::from_xywh(0., 0., shadow_options.width, shadow_options.height),
+                    skia_safe::Rect::from_xywh(
+                        shadow_options.blur,
+                        shadow_options.blur,
+                        shadow_options.width,
+                        shadow_options.height,
+                    ),
                     shadow_options.radius,
                     shadow_options.radius,
                 );
@@ -514,7 +519,12 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
             None => return,
         };
 
-        self.canvas.draw_image(cached_shadow_image, skia_safe::Point::from((ox, oy)), None);
+        let blur = box_shadow.blur() * self.scale_factor;
+        self.canvas.draw_image(
+            cached_shadow_image,
+            skia_safe::Point::from((ox - blur, oy - blur)),
+            None,
+        );
     }
 
     fn combine_clip(


### PR DESCRIPTION
Fix a regression in the appearance of box shadows with the FemtoVG backend and fix the appearance of box shadows with blur with the Skia backend to match FemtoVG.