### PR TITLE
Compiler: move the image and font embedding behind a software-renderer flag

### DIFF
--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -19,7 +19,7 @@ path = "lib.rs"
 default = []
 
 [dependencies]
-i-slint-compiler = { version = "=0.3.2", path = "../../../internal/compiler", features = ["rust", "display-diagnostics"] }
+i-slint-compiler = { version = "=0.3.2", path = "../../../internal/compiler", features = ["rust", "display-diagnostics", "software-renderer"] }
 
 spin_on = "0.1"
 thiserror = "1"

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -27,6 +27,9 @@ proc_macro_span = ["quote", "proc-macro2"]
 # Feature to print the diagnostics to the console
 display-diagnostics = ["codemap", "codemap-diagnostic"]
 
+# Enabled the support to render images and font in the binary
+software-renderer = ["image", "tiny-skia", "resvg", "usvg", "fontdb", "fontdue", "libc", "yeslogic-fontconfig-sys"]
+
 
 [dependencies]
 i-slint-common = { version = "=0.3.2", path = "../common" }
@@ -49,19 +52,19 @@ once_cell = "1"
 url = "2.2.1"
 dunce = "1.0.1"
 linked_hash_set = "0.1.4"
-fontdb = { version = "0.9.3", features = ["fontconfig"] }
-fontdue = { version = "0.7.1" }
 
 # for processing and embedding the rendered image (texture)
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-image = "0.24"
-tiny-skia = "0.8.2"
-resvg = "0.25"
-usvg = "0.25"
+image = { version = "0.24", optional = true }
+tiny-skia = { version = "0.8.2", optional = true }
+resvg = { version = "0.25", optional = true }
+usvg = { version = "0.25", optional = true }
+# font embedding
+fontdb = { version = "0.9.3", features = ["fontconfig"], optional = true }
+fontdue = { version = "0.7.1", optional = true }
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-libc = { version = "0.2" }
-yeslogic-fontconfig-sys = "3.2.0"
+libc = { version = "0.2", optional = true }
+yeslogic-fontconfig-sys = { version = "3.2.0", optional = true }
 
 [dev-dependencies]
 i-slint-parser-test-macro = { path = "./parser-test-macro" }

--- a/internal/compiler/embedded_resources.rs
+++ b/internal/compiler/embedded_resources.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "software-renderer")]
 pub use tiny_skia::IntRect as Rect;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -22,7 +22,7 @@ pub enum PixelFormat {
     AlphaMap([u8; 3]),
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "software-renderer")]
 #[derive(Debug, Clone)]
 pub struct Texture {
     pub total_size: Size,
@@ -32,7 +32,7 @@ pub struct Texture {
     pub format: PixelFormat,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "software-renderer")]
 impl Texture {
     pub fn new_empty() -> Self {
         Self {
@@ -45,7 +45,7 @@ impl Texture {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "software-renderer")]
 #[derive(Debug, Clone, Default)]
 pub struct BitmapGlyph {
     pub x: i16,
@@ -56,20 +56,21 @@ pub struct BitmapGlyph {
     pub data: Vec<u8>, // 8bit alpha map
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "software-renderer")]
 #[derive(Debug, Clone)]
 pub struct BitmapGlyphs {
     pub pixel_size: i16,
     pub glyph_data: Vec<BitmapGlyph>,
 }
 
+#[cfg(feature = "software-renderer")]
 #[derive(Debug, Clone)]
 pub struct CharacterMapEntry {
     pub code_point: char,
     pub glyph_index: u16,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "software-renderer")]
 #[derive(Debug, Clone)]
 pub struct BitmapFont {
     pub family_name: String,
@@ -85,9 +86,11 @@ pub enum EmbeddedResourcesKind {
     /// Just put the file content as a resource
     RawData,
     /// The data has been processed in a texture
-    TextureData(#[cfg(not(target_arch = "wasm32"))] Texture),
+    #[cfg(feature = "software-renderer")]
+    TextureData(Texture),
     /// A set of pre-rendered glyphs of a TrueType font
-    BitmapFontData(#[cfg(not(target_arch = "wasm32"))] BitmapFont),
+    #[cfg(feature = "software-renderer")]
+    BitmapFontData(BitmapFont),
 }
 
 #[derive(Debug, Clone)]

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -506,7 +506,9 @@ pub fn generate(doc: &Document) -> impl std::fmt::Display {
                         init: Some(init),
                     })
                 }
+                #[cfg(feature = "software-renderer")]
                 crate::embedded_resources::EmbeddedResourcesKind::TextureData(_) => todo!(),
+                #[cfg(feature = "software-renderer")]
                 crate::embedded_resources::EmbeddedResourcesKind::BitmapFontData(_) => todo!(),
             }
         },

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -188,6 +188,7 @@ pub fn generate(doc: &Document) -> TokenStream {
                     let data = embedded_file_tokens(path);
                     quote!(static #symbol: &'static [u8] = #data;)
                 }
+                #[cfg(feature = "software-renderer")]
                 crate::embedded_resources::EmbeddedResourcesKind::TextureData(crate::embedded_resources::Texture {
                     data, format, rect,
                     total_size: crate::embedded_resources::Size{width, height},
@@ -220,6 +221,7 @@ pub fn generate(doc: &Document) -> TokenStream {
                         };
                     )
                 },
+                #[cfg(feature = "software-renderer")]
                 crate::embedded_resources::EmbeddedResourcesKind::BitmapFontData(crate::embedded_resources::BitmapFont { family_name, character_map, units_per_em, ascent, descent, glyphs }) => {
 
                     let character_map_size = character_map.len();


### PR DESCRIPTION
Limit the dependency tree of things like the interpreter or the C++ compiler that doesn't support it anyway.
It is still enabled inconditionally in slint-build though