### PR TITLE
femtovg backend: fix the cursor position when the text ends with '\n'

### DIFF
--- a/internal/backends/winit/renderer/femtovg/fonts.rs
+++ b/internal/backends/winit/renderer/femtovg/fonts.rs
@@ -624,9 +624,9 @@ impl FontCache {
 }
 
 /// Layout the given string in lines, and call the `layout_line` callback with the line to draw at position y.
-/// The signature of the `layout_line` function is: `(canvas, text, pos, start_index, line_metrics)`.
+/// The signature of the `layout_line` function is: `(text, pos, start_index, line_metrics)`.
 /// start index is the starting byte of the text in the string.
-/// Returns the baseline y coordinate.
+/// Returns the y coordinate of where to place the cursor if it is at the end of the text
 pub(crate) fn layout_text_lines(
     string: &str,
     font: &Font,
@@ -739,5 +739,5 @@ pub(crate) fn layout_text_lines(
             start = index;
         }
     }
-    baseline_y
+    y
 }

--- a/internal/backends/winit/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/winit/renderer/femtovg/itemrenderer.rs
@@ -317,7 +317,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
 
         let mut cursor_point: Option<Point> = None;
 
-        let baseline_y = fonts::layout_text_lines(
+        let next_y = fonts::layout_text_lines(
             text.as_str(),
             &font,
             Size::new(width, height),
@@ -402,7 +402,9 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
                 };
                 if cursor_visible
                     && (range.contains(&cursor_pos)
-                        || (cursor_pos == range.end && cursor_pos == text.len()))
+                        || (cursor_pos == range.end
+                            && cursor_pos == text.len()
+                            && !text.ends_with('\n')))
                 {
                     let cursor_x = metrics
                         .glyphs
@@ -421,7 +423,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
         );
 
         if let Some(cursor_point) =
-            cursor_point.or_else(|| cursor_visible.then(|| [0., baseline_y].into()))
+            cursor_point.or_else(|| cursor_visible.then(|| [0., next_y].into()))
         {
             let mut cursor_rect = femtovg::Path::new();
             cursor_rect.rect(


### PR DESCRIPTION
Fixes #1318