### PR TITLE
vscode: Activate on command use

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -18,6 +18,8 @@
 	],
 	"preview": true,
 	"activationEvents": [
+		"onCommand:slint.showPreview",
+		"onCommand:slint.reload",
 		"onLanguage:slint",
 		"onWebviewPanel:slint-preview"
 	],


### PR DESCRIPTION
The VSCode documentation says "extensions must register an onCommand activationEvent for all user facing commands"