### PR TITLE
Move the documentation of the `log` feature before the backends

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -41,6 +41,10 @@ std = ["i-slint-core/std"]
 ## in MCU environments where the processor does not support floating point arithmetic.
 libm = ["i-slint-core/libm"]
 
+## If enabled, calls of `debug()` in `.slint` files use to the [`log::debug!()`] macro
+## of the [log](https://crates.io/crates/log) crate instead of just `println!()`.
+log = ["dep:log"]
+
 ## Slint uses internally some `thread_local` state.
 ##
 ## When the `std` feature is enabled, Slint can use [`std::thread_local!`], but when in a `#![no_std]`
@@ -116,8 +120,6 @@ once_cell = { version = "1.5", default-features = false, features = ["alloc"] }
 pin-weak = { version = "1.1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 
-## If enabled, calls of `debug()` in `.slint` files use to the `debug!()` macro
-## of the `log` crate instead of just `println!()`.
 log = { version = "0.4.17", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
We do that by using the `dep:` trick in the Cargo.toml