### PR TITLE
Fix #1733: Recurse into models

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// cSpell: ignore funcref
+
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::langtype::{BuiltinElement, EnumerationValue, Type};
 use crate::layout::Orientation;
@@ -659,7 +661,13 @@ impl Expression {
                 visitor(&**index);
             }
             Expression::RepeaterIndexReference { .. } => {}
-            Expression::RepeaterModelReference { .. } => {}
+            Expression::RepeaterModelReference { element } => {
+                if let Some(e) = element.upgrade() {
+                    if let Some(r) = &e.borrow().repeated {
+                        visitor(&r.model);
+                    }
+                }
+            }
             Expression::Cast { from, .. } => visitor(&**from),
             Expression::CodeBlock(sub) => {
                 sub.iter().for_each(visitor);

--- a/tests/cases/multi_file/struct_export_from_module/_child.slint
+++ b/tests/cases/multi_file/struct_export_from_module/_child.slint
@@ -1,0 +1,16 @@
+// Files starting with _ will be ignored by the test drivers
+import { ListView } from "std-widgets.slint";
+
+struct ExportMe := {
+    text: string,
+}
+
+export Child := VerticalLayout {
+    property<[ExportMe]> data;
+
+    ListView {
+        for d[i] in data: Text {
+            text: d.text;
+        }
+    }
+}

--- a/tests/cases/multi_file/struct_export_from_module/parent.slint
+++ b/tests/cases/multi_file/struct_export_from_module/parent.slint
@@ -1,0 +1,7 @@
+// Based on Issue #1733
+
+import { Child } from "./_child.slint";
+
+export MainWindow := Window {
+    Child { }
+}

--- a/tests/driver/driverlib/lib.rs
+++ b/tests/driver/driverlib/lib.rs
@@ -18,7 +18,7 @@ impl TestCase {
     }
 }
 
-/// Returns a list of all the `.slint` files in the `tests/cases` subfolders.
+/// Returns a list of all the `.slint` files in the `tests/cases` sub-folders.
 pub fn collect_test_cases() -> std::io::Result<Vec<TestCase>> {
     let mut results = vec![];
 
@@ -39,6 +39,12 @@ pub fn collect_test_cases() -> std::io::Result<Vec<TestCase>> {
             std::path::PathBuf::from(absolute_path.strip_prefix(&case_root_dir).unwrap());
         if let Some(filter) = &filter {
             if !relative_path.to_str().unwrap().contains(filter) {
+                continue;
+            }
+        }
+        if let Some(filename) = absolute_path.file_name() {
+            if filename.to_string_lossy().starts_with('_') {
+                // Skip files starting with '_' so that we can test multi-file setups
                 continue;
             }
         }


### PR DESCRIPTION
Recurse into Models and extract types used there. This prevents structs that are *only* used in a model and never set/read elsewhere to stay in the generated code.