### PR TITLE
Fix non-SVG images with transparency being rendered incorrectly in WA…

### DIFF
--- a/internal/backends/winit/renderer/femtovg/images.rs
+++ b/internal/backends/winit/renderer/femtovg/images.rs
@@ -104,13 +104,7 @@ impl Texture {
                     } else {
                         image_flags
                     };
-                    canvas
-                        .borrow_mut()
-                        .create_image(
-                            &html_image.dom_element,
-                            femtovg::ImageFlags::PREMULTIPLIED | image_flags,
-                        )
-                        .unwrap()
+                    canvas.borrow_mut().create_image(&html_image.dom_element, image_flags).unwrap()
                 } else {
                     return None;
                 }


### PR DESCRIPTION
…SM builds

Commit 05b16bed89ce46f866e6d23e065a699d7d3307ac introduced an exception for SVGs images to treat them as premultiplied, but commit 3ef35c5ef95af0ce7c5e4b5ed855934b3efc6c47 accidentally applied the flag to all HTML images, which is wrong.