### PR TITLE
lsp: Group and sort properties in the property extension call

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -626,7 +626,7 @@ impl Default for DefaultSizeBinding {
 pub struct BuiltinElement {
     pub name: String,
     pub native_class: Rc<NativeClass>,
-    pub properties: HashMap<String, BuiltinPropertyInfo>,
+    pub properties: BTreeMap<String, BuiltinPropertyInfo>,
     pub additional_accepted_child_types: HashMap<String, Type>,
     pub disallow_global_types_as_child_elements: bool,
     /// Non-item type do not have reserved properties (x/width/rowspan/...) added to them  (eg: PropertyAnimation)

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1167,28 +1167,26 @@ impl Element {
             let unresolved_name = crate::parser::normalize_identifier(name_token.text());
             let lookup_result = self.lookup_property(&unresolved_name);
             if !lookup_result.property_type.is_property_type() {
-                diag.push_error(
-                    match lookup_result.property_type {
+                match lookup_result.property_type {
                         Type::Invalid => {
                             if self.base_type != Type::Invalid {
-                                format!(
+                                diag.push_error(format!(
                                     "Unknown property {} in {}",
                                     unresolved_name, self.base_type
-                                )
-                            } else {
-                                continue;
+                                ),
+                                &name_token);
                             }
                         }
                         Type::Callback { .. } => {
-                            format!("'{}' is a callback. Use `=>` to connect", unresolved_name)
+                            diag.push_error(format!("'{}' is a callback. Use `=>` to connect", unresolved_name),
+                            &name_token)
                         }
-                        _ => format!(
+                        _ => diag.push_error(format!(
                             "Cannot assign to {} in {} because it does not have a valid property type",
                             unresolved_name, self.base_type,
                         ),
-                    },
-                    &name_token,
-                );
+                        &name_token),
+                    }
             } else if !lookup_result.is_local_to_component
                 && (lookup_result.property_visibility == PropertyVisibility::Private
                     || lookup_result.property_visibility == PropertyVisibility::Output)

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -11,7 +11,7 @@ use crate::expression_tree::{BuiltinFunction, Expression};
 use crate::langtype::{BuiltinPropertyInfo, Enumeration, PropertyLookupResult, Type};
 use crate::object_tree::Component;
 
-pub(crate) const RESERVED_GEOMETRY_PROPERTIES: &[(&str, Type)] = &[
+pub const RESERVED_GEOMETRY_PROPERTIES: &[(&str, Type)] = &[
     ("x", Type::LogicalLength),
     ("y", Type::LogicalLength),
     ("width", Type::LogicalLength),
@@ -19,7 +19,7 @@ pub(crate) const RESERVED_GEOMETRY_PROPERTIES: &[(&str, Type)] = &[
     ("z", Type::Float32),
 ];
 
-const RESERVED_LAYOUT_PROPERTIES: &[(&str, Type)] = &[
+pub const RESERVED_LAYOUT_PROPERTIES: &[(&str, Type)] = &[
     ("min-width", Type::LogicalLength),
     ("min-height", Type::LogicalLength),
     ("max-width", Type::LogicalLength),
@@ -79,20 +79,20 @@ const RESERVED_OTHER_PROPERTIES: &[(&str, Type)] = &[
     ("visible", Type::Bool), // ("enabled", Type::Bool),
 ];
 
-pub(crate) const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
+pub const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
     ("drop-shadow-offset-x", Type::LogicalLength),
     ("drop-shadow-offset-y", Type::LogicalLength),
     ("drop-shadow-blur", Type::LogicalLength),
     ("drop-shadow-color", Type::Color),
 ];
 
-pub(crate) const RESERVED_ROTATION_PROPERTIES: &[(&str, Type)] = &[
+pub const RESERVED_ROTATION_PROPERTIES: &[(&str, Type)] = &[
     ("rotation-angle", Type::Angle),
     ("rotation-origin-x", Type::LogicalLength),
     ("rotation-origin-y", Type::LogicalLength),
 ];
 
-pub(crate) const RESERVED_ACCESSIBILITY_PROPERTIES: &[(&str, Type)] = &[
+pub const RESERVED_ACCESSIBILITY_PROPERTIES: &[(&str, Type)] = &[
     //("accessible-role", ...)
     ("accessible-checkable", Type::Bool),
     ("accessible-checked", Type::Bool),


### PR DESCRIPTION
Group property from the base class they are defined, and for built in property, group them by category.
Also filter callback and other reserved properties that are not valid for some elements.

Other fixes: 
     - We should try to keep bindings in the Element even if the base type  is invalid
     - Fix querying the element at a position in case it is not in the last component of a file
