### PR TITLE
Skia: Use different types for physical and logical lengths

### DIFF
--- a/internal/core/lengths.rs
+++ b/internal/core/lengths.rs
@@ -5,10 +5,6 @@ use crate::Coord;
 /// This type is used as a tagging type for use with [`euclid::Scale`] to convert
 /// between physical and logical pixels.
 pub struct PhysicalPx;
-pub type PhysicalLength = euclid::Length<i16, PhysicalPx>;
-pub type PhysicalRect = euclid::Rect<i16, PhysicalPx>;
-pub type PhysicalSize = euclid::Size2D<i16, PhysicalPx>;
-pub type PhysicalPoint = euclid::Point2D<i16, PhysicalPx>;
 
 /// This type is used as a tagging type for use with [`euclid::Scale`] to convert
 /// between physical and logical pixels.

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -13,8 +13,8 @@ use crate::graphics::{IntRect, PixelFormat, Rect as RectF, SharedImageBuffer};
 use crate::item_rendering::ItemRenderer;
 use crate::items::{ImageFit, ItemRc};
 use crate::lengths::{
-    LogicalItemGeometry, LogicalLength, LogicalPoint, LogicalRect, PhysicalLength, PhysicalPoint,
-    PhysicalPx, PhysicalRect, PhysicalSize, PointLengths, RectLengths, ScaleFactor, SizeLengths,
+    LogicalItemGeometry, LogicalLength, LogicalPoint, LogicalRect, PhysicalPx, PointLengths,
+    RectLengths, ScaleFactor, SizeLengths,
 };
 use crate::renderer::Renderer;
 use crate::textlayout::{FontMetrics as _, TextParagraphLayout};
@@ -26,6 +26,11 @@ use core::cell::{Cell, RefCell};
 use core::pin::Pin;
 
 pub use draw_functions::{PremultipliedRgbaColor, Rgb565Pixel, TargetPixel};
+
+type PhysicalLength = euclid::Length<i16, PhysicalPx>;
+type PhysicalRect = euclid::Rect<i16, PhysicalPx>;
+type PhysicalSize = euclid::Size2D<i16, PhysicalPx>;
+type PhysicalPoint = euclid::Point2D<i16, PhysicalPx>;
 
 type DirtyRegion = PhysicalRect;
 

--- a/internal/core/software_renderer/draw_functions.rs
+++ b/internal/core/software_renderer/draw_functions.rs
@@ -4,8 +4,9 @@
 //! This is the module for the functions that are drawing the pixels
 //! on the line buffer
 
+use super::{PhysicalLength, PhysicalRect};
 use crate::graphics::{PixelFormat, Rgb8Pixel};
-use crate::lengths::{PhysicalLength, PhysicalRect, PointLengths, SizeLengths};
+use crate::lengths::{PointLengths, SizeLengths};
 use crate::Color;
 use derive_more::{Add, Mul, Sub};
 #[cfg(feature = "embedded-graphics")]

--- a/internal/core/software_renderer/fonts.rs
+++ b/internal/core/software_renderer/fonts.rs
@@ -7,8 +7,9 @@ use core::cell::RefCell;
 #[cfg(all(not(feature = "std"), feature = "unsafe-single-threaded"))]
 use crate::thread_local_ as thread_local;
 
+use super::{PhysicalLength, PhysicalSize};
 use crate::graphics::{BitmapFont, BitmapGlyph, BitmapGlyphs, FontRequest};
-use crate::lengths::{LogicalLength, LogicalSize, PhysicalLength, PhysicalSize, ScaleFactor};
+use crate::lengths::{LogicalLength, LogicalSize, ScaleFactor};
 use crate::slice::Slice;
 use crate::textlayout::{Glyph, TextLayout, TextShaper};
 use crate::Coord;


### PR DESCRIPTION
Reduce the changes of mixing up values between the two coordinate systems by using separate types, just like in the software renderer.