### PR TITLE
lsp: Use proper LSP types for `queryProperties`

### DIFF
--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -76,9 +76,8 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
 
             let r = await vscode.commands.executeCommand(
                 "queryProperties",
-                event.textEditor.document.uri.toString(),
-                selection.active.line,
-                selection.active.character,
+                { uri: event.textEditor.document.uri.toString(), },
+                { line: selection.active.line, character: selection.active.character, },
             );
             const msg = {
                 command: "set_properties",

--- a/tools/online_editor/src/editor_widget.ts
+++ b/tools/online_editor/src/editor_widget.ts
@@ -4,9 +4,7 @@
 // cSpell: ignore lumino inmemory mimetypes printerdemo
 
 import { slint_language } from "./highlighting";
-import {
-    lsp_range_to_editor_range,
-} from "./lsp_integration";
+import { lsp_range_to_editor_range } from "./lsp_integration";
 import {
     PropertyQuery,
     BindingTextProvider,
@@ -439,9 +437,11 @@ class EditorPaneWidget extends Widget {
                         commands
                             .executeCommand(
                                 "queryProperties",
-                                uri.toString(),
-                                pos.position.lineNumber - 1,
-                                offset,
+                                { uri: uri.toString() },
+                                {
+                                    line: pos.position.lineNumber - 1,
+                                    character: offset,
+                                },
                             )
                             .then((r) => {
                                 const result = r as PropertyQuery;


### PR DESCRIPTION
Use the right LSP types for text document and position. Makes things a bit simpler :-)