### PR TITLE
online_editor: Save/restore/reset dock layouts

### DIFF
--- a/tools/online_editor/src/editor_widget.ts
+++ b/tools/online_editor/src/editor_widget.ts
@@ -456,6 +456,9 @@ class EditorPaneWidget extends Widget {
     }
 
     const response = await fetch(url);
+    if (!response.ok) {
+      return "Failed to access URL: " + response.statusText;
+    }
     const doc = await response.text();
 
     model_and_state = this.#editor_documents.get(url);
@@ -476,22 +479,7 @@ class EditorPaneWidget extends Widget {
   }
 
   async read_from_url(url: string): Promise<string> {
-    let model_and_state = this.#editor_documents.get(url);
-    if (model_and_state != null) {
-      return model_and_state.model.getValue();
-    }
-
-    const response = await fetch(url);
-    const text = await response.text();
-
-    model_and_state = this.#editor_documents.get(url);
-    if (model_and_state != null) {
-      return model_and_state.model.getValue();
-    } else {
-      const model = createModel(text, monaco.Uri.parse(url));
-      this.add_model(url, model);
-      return text;
-    }
+    return this.fetch_url_content(this.#edit_era, url);
   }
 }
 

--- a/tools/online_editor/src/index.ts
+++ b/tools/online_editor/src/index.ts
@@ -21,6 +21,8 @@ import { WelcomeWidget } from "./welcome_widget";
 
 const commands = new CommandRegistry();
 
+const local_storage_key_layout = "layout_v1";
+
 function create_build_menu(): Menu {
   const menu = new Menu({ commands });
   menu.title.label = "Build";
@@ -114,7 +116,7 @@ function create_view_menu(dock_widgets: DockWidgets): Menu {
           }
           return result;
         });
-        localStorage.setItem("layout", layout_str);
+        localStorage.setItem(local_storage_key_layout, layout_str);
       } catch (e) {
         console.log("Failed to save dock layout!", e);
       }
@@ -124,19 +126,24 @@ function create_view_menu(dock_widgets: DockWidgets): Menu {
   commands.addCommand("slint:reset-dock-layout", {
     label: "Reset to Default Layout",
     caption: "Reset to default layout",
+    isEnabled: () => {
+      return localStorage.getItem(local_storage_key_layout) != null;
+    },
     execute: () => {
-      localStorage.removeItem("layout");
+      localStorage.removeItem(local_storage_key_layout);
     },
   });
 
   commands.addCommand("slint:restore-dock-layout", {
     label: "Restore Dock Layout",
     caption: "Restore the stored Dock layout",
+    isEnabled: () => {
+      return localStorage.getItem(local_storage_key_layout) != null;
+    },
     execute: () => {
-      const layout_str = localStorage.getItem("layout");
+      const layout_str = localStorage.getItem(local_storage_key_layout);
       if (layout_str != null && layout_str != "") {
-        const idMap: Map<string, Widget | Layout | null | undefined> =
-          new Map();
+        const idMap: Map<string, Widget | Layout | null> = new Map();
         for (const id of dock_widgets.ids) {
           idMap.set(widget_pseudo_url(id), dock_widgets.widget(id));
         }

--- a/tools/online_editor/src/preview_widget.ts
+++ b/tools/online_editor/src/preview_widget.ts
@@ -40,6 +40,7 @@ export class PreviewWidget extends Widget {
     this.addClass("preview");
     this.title.label = "Preview";
     this.title.caption = `Slint Viewer`;
+    this.title.closable = true;
 
     this.#canvas_id = "";
     this.#instance = null;

--- a/tools/online_editor/src/preview_widget.ts
+++ b/tools/online_editor/src/preview_widget.ts
@@ -3,8 +3,8 @@
 
 // cSpell: ignore bindgen lumino winit
 
-import { Widget } from "@lumino/widgets";
 import { Message } from "@lumino/messaging";
+import { Widget } from "@lumino/widgets";
 
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
@@ -51,6 +51,11 @@ export class PreviewWidget extends Widget {
     this.#ensure_attached_to_dom = new Promise((resolve) => {
       this.#resolve_attached_to_dom = resolve;
     });
+  }
+
+  protected onCloseRequest(msg: Message): void {
+    super.onCloseRequest(msg);
+    this.dispose();
   }
 
   protected get canvas_id(): string {

--- a/tools/online_editor/src/properties_widget.ts
+++ b/tools/online_editor/src/properties_widget.ts
@@ -3,6 +3,7 @@
 
 // cSpell: ignore lumino
 
+import { Message } from "@lumino/messaging";
 import { Widget } from "@lumino/widgets";
 
 import {
@@ -46,6 +47,11 @@ export class PropertiesWidget extends Widget {
     this.title.caption = `Element Properties`;
 
     this.set_header(null);
+  }
+
+  protected onCloseRequest(msg: Message): void {
+    super.onCloseRequest(msg);
+    this.dispose();
   }
 
   protected get contentNode(): HTMLDivElement {

--- a/tools/online_editor/src/properties_widget.ts
+++ b/tools/online_editor/src/properties_widget.ts
@@ -5,7 +5,12 @@
 
 import { Widget } from "@lumino/widgets";
 
-import { BindingTextProvider, Element, Property, PropertyQuery } from "./lsp_integration";
+import {
+  BindingTextProvider,
+  Element,
+  Property,
+  PropertyQuery,
+} from "./lsp_integration";
 
 export class PropertiesWidget extends Widget {
   static createNode(): HTMLElement {
@@ -37,7 +42,7 @@ export class PropertiesWidget extends Widget {
     this.addClass("content");
     this.addClass("properties-editor".toLowerCase());
     this.title.label = "Properties";
-    this.title.closable = false;
+    this.title.closable = true;
     this.title.caption = `Element Properties`;
 
     this.set_header(null);
@@ -71,7 +76,10 @@ export class PropertiesWidget extends Widget {
     }
   }
 
-  private populate_table(binding_text_provider: BindingTextProvider, properties: Property[]) {
+  private populate_table(
+    binding_text_provider: BindingTextProvider,
+    properties: Property[],
+  ) {
     const table = this.tableNode;
 
     table.innerHTML = "";
@@ -100,7 +108,7 @@ export class PropertiesWidget extends Widget {
       value_field.className = "value-column";
       if (p.defined_at != null) {
         value_field.innerText = binding_text_provider.binding_text(
-          p.defined_at
+          p.defined_at,
         );
       } else {
         value_field.innerText = "";
@@ -111,7 +119,10 @@ export class PropertiesWidget extends Widget {
     }
   }
 
-  set_properties(binding_text_provider: BindingTextProvider, properties: PropertyQuery) {
+  set_properties(
+    binding_text_provider: BindingTextProvider,
+    properties: PropertyQuery,
+  ) {
     this.set_header(properties.element);
     this.populate_table(binding_text_provider, properties.properties);
   }

--- a/tools/online_editor/src/welcome_widget.ts
+++ b/tools/online_editor/src/welcome_widget.ts
@@ -3,6 +3,7 @@
 
 // cSpell: ignore lumino
 
+import { Message } from "@lumino/messaging";
 import { Widget } from "@lumino/widgets";
 
 export class WelcomeWidget extends Widget {
@@ -33,5 +34,10 @@ export class WelcomeWidget extends Widget {
     this.title.label = "Welcome";
     this.title.closable = true;
     this.title.caption = `Welcome to Slint`;
+  }
+
+  protected onCloseRequest(msg: Message): void {
+    super.onCloseRequest(msg);
+    this.dispose();
   }
 }


### PR DESCRIPTION
Save the dock layout state into local storage and restore it on next start-up.

This shuffles all the code managing the panels around a bit: They all can get closed now and they can all be opened again via the menu. Their actual layout can also be saved (which will save it into the local browsers storage) and will then be restored on start.

That makes the online editor quite a bit more usable IMHO.