### PR TITLE
Introduce a `rem` unit in the type system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to this project are documented in this file.
  - LSP preview: highlight the selected element in the preview
  - LSP: Added a setting to change the style and the include paths
  - VSCode extension: added the property view.
+ - Added `rem` as unit that represents a relative font size and is multiplied with the `Window.default-font-size` when used.
+ - Added `relative-font-size` as type that holds values of `rem`.
 
 ### Fixed
 

--- a/api/cpp/docs/types.md
+++ b/api/cpp/docs/types.md
@@ -18,6 +18,7 @@ The follow table summarizes the entire mapping:
  :code:`length`              :code:`float`                       At run-time, logical lengths are automatically translated to physical pixels using the device pixel ratio.
  :code:`duration`            :code:`std::int64_t`                At run-time, durations are always represented as signed 64-bit integers with millisecond precision.
  :code:`angle`               :code:`float`                       The value in degrees.
+ :code:`relative-font-size`  :code:`float`                       Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`.
  structure                   A :code:`class` of the same name    The order of the data member are in the lexicographic order of their name
 ==========================  ==================================  =======================================================================================================================================
 ```

--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -166,6 +166,7 @@ fn to_eval_value<'cx>(
         | Type::Angle
         | Type::PhysicalLength
         | Type::LogicalLength
+        | Type::Rem
         | Type::Percent
         | Type::UnitProduct(_) => {
             Ok(Value::Number(val.downcast_or_throw::<JsNumber, _>(cx)?.value()))

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -184,6 +184,7 @@ The follow table summarizes the entire mapping:
 | `length` | `f32` | At run-time, logical lengths are automatically translated to physical pixels using the device pixel ratio. |
 | `duration` | `i64` | At run-time, durations are always represented as signed 64-bit integers with millisecond precision. |
 | `angle` | `f32` | The value in degrees |
+| `relative-font-size` | `f32` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
 | structure | `struct` of the same name | |
 | array | [`ModelRc`] |  |
 

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -251,6 +251,7 @@ All properties in elements have a type. The following types are supported:
 | `easing` | Property animation allow specifying an easing curve. Valid values are `linear` (values are interpolated linearly) and the [four common cubiz-bezier functions known from CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function#Keywords_for_common_cubic-bezier_easing_functions):  `ease`, `ease_in`, `ease_in_out`, `ease_out`. |
 | `percent` | Signed, 32-bit floating point number that is interpreted as percentage. Literal number assigned to properties of this type must have a `%` suffix. |
 | `image` | A reference to an image, can be initialized with the `@image-url("...")` construct |
+| `relative-font-size` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
 
 Please see the language specific API references how these types are mapped to the APIs of the different programming languages.
 

--- a/editors/kate/slint.ksyntaxhighlighter.xml
+++ b/editors/kate/slint.ksyntaxhighlighter.xml
@@ -17,6 +17,7 @@
       <item>color</item>
       <item>length</item>
       <item>physical-length</item>
+      <item>relative-font-size</item>
     </list>
     <list name="keywords">
       <item>import</item>

--- a/editors/sublime/Slint.sublime-syntax
+++ b/editors/sublime/Slint.sublime-syntax
@@ -38,7 +38,7 @@ contexts:
       scope: constant.other.color.slint
 
   types:
-    - match: '\b(int|bool|float|duration|angle|string|image|brush|color|length|physical-length)\b'
+    - match: '\b(int|bool|float|duration|angle|string|image|brush|color|length|physical-length|relative-font-size)\b'
       scope: storage.type.slint
 
   constants:

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -582,6 +582,7 @@ module.exports = grammar({
         "px",
         "%",
         "ms",
+        "rem",
       ),
 
     language_constant: ($) =>
@@ -623,6 +624,7 @@ module.exports = grammar({
           "percent",
           "physical-length",
           "physical_length",
+          "relative-font-size",
           "string",
         ),
       ),

--- a/editors/tree-sitter-slint/queries/highlights.scm
+++ b/editors/tree-sitter-slint/queries/highlights.scm
@@ -112,6 +112,7 @@
 "percent"
 "physical-length"
 "physical_length"
+"relative-font-size"
 "string"
 ] @type.builtin
 

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -238,6 +238,7 @@ fn to_debug_string(
         Type::Duration
         | Type::PhysicalLength
         | Type::LogicalLength
+        | Type::Rem
         | Type::Angle
         | Type::Percent
         | Type::UnitProduct(_) => Expression::BinaryExpression {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -314,6 +314,7 @@ impl CppType for Type {
             Type::Angle => Some("float".to_owned()),
             Type::PhysicalLength => Some("float".to_owned()),
             Type::LogicalLength => Some("float".to_owned()),
+            Type::Rem => Some("float".to_owned()),
             Type::Percent => Some("float".to_owned()),
             Type::Bool => Some("bool".to_owned()),
             Type::Struct { name: Some(name), node: Some(_), .. } => Some(ident(name)),
@@ -2394,6 +2395,10 @@ fn compile_builtin_function_call(
         BuiltinFunction::GetWindowScaleFactor => {
             let window = access_window_field(ctx);
             format!("{}.scale_factor()", window)
+        }
+        BuiltinFunction::GetWindowDefaultFontSize => {
+            let window_item_name = ident(&ctx.public_component.item_tree.root.items[0].name);
+            format!("{}->{}.default_font_size.get()", ctx.generator_state, window_item_name)
         }
         BuiltinFunction::AnimationTick => "slint::cbindgen_private::slint_animation_tick()".into(),
         BuiltinFunction::Debug => {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -76,6 +76,7 @@ fn rust_primitive_type(ty: &Type) -> Option<proc_macro2::TokenStream> {
         Type::Angle => Some(quote!(f32)),
         Type::PhysicalLength => Some(quote!(slint::private_unstable_api::re_exports::Coord)),
         Type::LogicalLength => Some(quote!(slint::private_unstable_api::re_exports::Coord)),
+        Type::Rem => Some(quote!(f32)),
         Type::Percent => Some(quote!(f32)),
         Type::Bool => Some(quote!(bool)),
         Type::Image => Some(quote!(slint::private_unstable_api::re_exports::Image)),
@@ -1863,6 +1864,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                             | Type::LogicalLength
                             | Type::Angle
                             | Type::Percent
+                            | Type::Rem
                     ) =>
                 {
                     (Some(quote!(as f64)), Some(quote!(as f64)))
@@ -2151,6 +2153,13 @@ fn compile_builtin_function_call(
         BuiltinFunction::GetWindowScaleFactor => {
             let window_adapter_tokens = access_window_adapter_field(ctx);
             quote!(slint::private_unstable_api::re_exports::WindowInner::from_pub(#window_adapter_tokens.window()).scale_factor())
+        }
+        BuiltinFunction::GetWindowDefaultFontSize => {
+            let window_item_name = ident(&ctx.public_component.item_tree.root.items[0].name);
+            let root_access = &ctx.generator_state;
+            let root_component_id = inner_component_id(&ctx.public_component.item_tree.root);
+            let item_field = access_component_field_offset(&root_component_id, &window_item_name);
+            quote!((#item_field + slint::private_unstable_api::re_exports::WindowItem::FIELD_OFFSETS.default_font_size).apply_pin(#root_access.as_pin_ref()).get().get())
         }
         BuiltinFunction::AnimationTick => {
             quote!(slint::private_unstable_api::re_exports::animation_tick())

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -195,6 +195,7 @@ impl Expression {
             | Type::Angle
             | Type::PhysicalLength
             | Type::LogicalLength
+            | Type::Rem
             | Type::UnitProduct(_) => Expression::NumberLiteral(0.),
             Type::Percent => Expression::NumberLiteral(1.),
             Type::String => Expression::StringLiteral(String::new()),

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -68,6 +68,7 @@ fn callback_cost(_callback: &crate::llr::PropertyReference, _ctx: &EvaluationCon
 fn builtin_function_cost(function: BuiltinFunction) -> isize {
     match function {
         BuiltinFunction::GetWindowScaleFactor => PROPERTY_ACCESS_COST,
+        BuiltinFunction::GetWindowDefaultFontSize => PROPERTY_ACCESS_COST,
         BuiltinFunction::AnimationTick => PROPERTY_ACCESS_COST,
         BuiltinFunction::Debug => isize::MAX,
         BuiltinFunction::Mod => 10,

--- a/internal/compiler/passes/check_expressions.rs
+++ b/internal/compiler/passes/check_expressions.rs
@@ -30,6 +30,11 @@ fn check_expression(component: &Rc<Component>, e: &Expression, diag: &mut BuildD
                 diag.push_error("Cannot convert between logical and physical length in a global component, because the scale factor is not known".into(), loc);
             }
         }
+        Expression::BuiltinFunctionReference(BuiltinFunction::GetWindowDefaultFontSize, loc) => {
+            if component.is_global() {
+                diag.push_error("Cannot convert between rem and logical length in a global component, because the default font size is not known".into(), loc);
+            }
+        }
         _ => e.visit(|e| check_expression(component, e, diag)),
     }
 }

--- a/internal/compiler/tests/syntax/lookup/conversion.slint
+++ b/internal/compiler/tests/syntax/lookup/conversion.slint
@@ -8,8 +8,11 @@ global Glob := {
 //                              ^error{Cannot convert between logical and physical length in a global component, because the scale factor is not known}
     property <float> ratio: allowed / 1phx;
 //                         ^error{Cannot convert between logical and physical length in a global component, because the scale factor is not known}
-    property <float> should_work: 45px / 8px;
+    property <length> converted_rem: 2rem;
+//                                  ^error{Cannot convert between rem and logical length in a global component, because the default font size is not known}    
+    property <float> should_work: 45px / 8px + (4rem / 2rem);
     property <length> allowed: 45px * 5;
+    property <relative-font-size> rem_allowed: 42rem;
 }
 
 X := Rectangle {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -227,6 +227,7 @@ impl TypeRegister {
         register.insert_type(Type::Easing);
         register.insert_type(Type::Angle);
         register.insert_type(Type::Brush);
+        register.insert_type(Type::Rem);
 
         BUILTIN_ENUMS.with(|e| e.fill_register(&mut register));
 

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -985,6 +985,7 @@ pub(crate) fn generate_component<'id>(
             Type::Angle => animated_property_info::<f32>(),
             Type::PhysicalLength => animated_property_info::<f32>(),
             Type::LogicalLength => animated_property_info::<f32>(),
+            Type::Rem => animated_property_info::<f32>(),
             Type::Image => property_info::<i_slint_core::graphics::Image>(),
             Type::Bool => property_info::<bool>(),
             Type::Callback { .. } => {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -399,6 +399,20 @@ fn call_builtin_function(
                 panic!("Cannot get the window from a global component")
             }
         },
+        BuiltinFunction::GetWindowDefaultFontSize => match local_context.component_instance {
+            ComponentInstance::InstanceRef(component) => Value::Number(
+                window_ref(component)
+                    .unwrap()
+                    .window_item()
+                    .unwrap()
+                    .as_pin_ref()
+                    .default_font_size()
+                    .get() as _,
+            ),
+            ComponentInstance::GlobalComponent(_) => {
+                panic!("Cannot get the window from a global component")
+            }
+        },
         BuiltinFunction::AnimationTick => {
             Value::Number(i_slint_core::animations::animation_tick() as f64)
         }
@@ -965,6 +979,7 @@ fn check_value_type(value: &Value, ty: &Type) -> bool {
         | Type::Duration
         | Type::PhysicalLength
         | Type::LogicalLength
+        | Type::Rem
         | Type::Angle
         | Type::Percent => matches!(value, Value::Number(_)),
         Type::Image => matches!(value, Value::Image(_)),
@@ -1235,7 +1250,7 @@ pub fn default_value_for_type(ty: &Type) -> Value {
         Type::Float32 | Type::Int32 => Value::Number(0.),
         Type::String => Value::String(Default::default()),
         Type::Color | Type::Brush => Value::Brush(Default::default()),
-        Type::Duration | Type::Angle | Type::PhysicalLength | Type::LogicalLength => {
+        Type::Duration | Type::Angle | Type::PhysicalLength | Type::LogicalLength | Type::Rem => {
             Value::Number(0.)
         }
         Type::Image => Value::Image(Default::default()),

--- a/tests/cases/types/rem.slint
+++ b/tests/cases/types/rem.slint
@@ -1,0 +1,59 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+global SomeGlobal := {
+    property<relative-font-size> global_rem: 4rem;
+}
+
+TestCase := Window {
+    default-font-size: 10px;
+    property<length> normal: 1rem;
+    property<length> double: 2rem;
+    property<length> half: 0.5rem;
+    property <relative-font-size> four_rem: 4rem;
+    property<length> four: four_rem;
+
+    property<physical-length> phys-pixel-size: 1rem;
+
+    property <relative-font-size> px_to_rem: 20px;
+    property <relative-font-size> phx_to_rem: 20phx;
+
+    property <bool> cmp_test: normal < 1rem && double > 1rem;
+
+    property<bool> test:(normal == 10px && double == 20px && half == 5px && four_rem == 40px && SomeGlobal.global_rem == 40px && phys-pixel-size == 10phx && px_to_rem == 2rem);
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+
+assert_eq(instance.get_phx_to_rem(), 2.);
+assert_eq(instance.get_px_to_rem(), 2.);
+instance.m_window.window_handle().set_scale_factor(2.0);
+assert_eq(instance.get_phys_pixel_size(), 20.);
+assert_eq(instance.get_phx_to_rem(), 1.);
+assert_eq(instance.get_px_to_rem(), 2.);
+```
+
+
+```rust
+let instance = TestCase::new();
+assert!(instance.get_test());
+
+assert_eq!(instance.get_phx_to_rem(), 2.);
+assert_eq!(instance.get_px_to_rem(), 2.);
+slint_testing::set_window_scale_factor(&instance, 2.0);
+assert_eq!(instance.get_phys_pixel_size(), 20.);
+assert_eq!(instance.get_phx_to_rem(), 1.);
+assert_eq!(instance.get_px_to_rem(), 2.);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
This allows specifying font sizes relative to the Window's default-font-size, similar to CSS rem.