### PR TITLE
femtovg renderer: don't draw svg if they are empty

### DIFF
--- a/internal/backends/winit/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/winit/renderer/femtovg/itemrenderer.rs
@@ -1175,14 +1175,19 @@ impl<'a> GLItemRenderer<'a> {
                 let image = source_property.get();
                 let image_inner: &ImageInner = (&image).into();
 
-                let target_size_for_scalable_source = image_inner.is_svg().then(|| {
-                    // get the scale factor as a property again, to ensure the cache is invalidated when the scale factor changes
+                let target_size_for_scalable_source = if image_inner.is_svg() {
+                    let image_size = image.size();
+                    if image_size.is_empty() {
+                        return None;
+                    }
                     let scale_factor = ScaleFactor::new(self.window.scale_factor());
                     let t = LogicalSize::from_lengths(target_width.get(), target_height.get())
                         * scale_factor;
 
-                    i_slint_core::graphics::fit_size(image_fit, t, image.size()).cast()
-                });
+                    Some(i_slint_core::graphics::fit_size(image_fit, t, image_size).cast())
+                } else {
+                    None
+                };
 
                 TextureCacheKey::new(image_inner, target_size_for_scalable_source, image_rendering)
                     .and_then(|cache_key| {


### PR DESCRIPTION
Otherwise computing the fit_size will lead to NaN and then panic.

The size is empty in the wasm case when loading an html image and it isn't loaded yet. We will be called again because the htmlimage has an internal property that will be changed when it is loaded