### PR TITLE
carousel: use "mcu-board-support" as feature name, so it is easier to use

### DIFF
--- a/examples/carousel/rust/Cargo.toml
+++ b/examples/carousel/rust/Cargo.toml
@@ -15,7 +15,7 @@ path = "main.rs"
 name = "carousel"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-0-3-0"] }
 mcu-board-support = { path = "../../mcu-board-support", optional = true }
 
 [build-dependencies]
@@ -23,8 +23,7 @@ slint-build = { path = "../../../api/rs/build" }
 
 [features]
 default = ["slint/default"]
-mcu = ["mcu-board-support", "slint/compat-0-3-0"]
-simulator = ["mcu", "slint/renderer-winit-software", "slint/backend-winit", "slint/std"]
+simulator = ["mcu-board-support", "slint/renderer-winit-software", "slint/backend-winit", "slint/std"]
 
 
 # Remove the `#wasm#` to uncomment the wasm build.

--- a/examples/carousel/rust/build.rs
+++ b/examples/carousel/rust/build.rs
@@ -1,12 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-#[cfg(not(feature = "mcu"))]
+#[cfg(not(feature = "mcu-board-support"))]
 fn main() {
     slint_build::compile("../ui/carousel_demo.slint").unwrap();
 }
 
-#[cfg(feature = "mcu")]
+#[cfg(feature = "mcu-board-support")]
 fn main() {
     let config = slint_build::CompilerConfiguration::new()
         .embed_resources(slint_build::EmbedResourcesKind::EmbedForSoftwareRenderer);

--- a/examples/carousel/rust/main.rs
+++ b/examples/carousel/rust/main.rs
@@ -1,10 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-#![cfg_attr(feature = "mcu", no_std)]
-#![cfg_attr(all(feature = "mcu", not(simulator)), no_main)]
+#![cfg_attr(feature = "mcu-board-support", no_std)]
+#![cfg_attr(all(feature = "mcu-board-support", not(simulator)), no_main)]
 
-#[cfg(feature = "mcu")]
+#[cfg(feature = "mcu-board-support")]
 extern crate alloc;
 
 #[cfg(target_arch = "wasm32")]
@@ -12,7 +12,7 @@ use wasm_bindgen::prelude::*;
 
 slint::include_modules!();
 
-#[cfg(not(feature = "mcu"))]
+#[cfg(not(feature = "mcu-board-support"))]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
     // This provides better error messages in debug mode.
@@ -23,7 +23,7 @@ pub fn main() {
     MainWindow::new().run()
 }
 
-#[cfg(feature = "mcu")]
+#[cfg(feature = "mcu-board-support")]
 #[mcu_board_support::entry]
 fn main() -> ! {
     mcu_board_support::init();


### PR DESCRIPTION
then we just enable the support for the pico with --features=mcu-board-support/pico-st7789