### PR TITLE
c++: Turn (Logical|Physical)(Size|Position)` into structs

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -182,7 +182,7 @@ public:
 
     slint::PhysicalPosition position() const
     {
-        slint::PhysicalPosition pos { 0, 0 };
+        slint::PhysicalPosition pos;
         cbindgen_private::slint_windowrc_position(&inner, &pos);
         return pos;
     }
@@ -197,7 +197,10 @@ public:
         cbindgen_private::slint_windowrc_set_physical_position(&inner, &pos);
     }
 
-    slint::PhysicalSize size() const { return cbindgen_private::slint_windowrc_size(&inner); }
+    slint::PhysicalSize size() const
+    {
+        return slint::PhysicalSize(cbindgen_private::slint_windowrc_size(&inner));
+    }
 
     void set_logical_size(const slint::LogicalSize &size)
     {

--- a/api/cpp/include/slint_point.h
+++ b/api/cpp/include/slint_point.h
@@ -22,15 +22,27 @@ struct Point
 };
 
 namespace cbindgen_private {
-// The Size types are expanded to the Point2D<...> type from the euclid crate which
+// The Point types are expanded to the Point2D<...> type from the euclid crate which
 // is binary compatible with Point<T>
 template<typename T>
 using Point2D = Point<T>;
 }
 
 /// A position in logical pixel coordinates
-using LogicalPosition = Point<float>;
+struct LogicalPosition : public Point<float>
+{
+    /// Explicitly convert a Point<float> to a LogicalPosition
+    explicit LogicalPosition(const Point<float> p) : Point<float>(p) {};
+    /// Default construct a LogicalPosition in the origin
+    LogicalPosition() : Point<float> { 0., 0. } {};
+};
 /// A position in physical pixel coordinates
-using PhysicalPosition = Point<int32_t>;
+struct PhysicalPosition : public Point<int32_t>
+{
+    /// Explicitly convert a Point<int32_t> to a LogicalPosition
+    explicit PhysicalPosition(const Point<int32_t> p) : Point<int32_t>(p) {};
+    /// Default construct a PhysicalPosition in the origin
+    PhysicalPosition() : Point<int32_t> { 0, 0 } {};
+};
 
 }

--- a/api/cpp/include/slint_size.h
+++ b/api/cpp/include/slint_size.h
@@ -29,8 +29,16 @@ using Size2D = Size<T>;
 }
 
 /// A size given in logical pixels
-using LogicalSize = Size<float>;
+struct LogicalSize : public Size<float>
+{
+    /// Explicitly convert a Size<float> to a LogicalSize
+    explicit LogicalSize(const Size<float> s) : Size<float>(s) {};
+};
 /// A size given in physical pixels.
-using PhysicalSize = Size<uint32_t>;
+struct PhysicalSize : public Size<uint32_t>
+{
+    /// Explicitly convert a Size<uint32_t> to a LogicalSize
+    explicit PhysicalSize(const Size<uint32_t> s) : Size<uint32_t>(s) {};
+};
 
 }


### PR DESCRIPTION
They used to declared by `using` before, so they were too easy to convert into.