### PR TITLE
collect_structs: Also visit the type of array expression

### DIFF
--- a/internal/compiler/passes/collect_structs.rs
+++ b/internal/compiler/passes/collect_structs.rs
@@ -43,10 +43,10 @@ fn collect_structs_in_component(root_component: &Rc<Component>, hash: &mut BTree
     });
 
     visit_all_expressions(root_component, |expr, _| {
-        expr.visit_recursive(&mut |expr| {
-            if let Expression::Struct { ty, .. } = expr {
-                maybe_collect_object(ty)
-            }
+        expr.visit_recursive(&mut |expr| match expr {
+            Expression::Struct { ty, .. } => maybe_collect_object(ty),
+            Expression::Array { element_ty, .. } => maybe_collect_object(element_ty),
+            _ => (),
         })
     });
 }

--- a/tests/cases/types/structs2.slint
+++ b/tests/cases/types/structs2.slint
@@ -7,6 +7,9 @@ struct Foo1 := { member: int, }
 struct Foo2 := { a: Foo1 }
 struct Foo3 := { b: int }
 
+
+struct DeleteMe := { c: color }
+
 TestCase := Rectangle {
     callback cb1(Foo2) -> Foo3;
     cb1(foo) => { return { b: foo.a.member+1 }; }
@@ -14,7 +17,15 @@ TestCase := Rectangle {
     property<Foo2> xx;
     callback cb2(Foo2, Foo2)->Foo2;
     property<Foo2> xx2: cb2(xx, xx);
+
+
+    // Based on Issue #1733
+    Rectangle {
+        property<[DeleteMe]> data;
+        for d[i] in data: Rectangle { }
+    }
 }
+
 
 /*
 ```rust


### PR DESCRIPTION
Prevent compilation error in the generated code when dealing with empty array expression of a given type, which is otherwise optimized out

Fixes #1733