### PR TITLE
Online editor: Fix binding expression text shown in the properties view

### DIFF
--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -60,6 +60,7 @@ euclid = "0.22"
 lsp-types = { version = "0.93.0", features = ["proposed"] }
 serde = "1.0.118"
 serde_json = "1.0.60"
+rowan = "0.15.5"
 
 
 # for the preview

--- a/tools/lsp/properties.rs
+++ b/tools/lsp/properties.rs
@@ -146,7 +146,7 @@ fn find_expression_range(
             },
             expression_range: lsp_types::Range {
                 start: offset_to_position(expression_start),
-                end: offset_to_position(expression_end + 1), // The end points to the first excluded character
+                end: offset_to_position(expression_end + 1),
             },
         });
     } else {

--- a/tools/lsp/properties.rs
+++ b/tools/lsp/properties.rs
@@ -10,16 +10,14 @@ use crate::wasm_prelude::*;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub(crate) struct DefinitionInformation {
-    start_offset: u32,
-    end_offset: u32,
-    expression_start: u32,
-    expression_end: u32,
+    property_definition_range: lsp_types::Range,
+    expression_range: lsp_types::Range,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub(crate) struct DeclarationInformation {
     uri: String,
-    start_offset: u32,
+    start_position: lsp_types::Position,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
@@ -63,20 +61,21 @@ fn source_file(element: &Element) -> Option<String> {
     element.source_file().map(|sf| sf.path().to_string_lossy().to_string())
 }
 
-fn get_element_properties(element: &Element) -> impl Iterator<Item = PropertyInformation> + '_ {
+fn get_element_properties<'a>(
+    element: &'a Element,
+    offset_to_position: &'a mut dyn FnMut(u32) -> lsp_types::Position,
+) -> impl Iterator<Item = PropertyInformation> + 'a {
     let file = source_file(element);
 
     element.property_declarations.iter().map(move |(name, value)| {
         let declared_at = file.as_ref().and_then(|file| {
             value.type_node().map(|n| n.text_range().start().into()).map(|p| {
+                let uri = lsp_types::Url::from_file_path(file).unwrap_or_else(|_| {
+                    lsp_types::Url::parse("file:///)").expect("That should have been valid as URL!")
+                });
                 DeclarationInformation {
-                    uri: lsp_types::Url::from_file_path(file)
-                        .unwrap_or_else(|_| {
-                            lsp_types::Url::parse("file:///)")
-                                .expect("That should have been valid as URL!")
-                        })
-                        .to_string(),
-                    start_offset: p,
+                    uri: uri.to_string(),
+                    start_position: offset_to_position(p),
                 }
             })
         });
@@ -103,13 +102,13 @@ fn insert_property_definition_range(
 fn find_expression_range(
     element: &syntax_nodes::Element,
     offset: u32,
+    offset_to_position: &mut dyn FnMut(u32) -> lsp_types::Position,
 ) -> Option<DefinitionInformation> {
-    let mut result = DefinitionInformation {
-        start_offset: 0,
-        end_offset: 0,
-        expression_start: 0,
-        expression_end: 0,
-    };
+    let mut start_offset: u32 = 0;
+    let mut end_offset: u32 = 0;
+    let mut expression_start: u32 = 0;
+    let mut expression_end: u32 = 0;
+
     if let Some(token) = element.token_at_offset(offset.into()).right_biased() {
         for ancestor in token.parent_ancestors() {
             if ancestor.kind() == SyntaxKind::BindingExpression {
@@ -118,14 +117,14 @@ fn find_expression_range(
                     .first_child()
                     .expect("A BindingExpression needs to have a child!")
                     .text_range();
-                result.expression_start = expr_range.start().into();
-                result.expression_end = expr_range.end().into();
+                expression_start = expr_range.start().into();
+                expression_end = expr_range.end().into();
                 continue;
             }
             if ancestor.kind() == SyntaxKind::Binding {
                 let total_range = ancestor.text_range();
-                result.start_offset = total_range.start().into();
-                result.end_offset = total_range.end().into();
+                start_offset = total_range.start().into();
+                end_offset = total_range.end().into();
                 break;
             }
             if ancestor.kind() == SyntaxKind::Element {
@@ -134,17 +133,32 @@ fn find_expression_range(
             }
         }
     }
-    if result.start_offset < result.expression_start
-        && result.expression_start <= result.expression_end
-        && result.expression_end < result.end_offset
+    if start_offset < expression_start
+        && expression_start <= expression_end
+        && expression_end < end_offset
     {
-        return Some(result);
+        return Some(DefinitionInformation {
+            // In the CST, the range end includes the last character, while in the lsp protocol the end of the
+            // range is exclusive, i.e. it refers to the first excluded character. Hence the +1 below:
+            property_definition_range: lsp_types::Range {
+                start: offset_to_position(start_offset),
+                end: offset_to_position(end_offset + 1),
+            },
+            expression_range: lsp_types::Range {
+                start: offset_to_position(expression_start),
+                end: offset_to_position(expression_end + 1), // The end points to the first excluded character
+            },
+        });
     } else {
         None
     }
 }
 
-fn insert_property_definitions(element: &Element, properties: &mut Vec<PropertyInformation>) {
+fn insert_property_definitions(
+    element: &Element,
+    properties: &mut Vec<PropertyInformation>,
+    offset_to_position: &mut dyn FnMut(u32) -> lsp_types::Position,
+) {
     let element_node = element.node.as_ref().expect("Element has to have a node here!");
     let element_range = element_node.text_range();
 
@@ -155,7 +169,9 @@ fn insert_property_definitions(element: &Element, properties: &mut Vec<PropertyI
                 == span.source_file.as_ref().map(|sf| sf.path())
                 && element_range.contains(offset.into())
             {
-                if let Some(definition) = find_expression_range(element_node, offset) {
+                if let Some(definition) =
+                    find_expression_range(element_node, offset, offset_to_position)
+                {
                     insert_property_definition_range(k, properties, definition);
                 }
             }
@@ -163,14 +179,17 @@ fn insert_property_definitions(element: &Element, properties: &mut Vec<PropertyI
     }
 }
 
-fn get_properties(element: &ElementRc) -> Vec<PropertyInformation> {
+fn get_properties(
+    element: &ElementRc,
+    offset_to_position: &mut dyn FnMut(u32) -> lsp_types::Position,
+) -> Vec<PropertyInformation> {
     let mut result = vec![];
 
     let mut current_element = Some(element.clone());
     while let Some(e) = current_element {
         use i_slint_compiler::langtype::Type;
 
-        result.extend(get_element_properties(&e.borrow()));
+        result.extend(get_element_properties(&e.borrow(), offset_to_position));
 
         // Go into base_type!
         match &e.borrow().base_type {
@@ -206,7 +225,7 @@ fn get_properties(element: &ElementRc) -> Vec<PropertyInformation> {
     result.dedup_by(|a, b| a.name == b.name); // LEave the property definition in place, remove
                                               // re-definitions
 
-    insert_property_definitions(&element.borrow(), &mut result);
+    insert_property_definitions(&element.borrow(), &mut result, offset_to_position);
 
     result
 }
@@ -216,9 +235,12 @@ fn get_element_information(element: &ElementRc) -> Option<ElementInformation> {
     Some(ElementInformation { id: e.id.clone(), type_name: format!("{}", e.base_type) })
 }
 
-pub(crate) fn query_properties(element: &ElementRc) -> Result<QueryPropertyResponse, crate::Error> {
+pub(crate) fn query_properties(
+    element: &ElementRc,
+    offset_to_position: &mut dyn FnMut(u32) -> lsp_types::Position,
+) -> Result<QueryPropertyResponse, crate::Error> {
     Ok(QueryPropertyResponse {
-        properties: get_properties(&element),
+        properties: get_properties(&element, offset_to_position),
         element: get_element_information(&element),
         source_uri: source_file(&element.borrow()),
     })
@@ -245,11 +267,13 @@ mod tests {
     ) -> Option<Vec<PropertyInformation>> {
         let element = crate::server_loop::element_at_position(
             &mut dc,
-            lsp_types::TextDocumentIdentifier { uri: url },
+            lsp_types::TextDocumentIdentifier { uri: url.clone() },
             lsp_types::Position { line, character },
         )
         .ok()?;
-        Some(get_properties(&element))
+        Some(get_properties(&element, &mut |offset| {
+            dc.byte_offset_to_position(offset, &url).expect("invalid node offset")
+        }))
     }
 
     fn properties_at_position(line: u32, character: u32) -> Option<Vec<PropertyInformation>> {
@@ -276,7 +300,12 @@ mod tests {
         let property = find_property(&result, "background").unwrap();
 
         let def_at = property.defined_at.as_ref().unwrap();
-        assert_eq!((def_at.expression_end - def_at.expression_start) as usize, "lightblue".len());
+        assert_eq!(def_at.expression_range.end.line, def_at.expression_range.start.line);
+        assert_eq!(
+            (def_at.expression_range.end.character - def_at.expression_range.start.character)
+                as usize,
+            "lightblue".len()
+        );
     }
 
     #[test]
@@ -354,7 +383,8 @@ MainWindow := Window {
 
         let declaration = foo_property.declared_at.as_ref().unwrap();
         assert_eq!(declaration.uri, file_url.to_string());
-        assert_eq!(declaration.start_offset, 125); // This should probably point to the start of
-                                                   // `property<int> foo = 42`, not to the `<`
+        assert_eq!(declaration.start_position.line, 3);
+        assert_eq!(declaration.start_position.character, 13); // This should probably point to the start of
+                                                              // `property<int> foo = 42`, not to the `<`
     }
 }

--- a/tools/lsp/properties.rs
+++ b/tools/lsp/properties.rs
@@ -293,8 +293,9 @@ mod tests {
 
         let def_at = property.defined_at.as_ref().unwrap();
         assert_eq!(def_at.expression_range.end.line, def_at.expression_range.start.line);
+        // -1 because the lsp range end location is exclusive.
         assert_eq!(
-            (def_at.expression_range.end.character - def_at.expression_range.start.character)
+            (def_at.expression_range.end.character - 1 - def_at.expression_range.start.character)
                 as usize,
             "lightblue".len()
         );

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -314,8 +314,12 @@ pub fn query_properties_command(
         TextDocumentIdentifier { uri: text_document.clone() },
         Position { line, character },
     ) {
-        properties::query_properties(&element)
-            .map(|r| serde_json::to_value(r).expect("Failed to serialize property query result!"))
+        properties::query_properties(&element, &mut |offset| {
+            document_cache
+                .byte_offset_to_position(offset, &text_document)
+                .expect("invalid node offset")
+        })
+        .map(|r| serde_json::to_value(r).expect("Failed to serialize property query result!"))
     } else {
         Ok(serde_json::to_value(properties::QueryPropertyResponse::no_element_response(
             text_document.to_string(),

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -145,6 +145,19 @@ fn to_range(span: (usize, usize)) -> lsp_types::Range {
     lsp_types::Range::new(pos, pos)
 }
 
+pub fn text_range_to_lsp_range(
+    range: rowan::TextRange,
+    offset_to_position: &mut dyn FnMut(u32) -> lsp_types::Position,
+) -> lsp_types::Range {
+    // In the CST, the range end includes the last character, while in the lsp protocol the end of the
+    // range is exclusive, i.e. it refers to the first excluded character. Hence the +1 below:
+    let range_end_offset: u32 = range.end().into();
+    lsp_types::Range {
+        start: offset_to_position(range.start().into()),
+        end: offset_to_position(range_end_offset + 1),
+    }
+}
+
 fn to_lsp_diag_level(level: DiagnosticLevel) -> lsp_types::DiagnosticSeverity {
     match level {
         DiagnosticLevel::Error => lsp_types::DiagnosticSeverity::ERROR,

--- a/tools/online_editor/src/editor_widget.ts
+++ b/tools/online_editor/src/editor_widget.ts
@@ -14,6 +14,8 @@ import { FilterProxyReader } from "./proxy";
 import { BoxLayout, TabBar, Title, Widget } from "@lumino/widgets";
 import { Message as LuminoMessage } from "@lumino/messaging";
 
+import { Position } from 'vscode-languageserver-types';
+
 import "monaco-editor/esm/vs/editor/editor.all.js";
 import "monaco-editor/esm/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.js";
 import "monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js";
@@ -689,8 +691,28 @@ class ModelBindingTextProvider implements BindingTextProvider {
     this.#model = model;
   }
   binding_text(location: DefinitionPosition): string {
+
+    const convertPosition = (protocolPosition: Position): monaco.Position => {
+      // LSP line numbers are zero based (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments)
+      // and Monaco's line numbers start at 1 (https://microsoft.github.io/monaco-editor/api/classes/monaco.Position.html#lineNumber)
+      const monacoLineNumber = protocolPosition.line + 1;
+      // Convert lsp utf-8 character index to JavaScript utf-16 string index
+      const line = this.#model.getLineContent(monacoLineNumber);
+      const line_utf8 = new TextEncoder().encode(line);
+      const line_utf8_until_character = line_utf8.slice(0, protocolPosition.character);
+      const line_until_character = new TextDecoder().decode(line_utf8_until_character);
+      return new monaco.Position(monacoLineNumber, line_until_character.length);
+    };
+
+    const startPos = convertPosition(location.expression_range.start);
+    const endPos = convertPosition(location.expression_range.end);
+
     return this.#model
-      .getValue()
-      .substring(location.expression_start, location.expression_end);
+      .getValueInRange({
+        startLineNumber: startPos.lineNumber,
+        startColumn: startPos.column,
+        endLineNumber: endPos.lineNumber,
+        endColumn: endPos.column,
+      });
   }
 }

--- a/tools/online_editor/src/lsp_integration.ts
+++ b/tools/online_editor/src/lsp_integration.ts
@@ -1,16 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+import { Position, Range } from 'vscode-languageserver-types'
+
 export interface DeclarationPosition {
   uri: string;
-  start_offset: number;
+  start_position: Position;
 }
 
 export interface DefinitionPosition {
-  start_offset: number;
-  end_offset: number;
-  expression_start: number;
-  expression_end: number;
+  property_definition_range: Range;
+  expression_range: Range;
 }
 
 export interface Property {


### PR DESCRIPTION
Use the zero-line based lsp range/position types for the QueryProperties lsp command results and convert them to monaco editor ranges for correct text extraction.