### PR TITLE
LSP: Keep current document version around

### DIFF
--- a/editors/vscode/src/browser-lsp-worker.ts
+++ b/editors/vscode/src/browser-lsp-worker.ts
@@ -40,11 +40,11 @@ slint_init(slint_wasm_data).then((_) => {
     });
 
     connection.onDidChangeTextDocument(async (param) => {
-        await the_lsp.reload_document(param.contentChanges[param.contentChanges.length - 1].text, param.textDocument.uri);
+        await the_lsp.reload_document(param.contentChanges[param.contentChanges.length - 1].text, param.textDocument.uri, param.textDocument.version);
     });
 
     connection.onDidOpenTextDocument(async (param) => {
-        await the_lsp.reload_document(param.textDocument.text, param.textDocument.uri);
+        await the_lsp.reload_document(param.textDocument.text, param.textDocument.uri, param.textDocument.version);
     });
 
     // Listen on the connection

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -184,6 +184,7 @@ pub fn handle_notification(
                 &ServerNotifier(connection.sender.clone()),
                 params.text_document.text,
                 params.text_document.uri,
+                params.text_document.version,
                 document_cache,
             ))?;
         }
@@ -193,6 +194,7 @@ pub fn handle_notification(
                 &ServerNotifier(connection.sender.clone()),
                 params.content_changes.pop().unwrap().text,
                 params.text_document.uri,
+                params.text_document.version,
                 document_cache,
             ))?;
         }

--- a/tools/lsp/test.rs
+++ b/tools/lsp/test.rs
@@ -28,7 +28,7 @@ pub fn loaded_document_cache(
         if cfg!(target_family = "windows") { "c://foo/bar.slint" } else { "/foo/bar.slint" };
     let url = Url::from_file_path(dummy_absolute_path).unwrap();
     let diag = spin_on::spin_on(async {
-        reload_document_impl(content, url.clone(), &mut dc)
+        reload_document_impl(content, url.clone(), 42, &mut dc)
             .await
             .expect("reload_document_impl failed.")
     });

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -181,16 +181,22 @@ impl SlintServer {
     }
 
     #[wasm_bindgen]
-    pub fn reload_document(&self, content: String, uri: JsValue) -> js_sys::Promise {
+    pub fn reload_document(&self, content: String, uri: JsValue, version: i32) -> js_sys::Promise {
         let document_cache = self.document_cache.clone();
         let notifier = self.notifier.clone();
         let guard = self.reentry_guard.clone();
         wasm_bindgen_futures::future_to_promise(async move {
             let _lock = ReentryGuard::lock(guard).await;
             let uri: lsp_types::Url = serde_wasm_bindgen::from_value(uri)?;
-            server_loop::reload_document(&notifier, content, uri, &mut document_cache.borrow_mut())
-                .await
-                .map_err(|e| JsError::new(&e.to_string()))?;
+            server_loop::reload_document(
+                &notifier,
+                content,
+                uri,
+                version,
+                &mut document_cache.borrow_mut(),
+            )
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
             Ok(JsValue::UNDEFINED)
         })
     }

--- a/tools/online_editor/src/worker/lsp_worker.ts
+++ b/tools/online_editor/src/worker/lsp_worker.ts
@@ -41,14 +41,16 @@ slint_init().then((_) => {
     connection.onDidChangeTextDocument(async (param) => {
         await the_lsp.reload_document(
             param.contentChanges[param.contentChanges.length - 1].text,
-            param.textDocument.uri
+            param.textDocument.uri,
+            param.textDocument.version
         );
     });
 
     connection.onDidOpenTextDocument(async (param) => {
         await the_lsp.reload_document(
             param.textDocument.text,
-            param.textDocument.uri
+            param.textDocument.uri,
+            param.textDocument.version
         );
     });
 


### PR DESCRIPTION
This will become helpful when actually updating the documents as it can help to detect races.