### PR TITLE
Fix temporary regression of window background not being drawn with the software renderer

### DIFF
--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -190,7 +190,7 @@ impl<const MAX_BUFFER_AGE: usize> SoftwareRenderer<MAX_BUFFER_AGE> {
                 LogicalLength::zero(),
             );
 
-            if background.is_transparent() {
+            if !background.is_transparent() {
                 // FIXME: gradient
                 renderer.actual_renderer.processor.process_rectangle(to_draw, background.color());
             }


### PR DESCRIPTION
There was an error drawing the window background in the software renderer because of a wrong check.