### PR TITLE
api: add `Window::is_visible` for `gl-all` and `qt` backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
  - Dark theme for the Fluent style
  - Added `fluent-light` and `fluent-dark` as explicit styles to select a light/dark variant,
    regardless of the system color scheme setting.
+ - Added `Window::is_visible` 
 
 ### Fixed
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1755,6 +1755,13 @@ impl WindowAdapterSealed for QtWindow {
         });
         ds.as_ref().get()
     }
+
+    fn is_visible(&self) -> bool {
+        let widget_ptr = self.widget_ptr();
+        cpp! {unsafe [widget_ptr as "QWidget*"] -> bool as "bool" {
+            return widget_ptr->isVisible();
+        }}
+    }
 }
 
 impl Renderer for QtWindow {

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -662,6 +662,17 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWind
     fn dark_color_scheme(&self) -> bool {
         dark_light::detect() == dark_light::Mode::Dark
     }
+
+    fn is_visible(&self) -> bool {
+        if let Some(mapped_window) = self.borrow_mapped_window() {
+            mapped_window
+                .canvas
+                .with_window_handle(&mut |win: &winit::window::Window| win.is_visible())
+                .unwrap_or(true)
+        } else {
+            false
+        }
+    }
 }
 
 impl<Renderer: WinitCompatibleRenderer + 'static> Drop for GLWindow<Renderer> {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -429,6 +429,11 @@ impl Window {
         // TODO make it really per window.
         crate::animations::CURRENT_ANIMATION_DRIVER.with(|driver| driver.has_active_animations())
     }
+
+    /// Get the visibility of the window
+    pub fn is_visible(&self) -> bool {
+        self.0.window_adapter().is_visible()
+    }
 }
 
 pub use crate::input::PointerEventButton;

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -146,6 +146,11 @@ pub trait WindowAdapterSealed {
 
     /// Return the renderer
     fn renderer(&self) -> &dyn Renderer;
+
+    /// Get the visibility of the window
+    fn is_visible(&self) -> bool {
+        false
+    }
 }
 
 struct WindowPropertiesTracker {


### PR DESCRIPTION
related to #325 

Adds `Window::is_visible` to the Rust API (need some pointers for adding them to C++ and JS as im not very familiar)

> Allow developers to specify a callback in C++/Rust/JS that's invoked when the visibility changes.
I couldn't quite figure out how to do this, some pointers would be nice if this is necessary. 

Please let me know how and what tests are to be added.

Since, this only supports `backend-gl-all` and `backend-qt` should i keep them only under these features?