### PR TITLE
Fix quality of SVG rendering in the online editor

### DIFF
--- a/internal/backends/winit/renderer/femtovg/images.rs
+++ b/internal/backends/winit/renderer/femtovg/images.rs
@@ -100,7 +100,7 @@ impl Texture {
                     // Anecdotal evidence suggests that HTMLImageElement converts to a texture with
                     // pre-multipled alpha. It's possible that this is not generally applicable, but it
                     // is the case for SVGs.
-                    let image_flags = if html_image.dom_element.current_src().ends_with(".svg") {
+                    let image_flags = if html_image.is_svg() {
                         if let Some(target_size) = target_size_for_scalable_source {
                             let dom_element = &html_image.dom_element;
                             dom_element.set_width(target_size.width);

--- a/internal/backends/winit/renderer/femtovg/images.rs
+++ b/internal/backends/winit/renderer/femtovg/images.rs
@@ -101,6 +101,11 @@ impl Texture {
                     // pre-multipled alpha. It's possible that this is not generally applicable, but it
                     // is the case for SVGs.
                     let image_flags = if html_image.dom_element.current_src().ends_with(".svg") {
+                        if let Some(target_size) = target_size_for_scalable_source {
+                            let dom_element = &html_image.dom_element;
+                            dom_element.set_width(target_size.width);
+                            dom_element.set_height(target_size.height);
+                        }
                         image_flags | femtovg::ImageFlags::PREMULTIPLIED
                     } else {
                         image_flags

--- a/internal/backends/winit/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/winit/renderer/femtovg/itemrenderer.rs
@@ -1168,16 +1168,15 @@ impl<'a> GLItemRenderer<'a> {
                 let image = source_property.get();
                 let image_inner: &ImageInner = (&image).into();
 
-                let target_size_for_scalable_source = matches!(image_inner, ImageInner::Svg(..))
-                    .then(|| {
-                        // get the scale factor as a property again, to ensure the cache is invalidated when the scale factor changes
-                        let scale_factor = ScaleFactor::new(self.window.scale_factor());
-                        PhysicalSize::from_lengths(
-                            LogicalLength::new(target_width.get()) * scale_factor,
-                            LogicalLength::new(target_height.get()) * scale_factor,
-                        )
-                        .cast()
-                    });
+                let target_size_for_scalable_source = image_inner.is_svg().then(|| {
+                    // get the scale factor as a property again, to ensure the cache is invalidated when the scale factor changes
+                    let scale_factor = ScaleFactor::new(self.window.scale_factor());
+                    PhysicalSize::from_lengths(
+                        LogicalLength::new(target_width.get()) * scale_factor,
+                        LogicalLength::new(target_height.get()) * scale_factor,
+                    )
+                    .cast()
+                });
 
                 TextureCacheKey::new(image_inner, target_size_for_scalable_source, image_rendering)
                     .and_then(|cache_key| {

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -435,6 +435,20 @@ impl ImageInner {
             _ => None,
         }
     }
+
+    /// Returns true if the image is an SVG (either backed by resvg or HTML image wrapper).
+    pub fn is_svg(&self) -> bool {
+        match self {
+            Self::Svg(_) => true,
+            #[cfg(target_arch = "wasm32")]
+            Self::HTMLImage(html_image)
+                if html_image.dom_element.current_src().ends_with(".svg") =>
+            {
+                true
+            }
+            _ => false,
+        }
+    }
 }
 
 impl PartialEq for ImageInner {

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -439,6 +439,7 @@ impl ImageInner {
     /// Returns true if the image is an SVG (either backed by resvg or HTML image wrapper).
     pub fn is_svg(&self) -> bool {
         match self {
+            #[cfg(feature = "svg")]
             Self::Svg(_) => true,
             #[cfg(target_arch = "wasm32")]
             Self::HTMLImage(html_image)

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -442,11 +442,7 @@ impl ImageInner {
             #[cfg(feature = "svg")]
             Self::Svg(_) => true,
             #[cfg(target_arch = "wasm32")]
-            Self::HTMLImage(html_image)
-                if html_image.dom_element.current_src().ends_with(".svg") =>
-            {
-                true
-            }
+            Self::HTMLImage(html_image) => html_image.is_svg(),
             _ => false,
         }
     }

--- a/internal/core/graphics/image/htmlimage.rs
+++ b/internal/core/graphics/image/htmlimage.rs
@@ -53,6 +53,10 @@ impl HTMLImage {
     pub fn source(&self) -> String {
         self.dom_element.src()
     }
+
+    pub fn is_svg(&self) -> bool {
+        self.dom_element.current_src().ends_with(".svg")
+    }
 }
 
 impl super::OpaqueImage for HTMLImage {


### PR DESCRIPTION
SVGs are rendered using HTML image elements, that are converted to textures. The size of the texture defaults to the SVGs viewbox, which may be small - despite it being possible to render the SVG at a higher resolution with great quality.

Similar to the native code path, this patch also uses the target image size and propagates it to the DOM HTML image element to instruct the browser to render the SVG at a higher resolution.