### PR TITLE
Florian/cpp popup px fix

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2442,7 +2442,7 @@ fn compile_builtin_function_call(
                     ident(&current_sub_component.popup_windows[*popup_index as usize].root.name);
                 let parent_component = access_item_rc(parent_ref, ctx);
                 let x = format!("(float){}", compile_expression(x, ctx));
-                let y =  format!("(float){}", compile_expression(y, ctx));
+                let y = format!("(float){}", compile_expression(y, ctx));
                 format!(
                     "{}.show_popup<{}>({}, {{ {}, {} }}, {{ {} }})",
                     window, popup_window_id, component_access, x, y, parent_component,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2441,8 +2441,8 @@ fn compile_builtin_function_call(
                 let popup_window_id =
                     ident(&current_sub_component.popup_windows[*popup_index as usize].root.name);
                 let parent_component = access_item_rc(parent_ref, ctx);
-                let x = format!("(float){}", compile_expression(x, ctx));
-                let y = format!("(float){}", compile_expression(y, ctx));
+                let x = compile_expression(x, ctx);
+                let y = compile_expression(y, ctx);
                 format!(
                     "{window}.show_popup<{popup_window_id}>({component_access}, {{ static_cast<float>({x}), static_cast<float>({y}) }}, {{ {parent_component} }})"
                 )

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2441,8 +2441,8 @@ fn compile_builtin_function_call(
                 let popup_window_id =
                     ident(&current_sub_component.popup_windows[*popup_index as usize].root.name);
                 let parent_component = access_item_rc(parent_ref, ctx);
-                let x = compile_expression(x, ctx);
-                let y = compile_expression(y, ctx);
+                let x = format!("(float){}", compile_expression(x, ctx));
+                let y =  format!("(float){}", compile_expression(y, ctx));
                 format!(
                     "{}.show_popup<{}>({}, {{ {}, {} }}, {{ {} }})",
                     window, popup_window_id, component_access, x, y, parent_component,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2187,7 +2187,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                     '≥' => ">=",
                     '&' => "&&",
                     '|' => "||",
-                    '/' => "/(double)",
+                    '/' => "/(float)",
                     _ => op.encode_utf8(&mut buffer),
                 },
             )

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2444,8 +2444,7 @@ fn compile_builtin_function_call(
                 let x = format!("(float){}", compile_expression(x, ctx));
                 let y = format!("(float){}", compile_expression(y, ctx));
                 format!(
-                    "{}.show_popup<{}>({}, {{ {}, {} }}, {{ {} }})",
-                    window, popup_window_id, component_access, x, y, parent_component,
+                    "{window}.show_popup<{popup_window_id}>({component_access}, {{ static_cast<float>({x}), static_cast<float>({y}) }}, {{ {parent_component} }})"
                 )
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {:?}", arguments)

--- a/tests/cases/elements/popupwindow.slint
+++ b/tests/cases/elements/popupwindow.slint
@@ -35,17 +35,12 @@ ComplexTestCase := Window {
 }
 
 TypeConversionTestCase := Window {
-    property<length> popup_y: height / 2;
     height: 400px;
-    popup := PopupWindow {   
-        y <=> popup_y;
+    popup := PopupWindow {
+        y: root.height / 2;
+        x: root.height + 155.52px;
     }
+    TouchArea {
+        clicked => { popup.show() }
+     }
 }
-
-/*
-```cpp
-auto handle = TypeConversionTestCase::create();
-const TypeConversionTestCase &instance = *handle;
-assert_eq(instance.get_popup_y(), 200.);
-```
-*/

--- a/tests/cases/elements/popupwindow.slint
+++ b/tests/cases/elements/popupwindow.slint
@@ -33,3 +33,19 @@ ComplexTestCase := Window {
     }
     TestCase {  }
 }
+
+TypeConversionTestCase := Window {
+    property<length> popup_y: height / 2;
+    height: 400px;
+    popup := PopupWindow {   
+        y <=> popup_y;
+    }
+}
+
+/*
+```cpp
+auto handle = TypeConversionTestCase::create();
+const TypeConversionTestCase &instance = *handle;
+assert_eq(instance.get_popup_y(), 200.);
+```
+*/


### PR DESCRIPTION
Fix type cast error for x and y on the cpp compiler for `show_popup`. This PR is related to #1732.