### PR TITLE
janitor: Fix warning about unused functions/modules when compiling wi…

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -13,7 +13,9 @@ use std::rc::Rc;
 
 mod glwindow;
 use glwindow::*;
+#[cfg(any(feature = "renderer-winit-femtovg", skia_backend_opengl))]
 mod glcontext;
+#[cfg(any(feature = "renderer-winit-femtovg", skia_backend_opengl))]
 use glcontext::*;
 pub(crate) mod event_loop;
 mod renderer {


### PR DESCRIPTION
…th Skia and D3d or Metal

When using Metal or D3D, we don't need the glcontext module.