### PR TITLE
Add a 100ms delay before forwarding the event in a Flickable

### DIFF
--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -166,7 +166,7 @@ pub fn set_platform(platform: Box<dyn Platform + 'static>) -> Result<(), SetPlat
 /// This function should be called before rendering or processing input event, at the
 /// beginning of each event loop iteration.
 pub fn update_timers_and_animations() {
-    crate::timers::TimerList::maybe_activate_timers();
+    crate::timers::TimerList::maybe_activate_timers(crate::animations::Instant::now());
     crate::animations::update_animations();
 }
 

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -16,12 +16,13 @@ use crate::SharedString;
 /// This function will add some milliseconds to the fake time
 #[no_mangle]
 pub extern "C" fn slint_mock_elapsed_time(time_in_ms: u64) {
-    crate::animations::CURRENT_ANIMATION_DRIVER.with(|driver| {
+    let tick = crate::animations::CURRENT_ANIMATION_DRIVER.with(|driver| {
         let mut tick = driver.current_tick();
         tick += core::time::Duration::from_millis(time_in_ms);
-        driver.update_animations(tick)
+        driver.update_animations(tick);
+        tick
     });
-    crate::platform::update_timers_and_animations();
+    crate::timers::TimerList::maybe_activate_timers(tick);
 }
 
 /// Simulate a click on a position within the component.

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -20,7 +20,8 @@ pub extern "C" fn slint_mock_elapsed_time(time_in_ms: u64) {
         let mut tick = driver.current_tick();
         tick += core::time::Duration::from_millis(time_in_ms);
         driver.update_animations(tick)
-    })
+    });
+    crate::platform::update_timers_and_animations();
 }
 
 /// Simulate a click on a position within the component.

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -495,28 +495,23 @@ state.borrow_mut().timer_500.start(TimerMode::Repeated, Duration::from_millis(50
 });
 slint::platform::update_timers_and_animations();
 i_slint_core::tests::slint_mock_elapsed_time(100);
-slint::platform::update_timers_and_animations();
-i_slint_core::tests::slint_mock_elapsed_time(100);
 assert_eq!(state.borrow().timer_200_called, 0);
 assert_eq!(state.borrow().timer_once_called, 0);
 assert_eq!(state.borrow().timer_500_called, 0);
-slint::platform::update_timers_and_animations();
+i_slint_core::tests::slint_mock_elapsed_time(100);
 assert_eq!(state.borrow().timer_200_called, 1);
 assert_eq!(state.borrow().timer_once_called, 0);
 assert_eq!(state.borrow().timer_500_called, 0);
 i_slint_core::tests::slint_mock_elapsed_time(100);
-slint::platform::update_timers_and_animations();
 assert_eq!(state.borrow().timer_200_called, 1);
 assert_eq!(state.borrow().timer_once_called, 1);
 assert_eq!(state.borrow().timer_500_called, 0);
 i_slint_core::tests::slint_mock_elapsed_time(200); // total: 500
-slint::platform::update_timers_and_animations();
 assert_eq!(state.borrow().timer_200_called, 2);
 assert_eq!(state.borrow().timer_once_called, 1);
 assert_eq!(state.borrow().timer_500_called, 1);
 for _ in 0..10 {
     i_slint_core::tests::slint_mock_elapsed_time(100);
-    slint::platform::update_timers_and_animations();
 }
 // total: 1500
 assert_eq!(state.borrow().timer_200_called, 7);
@@ -527,19 +522,16 @@ state.borrow().timer_200.restart();
 state.borrow().timer_500.stop();
 slint::platform::update_timers_and_animations();
 i_slint_core::tests::slint_mock_elapsed_time(100);
-slint::platform::update_timers_and_animations();
 assert_eq!(state.borrow().timer_200_called, 7);
 assert_eq!(state.borrow().timer_once_called, 1);
 assert_eq!(state.borrow().timer_500_called, 3);
 slint::platform::update_timers_and_animations();
 i_slint_core::tests::slint_mock_elapsed_time(100);
-slint::platform::update_timers_and_animations();
 assert_eq!(state.borrow().timer_200_called, 8);
 assert_eq!(state.borrow().timer_once_called, 1);
 assert_eq!(state.borrow().timer_500_called, 3);
 slint::platform::update_timers_and_animations();
 i_slint_core::tests::slint_mock_elapsed_time(100);
-slint::platform::update_timers_and_animations();
 assert_eq!(state.borrow().timer_200_called, 8);
 assert_eq!(state.borrow().timer_once_called, 2);
 assert_eq!(state.borrow().timer_500_called, 3);
@@ -557,7 +549,6 @@ state.borrow().timer_200.start(TimerMode::SingleShot, Duration::from_millis(200)
 });
 for _ in 0..5 {
     i_slint_core::tests::slint_mock_elapsed_time(75);
-    slint::platform::update_timers_and_animations();
 }
 assert_eq!(state.borrow().timer_200_called, 10);
 assert_eq!(state.borrow().timer_once_called, 2);
@@ -565,7 +556,6 @@ assert_eq!(state.borrow().timer_500_called, 3);
 state.borrow().timer_200.restart();
 for _ in 0..5 {
     i_slint_core::tests::slint_mock_elapsed_time(75);
-    slint::platform::update_timers_and_animations();
 }
 assert_eq!(state.borrow().timer_200_called, 11);
 assert_eq!(state.borrow().timer_once_called, 2);
@@ -586,7 +576,6 @@ state.borrow_mut().timer_500.start(TimerMode::Repeated, Duration::from_millis(50
 });
 for _ in 0..20 {
     i_slint_core::tests::slint_mock_elapsed_time(100);
-    slint::platform::update_timers_and_animations();
 }
 assert_eq!(state.borrow().timer_200_called, 7011);
 assert_eq!(state.borrow().timer_once_called, 2);

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -214,8 +214,7 @@ impl TimerList {
 
     /// Activates any expired timers by calling their callback function. Returns true if any timers were
     /// activated; false otherwise.
-    pub fn maybe_activate_timers() -> bool {
-        let now = Instant::now();
+    pub fn maybe_activate_timers(now: Instant) -> bool {
         // Shortcut: Is there any timer worth activating?
         if TimerList::next_timeout().map(|timeout| now < timeout).unwrap_or(false) {
             return false;

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -331,6 +331,15 @@ impl WindowInner {
             }
         }
     }
+
+    /// Called by the input code's internal timer to send an event that was delayed
+    pub(crate) fn process_delayed_event(&self) {
+        self.mouse_input_state.set(crate::input::process_delayed_event(
+            &self.window_adapter(),
+            self.mouse_input_state.take(),
+        ));
+    }
+
     /// Receive a key event and pass it to the items of the component to
     /// change their state.
     ///

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -11,13 +11,16 @@ TestCase := Window {
         height: parent.height;
         viewport_width: 2100phx;
         viewport_height: 2100phx;
-        TouchArea {
+        inner_ta := TouchArea {
             x: 150phx;
             y: 150phx;
-            width: 30phx;
-            height: 30phx;
+            width: 50phx;
+            height: 50phx;
             Rectangle {
                 background: parent.pressed ? blue : parent.has_hover ? green : red;
+            }
+            clicked => {
+                root.clicked = mouse_x/1phx * 100000 + mouse_y/1phx;
             }
         }
 
@@ -25,6 +28,9 @@ TestCase := Window {
 
     property<length> offset_x: -f.viewport_x;
     property<length> offset_y: -f.viewport_y;
+    property<bool> inner_ta_pressed <=>  inner_ta.pressed;
+    property<bool> inner_ta_has_hover <=>  inner_ta.has_hover;
+    property<int> clicked;
 }
 
 /*
@@ -65,6 +71,83 @@ assert_eq!(instance.get_offset_y(), 112.5);
 slint_testing::mock_elapsed_time(50);
 assert_eq!(instance.get_offset_x(), 450.);
 assert_eq!(instance.get_offset_y(), 112.5);
+
+assert!(!instance.get_inner_ta_pressed());
+assert!(!instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), 0);
 ```
+
+```rust
+// Test interaction with inner mouse area
+use slint::{WindowEvent, PointerEventButton, LogicalPosition};
+let instance = TestCase::new();
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(175.0, 175.0) });
+assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), 0);
+slint_testing::mock_elapsed_time(5000);
+assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), 0);
+
+// Start a press
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(175.0, 175.0), button: PointerEventButton::Left });
+//assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), 0);
+// Release almost immediately
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(178.0, 173.0), button: PointerEventButton::Left });
+//assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), 28_00023);
+assert_eq!(instance.get_offset_x(), 0.);
+assert_eq!(instance.get_offset_y(), 0.);
+
+instance.set_clicked(-1);
+
+// Start a press
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(175.0, 175.0), button: PointerEventButton::Left });
+assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), -1);
+assert_eq!(instance.get_offset_x(), 0.);
+assert_eq!(instance.get_offset_y(), 0.);
+
+//wait a delay
+slint_testing::mock_elapsed_time(300);
+assert!(instance.get_inner_ta_pressed()); // only now we are pressed
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), -1);
+assert_eq!(instance.get_offset_x(), 0.);
+assert_eq!(instance.get_offset_y(), 0.);
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(100.0, 120.0) });
+assert!(!instance.get_inner_ta_pressed()); // We should no longer be pressed
+//FIXME: we currently loose the has-hover when the flickable is flicking
+// assert!(instance.get_inner_ta_has_hover()); // We still have the mouse
+assert_eq!(instance.get_clicked(), -1); // not clicked
+assert_eq!(instance.get_offset_x(), 75.);
+assert_eq!(instance.get_offset_y(), 55.);
+
+slint_testing::mock_elapsed_time(10000);
+
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(100.0, 120.0), button: PointerEventButton::Left });
+assert!(!instance.get_inner_ta_pressed());
+//FIXME: assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), -1); // not clicked
+assert_eq!(instance.get_offset_x(), 75.);
+assert_eq!(instance.get_offset_y(), 55.);
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(200.0, 50.0) });
+slint_testing::mock_elapsed_time(1000);
+
+assert!(!instance.get_inner_ta_pressed());
+//FIXME: assert!(!instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), -1);
+assert!((instance.get_offset_x() - 75.).abs() < 5.); // only small animation on release
+assert!((instance.get_offset_y() - 55.).abs() < 5.);
+
+```
+
 
 */


### PR DESCRIPTION
It was reported an annoying visual bug when flicking over a listview with item that has a special effect on pressed, that the items would show "pressed" for a brief instant.  This patch add a small delay before sending the press event to the children.

The FIXME in the test is not a regression. (This happens because we send Exited event to the children when flicking, despite the mouse is still in the area)

Added a update_timers_and_animations from slint_mock_elapsed_time so we don't have to call update_timers_and_animations ourselves in the test anymore to fire the timers (it was previously only touching the animation property)