### PR TITLE
janitor: Bump various dependencies

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -42,13 +42,13 @@ lyon_path = "1.0"
 once_cell = "1.5"
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
-winit = { version = "0.27", default-features = false }
+winit = { version = "0.27.5", default-features = false }
 dark-light = "0.2.2"
 instant = "0.1"
 
 # For the FemtoVG renderer
 femtovg = { version = "0.3.7", optional = true, default-features = false, features = ["image-loading"] }
-fontdb = { version = "0.9.0", optional = true, default-features = false }
+fontdb = { version = "0.9.3", optional = true, default-features = false }
 ttf-parser = { version = "0.17.0", optional = true } # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
 unicode-script = { version = "0.5.4", optional = true } # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
 imgref = { version = "1.6.1", optional = true }
@@ -65,7 +65,7 @@ wasm-bindgen = { version = "0.2" }
 send_wrapper = "0.6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-fontdb = { version = "0.9.0", optional = true, features = ["memmap", "fontconfig"] }
+fontdb = { version = "0.9.3", optional = true, features = ["memmap", "fontconfig"] }
 glutin = { version = "0.29", default-features = false }
 
 # For the FemtoVG renderer
@@ -89,7 +89,7 @@ metal = { version = "0.24.0", optional = true }
 objc = { version = "0.2.7", optional = true }
 core-graphics-types = { version = "0.1.1", optional = true }
 skia-safe = { version = "0.55.0", optional = true, features = ["metal"] }
-foreign-types = { version = "0.3.2", optional = true }
+foreign-types = { version = "0.5.0", optional = true }
 
 [target.'cfg(not(any(target_os = "macos", target_family = "windows")))'.dependencies]
 skia-safe = { version = "0.55.0", optional = true, features = ["gl"] }

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -49,7 +49,7 @@ once_cell = "1"
 url = "2.2.1"
 dunce = "1.0.1"
 linked_hash_set = "0.1.4"
-fontdb = { version = "0.9.0", features = ["fontconfig"] }
+fontdb = { version = "0.9.3", features = ["fontconfig"] }
 fontdue = { version = "0.7.1" }
 
 # for processing and embedding the rendered image (texture)

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -75,7 +75,7 @@ clru = { version = "0.6.0", optional = true }
 
 resvg = { version= "0.23", optional = true, default-features = false }
 usvg = { version= "0.23", optional = true, default-features = false, features = ["text"] }
-tiny-skia = { version= "0.6", optional = true, default-features = false }
+tiny-skia = { version= "0.6.1", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1", features = [ "wasm-bindgen", "now" ] }
@@ -89,8 +89,8 @@ usvg = { version= "0.23", optional = true, default-features = false, features = 
 slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-0-3-0"] }
 i-slint-backend-testing = { path="../backends/testing" }
 rustybuzz = "0.6.0"
-ttf-parser = "0.15.0"
-fontdb = { version = "0.8.0" }
+ttf-parser = "0.17.0"
+fontdb = { version = "0.9.3" }
 
 image = { version = "0.24.0", default-features = false, features = [ "png" ] }
 pin-weak = "1"


### PR DESCRIPTION
Bump fontdb, foreign-types (used for skia/metal), ttf-parser and winit.