### PR TITLE
Skia: fix quality of SVG images when using scale factor

### DIFF
--- a/internal/backends/winit/renderer/skia/cached_image.rs
+++ b/internal/backends/winit/renderer/skia/cached_image.rs
@@ -29,6 +29,7 @@ pub(crate) fn as_skia_image(
     image: Image,
     target_width: std::pin::Pin<&i_slint_core::Property<f32>>,
     target_height: std::pin::Pin<&i_slint_core::Property<f32>>,
+    scale_factor: f32,
 ) -> Option<skia_safe::Image> {
     let image_inner: &ImageInner = (&image).into();
     match image_inner {
@@ -47,8 +48,8 @@ pub(crate) fn as_skia_image(
         }
         ImageInner::Svg(svg) => {
             // Query target_width/height here again to ensure that changes will invalidate the item rendering cache.
-            let target_width = target_width.get();
-            let target_height = target_height.get();
+            let target_width = target_width.get() * scale_factor;
+            let target_height = target_height.get() * scale_factor;
             let pixels =
                 match svg.render(IntSize::new(target_width as u32, target_height as u32)).ok()? {
                     SharedImageBuffer::RGB8(_) => unreachable!(),

--- a/internal/backends/winit/renderer/skia/itemrenderer.rs
+++ b/internal/backends/winit/renderer/skia/itemrenderer.rs
@@ -135,15 +135,18 @@ impl<'a> SkiaRenderer<'a> {
         // TODO: avoid doing creating an SkImage multiple times when the same source is used in multiple image elements
         let skia_image = self.image_cache.get_or_update_cache_entry(item_rc, || {
             let image = source_property.get();
-            super::cached_image::as_skia_image(image, target_width, target_height).and_then(
-                |skia_image| match colorize_property
-                    .map(|p| p.get())
-                    .filter(|c| !c.is_transparent())
-                {
+            super::cached_image::as_skia_image(
+                image,
+                target_width,
+                target_height,
+                self.scale_factor,
+            )
+            .and_then(|skia_image| {
+                match colorize_property.map(|p| p.get()).filter(|c| !c.is_transparent()) {
                     Some(color) => self.colorize_image(skia_image, color),
                     None => Some(skia_image),
-                },
-            )
+                }
+            })
         });
 
         let skia_image = match skia_image {


### PR DESCRIPTION
Suppose we render an SVG at 100px x 100px with a screen scale factor of 2. Consequently we should be rendering the SVG at 200phx x 200phx, not 100x100.

Do this by applying the scale factor, just like it is done in the femtovg renderer.