### PR TITLE
online_editor: Code navigation between files

### DIFF
--- a/tools/online_editor/src/preview_widget.ts
+++ b/tools/online_editor/src/preview_widget.ts
@@ -44,8 +44,6 @@ export class PreviewWidget extends Widget {
     this.title.caption = `Slint Viewer`;
     this.title.closable = true;
 
-    console.log("Event loop running?", is_event_loop_running);
-
     this.#canvas_id = "";
     this.#instance = null;
     this.#resolve_attached_to_dom = () => {


### PR DESCRIPTION
Enable code navigation between open files.

E.g. go to definition for "Homepage" in the printer demo's main page does work now. It used to open a new tab with the source code in it before.