### PR TITLE
Forbid usage of @children in repeated or conditional element

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -953,22 +953,36 @@ impl Element {
                     tr,
                 ));
             } else if se.kind() == SyntaxKind::RepeatedElement {
+                let mut sub_child_insertion_point = None;
                 let rep = Element::from_repeated_node(
                     se.into(),
                     &r,
-                    component_child_insertion_point,
+                    &mut sub_child_insertion_point,
                     diag,
                     tr,
                 );
+                if let Some((_, se)) = sub_child_insertion_point {
+                    diag.push_error(
+                        "The @children placeholder cannot appear in a repeated element".into(),
+                        &se,
+                    )
+                }
                 r.borrow_mut().children.push(rep);
             } else if se.kind() == SyntaxKind::ConditionalElement {
+                let mut sub_child_insertion_point = None;
                 let rep = Element::from_conditional_node(
                     se.into(),
                     r.borrow().base_type.clone(),
-                    component_child_insertion_point,
+                    &mut sub_child_insertion_point,
                     diag,
                     tr,
                 );
+                if let Some((_, se)) = sub_child_insertion_point {
+                    diag.push_error(
+                        "The @children placeholder cannot appear in a conditional element".into(),
+                        &se,
+                    )
+                }
                 r.borrow_mut().children.push(rep);
             } else if se.kind() == SyntaxKind::ChildrenPlaceholder {
                 if children_placeholder.is_some() {

--- a/internal/compiler/tests/syntax/basic/children_placeholder.slint
+++ b/internal/compiler/tests/syntax/basic/children_placeholder.slint
@@ -1,6 +1,24 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+NotInIf := Rectangle {
+    if true: Rectangle {
+        @children
+//      ^error{The @children placeholder cannot appear in a conditional element}
+    }
+}
+
+NotInFor := Rectangle {
+    HorizontalLayout {
+        for xxx in 12: Rectangle {
+            VerticalLayout {
+                @children
+//              ^error{The @children placeholder cannot appear in a repeated element}
+            }
+        }
+    }
+}
+
 TestBox := Rectangle {
     @children
     @children


### PR DESCRIPTION
It leads to compiler panic, or errors in the generated code.