### PR TITLE
online editor: simplify slint wasm bindgen glue initialization

### DIFF
--- a/tools/online_editor/src/preview_widget.ts
+++ b/tools/online_editor/src/preview_widget.ts
@@ -9,7 +9,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 import slint_init, * as slint from "@preview/slint_wasm_interpreter.js";
 
-const ensure_slint_wasm_bindgen_glue_initialized = slint_init();
+const ensure_slint_wasm_bindgen_glue_initialized: Promise<slint.InitOutput> = slint_init();
 
 export class PreviewWidget extends Widget {
   #instance: slint.WrappedInstance | null;

--- a/tools/online_editor/src/preview_widget.ts
+++ b/tools/online_editor/src/preview_widget.ts
@@ -9,14 +9,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 import slint_init, * as slint from "@preview/slint_wasm_interpreter.js";
 
-let was_initialized = false;
-
-async function setup_preview() {
-  if (!was_initialized) {
-    await slint_init();
-  }
-  was_initialized = true;
-}
+const ensure_slint_wasm_bindgen_glue_initialized = slint_init();
 
 export class PreviewWidget extends Widget {
   #instance: slint.WrappedInstance | null;
@@ -80,7 +73,7 @@ export class PreviewWidget extends Widget {
     base_url: string,
     load_callback: (_url: string) => Promise<string>,
   ): Promise<monaco.editor.IMarkerData[]> {
-    await setup_preview();
+    await ensure_slint_wasm_bindgen_glue_initialized;
 
     const { component, diagnostics, error_string } =
       await slint.compile_from_string_with_style(


### PR DESCRIPTION
We can store the promise that wasm bindgen generates to initialize glue code and simply await on it as needed. Calling then() on a fullfilled promise will just resolve to the promise result.