### PR TITLE
Clean up properties and editor widget dependencies

### DIFF
--- a/tools/online_editor/src/index.ts
+++ b/tools/online_editor/src/index.ts
@@ -58,11 +58,8 @@ function main() {
   editor.onRenderRequest = (style, source, url, fetcher) => {
     return preview.render(style, source, url, fetcher);
   };
-  editor.onNewPropertyData = (h, p) => {
-    properties.set_properties(h, p);
-  };
-  properties.onQueryText = (handler, start, end) => {
-    return editor.textAt(handler, start, end);
+  editor.onNewPropertyData = (binding_text_provider, p) => {
+    properties.set_properties(binding_text_provider, p);
   };
 
   commands.addCommand("slint:compile", {

--- a/tools/online_editor/src/lsp_integration.ts
+++ b/tools/online_editor/src/lsp_integration.ts
@@ -30,3 +30,7 @@ export interface PropertyQuery {
   element: Element | null;
   properties: Property[];
 }
+
+export interface BindingTextProvider {
+  binding_text(_location: DefinitionPosition): string;
+}

--- a/tools/online_editor/src/properties_widget.ts
+++ b/tools/online_editor/src/properties_widget.ts
@@ -5,13 +5,9 @@
 
 import { Widget } from "@lumino/widgets";
 
-import { Element, Property, PropertyQuery } from "./lsp_integration";
+import { BindingTextProvider, Element, Property, PropertyQuery } from "./lsp_integration";
 
 export class PropertiesWidget extends Widget {
-  #onQueryText = (_handler: unknown, _start: number, _end: number) => {
-    return "";
-  };
-
   static createNode(): HTMLElement {
     const node = document.createElement("div");
     const content = document.createElement("div");
@@ -75,7 +71,7 @@ export class PropertiesWidget extends Widget {
     }
   }
 
-  private populate_table(handler: unknown, properties: Property[]) {
+  private populate_table(binding_text_provider: BindingTextProvider, properties: Property[]) {
     const table = this.tableNode;
 
     table.innerHTML = "";
@@ -103,10 +99,8 @@ export class PropertiesWidget extends Widget {
       const value_field = document.createElement("td");
       value_field.className = "value-column";
       if (p.defined_at != null) {
-        value_field.innerText = this.#onQueryText(
-          handler,
-          p.defined_at.expression_start,
-          p.defined_at.expression_end,
+        value_field.innerText = binding_text_provider.binding_text(
+          p.defined_at
         );
       } else {
         value_field.innerText = "";
@@ -117,12 +111,8 @@ export class PropertiesWidget extends Widget {
     }
   }
 
-  set_properties(handler: unknown, properties: PropertyQuery) {
+  set_properties(binding_text_provider: BindingTextProvider, properties: PropertyQuery) {
     this.set_header(properties.element);
-    this.populate_table(handler, properties.properties);
-  }
-
-  set onQueryText(f: (_h: unknown, _s: number, _e: number) => string) {
-    this.#onQueryText = f;
+    this.populate_table(binding_text_provider, properties.properties);
   }
 }


### PR DESCRIPTION
* Use an alias for the signature of the property data notifier
* Replace the onQueryText interface from the editor and instead provide an object with the property data notifier. That way no second connection between editor and properties widget needs to be established, everything is provided in the one callback.

(This could also be simply a closure, instead of an interface implementation)