### PR TITLE
Dependency analysis: properly visit layout properties

### DIFF
--- a/tests/cases/crashes/issue1659_combobox_in_tab.slint
+++ b/tests/cases/crashes/issue1659_combobox_in_tab.slint
@@ -1,0 +1,22 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import { TabWidget } from "std-widgets.slint";
+
+export ComboBox := Rectangle {
+    min-height: max(32px, l.min-height);
+    l := HorizontalLayout { Text {} }
+}
+
+export Broken := TabWidget  {
+    t1 := Tab {
+        vl := VerticalLayout {
+            cb := ComboBox { }
+        }
+    }
+}
+export AppWindow := Window {
+    hl := HorizontalLayout {
+        broken := Broken {}
+    }
+}


### PR DESCRIPTION
in the funciton `visit_layout_items_dependencies` we were passing a NamedReference for a property that could have been in the base component type of an element, instead of in one of the element within the current visited component. This would result in wrong computation done later to find out the "element path" of the property. We then need to tell the visitor that the named reference is in a sub component. To do that, we need to visit a PropertyPath instead of just a NamedReference

Issue 1659 was showing one of the symptoms of this, which was an assert. But it could also result in wrong analysis (binding loop not detected when it should or vice versa)

Fixes #1659