### PR TITLE
remove alias pass: make sure to keep priority correctly

### DIFF
--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -121,8 +121,11 @@ pub fn remove_aliases(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
             // ensure that we set an expression, because the right hand side of a binding always wins,
             // and if that was not set, we must still kee the default then
             let mut b = BindingExpression::from(Expression::default_value_for_type(&to.ty()));
-            b.priority =
-                to_elem.borrow_mut().bindings.get(to.name()).map_or(0, |x| x.borrow().priority) + 1;
+            b.priority = to_elem
+                .borrow_mut()
+                .bindings
+                .get(to.name())
+                .map_or(i32::MAX, |x| x.borrow().priority.saturating_add(1));
             b
         });
 

--- a/tests/cases/bindings/two_way_deep.slint
+++ b/tests/cases/bindings/two_way_deep.slint
@@ -1,0 +1,45 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+export LineEdit := Rectangle {
+    property <string> text <=> ti.text;
+    ti := TextInput {  }
+}
+
+LiTest := Rectangle {
+    li1 := LineEdit { text: "li1"; }
+    li2 := LineEdit { text <=> li1.text; }
+    li3 := LineEdit { text <=> li4.text; }
+    li4 := LineEdit { text: "li4"; }
+    property <bool> test_li: li1.text == "li1" && li3.text == "li4";
+}
+
+TestCase := Window {
+
+    li := LiTest {  }
+
+    property <bool> test: li.test_li;
+}
+
+/*
+
+```rust
+let instance = TestCase::new();
+assert!(instance.get_test());
+```
+
+
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
Fixes the bug that caused the TextEdit in the gallery to sometimes be empty.

Generated default value without any priority means it should not be taken against a real binding if set