### PR TITLE
Try to fix the way the window is resized

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -365,13 +365,11 @@ impl Window {
     /// Resizes the window to the specified size on the screen, in physical pixels and excluding
     /// a window frame (if present).
     pub fn set_size(&self, size: PhysicalSize) {
-        if self.0.inner_size.replace(size) == size {
-            return;
-        }
-
         let l = size.to_logical(self.scale_factor());
         self.0.set_window_item_geometry(l.width as _, l.height as _);
-        self.0.window_adapter().set_inner_size(size)
+        if self.0.inner_size.replace(size) != size {
+            self.0.window_adapter().set_inner_size(size);
+        }
     }
 
     /// Dispatch a window event to the window


### PR DESCRIPTION
 - We must first set change the constraints before changing the size
   otherwise the new size might not be in the old constraint and the
   change might not take effect.

 - We must update the WindowItem's size even if the size of the window
   doesn't change. This happens when a component is set on a window that
   that doesn't change it size (eg, preview) but for which we need to
   set the geometry on the window