### PR TITLE
Speed up compiler syntax tests

### DIFF
--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -71,3 +71,4 @@ i-slint-parser-test-macro = { path = "./parser-test-macro" }
 
 regex = "1.3.7"
 spin_on = "0.1"
+rayon = "1.5.3"


### PR DESCRIPTION
Use rayon to run the compiler syntax tests in parallel. On my machine that reduces the time from 11 seconds to 1.5 seconds.