### PR TITLE
Replace the internal `WindowHandleAccess` trait with a doc-hidden inner() function on Window

### DIFF
--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -4,7 +4,7 @@
 use core::cell::RefCell;
 use i_slint_compiler::langtype::Type;
 use i_slint_core::model::{Model, ModelRc};
-use i_slint_core::window::WindowHandleAccess;
+use i_slint_core::window::WindowInner;
 use i_slint_core::{ImageInner, SharedVector};
 use neon::prelude::*;
 use rand::RngCore;
@@ -352,7 +352,7 @@ declare_types! {
             let this = cx.this();
             let component = cx.borrow(&this, |x| x.0.as_ref().map(|c| c.clone_strong()));
             let component = component.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
-            let window_adapter = component.window().window_handle().window_adapter();
+            let window_adapter = WindowInner::from_pub(component.window()).window_adapter();
             let mut obj = SlintWindow::new::<_, JsValue, _>(&mut cx, std::iter::empty())?;
             cx.borrow_mut(&mut obj, |mut obj| obj.0 = Some(window_adapter));
             Ok(obj.as_value(&mut cx))

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -269,14 +269,13 @@ pub mod testing {
     thread_local!(static KEYBOARD_MODIFIERS : Cell<i_slint_core::input::KeyboardModifiers> = Default::default());
 
     use super::ComponentHandle;
+    use i_slint_core::window::WindowInner;
 
     pub use i_slint_core::tests::slint_mock_elapsed_time as mock_elapsed_time;
 
     /// Simulate a mouse click
     pub fn send_mouse_click<
-        X: vtable::HasStaticVTable<i_slint_core::component::ComponentVTable>
-            + i_slint_core::window::WindowHandleAccess
-            + 'static,
+        X: vtable::HasStaticVTable<i_slint_core::component::ComponentVTable> + 'static,
         Component: Into<vtable::VRc<i_slint_core::component::ComponentVTable, X>> + ComponentHandle,
     >(
         component: &Component,
@@ -289,14 +288,13 @@ pub mod testing {
             &dyn_rc,
             x,
             y,
-            &rc.window_handle().window_adapter(),
+            &WindowInner::from_pub(component.window()).window_adapter(),
         );
     }
 
     /// Simulate a change in keyboard modifiers being pressed
     pub fn set_current_keyboard_modifiers<
-        X: vtable::HasStaticVTable<i_slint_core::component::ComponentVTable>
-            + i_slint_core::window::WindowHandleAccess,
+        X: vtable::HasStaticVTable<i_slint_core::component::ComponentVTable>,
         Component: Into<vtable::VRc<i_slint_core::component::ComponentVTable, X>> + ComponentHandle,
     >(
         _component: &Component,
@@ -307,33 +305,29 @@ pub mod testing {
 
     /// Simulate entering a sequence of ascii characters key by key.
     pub fn send_keyboard_string_sequence<
-        X: vtable::HasStaticVTable<i_slint_core::component::ComponentVTable>
-            + i_slint_core::window::WindowHandleAccess,
+        X: vtable::HasStaticVTable<i_slint_core::component::ComponentVTable>,
         Component: Into<vtable::VRc<i_slint_core::component::ComponentVTable, X>> + ComponentHandle,
     >(
         component: &Component,
         sequence: &str,
     ) {
-        let component = component.clone_strong().into();
         i_slint_core::tests::send_keyboard_string_sequence(
             &super::SharedString::from(sequence),
             KEYBOARD_MODIFIERS.with(|x| x.get()),
-            &component.window_handle().window_adapter(),
+            &WindowInner::from_pub(component.window()).window_adapter(),
         )
     }
 
     /// Applies the specified scale factor to the window that's associated with the given component.
     /// This overrides the value provided by the windowing system.
     pub fn set_window_scale_factor<
-        X: vtable::HasStaticVTable<i_slint_core::component::ComponentVTable>
-            + i_slint_core::window::WindowHandleAccess,
+        X: vtable::HasStaticVTable<i_slint_core::component::ComponentVTable>,
         Component: Into<vtable::VRc<i_slint_core::component::ComponentVTable, X>> + ComponentHandle,
     >(
         component: &Component,
         factor: f32,
     ) {
-        let component = component.clone_strong().into();
-        component.window_handle().set_scale_factor(factor)
+        WindowInner::from_pub(component.window()).set_scale_factor(factor)
     }
 }
 

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -173,7 +173,7 @@ pub mod re_exports {
     pub use i_slint_core::model::*;
     pub use i_slint_core::properties::{set_state_binding, Property, PropertyTracker, StateInfo};
     pub use i_slint_core::slice::Slice;
-    pub use i_slint_core::window::{WindowAdapter, WindowHandleAccess, WindowInner};
+    pub use i_slint_core::window::{WindowAdapter, WindowInner};
     pub use i_slint_core::Color;
     pub use i_slint_core::ComponentVTable_static;
     pub use i_slint_core::Coord;

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -8,7 +8,7 @@ use crate::accessible_generated::*;
 use i_slint_core::accessibility::AccessibleStringProperty;
 use i_slint_core::item_tree::{ItemRc, ItemWeak};
 use i_slint_core::properties::{PropertyDirtyHandler, PropertyTracker};
-use i_slint_core::window::WindowHandleAccess;
+use i_slint_core::window::WindowInner;
 use i_slint_core::SharedVector;
 
 use cpp::*;
@@ -330,7 +330,7 @@ cpp! {{
     void *root_item_for_window(void *rustWindow) {
         return rust!(root_item_for_window_ [rustWindow: &crate::qt_window::QtWindow as "void*"]
                 -> *mut c_void as "void*" {
-            let root_item = Box::new(ItemRc::new(rustWindow.window.window_handle().component(), 0).downgrade());
+            let root_item = Box::new(ItemRc::new(WindowInner::from_pub(&rustWindow.window).component(), 0).downgrade());
             Box::into_raw(root_item) as _
         });
     }

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -31,7 +31,7 @@ use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, RenderingResult,
 use i_slint_core::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use i_slint_core::rtti::*;
-use i_slint_core::window::{WindowAdapter, WindowAdapterRc, WindowHandleAccess};
+use i_slint_core::window::{WindowAdapter, WindowAdapterRc, WindowInner};
 use i_slint_core::{
     declare_item_vtable, Callback, ItemVTable_static, Property, SharedString, SharedVector,
 };
@@ -59,7 +59,7 @@ macro_rules! fn_render {
             let $dpr: f32 = backend.scale_factor();
 
             let window = backend.window();
-            let active: bool = window.window_handle().active();
+            let active: bool = WindowInner::from_pub(window).active();
             // This should include self.enabled() as well, but not every native widget
             // has that property right now.
             let $initial_state = cpp!(unsafe [ active as "bool" ] -> i32 as "int" {

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -188,7 +188,7 @@ impl Item for NativeSpinBox {
 
         if let MouseEvent::Pressed { .. } = event {
             if !self.has_focus() {
-                window_adapter.window().window_handle().set_focus_item(self_rc);
+                WindowInner::from_pub(window_adapter.window()).set_focus_item(self_rc);
             }
         }
         InputEventResult::EventAccepted

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -429,7 +429,7 @@ impl Item for NativeTab {
         if matches!(event, MouseEvent::Released { .. } if !click_on_press)
             || matches!(event, MouseEvent::Pressed { .. } if click_on_press)
         {
-            window_adapter.window().window_handle().set_focus_item(self_rc);
+            WindowInner::from_pub(window_adapter.window()).set_focus_item(self_rc);
             self.current.set(self.tab_index());
             InputEventResult::EventAccepted
         } else {

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -385,7 +385,7 @@ fn process_window_event(
         event
     }
 
-    let runtime_window = window.window().window_handle();
+    let runtime_window = WindowInner::from_pub(window.window());
     match event {
         WindowEvent::Resized(size) => {
             window.resize_event(size);
@@ -637,7 +637,7 @@ pub fn run() {
                 .drain(..)
                 .flat_map(|window_id| window_by_id(window_id))
             {
-                window.window().window_handle().update_window_properties();
+                WindowInner::from_pub(window.window()).update_window_properties();
             }
         }
 

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -16,7 +16,7 @@ use corelib::component::ComponentRc;
 use corelib::input::KeyboardModifiers;
 use corelib::items::{ItemRef, MouseCursor};
 use corelib::layout::Orientation;
-use corelib::window::{WindowAdapter, WindowAdapterSealed, WindowHandleAccess};
+use corelib::window::{WindowAdapter, WindowAdapterSealed, WindowInner};
 use corelib::Property;
 use corelib::{graphics::*, Coord};
 use i_slint_core as corelib;
@@ -106,7 +106,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> GLWindow<Renderer> {
             GraphicsWindowBackendState::Mapped(_) => return,
         };
 
-        let runtime_window = self.window().window_handle();
+        let runtime_window = WindowInner::from_pub(self.window());
         let component_rc = runtime_window.component();
         let component = ComponentRc::borrow_pin(&component_rc);
 
@@ -196,7 +196,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> GLWindow<Renderer> {
         let canvas = self.renderer.create_canvas(window_builder);
 
         let id = canvas.with_window_handle(|winit_window| {
-            self.window.window_handle().set_scale_factor(
+            WindowInner::from_pub(&self.window).set_scale_factor(
                 scale_factor_override.unwrap_or_else(|| winit_window.scale_factor()) as _,
             );
             // On wasm, with_inner_size on the WindowBuilder don't have effect, so apply manually

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -12,7 +12,7 @@ use i_slint_core::graphics::{
     euclid, rendering_metrics_collector::RenderingMetricsCollector, Point, Rect, Size,
 };
 use i_slint_core::renderer::Renderer;
-use i_slint_core::window::{WindowAdapter, WindowHandleAccess};
+use i_slint_core::window::{WindowAdapter, WindowInner};
 use i_slint_core::Coord;
 
 use crate::WindowSystemName;
@@ -135,7 +135,7 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
 
         canvas.opengl_context.make_current();
 
-        let window = window_adapter.window().window_handle();
+        let window = WindowInner::from_pub(window_adapter.window());
 
         window.draw_contents(|components| {
             {
@@ -228,7 +228,7 @@ impl Renderer for FemtoVGRenderer {
             None => return 0,
         };
 
-        let window = window_adapter.window().window_handle();
+        let window = WindowInner::from_pub(window_adapter.window());
 
         let scale_factor = window.scale_factor();
         let pos = pos * scale_factor;
@@ -307,7 +307,7 @@ impl Renderer for FemtoVGRenderer {
             None => return Default::default(),
         };
 
-        let window = window_adapter.window().window_handle();
+        let window = WindowInner::from_pub(window_adapter.window());
 
         let text = text_input.text();
         let scale_factor = window.scale_factor();

--- a/internal/backends/winit/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/winit/renderer/femtovg/itemrenderer.rs
@@ -14,7 +14,7 @@ use i_slint_core::items::{
     self, Clip, FillRule, ImageFit, ImageRendering, InputType, Item, ItemRc, Layer, Opacity,
     RenderingResult,
 };
-use i_slint_core::window::WindowHandleAccess;
+use i_slint_core::window::WindowInner;
 use i_slint_core::{Brush, Color, ImageInner, Property, SharedString};
 
 use super::fonts;
@@ -245,7 +245,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
         let string = string.as_str();
         let font = fonts::FONT_CACHE.with(|cache| {
             cache.borrow_mut().font(
-                text.font_request(self.window.window_handle()),
+                text.font_request(WindowInner::from_pub(&self.window)),
                 self.scale_factor,
                 &text.text(),
             )
@@ -283,7 +283,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
 
         let font = fonts::FONT_CACHE.with(|cache| {
             cache.borrow_mut().font(
-                text_input.font_request(&self.window.window_handle().window_adapter()),
+                text_input.font_request(&WindowInner::from_pub(&self.window).window_adapter()),
                 self.scale_factor,
                 &text_input.text(),
             )

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -9,7 +9,7 @@ use i_slint_core::api::{
 };
 use i_slint_core::graphics::rendering_metrics_collector::RenderingMetricsCollector;
 use i_slint_core::item_rendering::ItemCache;
-use i_slint_core::window::{WindowAdapter, WindowHandleAccess};
+use i_slint_core::window::{WindowAdapter, WindowInner};
 
 use crate::WindowSystemName;
 
@@ -80,11 +80,11 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
     }
 
     fn render(&self, canvas: &Self::Canvas, window_adapter: &dyn WindowAdapter) {
-        let window = window_adapter.window().window_handle();
+        let window_inner = WindowInner::from_pub(window_adapter.window());
 
         canvas.surface.render(|skia_canvas, gr_context| {
-            window.draw_contents(|components| {
-                if let Some(window_item) = window.window_item() {
+            window_inner.draw_contents(|components| {
+                if let Some(window_item) = window_inner.window_item() {
                     skia_canvas
                         .clear(itemrenderer::to_skia_color(&window_item.as_pin_ref().background()));
                 }

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use i_slint_core::graphics::euclid;
 use i_slint_core::item_rendering::{ItemCache, ItemRenderer};
 use i_slint_core::items::{ImageFit, ImageRendering, ItemRc, Layer, Opacity, RenderingResult};
-use i_slint_core::window::WindowHandleAccess;
+use i_slint_core::window::WindowInner;
 use i_slint_core::{items, Brush, Color, Property};
 
 use super::super::boxshadowcache::BoxShadowCache;
@@ -359,7 +359,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
 
         let string = text.text();
         let string = string.as_str();
-        let font_request = text.font_request(self.window.window_handle());
+        let font_request = text.font_request(WindowInner::from_pub(&self.window));
 
         let paint = match self.brush_to_paint(text.color(), max_width, max_height) {
             Some(paint) => paint,

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1118,7 +1118,7 @@ fn generate_item_tree(
             ),
             Some(quote! {
                 _self.window_adapter.set(window_adapter);
-                _self.window_adapter.get().unwrap().window().window_handle().set_component(&VRc::into_dyn(self_rc.clone()));
+                slint::private_unstable_api::re_exports::WindowInner::from_pub(_self.window_adapter.get().unwrap().window()).set_component(&VRc::into_dyn(self_rc.clone()));
             }),
         )
     } else {
@@ -1231,12 +1231,6 @@ fn generate_item_tree(
                 use slint::private_unstable_api::re_exports::*;
                 new_vref!(let vref : VRef<ComponentVTable> for Component = self.as_ref().get_ref());
                 slint::private_unstable_api::re_exports::unregister_component(self.as_ref(), vref, Self::item_array(), self.window_adapter.get().unwrap());
-            }
-        }
-
-        impl slint::private_unstable_api::re_exports::WindowHandleAccess for #inner_component_id {
-            fn window_handle(&self) -> &slint::private_unstable_api::re_exports::WindowInner {
-                self.window_adapter.get().unwrap().window().window_handle()
             }
         }
 
@@ -2000,7 +1994,7 @@ fn compile_builtin_function_call(
                 let window_tokens = access_window_adapter_field(ctx);
                 let focus_item = access_item_rc(pr, ctx);
                 quote!(
-                    #window_tokens.window().window_handle().set_focus_item(#focus_item);
+                    slint::private_unstable_api::re_exports::WindowInner::from_pub(#window_tokens.window()).set_focus_item(#focus_item);
                 )
             } else {
                 panic!("internal error: invalid args to SetFocusItem {:?}", arguments)
@@ -2028,7 +2022,7 @@ fn compile_builtin_function_call(
                 let y = compile_expression(y, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
                 quote!(
-                    #window_adapter_tokens.window().window_handle().show_popup(
+                    slint::private_unstable_api::re_exports::WindowInner::from_pub(#window_adapter_tokens.window()).show_popup(
                         &VRc::into_dyn(#popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone()).into()),
                         Point::new(#x as slint::private_unstable_api::re_exports::Coord, #y as slint::private_unstable_api::re_exports::Coord),
                         #parent_component
@@ -2079,7 +2073,7 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::GetWindowScaleFactor => {
             let window_adapter_tokens = access_window_adapter_field(ctx);
-            quote!(#window_adapter_tokens.window().window_handle().scale_factor())
+            quote!(slint::private_unstable_api::re_exports::WindowInner::from_pub(#window_adapter_tokens.window()).scale_factor())
         }
         BuiltinFunction::AnimationTick => {
             quote!(slint::private_unstable_api::re_exports::animation_tick())

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -239,7 +239,7 @@ pub enum SetRenderingNotifierError {
 /// scene of a component. It provides API to control windowing system specific aspects such
 /// as the position on the screen.
 #[repr(transparent)]
-pub struct Window(WindowInner);
+pub struct Window(pub(crate) WindowInner);
 
 /// This enum describes whether a Window is allowed to be hidden when the user tries to close the window.
 /// It is the return type of the callback provided to [Window::on_close_requested].
@@ -386,12 +386,6 @@ impl Window {
     pub fn has_active_animations(&self) -> bool {
         // TODO make it really per window.
         crate::animations::CURRENT_ANIMATION_DRIVER.with(|driver| driver.has_active_animations())
-    }
-}
-
-impl crate::window::WindowHandleAccess for Window {
-    fn window_handle(&self) -> &crate::window::WindowInner {
-        &self.0
     }
 }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -30,7 +30,7 @@ pub use crate::item_tree::ItemRc;
 use crate::layout::{LayoutInfo, Orientation};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::{WindowAdapter, WindowAdapterRc, WindowHandleAccess};
+use crate::window::{WindowAdapter, WindowAdapterRc, WindowInner};
 use crate::{Callback, Coord, Property, SharedString};
 use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
@@ -564,7 +564,7 @@ impl Item for FocusScope {
         self_rc: &ItemRc,
     ) -> InputEventResult {
         if self.enabled() && matches!(event, MouseEvent::Pressed { .. }) && !self.has_focus() {
-            window_adapter.window().window_handle().set_focus_item(self_rc);
+            WindowInner::from_pub(window_adapter.window()).set_focus_item(self_rc);
         }
         InputEventResult::EventIgnored
     }

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -6,7 +6,7 @@
 #![allow(unsafe_code)]
 
 use crate::input::{KeyEvent, KeyEventType, KeyboardModifiers, MouseEvent};
-use crate::window::WindowHandleAccess;
+use crate::window::WindowInner;
 use crate::Coord;
 use crate::SharedString;
 
@@ -70,12 +70,12 @@ pub extern "C" fn send_keyboard_string_sequence(
         let mut buffer = [0; 6];
         let text = SharedString::from(ch.encode_utf8(&mut buffer) as &str);
 
-        window_adapter.window().window_handle().process_key_input(&KeyEvent {
+        WindowInner::from_pub(window_adapter.window()).process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyPressed,
             text: text.clone(),
             modifiers,
         });
-        window_adapter.window().window_handle().process_key_input(&KeyEvent {
+        WindowInner::from_pub(window_adapter.window()).process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyReleased,
             text,
             modifiers,

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -598,7 +598,7 @@ impl WindowInner {
             None => PopupWindowLocation::ChildWindow(position),
 
             Some(window_adapter) => {
-                window_adapter.window().window_handle().set_component(popup_componentrc);
+                WindowInner::from_pub(window_adapter.window()).set_component(popup_componentrc);
                 PopupWindowLocation::TopLevel(window_adapter)
             }
         };
@@ -683,12 +683,11 @@ impl WindowInner {
     pub fn window_adapter(&self) -> Rc<dyn WindowAdapter> {
         self.window_adapter_weak.upgrade().unwrap()
     }
-}
 
-/// Internal trait used by generated code to access window internals.
-pub trait WindowHandleAccess {
-    /// Returns a reference to the window implementation.
-    fn window_handle(&self) -> &WindowInner;
+    /// Private access to the WindowInner for a given window.
+    pub fn from_pub(window: &crate::api::Window) -> &Self {
+        &window.0
+    }
 }
 
 /// Internal alias for Rc<dyn WindowAdapter>.
@@ -768,7 +767,7 @@ pub mod ffi {
             core::mem::size_of::<WindowAdapterRcOpaque>()
         );
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        window_adapter.window().window_handle().scale_factor()
+        WindowInner::from_pub(window_adapter.window()).scale_factor()
     }
 
     /// Sets the window scale factor, merely for testing purposes.
@@ -778,7 +777,7 @@ pub mod ffi {
         value: f32,
     ) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        window_adapter.window().window_handle().set_scale_factor(value)
+        WindowInner::from_pub(window_adapter.window()).set_scale_factor(value)
     }
 
     /// Sets the focus item.
@@ -788,7 +787,7 @@ pub mod ffi {
         focus_item: &ItemRc,
     ) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        window_adapter.window().window_handle().set_focus_item(focus_item)
+        WindowInner::from_pub(window_adapter.window()).set_focus_item(focus_item)
     }
 
     /// Associates the window with the given component.
@@ -798,7 +797,7 @@ pub mod ffi {
         component: &ComponentRc,
     ) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        window_adapter.window().window_handle().set_component(component)
+        WindowInner::from_pub(window_adapter.window()).set_component(component)
     }
 
     /// Show a popup.
@@ -810,12 +809,12 @@ pub mod ffi {
         parent_item: &ItemRc,
     ) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        window_adapter.window().window_handle().show_popup(popup, position, parent_item);
+        WindowInner::from_pub(window_adapter.window()).show_popup(popup, position, parent_item);
     }
     /// Close the current popup
     pub unsafe extern "C" fn slint_windowrc_close_popup(handle: *const WindowAdapterRcOpaque) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        window_adapter.window().window_handle().close_popup();
+        WindowInner::from_pub(window_adapter.window()).close_popup();
     }
 
     /// C binding to the set_rendering_notifier() API of Window
@@ -938,7 +937,7 @@ pub mod ffi {
     #[no_mangle]
     pub unsafe extern "C" fn slint_windowrc_size(handle: *const WindowAdapterRcOpaque) -> IntSize {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        window_adapter.window().window_handle().inner_size.get().to_euclid().cast()
+        WindowInner::from_pub(window_adapter.window()).inner_size.get().to_euclid().cast()
     }
 
     /// Resizes the window to the specified size on the screen, in physical pixels and excluding

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -5,7 +5,7 @@ use core::convert::TryFrom;
 use i_slint_compiler::langtype::Type as LangType;
 use i_slint_core::graphics::Image;
 use i_slint_core::model::{Model, ModelRc};
-use i_slint_core::window::WindowHandleAccess;
+use i_slint_core::window::WindowInner;
 use i_slint_core::{Brush, PathData, SharedString, SharedVector};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -586,7 +586,7 @@ impl ComponentDefinition {
                 .inner
                 .unerase(guard)
                 .clone()
-                .create_with_existing_window(&window.window_handle().window_adapter()),
+                .create_with_existing_window(&WindowInner::from_pub(window).window_adapter()),
         }
     }
 
@@ -1048,7 +1048,7 @@ pub fn run_event_loop() {
 /// This module contains a few function use by tests
 pub mod testing {
     use super::ComponentHandle;
-    use i_slint_core::window::WindowHandleAccess;
+    use i_slint_core::window::WindowInner;
 
     /// Wrapper around [`i_slint_core::tests::slint_send_mouse_click`]
     pub fn send_mouse_click(comp: &super::ComponentInstance, x: f32, y: f32) {
@@ -1056,7 +1056,7 @@ pub mod testing {
             &vtable::VRc::into_dyn(comp.inner.clone()),
             x,
             y,
-            &comp.window().window_handle().window_adapter(),
+            &WindowInner::from_pub(comp.window()).window_adapter(),
         );
     }
     /// Wrapper around [`i_slint_core::tests::send_keyboard_string_sequence`]
@@ -1067,7 +1067,7 @@ pub mod testing {
         i_slint_core::tests::send_keyboard_string_sequence(
             &string,
             Default::default(),
-            &comp.window().window_handle().window_adapter(),
+            &WindowInner::from_pub(comp.window()).window_adapter(),
         );
     }
 }

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -28,7 +28,7 @@ use i_slint_core::model::Repeater;
 use i_slint_core::properties::InterpolatedPropertyValue;
 use i_slint_core::rtti::{self, AnimatedBindingKind, FieldOffset, PropertyInfo};
 use i_slint_core::slice::Slice;
-use i_slint_core::window::{WindowAdapter, WindowHandleAccess};
+use i_slint_core::window::{WindowAdapter, WindowInner};
 use i_slint_core::{Brush, Color, Property, SharedString, SharedVector};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -405,11 +405,7 @@ impl<'id> ComponentDescription<'id> {
         window_adapter: &Rc<dyn WindowAdapter>,
     ) -> vtable::VRc<ComponentVTable, ErasedComponentBox> {
         let component_ref = instantiate(self, None, Some(window_adapter), Default::default());
-        component_ref
-            .as_pin_ref()
-            .window_adapter()
-            .window()
-            .window_handle()
+        WindowInner::from_pub(component_ref.as_pin_ref().window_adapter().window())
             .set_component(&vtable::VRc::into_dyn(component_ref.clone()));
         component_ref.run_setup_code();
         component_ref
@@ -1465,12 +1461,6 @@ impl<'id> From<ComponentBox<'id>> for ErasedComponentBox {
     }
 }
 
-impl i_slint_core::window::WindowHandleAccess for ErasedComponentBox {
-    fn window_handle(&self) -> &i_slint_core::window::WindowInner {
-        self.window_adapter().window().window_handle()
-    }
-}
-
 pub fn get_repeater_by_name<'a, 'id>(
     instance_ref: InstanceRef<'a, '_>,
     name: &str,
@@ -1737,7 +1727,7 @@ pub fn show_popup(
     let inst =
         instantiate(compiled, Some(parent_comp), Some(parent_window_adapter), Default::default());
     inst.run_setup_code();
-    parent_window_adapter.window().window_handle().show_popup(
+    WindowInner::from_pub(parent_window_adapter.window()).show_popup(
         &vtable::VRc::into_dyn(inst),
         pos,
         parent_item,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -9,7 +9,7 @@ use corelib::graphics::{GradientStop, LinearGradientBrush, PathElement, RadialGr
 use corelib::items::{ItemRef, PropertyAnimation};
 use corelib::model::{Model, ModelRc};
 use corelib::rtti::AnimatedBindingKind;
-use corelib::window::WindowHandleAccess;
+use corelib::window::WindowInner;
 use corelib::{Brush, Color, PathData, SharedString, SharedVector};
 use i_slint_compiler::expression_tree::{
     BuiltinFunction, EasingCurve, Expression, Path as ExprPath, PathElement as ExprPathElement,
@@ -1002,7 +1002,8 @@ pub fn window_adapter_ref<'a>(
 pub fn window_ref<'a>(
     component: InstanceRef<'a, '_>,
 ) -> Option<&'a i_slint_core::window::WindowInner> {
-    window_adapter_ref(component).map(|window_adapter| window_adapter.window().window_handle())
+    window_adapter_ref(component)
+        .map(|window_adapter| WindowInner::from_pub(window_adapter.window()))
 }
 
 /// Return the component instance which hold the given element.


### PR DESCRIPTION
The reversal of ownership removes the need for this glue.

cc #1502