### PR TITLE
Skia: fix the cursor computations

### DIFF
--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -441,23 +441,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
             && !text_input.read_only();
 
         if cursor_visible {
-            let cursor_byte_offset = cursor_pos as usize;
-
-            // TODO: This doesn't work at the end of the text.
-            let next_char_offset_after_cursor = string[cursor_byte_offset..]
-                .char_indices()
-                .skip(1)
-                .next()
-                .map_or_else(|| string.len(), |(offset, _)| cursor_byte_offset + offset);
-
-            let boxes = layout.get_rects_for_range(
-                cursor_byte_offset..next_char_offset_after_cursor,
-                skia_safe::textlayout::RectHeightStyle::Tight,
-                skia_safe::textlayout::RectWidthStyle::Tight,
-            );
-
-            let cursor_rect = boxes
-                .first()
+            let cursor_rect = super::textlayout::cursor_rect(string, cursor_pos as usize, layout)
                 .map(|text_box| {
                     let rect = text_box.rect;
                     skia_safe::Rect::from_xywh(

--- a/internal/backends/winit/renderer/skia/textlayout.rs
+++ b/internal/backends/winit/renderer/skia/textlayout.rs
@@ -128,3 +128,19 @@ pub fn register_font_from_memory(data: &'static [u8]) -> Result<(), Box<dyn std:
 pub fn register_font_from_path(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     register_font(CustomFontSource::ByPath(path.into()))
 }
+
+pub fn cursor_rect(
+    string: &str,
+    cursor_pos: usize,
+    layout: skia_safe::textlayout::Paragraph,
+) -> Option<skia_safe::textlayout::TextBox> {
+    // TODO: This doesn't work at the end of the text.
+    let cursor_utf16_offset = string[..cursor_pos].chars().map(char::len_utf16).sum();
+    let next = string[cursor_pos..].chars().next().map_or(0, char::len_utf16);
+    let boxes = layout.get_rects_for_range(
+        cursor_utf16_offset..cursor_utf16_offset + next,
+        skia_safe::textlayout::RectHeightStyle::Max,
+        skia_safe::textlayout::RectWidthStyle::Max,
+    );
+    boxes.into_iter().next()
+}


### PR DESCRIPTION
Skia understands glyph offsets, not byte offsets, so the conversion must be made