### PR TITLE
Don't depend on `clap` in wasm build

### DIFF
--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -55,7 +55,6 @@ default = ["backend-qt", "backend-winit", "renderer-winit-femtovg", "preview"]
 
 [dependencies]
 i-slint-compiler = { version = "=0.3.1", path = "../../internal/compiler"}
-clap = { version = "3.2", features = ["derive", "wrap_help"] }
 dunce = "1.0.1"
 euclid = "0.22"
 lsp-types = { version = "0.93.0", features = ["proposed"] }
@@ -69,6 +68,7 @@ slint-interpreter = { version = "=0.3.1", path = "../../internal/interpreter", d
 i-slint-backend-selector = { version = "=0.3.1", path="../../internal/backends/selector", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+clap = { version = "3.2", features = ["derive", "wrap_help"] }
 crossbeam-channel = "0.5"  # must match the version used by lsp-server
 lsp-server = "0.6"
 once_cell = "1.9.0"


### PR DESCRIPTION
We don't use it anyway when building on wasm.
A recent update of the textwrap crate to depends on the terminal_size crate which itself depends on the errno crate that doesn't build with wasm.
So this should fix the CI