### PR TITLE
doc: hide the testing module from slint::interpreter

### DIFF
--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1062,7 +1062,7 @@ pub fn run_event_loop() {
     i_slint_backend_selector::with_platform(|b| b.run_event_loop());
 }
 
-/// This module contains a few function use by tests
+/// This module contains a few functions used by the tests
 #[doc(hidden)]
 pub mod testing {
     use super::ComponentHandle;

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1063,6 +1063,7 @@ pub fn run_event_loop() {
 }
 
 /// This module contains a few function use by tests
+#[doc(hidden)]
 pub mod testing {
     use super::ComponentHandle;
     use i_slint_core::window::WindowInner;


### PR DESCRIPTION
This is not meant to be public API.