### PR TITLE
printerdemo_mcu: tweak the features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,7 +294,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
           command: check
-          args: --target=thumbv6m-none-eabi -p printerdemo_mcu --features mcu-pico-st7789
+          args: --target=thumbv6m-none-eabi -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789
 
   docs:
     uses: slint-ui/slint/.github/workflows/build_docs.yaml@master

--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -43,7 +43,7 @@ In your build.rs, you must include a call to `slint_build::print_rustc_flags().u
 
 
 ```sh
-cargo run -p printerdemo_mcu --features=mcu-simulator --release
+cargo run -p printerdemo_mcu --features=simulator --release
 ```
 
 ### On the Raspberry Pi Pico
@@ -53,7 +53,7 @@ You need nightly rust because that's the only way to get an allocator.
 Build the demo with:
 
 ```sh
-cargo +nightly build -p printerdemo_mcu --features=mcu-pico-st7789 --target=thumbv6m-none-eabi --release
+cargo +nightly build -p printerdemo_mcu --no-default-features --features=mcu-bord-support/pico-st7789 --target=thumbv6m-none-eabi --release
 ```
 
 You should process the file with  [elf2uf2-rs](https://github.com/jonil/elf2uf2-rs)
@@ -165,7 +165,7 @@ This was tested using a second Raspberry Pi Pico programmed as a probe with [Dap
 Using [probe-run](https://github.com/knurling-rs/probe-run) (`cargo install probe-run`)
 
 ```sh
-CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-run --chip STM32H735IGKx" cargo +nightly run -p printerdemo_mcu --features=mcu-board-support/stm32h735g --target=thumbv7em-none-eabihf --release
+CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-run --chip STM32H735IGKx" cargo +nightly run -p printerdemo_mcu --no-default-features  --features=mcu-board-support/stm32h735g --target=thumbv7em-none-eabihf --release
 ```
 
 ### ESP32-S2-Kaluga-1
@@ -176,7 +176,7 @@ Also `cargo instal espflash`
 To compile and run the demo:
 
 ```sh
-cargo +esp build -p printerdemo_mcu --target xtensa-esp32s2-none-elf --features=mcu-board-support/esp32-s2-kaluga-1 --release --config examples/mcu-board-support/esp32_s2_kaluga_1/cargo-config.toml
+cargo +esp build -p printerdemo_mcu --target xtensa-esp32s2-none-elf --no-default-features --features=mcu-board-support/esp32-s2-kaluga-1 --release --config examples/mcu-board-support/esp32_s2_kaluga_1/cargo-config.toml
 espflash --monitor /dev/ttyUSB1 target/xtensa-esp32s2-none-elf/release/printerdemo_mcu
 ```
 

--- a/examples/printerdemo_mcu/Cargo.toml
+++ b/examples/printerdemo_mcu/Cargo.toml
@@ -15,8 +15,8 @@ path = "main.rs"
 name = "printerdemo_mcu"
 
 [features]
-mcu-simulator = ["slint/renderer-winit-software", "slint/backend-winit", "slint/std"]
-mcu-pico-st7789 = ["mcu-board-support/pico-st7789"]
+simulator = ["slint/renderer-winit-software", "slint/backend-winit", "slint/std"]
+default = ["simulator"]
 
 [dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-0.3.0"] }

--- a/examples/printerdemo_mcu/Cargo.toml
+++ b/examples/printerdemo_mcu/Cargo.toml
@@ -21,7 +21,6 @@ default = ["simulator"]
 [dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-0.3.0"] }
 mcu-board-support = { path = "../mcu-board-support" }
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"], optional = true }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }

--- a/examples/printerdemo_mcu/main.rs
+++ b/examples/printerdemo_mcu/main.rs
@@ -13,14 +13,6 @@ use slint::Model;
 
 slint::include_modules!();
 
-/// Returns the current time formated as a string
-fn current_time() -> slint::SharedString {
-    #[cfg(feature = "chrono")]
-    return chrono::Local::now().format("%H:%M:%S %d/%m/%Y").to_string().into();
-    #[cfg(not(feature = "chrono"))]
-    return "".into();
-}
-
 struct PrinterQueueData {
     data: Rc<slint::VecModel<PrinterQueueItem>>,
     print_progress_timer: slint::Timer,
@@ -35,7 +27,7 @@ impl PrinterQueueData {
             owner: env!("CARGO_PKG_AUTHORS").into(),
             pages: 1,
             size: "100kB".into(),
-            submission_date: current_time(),
+            submission_date: "".into(),
         })
     }
 }

--- a/examples/printerdemo_mcu/main.rs
+++ b/examples/printerdemo_mcu/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 #![no_std]
-#![cfg_attr(not(feature = "mcu-simulator"), no_main)]
+#![cfg_attr(not(feature = "simulator"), no_main)]
 
 extern crate alloc;
 


### PR DESCRIPTION
 - rename the mcu-simulator feature to just "simulator" (the mcu is redundent)
 - Don't forward other feature than the simulator from the board support crate. (i don't want to have to forward all features from all examples)
 - default to the simulator (doesn't compile without any feature otherwise, leads to error in rust-analyzer)