### PR TITLE
Rename `inout` property to `input output`

### DIFF
--- a/editors/kate/slint.ksyntaxhighlighter.xml
+++ b/editors/kate/slint.ksyntaxhighlighter.xml
@@ -27,7 +27,6 @@
       <item>component</item>
       <item>inherits</item>
       <item>property</item>
-      <item>inout</item>
       <item>input</item>
       <item>output</item>
       <item>callback</item>

--- a/editors/sublime/Slint.sublime-syntax
+++ b/editors/sublime/Slint.sublime-syntax
@@ -52,7 +52,7 @@ contexts:
     # other.
     - match: '\b(import|from|export|global|struct|component|inherits)\b'
       scope: keyword.slint
-    - match: '\b(property|callback|animate|states|transitions|inout|input|output)\b'
+    - match: '\b(property|callback|animate|states|transitions|input|output)\b'
       scope: keyword.other.slint
     - match: '\b(if|for|return)\b'
       scope: keyword.control.slint

--- a/editors/vscode/slint.tmLanguage.json
+++ b/editors/vscode/slint.tmLanguage.json
@@ -17,7 +17,7 @@
                     "name": "keyword"
                 },
                 {
-                    "match": "\\b(property|callback|animate|states|transitions|inout|input|output)\\b",
+                    "match": "\\b(property|callback|animate|states|transitions|input|output)\\b",
                     "name": "keyword.other"
                 },
                 {

--- a/internal/compiler/tests/syntax/new_syntax/input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output.slint
@@ -6,7 +6,7 @@ component Compo inherits Rectangle {
     private property <int> priv2: priv1;
     output property <int> output1: priv2;
     input property <int> input1: output1;
-    inout property <int> inout1: input1;
+    input output property <int> inout1: input1;
 
     TouchArea {
         clicked => {
@@ -38,7 +38,7 @@ OldCompo := Rectangle {
     private property <int> priv2: inout2;
     output property <int> output1: priv2;
     input property <int> input1: output1;
-    inout property <int> inout1: input1;
+    input output property <int> inout1: input1;
 
     TouchArea {
         clicked => {
@@ -93,5 +93,11 @@ component Foo inherits Rectangle {
 //          ^error{'c2.output1' cannot be set in a state because it is output}
         }
     ]
+
+    output input output property <int> extra1;
+//               ^error{Extra 'output' keyword}
+    input input property <int> extra2;
+//        ^error{Extra 'input' keyword}
+
 }
 

--- a/internal/compiler/tests/syntax/new_syntax/input_output2.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output2.slint
@@ -6,7 +6,7 @@ component Compo inherits Rectangle {
     private property <int> priv2: priv1;
     output property <int> output1: priv2;
     input property <int> input1: output1;
-    inout property <int> inout1: input1;
+    output input property <int> inout1: input1;
 
     TouchArea {
         clicked => {
@@ -26,7 +26,7 @@ OldCompo := Rectangle {
     private property <int> priv2: inout2;
     output property <int> output1: priv2;
     input property <int> input1: output1;
-    inout property <int> inout1: input1;
+    input output property <int> inout1: input1;
 
     TouchArea {
         clicked => {

--- a/tools/syntax_updater/experiments/input_output_properties.rs
+++ b/tools/syntax_updater/experiments/input_output_properties.rs
@@ -17,11 +17,11 @@ pub(crate) fn fold_node(
             .and_then(|n| n.parent())
             .map_or(false, |n| n.kind() == SyntaxKind::Component)
     {
-        // check that the first identifier is "property" as opposed to an already converted "inout" token
+        // check that the first identifier is "property" as opposed to an already converted "input output" token
         if node.child_token(SyntaxKind::Identifier).map_or(false, |t| t.text() == "property") {
-            // Consider that all property are inout, because we don't do enough analysis in the syntax_updater to know
+            // Consider that all property are input output, because we don't do enough analysis in the syntax_updater to know
             // if they should be private
-            write!(file, "inout ")?;
+            write!(file, "input output ")?;
         }
     }
     Ok(false)


### PR DESCRIPTION
`inout` and `input` are too similar, so use a longer form for `inout`

CC https://github.com/slint-ui/slint/issues/191#issuecomment-1296176978