### PR TITLE
Make sure that the Clip element created for a visible binding has an empty size

### DIFF
--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -48,10 +48,11 @@ pub fn handle_visible(component: &Rc<Component>, type_register: &TypeRegister) {
                 if child.borrow().repeated.is_some() {
                     let root_elem = child.borrow().base_type.as_component().root_element.clone();
                     if has_visible_binding(&root_elem) {
-                        object_tree::inject_element_as_repeated_element(
-                            &child,
-                            create_visibility_element(&root_elem, &native_clip),
-                        )
+                        let clip_elem = create_visibility_element(&root_elem, &native_clip);
+                        object_tree::inject_element_as_repeated_element(&child, clip_elem.clone());
+                        // The width and the height must be null
+                        clip_elem.borrow_mut().bindings.remove("width");
+                        clip_elem.borrow_mut().bindings.remove("height");
                     }
                 } else if has_visible_binding(&child) {
                     let new_child = create_visibility_element(&child, &native_clip);

--- a/tests/cases/issues/issue_1846_visibility_in_for.slint
+++ b/tests/cases/issues/issue_1846_visibility_in_for.slint
@@ -1,0 +1,51 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+TestCase := Rectangle {
+    height: 100phx;
+    width: 100phx;
+    property <int> clicked;
+    property <bool> condition;
+
+    if true : TouchArea {
+        visible: condition;
+        clicked => { root.clicked += 1; }
+    }
+
+    HorizontalLayout {
+        for xx in [10] : TouchArea {
+            visible: false;
+            clicked => { root.clicked += xx; }
+        }
+    }
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+slint_testing::send_mouse_click(&instance, 37., 27.);
+assert_eq(instance.get_clicked(), 0);
+
+instance.set_condition(true);
+slint_testing::send_mouse_click(&instance, 37., 27.);
+assert_eq(instance.get_clicked(), 1);
+
+```
+
+
+```rust
+let instance = TestCase::new();
+slint_testing::send_mouse_click(&instance, 37., 27.);
+assert_eq!(instance.get_clicked(), 0);
+
+instance.set_condition(true);
+slint_testing::send_mouse_click(&instance, 37., 27.);
+assert_eq!(instance.get_clicked(), 1);
+
+
+```
+
+*/


### PR DESCRIPTION
The `inject_element_as_repeated_element` will create width and height binding that we should not have.

Fixes #1846