### PR TITLE
Don't generate setter for output properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
    There was a warning about this change in previous versions (#1394)
  - `Window`'s `default-font-size` property is now always set to a non-zero value, provided by 
    either the style or the backend.
+ - In the interpreter, calling `set_property` or `get_property` on properties of the base no longer works.
 
 ### Added
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -174,6 +174,7 @@ pub fn generate(doc: &Document) -> TokenStream {
         std::iter::once(ident(&glob.name)).chain(glob.aliases.iter().map(|x| ident(x)))
     });
 
+    #[cfg(feature = "software-renderer")]
     let link_section =
         std::env::var("SLINT_ASSET_SECTION").ok().map(|section| quote!(#[link_section = #section]));
 

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -352,4 +352,11 @@ impl PublicComponent {
     }
 }
 
-pub type PublicProperties = BTreeMap<String, (Type, PropertyReference)>;
+#[derive(Debug, Clone)]
+pub struct PublicProperty {
+    pub name: String,
+    pub ty: Type,
+    pub prop: PropertyReference,
+    pub read_only: bool,
+}
+pub type PublicProperties = Vec<PublicProperty>;

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -7,7 +7,7 @@ use crate::expression_tree::Expression as tree_Expression;
 use crate::langtype::{ElementType, Type};
 use crate::llr::item_tree::*;
 use crate::namedreference::NamedReference;
-use crate::object_tree::{Component, ElementRc};
+use crate::object_tree::{Component, ElementRc, PropertyVisibility};
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -661,7 +661,12 @@ fn public_properties(
         .map(|(p, c)| {
             let property_reference = mapping
                 .map_property_reference(&NamedReference::new(&component.root_element, p), state);
-            (p.clone(), (c.property_type.clone(), property_reference))
+            PublicProperty {
+                name: p.clone(),
+                ty: c.property_type.clone(),
+                prop: property_reference,
+                read_only: c.visibility == PropertyVisibility::Output,
+            }
         })
         .collect()
 }

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -11,13 +11,13 @@ pub fn count_property_use(root: &PublicComponent) {
     // Visit the root properties that are used.
     // 1. the public properties
     let root_ctx = EvaluationContext::new_sub_component(root, &root.item_tree.root, (), None);
-    for (_, pr) in root.public_properties.values() {
-        visit_property(pr, &root_ctx);
+    for p in root.public_properties.iter() {
+        visit_property(&p.prop, &root_ctx);
     }
     for g in root.globals.iter().filter(|g| g.exported) {
         let ctx = EvaluationContext::new_global(root, g, ());
-        for (_, pr) in g.public_properties.values() {
-            visit_property(pr, &ctx);
+        for p in g.public_properties.iter() {
+            visit_property(&p.prop, &ctx);
         }
     }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -833,6 +833,7 @@ impl Element {
                     PropertyDeclaration {
                         property_type: Type::InferredCallback,
                         node: Some(Either::Right(sig_decl)),
+                        visibility: PropertyVisibility::InOut,
                         ..Default::default()
                     },
                 );
@@ -848,6 +849,7 @@ impl Element {
                 PropertyDeclaration {
                     property_type: Type::Callback { return_type, args },
                     node: Some(Either::Right(sig_decl)),
+                    visibility: PropertyVisibility::InOut,
                     ..Default::default()
                 },
             );


### PR DESCRIPTION
Also make it an error to change the value from the interpreter