### PR TITLE
LSP: features overhaul

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -89,7 +89,7 @@
 	],
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
-		"compile": "wasm-pack build --target web --out-name index ../../tools/lsp --no-default-features && node ./esbuild.js && wasm-pack build --release --target web --out-dir $PWD/out ../../api/wasm-interpreter",
+		"compile": "wasm-pack build --target web --out-name index ../../tools/lsp --no-default-features --features preview-lense && node ./esbuild.js && wasm-pack build --release --target web --out-dir $PWD/out ../../api/wasm-interpreter",
 		"local-package": "mkdir -p bin && cp ../../target/debug/slint-lsp bin/ && npx vsce package",
 		"watch": "tsc -watch -p ./",
 		"pretest": "npm run compile && npm run lint",

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -49,7 +49,8 @@ backend-gl-all = ["backend-winit", "renderer-winit-femtovg"]
 backend-gl-wayland = ["backend-winit-wayland", "renderer-winit-femtovg"]
 backend-gl-x11 = ["backend-winit-x11", "renderer-winit-femtovg"]
 
-preview = ["slint-interpreter", "i-slint-core", "i-slint-backend-selector"]
+preview = ["slint-interpreter", "i-slint-core", "i-slint-backend-selector", "preview-lense"]
+preview-lense = []
 
 default = ["backend-qt", "backend-winit", "renderer-winit-femtovg", "preview"]
 


### PR DESCRIPTION
* Do not set `preview` feature based on `backend-*`, these two are orthogonal
* Do not use wasm build in conjunction with `preview` to keep code lense support on. Add `preview-lense` feature instead.
* Add `*-build` features for common feature sets built in CI. This was necessary since we build in without default features in places and relied on the `backend-*` features to also turn on `preview`
   * Consistently use `vscode-build` to build the vscode extension
   * Consistently use `vscode-web-build` for the web extension
   * Consistently use `online-editor-build` to build the online editor
   * Use `snapshot-build` to build nightly snapshots.

With this patch a LSP built for the online-editor is about 10KB smaller than before.