### PR TITLE
Skia: Make it possible to explicitly select the OpenGL backend of Skia

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -86,6 +86,7 @@ define_cargo_feature(eventloop-winit-wayland "Enable support for the winit creat
 
 define_cargo_feature(renderer-femtovg "Enable support for the OpenGL ES 2.0 based FemtoVG rendering engine." ON)
 define_cargo_feature(renderer-skia "Enable support for the Skia based rendering engine." ON)
+define_cargo_feature(renderer-skia-opengl "Enable support for the Skia based rendering engine with its OpenGL backend." ON)
 
 define_cargo_feature(backend-qt "Enable Qt based rendering backend" ON)
 
@@ -173,7 +174,7 @@ endif(SLINT_STYLE)
 #  * We look for clang or gcc in PATH - unprefixed those are usually host compilers.
 #  * Through corrosion we know the correct host value of CC_<triplet>.
 # Finally, we set CC_<host triplet> to clang or gcc and empty CFLAGS_<host triplet>
-if(SLINT_FEATURE_RENDERER_SKIA AND CMAKE_CROSSCOMPILING AND Rust_CARGO_HOST_TARGET)
+if((SLINT_FEATURE_RENDERER_SKIA OR SLINT_FEATURE_RENDERER_SKIA_OPENGL) AND CMAKE_CROSSCOMPILING AND Rust_CARGO_HOST_TARGET)
     find_program(CLANG clang)
     if(CLANG)
         set(host_cc "${CLANG}")

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -32,6 +32,7 @@ eventloop-winit-x11 = ["i-slint-backend-selector/eventloop-winit-x11"]
 eventloop-winit-wayland = ["i-slint-backend-selector/eventloop-winit-wayland"]
 renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg"]
 renderer-skia = ["i-slint-backend-selector/renderer-skia"]
+renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl"]
 
 default = ["eventloop-winit", "renderer-femtovg", "backend-qt"]
 

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -88,6 +88,9 @@ renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "std"]
 ## The Skia based rendering engine.
 renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
 
+## The Skia based rendering engine that will always use OpenGL.
+renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "std"]
+
 ## This feature makes the `slint::platform::swrenderer` module available in the public API.
 ## Use this to render with Slint for example on MCUs, when you provide you own `slint::platform::Platform`.
 ## Alternatively, enabling this feature alongside `eventloop-winit` enables selecting the software

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -21,6 +21,7 @@ eventloop-winit-wayland = ["i-slint-backend-winit/wayland"]
 
 renderer-femtovg = ["i-slint-backend-winit/renderer-femtovg"]
 renderer-skia = ["i-slint-backend-winit/renderer-skia"]
+renderer-skia-opengl = ["i-slint-backend-winit/renderer-skia-opengl"]
 renderer-software = ["i-slint-backend-winit?/renderer-software"]
 
 rtti = ["i-slint-backend-winit?/rtti", "i-slint-backend-qt?/rtti"]

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
 description = "OpenGL rendering backend for Slint"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
+build = "build.rs"
 
 [lib]
 path = "lib.rs"
@@ -21,6 +22,7 @@ wayland = ["winit/wayland", "glutin/wayland", "copypasta/wayland"]
 x11 = ["winit/x11", "glutin/x11", "copypasta/x11"]
 renderer-femtovg = ["femtovg", "fontdb", "libc", "servo-fontconfig", "winapi", "dwrote", "imgref", "unicode-script", "ttf-parser", "rgb"]
 renderer-skia = ["skia-safe", "glow", "metal", "objc", "core-graphics-types", "foreign-types", "wio", "winapi/d3d12", "winapi/dxgi", "winapi/dxgi1_2", "winapi/dxgi1_3", "winapi/dxgi1_4", "winapi/d3d12sdklayers", "winapi/synchapi"]
+renderer-skia-opengl = ["skia-safe/gl", "glow"]
 renderer-software = ["i-slint-core/swrenderer", "femtovg", "imgref", "rgb"]
 rtti = ["i-slint-core/rtti"]
 default = []
@@ -92,3 +94,6 @@ foreign-types = { version = "0.3.2", optional = true }
 
 [target.'cfg(not(any(target_os = "macos", target_family = "windows")))'.dependencies]
 skia-safe = { version = "0.54.0", optional = true, features = ["gl"] }
+
+[build-dependencies]
+cfg_aliases = "0.1.0"

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -7,7 +7,7 @@ fn main() {
     // Setup cfg aliases
     cfg_aliases! {
        enable_skia_renderer: { any(feature = "renderer-skia", feature = "renderer-skia-opengl")},
-       skia_backend_opengl: { feature = "renderer-skia-opengl" },
+       skia_backend_opengl: { any(feature = "renderer-skia-opengl", all(feature = "renderer-skia", not(any(target_os = "macos", target_family = "windows", target_arch = "wasm32")))) },
        skia_backend_metal: { all(target_os = "macos", not(feature = "renderer-skia-opengl")) },
        skia_backend_d3d: { all(target_family = "windows", not(feature = "renderer-skia-opengl")) },
     }

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    // Setup cfg aliases
+    cfg_aliases! {
+       enable_skia_renderer: { any(feature = "renderer-skia", feature = "renderer-skia-opengl")},
+       skia_backend_opengl: { feature = "renderer-skia-opengl" },
+       skia_backend_metal: { all(target_os = "macos", not(feature = "renderer-skia-opengl")) },
+       skia_backend_d3d: { all(target_family = "windows", not(feature = "renderer-skia-opengl")) },
+    }
+}

--- a/internal/backends/winit/glcontext.rs
+++ b/internal/backends/winit/glcontext.rs
@@ -37,10 +37,7 @@ impl OpenGLContext {
         })
     }
 
-    #[cfg(all(
-        feature = "renderer-skia",
-        not(any(target_os = "macos", target_family = "windows", target_arch = "wasm32"))
-    ))]
+    #[cfg(skia_backend_opengl)]
     pub fn glutin_context(
         &self,
     ) -> std::cell::Ref<glutin::WindowedContext<glutin::PossiblyCurrent>> {
@@ -79,7 +76,7 @@ impl OpenGLContext {
         }
     }
 
-    #[cfg(any(feature = "renderer-femtovg", feature = "renderer-skia"))]
+    #[cfg(any(feature = "renderer-femtovg", enable_skia_renderer))]
     pub fn with_current_context<T>(&self, cb: impl FnOnce(&Self) -> T) -> T {
         if matches!(self.0.borrow().as_ref().unwrap(), OpenGLContextState::Current { .. }) {
             cb(self)

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -21,7 +21,7 @@ mod renderer {
 
     use i_slint_core::window::WindowAdapter;
 
-    #[cfg(any(feature = "renderer-femtovg", feature = "renderer-skia"))]
+    #[cfg(any(feature = "renderer-femtovg", enable_skia_renderer))]
     mod boxshadowcache;
 
     pub(crate) trait WinitCompatibleRenderer: i_slint_core::renderer::Renderer {
@@ -52,7 +52,7 @@ mod renderer {
 
     #[cfg(feature = "renderer-femtovg")]
     pub(crate) mod femtovg;
-    #[cfg(feature = "renderer-skia")]
+    #[cfg(enable_skia_renderer)]
     pub(crate) mod skia;
 
     #[cfg(feature = "renderer-software")]
@@ -79,12 +79,12 @@ fn window_factory_fn<R: WinitCompatibleRenderer + 'static>() -> Rc<dyn WindowAda
 cfg_if::cfg_if! {
     if #[cfg(feature = "renderer-femtovg")] {
         type DefaultRenderer = renderer::femtovg::FemtoVGRenderer;
-    } else if #[cfg(feature = "renderer-skia")] {
+    } else if #[cfg(enable_skia_renderer)] {
         type DefaultRenderer = renderer::skia::SkiaRenderer;
     } else if #[cfg(feature = "renderer-software")] {
         type DefaultRenderer = renderer::sw::SoftwareRenderer;
     } else {
-        compile_error!("Please select a feature to build with the winit event loop: `renderer-femtovg`, `renderer-skia`, `renderer-software`");
+        compile_error!("Please select a feature to build with the winit event loop: `renderer-femtovg`, `renderer-skia`, `renderer-skia-opengl` or `renderer-software`");
     }
 }
 
@@ -112,7 +112,7 @@ impl Backend {
         let window_factory_fn = match renderer_name {
             #[cfg(feature = "renderer-femtovg")]
             Some("gl") | Some("femtovg") => window_factory_fn::<renderer::femtovg::FemtoVGRenderer>,
-            #[cfg(feature = "renderer-skia")]
+            #[cfg(enable_skia_renderer)]
             Some("skia") => window_factory_fn::<renderer::skia::SkiaRenderer>,
             #[cfg(feature = "renderer-software")]
             Some("sw") | Some("software") => window_factory_fn::<renderer::sw::SoftwareRenderer>,

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -17,22 +17,16 @@ mod cached_image;
 mod itemrenderer;
 mod textlayout;
 
-#[cfg(not(any(target_os = "macos", target_family = "windows")))]
-mod opengl_surface;
-
-#[cfg(target_os = "macos")]
-mod metal_surface;
-
-#[cfg(target_family = "windows")]
-mod d3d_surface;
-
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "macos")] {
-        type DefaultSurface = metal_surface::MetalSurface;
-    } else if #[cfg(target_family = "windows")] {
-        type DefaultSurface = d3d_surface::D3DSurface;
-    } else {
+    if #[cfg(skia_backend_opengl)] {
+        mod opengl_surface;
         type DefaultSurface = opengl_surface::OpenGLSurface;
+    } else if #[cfg(skia_backend_metal)] {
+        mod metal_surface;
+        type DefaultSurface = metal_surface::MetalSurface;
+    } else if #[cfg(skia_backend_d3d)] {
+        mod d3d_surface;
+        type DefaultSurface = d3d_surface::D3DSurface;
     }
 }
 

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -71,6 +71,9 @@ renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "std"]
 ## The Skia based rendering engine.
 renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
 
+## The Skia based rendering engine that will always use OpenGL.
+renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "std"]
+
 ## This feature is an alias for `backend-qt`
 renderer-qt = ["backend-qt"]
 

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -42,6 +42,7 @@ eventloop-winit-wayland = ["slint-interpreter/eventloop-winit-wayland", "preview
 
 renderer-femtovg = ["slint-interpreter/renderer-femtovg", "preview"]
 renderer-skia = ["slint-interpreter/renderer-skia", "preview"]
+renderer-skia-opengl = ["slint-interpreter/renderer-skia-opengl", "preview"]
 
 # Compat
 backend-gl-all = ["eventloop-winit", "renderer-femtovg"]

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -24,6 +24,7 @@ eventloop-winit-x11 = ["slint-interpreter/eventloop-winit-x11"]
 
 renderer-femtovg = ["slint-interpreter/renderer-femtovg"]
 renderer-skia = ["slint-interpreter/renderer-skia"]
+renderer-skia-opengl = ["slint-interpreter/renderer-skia-opengl"]
 
 # Compat
 backend-gl-all = ["eventloop-winit", "renderer-femtovg"]


### PR DESCRIPTION
When opting into the Skia renderer, we default to metal on macOS and D3D on Windows.
However if you want to develop a cross-platform application with Skia and
for example rely on OpenGL to be able to implement an OpenGL underlay or overlay,
then we need the ability to explicitly opt into skia's GL renderer.

cc #1445