### PR TITLE
Add support for debug output for ESP32 using esp-println

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -90,6 +90,12 @@ renderer-qt = ["backend-qt"]
 ## Use this in MCU environments where defmt is supported.
 defmt = ["i-slint-core/defmt"]
 
+## This feature enables debug output to be sent via the [ESP println crate](https://github.com/esp-rs/esp-println).
+## Use this in ESP32 based MCU environments.
+## Note that in your application it is also necessary to depend esp-println crate and select the specific device
+## family (esp32s2, esp32s3, etc.).
+esp-println = ["i-slint-core/esp-println"]
+
 ## This feature enables floating point arithmetic emulation using the [libm](https://crates.io/crates/libm) crate. Use this
 ## in MCU environments where the processor does not support floating point arithmetic.
 libm = ["i-slint-core/libm"]

--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -19,7 +19,7 @@ path = "lib.rs"
 [features]
 pico-st7789 = ["slint/unsafe-single-threaded", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "fugit", "cortex-m", "cortex-m", "display-interface", "st7789", "defmt", "defmt-rtt",  "slint/defmt", "shared-bus", "slint/libm", "embedded-dma", "embedded-graphics", "euclid/libm"]
 stm32h735g = ["slint/unsafe-single-threaded", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "slint/defmt", "stm32h7xx-hal/stm32h735", "defmt", "defmt-rtt", "embedded-display-controller", "ft5336", "panic-probe", "slint/libm"]
-esp32-s2-kaluga-1 = ["slint/unsafe-single-threaded", "esp32s2-hal", "embedded-hal", "xtensa-lx-rt", "esp-alloc", "esp-println", "display-interface", "display-interface-spi", "st7789", "slint/libm"]
+esp32-s2-kaluga-1 = ["slint/unsafe-single-threaded", "esp32s2-hal", "embedded-hal", "xtensa-lx-rt", "esp-alloc", "esp-println", "display-interface", "display-interface-spi", "st7789", "slint/libm", "slint/esp-println"]
 
 [dependencies]
 slint = { version = "=0.2.6", path = "../../api/rs/slint", default-features = false, features = ["compat-0-2-0", "renderer-software"] }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -83,6 +83,10 @@ resvg = { version= "0.23", optional = true, default-features = false }
 usvg = { version= "0.23", optional = true, default-features = false, features = ["text"] }
 tiny-skia = { version= "0.6", optional = true, default-features = false }
 
+# This is sub-optimal, it should be limited to esp32 family, but sadly rustc --print=cfg doesn't show any variables to narrow this choice.
+[target.'cfg(target_arch = "xtensa")'.dependencies]
+esp-println = { version = "0.3.0", optional = true, default-features = false }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1", features = [ "wasm-bindgen", "now" ] }
 wasm-bindgen = { version = "0.2" }

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -120,6 +120,16 @@ cfg_if::cfg_if! {
         macro_rules! debug_log {
             ($($t:tt)*) => ($crate::tests::log({ use alloc::string::ToString; &format_args!($($t)*).to_string() }))
         }
+    } else if #[cfg(feature = "esp-println")] {
+        #[doc(hidden)]
+        pub use esp_println;
+
+        /// This macro allows producing debug output that will appear on stderr in regular builds
+        /// and in the console log for wasm builds.
+        #[macro_export]
+        macro_rules! debug_log {
+            ($($t:tt)*) => ($crate::tests::esp_println::println!($($t)*))
+        }
     } else {
         #[macro_export]
         /// Do nothing


### PR DESCRIPTION
Similar to the defmt feature, this adds support for redirecting slint debug! to the ESP
debugging facilities.

Similar to defmt, this also means that the crate of defmt or esp-println
we depend on becomes basically a public
dependency.