### PR TITLE
Always set `Window.default-font-size`

### DIFF
--- a/internal/backends/qt/qt_widgets/stylemetrics.rs
+++ b/internal/backends/qt/qt_widgets/stylemetrics.rs
@@ -35,6 +35,7 @@ pub struct NativeStyleMetrics {
     pub text_cursor_width: Property<LogicalLength>,
     pub window_background: Property<Color>,
     pub default_text_color: Property<Color>,
+    pub default_font_size: Property<LogicalLength>,
     pub textedit_background: Property<Color>,
     pub textedit_text_color: Property<Color>,
     pub textedit_background_disabled: Property<Color>,
@@ -65,6 +66,7 @@ impl NativeStyleMetrics {
             text_cursor_width: Default::default(),
             window_background: Default::default(),
             default_text_color: Default::default(),
+            default_font_size: Default::default(),
             textedit_background: Default::default(),
             textedit_text_color: Default::default(),
             textedit_background_disabled: Default::default(),
@@ -122,6 +124,10 @@ impl NativeStyleMetrics {
             return qApp->palette().color(QPalette::WindowText).rgba();
         });
         self.default_text_color.set(Color::from_argb_encoded(default_text_color));
+        let default_font_size = cpp!(unsafe[] -> i32 as "int" {
+            return QFontInfo(qApp->font()).pixelSize();
+        });
+        self.default_font_size.set(LogicalLength::new(default_font_size as f32));
         let textedit_text_color = cpp!(unsafe[] -> u32 as "QRgb" {
             return qApp->palette().color(QPalette::Text).rgba();
         });

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -263,6 +263,14 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWind
         }
     }
 
+    fn register_root_component(&self, window_item: Pin<&i_slint_core::items::WindowItem>) {
+        let default_font_size_prop =
+            i_slint_core::items::WindowItem::FIELD_OFFSETS.default_font_size.apply_pin(window_item);
+        if default_font_size_prop.get().get() <= 0 as Coord {
+            default_font_size_prop.set(Renderer::default_font_size());
+        }
+    }
+
     fn request_window_properties_update(&self) {
         self.call_with_event_loop(|self_| {
             self_.with_window_handle(&mut |window| {

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -21,6 +21,7 @@ pub(crate) mod event_loop;
 mod renderer {
     use std::rc::Weak;
 
+    use i_slint_core::lengths::LogicalLength;
     use i_slint_core::window::WindowAdapter;
 
     #[cfg(any(feature = "renderer-winit-femtovg", enable_skia_renderer))]
@@ -39,6 +40,8 @@ mod renderer {
         fn release_canvas(&self, canvas: Self::Canvas);
 
         fn render(&self, canvas: &Self::Canvas, window: &dyn WindowAdapter);
+
+        fn default_font_size() -> LogicalLength;
     }
 
     pub(crate) trait WinitCompatibleCanvas {

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -225,6 +225,10 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
         canvas.opengl_context.swap_buffers();
         canvas.opengl_context.make_not_current();
     }
+
+    fn default_font_size() -> LogicalLength {
+        self::fonts::DEFAULT_FONT_SIZE
+    }
 }
 
 impl Renderer for FemtoVGRenderer {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -159,6 +159,10 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
             }
         });
     }
+
+    fn default_font_size() -> LogicalLength {
+        self::textlayout::DEFAULT_FONT_SIZE
+    }
 }
 
 impl i_slint_core::renderer::Renderer for SkiaRenderer {

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -5,6 +5,7 @@
 
 use super::WinitCompatibleCanvas;
 use i_slint_core::graphics::Rgb8Pixel;
+use i_slint_core::lengths::LogicalLength;
 pub use i_slint_core::software_renderer::SoftwareRenderer;
 use i_slint_core::window::WindowAdapter;
 use std::cell::RefCell;
@@ -98,6 +99,10 @@ impl<const BUFFER_COUNT: usize> super::WinitCompatibleRenderer for SoftwareRende
 
         canvas.opengl_context.swap_buffers();
         canvas.opengl_context.make_not_current();
+    }
+
+    fn default_font_size() -> LogicalLength {
+        i_slint_core::software_renderer::SoftwareRenderer::<BUFFER_COUNT>::default_font_size()
     }
 }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -157,7 +157,7 @@ WindowItem := _ {
     input property <string> title: "Slint Window";
     input property <bool> no-frame;
     input property <string> default-font-family;
-    input property <length> default-font-size;
+    input output property <length> default-font-size; // <=> StyleMetrics.default-font-size  set in apply_default_properties_from_style
     input property <int> default-font-weight;
     input property <image> icon;
 }
@@ -613,6 +613,7 @@ export global NativeStyleMetrics := {
     output property <length> text-cursor-width;
     output property <color> window-background;
     output property <color> default-text-color;
+    output property <length> default-font-size;
     output property <color> textedit-background;
     output property <color> textedit-text-color;
     output property <color> textedit-background-disabled;

--- a/internal/compiler/passes/apply_default_properties_from_style.rs
+++ b/internal/compiler/passes/apply_default_properties_from_style.rs
@@ -58,6 +58,25 @@ pub fn apply_default_properties_from_style(
                         .into(),
                         to: Type::Brush,
                     });
+                    if !matches!(
+                        style_metrics
+                            .root_element
+                            .borrow()
+                            .lookup_property("default-font-size")
+                            .property_type,
+                        Type::Invalid,
+                    ) {
+                        elem.set_binding_if_not_set("default-font-size".into(), || {
+                            Expression::Cast {
+                                from: Expression::PropertyReference(NamedReference::new(
+                                    &style_metrics.root_element,
+                                    "default-font-size",
+                                ))
+                                .into(),
+                                to: Type::LogicalLength,
+                            }
+                        });
+                    }
                 }
 
                 _ => {}

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -252,6 +252,11 @@ impl<const MAX_BUFFER_AGE: usize> SoftwareRenderer<MAX_BUFFER_AGE> {
             );
         }
     }
+
+    #[doc(hidden)]
+    pub fn default_font_size() -> LogicalLength {
+        self::fonts::DEFAULT_FONT_SIZE
+    }
 }
 
 #[doc(hidden)]
@@ -1350,6 +1355,13 @@ impl<const MAX_BUFFER_AGE: usize> crate::window::WindowAdapterSealed
     }
     fn renderer(&self) -> &dyn Renderer {
         &self.renderer
+    }
+    fn register_root_component(&self, window_item: Pin<&crate::items::WindowItem>) {
+        let default_font_size_prop =
+            crate::items::WindowItem::FIELD_OFFSETS.default_font_size.apply_pin(window_item);
+        if default_font_size_prop.get().get() <= 0 as Coord {
+            default_font_size_prop.set(SoftwareRenderer::<MAX_BUFFER_AGE>::default_font_size());
+        }
     }
 }
 

--- a/internal/core/software_renderer/fonts.rs
+++ b/internal/core/software_renderer/fonts.rs
@@ -69,7 +69,7 @@ impl FontMetrics for BitmapGlyphs {
     }
 }
 
-const DEFAULT_FONT_SIZE: LogicalLength = LogicalLength::new(12 as Coord);
+pub(super) const DEFAULT_FONT_SIZE: LogicalLength = LogicalLength::new(12 as Coord);
 
 // A font that is resolved to a specific pixel size.
 pub struct PixelFont {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -270,7 +270,6 @@ impl WindowInner {
         self.mouse_input_state.replace(Default::default());
         self.component.replace(ComponentRc::downgrade(component));
         self.window_properties_tracker.set_dirty(); // component changed, layout constraints for sure must be re-calculated
-        self.window_adapter().request_window_properties_update();
         let window_adapter = self.window_adapter();
         window_adapter.request_window_properties_update();
         window_adapter.request_redraw();


### PR DESCRIPTION
Permit the style metrics to provide a `default-font-size` and bind that
to the `Window` if set. If not provided, then the backend can set a
`default-font-size`. By ensuring that the value is non-zero at run-time,
we can later introduce a rem unit that can act as factor relative to
this non-zero font size.