### PR TITLE
Use logical coordinate types for internal popup handling

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -10,9 +10,7 @@ use i_slint_core::graphics::euclid::num::Zero;
 use i_slint_core::graphics::rendering_metrics_collector::{
     RenderingMetrics, RenderingMetricsCollector,
 };
-use i_slint_core::graphics::{
-    euclid, Brush, Color, FontRequest, Image, Point, Rect, SharedImageBuffer,
-};
+use i_slint_core::graphics::{euclid, Brush, Color, FontRequest, Image, Point, SharedImageBuffer};
 use i_slint_core::input::{KeyEvent, KeyEventType, MouseEvent};
 use i_slint_core::item_rendering::{ItemCache, ItemRenderer};
 use i_slint_core::items::{
@@ -1614,7 +1612,7 @@ impl WindowAdapterSealed for QtWindow {
         self.tree_structure_changed.replace(true);
     }
 
-    fn create_popup(&self, geometry: Rect) -> Option<Rc<dyn WindowAdapter>> {
+    fn create_popup(&self, geometry: LogicalRect) -> Option<Rc<dyn WindowAdapter>> {
         let popup_window = QtWindow::new();
 
         let size = qttypes::QSize { width: geometry.width() as _, height: geometry.height() as _ };

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -178,7 +178,7 @@ impl crate::properties::PropertyDirtyHandler for WindowRedrawTracker {
 }
 
 /// This enum describes the different ways a popup can be rendered by the back-end.
-pub enum PopupWindowLocation {
+enum PopupWindowLocation {
     /// The popup is rendered in its own top-level window that is know to the windowing system.
     TopLevel(Rc<dyn WindowAdapter>),
     /// The popup is rendered as an embedded child window at the given position.
@@ -187,11 +187,11 @@ pub enum PopupWindowLocation {
 
 /// This structure defines a graphical element that is designed to pop up from the surrounding
 /// UI content, for example to show a context menu.
-pub struct PopupWindow {
+struct PopupWindow {
     /// The location defines where the pop up is rendered.
-    pub location: PopupWindowLocation,
+    location: PopupWindowLocation,
     /// The component that is responsible for providing the popup content.
-    pub component: ComponentRc,
+    component: ComponentRc,
 }
 
 /// Inner datastructure for the [`crate::api::Window`]

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -10,13 +10,13 @@ use crate::api::{
     CloseRequestResponse, PhysicalPosition, PhysicalSize, Window, WindowPosition, WindowSize,
 };
 use crate::component::{ComponentRc, ComponentRef, ComponentVTable, ComponentWeak};
-use crate::graphics::{Point, Rect};
+use crate::graphics::Point;
 use crate::input::{
     key_codes, KeyEvent, KeyEventType, MouseEvent, MouseInputState, TextCursorBlinker,
 };
 use crate::item_tree::ItemRc;
 use crate::items::{ItemRef, MouseCursor};
-use crate::lengths::{LogicalLength, LogicalPoint, LogicalSize, SizeLengths};
+use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, SizeLengths};
 use crate::properties::{Property, PropertyTracker};
 use crate::renderer::Renderer;
 use crate::Callback;
@@ -81,7 +81,7 @@ pub trait WindowAdapterSealed {
     ///
     /// If this function return None (the default implementation), then the
     /// popup will be rendered within the window itself.
-    fn create_popup(&self, _geometry: Rect) -> Option<Rc<dyn WindowAdapter>> {
+    fn create_popup(&self, _geometry: LogicalRect) -> Option<Rc<dyn WindowAdapter>> {
         None
     }
 
@@ -630,10 +630,7 @@ impl WindowInner {
             height_property.set(size.height_length());
         };
 
-        let location = match self
-            .window_adapter()
-            .create_popup(Rect::new(position.to_untyped(), size.to_untyped()))
-        {
+        let location = match self.window_adapter().create_popup(LogicalRect::new(position, size)) {
             None => {
                 self.window_adapter().request_redraw();
                 PopupWindowLocation::ChildWindow(position.to_untyped())


### PR DESCRIPTION
This removes another place where we erased logical vs. physical type information.