### PR TITLE
Florian/sort todo

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -967,6 +967,11 @@ public:
         return inner->source_model->row_data(inner->accepted_rows[i]);
     }
 
+    void set_row_data(int i, const ModelData &value) override
+    {
+        inner->source_model->set_row_data(inner->accepted_rows[i], value);
+    }
+
     /// Re-applies the model's filter function on each row of the source model. Use this if state
     /// external to the filter function has changed.
     void apply_filter() { inner->reset(); }
@@ -1204,6 +1209,11 @@ public:
     {
         inner->ensure_sorted();
         return inner->source_model->row_data(inner->sorted_rows[i]);
+    }
+
+    void set_row_data(int i, const ModelData &value) override
+    {
+        inner->source_model->set_row_data(inner->sorted_rows[i], value);
     }
 
     /// Re-applies the model's sort function on each row of the source model. Use this if state

--- a/examples/todo/cpp/main.cpp
+++ b/examples/todo/cpp/main.cpp
@@ -44,26 +44,25 @@ int main()
         return slint::CloseRequestResponse::HideWindow;
     });
 
-    demo->set_is_sorting_enabled(true);
+    demo->set_is_header_visible(true);
 
-    demo->on_sort([todo_model, demo = slint::ComponentWeakHandle(demo)](bool sort_by_name,
-                                                                        bool sort_by_done) {
-        if (!sort_by_name && !sort_by_done) {
-            (*demo.lock())->set_todo_model(todo_model);
-            return;
-        }
+    demo->on_sort_filter([todo_model, demo = slint::ComponentWeakHandle(demo)] {
+        (*demo.lock())->set_todo_model(todo_model);
 
-        if (sort_by_name) {
+        if ((*demo.lock())->get_is_filter_done())
+        {
             (*demo.lock())
-                    ->set_todo_model(std::make_shared<slint::SortModel<TodoItem>>(
-                            todo_model, [](auto lhs, auto rhs) { return lhs.title < rhs.title; }));
+                    ->set_todo_model(std::make_shared<slint::FilterModel<TodoItem>>(
+                            todo_model, [](auto e) { return !e.checked; }));
         }
 
-         if (sort_by_done) {
-            (*demo.lock())
-                    ->set_todo_model(std::make_shared<slint::SortModel<TodoItem>>(
-                            todo_model, [](auto lhs, auto rhs) { return lhs.checked > rhs.checked; }));
-        }
+        if ((*demo.lock())->get_is_sort_by_name())
+            {
+                (*demo.lock())
+                        ->set_todo_model(std::make_shared<slint::SortModel<TodoItem>>(
+                                todo_model,
+                                [](auto lhs, auto rhs) { return lhs.title < rhs.title; }));
+            }
     });
 
     demo->run();

--- a/examples/todo/cpp/main.cpp
+++ b/examples/todo/cpp/main.cpp
@@ -47,22 +47,21 @@ int main()
     demo->set_is_header_visible(true);
 
     demo->on_sort_filter([todo_model, demo = slint::ComponentWeakHandle(demo)] {
-        (*demo.lock())->set_todo_model(todo_model);
+        auto demo_lock = *demo.lock();
+        (*demo_lock)->set_todo_model(todo_model);
 
-        if ((*demo.lock())->get_is_filter_done())
-        {
-            (*demo.lock())
+        if ((*demo_lock)->get_is_filter_done()) {
+            (*demo_lock)
                     ->set_todo_model(std::make_shared<slint::FilterModel<TodoItem>>(
-                            todo_model, [](auto e) { return !e.checked; }));
+                            (*demo_lock)->get_todo_model(), [](auto e) { return !e.checked; }));
         }
 
-        if ((*demo.lock())->get_is_sort_by_name())
-            {
-                (*demo.lock())
-                        ->set_todo_model(std::make_shared<slint::SortModel<TodoItem>>(
-                                todo_model,
-                                [](auto lhs, auto rhs) { return lhs.title < rhs.title; }));
-            }
+        if ((*demo_lock)->get_is_sort_by_name()) {
+            (*demo_lock)
+                    ->set_todo_model(std::make_shared<slint::SortModel<TodoItem>>(
+                            (*demo_lock)->get_todo_model(),
+                            [](auto lhs, auto rhs) { return lhs.title < rhs.title; }));
+        }
     });
 
     demo->run();

--- a/examples/todo/cpp/main.cpp
+++ b/examples/todo/cpp/main.cpp
@@ -44,13 +44,13 @@ int main()
         return slint::CloseRequestResponse::HideWindow;
     });
 
-    demo->set_is_header_visible(true);
+    demo->set_show_header(true);
 
-    demo->on_sort_filter([todo_model, demo = slint::ComponentWeakHandle(demo)] {
-        auto demo_lock = *demo.lock();
+    demo->on_apply_sorting_and_filtering([todo_model, demo = slint::ComponentWeakHandle(demo)] {
+        auto demo_lock = demo.lock();
         (*demo_lock)->set_todo_model(todo_model);
 
-        if ((*demo_lock)->get_is_filter_done()) {
+        if ((*demo_lock)->get_hide_done_items()) {
             (*demo_lock)
                     ->set_todo_model(std::make_shared<slint::FilterModel<TodoItem>>(
                             (*demo_lock)->get_todo_model(), [](auto e) { return !e.checked; }));

--- a/examples/todo/cpp/main.cpp
+++ b/examples/todo/cpp/main.cpp
@@ -44,5 +44,27 @@ int main()
         return slint::CloseRequestResponse::HideWindow;
     });
 
+    demo->set_is_sorting_enabled(true);
+
+    demo->on_sort([todo_model, demo = slint::ComponentWeakHandle(demo)](bool sort_by_name,
+                                                                        bool sort_by_done) {
+        if (!sort_by_name && !sort_by_done) {
+            (*demo.lock())->set_todo_model(todo_model);
+            return;
+        }
+
+        if (sort_by_name) {
+            (*demo.lock())
+                    ->set_todo_model(std::make_shared<slint::SortModel<TodoItem>>(
+                            todo_model, [](auto lhs, auto rhs) { return lhs.title < rhs.title; }));
+        }
+
+         if (sort_by_done) {
+            (*demo.lock())
+                    ->set_todo_model(std::make_shared<slint::SortModel<TodoItem>>(
+                            todo_model, [](auto lhs, auto rhs) { return lhs.checked > rhs.checked; }));
+        }
+    });
+
     demo->run();
 }

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -94,7 +94,7 @@ pub fn main() {
         }
     });
 
-    main_window.set_is_sorting_enabled(true);
+    main_window.set_is_header_visible(true);
     main_window.set_todo_model(todo_model.into());
 
     main_window.run();

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -97,6 +97,7 @@ pub fn main() {
         }
     });
 
+    main_window.set_is_sorting_enabled(true);
     main_window.set_todo_model(todo_model.into());
 
     main_window.run();

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -66,7 +66,7 @@ pub fn main() {
         });
     }
 
-    main_window.on_sort_filter({
+    main_window.on_apply_sorting_and_filtering({
         let weak_window = main_window.as_weak();
         let todo_model = todo_model.clone();
 
@@ -74,7 +74,7 @@ pub fn main() {
             let window = weak_window.unwrap();
             window.set_todo_model(todo_model.clone().into());
 
-            if window.get_is_filter_done() {
+            if window.get_hide_done_items() {
                 window.set_todo_model(
                     Rc::new(FilterModel::new(window.get_todo_model(), |e| !e.checked)).into(),
                 );
@@ -91,7 +91,7 @@ pub fn main() {
         }
     });
 
-    main_window.set_is_header_visible(true);
+    main_window.set_show_header(true);
     main_window.set_todo_model(todo_model.into());
 
     main_window.run();

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -1,8 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use slint::Model;
-use std::rc::Rc;
+use slint::{Model, SortModel};
+use std::{borrow::Borrow, rc::Rc};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -65,6 +65,26 @@ pub fn main() {
             }
         });
     }
+
+    let weak_window = main_window.as_weak();
+
+    main_window.on_sort_by_name({
+        let todo_model = todo_model.clone();
+
+        move |active| {
+            if active {
+                weak_window.unwrap().set_todo_model(
+                    Rc::new(SortModel::new(todo_model.clone(), |lhs, rhs| {
+                        lhs.title.to_lowercase().cmp(&rhs.title.to_lowercase())
+                    }))
+                    .into(),
+                )
+            } else {
+                weak_window.unwrap().set_todo_model(todo_model.clone().into());
+            }
+          
+        }
+    });
 
     main_window.set_todo_model(todo_model.into());
 

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use slint::{Model, SortModel, FilterModel};
+use slint::{FilterModel, Model, SortModel};
 use std::rc::Rc;
 
 #[cfg(target_arch = "wasm32")]
@@ -76,13 +76,10 @@ pub fn main() {
 
             if window.get_is_filter_done() {
                 window.set_todo_model(
-                    Rc::new(FilterModel::new(window.get_todo_model(), |e| {
-                        !e.checked
-                    }))
-                    .into(),
+                    Rc::new(FilterModel::new(window.get_todo_model(), |e| !e.checked)).into(),
                 );
             }
-            
+
             if window.get_is_sort_by_name() {
                 window.set_todo_model(
                     Rc::new(SortModel::new(window.get_todo_model(), |lhs, rhs| {

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -71,24 +71,17 @@ pub fn main() {
     main_window.on_sort({
         let todo_model = todo_model.clone();
 
-        move |sort_by_name, sort_by_done| {
-            if !sort_by_name && !sort_by_done {
-                weak_window.unwrap().set_todo_model(todo_model.clone().into());
+        move || {
+            let window = weak_window.unwrap();
+
+            if !window.get_is_sort_by_done() {
+                window.set_todo_model(todo_model.clone().into());
                 return;
             }
-
-            if sort_by_name {
-                weak_window.unwrap().set_todo_model(
-                    Rc::new(SortModel::new(weak_window.unwrap().get_todo_model(), |lhs, rhs| {
-                        lhs.title.to_lowercase().cmp(&rhs.title.to_lowercase())
-                    }))
-                    .into(),
-                )
-            }
-
-            if sort_by_done {
-                weak_window.unwrap().set_todo_model(
-                    Rc::new(SortModel::new(weak_window.unwrap().get_todo_model(), |lhs, rhs| {
+            
+            if window.get_is_sort_by_done() {
+                window.set_todo_model(
+                    Rc::new(SortModel::new(window.get_todo_model(), |lhs, rhs| {
                         rhs.checked.cmp(&lhs.checked)
                     }))
                     .into(),

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 use slint::{Model, SortModel};
-use std::{borrow::Borrow, rc::Rc};
+use std::rc::Rc;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -68,21 +68,32 @@ pub fn main() {
 
     let weak_window = main_window.as_weak();
 
-    main_window.on_sort_by_name({
+    main_window.on_sort({
         let todo_model = todo_model.clone();
 
-        move |active| {
-            if active {
+        move |sort_by_name, sort_by_done| {
+            if !sort_by_name && !sort_by_done {
+                weak_window.unwrap().set_todo_model(todo_model.clone().into());
+                return;
+            }
+
+            if sort_by_name {
                 weak_window.unwrap().set_todo_model(
-                    Rc::new(SortModel::new(todo_model.clone(), |lhs, rhs| {
+                    Rc::new(SortModel::new(weak_window.unwrap().get_todo_model(), |lhs, rhs| {
                         lhs.title.to_lowercase().cmp(&rhs.title.to_lowercase())
                     }))
                     .into(),
                 )
-            } else {
-                weak_window.unwrap().set_todo_model(todo_model.clone().into());
             }
-          
+
+            if sort_by_done {
+                weak_window.unwrap().set_todo_model(
+                    Rc::new(SortModel::new(weak_window.unwrap().get_todo_model(), |lhs, rhs| {
+                        rhs.checked.cmp(&lhs.checked)
+                    }))
+                    .into(),
+                );
+            }
         }
     });
 

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use slint::{Model, SortModel};
+use slint::{Model, SortModel, FilterModel};
 use std::rc::Rc;
 
 #[cfg(target_arch = "wasm32")]
@@ -66,23 +66,27 @@ pub fn main() {
         });
     }
 
-    let weak_window = main_window.as_weak();
-
-    main_window.on_sort({
+    main_window.on_sort_filter({
+        let weak_window = main_window.as_weak();
         let todo_model = todo_model.clone();
 
         move || {
             let window = weak_window.unwrap();
+            window.set_todo_model(todo_model.clone().into());
 
-            if !window.get_is_sort_by_done() {
-                window.set_todo_model(todo_model.clone().into());
-                return;
+            if window.get_is_filter_done() {
+                window.set_todo_model(
+                    Rc::new(FilterModel::new(window.get_todo_model(), |e| {
+                        !e.checked
+                    }))
+                    .into(),
+                );
             }
             
-            if window.get_is_sort_by_done() {
+            if window.get_is_sort_by_name() {
                 window.set_todo_model(
                     Rc::new(SortModel::new(window.get_todo_model(), |lhs, rhs| {
-                        rhs.checked.cmp(&lhs.checked)
+                        lhs.title.to_lowercase().cmp(&rhs.title.to_lowercase())
                     }))
                     .into(),
                 );

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -86,6 +86,10 @@ MainWindow := Window {
                     sort();
                 }
             }
+
+            LineEdit {
+                placeholder-text: "Search by name 🔍";
+            }
         }
 
         list-view := ListView {

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -69,6 +69,23 @@ MainWindow := Window {
             }
         }
 
+        HorizontalBox { 
+            alignment: start; 
+
+            Text {  
+                text: "Sorty by";
+                vertical-alignment: center;
+            }
+
+            CheckBox {  
+                text: "Name";
+            }
+
+            CheckBox {  
+                text: "Done";
+            }
+        }
+
         list-view := ListView {
             for todo in todo-model:  HorizontalLayout {
                 CheckBox {

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -18,7 +18,7 @@ MainWindow := Window {
     callback popup_confirmed;
     callback show_confirm_popup;
 
-    callback sort();
+    callback sort_filter();
 
     show_confirm_popup => { confirm_popup.show(); }
 
@@ -54,7 +54,8 @@ MainWindow := Window {
     ];
 
     property <bool> is-sorting-enabled: false;
-    property <bool> is-sort-by-done <=> cb-sort-by-done.checked;
+    property <bool> is-sort-by-name <=> cb-sort-by-name.checked;
+    property <bool> is-filter-done <=> cb-filter-done.checked;
 
     VerticalBox {
         HorizontalBox {
@@ -79,16 +80,20 @@ MainWindow := Window {
             visible: is-sorting-enabled;
             alignment: start; 
 
-            cb-sort-by-done := CheckBox {  
-                text: "Sort by done";
+            cb-sort-by-name := CheckBox {  
+                text: "Sort by name";
 
                 toggled => {
-                    sort();
+                    sort_filter();
                 }
             }
 
-            LineEdit {
-                placeholder-text: "Search by name 🔍";
+            cb-filter-done := CheckBox {  
+                text: "Hide done items";
+
+                toggled => {
+                    sort_filter();
+                }
             }
         }
 

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -17,6 +17,9 @@ MainWindow := Window {
 
     callback popup_confirmed;
     callback show_confirm_popup;
+
+    callback sort-by-name(bool);
+
     show_confirm_popup => { confirm_popup.show(); }
 
     confirm_popup := PopupWindow {
@@ -79,6 +82,10 @@ MainWindow := Window {
 
             CheckBox {  
                 text: "Name";
+
+                toggled => {
+                    sort-by-name(checked);
+                }
             }
 
             CheckBox {  

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -18,7 +18,7 @@ MainWindow := Window {
     callback popup_confirmed;
     callback show_confirm_popup;
 
-    callback sort_filter();
+    callback apply_sorting_and_filtering();
 
     show_confirm_popup => { confirm_popup.show(); }
 
@@ -53,9 +53,9 @@ MainWindow := Window {
         { title: "Profit", checked: false },
     ];
 
-    property <bool> is-header-visible: false;
+    property <bool> show-header: false;
     property <bool> is-sort-by-name: false;
-    property <bool> is-filter-done: false;
+    property <bool> hide-done-items: false;
 
     VerticalBox {
         HorizontalBox {
@@ -76,7 +76,7 @@ MainWindow := Window {
             }
         }
 
-        if (is-header-visible) : HorizontalBox { 
+        if (show-header) : HorizontalBox { 
             alignment: start; 
 
             CheckBox {  
@@ -84,16 +84,16 @@ MainWindow := Window {
                 checked <=> is-sort-by-name;
 
                 toggled => {
-                    sort_filter();
+                    apply_sorting_and_filtering();
                 }
             }
 
             CheckBox {  
                 text: "Hide done items";
-                checked <=> is-filter-done;
+                checked <=> hide-done-items;
 
                 toggled => {
-                    sort_filter();
+                    apply_sorting_and_filtering();
                 }
             }
         }

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -54,8 +54,8 @@ MainWindow := Window {
     ];
 
     property <bool> is-header-visible: false;
-    property <bool> is-sort-by-name <=> cb-sort-by-name.checked;
-    property <bool> is-filter-done <=> cb-filter-done.checked;
+    property <bool> is-sort-by-name: false;
+    property <bool> is-filter-done: false;
 
     VerticalBox {
         HorizontalBox {
@@ -76,20 +76,21 @@ MainWindow := Window {
             }
         }
 
-        HorizontalBox { 
-            visible: is-header-visible;
+        if (is-header-visible) : HorizontalBox { 
             alignment: start; 
 
-            cb-sort-by-name := CheckBox {  
+            CheckBox {  
                 text: "Sort by name";
+                checked <=> is-sort-by-name;
 
                 toggled => {
                     sort_filter();
                 }
             }
 
-            cb-filter-done := CheckBox {  
+            CheckBox {  
                 text: "Hide done items";
+                checked <=> is-filter-done;
 
                 toggled => {
                     sort_filter();

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -18,7 +18,7 @@ MainWindow := Window {
     callback popup_confirmed;
     callback show_confirm_popup;
 
-    callback sort(bool, bool);
+    callback sort();
 
     show_confirm_popup => { confirm_popup.show(); }
 
@@ -54,7 +54,6 @@ MainWindow := Window {
     ];
 
     property <bool> is-sorting-enabled: false;
-    property <bool> is-sort-by-name <=> cb-sort-by-name.checked;
     property <bool> is-sort-by-done <=> cb-sort-by-done.checked;
 
     VerticalBox {
@@ -80,24 +79,11 @@ MainWindow := Window {
             visible: is-sorting-enabled;
             alignment: start; 
 
-            Text {  
-                text: "Sorty by";
-                vertical-alignment: center;
-            }
-
-            cb-sort-by-name := CheckBox {  
-                text: "Name";
-
-                toggled => {
-                    sort(is-sort-by-name, is-sort-by-done);
-                }
-            }
-
             cb-sort-by-done := CheckBox {  
-                text: "Done";
+                text: "Sort by done";
 
                 toggled => {
-                    sort(is-sort-by-name, is-sort-by-done);
+                    sort();
                 }
             }
         }

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -53,6 +53,7 @@ MainWindow := Window {
         { title: "Profit", checked: false },
     ];
 
+    property <bool> is-sorting-enabled: false;
     property <bool> is-sort-by-name <=> cb-sort-by-name.checked;
     property <bool> is-sort-by-done <=> cb-sort-by-done.checked;
 
@@ -76,6 +77,7 @@ MainWindow := Window {
         }
 
         HorizontalBox { 
+            visible: is-sorting-enabled;
             alignment: start; 
 
             Text {  

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -18,7 +18,7 @@ MainWindow := Window {
     callback popup_confirmed;
     callback show_confirm_popup;
 
-    callback sort-by-name(bool);
+    callback sort(bool, bool);
 
     show_confirm_popup => { confirm_popup.show(); }
 
@@ -53,6 +53,9 @@ MainWindow := Window {
         { title: "Profit", checked: false },
     ];
 
+    property <bool> is-sort-by-name <=> cb-sort-by-name.checked;
+    property <bool> is-sort-by-done <=> cb-sort-by-done.checked;
+
     VerticalBox {
         HorizontalBox {
             text-edit := LineEdit {
@@ -80,16 +83,20 @@ MainWindow := Window {
                 vertical-alignment: center;
             }
 
-            CheckBox {  
+            cb-sort-by-name := CheckBox {  
                 text: "Name";
 
                 toggled => {
-                    sort-by-name(checked);
+                    sort(is-sort-by-name, is-sort-by-done);
                 }
             }
 
-            CheckBox {  
+            cb-sort-by-done := CheckBox {  
                 text: "Done";
+
+                toggled => {
+                    sort(is-sort-by-name, is-sort-by-done);
+                }
             }
         }
 

--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -53,7 +53,7 @@ MainWindow := Window {
         { title: "Profit", checked: false },
     ];
 
-    property <bool> is-sorting-enabled: false;
+    property <bool> is-header-visible: false;
     property <bool> is-sort-by-name <=> cb-sort-by-name.checked;
     property <bool> is-filter-done <=> cb-filter-done.checked;
 
@@ -77,7 +77,7 @@ MainWindow := Window {
         }
 
         HorizontalBox { 
-            visible: is-sorting-enabled;
+            visible: is-header-visible;
             alignment: start; 
 
             cb-sort-by-name := CheckBox {  

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -768,6 +768,11 @@ where
             .and_then(|&wrapped_row| self.0.wrapped_model.row_data(wrapped_row))
     }
 
+    fn set_row_data(&self, row: usize, data: Self::Data) {
+        let mapped_row = self.0.mapping.borrow().binary_search(&row).unwrap();
+        self.0.wrapped_model.set_row_data(mapped_row, data);
+    }
+
     fn model_tracker(&self) -> &dyn ModelTracker {
         &self.0.notify
     }

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -604,7 +604,7 @@ where
 ///     SharedString::from("dolor"),
 /// ]);
 ///
-/// let sorted_model = SortModel::new(model, |lhs, rhs| lhs.to_lowercase().cmp(&rhs.to_lowercase()));
+/// let sorted_model = SortModel::new(model, ≈));
 ///
 /// assert_eq!(sorted_model.row_data(0).unwrap(), SharedString::from("dolor"));
 /// assert_eq!(sorted_model.row_data(1).unwrap(), SharedString::from("ipsum"));

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -769,7 +769,7 @@ where
     }
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
-        let mapped_row = self.0.mapping.borrow().binary_search(&row).unwrap();
+        let mapped_row = self.0.mapping.borrow().iter().position(|r| *r == row).unwrap();
         self.0.wrapped_model.set_row_data(mapped_row, data);
     }
 

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -372,7 +372,7 @@ where
     }
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
-        let wrapped_row = self.0.mapping.borrow()[row]; 
+        let wrapped_row = self.0.mapping.borrow()[row];
         self.0.wrapped_model.set_row_data(wrapped_row, data);
     }
 
@@ -774,8 +774,8 @@ where
     }
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
-       let wrapped_row = self.0.mapping.borrow()[row]; 
-       self.0.wrapped_model.set_row_data(wrapped_row, data);
+        let wrapped_row = self.0.mapping.borrow()[row];
+        self.0.wrapped_model.set_row_data(wrapped_row, data);
     }
 
     fn model_tracker(&self) -> &dyn ModelTracker {

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -372,8 +372,8 @@ where
     }
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
-        let mapped_row = self.0.mapping.borrow().binary_search(&row).unwrap();
-        self.0.wrapped_model.set_row_data(mapped_row, data);
+        let wrapped_row = self.0.mapping.borrow()[row]; 
+        self.0.wrapped_model.set_row_data(wrapped_row, data);
     }
 
     fn model_tracker(&self) -> &dyn ModelTracker {
@@ -774,8 +774,8 @@ where
     }
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
-        let mapped_row = self.0.mapping.borrow().iter().find(|r| **r == row).copied().unwrap();
-        self.0.wrapped_model.set_row_data(mapped_row, data);
+       let wrapped_row = self.0.mapping.borrow()[row]; 
+       self.0.wrapped_model.set_row_data(wrapped_row, data);
     }
 
     fn model_tracker(&self) -> &dyn ModelTracker {

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -609,7 +609,7 @@ where
 ///     SharedString::from("dolor"),
 /// ]);
 ///
-/// let sorted_model = SortModel::new(model, ≈));
+/// let sorted_model = SortModel::new(model, |lhs, rhs| lhs.to_lowercase().cmp(&rhs.to_lowercase()));
 ///
 /// assert_eq!(sorted_model.row_data(0).unwrap(), SharedString::from("dolor"));
 /// assert_eq!(sorted_model.row_data(1).unwrap(), SharedString::from("ipsum"));

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -371,6 +371,11 @@ where
             .and_then(|&wrapped_row| self.0.wrapped_model.row_data(wrapped_row))
     }
 
+    fn set_row_data(&self, row: usize, data: Self::Data) {
+        let mapped_row = self.0.mapping.borrow().binary_search(&row).unwrap();
+        self.0.wrapped_model.set_row_data(mapped_row, data);
+    }
+
     fn model_tracker(&self) -> &dyn ModelTracker {
         &self.0.notify
     }

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -769,7 +769,7 @@ where
     }
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
-        let mapped_row = self.0.mapping.borrow().iter().position(|r| *r == row).unwrap();
+        let mapped_row = self.0.mapping.borrow().iter().find(|r| **r == row).copied().unwrap();
         self.0.wrapped_model.set_row_data(mapped_row, data);
     }
 


### PR DESCRIPTION
Add a header to the `todo` example that contains a `CheckBox` to sort the entries by name and a second `CheckBox` to filter the done items. Also implemented `set_row_data` for the `SortModel` and `FilterModel` (rust and cpp), to allow item data changes using that model types.