### PR TITLE
material design style: Replace remaining uses of pt with px

### DIFF
--- a/internal/compiler/widgets/material-base/md.slint
+++ b/internal/compiler/widgets/material-base/md.slint
@@ -70,35 +70,35 @@ export global md := {
         },
 
         elevation: {
-            level0: 0pt,
-            level1: 1pt,
-            level2: 2pt
+            level0: 0px,
+            level1: 1px,
+            level2: 2px
         },
 
         typescale: {
             label-large: {
                 font: "Roboto Medium",
-                size: 14pt,
+                size: 14px,
                 weight: 500
             },
             label-medium: {
                 font: "Roboto Medium",
-                size: 12pt,
+                size: 12px,
                 weight: 500
             },
             body-large: {
                 font: "Roboto Medium",
-                size: 14pt,
+                size: 14px,
                 weight: 400
             },
             body-small: {
                 font: "Roboto Regular",
-                size: 12pt,
+                size: 12px,
                 weight: 400
             },
             title-small: {
                 font: "Roboto Medium",
-                size: 14pt,
+                size: 14px,
                 weight: 500
             },
         }

--- a/internal/compiler/widgets/material-base/widget-groupbox.slint
+++ b/internal/compiler/widgets/material-base/widget-groupbox.slint
@@ -28,7 +28,7 @@ export GroupBox := Rectangle {
         label := Text {
             x: 4px;
             y: 4px;
-            width: min(root.width - 24pt, preferred-width);
+            width: min(root.width - 24px, preferred-width);
           
             color: md.sys.color.on-surface;
             // FIXME after Roboto font can be loaded


### PR DESCRIPTION
This is consistent with the use of `px` for the sizes and matches the expected conversion to css pixels.