### PR TITLE
Replace the built-in defmt debug logging to the platform trait

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -86,10 +86,6 @@ renderer-software = [
 ## This feature is an alias for `backend-qt`
 renderer-qt = ["backend-qt"]
 
-## This feature enables debug output to be sent via the [deferred formatting framework](https://defmt.ferrous-systems.com).
-## Use this in MCU environments where defmt is supported.
-defmt = ["i-slint-core/defmt"]
-
 ## This feature enables floating point arithmetic emulation using the [libm](https://crates.io/crates/libm) crate. Use this
 ## in MCU environments where the processor does not support floating point arithmetic.
 libm = ["i-slint-core/libm"]

--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -17,8 +17,8 @@ links = "mcu_board_support" # just so we can pass metadata to the slint build cr
 path = "lib.rs"
 
 [features]
-pico-st7789 = ["slint/unsafe-single-threaded", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "fugit", "cortex-m", "cortex-m", "display-interface", "st7789", "defmt", "defmt-rtt",  "slint/defmt", "shared-bus", "slint/libm", "embedded-dma", "embedded-graphics", "euclid/libm"]
-stm32h735g = ["slint/unsafe-single-threaded", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "slint/defmt", "stm32h7xx-hal/stm32h735", "defmt", "defmt-rtt", "embedded-display-controller", "ft5336", "panic-probe", "slint/libm"]
+pico-st7789 = ["slint/unsafe-single-threaded", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "fugit", "cortex-m", "cortex-m", "display-interface", "st7789", "defmt", "defmt-rtt",  "shared-bus", "slint/libm", "embedded-dma", "embedded-graphics", "euclid/libm"]
+stm32h735g = ["slint/unsafe-single-threaded", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "stm32h7xx-hal/stm32h735", "defmt", "defmt-rtt", "embedded-display-controller", "ft5336", "panic-probe", "slint/libm"]
 esp32-s2-kaluga-1 = ["slint/unsafe-single-threaded", "esp32s2-hal", "embedded-hal", "xtensa-lx-rt", "esp-alloc", "esp-println", "display-interface", "display-interface-spi", "st7789", "slint/libm"]
 
 [dependencies]

--- a/examples/mcu-board-support/pico_st7789.rs
+++ b/examples/mcu-board-support/pico_st7789.rs
@@ -262,8 +262,9 @@ impl slint::platform::Platform for PicoBackend {
         }
     }
 
-    fn debug_log(&self, text: &str) {
-        defmt::println!("{=str}", text);
+    fn debug_log(&self, arguments: core::fmt::Arguments) {
+        use alloc::string::ToString;
+        defmt::println!("{=str}", arguments.to_string());
     }
 }
 

--- a/examples/mcu-board-support/pico_st7789.rs
+++ b/examples/mcu-board-support/pico_st7789.rs
@@ -261,6 +261,10 @@ impl slint::platform::Platform for PicoBackend {
             cortex_m::asm::wfe();
         }
     }
+
+    fn debug_log(&self, text: &str) {
+        defmt::println!("{=str}", text);
+    }
 }
 
 enum PioTransfer<TO: WriteTarget, CH: SingleChannel> {

--- a/examples/mcu-board-support/stm32h735g.rs
+++ b/examples/mcu-board-support/stm32h735g.rs
@@ -361,4 +361,8 @@ impl slint::platform::Platform for StmBackend {
         let val = self.timer.get().map_or(0, |t| t.counter() / 10);
         core::time::Duration::from_millis(val.into())
     }
+
+    fn debug_log(&self, text: &str) {
+        defmt::println!("{=str}", text);
+    }
 }

--- a/examples/mcu-board-support/stm32h735g.rs
+++ b/examples/mcu-board-support/stm32h735g.rs
@@ -362,7 +362,8 @@ impl slint::platform::Platform for StmBackend {
         core::time::Duration::from_millis(val.into())
     }
 
-    fn debug_log(&self, text: &str) {
-        defmt::println!("{=str}", text);
+    fn debug_log(&self, arguments: core::fmt::Arguments) {
+        use alloc::string::ToString;
+        defmt::println!("{=str}", arguments.to_string());
     }
 }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -51,7 +51,6 @@ vtable = { version="0.1.9", path = "../../helper_crates/vtable" }
 atomic-polyfill = "1.0.1"
 auto_enums = "0.7"
 cfg-if = "1"
-defmt = { version = "0.3.0", optional = true }
 derive_more = "0.99.5"
 euclid = { version = "0.22.1", default-features = false }
 instant = { version = "0.1", features = [ "now" ], optional = true }

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -76,7 +76,7 @@ pub trait Platform {
     /// This function is called when debug() is used in .slint files. The implementation
     /// should direct the output to some developer visible terminal. The default implementation
     /// uses stderr if available, or `console.log` when targeting wasm.
-    fn debug_log(&self, _text: &str) {
+    fn debug_log(&self, _arguments: core::fmt::Arguments) {
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "wasm32")] {
                 use wasm_bindgen::prelude::*;
@@ -87,9 +87,9 @@ pub trait Platform {
                     pub fn log(s: &str);
                 }
 
-                log(_text);
+                log(&_arguments.to_string());
             } else if #[cfg(feature = "std")] {
-                eprintln!("{}", _text);
+                eprintln!("{}", _arguments);
             }
         }
     }

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -89,5 +89,5 @@ pub use alloc::string::ToString;
 /// This macro allows producing debug output that will appear on stderr in regular builds
 /// and in the console log for wasm builds.
 macro_rules! debug_log {
-    ($($t:tt)*) => ($crate::platform::PLATFORM_INSTANCE.with(|p| { use $crate::tests::ToString; p.get().map(|p| p.debug_log(&format_args!($($t)*).to_string()));}))
+    ($($t:tt)*) => ($crate::platform::PLATFORM_INSTANCE.with(|p| { use $crate::tests::ToString; p.get().map(|p| p.debug_log(format_args!($($t)*)));}))
 }

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -83,22 +83,11 @@ pub extern "C" fn send_keyboard_string_sequence(
     }
 }
 
-cfg_if::cfg_if! {
+pub use alloc::string::ToString;
 
-    if #[cfg(feature = "std")] {
-        #[macro_export]
-        /// This macro allows producing debug output that will appear on stderr in regular builds
-        /// and in the console log for wasm builds.
-        macro_rules! debug_log {
-            ($($t:tt)*) => ($crate::platform::PLATFORM_INSTANCE.with(|p| {p.get().map(|p| p.debug_log(&format_args!($($t)*).to_string()));}))
-        }
-    } else {
-        #[macro_export]
-        /// This macro allows producing debug output that will appear on stderr in regular builds
-        /// and in the console log for wasm builds.
-        macro_rules! debug_log {
-            ($($t:tt)*) => ($crate::platform::PLATFORM_INSTANCE.with(|p| { use alloc::string::ToString; p.get().map(|p| p.debug_log(&format_args!($($t)*).to_string()));}))
-        }
-    }
-
+#[macro_export]
+/// This macro allows producing debug output that will appear on stderr in regular builds
+/// and in the console log for wasm builds.
+macro_rules! debug_log {
+    ($($t:tt)*) => ($crate::platform::PLATFORM_INSTANCE.with(|p| { use $crate::tests::ToString; p.get().map(|p| p.debug_log(&format_args!($($t)*).to_string()));}))
 }


### PR DESCRIPTION
This way we don't have to add defmt, esp32-println and others as features to corelib and the slint api crate
(which would also expose them as public dependencies),
but instead this can be simply delegated to the Platform trait.