### PR TITLE
Rename set_event_loop_quit_on_last_window_closed to remove EventLoopQuitBehavior

### DIFF
--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -146,21 +146,14 @@ impl i_slint_core::platform::Platform for Backend {
         }
     }
 
-    fn set_event_loop_quit_behavior(
-        &self,
-        _behavior: i_slint_core::platform::EventLoopQuitBehavior,
-    ) {
+    fn set_event_loop_quit_on_last_window_closed(&self, _quit_on_last_window_closed: bool) {
         #[cfg(not(no_qt))]
         {
-            let quit_on_last_window_closed = match _behavior {
-                i_slint_core::platform::EventLoopQuitBehavior::QuitOnLastWindowClosed => true,
-                i_slint_core::platform::EventLoopQuitBehavior::QuitOnlyExplicitly => false,
-            };
             // Schedule any timers with Qt that were set up before this event loop start.
             use cpp::cpp;
-            cpp! {unsafe [quit_on_last_window_closed as "bool"] {
+            cpp! {unsafe [_quit_on_last_window_closed as "bool"] {
                 ensure_initialized(true);
-                qApp->setQuitOnLastWindowClosed(quit_on_last_window_closed);
+                qApp->setQuitOnLastWindowClosed(_quit_on_last_window_closed);
             } }
         };
     }

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -20,15 +20,6 @@ use alloc::string::String;
 #[cfg(feature = "std")]
 use once_cell::sync::OnceCell;
 
-#[derive(Copy, Clone)]
-/// Behavior describing how the event loop should terminate.
-pub enum EventLoopQuitBehavior {
-    /// Terminate the event loop when the last window was closed.
-    QuitOnLastWindowClosed,
-    /// Keep the event loop running until [`Backend::quit_event_loop()`] is called.
-    QuitOnlyExplicitly,
-}
-
 /// Interface implemented by back-ends
 pub trait Platform {
     /// Instantiate a window for a component.
@@ -39,8 +30,12 @@ pub trait Platform {
         unimplemented!("The backend does not implement running an eventloop")
     }
 
+    /// Specify if the event loop should quit quen the last window is closed.
+    /// The default behavior is `true`.
+    /// When this is set to `false`, the event loop must keep running until
+    /// [`slint::quit_event_loop()`](crate::api::quit_event_loop()) is called
     #[doc(hidden)]
-    fn set_event_loop_quit_behavior(&self, _behavior: EventLoopQuitBehavior) {
+    fn set_event_loop_quit_on_last_window_closed(&self, _quit_on_last_window_closed: bool) {
         unimplemented!("The backend does not implement event loop quit behaviors")
     }
 

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -98,9 +98,7 @@ pub fn start_ui_event_loop() {
     }
 
     i_slint_backend_selector::with_platform(|b| {
-        b.set_event_loop_quit_behavior(
-            i_slint_core::platform::EventLoopQuitBehavior::QuitOnlyExplicitly,
-        );
+        b.set_event_loop_quit_on_last_window_closed(false);
         b.run_event_loop()
     });
 }


### PR DESCRIPTION
For the winit backend, also make the function work after a call to run()