### PR TITLE
Make SlintInternal.dark-color-scheme a property instead of a function

### DIFF
--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -627,10 +627,15 @@ impl LookupObject for SlintInternal {
     ) -> Option<R> {
         f(
             "dark-color-scheme",
-            Expression::BuiltinFunctionReference(
-                BuiltinFunction::DarkColorScheme,
-                ctx.current_token.as_ref().map(|t| t.to_source_location()),
-            )
+            Expression::FunctionCall {
+                function: Expression::BuiltinFunctionReference(
+                    BuiltinFunction::DarkColorScheme,
+                    None,
+                )
+                .into(),
+                arguments: vec![],
+                source_location: ctx.current_token.as_ref().map(|t| t.to_source_location()),
+            }
             .into(),
         )
     }

--- a/internal/compiler/tests/syntax/lookup/property.slint
+++ b/internal/compiler/tests/syntax/lookup/property.slint
@@ -41,5 +41,10 @@ X := Rectangle {
 //              ^error{Element 'Comp' does not have a property 'not_exist'}
     }
 
+    callback dummy;
+    dummy => {
+        SlintInternal.dark-color-scheme = false;
+//      ^error{Assignment needs to be done on a property}
+    }
 
 }

--- a/internal/compiler/widgets/fluent/color-scheme.slint
+++ b/internal/compiler/widgets/fluent/color-scheme.slint
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 export global ColorSchemeSelector := {
-    property<bool> dark-color-scheme: SlintInternal.dark-color-scheme();
+    property<bool> dark-color-scheme: SlintInternal.dark-color-scheme;
 }


### PR DESCRIPTION
That's a more idiomatic API - the compiler can map the lookup straight to a function call.