### PR TITLE
Fix console errors in the online editor about GL context losses after some editing

### DIFF
--- a/api/wasm-interpreter/src/lib.rs
+++ b/api/wasm-interpreter/src/lib.rs
@@ -153,6 +153,17 @@ impl WrappedCompiledComp {
     pub fn create(&self, canvas_id: String) -> Result<WrappedInstance, JsValue> {
         Ok(WrappedInstance(self.0.create_with_canvas_id(&canvas_id)))
     }
+    /// Creates this compiled component in the canvas of the provided instance.
+    /// For this to work, the provided instance needs to be visible (show() must've been
+    /// called) and the event loop must be running (`slint.run_event_loop()`). After this
+    /// call the provided instance is not rendered anymore and can be discarded.
+    #[wasm_bindgen]
+    pub fn create_with_existing_window(
+        &self,
+        instance: WrappedInstance,
+    ) -> Result<WrappedInstance, JsValue> {
+        Ok(WrappedInstance(self.0.create_with_existing_window(instance.0.window())))
+    }
 }
 
 #[wasm_bindgen]

--- a/tools/online_editor/index.html
+++ b/tools/online_editor/index.html
@@ -53,7 +53,10 @@
       >
     </p>
 
-    <div id="preview" style="max-width: 48%; float: right"></div>
+    <div id="preview" style="max-width: 48%; float: right">
+        <canvas id="rendering_canvas" width="800" height="600"></canvas>
+        <pre id="rendering_errors" style='color: red; background-color:#fee; margin:0'></pre>
+    </div>
     <div id="editor_area" class="d-block" style="height: 600px; width: 48%">
       <ul id="tabs" class="nav nav-tabs"></ul>
       <div id="editor" class="h-100 border"></div>


### PR DESCRIPTION
There's a memory leak that causes the created canvas elements not be
deleted.  I've tried a few thing such as explicitly hiding the window
(destroying the canvas element instance refs and gl resources we keep in
Rust), but it's not enough - somewhere there remains a circular
reference. Possibly between some of the closures installed in Rust and
DOM elements they are installed on as event handlers.

I also tried using the wasm-bindgen support for weak refs, but no luck.

So instead, to plug the leak, this patch introduces the re-use of the
HTML canvas element in a way that is similar to how the preview works in
vs code's live preview.

I verified that no GL resources or new canvas elements are leaked in
Chrome's heap profiler via snapshot comparison and filtering for the
corresponding DOM element types.