### PR TITLE
GH Actions: Define an action to handle Linux package and nodejs installs

### DIFF
--- a/.github/actions/install-linux-dependencies/action.yaml
+++ b/.github/actions/install-linux-dependencies/action.yaml
@@ -1,0 +1,35 @@
+# Copyright © SixtyFPS GmbH <info@slint-ui.com>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+# cSpell: ignore libxcb libxkbcommon xfixes
+---
+name: Install Linux dependencies
+description: Set up Linux dependencies for Slint
+
+inputs:
+  extra-packages:
+    description: 'Extra packages to install'
+    required: false
+    default: ""
+  force-gcc-10:
+    description: 'Force GCC version 10 (default: "no")'
+    required: false
+    default: "no"
+
+runs:
+  using: composite
+  steps:
+    - name: Install Linux dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get upgrade
+        sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev ${{ inputs.extra-packages }}
+      shell: bash
+    - name: Install C++ compiler
+      if: ${{ (runner.os == 'Linux') && (inputs.force-gcc-10 == 'true') }}
+      run: |
+        sudo apt-get install gcc-10 g++-10
+        echo "CC=gcc-10" >> $GITHUB_ENV
+        echo "CXX=g++-10" >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/install-nodejs/action.yaml
+++ b/.github/actions/install-nodejs/action.yaml
@@ -1,0 +1,40 @@
+# Copyright © SixtyFPS GmbH <info@slint-ui.com>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+---
+name: Install NodeJS
+description: Set up NodeJS
+
+outputs:
+  node-version:
+    description: "The node JS version that was installed"
+    value: ${{ steps.node-query.outputs.node-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: "12"
+    - id: node-version
+      if: runner.os == 'Windows'
+      run: |
+        echo "::set-output name=node-version::$(node --version)"
+      shell: powershell
+    - id: node-query
+      if: runner.os != 'Windows'
+      run: |
+        echo "::set-output name=node-version::$(node --version)"
+      shell: bash
+    - name: Cache native node libraries
+      uses: actions/cache@v2
+      if: runner.os == 'Windows'
+      with:
+        path: ~/node-gyp/cache
+        key: ${{ runner.os }}-${{ github.job }}-${{ steps.node-version.outputs.node-version }}
+    - name: Ensure node-gyp cache is populated
+      if: runner.os == 'Windows'
+      run: |
+        npm install -g node-gyp
+      shell: powershell

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -25,10 +25,7 @@ jobs:
       run: |
         rgb_version=`grep 'rgb = '  internal/core/Cargo.toml | sed 's/^.*"\(.*\)"/\1/'`
         echo "RUSTDOCFLAGS=$RUSTDOCFLAGS --extern-html-root-url rgb=https://docs.rs/rgb/$rgb_version/ -Z unstable-options" >> $GITHUB_ENV
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12'
+    - uses: ./.github/actions/install-nodejs
     - name: Cache mdbook and mdbook-linkcheck
       uses: actions/cache@v2
       with:
@@ -58,7 +55,7 @@ jobs:
         key: ${{ runner.os }}-pipenv-v1-${{ hashFiles('**/Pipfile') }}
         restore-keys: |
           ${{ runner.os }}-pipenv-v1
-    - name: Remove docs from cache # Avoid stale docs
+    - name: Remove docs from cache  # Avoid stale docs
       run: |
           rm -rf target/doc target/cppdocs api/node/docs
     - name: Check Rust formatting

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -48,27 +48,11 @@ jobs:
       run: |
           echo "SLINT_STYLE=fluent" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "SLINT_NO_QT=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12'
-    - id: nodeversion
-      run: |
-          echo "::set-output name=node-version::$(node --version)"
-    - name: Cache native node libraries
-      uses: actions/cache@v2
-      if: matrix.os == 'windows-2022'
-      with:
-        path: ~/node-gyp/cache
-        key: ${{ runner.os }}-${{ github.job }}-${{ steps.nodeversion.outputs.node-version }}
-    - name: Ensure node-gyp cache is populated
-      if: matrix.os == 'windows-2022'
-      run: |
-          npm install -g node-gyp
-          node-gyp install
+    - uses: ./.github/actions/install-nodejs
+      id: node-install
     - uses: ./.github/actions/setup-rust
       with:
-        key: x-v2-${{ steps.nodeversion.outputs.node-version }} # the cache key consists of a manually bumpable version and the node version, as the cached rustc artifacts contain linking information where to find node.lib, which is in a versioned directory.
+        key: x-v2-${{ steps.node-install.outputs.node-version }} # the cache key consists of a manually bumpable version and the node version, as the cached rustc artifacts contain linking information where to find node.lib, which is in a versioned directory.
     - name: Build
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,11 +33,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install Linux Dependencies
-      if: matrix.os == 'ubuntu-20.04'
-      run: sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
+    - uses: ./.github/actions/install-linux-dependencies
     - name: Install Qt
-      if: matrix.os != 'windows-2022'
+      if: runner.os != 'Windows'
       uses: jurplel/install-qt-action@v3
       with:
         version: '5.15.2'
@@ -91,27 +89,24 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-11, windows-2022]
+        os: [ubuntu-20.04, macos-11, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install Linux Dependencies
-      if: matrix.os == 'ubuntu-20.04'
-      run: |
-          sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev gcc-10 g++-10
-          echo "CXX=g++-10" >> $GITHUB_ENV
+    - uses: ./.github/actions/install-linux-dependencies
+      with:
+        force-gcc-10: true
     - name: Install Qt
-      if: matrix.os != 'windows-2022'
+      if: runner.os != 'Windows'
       uses: jurplel/install-qt-action@v3
       with:
         version: '5.15.2'
     - name: Set default style
-      if: matrix.os != 'windows-2022'
-      run: |
-          echo "SLINT_STYLE=native" >> $GITHUB_ENV
+      if: runner.os != 'Windows'
+      run: echo "SLINT_STYLE=native" >> $GITHUB_ENV
     - name: Set default style
-      if: matrix.os == 'windows-2022'
+      if: runner.os == 'Windows'
       run: |
           echo "SLINT_STYLE=fluent" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "SLINT_NO_QT=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -134,15 +129,13 @@ jobs:
       CARGO_INCREMENTAL: false
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-11, windows-2022]
+        os: [ubuntu-20.04, macos-11, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - name: Install Linux Dependencies
-      if: matrix.os == 'ubuntu-20.04'
-      run: |
-          sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev gcc-10 g++-10
-          echo "CXX=g++-10" >> $GITHUB_ENV
+    - uses: ./.github/actions/install-linux-dependencies
+      with:
+        force-gcc-10: true
     - name: Install Qt (Ubuntu)
       uses: jurplel/install-qt-action@v3
       if: matrix.os == 'ubuntu-20.04'
@@ -193,10 +186,9 @@ jobs:
       CARGO_INCREMENTAL: false
     steps:
     - uses: actions/checkout@v2
-    - name: Install Linux Dependencies
-      run: |
-          sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev gcc-10 g++-10
-          echo "CXX=g++-10" >> $GITHUB_ENV
+    - uses: ./.github/actions/install-linux-dependencies
+      with:
+        force-gcc-10: true
     - name: Install Qt (Ubuntu)
       uses: jurplel/install-qt-action@v3
       with:
@@ -264,8 +256,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Install Linux Dependencies
-      run: sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
+    - uses: ./.github/actions/install-linux-dependencies
     - uses: ./.github/actions/setup-rust
     - name: Checkout old version
       run: |

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -19,9 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - name: Install Linux Dependencies
-      if: matrix.os == 'ubuntu-20.04'
-      run: sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
+    - uses: ./.github/actions/install-linux-dependencies
     - name: Install Qt (Ubuntu)
       uses: jurplel/install-qt-action@v3
       if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/crater.yaml
+++ b/.github/workflows/crater.yaml
@@ -41,10 +41,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Install Linux Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libpango1.0-dev libatk1.0-dev libgtk-3-dev alsa-utils libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libjack-jackd2-dev autoconf libxcb-xrm0 libxcb-xrm-dev automake  libxcb-keysyms1-dev libxcb-util0-dev libxcb-icccm4-dev libyajl-dev libstartup-notification0-dev libxcb-randr0-dev libev-dev libxcb-cursor-dev libxcb-xinerama0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev
+    - uses: ./.github/actions/install-linux-dependencies
+      with:
+        extra-packages: libpango1.0-dev libatk1.0-dev libgtk-3-dev alsa-utils libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libjack-jackd2-dev autoconf libxcb-xrm0 libxcb-xrm-dev automake  libxcb-keysyms1-dev libxcb-util0-dev libxcb-icccm4-dev libyajl-dev libstartup-notification0-dev libxcb-randr0-dev libev-dev libxcb-cursor-dev libxcb-xinerama0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev
     - uses: ./.github/actions/setup-rust
     - name: setup patch
       run: |

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -61,9 +61,7 @@ jobs:
     - uses: ./.github/actions/setup-rust
       with:
         target: ${{ matrix.toolchain }}
-    - name: Install Linux Dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
+    - uses: ./.github/actions/install-linux-dependencies
     - name: Build LSP
       uses: actions-rs/cargo@v1
       with:
@@ -84,7 +82,7 @@ jobs:
   build_vscode_lsp_macos_x86_64:
     env:
       SLINT_NO_QT: 1
-    runs-on: macOS-11
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-rust
@@ -109,7 +107,7 @@ jobs:
   build_vscode_lsp_macos_aarch64:
     env:
       SLINT_NO_QT: 1
-    runs-on: macOS-11
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-rust
@@ -134,7 +132,7 @@ jobs:
 
   build_vscode_lsp_macos_bundle:
     needs: [build_vscode_lsp_macos_x86_64, build_vscode_lsp_macos_aarch64]
-    runs-on: macOS-11
+    runs-on: macos-11
     steps:
     - uses: actions/download-artifact@v2
       with:
@@ -187,7 +185,7 @@ jobs:
 
   build_vscode_extension:
     needs: [build_vscode_lsp_linux_windows, build_vscode_lsp_macos_bundle, build_vscode_cross_linux_lsp]
-    runs-on: macOS-11
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - uses: actions/download-artifact@v2

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -210,10 +210,7 @@ jobs:
         path: editors/vscode/bin
     - name: Fix permissions
       run: chmod 755 editors/vscode/bin/* editors/vscode/bin/*.app/Contents/MacOS/*
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12'
+    - uses: ./.github/actions/install-nodejs
     - name: "Prepare meta-data files for nightly package"
       env:
         RELEASE_INPUT: ${{ github.event.inputs.release }}

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -15,13 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12'
-    - id: nodeversion
-      run: |
-          echo "::set-output name=node-version::$(node --version)"
+    - uses: ./.github/actions/install-nodejs
     - uses: actions/cache@v2
       with:
         path: ~/.npm


### PR DESCRIPTION
Both were used in several places and might benefit from being configured in one central place.

The nodejs action will always install npm-gyp on Windows now. We only did that in one place before. I think that makes sense to do in case we ever need to build extra modules on windows. Not that we do many Node installs on windows in our CI in the first place:-)