### PR TITLE
CI: prospective fix of the build by setting the Python version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,11 +35,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/install-linux-dependencies
+    # Python 3.11 breaks the neon-sys build
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: Install Qt
       if: runner.os != 'Windows'
       uses: jurplel/install-qt-action@v3
       with:
         version: '5.15.2'
+        setup-python: false
     - name: Set default style
       if: matrix.os != 'windows-2022'
       run: |


### PR DESCRIPTION
Python recently was updated to 3.11 and the build of the node binding is now failing.
(Apparently still using a quite old version of node-gyp, because this was fixed in `https://github.com/nodejs/node-gyp/issues/2219`)

```
     File "/home/runner/work/slint/slint/target/debug/build/neon-sys-4b140f4af6e7aeb3/out/native/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 239, in LoadOneBuildFile
      build_file_contents = open(build_file_path, "rU").read()
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ValueError: invalid mode: 'rU' while trying to load binding.gyp
```