### PR TITLE
Properties view for the vscode extension

### DIFF
--- a/editors/vscode/esbuild.js
+++ b/editors/vscode/esbuild.js
@@ -54,3 +54,10 @@ esbuild.build({
     format: 'cjs',
 }).catch(() => process.exit(1))
 
+esbuild.build({
+    entryPoints: ['src/propertiesView.ts'],
+    bundle: true,
+    outfile: 'out/propertiesView.js',
+    format: 'iife',
+}).catch(() => process.exit(1))
+

--- a/editors/vscode/esbuild.js
+++ b/editors/vscode/esbuild.js
@@ -49,7 +49,8 @@ esbuild.build({
 
 esbuild.build({
     entryPoints: ['src/extension.ts'],
-    bundle: false,
+    bundle: true,
+    external: ['vscode', 'vscode-languageclient', 'vscode-languageclient/node', 'path', 'fs'],
     outfile: 'out/extension.js',
     format: 'cjs',
 }).catch(() => process.exit(1))

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -19,7 +19,8 @@
 	"preview": true,
 	"activationEvents": [
 		"onLanguage:slint",
-		"onWebviewPanel:slint-preview"
+		"onWebviewPanel:slint-preview",
+		"onView:slint.propertiesView"
 	],
 	"main": "./out/extension.js",
 	"browser": "./out/browser.js",
@@ -79,6 +80,16 @@
 					"description": "The command line arguments passed to the Slint LSP server"
 				}
 			}
+		},
+		"views": {
+			"explorer": [
+				{
+					"type": "webview",
+					"id": "slint.propertiesView",
+					"name": "Properties",
+					"contextualTitle": "Slint Properties"
+				}
+			]
 		}
 	},
 	"dependencies": {

--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -1,11 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// This file is the entry point for the vscode web extension
 
 import { ExtensionContext, Uri } from 'vscode';
 import * as vscode from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/browser';
+import { set_client, PropertiesViewProvider } from "./common";
 
 let client: LanguageClient;
 let statusBar: vscode.StatusBarItem;
@@ -31,6 +33,7 @@ function startClient(context: vscode.ExtensionContext) {
         if (m.data === "OK") {
 
             client = new LanguageClient('slint-lsp', 'Slint LSP', clientOptions, worker);
+            set_client(client);
             const disposable = client.start();
             context.subscriptions.push(disposable);
 
@@ -111,6 +114,10 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     vscode.window.registerWebviewPanelSerializer('slint-preview', new PreviewSerializer(context));
+
+    const properties_provider = new PropertiesViewProvider(context.extensionUri);
+    context.subscriptions.push(
+        vscode.window.registerWebviewViewProvider(PropertiesViewProvider.viewType, properties_provider));
 }
 
 async function showPreview(context: vscode.ExtensionContext, path: string, component: string) {

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -1,0 +1,201 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// This file contains the common code for both the normal and the browser extension
+
+import * as vscode from 'vscode';
+import { BaseLanguageClient } from 'vscode-languageclient';
+import { Property, PropertyQuery } from '../../../tools/online_editor/src/shared/properties';
+
+let client: BaseLanguageClient;
+export function set_client(c: BaseLanguageClient) {
+    client = c;
+}
+
+export class PropertiesViewProvider implements vscode.WebviewViewProvider {
+
+    public static readonly viewType = 'slint.propertiesView';
+
+    private _view?: vscode.WebviewView;
+
+    constructor(private readonly _extensionUri: vscode.Uri) { }
+
+    public resolveWebviewView(
+        webviewView: vscode.WebviewView,
+        _context: vscode.WebviewViewResolveContext,
+        _token: vscode.CancellationToken,
+    ) {
+        this._view = webviewView;
+
+        webviewView.webview.options = {
+            // Allow scripts in the webview
+            enableScripts: true,
+
+            localResourceRoots: [
+                this._extensionUri
+            ]
+        };
+
+        webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+
+        webviewView.webview.onDidReceiveMessage(data => {
+            switch (data.command) {
+                case 'property_clicked':
+                    if (vscode.window.activeTextEditor) {
+                        const p = data.property as Property;
+                        if (p.defined_at && p.defined_at.property_definition_range) {
+                            let range = client.protocol2CodeConverter.asRange(p.defined_at.property_definition_range);
+                            vscode.window.activeTextEditor.revealRange(range);
+                            vscode.window.activeTextEditor.selection = new vscode.Selection(range.start, range.end);
+                        }
+                    }
+                    break;
+                case 'change_property':
+                    if (vscode.window.activeTextEditor) {
+                        const p = data.property as Property;
+                        if (p.defined_at && p.defined_at.expression_range) {
+                            let range = client.protocol2CodeConverter.asRange(p.defined_at.expression_range);
+                            let old = vscode.window.activeTextEditor.document.getText(range);
+                            console.log("maybe", old, data.old_value)
+                            if (old === data.old_value) {
+                                vscode.window.activeTextEditor.edit(b => b.replace(range, data.new_value));
+                            }
+                        }
+                    }
+                    break;
+            }
+        });
+
+
+        vscode.window.onDidChangeTextEditorSelection(async (event: vscode.TextEditorSelectionChangeEvent) => {
+            //client.comma sendRequest("slint/showPreview", ae.document.uri.fsPath.toString());
+
+            if (event.selections.length == 0) {
+                return;
+            }
+            let selection = event.selections[0];
+
+            let r = await vscode.commands.executeCommand(
+                "queryProperties",
+                event.textEditor.document.uri.toString(),
+                selection.active.line,
+                selection.active.character,
+            );
+            const result = r as PropertyQuery;
+            const result_str = JSON.stringify(result);
+            const msg = {
+                command: "set_properties",
+                properties: r,
+                code: event.textEditor.document.getText(),
+            };
+            webviewView.webview.postMessage(msg);
+        });
+    }
+
+    private _getHtmlForWebview(webview: vscode.Webview) {
+
+        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out/propertiesView.js'));
+        const nonce = getNonce();
+
+
+        // FIXME: share with the online editor?
+        const css = `
+            :root {
+                /* Slint colors */
+                --slint-blue: #0025ff;
+                --slint-black: #000000;
+                --slint-dark-grey: #191c20;
+                --slint-grey: #2c2f36;
+                --slint-white: #ffffff;
+                --slint-green: #dbff00;
+
+                /* style properties */
+                --error-bg: #ff0000;
+                --error-fg: var(--slint-black);
+
+                --highlight-bg: var(--slint-blue);
+                --highlight-fg: var(--slint-white);
+
+                --highlight2-bg: var(--slint-green);
+                --highlight2-fg: var(--slint-black);
+
+                --undefined-bg: #c0c0c0;
+                --undefined-fg: var(--slint-black);
+
+                --default-font: 12px Helvetica, Arial, sans-serif;
+            }
+
+
+            .properties-editor .element-header {
+                background: var(--highlight-bg);
+                color: var(--highlight-fg);
+                font-size: 140%;
+                font-weight: bold;
+
+                width: 100%;
+                height: 50px;
+            }
+
+            .properties-editor .name-column {
+                white-space: nowrap;
+            }
+
+            .properties-editor .value-column {
+                width: 90%;
+            }
+
+            .properties-editor .properties-table {
+                width: 100%;
+            }
+
+            .properties-editor .properties-table .group-header td {
+                background-color: var(--highlight2-bg);
+                color: var(--highlight2-fg);
+                font-weight: bold;
+            }
+
+            .properties-editor .properties-table .undefined {
+                background-color: var(--undefined-bg);
+                color: var(--undefined-fg);
+            }
+
+            .properties-editor .value-column.type-unknown:before {
+                content: "??? ";
+                padding: 2px;
+            }
+
+            .properties-editor .properties-table input {
+                margin: 0px;
+                border: none;
+                width: 100%;
+            }
+
+            .properties-editor .properties-table input.value-changed {
+                color: var(--error-bg);
+            }
+        `;
+
+        return `<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>Slint preview</title>
+                <style nonce=${nonce}">${css}</style>
+			</head>
+			<body class="properties-editor">
+                <script nonce="${nonce}" src="${scriptUri}"></script>
+			</body>
+			</html>`;
+    }
+}
+
+function getNonce() {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+}

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { BaseLanguageClient } from 'vscode-languageclient';
-import { Property, PropertyQuery } from '../../../tools/online_editor/src/shared/properties';
+import { Property } from '../../../tools/online_editor/src/shared/properties';
 
 let client: BaseLanguageClient;
 export function set_client(c: BaseLanguageClient) {
@@ -56,7 +56,6 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
                         if (p.defined_at && p.defined_at.expression_range) {
                             let range = client.protocol2CodeConverter.asRange(p.defined_at.expression_range);
                             let old = vscode.window.activeTextEditor.document.getText(range);
-                            console.log("maybe", old, data.old_value)
                             if (old === data.old_value) {
                                 vscode.window.activeTextEditor.edit(b => b.replace(range, data.new_value));
                             }
@@ -81,8 +80,6 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
                 selection.active.line,
                 selection.active.character,
             );
-            const result = r as PropertyQuery;
-            const result_str = JSON.stringify(result);
             const msg = {
                 command: "set_properties",
                 properties: r,
@@ -96,7 +93,6 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
 
         const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out/propertiesView.js'));
         const nonce = getNonce();
-
 
         // FIXME: share with the online editor?
         const css = `

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -12,6 +12,7 @@ import {
     NotificationType,
     ExecutableOptions,
 } from 'vscode-languageclient/node';
+import { Property, PropertyQuery } from '../../../tools/online_editor/src/shared/properties';
 
 
 export interface ServerStatusParams {
@@ -152,11 +153,16 @@ export function activate(context: vscode.ExtensionContext) {
         client.sendNotification("slint/showPreview", ae.document.uri.fsPath.toString());
     }));
 
+
     context.subscriptions.push(vscode.commands.registerCommand('slint.reload', async function () {
         statusBar.hide();
         await client.stop();
         startClient(context);
     }));
+
+    const properties_provider = new PropertiesViewProvider(context.extensionUri);
+    context.subscriptions.push(
+        vscode.window.registerWebviewViewProvider(PropertiesViewProvider.viewType, properties_provider));
 }
 
 export function deactivate(): Thenable<void> | undefined {
@@ -184,4 +190,193 @@ function setServerStatus(status: ServerStatusParams, statusBar: vscode.StatusBar
     statusBar.tooltip = "Slint";
     statusBar.text = `${icon} ${status.message ?? "Slint"}`;
     statusBar.show();
+}
+
+
+class PropertiesViewProvider implements vscode.WebviewViewProvider {
+
+    public static readonly viewType = 'slint.propertiesView';
+
+    private _view?: vscode.WebviewView;
+
+    constructor(private readonly _extensionUri: vscode.Uri) { }
+
+    public resolveWebviewView(
+        webviewView: vscode.WebviewView,
+        _context: vscode.WebviewViewResolveContext,
+        _token: vscode.CancellationToken,
+    ) {
+        this._view = webviewView;
+
+        webviewView.webview.options = {
+            // Allow scripts in the webview
+            enableScripts: true,
+
+            localResourceRoots: [
+                this._extensionUri
+            ]
+        };
+
+        webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+
+        webviewView.webview.onDidReceiveMessage(data => {
+            switch (data.command) {
+                case 'property_clicked':
+                    if (vscode.window.activeTextEditor) {
+                        const p = data.property as Property;
+                        if (p.defined_at && p.defined_at.property_definition_range) {
+                            let range = client.protocol2CodeConverter.asRange(p.defined_at.property_definition_range);
+                            vscode.window.activeTextEditor.revealRange(range);
+                            vscode.window.activeTextEditor.selection = new vscode.Selection(range.start, range.end);
+                        }
+                    }
+                    break;
+                case 'change_property':
+                    if (vscode.window.activeTextEditor) {
+                        const p = data.property as Property;
+                        if (p.defined_at && p.defined_at.expression_range) {
+                            let range = client.protocol2CodeConverter.asRange(p.defined_at.expression_range);
+                            let old = vscode.window.activeTextEditor.document.getText(range);
+                            console.log("maybe", old, data.old_value)
+                            if (old === data.old_value) {
+                                vscode.window.activeTextEditor.edit(b => b.replace(range, data.new_value));
+                            }
+                        }
+                    }
+                    break;
+            }
+        });
+
+
+        vscode.window.onDidChangeTextEditorSelection(async (event: vscode.TextEditorSelectionChangeEvent) => {
+            //client.comma sendRequest("slint/showPreview", ae.document.uri.fsPath.toString());
+
+            if (event.selections.length == 0) {
+                return;
+            }
+            let selection = event.selections[0];
+
+            let r = await vscode.commands.executeCommand(
+                "queryProperties",
+                event.textEditor.document.uri.toString(),
+                selection.active.line,
+                selection.active.character,
+            );
+            const result = r as PropertyQuery;
+            const result_str = JSON.stringify(result);
+            const msg = {
+                command: "set_properties",
+                properties: r,
+                code: event.textEditor.document.getText(),
+            };
+            webviewView.webview.postMessage(msg);
+        });
+    }
+
+    private _getHtmlForWebview(webview: vscode.Webview) {
+
+        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out/propertiesView.js'));
+        const nonce = getNonce();
+
+
+        // FIXME: share with the online editor?
+        const css = `
+            :root {
+                /* Slint colors */
+                --slint-blue: #0025ff;
+                --slint-black: #000000;
+                --slint-dark-grey: #191c20;
+                --slint-grey: #2c2f36;
+                --slint-white: #ffffff;
+                --slint-green: #dbff00;
+
+                /* style properties */
+                --error-bg: #ff0000;
+                --error-fg: var(--slint-black);
+
+                --highlight-bg: var(--slint-blue);
+                --highlight-fg: var(--slint-white);
+
+                --highlight2-bg: var(--slint-green);
+                --highlight2-fg: var(--slint-black);
+
+                --undefined-bg: #c0c0c0;
+                --undefined-fg: var(--slint-black);
+
+                --default-font: 12px Helvetica, Arial, sans-serif;
+            }
+
+
+            .properties-editor .element-header {
+                background: var(--highlight-bg);
+                color: var(--highlight-fg);
+                font-size: 140%;
+                font-weight: bold;
+
+                width: 100%;
+                height: 50px;
+            }
+
+            .properties-editor .name-column {
+                white-space: nowrap;
+            }
+
+            .properties-editor .value-column {
+                width: 90%;
+            }
+
+            .properties-editor .properties-table {
+                width: 100%;
+            }
+
+            .properties-editor .properties-table .group-header td {
+                background-color: var(--highlight2-bg);
+                color: var(--highlight2-fg);
+                font-weight: bold;
+            }
+
+            .properties-editor .properties-table .undefined {
+                background-color: var(--undefined-bg);
+                color: var(--undefined-fg);
+            }
+
+            .properties-editor .value-column.type-unknown:before {
+                content: "??? ";
+                padding: 2px;
+            }
+
+            .properties-editor .properties-table input {
+                margin: 0px;
+                border: none;
+                width: 100%;
+            }
+
+            .properties-editor .properties-table input.value-changed {
+                color: var(--error-bg);
+            }
+        `;
+
+        return `<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>Slint preview</title>
+                <style nonce=${nonce}">${css}</style>
+			</head>
+			<body class="properties-editor">
+                <script nonce="${nonce}" src="${scriptUri}"></script>
+			</body>
+			</html>`;
+    }
+}
+
+function getNonce() {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,9 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+// This file is the entry point for the vscode extension (not the browser one)
+
 import * as path from 'path';
 import { existsSync } from 'fs';
 import * as vscode from 'vscode';
+import { PropertiesViewProvider, set_client } from "./common"
 
 import {
     LanguageClient,
@@ -12,8 +15,6 @@ import {
     NotificationType,
     ExecutableOptions,
 } from 'vscode-languageclient/node';
-import { Property, PropertyQuery } from '../../../tools/online_editor/src/shared/properties';
-
 
 export interface ServerStatusParams {
     health: "ok" | "warning" | "error";
@@ -128,6 +129,7 @@ function startClient(context: vscode.ExtensionContext) {
         serverOptions,
         clientOptions
     );
+    set_client(client);
 
     client.start();
     let initClient = () => {
@@ -190,193 +192,4 @@ function setServerStatus(status: ServerStatusParams, statusBar: vscode.StatusBar
     statusBar.tooltip = "Slint";
     statusBar.text = `${icon} ${status.message ?? "Slint"}`;
     statusBar.show();
-}
-
-
-class PropertiesViewProvider implements vscode.WebviewViewProvider {
-
-    public static readonly viewType = 'slint.propertiesView';
-
-    private _view?: vscode.WebviewView;
-
-    constructor(private readonly _extensionUri: vscode.Uri) { }
-
-    public resolveWebviewView(
-        webviewView: vscode.WebviewView,
-        _context: vscode.WebviewViewResolveContext,
-        _token: vscode.CancellationToken,
-    ) {
-        this._view = webviewView;
-
-        webviewView.webview.options = {
-            // Allow scripts in the webview
-            enableScripts: true,
-
-            localResourceRoots: [
-                this._extensionUri
-            ]
-        };
-
-        webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
-
-        webviewView.webview.onDidReceiveMessage(data => {
-            switch (data.command) {
-                case 'property_clicked':
-                    if (vscode.window.activeTextEditor) {
-                        const p = data.property as Property;
-                        if (p.defined_at && p.defined_at.property_definition_range) {
-                            let range = client.protocol2CodeConverter.asRange(p.defined_at.property_definition_range);
-                            vscode.window.activeTextEditor.revealRange(range);
-                            vscode.window.activeTextEditor.selection = new vscode.Selection(range.start, range.end);
-                        }
-                    }
-                    break;
-                case 'change_property':
-                    if (vscode.window.activeTextEditor) {
-                        const p = data.property as Property;
-                        if (p.defined_at && p.defined_at.expression_range) {
-                            let range = client.protocol2CodeConverter.asRange(p.defined_at.expression_range);
-                            let old = vscode.window.activeTextEditor.document.getText(range);
-                            console.log("maybe", old, data.old_value)
-                            if (old === data.old_value) {
-                                vscode.window.activeTextEditor.edit(b => b.replace(range, data.new_value));
-                            }
-                        }
-                    }
-                    break;
-            }
-        });
-
-
-        vscode.window.onDidChangeTextEditorSelection(async (event: vscode.TextEditorSelectionChangeEvent) => {
-            //client.comma sendRequest("slint/showPreview", ae.document.uri.fsPath.toString());
-
-            if (event.selections.length == 0) {
-                return;
-            }
-            let selection = event.selections[0];
-
-            let r = await vscode.commands.executeCommand(
-                "queryProperties",
-                event.textEditor.document.uri.toString(),
-                selection.active.line,
-                selection.active.character,
-            );
-            const result = r as PropertyQuery;
-            const result_str = JSON.stringify(result);
-            const msg = {
-                command: "set_properties",
-                properties: r,
-                code: event.textEditor.document.getText(),
-            };
-            webviewView.webview.postMessage(msg);
-        });
-    }
-
-    private _getHtmlForWebview(webview: vscode.Webview) {
-
-        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out/propertiesView.js'));
-        const nonce = getNonce();
-
-
-        // FIXME: share with the online editor?
-        const css = `
-            :root {
-                /* Slint colors */
-                --slint-blue: #0025ff;
-                --slint-black: #000000;
-                --slint-dark-grey: #191c20;
-                --slint-grey: #2c2f36;
-                --slint-white: #ffffff;
-                --slint-green: #dbff00;
-
-                /* style properties */
-                --error-bg: #ff0000;
-                --error-fg: var(--slint-black);
-
-                --highlight-bg: var(--slint-blue);
-                --highlight-fg: var(--slint-white);
-
-                --highlight2-bg: var(--slint-green);
-                --highlight2-fg: var(--slint-black);
-
-                --undefined-bg: #c0c0c0;
-                --undefined-fg: var(--slint-black);
-
-                --default-font: 12px Helvetica, Arial, sans-serif;
-            }
-
-
-            .properties-editor .element-header {
-                background: var(--highlight-bg);
-                color: var(--highlight-fg);
-                font-size: 140%;
-                font-weight: bold;
-
-                width: 100%;
-                height: 50px;
-            }
-
-            .properties-editor .name-column {
-                white-space: nowrap;
-            }
-
-            .properties-editor .value-column {
-                width: 90%;
-            }
-
-            .properties-editor .properties-table {
-                width: 100%;
-            }
-
-            .properties-editor .properties-table .group-header td {
-                background-color: var(--highlight2-bg);
-                color: var(--highlight2-fg);
-                font-weight: bold;
-            }
-
-            .properties-editor .properties-table .undefined {
-                background-color: var(--undefined-bg);
-                color: var(--undefined-fg);
-            }
-
-            .properties-editor .value-column.type-unknown:before {
-                content: "??? ";
-                padding: 2px;
-            }
-
-            .properties-editor .properties-table input {
-                margin: 0px;
-                border: none;
-                width: 100%;
-            }
-
-            .properties-editor .properties-table input.value-changed {
-                color: var(--error-bg);
-            }
-        `;
-
-        return `<!DOCTYPE html>
-			<html lang="en">
-			<head>
-				<meta charset="UTF-8">
-                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
-				<meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <title>Slint preview</title>
-                <style nonce=${nonce}">${css}</style>
-			</head>
-			<body class="properties-editor">
-                <script nonce="${nonce}" src="${scriptUri}"></script>
-			</body>
-			</html>`;
-    }
-}
-
-function getNonce() {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
 }

--- a/editors/vscode/src/propertiesView.ts
+++ b/editors/vscode/src/propertiesView.ts
@@ -1,0 +1,47 @@
+import { BindingTextProvider, DefinitionPosition, PropertiesView } from "../../../tools/online_editor/src/shared/properties";
+
+let node = PropertiesView.createNode();
+let view = new PropertiesView(node);
+document.body.appendChild(node);
+
+const vscode = acquireVsCodeApi();
+view.property_clicked = (uri, p) => {
+    vscode.postMessage({ command: 'property_clicked', uri: uri, property: p });
+};
+view.change_property = (uri, p, new_value, old_value) => {
+    vscode.postMessage({ command: 'change_property', uri: uri, property: p, old_value: old_value, new_value: new_value });
+};
+
+class TextProvider implements BindingTextProvider {
+    #code: string[];
+    constructor(code: string) {
+        this.#code = code.split('\n');
+    }
+
+    binding_text(location: DefinitionPosition): string {
+        let l = location.expression_range.start.line;
+        const line_utf8 = new TextEncoder().encode(this.#code[l]);
+        let l2 = location.expression_range.end.line;
+        if (l == l2) {
+            return new TextDecoder().decode(
+                line_utf8.slice(location.expression_range.start.character, location.expression_range.end.character));
+        }
+        let result = new TextDecoder().decode(
+            line_utf8.slice(location.expression_range.start.character));
+        l++;
+        while (l < l2) {
+            result += "\n" + this.#code[l];
+            l++;
+        }
+        const end_utf8 = new TextEncoder().encode(this.#code[l]);
+        return result + new TextDecoder().decode(
+            end_utf8.slice(0, location.expression_range.end.character));
+    }
+}
+
+
+window.addEventListener('message', async event => {
+    if (event.data.command === "set_properties") {
+        view.set_properties(new TextProvider(event.data.code), event.data.properties);
+    }
+});

--- a/editors/vscode/src/propertiesView.ts
+++ b/editors/vscode/src/propertiesView.ts
@@ -1,3 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
 import { BindingTextProvider, DefinitionPosition, PropertiesView } from "../../../tools/online_editor/src/shared/properties";
 
 let node = PropertiesView.createNode();
@@ -21,15 +24,15 @@ class TextProvider implements BindingTextProvider {
     binding_text(location: DefinitionPosition): string {
         let l = location.expression_range.start.line;
         const line_utf8 = new TextEncoder().encode(this.#code[l]);
-        let l2 = location.expression_range.end.line;
-        if (l == l2) {
+        const l_end = location.expression_range.end.line;
+        if (l == l_end) {
             return new TextDecoder().decode(
                 line_utf8.slice(location.expression_range.start.character, location.expression_range.end.character));
         }
         let result = new TextDecoder().decode(
             line_utf8.slice(location.expression_range.start.character));
         l++;
-        while (l < l2) {
+        while (l < l_end) {
             result += "\n" + this.#code[l];
             l++;
         }

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -5,7 +5,8 @@
 		"outDir": "out",
 		"lib": [
 			"es2020",
-			"WebWorker"
+			"WebWorker",
+			"dom",
 		],
 		"sourceMap": true,
 		"rootDir": ".",

--- a/tools/online_editor/src/editor_widget.ts
+++ b/tools/online_editor/src/editor_widget.ts
@@ -5,11 +5,13 @@
 
 import { slint_language } from "./highlighting";
 import {
+    lsp_range_to_editor_range,
+} from "./lsp_integration";
+import {
     PropertyQuery,
     BindingTextProvider,
     DefinitionPosition,
-    lsp_range_to_editor_range,
-} from "./lsp_integration";
+} from "./shared/properties";
 import { FilterProxyReader } from "./proxy";
 import {
     TextPosition,

--- a/tools/online_editor/src/lsp_integration.ts
+++ b/tools/online_editor/src/lsp_integration.ts
@@ -64,36 +64,3 @@ export function lsp_range_to_editor_range(
         endColumn: endPos.column - 1, // LSP reports the first letter *not* part of the range anymore, so go for the one before that!
     };
 }
-
-export interface DeclarationPosition {
-    uri: string;
-    start_position: LspPosition;
-}
-
-export interface DefinitionPosition {
-    property_definition_range: LspRange;
-    expression_range: LspRange;
-}
-
-export interface Property {
-    name: string;
-    group: string;
-    type_name: string;
-    declared_at: DeclarationPosition | null;
-    defined_at: DefinitionPosition | null;
-}
-
-export interface Element {
-    id: string;
-    type_name: string;
-}
-
-export interface PropertyQuery {
-    source_uri: string;
-    element: Element | null;
-    properties: Property[];
-}
-
-export interface BindingTextProvider {
-    binding_text(_location: DefinitionPosition): string;
-}

--- a/tools/online_editor/src/properties_widget.ts
+++ b/tools/online_editor/src/properties_widget.ts
@@ -3,10 +3,10 @@
 
 // cSpell: ignore lumino
 
+
 import { GotoPositionCallback, ReplaceTextFunction, TextRange } from "./text";
 import {
     lsp_range_to_editor_range,
-    DefinitionPosition,
 } from "./lsp_integration";
 
 import { Message } from "@lumino/messaging";
@@ -14,33 +14,11 @@ import { Widget } from "@lumino/widgets";
 
 import {
     BindingTextProvider,
-    Element,
-    Property,
     PropertyQuery,
-} from "./lsp_integration";
+    DefinitionPosition,
+} from "./shared/properties";
 
-const TYPE_PATTERN = /^[a-z-]+$/i;
-
-let FOCUSING = false;
-
-function type_class_for_typename(name: string): string {
-    if (name === "callback" || name.slice(0, 9) === "callback(") {
-        return "type-callback";
-    }
-    if (name.slice(0, 5) === "enum ") {
-        return "type-enum";
-    }
-    if (name.slice(0, 9) === "function(") {
-        return "type-function";
-    }
-    if (name === "element ref") {
-        return "type-element-ref";
-    }
-    if (TYPE_PATTERN.test(name)) {
-        return "type-" + name;
-    }
-    return "type-unknown";
-}
+import { PropertiesView } from "./shared/properties"
 
 function editor_definition_range(
     uri: string,
@@ -60,31 +38,11 @@ export class PropertiesWidget extends Widget {
         return true;
     };
 
-    static createNode(): HTMLElement {
-        const node = document.createElement("div");
-        const content = document.createElement("div");
-        node.appendChild(content);
-
-        const header = document.createElement("div");
-        header.className = "element-header";
-        const element_type = document.createElement("div");
-        element_type.className = "element-type";
-        const element_id = document.createElement("div");
-        element_id.className = "element-id";
-        header.appendChild(element_type);
-        header.appendChild(element_id);
-
-        const table = document.createElement("table");
-        table.className = "properties-table";
-
-        content.appendChild(header);
-        content.appendChild(table);
-
-        return node;
-    }
+    #propertiesView: PropertiesView;
 
     constructor() {
-        super({ node: PropertiesWidget.createNode() });
+        let node = PropertiesView.createNode();
+        super({ node: node });
         this.setFlag(Widget.Flag.DisallowLayout);
         this.addClass("content");
         this.addClass("properties-editor".toLowerCase());
@@ -92,7 +50,34 @@ export class PropertiesWidget extends Widget {
         this.title.closable = true;
         this.title.caption = `Element Properties`;
 
-        this.set_header(null);
+        this.#propertiesView = new PropertiesView(node);
+
+        this.#propertiesView.property_clicked = (uri, p) => {
+            const expression_range = editor_definition_range(uri, p.defined_at);
+            if (expression_range != null) {
+                this.#onGotoPosition(uri, expression_range);
+            }
+        }
+        this.#propertiesView.change_property = (uri, p, current_text, code_text) => {
+            const expression_range = editor_definition_range(uri, p.defined_at);
+            if (expression_range != null) {
+                this.replace_property_value(
+                    uri,
+                    expression_range,
+                    current_text,
+                    (old_text) => old_text == code_text,
+                );
+            }
+        }
+    }
+
+    private replace_property_value(
+        uri: string,
+        range: TextRange,
+        new_value: string,
+        validator: (_old: string) => boolean,
+    ): boolean {
+        return this.#replaceText(uri, range, new_value, validator);
     }
 
     protected onCloseRequest(msg: Message): void {
@@ -108,151 +93,11 @@ export class PropertiesWidget extends Widget {
         this.#replaceText = fn;
     }
 
-    protected get contentNode(): HTMLDivElement {
-        return this.node.getElementsByTagName("div")[0] as HTMLDivElement;
-    }
-    protected get headerNode(): HTMLDivElement {
-        return this.contentNode.getElementsByTagName(
-            "div",
-        )[0] as HTMLDivElement;
-    }
-    protected get elementTypeNode(): HTMLDivElement {
-        return this.headerNode.getElementsByTagName("div")[0] as HTMLDivElement;
-    }
-    protected get elementIdNode(): HTMLDivElement {
-        return this.headerNode.getElementsByTagName("div")[1] as HTMLDivElement;
-    }
-    protected get tableNode(): HTMLTableElement {
-        return this.contentNode.getElementsByTagName(
-            "table",
-        )[0] as HTMLTableElement;
-    }
-
-    private set_header(element: Element | null) {
-        if (element == null) {
-            this.elementTypeNode.innerText = "<Unknown>";
-            this.elementIdNode.innerText = "";
-        } else {
-            this.elementTypeNode.innerText = element.type_name;
-            this.elementIdNode.innerText = element.id;
-        }
-    }
-
-    private replace_property_value(
-        uri: string,
-        range: TextRange,
-        new_value: string,
-        validator: (_old: string) => boolean,
-    ): boolean {
-        return this.#replaceText(uri, range, new_value, validator);
-    }
-
-    private populate_table(
-        binding_text_provider: BindingTextProvider,
-        properties: Property[],
-        uri: string,
-    ) {
-        const table = this.tableNode;
-
-        let current_group = "";
-
-        table.innerHTML = "";
-
-        for (const p of properties) {
-            if (p.group !== current_group) {
-                const group_header = document.createElement("tr");
-                group_header.className = "group-header";
-
-                const group_cell = document.createElement("td");
-                group_cell.innerText = p.group;
-                group_cell.setAttribute("colspan", "2");
-                current_group = p.group;
-
-                group_header.appendChild(group_cell);
-                table.appendChild(group_header);
-            }
-            const row = document.createElement("tr");
-            row.className = "property";
-            if (p.declared_at == null) {
-                row.classList.add("builtin");
-            }
-            if (p.defined_at == null) {
-                row.classList.add("undefined");
-            }
-
-            const expression_range = editor_definition_range(uri, p.defined_at);
-
-            const goto_property = () => {
-                if (expression_range != null) {
-                    this.#onGotoPosition(uri, expression_range);
-                }
-            };
-
-            const name_field = document.createElement("td");
-            name_field.className = "name-column";
-            name_field.innerText = p.name;
-            name_field.addEventListener("click", goto_property);
-            row.appendChild(name_field);
-
-            const value_field = document.createElement("td");
-            value_field.className = "value-column";
-            value_field.classList.add(type_class_for_typename(p.type_name));
-            value_field.setAttribute("title", p.type_name);
-            const input = document.createElement("input");
-            input.type = "text";
-            if (p.defined_at != null) {
-                const code_text = binding_text_provider.binding_text(
-                    p.defined_at,
-                );
-                input.value = code_text;
-                const changed_class = "value-changed";
-                input.addEventListener("focus", (_) => {
-                    if (FOCUSING) {
-                        FOCUSING = false;
-                    } else {
-                        FOCUSING = true;
-                        goto_property();
-                        input.focus();
-                    }
-                });
-                input.addEventListener("input", (_) => {
-                    const current_text = input.value;
-                    if (current_text != code_text) {
-                        input.classList.add(changed_class);
-                    } else {
-                        input.classList.remove(changed_class);
-                    }
-                });
-                input.addEventListener("change", (_) => {
-                    const current_text = input.value;
-                    if (current_text != code_text && expression_range != null) {
-                        this.replace_property_value(
-                            uri,
-                            expression_range,
-                            current_text,
-                            (old_text) => old_text == code_text,
-                        );
-                    }
-                });
-            } else {
-                input.disabled = true;
-            }
-            value_field.appendChild(input);
-            row.appendChild(value_field);
-
-            table.appendChild(row);
-        }
-    }
-
     set_properties(
         binding_text_provider: BindingTextProvider,
         properties: PropertyQuery,
     ) {
-        this.set_header(properties.element);
-        this.populate_table(
-            binding_text_provider,
-            properties.properties,
-            properties.source_uri,
-        );
+        this.#propertiesView.set_properties(binding_text_provider, properties);
     }
+
 }

--- a/tools/online_editor/src/properties_widget.ts
+++ b/tools/online_editor/src/properties_widget.ts
@@ -41,7 +41,7 @@ export class PropertiesWidget extends Widget {
     #propertiesView: PropertiesView;
 
     constructor() {
-        let node = PropertiesView.createNode();
+        const node = PropertiesView.createNode();
         super({ node: node });
         this.setFlag(Widget.Flag.DisallowLayout);
         this.addClass("content");

--- a/tools/online_editor/src/shared/properties.ts
+++ b/tools/online_editor/src/shared/properties.ts
@@ -95,9 +95,9 @@ export class PropertiesView {
 
     node: HTMLElement;
     /// Callback called when the property is clicked
-    property_clicked: (uri: LspURI, p: Property) => void = (_) => { };
+    property_clicked: (_uri: LspURI, _p: Property) => void = (_) => { /**/ };
     /// Callback called when the property is modified. The old value is given so it can be checked
-    change_property: (uri: LspURI, p: Property, new_value: string, old_value: string) => void = (_) => { };
+    change_property: (_uri: LspURI, _p: Property, _new_value: string, _old_value: string) => void = (_) => { /**/ };
 
     protected get contentNode(): HTMLDivElement {
         return this.node.getElementsByTagName("div")[0] as HTMLDivElement;

--- a/tools/online_editor/src/shared/properties.ts
+++ b/tools/online_editor/src/shared/properties.ts
@@ -1,0 +1,227 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import {
+    Position as LspPosition,
+    Range as LspRange,
+    URI as LspURI,
+} from "vscode-languageserver-types";
+
+export interface DeclarationPosition {
+    uri: LspURI;
+    start_position: LspPosition;
+}
+
+export interface DefinitionPosition {
+    property_definition_range: LspRange;
+    expression_range: LspRange;
+}
+
+export interface Property {
+    name: string;
+    group: string;
+    type_name: string;
+    declared_at: DeclarationPosition | null;
+    defined_at: DefinitionPosition | null;
+}
+
+export interface Element {
+    id: string;
+    type_name: string;
+}
+
+export interface BindingTextProvider {
+    binding_text(_location: DefinitionPosition): string;
+}
+
+export interface PropertyQuery {
+    source_uri: string;
+    element: Element | null;
+    properties: Property[];
+}
+
+const TYPE_PATTERN = /^[a-z-]+$/i;
+
+let FOCUSING = false;
+
+function type_class_for_typename(name: string): string {
+    if (name === "callback" || name.slice(0, 9) === "callback(") {
+        return "type-callback";
+    }
+    if (name.slice(0, 5) === "enum ") {
+        return "type-enum";
+    }
+    if (name.slice(0, 9) === "function(") {
+        return "type-function";
+    }
+    if (name === "element ref") {
+        return "type-element-ref";
+    }
+    if (TYPE_PATTERN.test(name)) {
+        return "type-" + name;
+    }
+    return "type-unknown";
+}
+
+export class PropertiesView {
+
+    static createNode(): HTMLElement {
+        const node = document.createElement("div");
+        const content = document.createElement("div");
+        node.appendChild(content);
+
+        const header = document.createElement("div");
+        header.className = "element-header";
+        const element_type = document.createElement("div");
+        element_type.className = "element-type";
+        const element_id = document.createElement("div");
+        element_id.className = "element-id";
+        header.appendChild(element_type);
+        header.appendChild(element_id);
+
+        const table = document.createElement("table");
+        table.className = "properties-table";
+
+        content.appendChild(header);
+        content.appendChild(table);
+
+        return node;
+    }
+
+    constructor(node: HTMLElement) {
+        this.node = node;
+        this.set_header(null);
+    }
+
+    node: HTMLElement;
+    /// Callback called when the property is clicked
+    property_clicked: (uri: LspURI, p: Property) => void = (_) => { };
+    /// Callback called when the property is modified. The old value is given so it can be checked
+    change_property: (uri: LspURI, p: Property, new_value: string, old_value: string) => void = (_) => { };
+
+    protected get contentNode(): HTMLDivElement {
+        return this.node.getElementsByTagName("div")[0] as HTMLDivElement;
+    }
+    protected get headerNode(): HTMLDivElement {
+        return this.contentNode.getElementsByTagName("div")[0] as HTMLDivElement;
+    }
+    protected get elementTypeNode(): HTMLDivElement {
+        return this.headerNode.getElementsByTagName("div")[0] as HTMLDivElement;
+    }
+    protected get elementIdNode(): HTMLDivElement {
+        return this.headerNode.getElementsByTagName("div")[1] as HTMLDivElement;
+    }
+    protected get tableNode(): HTMLTableElement {
+        return this.contentNode.getElementsByTagName(
+            "table",
+        )[0] as HTMLTableElement;
+    }
+
+    private set_header(element: Element | null) {
+        if (element == null) {
+            this.elementTypeNode.innerText = "<Unknown>";
+            this.elementIdNode.innerText = "";
+        } else {
+            this.elementTypeNode.innerText = element.type_name;
+            this.elementIdNode.innerText = element.id;
+        }
+    }
+
+    private populate_table(
+        binding_text_provider: BindingTextProvider,
+        properties: Property[],
+        uri: LspURI,
+    ) {
+        const table = this.tableNode;
+
+        let current_group = "";
+
+        table.innerHTML = "";
+
+        for (const p of properties) {
+            if (p.group !== current_group) {
+                const group_header = document.createElement("tr");
+                group_header.className = "group-header";
+
+                const group_cell = document.createElement("td");
+                group_cell.innerText = p.group;
+                group_cell.setAttribute("colspan", "2");
+                current_group = p.group;
+
+                group_header.appendChild(group_cell);
+                table.appendChild(group_header);
+            }
+            const row = document.createElement("tr");
+            row.className = "property";
+            if (p.declared_at == null) {
+                row.classList.add("builtin");
+            }
+            if (p.defined_at == null) {
+                row.classList.add("undefined");
+            }
+
+            const goto_property = () => {
+                this.property_clicked(uri, p)
+            }
+
+            const name_field = document.createElement("td");
+            name_field.className = "name-column";
+            name_field.innerText = p.name;
+            name_field.addEventListener("click", goto_property);
+            row.appendChild(name_field);
+
+            const value_field = document.createElement("td");
+            value_field.className = "value-column";
+            value_field.classList.add(type_class_for_typename(p.type_name));
+            value_field.setAttribute("title", p.type_name);
+            const input = document.createElement("input");
+            input.type = "text";
+            if (p.defined_at != null) {
+                const code_text = binding_text_provider.binding_text(p.defined_at);
+                input.value = code_text;
+                const changed_class = "value-changed";
+                input.addEventListener("focus", (_) => {
+                    if (FOCUSING) {
+                        FOCUSING = false;
+                    } else {
+                        FOCUSING = true;
+                        goto_property();
+                        input.focus();
+                    }
+                });
+                input.addEventListener("input", (_) => {
+                    const current_text = input.value;
+                    if (current_text != code_text) {
+                        input.classList.add(changed_class);
+                    } else {
+                        input.classList.remove(changed_class);
+                    }
+                });
+                input.addEventListener("change", (_) => {
+                    const current_text = input.value;
+                    if (current_text != code_text) {
+                        this.change_property(uri, p, current_text, code_text);
+                    }
+                });
+            } else {
+                input.disabled = true;
+            }
+            value_field.appendChild(input);
+            row.appendChild(value_field);
+
+            table.appendChild(row);
+        }
+    }
+
+    set_properties(
+        binding_text_provider: BindingTextProvider,
+        properties: PropertyQuery,
+    ) {
+        this.set_header(properties.element);
+        this.populate_table(
+            binding_text_provider,
+            properties.properties,
+            properties.source_uri,
+        );
+    }
+}

--- a/tools/online_editor/src/tsconfig.json
+++ b/tools/online_editor/src/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": ["dom", "es2020"],
         "types": ["json-schema", "vscode"]
     },
-    "include": ["./*.ts"],
+    "include": ["./*.ts", "./shared/*.ts"],
     "references": [
         {
             "path": "worker"


### PR DESCRIPTION
Some refactoring will be required later because the current interface is a bit awkward, especially the `BindingTextProvider` because the webview can't easily access the text editor as it can only communicate to the extension with messages.
But this get the thing done.