### PR TITLE
Fix partial renderer not rendering some dirty area that were clipped

### DIFF
--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -1209,7 +1209,7 @@ impl<DirtyHandler: PropertyDirtyHandler> PropertyTracker<DirtyHandler> {
     }
 
     /// Register this property tracker as a dependency to the current binding/property tracker being evaluated
-    fn register_as_dependency_to_current_binding(self: Pin<&Self>) {
+    pub fn register_as_dependency_to_current_binding(self: Pin<&Self>) {
         if CURRENT_BINDING.is_set() {
             CURRENT_BINDING.with(|cur_binding| {
                 if let Some(cur_binding) = cur_binding {


### PR DESCRIPTION
During the rendering, if an area is clipped, it will not be rendered and therefore will not be rendered as a dependency.

Consider this example:

```
    HorizontalBox {
        Rectangle {
           TouchArea{
              Rectangle { background: parent.pressed ? red : blue; }
           }
        }

        Rectangle {
           clip: true;
           TouchArea{
              Rectangle { background: parent.pressed ? red: blue; }
           }
        }
    }
}

```

Clicking on the first rectangle will make that area dirty and it will be redrawn, but since the second one is clipped away, the renderer will not visit the child items. And clicking on the second rectangle will not make it re-drawn.

This patch makes sure we rejuster ad dependency of the window tracker the non-dirty areas

This fix the printerdemo_mcu stopping to render in some cases