### PR TITLE
Rgb565Pixel: remove color accessor, add conversion to Rgb8Pixel

### DIFF
--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -58,9 +58,7 @@ impl<const BUFFER_COUNT: usize> super::WinitCompatibleRenderer for SoftwareRende
                     let sub = &mut self.line[..range.len()];
                     render_fn(sub);
                     for (dst, src) in self.buffer[line_begin..][range].iter_mut().zip(sub) {
-                        dst.r = src.red();
-                        dst.g = src.green();
-                        dst.b = src.blue();
+                        *dst = (*src).into();
                     }
                 }
             }

--- a/internal/core/swrenderer/draw_functions.rs
+++ b/internal/core/swrenderer/draw_functions.rs
@@ -418,6 +418,8 @@ impl TargetPixel for Rgb565Pixel {
         // gggggggg_000rrrrr_rrr000bbb_bbbbb00
         let c =
             ((color.red as u32) << 13) | ((color.green as u32) << 24) | ((color.blue as u32) << 2);
+        // gggggg00_000rrrrr_00000bbb_bb00000
+        let c = c & 0b11111100_00011111_00000111_11000000;
 
         let res = expanded * a + c;
 

--- a/internal/core/swrenderer/draw_functions.rs
+++ b/internal/core/swrenderer/draw_functions.rs
@@ -4,7 +4,7 @@
 //! This is the module for the functions that are drawing the pixels
 //! on the line buffer
 
-use crate::graphics::PixelFormat;
+use crate::graphics::{PixelFormat, Rgb8Pixel};
 use crate::lengths::{PhysicalLength, PhysicalRect, PointLengths, SizeLengths};
 use crate::Color;
 use derive_more::{Add, Mul, Sub};
@@ -388,19 +388,19 @@ impl Rgb565Pixel {
     /// Return the red component as a u8.
     ///
     /// The bits are shifted so that the result is between 0 and 255
-    pub fn red(self) -> u8 {
+    fn red(self) -> u8 {
         ((self.0 & Self::R_MASK) >> 8) as u8
     }
     /// Return the green component as a u8.
     ///
     /// The bits are shifted so that the result is between 0 and 255
-    pub fn green(self) -> u8 {
+    fn green(self) -> u8 {
         ((self.0 & Self::G_MASK) >> 3) as u8
     }
     /// Return the blue component as a u8.
     ///
     /// The bits are shifted so that the result is between 0 and 255
-    pub fn blue(self) -> u8 {
+    fn blue(self) -> u8 {
         ((self.0 & Self::B_MASK) << 3) as u8
     }
 }
@@ -430,4 +430,27 @@ impl TargetPixel for Rgb565Pixel {
     fn from_rgb(r: u8, g: u8, b: u8) -> Self {
         Self(((r as u16 & 0b11111000) << 8) | ((g as u16 & 0b11111100) << 3) | (b as u16 >> 3))
     }
+}
+
+impl From<Rgb8Pixel> for Rgb565Pixel {
+    fn from(p: Rgb8Pixel) -> Self {
+        Self::from_rgb(p.r, p.g, p.b)
+    }
+}
+
+impl From<Rgb565Pixel> for Rgb8Pixel {
+    fn from(p: Rgb565Pixel) -> Self {
+        Rgb8Pixel { r: p.red(), g: p.green(), b: p.blue() }
+    }
+}
+
+#[test]
+fn rgb565() {
+    let pix565 = Rgb565Pixel::from_rgb(0xff, 0x25, 0);
+    let pix888: Rgb8Pixel = pix565.into();
+    assert_eq!(pix565, pix888.into());
+
+    let pix565 = Rgb565Pixel::from_rgb(0x56, 0x42, 0xe3);
+    let pix888: Rgb8Pixel = pix565.into();
+    assert_eq!(pix565, pix888.into());
 }


### PR DESCRIPTION
Closes #1540
    
(Went or Rgb8Pixel instead of color, because color can have alpha)

Also fix an overflow in the rgb565 pixel blending
