### PR TITLE
Add support for dispatching key events through the public platform API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 
  - Added `material` style with `material-light` and `fluent-dark` as explicit styles
  - Added `Window::is_visible` 
+ - Added `From<char>` for `SharedString` in Rust.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@ All notable changes to this project are documented in this file.
  - `Window`'s `default-font-size` property is now always set to a non-zero value, provided by 
    either the style or the backend.
  - In the interpreter, calling `set_property` or `get_property` on properties of the base no longer works.
+ - Renamed the `Keys` namespace for use in `key-pressed`/`key-released` callbacks to `Key`. The
+   old name continues to work.
 
 ### Added
 
  - Added `material` style with `material-light` and `fluent-dark` as explicit styles
  - Added `Window::is_visible` 
  - Added `From<char>` for `SharedString` in Rust.
+ - Added `KeyPressed` and `KeyReleased` variants to `slint::WindowEvent` in Rust, along
+   with `slint::Key`, for use by custom platform backends.
 
 ### Fixed
 

--- a/api/cpp/include/slint_interpreter.h
+++ b/api/cpp/include/slint_interpreter.h
@@ -1006,14 +1006,24 @@ namespace slint::testing {
 using cbindgen_private::KeyboardModifiers;
 
 /// Send a key events to the given component instance
+inline void send_keyboard_char(const slint::interpreter::ComponentInstance *component,
+                               const slint::SharedString &str, bool pressed)
+{
+    const cbindgen_private::WindowAdapterRcOpaque *win_ptr = nullptr;
+    cbindgen_private::slint_interpreter_component_instance_window(
+            reinterpret_cast<const cbindgen_private::ErasedComponentBox *>(component), &win_ptr);
+    cbindgen_private::slint_send_keyboard_char(
+            &str, pressed, reinterpret_cast<const cbindgen_private::WindowAdapterRc *>(win_ptr));
+}
+
+/// Send a key events to the given component instance
 inline void send_keyboard_string_sequence(const slint::interpreter::ComponentInstance *component,
-                                          const slint::SharedString &str,
-                                          KeyboardModifiers modifiers = {})
+                                          const slint::SharedString &str)
 {
     const cbindgen_private::WindowAdapterRcOpaque *win_ptr = nullptr;
     cbindgen_private::slint_interpreter_component_instance_window(
             reinterpret_cast<const cbindgen_private::ErasedComponentBox *>(component), &win_ptr);
     cbindgen_private::send_keyboard_string_sequence(
-            &str, modifiers, reinterpret_cast<const cbindgen_private::WindowAdapterRc *>(win_ptr));
+            &str, reinterpret_cast<const cbindgen_private::WindowAdapterRc *>(win_ptr));
 }
 }

--- a/api/cpp/include/slint_testing.h
+++ b/api/cpp/include/slint_testing.h
@@ -24,12 +24,17 @@ inline void send_mouse_click(const Component *component, float x, float y)
 }
 
 template<typename Component>
-inline void send_keyboard_string_sequence(const Component *component,
-                                          const slint::SharedString &str,
-                                          cbindgen_private::KeyboardModifiers modifiers = {})
+inline void send_keyboard_char(const Component *component, const slint::SharedString &str,
+                               bool pressed)
 {
-    cbindgen_private::send_keyboard_string_sequence(&str, modifiers,
-                                                    &component->m_window.window_handle());
+    cbindgen_private::slint_send_keyboard_char(&str, pressed, &component->m_window.window_handle());
+}
+
+template<typename Component>
+inline void send_keyboard_string_sequence(const Component *component,
+                                          const slint::SharedString &str)
+{
+    cbindgen_private::send_keyboard_string_sequence(&str, &component->m_window.window_handle());
 }
 
 #define assert_eq(A, B)                                                                            \

--- a/api/cpp/tests/interpreter.cpp
+++ b/api/cpp/tests/interpreter.cpp
@@ -478,7 +478,9 @@ SCENARIO("Send key events")
             property <string> result;
             scope := FocusScope {
                 key-pressed(event) => {
-                    result += event.text;
+                    if (event.text != Key.Shift && event.text != Key.Control) {
+                        result += event.text;
+                    }
                     return accept;
                 }
             }
@@ -487,7 +489,7 @@ SCENARIO("Send key events")
                                                "");
     REQUIRE(comp_def.has_value());
     auto instance = comp_def->create();
-    slint::testing::send_keyboard_string_sequence(&*instance, "Hello keys!", {});
+    slint::testing::send_keyboard_string_sequence(&*instance, "Hello keys!");
     REQUIRE(*instance->get_property("result")->to_string() == "Hello keys!");
 }
 

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -162,7 +162,8 @@ pub mod re_exports {
     };
     pub use i_slint_core::graphics::*;
     pub use i_slint_core::input::{
-        FocusEvent, InputEventResult, KeyEvent, KeyEventResult, KeyboardModifiers, MouseEvent,
+        key_codes::Key, FocusEvent, InputEventResult, KeyEvent, KeyEventResult, KeyboardModifiers,
+        MouseEvent,
     };
     pub use i_slint_core::item_tree::{
         visit_item_tree, ItemTreeNode, ItemVisitorRefMut, ItemVisitorVTable, ItemWeak,

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -494,7 +494,7 @@ The FocusScope exposes callback to intercept the pressed key when it has focus.
 
 The KeyEvent has a text property which is a character of the key entered.
 When a non-printable key is pressed, the character will be either a control character,
-or it will be mapped to a private unicode character. The mapping of these non-printable, special characters is available in the [`Keys`](#keys) namespace
+or it will be mapped to a private unicode character. The mapping of these non-printable, special characters is available in the [`Key`](#key) namespace
 
 ### Properties
 
@@ -522,7 +522,7 @@ Example := Window {
             if (event.modifiers.control) {
                 debug("control was pressed during this event");
             }
-            if (event.text == Keys.Escape) {
+            if (event.text == Key.Escape) {
                 debug("Esc key was pressed")
             }
             accept
@@ -820,9 +820,9 @@ This structure is generated and passed to the `pointer-event` callback of the `T
 
 The following namespaces provide access to common constants such as special keys or named colors.
 
-## `Keys`
+## `Key`
 
-Use the constants in the `Keys` namespace to handle pressing of keys that don't have a printable character. Check the value of [`KeyEvent`](#keyevent)'s `text` property
+Use the constants in the `Key` namespace to handle pressing of keys that don't have a printable character. Check the value of [`KeyEvent`](#keyevent)'s `text` property
 against the constants below.
 
 * **`Backspace`**
@@ -831,6 +831,15 @@ against the constants below.
 * **`Escape`**
 * **`Backtab`**
 * **`Delete`**
+* **`Shift`**
+* **`Control`**
+* **`Alt`**
+* **`AltGr`**
+* **`CapsLock`**
+* **`ShiftR`**
+* **`ControlR`**
+* **`Meta`**
+* **`MetaR`**
 * **`UpArrow`**
 * **`DownArrow`**
 * **`LeftArrow`**

--- a/examples/carousel/ui/carousel.slint
+++ b/examples/carousel/ui/carousel.slint
@@ -28,17 +28,17 @@ export Carousel := FocusScope {
     
     focus-scope:= FocusScope {
         key-pressed(event) => {
-            if(event.text == Keys.UpArrow) {
+            if(event.text == Key.UpArrow) {
                 root.move-focus-up();
                 return accept;
             }
 
-            if(event.text == Keys.RightArrow) {
+            if(event.text == Key.RightArrow) {
                 root.move-right();
                 return accept;
             }
 
-            if(event.text == Keys.LeftArrow) {
+            if(event.text == Key.LeftArrow) {
                 root.move-left();
                 return accept;
             }

--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -74,11 +74,11 @@ export SideBar := Rectangle {
                      current-item = current-focused;
                      return accept;
                 }
-                if (event.text == Keys.UpArrow) {
+                if (event.text == Key.UpArrow) {
                      focused-tab = Math.max(focused-tab - 1,  0);
                      return accept;
                 }
-                if (event.text == Keys.DownArrow) {
+                if (event.text == Key.DownArrow) {
                      focused-tab = Math.min(focused-tab + 1, model.length - 1);
                      return accept;
                 }

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -132,13 +132,10 @@ pub fn init() {
 
 /// This module contains functions useful for unit tests
 mod for_unit_test {
-    use core::cell::Cell;
     use i_slint_core::api::ComponentHandle;
     pub use i_slint_core::tests::slint_mock_elapsed_time as mock_elapsed_time;
     use i_slint_core::window::WindowInner;
     use i_slint_core::SharedString;
-
-    thread_local!(static KEYBOARD_MODIFIERS : Cell<i_slint_core::input::KeyboardModifiers> = Default::default());
 
     /// Simulate a mouse click
     pub fn send_mouse_click<
@@ -159,15 +156,20 @@ mod for_unit_test {
         );
     }
 
-    /// Simulate a change in keyboard modifiers being pressed
-    pub fn set_current_keyboard_modifiers<
+    /// Simulate entering a sequence of ascii characters key by (pressed or released).
+    pub fn send_keyboard_char<
         X: vtable::HasStaticVTable<i_slint_core::component::ComponentVTable>,
         Component: Into<vtable::VRc<i_slint_core::component::ComponentVTable, X>> + ComponentHandle,
     >(
-        _component: &Component,
-        modifiers: i_slint_core::input::KeyboardModifiers,
+        component: &Component,
+        string: char,
+        pressed: bool,
     ) {
-        KEYBOARD_MODIFIERS.with(|x| x.set(modifiers))
+        i_slint_core::tests::slint_send_keyboard_char(
+            &SharedString::from(string),
+            pressed,
+            &WindowInner::from_pub(component.window()).window_adapter(),
+        )
     }
 
     /// Simulate entering a sequence of ascii characters key by key.
@@ -180,7 +182,6 @@ mod for_unit_test {
     ) {
         i_slint_core::tests::send_keyboard_string_sequence(
             &SharedString::from(sequence),
-            KEYBOARD_MODIFIERS.with(|x| x.get()),
             &WindowInner::from_pub(component.window()).window_adapter(),
         )
     }

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -14,7 +14,6 @@ use crate::renderer::{WinitCompatibleCanvas, WinitCompatibleRenderer};
 use const_field_offset::FieldOffsets;
 use corelib::component::ComponentRc;
 use corelib::graphics::euclid::num::Zero;
-use corelib::input::KeyboardModifiers;
 use corelib::items::{ItemRef, MouseCursor};
 use corelib::layout::Orientation;
 use corelib::lengths::{LogicalLength, LogicalPoint, LogicalSize};
@@ -83,7 +82,6 @@ pub(crate) struct GLWindow<Renderer: WinitCompatibleRenderer + 'static> {
     window: corelib::api::Window,
     self_weak: Weak<Self>,
     map_state: RefCell<GraphicsWindowBackendState<Renderer>>,
-    keyboard_modifiers: std::cell::Cell<KeyboardModifiers>,
     currently_pressed_key_code: std::cell::Cell<Option<winit::event::VirtualKeyCode>>,
     pending_redraw: Cell<bool>,
 
@@ -108,7 +106,6 @@ impl<Renderer: WinitCompatibleRenderer + 'static> GLWindow<Renderer> {
                 requested_position: None,
                 requested_size: None,
             }),
-            keyboard_modifiers: Default::default(),
             currently_pressed_key_code: Default::default(),
             pending_redraw: Cell::new(false),
             renderer: Renderer::new(
@@ -182,10 +179,6 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Rende
 
     fn currently_pressed_key_code(&self) -> &Cell<Option<winit::event::VirtualKeyCode>> {
         &self.currently_pressed_key_code
-    }
-
-    fn current_keyboard_modifiers(&self) -> &Cell<KeyboardModifiers> {
-        &self.keyboard_modifiers
     }
 
     /// Draw the items of the specified `component` in the given window.

--- a/internal/common/key_codes.rs
+++ b/internal/common/key_codes.rs
@@ -18,6 +18,20 @@ macro_rules! for_each_special_keys {
 '\u{0019}'  # Backtab     # Qt_Key_Key_Backtab      #              ;
 '\u{007f}'  # Delete      # Qt_Key_Key_Delete       # Delete       ;
 
+// The modifier key codes comes from https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode.
+'\u{0010}'  # Shift       # Qt_Key_Key_Shift        # LShift       ;
+'\u{0011}'  # Control     # Qt_Key_Key_Meta         # LControl     ;
+'\u{0012}'  # Alt         # Qt_Key_Key_Alt          # LAlt         ;
+'\u{0013}'  # AltGr       # Qt_Key_Key_AltGr        # RAlt         ;
+'\u{0014}'  # CapsLock    # Qt_Key_Key_CapsLock     #              ;
+
+'\u{0015}'  # ShiftR      #                         # RShift       ;
+'\u{0016}'  # ControlR    #                         # RControl     ;
+
+// meta defines the macos command key (check DOM_VK_META on https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)
+'\u{00E0}'  # Meta        # Qt_Key_Key_Control      # LWin         ;
+'\u{00E1}'  # MetaR       #                         # RWin         ;
+
 '\u{F700}'	# UpArrow     # Qt_Key_Key_Up           # Up           ;
 '\u{F701}'	# DownArrow   # Qt_Key_Key_Down         # Down         ;
 '\u{F702}'	# LeftArrow   # Qt_Key_Key_Left         # Left         ;

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -89,6 +89,7 @@ pub enum BuiltinNamespace {
     Colors,
     Math,
     Keys,
+    Key,
     SlintInternal,
 }
 
@@ -102,6 +103,7 @@ impl LookupResult {
     pub fn deprecated(&self) -> Option<&str> {
         match self {
             Self::Expression { deprecated: Some(x), .. } => Some(x.as_str()),
+            Self::Namespace(BuiltinNamespace::Keys) => Some("Key"),
             _ => None,
         }
     }
@@ -152,6 +154,7 @@ impl LookupObject for LookupResult {
             }
             LookupResult::Namespace(BuiltinNamespace::Math) => MathFunctions.for_each_entry(ctx, f),
             LookupResult::Namespace(BuiltinNamespace::Keys) => KeysLookup.for_each_entry(ctx, f),
+            LookupResult::Namespace(BuiltinNamespace::Key) => KeysLookup.for_each_entry(ctx, f),
             LookupResult::Namespace(BuiltinNamespace::SlintInternal) => {
                 SlintInternal.for_each_entry(ctx, f)
             }
@@ -167,6 +170,7 @@ impl LookupObject for LookupResult {
             }
             LookupResult::Namespace(BuiltinNamespace::Math) => MathFunctions.lookup(ctx, name),
             LookupResult::Namespace(BuiltinNamespace::Keys) => KeysLookup.lookup(ctx, name),
+            LookupResult::Namespace(BuiltinNamespace::Key) => KeysLookup.lookup(ctx, name),
             LookupResult::Namespace(BuiltinNamespace::SlintInternal) => {
                 SlintInternal.lookup(ctx, name)
             }
@@ -701,6 +705,7 @@ impl LookupObject for BuiltinNamespaceLookup {
         None.or_else(|| f("Colors", LookupResult::Namespace(BuiltinNamespace::Colors)))
             .or_else(|| f("Math", LookupResult::Namespace(BuiltinNamespace::Math)))
             .or_else(|| f("Keys", LookupResult::Namespace(BuiltinNamespace::Keys)))
+            .or_else(|| f("Key", LookupResult::Namespace(BuiltinNamespace::Key)))
             .or_else(|| {
                 f("SlintInternal", LookupResult::Namespace(BuiltinNamespace::SlintInternal))
             })

--- a/internal/compiler/tests/syntax/lookup/deprecated_property.slint
+++ b/internal/compiler/tests/syntax/lookup/deprecated_property.slint
@@ -23,4 +23,15 @@ Xxx := Rectangle {
         color = #000000;
 //      ^warning{The property 'color' has been deprecated. Please use 'background' instead}
     }
+
+    Foo := FocusScope {
+        key-pressed(event) => {
+            if (event.text == Keys.Escape) {
+//                            ^warning{The property 'Keys' has been deprecated. Please use 'Key' instead}
+                debug("Esc key was pressed")
+            }
+            accept
+        }
+    }
+    
 }

--- a/internal/compiler/widgets/fluent-base/std-widgets.slint
+++ b/internal/compiler/widgets/fluent-base/std-widgets.slint
@@ -202,10 +202,10 @@ export SpinBox := FocusScope {
     }
 
     key-pressed(event) => {
-        if (enabled && event.text == Keys.UpArrow && value < maximum) {
+        if (enabled && event.text == Key.UpArrow && value < maximum) {
             value += 1;
             accept
-        } else if (enabled && event.text == Keys.DownArrow && value > minimum) {
+        } else if (enabled && event.text == Key.DownArrow && value > minimum) {
             value -= 1;
             accept
         } else {
@@ -291,10 +291,10 @@ export Slider := Rectangle {
         width: 0px;
 
         key-pressed(event) => {
-            if (enabled && event.text == Keys.RightArrow) {
+            if (enabled && event.text == Key.RightArrow) {
                 value = Math.min(value + 1, maximum);
                 accept
-            } else if (enabled && event.text == Keys.LeftArrow) {
+            } else if (enabled && event.text == Key.LeftArrow) {
                 value = Math.max(value - 1, minimum);
                 accept
             } else {
@@ -431,11 +431,11 @@ export TabBarImpl := Rectangle {
                  current = current-focused;
                  return accept;
             }
-            if (event.text == Keys.LeftArrow) {
+            if (event.text == Key.LeftArrow) {
                  focused-tab = Math.max(focused-tab - 1,  0);
                  return accept;
             }
-            if (event.text == Keys.RightArrow) {
+            if (event.text == Key.RightArrow) {
                  focused-tab = Math.min(focused-tab + 1, num-tabs - 1);
                  return accept;
             }
@@ -516,10 +516,10 @@ export StandardListView := ListView {
     }
     FocusScope {
         key-pressed(event) => {
-            if (event.text == Keys.UpArrow && current-item > 0) {
+            if (event.text == Key.UpArrow && current-item > 0) {
                 current-item -= 1;
                 return accept;
-            } else if (event.text == Keys.DownArrow && current-item + 1 < model.length) {
+            } else if (event.text == Key.DownArrow && current-item + 1 < model.length) {
                 current-item += 1;
                 return accept;
             }
@@ -539,16 +539,16 @@ export ComboBox := FocusScope {
     accessible-value <=> current-value;
 
     key-pressed(event) => {
-        if (event.text == Keys.UpArrow) {
+        if (event.text == Key.UpArrow) {
             current-index = Math.max(current-index - 1, 0);
             current-value = model[current-index];
             return accept;
-        } else if (event.text == Keys.DownArrow) {
+        } else if (event.text == Key.DownArrow) {
             current-index = Math.min(current-index + 1, model.length - 1);
             current-value = model[current-index];
             return accept;
         // PopupWindow can not get hidden again at this time, so do not allow to pop that up.
-        // } else if (event.text == Keys.Return) {
+        // } else if (event.text == Key.Return) {
         //     touch.clicked()
         //     return accept;
         }

--- a/internal/compiler/widgets/material-base/widget-combobox.slint
+++ b/internal/compiler/widgets/material-base/widget-combobox.slint
@@ -88,11 +88,11 @@ export ComboBox := FocusScope {
     }
 
     key-pressed(event) => {
-        if (event.text == Keys.UpArrow) {
+        if (event.text == Key.UpArrow) {
             current-index = Math.max(current-index - 1, 0);
             current-value = model[current-index];
             return accept;
-        } else if (event.text == Keys.DownArrow) {
+        } else if (event.text == Key.DownArrow) {
             current-index = Math.min(current-index + 1, model.length - 1);
             current-value = model[current-index];
             return accept;

--- a/internal/compiler/widgets/material-base/widget-listview.slint
+++ b/internal/compiler/widgets/material-base/widget-listview.slint
@@ -23,10 +23,10 @@ export StandardListView := ListView {
 
     FocusScope {
         key-pressed(event) => {
-            if (event.text == Keys.UpArrow && current-item > 0) {
+            if (event.text == Key.UpArrow && current-item > 0) {
                 current-item -= 1;
                 return accept;
-            } else if (event.text == Keys.DownArrow && current-item + 1 < model.length) {
+            } else if (event.text == Key.DownArrow && current-item + 1 < model.length) {
                 current-item += 1;
                 return accept;
             }

--- a/internal/compiler/widgets/material-base/widget-slider.slint
+++ b/internal/compiler/widgets/material-base/widget-slider.slint
@@ -86,10 +86,10 @@ export Slider := Rectangle {
         width: 0px;
 
         key-pressed(event) => {
-            if (enabled && event.text == Keys.RightArrow) {
+            if (enabled && event.text == Key.RightArrow) {
                 value = Math.min(value + 1, maximum);
                 accept
-            } else if (enabled && event.text == Keys.LeftArrow) {
+            } else if (enabled && event.text == Key.LeftArrow) {
                 value = Math.max(value - 1, minimum);
                 accept
             } else {

--- a/internal/compiler/widgets/material-base/widget-spinbox.slint
+++ b/internal/compiler/widgets/material-base/widget-spinbox.slint
@@ -149,10 +149,10 @@ export SpinBox := FocusScope {
     }
 
     key-pressed(event) => {
-        if (enabled && event.text == Keys.UpArrow && value < maximum) {
+        if (enabled && event.text == Key.UpArrow && value < maximum) {
             value += 1;
             accept
-        } else if (enabled && event.text == Keys.DownArrow && value > minimum) {
+        } else if (enabled && event.text == Key.DownArrow && value > minimum) {
             value -= 1;
             accept
         } else {

--- a/internal/compiler/widgets/material-base/widget-tabwidget.slint
+++ b/internal/compiler/widgets/material-base/widget-tabwidget.slint
@@ -112,11 +112,11 @@ export TabBarImpl := Rectangle {
                  current = current-focused;
                  return accept;
             }
-            if (event.text == Keys.LeftArrow) {
+            if (event.text == Key.LeftArrow) {
                  focused-tab = Math.max(focused-tab - 1,  0);
                  return accept;
             }
-            if (event.text == Keys.RightArrow) {
+            if (event.text == Key.RightArrow) {
                  focused-tab = Math.min(focused-tab + 1, num-tabs - 1);
                  return accept;
             }

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -58,10 +58,10 @@ export Slider := NativeSlider {
         width: 0px;
 
         key-pressed(event) => {
-            if (root.enabled && event.text == Keys.RightArrow) {
+            if (root.enabled && event.text == Key.RightArrow) {
                 root.value = Math.min(root.value + 1, root.maximum);
                 accept
-            } else if (root.enabled && event.text == Keys.LeftArrow) {
+            } else if (root.enabled && event.text == Key.LeftArrow) {
                 root.value = Math.max(root.value - 1, root.minimum);
                 accept
             } else {
@@ -127,10 +127,10 @@ export StandardListView := ListView {
     }
     FocusScope {
         key-pressed(event) => {
-            if (event.text == Keys.UpArrow && current-item > 0) {
+            if (event.text == Key.UpArrow && current-item > 0) {
                 current-item -= 1;
                 accept
-            } else if (event.text == Keys.DownArrow && current-item + 1 < model.length) {
+            } else if (event.text == Key.DownArrow && current-item + 1 < model.length) {
                 current-item += 1;
                 accept
             } else {
@@ -180,16 +180,16 @@ export ComboBox := NativeComboBox {
 
     fs := FocusScope {
         key-pressed(event) => {
-            if (event.text == Keys.UpArrow) {
+            if (event.text == Key.UpArrow) {
                 root.current-index = Math.max(root.current-index - 1, 0);
                 root.current-value = model[root.current-index];
                 return accept;
-            } else if (event.text == Keys.DownArrow) {
+            } else if (event.text == Key.DownArrow) {
                 root.current-index = Math.min(root.current-index + 1, root.model.length - 1);
                 root.current-value = model[root.current-index];
                 return accept;
             // PopupWindow can not get hidden again at this time, so do not allow to pop that up.
-            // } else if (event.text == Keys.Return) {
+            // } else if (event.text == Key.Return) {
             //     touch.clicked()
             //     return accept;
             }
@@ -223,11 +223,11 @@ export TabBarImpl := Rectangle {
     fs := FocusScope {
         width: 0px; // Do not react on clicks
         key-pressed(event) => {
-            if (event.text == Keys.LeftArrow) {
+            if (event.text == Key.LeftArrow) {
                  root.current = Math.max(root.current - 1,  0);
                  return accept;
             }
-            if (event.text == Keys.RightArrow) {
+            if (event.text == Key.RightArrow) {
                  root.current = Math.min(root.current + 1, num-tabs - 1);
                  return accept;
             }

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -190,6 +190,12 @@ impl From<&String> for SharedString {
     }
 }
 
+impl From<char> for SharedString {
+    fn from(c: char) -> Self {
+        SharedString::from(c.encode_utf8(&mut [0; 6]) as &str)
+    }
+}
+
 impl From<SharedString> for String {
     fn from(s: SharedString) -> String {
         s.as_str().into()
@@ -256,6 +262,8 @@ fn simple_test() {
         (&x as &dyn AsRef<std::ffi::CStr>).as_ref(),
         &*std::ffi::CString::new("hello world!").unwrap()
     );
+    assert_eq!(SharedString::from('h'), "h");
+    assert_eq!(SharedString::from('😎'), "😎");
 }
 
 #[test]

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1108,6 +1108,18 @@ pub mod testing {
             &WindowInner::from_pub(comp.window()).window_adapter(),
         );
     }
+    /// Wrapper around [`i_slint_core::tests::slint_send_keyboard_char`]
+    pub fn send_keyboard_char(
+        comp: &super::ComponentInstance,
+        string: i_slint_core::SharedString,
+        pressed: bool,
+    ) {
+        i_slint_core::tests::slint_send_keyboard_char(
+            &string,
+            pressed,
+            &WindowInner::from_pub(comp.window()).window_adapter(),
+        );
+    }
     /// Wrapper around [`i_slint_core::tests::send_keyboard_string_sequence`]
     pub fn send_keyboard_string_sequence(
         comp: &super::ComponentInstance,
@@ -1115,7 +1127,6 @@ pub mod testing {
     ) {
         i_slint_core::tests::send_keyboard_string_sequence(
             &string,
-            Default::default(),
             &WindowInner::from_pub(comp.window()).window_adapter(),
         );
     }

--- a/tests/cases/examples/key_press.slint
+++ b/tests/cases/examples/key_press.slint
@@ -7,10 +7,10 @@ W := Window {
         field := FocusScope {
             vertical_stretch: 1;
             key-pressed(event) => {
-                if (event.text == Keys.F1) {
+                if (event.text == Key.F1) {
                     debug("F1");
                 }
-                if (event.text == Keys.PageUp) {
+                if (event.text == Key.PageUp) {
                     debug("PageUp");
                 }
                 if (event.modifiers.control) {

--- a/tests/cases/focus/event_propagation.slint
+++ b/tests/cases/focus/event_propagation.slint
@@ -13,7 +13,9 @@ TestCase := Rectangle {
             FocusScope {
                 width: 75%;
                 key-pressed(event) => {
-                    received += event.text;
+                    if (event.text != Key.Shift && event.text != Key.Control) {
+                        received += event.text;
+                    }
                     accept
                 }
 
@@ -39,12 +41,6 @@ TestCase := Rectangle {
 }
 
 /*
-```rust
-let ctrl_modifier = slint::private_unstable_api::re_exports::KeyboardModifiers {
-    control: true,
-    ..Default::default()
-};
-
 let instance = TestCase::new();
 
 assert!(!instance.get_input1_focused());
@@ -55,7 +51,7 @@ assert_eq!(instance.get_input2_text(), "Hello");
 assert_eq!(instance.get_input1_text(), "");
 assert_eq!(instance.get_received(), "");
 
-slint_testing::set_current_keyboard_modifiers(&instance, ctrl_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, "ß");
 assert_eq!(instance.get_input2_text(), "Hello");
 assert_eq!(instance.get_input1_text(), "");
@@ -63,9 +59,6 @@ assert_eq!(instance.get_received(), "ß");
 ```
 
 ```cpp
-slint::cbindgen_private::KeyboardModifiers ctrl_modifier{};
-ctrl_modifier.control = true;
-
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
 
@@ -77,7 +70,9 @@ assert_eq(instance.get_input2_text(), "Hello");
 assert_eq(instance.get_input1_text(), "");
 assert_eq(instance.get_received(), "");
 
-slint_testing::send_keyboard_string_sequence(&instance, "ß", ctrl_modifier);
+// Control key
+slint_testing::send_keyboard_char(&instance, slint::SharedString(u8"\U00000011"), true);
+slint_testing::send_keyboard_string_sequence(&instance, "ß");
 assert_eq(instance.get_input2_text(), "Hello");
 assert_eq(instance.get_input1_text(), "");
 assert_eq(instance.get_received(), "ß");

--- a/tests/cases/text/cursor_move.slint
+++ b/tests/cases/text/cursor_move.slint
@@ -21,23 +21,27 @@ const RIGHT_CODE: char = '\u{F703}';
 const DEL_CODE: char = '\u{007f}';
 const BACK_CODE: char = '\u{0008}'; // backspace \b
 
-let shift_modifier = slint::private_unstable_api::re_exports::KeyboardModifiers {
-    shift: true,
-    ..Default::default()
-};
+fn send_move_mod_modifier(instance: &TestCase, pressed: bool) {
+    if cfg!(not(target_os = "macos")) {
+        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), pressed);
+    }
 
-let move_mod_shift_modifier = slint::private_unstable_api::re_exports::KeyboardModifiers {
-    shift: true,
-    control: cfg!(not(target_os = "macos")),
-    alt: cfg!(target_os = "macos"),
-    ..Default::default()
-};
+    if cfg!(target_os = "macos") {
+        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Alt.into(), pressed);
+    }
+}
 
-let move_mod_modifier = slint::private_unstable_api::re_exports::KeyboardModifiers {
-    control: cfg!(not(target_os = "macos")),
-    alt: cfg!(target_os = "macos"),
-    ..Default::default()
-};
+fn send_move_mod_shift_modifier(instance: &TestCase, pressed: bool) {
+    slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Shift.into(), pressed);
+
+    if cfg!(not(target_os = "macos")) {
+        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), pressed);
+    }
+
+    if cfg!(target_os = "macos") {
+        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Alt.into(), pressed);
+    }
+}
 
 let instance = TestCase::new();
 slint_testing::send_mouse_click(&instance, 50., 50.);
@@ -47,9 +51,9 @@ slint_testing::send_keyboard_string_sequence(&instance, "Test");
 assert_eq!(instance.get_test_text(), "Test");
 assert!(!instance.get_has_selection());
 
-slint_testing::set_current_keyboard_modifiers(&instance, shift_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
 assert!(!instance.get_has_selection());
@@ -69,9 +73,9 @@ slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 assert_eq!(instance.get_test_cursor_pos(), 0);
 
-slint_testing::set_current_keyboard_modifiers(&instance, move_mod_shift_modifier);
+send_move_mod_shift_modifier(&instance, true);
 slint_testing::send_keyboard_string_sequence(&instance, &DOWN_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+send_move_mod_shift_modifier(&instance, false);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 2);
 assert_eq!(instance.get_test_anchor_pos(), 0);
@@ -79,20 +83,17 @@ assert_eq!(instance.get_test_anchor_pos(), 0);
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 assert!(!instance.get_has_selection());
 
-slint_testing::set_current_keyboard_modifiers(&instance, move_mod_shift_modifier);
+send_move_mod_shift_modifier(&instance, true);
 slint_testing::send_keyboard_string_sequence(&instance, &UP_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+send_move_mod_shift_modifier(&instance, false);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 0);
 assert_eq!(instance.get_test_anchor_pos(), 1);
 
 // Select all and start over
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers {
-    control: true,
-    ..Default::default()
-});
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &"a");
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
 slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_text(), "");
@@ -108,15 +109,15 @@ assert_eq!(instance.get_test_cursor_pos(), 22);
 
 // Delete word backwards when the cursor is between the 'F' of Fifth and the leading space.
 // -> Delete "Word"
-slint_testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+send_move_mod_modifier(&instance, true);
 slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "First Word Third Fifth");
 
 // Once more :-)
-slint_testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+send_move_mod_modifier(&instance, true);
 slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "First Word Fifth");
 
 // Move cursor between the "d" of "Word" and the trailing space
@@ -128,18 +129,15 @@ slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 
 // Delete word forwards
-slint_testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+send_move_mod_modifier(&instance, true);
 slint_testing::send_keyboard_string_sequence(&instance, &DEL_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "First Fifth");
 
 // Select all and start over
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers {
-    control: true,
-    ..Default::default()
-});
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &"a");
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
 slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_text(), "");
@@ -150,16 +148,16 @@ assert_eq!(instance.get_test_text(), "First Second");
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 
-slint_testing::set_current_keyboard_modifiers(&instance, shift_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 
 // When there's an existing selection, always just delete that
-slint_testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+send_move_mod_modifier(&instance, true);
 slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "First Send");
 
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
@@ -168,15 +166,15 @@ slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 
-slint_testing::set_current_keyboard_modifiers(&instance, shift_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 
 // When there's an existing selection, always just delete that
-slint_testing::set_current_keyboard_modifiers(&instance, move_mod_modifier);
+send_move_mod_modifier(&instance, true);
 slint_testing::send_keyboard_string_sequence(&instance, &DEL_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "Fist Send");
 ```
 */

--- a/tests/cases/text/cursor_move_grapheme.slint
+++ b/tests/cases/text/cursor_move_grapheme.slint
@@ -17,11 +17,6 @@ TestCase := TextInput {
 const LEFT_CODE: char = '\u{F702}';
 const BACK_CODE: char = '\u{0008}'; // backspace \b
 
-let shift_modifier = slint::private_unstable_api::re_exports::KeyboardModifiers {
-    shift: true,
-    ..Default::default()
-};
-
 let instance = TestCase::new();
 slint_testing::send_mouse_click(&instance, 50., 50.);
 assert!(instance.get_input_focused());
@@ -31,9 +26,9 @@ assert_eq!(instance.get_test_text(), "e\u{0301}");
 assert!(!instance.get_has_selection());
 
 // Test that selecting the grapheme works
-slint_testing::set_current_keyboard_modifiers(&instance, shift_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
 

--- a/tests/cases/text/cut.slint
+++ b/tests/cases/text/cut.slint
@@ -16,16 +16,6 @@ TestCase := TextInput {
 
 const LEFT_CODE: char = '\u{F702}';
 
-let shift_modifier = slint::private_unstable_api::re_exports::KeyboardModifiers {
-    shift: true,
-    ..Default::default()
-};
-
-let control_modifier = slint::private_unstable_api::re_exports::KeyboardModifiers {
-    control: true,
-    ..Default::default()
-};
-
 let instance = TestCase::new();
 slint_testing::send_mouse_click(&instance, 50., 50.);
 assert!(instance.get_input_focused());
@@ -34,14 +24,16 @@ slint_testing::send_keyboard_string_sequence(&instance, "Test");
 assert_eq!(instance.get_test_text(), "Test");
 assert!(!instance.get_has_selection());
 
-slint_testing::set_current_keyboard_modifiers(&instance, control_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, "a");
-slint_testing::set_current_keyboard_modifiers(&instance, shift_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::set_current_keyboard_modifiers(&instance, control_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, "x");
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_text(), "st");
 assert_eq!(instance.get_test_cursor_pos(), 0);

--- a/tests/cases/text/keyboard_modifiers.slint
+++ b/tests/cases/text/keyboard_modifiers.slint
@@ -1,0 +1,186 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+TestCase := Window {
+    width: 100phx;
+    height: 100phx;
+    ti := FocusScope { 
+        key-pressed(event) => {
+            debug("pressy");
+            debug(event.modifiers.shift);
+            shift_modifier = event.modifiers.shift;
+            alt_modifier = event.modifiers.alt;
+            control_modifier = event.modifiers.control;
+            meta_modifier = event.modifiers.meta;
+            accept;
+        }
+        key-released(event) => {
+            shift_modifier = event.modifiers.shift;
+            alt_modifier = event.modifiers.alt;
+            control_modifier = event.modifiers.control;
+            meta_modifier = event.modifiers.meta;
+            accept;
+        }
+    }
+
+    property <bool> input_focused: ti.has_focus;
+    property <bool> shift_modifier;
+    property <bool> alt_modifier;
+    property <bool> control_modifier;
+    property <bool> meta_modifier;
+}
+
+/*
+```rust
+
+const SHIFT_CODE: char = '\u{0010}';
+const SHIFTR_CODE: char = '\u{0015}';
+const ALT_CODE: char = '\u{0012}';
+const ALTGR_CODE: char = '\u{0013}';
+const CONTROL_CODE: char = '\u{0011}';
+const CONTROLR_CODE: char = '\u{0016}';
+const META_CODE: char = '\u{00E0}';
+const METAR_CODE: char = '\u{00E1}';
+
+let instance = TestCase::new();
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_input_focused());
+
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, SHIFT_CODE, true);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), true);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, SHIFTR_CODE, true);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), true);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, SHIFT_CODE, false);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), true);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, SHIFTR_CODE, false);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, ALT_CODE, true);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), true);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, ALTGR_CODE, true);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), true);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+// AltGr does not set the alt modifier
+slint_testing::send_keyboard_char(&instance, ALT_CODE, false);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, ALTGR_CODE, false);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, CONTROL_CODE, true);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), true);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, CONTROLR_CODE, true);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), true);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, CONTROL_CODE, false);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), true);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, CONTROLR_CODE, false);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+slint_testing::send_keyboard_char(&instance, META_CODE, true);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), true);
+
+slint_testing::send_keyboard_char(&instance, METAR_CODE, true);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), true);
+
+slint_testing::send_keyboard_char(&instance, META_CODE, false);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), true);
+
+slint_testing::send_keyboard_char(&instance, METAR_CODE, false);
+slint_testing::send_keyboard_char(&instance, 'a', true);
+slint_testing::send_keyboard_char(&instance, 'a', false);
+assert_eq!(instance.get_shift_modifier(), false);
+assert_eq!(instance.get_alt_modifier(), false);
+assert_eq!(instance.get_control_modifier(), false);
+assert_eq!(instance.get_meta_modifier(), false);
+
+```
+*/

--- a/tests/cases/text/select_all.slint
+++ b/tests/cases/text/select_all.slint
@@ -14,12 +14,6 @@ TestCase := TextInput {
 /*
 ```rust
 
-
-let control_modifier = slint::private_unstable_api::re_exports::KeyboardModifiers {
-    control: true,
-    ..Default::default()
-};
-
 let instance = TestCase::new();
 slint_testing::send_mouse_click(&instance, 50., 50.);
 assert!(instance.get_input_focused());
@@ -28,9 +22,9 @@ slint_testing::send_keyboard_string_sequence(&instance, "Test");
 assert_eq!(instance.get_test_text(), "Test");
 assert!(!instance.get_has_selection());
 
-slint_testing::set_current_keyboard_modifiers(&instance, control_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, "a");
-slint_testing::set_current_keyboard_modifiers(&instance, slint::private_unstable_api::re_exports::KeyboardModifiers::default());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 4);
 assert_eq!(instance.get_test_anchor_pos(), 0);

--- a/tests/cases/text/surrogate_cursor.slint
+++ b/tests/cases/text/surrogate_cursor.slint
@@ -17,11 +17,6 @@ TestCase := TextInput {
 const LEFT_CODE: char = '\u{F702}';
 const BACK_CODE: char = '\u{0008}'; // backspace \b
 
-let shift_modifier = slint::private_unstable_api::re_exports::KeyboardModifiers {
-    shift: true,
-    ..Default::default()
-};
-
 let instance = TestCase::new();
 slint_testing::send_mouse_click(&instance, 50., 50.);
 assert!(instance.get_input_focused());
@@ -30,7 +25,7 @@ slint_testing::send_keyboard_string_sequence(&instance, "😍");
 assert_eq!(instance.get_test_text(), "😍");
 assert!(!instance.get_has_selection());
 
-slint_testing::set_current_keyboard_modifiers(&instance, shift_modifier);
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 0);


### PR DESCRIPTION
Now it is possible to dispatch key events from the public api using the `WindowEvent` enum. Related to #1745. Add `impl From<char> for SharedString`