### PR TITLE
tools: Make use of embedded properties value

### DIFF
--- a/editors/vscode/src/propertiesView.ts
+++ b/editors/vscode/src/propertiesView.ts
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import { BindingTextProvider, DefinitionPosition, PropertiesView } from "../../../tools/online_editor/src/shared/properties";
+import { DefinitionPosition, PropertiesView } from "../../../tools/online_editor/src/shared/properties";
 
 let node = PropertiesView.createNode();
 let view = new PropertiesView(node);
@@ -15,36 +15,8 @@ view.change_property = (uri, p, new_value, old_value) => {
     vscode.postMessage({ command: 'change_property', uri: uri, property: p, old_value: old_value, new_value: new_value });
 };
 
-class TextProvider implements BindingTextProvider {
-    #code: string[];
-    constructor(code: string) {
-        this.#code = code.split('\n');
-    }
-
-    binding_text(location: DefinitionPosition): string {
-        let l = location.expression_range.start.line;
-        const line_utf8 = new TextEncoder().encode(this.#code[l]);
-        const l_end = location.expression_range.end.line;
-        if (l == l_end) {
-            return new TextDecoder().decode(
-                line_utf8.slice(location.expression_range.start.character, location.expression_range.end.character));
-        }
-        let result = new TextDecoder().decode(
-            line_utf8.slice(location.expression_range.start.character));
-        l++;
-        while (l < l_end) {
-            result += "\n" + this.#code[l];
-            l++;
-        }
-        const end_utf8 = new TextEncoder().encode(this.#code[l]);
-        return result + new TextDecoder().decode(
-            end_utf8.slice(0, location.expression_range.end.character));
-    }
-}
-
-
 window.addEventListener('message', async event => {
     if (event.data.command === "set_properties") {
-        view.set_properties(new TextProvider(event.data.code), event.data.properties);
+        view.set_properties(event.data.properties);
     }
 });

--- a/tools/online_editor/src/editor_widget.ts
+++ b/tools/online_editor/src/editor_widget.ts
@@ -4,12 +4,7 @@
 // cSpell: ignore lumino inmemory mimetypes printerdemo
 
 import { slint_language } from "./highlighting";
-import { lsp_range_to_editor_range } from "./lsp_integration";
-import {
-    PropertyQuery,
-    BindingTextProvider,
-    DefinitionPosition,
-} from "./shared/properties";
+import { PropertyQuery } from "./shared/properties";
 import { FilterProxyReader } from "./proxy";
 import {
     TextPosition,
@@ -105,10 +100,7 @@ function tabTitleFromURL(url: monaco.Uri): string {
     }
 }
 
-type PropertyDataNotifier = (
-    _binding_text_provider: BindingTextProvider,
-    _p: PropertyQuery,
-) => void;
+type PropertyDataNotifier = (_p: PropertyQuery) => void;
 
 class EditorPaneWidget extends Widget {
     auto_compile = true;
@@ -448,10 +440,7 @@ class EditorPaneWidget extends Widget {
                                 const result_str = JSON.stringify(result);
                                 if (this.#current_properties != result_str) {
                                     this.#current_properties = result_str;
-                                    this.onNewPropertyData?.(
-                                        new ModelBindingTextProvider(model),
-                                        result,
-                                    );
+                                    this.onNewPropertyData?.(result);
                                 }
                             });
                     }
@@ -823,25 +812,5 @@ export class EditorWidget extends Widget {
 
     get position(): DocumentAndTextPosition {
         return this.#editor.position;
-    }
-}
-
-class ModelBindingTextProvider implements BindingTextProvider {
-    #model: monaco.editor.ITextModel;
-    constructor(model: monaco.editor.ITextModel) {
-        this.#model = model;
-    }
-
-    binding_text(location: DefinitionPosition): string {
-        const monaco_range = lsp_range_to_editor_range(
-            this.#model,
-            location.expression_range,
-        );
-
-        if (monaco_range == null) {
-            return "";
-        }
-
-        return this.#model.getValueInRange(monaco_range);
     }
 }

--- a/tools/online_editor/src/index.ts
+++ b/tools/online_editor/src/index.ts
@@ -369,8 +369,8 @@ function main() {
         [
             () => {
                 const properties = new PropertiesWidget();
-                editor.onNewPropertyData = (binding_text_provider, p) => {
-                    properties.set_properties(binding_text_provider, p);
+                editor.onNewPropertyData = (p) => {
+                    properties.set_properties(p);
                 };
 
                 properties.on_goto_position = (uri, pos) => {

--- a/tools/online_editor/src/properties_widget.ts
+++ b/tools/online_editor/src/properties_widget.ts
@@ -3,22 +3,15 @@
 
 // cSpell: ignore lumino
 
-
 import { GotoPositionCallback, ReplaceTextFunction, TextRange } from "./text";
-import {
-    lsp_range_to_editor_range,
-} from "./lsp_integration";
+import { lsp_range_to_editor_range } from "./lsp_integration";
 
 import { Message } from "@lumino/messaging";
 import { Widget } from "@lumino/widgets";
 
-import {
-    BindingTextProvider,
-    PropertyQuery,
-    DefinitionPosition,
-} from "./shared/properties";
+import { PropertyQuery, DefinitionPosition } from "./shared/properties";
 
-import { PropertiesView } from "./shared/properties"
+import { PropertiesView } from "./shared/properties";
 
 function editor_definition_range(
     uri: string,
@@ -57,8 +50,13 @@ export class PropertiesWidget extends Widget {
             if (expression_range != null) {
                 this.#onGotoPosition(uri, expression_range);
             }
-        }
-        this.#propertiesView.change_property = (uri, p, current_text, code_text) => {
+        };
+        this.#propertiesView.change_property = (
+            uri,
+            p,
+            current_text,
+            code_text,
+        ) => {
             const expression_range = editor_definition_range(uri, p.defined_at);
             if (expression_range != null) {
                 this.replace_property_value(
@@ -68,7 +66,7 @@ export class PropertiesWidget extends Widget {
                     (old_text) => old_text == code_text,
                 );
             }
-        }
+        };
     }
 
     private replace_property_value(
@@ -93,11 +91,7 @@ export class PropertiesWidget extends Widget {
         this.#replaceText = fn;
     }
 
-    set_properties(
-        binding_text_provider: BindingTextProvider,
-        properties: PropertyQuery,
-    ) {
-        this.#propertiesView.set_properties(binding_text_provider, properties);
+    set_properties(properties: PropertyQuery) {
+        this.#propertiesView.set_properties(properties);
     }
-
 }

--- a/tools/online_editor/src/shared/properties.ts
+++ b/tools/online_editor/src/shared/properties.ts
@@ -32,10 +32,6 @@ export interface Element {
     range: LspRange | null;
 }
 
-export interface BindingTextProvider {
-    binding_text(_location: DefinitionPosition): string;
-}
-
 export interface PropertyQuery {
     source_uri: string;
     source_version: number;
@@ -140,11 +136,7 @@ export class PropertiesView {
         }
     }
 
-    private populate_table(
-        binding_text_provider: BindingTextProvider,
-        properties: Property[],
-        uri: LspURI,
-    ) {
+    private populate_table(properties: Property[], uri: LspURI) {
         const table = this.tableNode;
 
         let current_group = "";
@@ -190,9 +182,7 @@ export class PropertiesView {
             const input = document.createElement("input");
             input.type = "text";
             if (p.defined_at != null) {
-                const code_text = binding_text_provider.binding_text(
-                    p.defined_at,
-                );
+                const code_text = p.defined_at.expression_value;
                 input.value = code_text;
                 const changed_class = "value-changed";
                 input.addEventListener("focus", (_) => {
@@ -228,15 +218,8 @@ export class PropertiesView {
         }
     }
 
-    set_properties(
-        binding_text_provider: BindingTextProvider,
-        properties: PropertyQuery,
-    ) {
+    set_properties(properties: PropertyQuery) {
         this.set_header(properties.element);
-        this.populate_table(
-            binding_text_provider,
-            properties.properties,
-            properties.source_uri,
-        );
+        this.populate_table(properties.properties, properties.source_uri);
     }
 }


### PR DESCRIPTION
Make use of embedded properties values in VSCode extension and online editor.

This removes all code related to `BindingTextProvider`.