### PR TITLE
Default to the light fluent style in the online editor

### DIFF
--- a/tools/online_editor/src/editor_widget.ts
+++ b/tools/online_editor/src/editor_widget.ts
@@ -110,7 +110,7 @@ type PropertyDataNotifier = (
 
 class EditorPaneWidget extends Widget {
   auto_compile = true;
-  #style = "fluent";
+  #style = "fluent-light";
   #editor_view_states: Map<
     monaco.Uri,
     monaco.editor.ICodeEditorViewState | null | undefined


### PR DESCRIPTION
Until the online editor supports a dark color scheme, also default to the light fluent style, so that by default on a dark color scheme system the hello world example doesn't look out of place.