### PR TITLE
Fix gallery window size being far too high when using Skia

### DIFF
--- a/internal/backends/winit/renderer/skia/textlayout.rs
+++ b/internal/backends/winit/renderer/skia/textlayout.rs
@@ -46,6 +46,14 @@ pub fn create_layout(
     h_align: items::TextHorizontalAlignment,
     overflow: items::TextOverflow,
 ) -> skia_safe::textlayout::Paragraph {
+    // For the Qt backend, text_size() with max_width == Some(0.) results in an empty
+    // bounding rect and Qt::Qt::TextWordWrap being omitted from the text flags. That
+    // means qt_format_text() will call QTextLine::setLineWidth() with "infinite width"
+    // and essentially treat it as if max_width was None. For compatibility we do the same.
+    // During the layout computation we might get called with 0 when computing text height
+    // constraints on a window that's not shown yet and stil has a zero width.
+    let max_width = max_width.filter(|width| *width > 0.);
+
     let mut text_style = text_style.unwrap_or_default();
 
     if let Some(family_name) = font_request.family {


### PR DESCRIPTION
This bug is a combination of a few issues, with one specific fix now in the Skia renderer.

A simpler test-case illustrates this:

export App := Window {
    preferred-width: 300px;
    preferred-height: 300px;

    VerticalLayout {
        Text {
            text: "Lots of text with\nnewlines etc.";
            wrap: word-wrap;
        }
    }
}

This is what happens when showing the above:

1. With the Qt backend, the window's layout horizontal and vertical layout info is computed. Before that the window_item's width and height is set to whatever QWidget::size() reports (show() calls first apply_window_properties()). A QWidget that has never been shown reports a size of 640x480, and size the width and height of the window_item are zero, they're set to these values. Consequently, the vertical layout info computation for the TextEdit that has word-wrap enabled is done based on the width of the Text element, which is 640. The height that QFontMetrics::boundingRect() computes is a reasonable text height.

2. With the winit backend and FemtoVG, the width and height of the window_item remains zero and for the vertical layout info, femtovg's break_text() is called with max_width == Some(0.). Due to what I'd call a bug in femtovg's text breaking, this aborts the line breaking after adding the first word, realizing that it doesn't fit already and so just adds one single character and calls it a day. The resulting height is the height of one line of text. That's not quite correct, but it just means the minimum and preferred height of the Text element is a little too small.

3. With the winit backend and Skia, the width and height of the window_item still remain zero for the vertical layout info call on the Text element. For a zero width, Skia's textlayout::Paragraph reports a large intrinsic width (as if single-line) as well as a very large layout height (everything broken into one character per line). This large height becomes the minimum and prefered height of the Text element, this propagates and (back to the gallery) the entire window is ridiculously tall.

I tried to see how Qt would behave if QWidget did not report 640x480 for a widget that's not shown yet but also stick to 0x0 like with winit. The result is that we do also end up calling text_size() with max_width == Some(0.). The resulting QRectF for the call to
QFontMetrics::boundingRect() has therefore a width of 0 and f32::MAX as height. This means that QRectF::isEmpty() returns true, the text flags passed to boundingRect() are 0 and word-wrap is disabled. Consequently the returned height is the height of one line of text. That's not quite correct for a preferred or minimum height, as it's too low, but better than giving the window an excessive height through constraints propagation.

This patch makes the Skia renderer behave like qt_window.rs and QFontMetrics::boundingRect when a zero width is passed. This is sub-optimal as it glosses over the fact that there's

(a) an inconsistency between the Qt and the winit backend over the initial size of the window_item when not specified, before showing the window the first time.

(b) doesn't quite satisfyingly answer the question: What should the minimum size of a text element be given a zero width and height?