### PR TITLE
Fix panic when the forward-focus expression is invalid

### DIFF
--- a/internal/compiler/passes/focus_item.rs
+++ b/internal/compiler/passes/focus_item.rs
@@ -37,7 +37,7 @@ fn element_focus_check(element: &ElementRc) -> FocusCheckResult {
                 forwarded_focus_binding.to_source_location(),
             );
         } else {
-            panic!("internal error: forward-focus property is of type ElementReference but received non-element-reference binding");
+            assert!(matches!(forwarded_focus_binding.expression, Expression::Invalid), "internal error: forward-focus property is of type ElementReference but received non-element-reference binding");
         }
     }
 

--- a/internal/compiler/tests/syntax/focus/focus_invalid.slint
+++ b/internal/compiler/tests/syntax/focus/focus_invalid.slint
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+X := Rectangle {
+    forward-focus: nothingness;
+    //             ^error{Unknown unqualified identifier}
+}


### PR DESCRIPTION
Caused a crash of the LSP when having invalid element in the forward-focus property