### PR TITLE
Fix panic in online editor when resizing the preview widget

### DIFF
--- a/internal/backends/winit/glcontext.rs
+++ b/internal/backends/winit/glcontext.rs
@@ -244,13 +244,13 @@ impl OpenGLContext {
                     );
 
                     window.set_inner_size(existing_canvas_size);
-                    window.request_redraw();
-                    crate::event_loop::with_window_target(|event_loop| {
-                        event_loop
-                            .event_loop_proxy()
-                            .send_event(crate::event_loop::CustomEvent::RedrawAllWindows)
-                            .ok();
+                    let winit_window_weak = send_wrapper::SendWrapper::new(Rc::downgrade(&window));
+                    i_slint_core::api::invoke_from_event_loop(move || {
+                        if let Some(winit_window) = winit_window_weak.take().upgrade() {
+                            winit_window.request_redraw();
+                        }
                     })
+                    .unwrap();
                 }
             };
 


### PR DESCRIPTION
A resize of the HTML canvas element would trigger our own resize handler, which tried to do a special dance to trigger a redraw.

As it turns out, this breaks with current winit as the event loop target is gone, so calling with_window_target() panics.

See also commit 8b728df021cfe86830b3f45fe0c4fd707e9ea7cc

Instead, this patch reverts to the simpler method of calling invoke_from_event_loop, has workarounds for how to properly wake up the event loop and return poll. In there we can just call request_redraw() on the winit window directly to trigger a draw.