### PR TITLE
ci: Update github actions

### DIFF
--- a/.github/actions/install-nodejs/action.yaml
+++ b/.github/actions/install-nodejs/action.yaml
@@ -5,6 +5,16 @@
 name: Install NodeJS
 description: Set up NodeJS
 
+inputs:
+  package-lock:
+    description: "The package-lock-json file to use"
+    required: false
+    default: ""
+  package-manager:
+    description: "The package manager (e.g. npm) in use (requires package-lock)"
+    required: false
+    default: ""
+
 outputs:
   node-version:
     description: "The node JS version that was installed"
@@ -14,9 +24,11 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: "12"
+        cache: ${{ inputs.package-manager }}
+        cache-dependency-path: ${{ inputs.package-lock }}
     - id: node-version
       if: runner.os == 'Windows'
       run: |
@@ -28,7 +40,7 @@ runs:
         echo "::set-output name=node-version::$(node --version)"
       shell: bash
     - name: Cache native node libraries
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       if: runner.os == 'Windows'
       with:
         path: ~/node-gyp/cache

--- a/.github/actions/test-online-editor/action.yaml
+++ b/.github/actions/test-online-editor/action.yaml
@@ -28,6 +28,11 @@ runs:
       with:
         name: ${{ inputs.wasm-binaries }}
 
+    - uses: ./.github/actions/install-nodejs
+      with:
+        package-manager: "npm"
+        package-lock: tools/online_editor/package-lock.json
+
     - name: Install NPM dependencies
       run: npm install
       shell: bash
@@ -45,7 +50,7 @@ runs:
       env:
         DEBUG: "cypress:server:args"
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: cypress-screenshots-chrome

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -20,14 +20,14 @@ jobs:
       SLINT_NO_QT: 1
       CARGO_INCREMENTAL: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up rgb crate rustdoc link
       run: |
         rgb_version=`grep 'rgb = '  internal/core/Cargo.toml | sed 's/^.*"\(.*\)"/\1/'`
         echo "RUSTDOCFLAGS=$RUSTDOCFLAGS --extern-html-root-url rgb=https://docs.rs/rgb/$rgb_version/ -Z unstable-options" >> $GITHUB_ENV
     - uses: ./.github/actions/install-nodejs
     - name: Cache mdbook and mdbook-linkcheck
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
            ~/.cargo/bin/mdbook
@@ -48,7 +48,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install --user pipenv
     - name: Cache Pipenv virtualenv
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: pipenv-cache
       with:
         path: ~/.local/share/virtualenvs
@@ -96,7 +96,7 @@ jobs:
           npm run docs
       working-directory: api/node
     - name: "Upload Docs Artifacts"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: docs
           path: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/install-linux-dependencies
     - name: Install Qt
       if: runner.os != 'Windows'
@@ -77,7 +77,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
@@ -116,7 +116,7 @@ jobs:
         os: [ubuntu-20.04, macos-11, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
@@ -156,7 +156,7 @@ jobs:
       working-directory: ${{ runner.workspace }}/cppbuild
       run: cmake --build . --config Debug --target package
     - name: "Create C++ packages artefact"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: cpp_bin-${{ matrix.os }}
           path: ${{ runner.workspace }}/cppbuild/Slint-cpp-*
@@ -169,7 +169,7 @@ jobs:
       QT_QPA_PLATFORM: offscreen
       CARGO_INCREMENTAL: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
@@ -177,7 +177,7 @@ jobs:
       uses: jurplel/install-qt-action@v3
       with:
         version: 5.15.2
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: cpp_bin-ubuntu-20.04
         path: cpp-package
@@ -205,7 +205,7 @@ jobs:
       RUSTFLAGS: --cfg slint_int_coord
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-rust
       with:
         toolchain: nightly
@@ -237,7 +237,7 @@ jobs:
         from_version: ['0.3.0']
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: ./.github/actions/install-linux-dependencies

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-20.04, macOS-11, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/install-linux-dependencies
     - name: Install Qt (Ubuntu)
       uses: jurplel/install-qt-action@v3
@@ -58,7 +58,7 @@ jobs:
       working-directory: ${{ runner.workspace }}/cppbuild
       run: cmake --build . --config Release --target package
     - name: "Upload C++ packages"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: cpp_bin
           path: ${{ runner.workspace }}/cppbuild/Slint-cpp-*

--- a/.github/workflows/crater.yaml
+++ b/.github/workflows/crater.yaml
@@ -40,7 +40,7 @@ jobs:
           - "https://github.com/Sekky61/raycaster_lib"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/install-linux-dependencies
       with:
         extra-packages: libpango1.0-dev libatk1.0-dev libgtk-3-dev alsa-utils libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libjack-jackd2-dev autoconf libxcb-xrm0 libxcb-xrm-dev automake  libxcb-keysyms1-dev libxcb-util0-dev libxcb-icccm4-dev libyajl-dev libstartup-notification0-dev libxcb-randr0-dev libev-dev libxcb-cursor-dev libxcb-xinerama0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev

--- a/.github/workflows/embedded_build.yaml
+++ b/.github/workflows/embedded_build.yaml
@@ -20,17 +20,17 @@ jobs:
       SLINT_NO_QT: 1
       SLINT_STYLE: fluent
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.CR_PAT }}
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         file: ./docker/Dockerfile.${{ matrix.target }}
@@ -48,7 +48,7 @@ jobs:
           - riscv64gc-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-rust
       with:
         target: ${{ matrix.target }}
@@ -59,7 +59,7 @@ jobs:
           command: build
           args: --release --target=${{ matrix.target }} --workspace --exclude slint-node --exclude mcu-board-support --exclude printerdemo_mcu
     - name: "Upload printerdemo artifact"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: printerdemo-${{ matrix.target }}
           path: |

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -57,7 +57,7 @@ jobs:
             artifact_name: slint-lsp-x86_64-pc-windows-gnu.exe
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-rust
       with:
         target: ${{ matrix.toolchain }}
@@ -73,7 +73,7 @@ jobs:
           mkdir bin
           cp target/${{ matrix.toolchain }}/release/${{ matrix.binary_built }} bin/${{ matrix.artifact_name }}
     - name: "Upload LSP Artifact"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: vscode-lsp-binary-${{ matrix.toolchain }}
           path: |
@@ -84,7 +84,7 @@ jobs:
       SLINT_NO_QT: 1
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-rust
       with:
         target: x86_64-apple-darwin
@@ -98,7 +98,7 @@ jobs:
           mkdir bin
           cp -a target/release/bundle/osx/Slint\ Live\ Preview.app bin
     - name: "Upload LSP Artifact"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: vscode-lsp-binary-x86_64-apple-darwin
           path: |
@@ -109,7 +109,7 @@ jobs:
       SLINT_NO_QT: 1
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-rust
       with:
         target: aarch64-apple-darwin
@@ -124,7 +124,7 @@ jobs:
           mkdir bin
           cp -a target/aarch64-apple-darwin/release/slint-lsp bin/slint-lsp-aarch64-apple-darwin
     - name: "Upload LSP Artifact"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: vscode-lsp-binary-aarch64-apple-darwin
           path: |
@@ -134,10 +134,10 @@ jobs:
     needs: [build_vscode_lsp_macos_x86_64, build_vscode_lsp_macos_aarch64]
     runs-on: macos-11
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: vscode-lsp-binary-x86_64-apple-darwin
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: vscode-lsp-binary-aarch64-apple-darwin
         path: bin
@@ -147,7 +147,7 @@ jobs:
         mv tmp Slint\ Live\ Preview.app/Contents/MacOS/slint-lsp
         rm -rf bin
     - name: "Upload LSP macOS bundle Artifact"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: vscode-lsp-binary-darwin
           path: .
@@ -162,7 +162,7 @@ jobs:
           - aarch64-unknown-linux-gnu
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-rust
       with:
         target: ${{ matrix.target }}
@@ -177,7 +177,7 @@ jobs:
           mkdir bin
           cp target/${{ matrix.target }}/release/slint-lsp bin/slint-lsp-${{ matrix.target }}
     - name: "Upload LSP Artifact"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: vscode-lsp-binary-${{ matrix.target }}
           path: |
@@ -187,24 +187,24 @@ jobs:
     needs: [build_vscode_lsp_linux_windows, build_vscode_lsp_macos_bundle, build_vscode_cross_linux_lsp]
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
       with:
         name: vscode-lsp-binary-x86_64-unknown-linux-gnu
         path: editors/vscode/bin
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: vscode-lsp-binary-x86_64-pc-windows-gnu
         path: editors/vscode/bin
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: vscode-lsp-binary-darwin
         path: editors/vscode/bin
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: vscode-lsp-binary-armv7-unknown-linux-gnueabihf
         path: editors/vscode/bin
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: vscode-lsp-binary-aarch64-unknown-linux-gnu
         path: editors/vscode/bin
@@ -241,7 +241,7 @@ jobs:
         extensionFile: ${{ steps.publishToVSCM.outputs.vsixPath }}
         packagePath: ''
     - name: "Upload extension artifact"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: slint-vscode.zip
           path: |
@@ -252,16 +252,16 @@ jobs:
     needs: [docs, wasm_demo, wasm]
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: docs
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: online_editor
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wasm
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wasm_demo
       - name: Publish Docs and Demos

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -22,7 +22,7 @@ jobs:
   build_windows:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-rust
         with:
           target: x86_64-pc-windows-msvc
@@ -60,7 +60,7 @@ jobs:
             bash -x ./scripts/prepare_binary_package.sh pkg\${{ github.event.inputs.program || inputs.program }} --with-qt
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
             name: ${{ github.event.inputs.program || inputs.program }}-windows
             path: |
@@ -69,7 +69,7 @@ jobs:
   build_linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-rust
         with:
           target: x86_64-unknown-linux-gnu
@@ -93,7 +93,7 @@ jobs:
       - name: Tar artifacts to preserve permissions
         run: tar czvf ${{ github.event.inputs.program || inputs.program }}-linux.tar.gz ${{ github.event.inputs.program || inputs.program }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
             name: ${{ github.event.inputs.program || inputs.program }}-linux
             path: ${{ github.event.inputs.program || inputs.program }}-linux.tar.gz
@@ -101,7 +101,7 @@ jobs:
   build_macos:
     runs-on: macOS-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-rust
         with:
           target: x86_64-apple-darwin
@@ -144,7 +144,7 @@ jobs:
       - name: Tar artifacts to preserve permissions
         run: tar czvf ${{ github.event.inputs.program || inputs.program }}-macos.tar.gz ${{ github.event.inputs.program || inputs.program }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
             name: ${{ github.event.inputs.program || inputs.program }}-macos
             path: ${{ github.event.inputs.program || inputs.program }}-macos.tar.gz

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -11,8 +11,8 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: streetsidesoftware/cspell-action@v1.2.4
+    - uses: actions/checkout@v3
+    - uses: streetsidesoftware/cspell-action@v2
       with:
         config: './cspell.json'
         strict: false

--- a/.github/workflows/upgrade_version.yaml
+++ b/.github/workflows/upgrade_version.yaml
@@ -14,7 +14,7 @@ jobs:
   upgrade_version_number:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Do replacements
       run: |
         # Each Cargo.toml need to have the version updated

--- a/.github/workflows/wasm_demos.yaml
+++ b/.github/workflows/wasm_demos.yaml
@@ -14,7 +14,7 @@ jobs:
       CARGO_INCREMENTAL: false
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-rust
       with:
         target: wasm32-unknown-unknown
@@ -66,7 +66,7 @@ jobs:
         wasm-pack build --release --target web
       working-directory: examples/opengl_underlay
     - name: "Upload Demo Artifacts"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: wasm_demo
           path: |

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-nodejs
+        with:
+          package-manager: "npm"
+          package-lock: "tools/online_editor/package-lock.json"
       - uses: ./.github/actions/setup-rust
         with:
           target: wasm32-unknown-unknown
@@ -31,7 +34,7 @@ jobs:
         working-directory: tools/online_editor
 
       - name: "Upload wasm Artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wasm
           path: |
@@ -44,16 +47,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-nodejs
+        with:
+          package-manager: "npm"
+          package-lock: "tools/online_editor/package-lock.json"
       - name: Download the WASM binaries
         uses: actions/download-artifact@v3
         with:
           name: wasm
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-${{ github.job }}-node-${{ hashFiles('api/wasm-interpreter/pkg/package.json', 'tools/lsp/pkg/package.json', 'tools/online_editor/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-node-
 
       - name: Install NPM dependencies
         run: npm install
@@ -64,7 +64,7 @@ jobs:
         working-directory: tools/online_editor
 
       - name: "Upload online_editor Artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: online_editor
           path: tools/online_editor/dist/
@@ -75,22 +75,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-nodejs
+        with:
+          package-manager: "npm"
+          package-lock: "tools/online_editor/package-lock.json"
       - name: Download the WASM binaries
         uses: actions/download-artifact@v3
         with:
           name: wasm
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-${{ github.job }}-node-${{ hashFiles('api/wasm-interpreter/pkg/package.json', 'tools/lsp/pkg/package.json', 'tools/online_editor/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-node-
 
       - name: Install NPM dependencies
         run: npm install
         working-directory: tools/online_editor
 
-      - name: Lint online editor # This needs the slint-wasm-interpreter!
+      - name: Lint online editor
         run: |
           npm run syntax_check
           npm run lint


### PR DESCRIPTION
... and make use of the caching built into the nodejs setup action.

This did skip the update of the run_cmake action to version 10 as that is now based on CMake preset files.