### PR TITLE
Fix software renderer line breaker without the unicode feature

### DIFF
--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -340,7 +340,7 @@ fn test_exact_fit() {
 #[test]
 fn test_no_line_separators_characters_rendered() {
     let font = FixedTestFont;
-    let text = "Hello\nWorld";
+    let text = "Hello\nWorld\n";
 
     let mut lines = Vec::new();
 

--- a/internal/core/textlayout/linebreak_simple.rs
+++ b/internal/core/textlayout/linebreak_simple.rs
@@ -10,12 +10,11 @@ pub enum BreakOpportunity {
 #[derive(Clone)]
 pub struct LineBreakIterator<'a> {
     it: core::str::CharIndices<'a>,
-    leading_whitespace: bool,
 }
 
 impl<'a> LineBreakIterator<'a> {
     pub fn new(text: &'a str) -> Self {
-        Self { it: text.char_indices(), leading_whitespace: false }
+        Self { it: text.char_indices() }
     }
 }
 
@@ -27,13 +26,11 @@ impl<'a> Iterator for LineBreakIterator<'a> {
             let maybe_opportunity = match char {
                 '\u{2028}' | '\u{2029}' => Some(BreakOpportunity::Mandatory), // unicode line- and paragraph separators
                 '\n' => Some(BreakOpportunity::Mandatory),                    // ascii line break
-                _ if self.leading_whitespace => Some(BreakOpportunity::Allowed),
+                _ if char.is_ascii_whitespace() => Some(BreakOpportunity::Allowed),
                 _ => None,
             };
-            self.leading_whitespace = char.is_ascii_whitespace();
-
             if let Some(opportunity) = maybe_opportunity {
-                return Some((byte_offset, opportunity));
+                return Some((byte_offset + 1, opportunity));
             }
         }
 

--- a/internal/core/textlayout/shaping.rs
+++ b/internal/core/textlayout/shaping.rs
@@ -231,6 +231,10 @@ fn test_shape_boundaries_empty() {
 }
 
 #[test]
+#[cfg_attr(
+    not(feature = "unicode-script"),
+    ignore = "Not supported without the unicode-script feature"
+)]
 fn test_shape_boundaries_script_change() {
     {
         let text = "abc🍌🐒defதோசை.";


### PR DESCRIPTION
This change makes the test pass without the unicode feature.

Note that it is not possible to run the test without the unicode feature unless one changes the Cargo.toml, so I did that locally to run the tests