### PR TITLE
winit: Work around request_redraw() not always resulting in a Event::…

### DIFF
--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -134,22 +134,16 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Rende
     }
 
     /// Draw the items of the specified `component` in the given window.
-    fn draw(&self) {
+    fn draw(&self) -> bool {
         let window = match self.borrow_mapped_window() {
             Some(window) => window,
-            None => return, // caller bug, doesn't make sense to call draw() when not mapped
+            None => return false, // caller bug, doesn't make sense to call draw() when not mapped
         };
 
         self.pending_redraw.set(false);
         self.renderer.render(&window.canvas, self);
 
-        // If during rendering a new redraw_request() was issued (for example in a rendering notifier callback), then
-        // pretend that an animation is running, so that we return Poll from the event loop to ensure a repaint as
-        // soon as possible.
-        if self.pending_redraw.get() {
-            i_slint_core::animations::CURRENT_ANIMATION_DRIVER
-                .with(|driver| driver.set_has_active_animations());
-        }
+        self.pending_redraw.get()
     }
 
     fn with_window_handle(&self, callback: &mut dyn FnMut(&winit::window::Window)) {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -327,14 +327,6 @@ impl Window {
     /// This function issues a request to the windowing system to redraw the contents of the window.
     pub fn request_redraw(&self) {
         self.0.window_adapter().request_redraw();
-
-        // When this function is called by the user, we want it to translate to a requestAnimationFrame()
-        // on the web. If called through the rendering notifier (so from within the event loop processing),
-        // unfortunately winit will only do that if set the control flow to Poll. This hack achieves that.
-        // Similarly, the winit win32 event loop doesn't queue the redraw request and needs a Poll nudge.
-        #[cfg(any(target_arch = "wasm32", target_os = "windows"))]
-        crate::animations::CURRENT_ANIMATION_DRIVER
-            .with(|driver| driver.set_has_active_animations());
     }
 
     /// This function returns the scale factor that allows converting between logical and


### PR DESCRIPTION
…RedrawRequested

The old workaround doesn't work anymore (commit
575665994aa348abec097178f3cc0b57333c110e removed the redraw_all_windows() but that was correct as well). Instead we take an approach that is hopefully more idiomatic to winit:

The winit documention suggests two methods: For continuously repainting windows, we can just draw in MainEventsCleared. Otherwise call request_redraw() and wait for Event::RedrawRequested(id).

In practice sometimes a call to request_redraw() from within the input event processing results right away in a Event::RedrawRequested (observed on Windows). Sometimes a request_redraw() results in waking up with NewEvents() but no Event::RedrawRequested, and then in the next iteration a new request_redraw() is included (observed on Windows).

We will continue to issue request_redraw() but for any windows that haven't received Event::RedrawRequested() we will just draw. This still allows the windowing system to compress / combine paint events.

If during draw() request_redraw() is called, we assume that the application wants to redraw ASAP and we fall back to Poll. This was previously the workaround in corelib that's now only in the winit code.

Fixes #1574