### PR TITLE
Enable Skia for the live preview in VS code on macOS, Linux and Windows

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -51,10 +51,10 @@ jobs:
             target_dir:
             artifact_name: slint-lsp-x86_64-unknown-linux-gnu
           - os: windows-2022
-            toolchain: x86_64-pc-windows-gnu
+            toolchain: x86_64-pc-windows-msvc
             binary_built: slint-lsp.exe
             target_dir:
-            artifact_name: slint-lsp-x86_64-pc-windows-gnu.exe
+            artifact_name: slint-lsp-x86_64-pc-windows-msvc.exe
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -194,7 +194,7 @@ jobs:
         path: editors/vscode/bin
     - uses: actions/download-artifact@v2
       with:
-        name: vscode-lsp-binary-x86_64-pc-windows-gnu
+        name: vscode-lsp-binary-x86_64-pc-windows-msvc
         path: editors/vscode/bin
     - uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -67,7 +67,7 @@ jobs:
       with:
           command: build
           toolchain: stable
-          args: --target ${{ matrix.toolchain }} --release -p slint-lsp
+          args: --target ${{ matrix.toolchain }} --release -p slint-lsp --no-default-features --features preview,backend-winit,renderer-winit-skia
     - name: Create artifact directory
       run: |
           mkdir bin
@@ -92,7 +92,7 @@ jobs:
       run: cargo install cargo-bundle
     - name: Build Main LSP Bundle
       working-directory: tools/lsp
-      run: cargo bundle --release
+      run: cargo bundle --release --no-default-features --features preview,renderer-winit-skia
     - name: Create artifact directory
       run: |
           mkdir bin
@@ -118,7 +118,7 @@ jobs:
       with:
           command: build
           toolchain: stable
-          args: --target aarch64-apple-darwin --release -p slint-lsp
+          args: --target aarch64-apple-darwin --release -p slint-lsp --no-default-features --features preview,renderer-winit-skia
     - name: Create artifact directory
       run: |
           mkdir bin

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -71,7 +71,7 @@ function lspPlatform(): Platform | null {
     }
     else if (process.platform === "win32") {
         return {
-            program_name: "slint-lsp-x86_64-pc-windows-gnu.exe"
+            program_name: "slint-lsp-x86_64-pc-windows-msvc.exe"
         };
     }
     return null;


### PR DESCRIPTION
Skia's rendering quality is better than FemtoVG.

The WASM build remains with FemtoVG (that's not just flipping a switch). The rest of our binaries are built with Qt support.