### PR TITLE
Fix "glyph box" in AboutSlint when rendered on MCU

### DIFF
--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -336,3 +336,42 @@ fn test_exact_fit() {
         lines[0].iter().map(|platform_glyph| platform_glyph.char.unwrap()).collect::<String>();
     debug_assert_eq!(rendered_text, "Fits")
 }
+
+#[test]
+fn test_no_line_separators_characters_rendered() {
+    let font = FixedTestFont;
+    let text = "Hello\nWorld";
+
+    let mut lines = Vec::new();
+
+    let paragraph = TextParagraphLayout {
+        string: text,
+        layout: TextLayout { font: &font, letter_spacing: None },
+        max_width: 13. * 10.,
+        max_height: 10.,
+        horizontal_alignment: TextHorizontalAlignment::Left,
+        vertical_alignment: TextVerticalAlignment::Top,
+        wrap: TextWrap::NoWrap,
+        overflow: TextOverflow::Clip,
+        single_line: true,
+    };
+    paragraph.layout_lines(|glyphs, _, _| {
+        lines.push(
+            glyphs
+                .map(|positioned_glyph| positioned_glyph.platform_glyph.clone())
+                .collect::<Vec<_>>(),
+        );
+    });
+
+    assert_eq!(lines.len(), 2);
+    let rendered_text = lines
+        .iter()
+        .map(|glyphs_per_line| {
+            glyphs_per_line
+                .iter()
+                .map(|platform_glyph| platform_glyph.char.unwrap())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>();
+    debug_assert_eq!(rendered_text, vec!["Hello", "World"]);
+}

--- a/internal/core/textlayout/fragments.rs
+++ b/internal/core/textlayout/fragments.rs
@@ -72,6 +72,10 @@ impl<'a, Length: Clone + Default + core::ops::AddAssign + Zero + Copy, PlatformG
                 None => break,
             };
 
+            if next_glyph_cluster.is_line_or_paragraph_separator {
+                break;
+            }
+
             if next_glyph_cluster.is_whitespace {
                 fragment.trailing_whitespace_width += next_glyph_cluster.width;
             } else {
@@ -163,9 +167,9 @@ fn fragment_iterator_forced_break() {
         vec![
             TextFragment {
                 byte_range: Range { start: 0, end: 1 },
-                glyph_range: Range { start: 0, end: 2 },
+                glyph_range: Range { start: 0, end: 1 },
                 width: 10.,
-                trailing_whitespace_width: 10.,
+                trailing_whitespace_width: 0.,
                 trailing_mandatory_break: true,
             },
             TextFragment {
@@ -190,9 +194,9 @@ fn fragment_iterator_forced_break_multi() {
         vec![
             TextFragment {
                 byte_range: Range { start: 0, end: 1 },
-                glyph_range: Range { start: 0, end: 2 },
+                glyph_range: Range { start: 0, end: 1 },
                 width: 10.,
-                trailing_whitespace_width: 10.,
+                trailing_whitespace_width: 0.,
                 trailing_mandatory_break: true,
             },
             TextFragment {
@@ -257,9 +261,9 @@ fn fragment_iterator_break_anywhere() {
         fragments.next(),
         Some(TextFragment {
             byte_range: Range { start: 0, end: 2 },
-            glyph_range: Range { start: 0, end: 3 },
+            glyph_range: Range { start: 0, end: 2 },
             width: 20.,
-            trailing_whitespace_width: 10.,
+            trailing_whitespace_width: 0.,
             trailing_mandatory_break: true,
         })
     );
@@ -267,9 +271,9 @@ fn fragment_iterator_break_anywhere() {
         fragments.next(),
         Some(TextFragment {
             byte_range: Range { start: 3, end: 5 },
-            glyph_range: Range { start: 3, end: 6 },
+            glyph_range: Range { start: 3, end: 5 },
             width: 20.,
-            trailing_whitespace_width: 10.,
+            trailing_whitespace_width: 0.,
             trailing_mandatory_break: true,
         },)
     );

--- a/internal/core/textlayout/glyphclusters.rs
+++ b/internal/core/textlayout/glyphclusters.rs
@@ -13,6 +13,7 @@ pub struct GlyphCluster<Length: Clone> {
     pub glyph_range: Range<usize>,
     pub width: Length,
     pub is_whitespace: bool,
+    pub is_line_or_paragraph_separator: bool,
 }
 
 #[derive(Clone)]
@@ -79,10 +80,14 @@ impl<'a, Length: Copy + Clone + Zero + core::ops::AddAssign, PlatformGlyph> Iter
             }
         }
         let byte_range = self.byte_offset..cluster_byte_offset;
-        let is_whitespace = self.text[self.byte_offset..]
+        let (is_whitespace, is_line_or_paragraph_separator) = self.text[self.byte_offset..]
             .chars()
             .next()
-            .map(|ch| ch.is_whitespace())
+            .map(|ch| {
+                let is_line_or_paragraph_separator =
+                    ch == '\n' || ch == '\u{2028}' || ch == '\u{2029}';
+                (ch.is_whitespace(), is_line_or_paragraph_separator)
+            })
             .unwrap_or_default();
         self.byte_offset = cluster_byte_offset;
 
@@ -91,6 +96,7 @@ impl<'a, Length: Copy + Clone + Zero + core::ops::AddAssign, PlatformGlyph> Iter
             glyph_range: Range { start: cluster_start, end: self.glyph_index },
             width: cluster_width,
             is_whitespace,
+            is_line_or_paragraph_separator,
         })
     }
 }


### PR DESCRIPTION
The AboutSlint text has a forced linebreak in it, which becomes a box
glyph on MCUs when the font on the host system doesn't use an empty
glyph but a box glyph for \n.

This patch explicitly excludes glyph clusters from text fragments that
feed into lines that originate from one of the three valid separators:
ascii newline, unicode paragraph and unicode line separators.