### PR TITLE
Fix the initial window size when the height depends on the width

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -16,7 +16,7 @@ use i_slint_core::input::{KeyEvent, KeyEventType, MouseEvent};
 use i_slint_core::item_rendering::{ItemCache, ItemRenderer};
 use i_slint_core::items::{
     self, FillRule, ImageRendering, InputType, ItemRc, ItemRef, Layer, MouseCursor, Opacity,
-    PointerEventButton, RenderingResult, TextOverflow, TextWrap,
+    PointerEventButton, RenderingResult, TextOverflow, TextWrap, WindowItem,
 };
 use i_slint_core::layout::Orientation;
 use i_slint_core::window::{WindowAdapter, WindowAdapterSealed, WindowInner};
@@ -1347,7 +1347,18 @@ impl WindowAdapterSealed for QtWindow {
         let component_rc = WindowInner::from_pub(&self.window).component();
         let component = ComponentRc::borrow_pin(&component_rc);
         let root_item = component.as_ref().get_item_ref(0);
-        if let Some(window_item) = ItemRef::downcast_pin(root_item) {
+        if let Some(window_item) = ItemRef::downcast_pin::<WindowItem>(root_item) {
+            if window_item.width() <= 0. {
+                window_item.width.set(
+                    component.as_ref().layout_info(Orientation::Horizontal).preferred_bounded(),
+                )
+            }
+            if window_item.height() <= 0. {
+                window_item
+                    .height
+                    .set(component.as_ref().layout_info(Orientation::Vertical).preferred_bounded())
+            }
+
             self.apply_window_properties(window_item);
         }
 

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -433,6 +433,11 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWind
             };
 
             let layout_info_h = component.as_ref().layout_info(Orientation::Horizontal);
+            if let Some(window_item) = runtime_window.window_item() {
+                // Setting the width to its preferred size before querying the vertical layout info
+                // is important in case the height depends on the width
+                window_item.width.set(layout_info_h.preferred_bounded());
+            }
             let layout_info_v = component.as_ref().layout_info(Orientation::Vertical);
             let s = LogicalSize::new(
                 layout_info_h.preferred_bounded(),


### PR DESCRIPTION
We need to assign the width beofre computing the preferred height otherwise zero or very small value can be assumed and it will case the text engine return a huge preferred height.

Testcase:

```
export App := Window {
  VerticalLayout {
    padding: -10px;
    Text {
        text: "Lots of text with\nnewlines etc.\n lorem ipsum dolor sit amet";
        wrap: word-wrap;
    }
  }
}
```

In particular, this fixes the gallery window size being too high when using the skia renderer, because when given a zero width, skia return a big size for the height, (contrary to the Qt backend that consider 0 as infinite, or the femtovg backend that will stop rendering once a line can't fit)

Replaces #1621