### PR TITLE
Improve internal default logging behavior with std

### DIFF
--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -74,21 +74,7 @@ pub trait Platform {
     /// should direct the output to some developer visible terminal. The default implementation
     /// uses stderr if available, or `console.log` when targeting wasm.
     fn debug_log(&self, _arguments: core::fmt::Arguments) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
-                use wasm_bindgen::prelude::*;
-
-                #[wasm_bindgen]
-                extern "C" {
-                    #[wasm_bindgen(js_namespace = console)]
-                    pub fn log(s: &str);
-                }
-
-                log(&_arguments.to_string());
-            } else if #[cfg(feature = "std")] {
-                eprintln!("{}", _arguments);
-            }
-        }
+        crate::tests::default_debug_log(_arguments);
     }
 }
 

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -49,7 +49,7 @@ backend-gl-all = ["backend-winit", "renderer-winit-femtovg"]
 backend-gl-wayland = ["backend-winit-wayland", "renderer-winit-femtovg"]
 backend-gl-x11 = ["backend-winit-x11", "renderer-winit-femtovg"]
 
-preview = ["slint-interpreter", "i-slint-backend-selector"]
+preview = ["slint-interpreter", "i-slint-core", "i-slint-backend-selector"]
 
 default = ["backend-qt", "backend-winit", "renderer-winit-femtovg", "preview"]
 
@@ -60,10 +60,10 @@ euclid = "0.22"
 lsp-types = { version = "0.93.0", features = ["proposed"] }
 serde = "1.0.118"
 serde_json = "1.0.60"
-i-slint-core = { version = "=0.3.1", path = "../../internal/core" }
 
 
 # for the preview
+i-slint-core = { version = "=0.3.1", path = "../../internal/core", optional = true }
 slint-interpreter = { version = "=0.3.1", path = "../../internal/interpreter", default-features = false, features = ["compat-0-3-0"], optional = true  }
 i-slint-backend-selector = { version = "=0.3.1", path="../../internal/backends/selector", optional = true }
 

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -12,8 +12,6 @@ mod server_loop;
 mod util;
 
 use i_slint_compiler::CompilerConfiguration;
-#[cfg(not(feature = "preview"))]
-use i_slint_core::window::WindowAdapter;
 use js_sys::Function;
 use lsp_types::InitializeParams;
 use serde::Serialize;
@@ -145,11 +143,6 @@ pub fn create(
 ) -> Result<SlintServer, JsError> {
     console_error_panic_hook::set_once();
 
-    // make sure the backend is initialized for logging
-    #[cfg(not(feature = "preview"))]
-    i_slint_core::platform::set_platform(Box::new(DummyBackend {}))
-        .expect("platform already initialized");
-
     let init_param = init_param.into_serde()?;
 
     let mut compiler_config =
@@ -238,14 +231,4 @@ async fn load_file(path: String, load_file: &Function) -> std::io::Result<String
         .map_err(|e| std::io::Error::new(ErrorKind::Other, format!("{e:?}")))?;
     String::from_utf8(js_sys::Uint8Array::from(array).to_vec())
         .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e.to_string()))
-}
-
-#[cfg(not(feature = "preview"))]
-struct DummyBackend {}
-
-#[cfg(not(feature = "preview"))]
-impl i_slint_core::platform::Platform for DummyBackend {
-    fn create_window_adapter(&self) -> Rc<dyn WindowAdapter> {
-        unimplemented!()
-    }
 }


### PR DESCRIPTION
Previously, any use of our internal debug_log!() macro would require a platform backend to be initialized. This was confusing when debugging something in the (headless) wasm lsp implementation and nothing showed up on the console.

Now if we can, we will always log. If a platform backend exists, we route through it, otherwise we can do the fallback ourselves.