### PR TITLE
Remove `slint::testing` from the C++ API Docs

### DIFF
--- a/api/cpp/docs/conf.py
+++ b/api/cpp/docs/conf.py
@@ -60,7 +60,7 @@ exhale_args = {
     "createTreeView": True,
     "exhaleExecutesDoxygen": True,
     "exhaleDoxygenStdin": """INPUT = ../../api/cpp/include generated_include
-EXCLUDE_SYMBOLS = slint::cbindgen_private* slint::private_api* vtable* SLINT_DECL_ITEM
+EXCLUDE_SYMBOLS = slint::cbindgen_private* slint::private_api* vtable* slint::testing* SLINT_DECL_ITEM
 EXCLUDE = ../../api/cpp/include/vtable.h ../../api/cpp/include/slint_testing.h
 ENABLE_PREPROCESSING = YES
 PREDEFINED += DOXYGEN


### PR DESCRIPTION
We already avoid parsing `slint_testing.h`. But we have a variant of `send_keyboard_string_sequence` in `slint_interpreter.h` because the function takes a ComponentInstance. Exclude all symbols from that namespace from the docs to continue the intent.