### PR TITLE
Streamline online editor startup

### DIFF
--- a/tools/online_editor/index.html
+++ b/tools/online_editor/index.html
@@ -1,20 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <link rel="stylesheet" href="/styles/index.css" />
-    <link
-      href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
-      rel="stylesheet"
-      integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN"
-      crossorigin="anonymous"
-    />
-    <script type="module" src="./src/index.ts"></script>
-  </head>
 
-  <body>
-    <div class="loader">
-      <img class="loader-image" src="static/loader.svg" />
-    </div>
-  </body>
+<head>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" href="/styles/index.css" />
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
+    integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous" />
+  <script type="module" src="./src/index.ts"></script>
+</head>
+
+<body>
+  <div class="loader" style="z-index: 1000; position: absolute;">
+    <img class=" loader-image" src="static/loader.svg" />
+  </div>
+</body>
+
 </html>

--- a/tools/online_editor/src/index.ts
+++ b/tools/online_editor/src/index.ts
@@ -121,7 +121,9 @@ function main() {
     commands.processKeydownEvent(event);
   });
 
-  document.body.innerHTML = ""; // clear loader
+  editor.editor_ready.then(() => {
+    document.body.getElementsByClassName("loader")[0].remove()
+  });
   Widget.attach(menu_bar, document.body);
   Widget.attach(main, document.body);
 }


### PR DESCRIPTION
Put some building blocks in place for an orderly startup sequence. The same method could be used for the other widgets as well.