### PR TITLE
Fix panic when doing binding analysis of properties in repeater in layout

### DIFF
--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout3.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout3.slint
@@ -1,0 +1,31 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+Compo := Rectangle {
+//      ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+
+    property <string> the_text;
+
+    lay := HorizontalLayout {
+//        ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+        if true : Rectangle {
+//                ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+            VerticalLayout {
+//          ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+                Text {
+                    text: root.the_text;
+//                       ^error{The binding for the property 'text' is part of a binding loop}
+                }
+            }
+        }
+    }
+
+}
+
+Foo := Rectangle {
+    Compo {
+//  ^error{The binding for the property 'preferred-width' is part of a binding loop}
+        the_text: self.preferred-width / 1px;
+//               ^error{The binding for the property 'the-text' is part of a binding loop}
+    }
+}

--- a/tests/cases/crashes/alias_in_if.slint
+++ b/tests/cases/crashes/alias_in_if.slint
@@ -5,5 +5,22 @@ App := Rectangle {
     property <string> hello: "ooo";
     if (hello != "") : Text { text <=> hello; }
 
-    property<bool> test: hello == "ooo";
+    property<bool> test1: hello == "ooo";
+
+    // Another crash:
+    property <string> directory: "hello";
+    vl := VerticalLayout {
+        if true: pp:= Rectangle {
+            property <string> text <=> root.directory;
+            HorizontalLayout {
+                inner := Text {
+                    text: pp.text;
+                }
+            }
+        }
+    }
+    ref := Text { text: "hello"; }
+    property<bool> test2: vl.preferred-width == ref.preferred-width;
+
+    property<bool> test: test1 && test2;
 }


### PR DESCRIPTION
Given an element in a layout, we must visit the properties in the repeated component, not the dummy repeated element.

The panic is a regression since e7506e0d2a14285a246f73cbb1ec4b282ce20421, but the missing binding loop detection was there before