### PR TITLE
Refactoring: split ElementType away from the types used as property type

### DIFF
--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -228,13 +228,10 @@ fn to_eval_value<'cx>(
         | Type::Void
         | Type::InferredProperty
         | Type::InferredCallback
-        | Type::Builtin(_)
-        | Type::Native(_)
         | Type::Function { .. }
         | Type::Model
         | Type::Callback { .. }
         | Type::Easing
-        | Type::Component(_)
         | Type::PathData
         | Type::LayoutCache
         | Type::ElementReference => cx.throw_error("Cannot convert to a Slint property value"),

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -220,9 +220,6 @@ fn to_debug_string(
         Type::Void
         | Type::InferredCallback
         | Type::InferredProperty
-        | Type::Component(_)
-        | Type::Builtin(_)
-        | Type::Native(_)
         | Type::Callback { .. }
         | Type::Function { .. }
         | Type::ElementReference

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -541,7 +541,6 @@ impl Expression {
                 Type::Struct { fields, .. } => {
                     fields.get(name.as_str()).unwrap_or(&Type::Invalid).clone()
                 }
-                Type::Component(c) => c.root_element.borrow().lookup_property(name).property_type,
                 _ => Type::Invalid,
             },
             Expression::ArrayIndex { array, .. } => match array.ty() {
@@ -975,22 +974,6 @@ impl Expression {
                         Expression::Struct { values: new_values, ty: target_type },
                     ]);
                 }
-                (Type::Struct { .. }, Type::Component(component)) => {
-                    let struct_type_for_component = Type::Struct {
-                        fields: component
-                            .root_element
-                            .borrow()
-                            .property_declarations
-                            .iter()
-                            .map(|(name, prop_decl)| {
-                                (name.clone(), prop_decl.property_type.clone())
-                            })
-                            .collect(),
-                        name: None,
-                        node: None,
-                    };
-                    self.maybe_convert_to(struct_type_for_component, node, diag)
-                }
                 (left, right) => match (left.as_unit_product(), right.as_unit_product()) {
                     (Some(left), Some(right)) => {
                         if let Some(power) =
@@ -1086,9 +1069,6 @@ impl Expression {
     pub fn default_value_for_type(ty: &Type) -> Expression {
         match ty {
             Type::Invalid
-            | Type::Component(_)
-            | Type::Builtin(_)
-            | Type::Native(_)
             | Type::Callback { .. }
             | Type::Function { .. }
             | Type::Void

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeSet, HashSet, VecDeque};
 use std::rc::{Rc, Weak};
 
 use crate::expression_tree::{BindingExpression, Expression};
-use crate::langtype::Type;
+use crate::langtype::ElementType;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, Document, ElementRc};
 
@@ -65,7 +65,7 @@ pub fn generate(
     #![allow(unused_variables)]
     #![allow(unreachable_code)]
 
-    if matches!(doc.root_component.root_element.borrow().base_type, Type::Invalid | Type::Void) {
+    if matches!(doc.root_component.root_element.borrow().base_type, ElementType::Error) {
         // empty document, nothing to generate
         return Ok(());
     }
@@ -415,10 +415,10 @@ pub fn for_each_const_properties(component: &Rc<Component>, mut f: impl FnMut(&E
                     .map(|(k, _)| k.clone()),
             );
             match &e.clone().borrow().base_type {
-                Type::Component(c) => {
+                ElementType::Component(c) => {
                     e = c.root_element.clone();
                 }
-                Type::Native(n) => {
+                ElementType::Native(n) => {
                     let mut n = n;
                     loop {
                         all_prop.extend(
@@ -438,7 +438,10 @@ pub fn for_each_const_properties(component: &Rc<Component>, mut f: impl FnMut(&E
                     }
                     break;
                 }
-                _ => break,
+                ElementType::Builtin(_) => {
+                    unreachable!("builtin element should have been resolved")
+                }
+                ElementType::Global | ElementType::Error => break,
             }
         }
         for c in all_prop {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -332,7 +332,6 @@ impl CppType for Type {
 
             Type::Array(i) => Some(format!("std::shared_ptr<slint::Model<{}>>", i.cpp_type()?)),
             Type::Image => Some("slint::Image".to_owned()),
-            Type::Builtin(elem) => elem.native_class.cpp_type.clone(),
             Type::Enumeration(enumeration) => {
                 Some(format!("slint::cbindgen_private::{}", ident(&enumeration.name)))
             }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -13,7 +13,7 @@ Some convention used in the generated code:
 */
 
 use crate::expression_tree::{BuiltinFunction, EasingCurve, OperatorClass};
-use crate::langtype::Type;
+use crate::langtype::{ElementType, Type};
 use crate::layout::Orientation;
 use crate::llr::{
     self, EvaluationContext as llr_EvaluationContext, Expression, ParentCtx as llr_ParentCtx,
@@ -130,7 +130,7 @@ fn set_primitive_property_value(ty: &Type, value_expression: TokenStream) -> Tok
 
 /// Generate the rust code for the given component.
 pub fn generate(doc: &Document) -> TokenStream {
-    if matches!(doc.root_component.root_element.borrow().base_type, Type::Invalid | Type::Void) {
+    if matches!(doc.root_component.root_element.borrow().base_type, ElementType::Error) {
         // empty document, nothing to generate
         return TokenStream::default();
     }
@@ -1652,15 +1652,6 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                 }
                 (Type::Brush, Type::Color) => {
                     quote!(#f.color())
-                }
-                (Type::Struct { ref fields, .. }, Type::Component(c)) => {
-                    let fields = fields.iter().enumerate().map(|(index, (name, _))| {
-                        let index = proc_macro2::Literal::usize_unsuffixed(index);
-                        let name = ident(name);
-                        quote!(#name: obj.#index as _)
-                    });
-                    let id: TokenStream = c.id.parse().unwrap();
-                    quote!({ let obj = #f; #id { #(#fields),*} })
                 }
                 (Type::Struct { ref fields, .. }, Type::Struct { name: Some(n), .. }) => {
                     let fields = fields.iter().enumerate().map(|(index, (name, _))| {

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -5,7 +5,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::*;
-use crate::langtype::{PropertyLookupResult, Type};
+use crate::langtype::{ElementType, PropertyLookupResult, Type};
 use crate::object_tree::{Component, ElementRc};
 
 use std::cell::RefCell;
@@ -377,7 +377,7 @@ fn find_binding<R>(
             return Some(f(&b.borrow(), &element.borrow().enclosing_component, depth));
         }
         let e = match &element.borrow().base_type {
-            Type::Component(base) => base.root_element.clone(),
+            ElementType::Component(base) => base.root_element.clone(),
             _ => return None,
         };
         element = e;
@@ -489,7 +489,7 @@ pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> 
     let mut elem_it = elem.clone();
     loop {
         return match &elem_it.clone().borrow().base_type {
-            Type::Component(base_comp) => {
+            ElementType::Component(base_comp) => {
                 match base_comp.root_element.borrow().layout_info_prop(orientation) {
                     Some(nr) => {
                         // We cannot take nr as is because it is relative to the elem's component. We therefore need to
@@ -503,7 +503,7 @@ pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> 
                     }
                 }
             }
-            Type::Builtin(base_type) if base_type.name == "Rectangle" => {
+            ElementType::Builtin(base_type) if base_type.name == "Rectangle" => {
                 // hard-code the value for rectangle because many rectangle end up optimized away and we
                 // don't want to depend on the element.
                 Expression::Struct {

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -182,9 +182,6 @@ impl Expression {
     pub fn default_value_for_type(ty: &Type) -> Option<Self> {
         Some(match ty {
             Type::Invalid
-            | Type::Component(_)
-            | Type::Builtin(_)
-            | Type::Native(_)
             | Type::Callback { .. }
             | Type::Function { .. }
             | Type::Void

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -4,7 +4,7 @@
 use by_address::ByAddress;
 
 use crate::expression_tree::Expression as tree_Expression;
-use crate::langtype::Type;
+use crate::langtype::{ElementType, Type};
 use crate::llr::item_tree::*;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, ElementRc};
@@ -93,7 +93,7 @@ impl LoweredSubComponentMapping {
         }
         match self.element_mapping.get(&element.clone().into()).unwrap() {
             LoweredElement::SubComponent { sub_component_index } => {
-                if let Type::Component(base) = &element.borrow().base_type {
+                if let ElementType::Component(base) = &element.borrow().base_type {
                     return property_reference_within_sub_component(
                         state.map_property_reference(&NamedReference::new(
                             &base.root_element,
@@ -245,7 +245,7 @@ fn lower_sub_component(
             return None;
         }
         match &elem.base_type {
-            Type::Component(comp) => {
+            ElementType::Component(comp) => {
                 let lc = state.sub_component(comp);
                 let ty = lc.sub_component.clone();
                 let sub_component_index = sub_component.sub_components.len();
@@ -263,7 +263,7 @@ fn lower_sub_component(
                 repeater_offset += ty.repeater_count();
             }
 
-            Type::Native(n) => {
+            ElementType::Native(n) => {
                 let item_index = sub_component.items.len();
                 mapping
                     .element_mapping
@@ -422,12 +422,12 @@ fn get_property_analysis(elem: &ElementRc, p: &str) -> crate::object_tree::Prope
     loop {
         let base = elem.borrow().base_type.clone();
         match base {
-            Type::Native(n) => {
+            ElementType::Native(n) => {
                 if n.properties.get(p).map_or(false, |p| p.is_native_output) {
                     a.is_set = true;
                 }
             }
-            Type::Component(c) => {
+            ElementType::Component(c) => {
                 elem = c.root_element.clone();
                 if let Some(a2) = elem.borrow().property_analysis.borrow().get(p) {
                     a.merge_with_base(a2);

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -14,7 +14,8 @@ use crate::diagnostics::Spanned;
 use crate::expression_tree::BindingExpression;
 use crate::expression_tree::BuiltinFunction;
 use crate::expression_tree::Expression;
-use crate::langtype::Type;
+use crate::langtype::ElementType;
+
 use crate::layout::LayoutItem;
 use crate::layout::Orientation;
 use crate::namedreference::NamedReference;
@@ -309,7 +310,7 @@ fn process_property(
         if element.borrow().bindings.contains_key(prop.prop.name()) {
             analyse_binding(&prop, context, reverse_aliases, diag);
         }
-        let next = if let Type::Component(base) = &element.borrow().base_type {
+        let next = if let ElementType::Component(base) = &element.borrow().base_type {
             if element.borrow().property_declarations.contains_key(prop.prop.name()) {
                 break;
             }
@@ -397,7 +398,7 @@ fn visit_layout_items_dependencies<'a>(
         if let Some(nr) = element.borrow().layout_info_prop(orientation) {
             vis(&nr.clone().into());
         } else {
-            if let Type::Component(base) = &element.borrow().base_type {
+            if let ElementType::Component(base) = &element.borrow().base_type {
                 if let Some(nr) = base.root_element.borrow().layout_info_prop(orientation) {
                     vis(&PropertyPath {
                         elements: vec![ByAddress(element.clone())],
@@ -543,7 +544,7 @@ fn mark_used_base_properties(component: &Rc<Component>) {
         component,
         &(),
         &mut |element, _| {
-            if !matches!(element.borrow().base_type, Type::Component(_)) {
+            if !matches!(element.borrow().base_type, ElementType::Component(_)) {
                 return;
             }
             for (name, binding) in &element.borrow().bindings {

--- a/internal/compiler/passes/check_aliases.rs
+++ b/internal/compiler/passes/check_aliases.rs
@@ -5,13 +5,13 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::Expression;
-use crate::langtype::Type;
+use crate::langtype::ElementType;
 use crate::object_tree::{Component, ElementRc};
 use std::rc::Rc;
 
 pub fn check_aliases(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
     crate::object_tree::recurse_elem_including_sub_components(&component, &(), &mut |elem, _| {
-        let base = if let Type::Component(base) = &elem.borrow().base_type {
+        let base = if let ElementType::Component(base) = &elem.borrow().base_type {
             base.clone()
         } else {
             return;
@@ -54,7 +54,7 @@ fn explicit_binding_priority(elem: &ElementRc, name: &str) -> Option<i32> {
             }
             None
         }
-    } else if let Type::Component(base) = &elem.borrow().base_type {
+    } else if let ElementType::Component(base) = &elem.borrow().base_type {
         explicit_binding_priority(&base.root_element, name).map(|p| p.saturating_add(1))
     } else {
         None

--- a/internal/compiler/passes/check_public_api.rs
+++ b/internal/compiler/passes/check_public_api.rs
@@ -6,13 +6,12 @@
 use std::rc::Rc;
 
 use crate::diagnostics::{BuildDiagnostics, DiagnosticLevel};
-use crate::langtype::Type;
 use crate::object_tree::{Component, Document};
 
 pub fn check_public_api(doc: &Document, diag: &mut BuildDiagnostics) {
     check_public_api_component(&doc.root_component, diag);
-    for (export_name, ty) in doc.exports() {
-        if let Type::Component(c) = ty {
+    for (export_name, e) in &doc.exports.0 {
+        if let Some(c) = e.as_ref().left() {
             if c.is_global() {
                 // This global will become part of the public API.
                 c.exported_global_names.borrow_mut().push(export_name.clone());

--- a/internal/compiler/passes/check_rotation.rs
+++ b/internal/compiler/passes/check_rotation.rs
@@ -3,7 +3,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::diagnostics::Spanned;
-use crate::langtype::Type;
+use crate::langtype::ElementType;
 use crate::object_tree::Element;
 
 /// Check that the rotation is only on Image
@@ -40,12 +40,12 @@ pub fn check_rotation(doc: &crate::object_tree::Document, diag: &mut BuildDiagno
 /// Returns true if this element or its base have any children.
 fn has_any_children(e: &Element) -> bool {
     !e.children.is_empty()
-        || matches!(&e.base_type, Type::Component(base) if has_any_children(&base.root_element.borrow()))
+        || matches!(&e.base_type, ElementType::Component(base) if has_any_children(&base.root_element.borrow()))
 }
 
 /// Returns true if the property is set.
 fn is_property_set(e: &Element, property_name: &str) -> bool {
     e.bindings.contains_key(property_name)
         || e.property_analysis.borrow().get(property_name).map_or(false, |a| a.is_set)
-        || matches!(&e.base_type, Type::Component(base) if is_property_set(&base.root_element.borrow(), property_name))
+        || matches!(&e.base_type, ElementType::Component(base) if is_property_set(&base.root_element.borrow(), property_name))
 }

--- a/internal/compiler/passes/clip.rs
+++ b/internal/compiler/passes/clip.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{BindingExpression, Expression, NamedReference};
-use crate::langtype::{NativeClass, Type};
+use crate::langtype::NativeClass;
 use crate::object_tree::{Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
 
@@ -17,7 +17,8 @@ pub fn handle_clip(
     type_register: &TypeRegister,
     diag: &mut BuildDiagnostics,
 ) {
-    let native_clip = type_register.lookup("Clip").as_builtin().native_class.clone();
+    let native_clip =
+        type_register.lookup_element("Clip").unwrap().as_builtin().native_class.clone();
 
     crate::object_tree::recurse_elem_including_sub_components(
         component,
@@ -55,7 +56,7 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
     let mut parent = parent_elem.borrow_mut();
     let clip = Rc::new(RefCell::new(Element {
         id: format!("{}-clip", parent.id),
-        base_type: Type::Native(native_clip.clone()),
+        base_type: crate::langtype::ElementType::Native(native_clip.clone()),
         children: std::mem::take(&mut parent.children),
         enclosing_component: parent.enclosing_component.clone(),
         ..Element::default()

--- a/internal/compiler/passes/collect_globals.rs
+++ b/internal/compiler/passes/collect_globals.rs
@@ -7,7 +7,6 @@ use by_address::ByAddress;
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::NamedReference;
-use crate::langtype::Type;
 use crate::object_tree::*;
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -17,8 +16,8 @@ pub fn collect_globals(doc: &Document, _diag: &mut BuildDiagnostics) {
     doc.root_component.used_types.borrow_mut().globals.clear();
     let mut set = HashSet::new();
     let mut sorted_globals = vec![];
-    for (_, ty) in doc.exports() {
-        if let Type::Component(c) = ty {
+    for (_, ty) in &doc.exports.0 {
+        if let Some(c) = ty.as_ref().left() {
             if c.is_global() {
                 if set.insert(ByAddress(c.clone())) {
                     collect_in_component(c, &mut set, &mut sorted_globals);

--- a/internal/compiler/passes/collect_subcomponents.rs
+++ b/internal/compiler/passes/collect_subcomponents.rs
@@ -5,7 +5,7 @@
 
 use by_address::ByAddress;
 
-use crate::langtype::Type;
+use crate::langtype::ElementType;
 use crate::object_tree::*;
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -28,7 +28,7 @@ fn collect_subcomponents_recursive(
     hash.insert(ByAddress(component.clone()));
     recurse_elem(&component.root_element, &(), &mut |elem: &ElementRc, &()| {
         let base_comp = match &elem.borrow().base_type {
-            Type::Component(base_comp) => {
+            ElementType::Component(base_comp) => {
                 if hash.contains(&ByAddress(base_comp.clone())) {
                     return;
                 }

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -11,6 +11,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::*;
+use crate::langtype::ElementType;
 use crate::langtype::Type;
 use crate::object_tree::*;
 use std::cell::RefCell;
@@ -21,19 +22,19 @@ pub fn compile_paths(
     tr: &crate::typeregister::TypeRegister,
     diag: &mut BuildDiagnostics,
 ) {
-    let path_type = tr.lookup("Path");
+    let path_type = tr.lookup_element("Path").unwrap();
     let path_type = path_type.as_builtin();
-    let pathlayout_type = tr.lookup("PathLayout");
+    let pathlayout_type = tr.lookup_element("PathLayout").unwrap();
     let pathlayout_type = pathlayout_type.as_builtin();
 
     recurse_elem(&component.root_element, &(), &mut |elem_, _| {
         let accepted_type = match &elem_.borrow().base_type {
-            Type::Builtin(be)
+            ElementType::Builtin(be)
                 if be.native_class.class_name == path_type.native_class.class_name =>
             {
                 path_type
             }
-            Type::Builtin(be)
+            ElementType::Builtin(be)
                 if be.native_class.class_name == pathlayout_type.native_class.class_name =>
             {
                 pathlayout_type
@@ -94,7 +95,7 @@ pub fn compile_paths(
 
                 if let Some(path_element) = element_types.get(element_name) {
                     let element_type = match path_element {
-                        Type::Builtin(b) => b.clone(),
+                        ElementType::Builtin(b) => b.clone(),
                         _ => panic!(
                             "Incorrect type registry -- expected built-in type for path element {}",
                             element_name

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -4,6 +4,7 @@
 //! Try to simplify property bindings by propagating constant expressions
 
 use crate::expression_tree::*;
+use crate::langtype::ElementType;
 use crate::langtype::Type;
 use crate::object_tree::*;
 
@@ -152,7 +153,7 @@ fn extract_constant_property_reference(nr: &NamedReference) -> Option<Expression
             if let Some(alias) = &decl.is_alias {
                 return extract_constant_property_reference(alias);
             }
-        } else if let Type::Component(c) = &element.clone().borrow().base_type {
+        } else if let ElementType::Component(c) = &element.clone().borrow().base_type {
             element = c.root_element.clone();
             continue;
         }

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -14,16 +14,16 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::expression_tree::{BindingExpression, Expression, NamedReference};
-use crate::langtype::{NativeClass, Type};
+use crate::langtype::{ElementType, NativeClass};
 use crate::object_tree::{Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
 
 pub fn is_flickable_element(element: &ElementRc) -> bool {
-    matches!(&element.borrow().base_type, Type::Builtin(n) if n.name == "Flickable")
+    matches!(&element.borrow().base_type, ElementType::Builtin(n) if n.name == "Flickable")
 }
 
 pub fn handle_flickable(root_component: &Rc<Component>, tr: &TypeRegister) {
-    let mut native_rect = tr.lookup("Rectangle").as_builtin().native_class.clone();
+    let mut native_rect = tr.lookup_element("Rectangle").unwrap().as_builtin().native_class.clone();
     while let Some(p) = native_rect.parent.clone() {
         native_rect = p;
     }
@@ -47,7 +47,7 @@ fn create_viewport_element(flickable_elem: &ElementRc, native_rect: &Rc<NativeCl
     let flickable = &mut *flickable;
     let viewport = Rc::new(RefCell::new(Element {
         id: format!("{}-viewport", flickable.id),
-        base_type: Type::Native(native_rect.clone()),
+        base_type: ElementType::Native(native_rect.clone()),
         children: std::mem::take(&mut flickable.children),
         enclosing_component: flickable.enclosing_component.clone(),
         is_flickable_viewport: true,
@@ -142,8 +142,8 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
 }
 
 /// Return true if this type is a layout that has constraints
-fn is_layout(base_type: &Type) -> bool {
-    if let Type::Builtin(be) = base_type {
+fn is_layout(base_type: &ElementType) -> bool {
+    if let ElementType::Builtin(be) = base_type {
         match be.name.as_str() {
             "GridLayout" | "HorizontalLayout" | "VerticalLayout" => true,
             "PathLayout" => false,

--- a/internal/compiler/passes/focus_item.rs
+++ b/internal/compiler/passes/focus_item.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::expression_tree::{BindingExpression, BuiltinFunction, Expression};
-use crate::langtype::Type;
+use crate::langtype::ElementType;
 use crate::object_tree::*;
 
 enum FocusCheckResult {
@@ -41,7 +41,7 @@ fn element_focus_check(element: &ElementRc) -> FocusCheckResult {
         }
     }
 
-    if matches!(&element.borrow().base_type.clone(), Type::Builtin(b) if b.accepts_focus) {
+    if matches!(&element.borrow().base_type.clone(), ElementType::Builtin(b) if b.accepts_focus) {
         return FocusCheckResult::ElementIsFocusable;
     }
 

--- a/internal/compiler/passes/generate_item_indices.rs
+++ b/internal/compiler/passes/generate_item_indices.rs
@@ -59,7 +59,7 @@ impl crate::generator::ItemTreeBuilder for Helper {
     ) {
         if !component_state {
             item.borrow().item_index.set(self.current_item_index).unwrap();
-            if let crate::langtype::Type::Component(c) = &item.borrow().base_type {
+            if let crate::langtype::ElementType::Component(c) = &item.borrow().base_type {
                 generate_item_indices(c);
             }
         }

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -5,7 +5,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Expression, NamedReference};
-use crate::langtype::Type;
+use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use crate::typeregister::TypeRegister;
 use std::cell::RefCell;
@@ -34,7 +34,7 @@ pub fn lower_popups(
 fn lower_popup_window(
     popup_window_element: &ElementRc,
     parent_element: Option<&ElementRc>,
-    window_type: &Type,
+    window_type: &ElementType,
     diag: &mut BuildDiagnostics,
 ) {
     let parent_element = match parent_element {

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -6,6 +6,7 @@
 use crate::diagnostics::BuildDiagnostics;
 use crate::diagnostics::SourceLocation;
 use crate::expression_tree::*;
+use crate::langtype::ElementType;
 use crate::langtype::Type;
 use crate::object_tree::*;
 use std::cell::RefCell;
@@ -229,7 +230,7 @@ fn expression_for_property(element: &ElementRc, name: &str) -> ExpressionForProp
                 return ExpressionForProperty::Expression(e.expression.clone());
             }
         }
-        element_it = if let Type::Component(base) = &element.borrow().base_type {
+        element_it = if let ElementType::Component(base) = &element.borrow().base_type {
             in_base = true;
             Some(base.root_element.clone())
         } else {

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -10,7 +10,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BindingExpression, Expression, NamedReference, Unit};
-use crate::langtype::Type;
+use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -23,15 +23,15 @@ pub async fn lower_tabwidget(
     // Ignore import errors
     let mut build_diags_to_ignore = BuildDiagnostics::default();
     let tabwidget_impl = type_loader
-        .import_type("std-widgets.slint", "TabWidgetImpl", &mut build_diags_to_ignore)
+        .import_component("std-widgets.slint", "TabWidgetImpl", &mut build_diags_to_ignore)
         .await
         .expect("can't load TabWidgetImpl from std-widgets.slint");
     let tab_impl = type_loader
-        .import_type("std-widgets.slint", "TabImpl", &mut build_diags_to_ignore)
+        .import_component("std-widgets.slint", "TabImpl", &mut build_diags_to_ignore)
         .await
         .expect("can't load TabImpl from std-widgets.slint");
     let tabbar_impl = type_loader
-        .import_type("std-widgets.slint", "TabBarImpl", &mut build_diags_to_ignore)
+        .import_component("std-widgets.slint", "TabBarImpl", &mut build_diags_to_ignore)
         .await
         .expect("can't load TabBarImpl from std-widgets.slint");
     let rectangle_type =
@@ -41,9 +41,9 @@ pub async fn lower_tabwidget(
         if elem.borrow().base_type.to_string() == "TabWidget" {
             process_tabwidget(
                 elem,
-                &tabwidget_impl,
-                &tab_impl,
-                &tabbar_impl,
+                ElementType::Component(tabwidget_impl.clone()),
+                ElementType::Component(tab_impl.clone()),
+                ElementType::Component(tabbar_impl.clone()),
                 &rectangle_type,
                 diag,
             );
@@ -53,13 +53,13 @@ pub async fn lower_tabwidget(
 
 fn process_tabwidget(
     elem: &ElementRc,
-    tabwidget_impl: &Type,
-    tab_impl: &Type,
-    tabbar_impl: &Type,
-    rectangle_type: &Type,
+    tabwidget_impl: ElementType,
+    tab_impl: ElementType,
+    tabbar_impl: ElementType,
+    rectangle_type: &ElementType,
     diag: &mut BuildDiagnostics,
 ) {
-    elem.borrow_mut().base_type = tabwidget_impl.clone();
+    elem.borrow_mut().base_type = tabwidget_impl;
     let mut children = std::mem::take(&mut elem.borrow_mut().children);
     let num_tabs = children.len();
     let mut tabs = Vec::new();

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -7,7 +7,7 @@
 
 use crate::diagnostics::Spanned;
 use crate::expression_tree::{BindingExpression, Expression, Unit};
-use crate::langtype::Type;
+use crate::langtype::{ElementType, Type};
 use crate::layout::Orientation;
 use crate::namedreference::NamedReference;
 use crate::object_tree::*;
@@ -84,19 +84,19 @@ fn must_initialize(elem: &Element, prop: &str) -> bool {
 /// Returns a type if the property needs to be materialized.
 fn should_materialize(
     property_declarations: &BTreeMap<String, PropertyDeclaration>,
-    base_type: &Type,
+    base_type: &ElementType,
     prop: &str,
 ) -> Option<Type> {
     if property_declarations.contains_key(prop) {
         return None;
     }
     let has_declared_property = match &base_type {
-        Type::Component(c) => has_declared_property(&c.root_element.borrow(), prop),
-        Type::Builtin(b) => b.properties.contains_key(prop),
-        Type::Native(n) => {
+        ElementType::Component(c) => has_declared_property(&c.root_element.borrow(), prop),
+        ElementType::Builtin(b) => b.properties.contains_key(prop),
+        ElementType::Native(n) => {
             n.lookup_property(prop).map_or(false, |prop_type| prop_type.is_property_type())
         }
-        _ => false,
+        ElementType::Global | ElementType::Error => false,
     };
 
     if !has_declared_property {
@@ -115,10 +115,10 @@ fn has_declared_property(elem: &Element, prop: &str) -> bool {
         return true;
     }
     match &elem.base_type {
-        Type::Component(c) => has_declared_property(&c.root_element.borrow(), prop),
-        Type::Builtin(b) => b.properties.contains_key(prop),
-        Type::Native(n) => n.lookup_property(prop).is_some(),
-        _ => false,
+        ElementType::Component(c) => has_declared_property(&c.root_element.borrow(), prop),
+        ElementType::Builtin(b) => b.properties.contains_key(prop),
+        ElementType::Native(n) => n.lookup_property(prop).is_some(),
+        ElementType::Global | ElementType::Error => false,
     }
 }
 

--- a/internal/compiler/passes/optimize_useless_rectangles.rs
+++ b/internal/compiler/passes/optimize_useless_rectangles.rs
@@ -6,7 +6,8 @@
 //! Rectangles which do not draw anything and have no x or y don't need to be in
 //! the item tree, we can just remove them.
 
-use crate::{langtype::Type, object_tree::*};
+use crate::langtype::ElementType;
+use crate::object_tree::*;
 use std::rc::Rc;
 
 pub fn optimize_useless_rectangles(root_component: &Rc<Component>) {
@@ -46,7 +47,7 @@ fn can_optimize(elem: &ElementRc) -> bool {
     }
 
     let base_type = match &e.base_type {
-        Type::Builtin(base_type) if base_type.name == "Rectangle" => base_type,
+        ElementType::Builtin(base_type) if base_type.name == "Rectangle" => base_type,
         _ => return false,
     };
 

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -6,7 +6,7 @@ Make sure that the Repeated expression are just components without any children
  */
 
 use crate::expression_tree::{Expression, NamedReference};
-use crate::langtype::Type;
+use crate::langtype::ElementType;
 use crate::object_tree::*;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -78,7 +78,7 @@ fn create_repeater_components(component: &Rc<Component>) {
             e.borrow_mut().enclosing_component = weak.clone()
         });
         create_repeater_components(&comp);
-        elem.base_type = Type::Component(comp);
+        elem.base_type = ElementType::Component(comp);
     });
 
     for p in component.popup_windows.borrow().iter() {
@@ -95,7 +95,7 @@ fn adjust_references(comp: &Rc<Component>) {
         }
         let e = nr.element();
         if e.borrow().repeated.is_some() {
-            if let Type::Component(c) = e.borrow().base_type.clone() {
+            if let ElementType::Component(c) = e.borrow().base_type.clone() {
                 *nr = NamedReference::new(&c.root_element, nr.name())
             };
         }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -10,7 +10,7 @@
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::*;
-use crate::langtype::Type;
+use crate::langtype::{ElementType, Type};
 use crate::lookup::{LookupCtx, LookupObject, LookupResult};
 use crate::object_tree::*;
 use crate::parser::{identifier_text, syntax_nodes, NodeOrToken, SyntaxKind, SyntaxNode};
@@ -1070,14 +1070,15 @@ fn continue_lookup_within_element(
     } else {
         let mut err = |extra: &str| {
             let what = match &elem.borrow().base_type {
-                Type::Void => {
+                ElementType::Global => {
                     let global = elem.borrow().enclosing_component.upgrade().unwrap();
                     assert!(global.is_global());
                     format!("'{}'", global.id)
                 }
-                Type::Component(c) => format!("Element '{}'", c.id),
-                Type::Builtin(b) => format!("Element '{}'", b.name),
-                _ => {
+                ElementType::Component(c) => format!("Element '{}'", c.id),
+                ElementType::Builtin(b) => format!("Element '{}'", b.name),
+                ElementType::Native(_) => unreachable!("the native pass comes later"),
+                ElementType::Error => {
                     assert!(ctx.diag.has_error());
                     return;
                 }

--- a/internal/compiler/passes/unique_id.rs
+++ b/internal/compiler/passes/unique_id.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 use crate::diagnostics::BuildDiagnostics;
-use crate::langtype::Type;
+use crate::langtype::ElementType;
 use crate::object_tree::*;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -38,7 +38,7 @@ fn rename_globals(component: &Rc<Component>, mut count: u32) {
     for g in &component.used_types.borrow().globals {
         count += 1;
         let mut root = g.root_element.borrow_mut();
-        if matches!(&root.base_type, Type::Builtin(_)) {
+        if matches!(&root.base_type, ElementType::Builtin(_)) {
             // builtin global keeps its name
             root.id = g.id.clone();
         } else if let Some(s) = g.exported_global_names.borrow().first() {

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -7,12 +7,13 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::expression_tree::{Expression, NamedReference};
-use crate::langtype::{NativeClass, Type};
+use crate::langtype::{ElementType, NativeClass, Type};
 use crate::object_tree::{self, Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
 
 pub fn handle_visible(component: &Rc<Component>, type_register: &TypeRegister) {
-    let native_clip = type_register.lookup("Clip").as_builtin().native_class.clone();
+    let native_clip =
+        type_register.lookup_element("Clip").unwrap().as_builtin().native_class.clone();
 
     crate::object_tree::recurse_elem_including_sub_components(
         component,
@@ -67,7 +68,7 @@ pub fn handle_visible(component: &Rc<Component>, type_register: &TypeRegister) {
 fn create_visibility_element(child: &ElementRc, native_clip: &Rc<NativeClass>) -> ElementRc {
     let element = Element {
         id: format!("{}-visibility", child.borrow().id),
-        base_type: Type::Native(native_clip.clone()),
+        base_type: ElementType::Native(native_clip.clone()),
         enclosing_component: child.borrow().enclosing_component.clone(),
         bindings: std::iter::once((
             "clip".to_owned(),

--- a/internal/compiler/passes/z_order.rs
+++ b/internal/compiler/passes/z_order.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Expression, Unit};
-use crate::langtype::Type;
+use crate::langtype::ElementType;
 use crate::object_tree::{Component, ElementRc};
 
 pub fn reorder_by_z_order(root_component: &Rc<Component>, diag: &mut BuildDiagnostics) {
@@ -36,7 +36,7 @@ fn reorder_children_by_zorder(
         let z =
             z.or_else(|| {
                 child_elm.borrow().repeated.as_ref()?;
-                if let Type::Component(c) = &child_elm.borrow().base_type {
+                if let ElementType::Component(c) = &child_elm.borrow().base_type {
                     c.root_element.borrow_mut().bindings.remove("z").and_then(|e| {
                         eval_const_expr(&e.borrow().expression, "z", &*e.borrow(), diag)
                     })

--- a/internal/compiler/tests/syntax/basic/item_as_property.slint
+++ b/internal/compiler/tests/syntax/basic/item_as_property.slint
@@ -23,6 +23,6 @@ Foo := Rectangle {
     xx := Rectangle { }
     Comp {
         r: xx;
-//      ^error{Cannot assign to r in Comp}
+//      ^error{Unknown property}
     }
 }

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -9,7 +9,7 @@ use core::convert::TryInto;
 use core::ptr::NonNull;
 use dynamic_type::{Instance, InstanceBox};
 use i_slint_compiler::expression_tree::{Expression, NamedReference};
-use i_slint_compiler::langtype::Type;
+use i_slint_compiler::langtype::{ElementType, Type};
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::*;
 use i_slint_compiler::{diagnostics::BuildDiagnostics, object_tree::PropertyDeclaration};
@@ -754,7 +754,10 @@ pub async fn load(
     if diag.has_error() {
         return (Err(()), diag);
     }
-    if matches!(doc.root_component.root_element.borrow().base_type, Type::Invalid | Type::Void) {
+    if matches!(
+        doc.root_component.root_element.borrow().base_type,
+        ElementType::Global | ElementType::Error
+    ) {
         diag.push_error_with_span("No component found".into(), Default::default());
         return (Err(()), diag);
     }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -954,9 +954,6 @@ fn check_value_type(value: &Value, ty: &Type) -> bool {
         Type::Invalid
         | Type::InferredProperty
         | Type::InferredCallback
-        | Type::Component(_)
-        | Type::Builtin(_)
-        | Type::Native(_)
         | Type::Callback { .. }
         | Type::Function { .. }
         | Type::ElementReference => panic!("not valid property type"),
@@ -1260,9 +1257,6 @@ pub fn default_value_for_type(ty: &Type) -> Value {
         Type::InferredProperty
         | Type::InferredCallback
         | Type::ElementReference
-        | Type::Builtin(_)
-        | Type::Component(_)
-        | Type::Native(_)
         | Type::Function { .. } => {
             panic!("There can't be such property")
         }

--- a/internal/interpreter/global_component.rs
+++ b/internal/interpreter/global_component.rs
@@ -8,9 +8,10 @@ use std::rc::Rc;
 use crate::api::Value;
 use crate::dynamic_component::{ErasedComponentBox, ErasedComponentDescription};
 use crate::SetPropertyError;
+use i_slint_compiler::langtype::ElementType;
 use i_slint_compiler::namedreference::NamedReference;
+use i_slint_compiler::object_tree::Component;
 use i_slint_compiler::object_tree::PropertyDeclaration;
-use i_slint_compiler::{langtype::Type, object_tree::Component};
 use i_slint_core::component::ComponentVTable;
 use i_slint_core::rtti;
 use i_slint_core::window::WindowAdapter;
@@ -228,18 +229,18 @@ impl<T: rtti::BuiltinItem + 'static> GlobalComponent for T {
 pub(crate) fn generate(component: &Rc<Component>) -> CompiledGlobal {
     debug_assert!(component.is_global());
     match &component.root_element.borrow().base_type {
-        Type::Void => {
+        ElementType::Global => {
             generativity::make_guard!(guard);
             CompiledGlobal::Component {
                 component: crate::dynamic_component::generate_component(component, guard).into(),
                 public_properties: Default::default(),
             }
         }
-        Type::Builtin(b) => CompiledGlobal::Builtin {
+        ElementType::Builtin(b) => CompiledGlobal::Builtin {
             name: component.id.clone(),
             element: b.clone(),
             public_properties: Default::default(),
         },
-        _ => unreachable!(),
+        ElementType::Error | ElementType::Native(_) | ElementType::Component(_) => unreachable!(),
     }
 }

--- a/tools/lsp/properties.rs
+++ b/tools/lsp/properties.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 use i_slint_compiler::diagnostics::Spanned;
-use i_slint_compiler::langtype::Type;
+use i_slint_compiler::langtype::{ElementType, Type};
 use i_slint_compiler::object_tree::{Element, ElementRc};
 use i_slint_compiler::parser::{syntax_nodes, SyntaxKind};
 use std::collections::HashSet;
@@ -187,7 +187,7 @@ fn get_properties(
     loop {
         let base_type = current_element.borrow().base_type.clone();
         match base_type {
-            Type::Component(c) => {
+            ElementType::Component(c) => {
                 current_element = c.root_element.clone();
                 result.extend(get_element_properties(
                     &current_element.borrow(),
@@ -196,7 +196,7 @@ fn get_properties(
                 ));
                 continue;
             }
-            Type::Builtin(b) => {
+            ElementType::Builtin(b) => {
                 result.extend(b.properties.iter().filter_map(|(k, t)| {
                     if geometry_prop.contains(k.as_str()) {
                         // skip geometry property because they are part of the reserved ones
@@ -255,10 +255,10 @@ fn get_properties(
                     ));
                 }
             }
-            Type::Void => {
-                // a global
+            ElementType::Global => {
                 break;
             }
+
             _ => {}
         }
 


### PR DESCRIPTION
These are two different concept, and it is confusing to keep them in the same enum

We want to support component without any base element, and Void is already used for global component, so do this refactoring before