### PR TITLE
online_editor: Make syntax_check work again

### DIFF
--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint src",
     "start": "rimraf dist && npm run build:wasm_lsp && npm run build:wasm_preview && npm run start:vite",
     "start:vite": "vite --open",
-    "syntax_check": "tsc --build"
+    "syntax_check": "tsc --build --force"
   },
   "keywords": [],
   "author": "",

--- a/tools/online_editor/src/editor_widget.ts
+++ b/tools/online_editor/src/editor_widget.ts
@@ -87,7 +87,7 @@ class EditorPaneWidget extends Widget {
   #style = "fluent";
   #editor_documents: Map<string, ModelAndViewState>;
   #editor: monaco.editor.IStandaloneCodeEditor | null;
-  #keystroke_timeout_handle: number | undefined;
+  #keystroke_timeout_handle: number | NodeJS.Timeout | undefined;
   #base_url: string | undefined;
   #edit_era: number;
 

--- a/tools/online_editor/src/tsconfig.json
+++ b/tools/online_editor/src/tsconfig.json
@@ -5,8 +5,7 @@
   },
   "include": ["./*.ts"],
   "references": [
-    {
-      "path": "worker"
-    }
+    // Disable due to https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60868
+    // { "path": "worker" }
   ]
 }

--- a/tools/online_editor/src/worker/types.ts
+++ b/tools/online_editor/src/worker/types.ts
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+/* eslint-disable */
+type Document = any; // This type is defined in the `dom` library, which is not compatible with `webworker`
+type DocumentFragment = any; // This type is defined in the `dom` library, which is not compatible with `webworker`
+type Element = any; // This type is defined in the `dom` library, which is not compatible with `webworker`
+/* eslint-enable */


### PR DESCRIPTION
Turns out that was not actually doing anything locally :-/

So force the compiler to run, add some types that went missing and disable checking of the webworkers -- there is a type conflict in there that needs to be fixed upstream (Issue is:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60868).