### PR TITLE
internal: move the setup_code as init_code into ElementRc

### DIFF
--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -368,8 +368,9 @@ fn lower_sub_component(
     });
 
     sub_component.init_code = component
-        .setup_code
+        .root_element
         .borrow()
+        .init_code
         .iter()
         .map(|e| super::lower_expression::lower_expression(e, &ctx).into())
         .collect();

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -371,6 +371,7 @@ fn lower_sub_component(
         .root_element
         .borrow()
         .init_code
+        .borrow()
         .iter()
         .map(|e| super::lower_expression::lower_expression(e, &ctx).into())
         .collect();

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -222,9 +222,6 @@ pub struct Component {
     /// the element pointer to by this field.
     pub child_insertion_point: RefCell<Option<ChildrenInsertionPoint>>,
 
-    /// Code to be inserted into the constructor
-    pub setup_code: RefCell<Vec<Expression>>,
-
     /// The list of used extra types used (recursively) by this root component.
     /// (This only make sense on the root component)
     pub used_types: RefCell<UsedSubTypes>,
@@ -468,6 +465,9 @@ pub struct Element {
     /// Currently contains also the callbacks. FIXME: should that be changed?
     pub bindings: BindingsMap,
     pub property_analysis: RefCell<HashMap<String, PropertyAnalysis>>,
+
+    /// Code to be inserted into the constructor for root elements of components
+    pub init_code: Vec<Expression>,
 
     pub children: Vec<ElementRc>,
     /// The component which contains this element.
@@ -1732,6 +1732,12 @@ pub fn visit_element_expressions(
         }
     }
     elem.borrow_mut().transitions = transitions;
+
+    let mut init_code = std::mem::take(&mut elem.borrow_mut().init_code);
+    for expr in &mut init_code {
+        vis(expr, None, &|| Type::Void)
+    }
+    elem.borrow_mut().init_code = init_code;
 }
 
 /// Visit all the named reference in an element

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -466,7 +466,10 @@ pub struct Element {
     pub bindings: BindingsMap,
     pub property_analysis: RefCell<HashMap<String, PropertyAnalysis>>,
 
-    /// Code to be inserted into the constructor for root elements of components
+    /// Code to be inserted into the constructor of components when this element is
+    /// instantiated. At the moment this is only used on the root element of components
+    /// for generated code such as font registration or initial focus setting, not for
+    /// user code.
     pub init_code: RefCell<Vec<Expression>>,
 
     pub children: Vec<ElementRc>,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -467,7 +467,7 @@ pub struct Element {
     pub property_analysis: RefCell<HashMap<String, PropertyAnalysis>>,
 
     /// Code to be inserted into the constructor for root elements of components
-    pub init_code: Vec<Expression>,
+    pub init_code: RefCell<Vec<Expression>>,
 
     pub children: Vec<ElementRc>,
     /// The component which contains this element.
@@ -1733,8 +1733,8 @@ pub fn visit_element_expressions(
     }
     elem.borrow_mut().transitions = transitions;
 
-    let mut init_code = std::mem::take(&mut elem.borrow_mut().init_code);
-    for expr in &mut init_code {
+    let init_code = std::mem::take(&mut elem.borrow_mut().init_code);
+    for expr in &mut init_code.borrow_mut().iter_mut() {
         vis(expr, None, &|| Type::Void)
     }
     elem.borrow_mut().init_code = init_code;

--- a/internal/compiler/passes/collect_custom_fonts.rs
+++ b/internal/compiler/passes/collect_custom_fonts.rs
@@ -56,7 +56,7 @@ pub fn collect_custom_fonts<'a>(
         Box::new(|font_path| Expression::StringLiteral(font_path.clone()))
     };
 
-    root_component.root_element.borrow_mut().init_code.extend(all_fonts.into_iter().map(
+    root_component.root_element.borrow().init_code.borrow_mut().extend(all_fonts.into_iter().map(
         |font_path| Expression::FunctionCall {
             function: Box::new(registration_function.clone()),
             arguments: vec![prepare_font_registration_argument(font_path)],

--- a/internal/compiler/passes/collect_custom_fonts.rs
+++ b/internal/compiler/passes/collect_custom_fonts.rs
@@ -56,11 +56,11 @@ pub fn collect_custom_fonts<'a>(
         Box::new(|font_path| Expression::StringLiteral(font_path.clone()))
     };
 
-    root_component.setup_code.borrow_mut().extend(all_fonts.into_iter().map(|font_path| {
-        Expression::FunctionCall {
+    root_component.root_element.borrow_mut().init_code.extend(all_fonts.into_iter().map(
+        |font_path| Expression::FunctionCall {
             function: Box::new(registration_function.clone()),
             arguments: vec![prepare_font_registration_argument(font_path)],
             source_location: None,
-        }
-    }));
+        },
+    ));
 }

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -170,7 +170,7 @@ pub fn embed_glyphs<'a>(
             },
         );
 
-        component.setup_code.borrow_mut().push(Expression::FunctionCall {
+        component.root_element.borrow_mut().init_code.push(Expression::FunctionCall {
             function: Box::new(Expression::BuiltinFunctionReference(
                 BuiltinFunction::RegisterBitmapFont,
                 None,

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -170,7 +170,7 @@ pub fn embed_glyphs<'a>(
             },
         );
 
-        component.root_element.borrow_mut().init_code.push(Expression::FunctionCall {
+        component.root_element.borrow().init_code.borrow_mut().push(Expression::FunctionCall {
             function: Box::new(Expression::BuiltinFunctionReference(
                 BuiltinFunction::RegisterBitmapFont,
                 None,

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -34,6 +34,7 @@ pub fn ensure_window(
         base_type: std::mem::replace(&mut win_elem_mut.base_type, window_type),
         bindings: Default::default(),
         property_analysis: Default::default(),
+        init_code: Default::default(),
         children: std::mem::take(&mut win_elem_mut.children),
         enclosing_component: win_elem_mut.enclosing_component.clone(),
         property_declarations: Default::default(),

--- a/internal/compiler/passes/focus_item.rs
+++ b/internal/compiler/passes/focus_item.rs
@@ -119,7 +119,7 @@ pub fn determine_initial_focus_item(component: &Rc<Component>, diag: &mut BuildD
             source_location: None,
         };
 
-        component.setup_code.borrow_mut().push(setup_code);
+        component.root_element.borrow_mut().init_code.push(setup_code);
     }
 }
 

--- a/internal/compiler/passes/focus_item.rs
+++ b/internal/compiler/passes/focus_item.rs
@@ -119,7 +119,7 @@ pub fn determine_initial_focus_item(component: &Rc<Component>, diag: &mut BuildD
             source_location: None,
         };
 
-        component.root_element.borrow_mut().init_code.push(setup_code);
+        component.root_element.borrow().init_code.borrow_mut().push(setup_code);
     }
 }
 

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -165,6 +165,13 @@ fn inline_element(
 
     core::mem::drop(elem_mut);
 
+    root_component
+        .root_element
+        .borrow()
+        .init_code
+        .borrow_mut()
+        .extend(inlined_component.root_element.borrow().init_code.borrow().iter().cloned());
+
     // Now fixup all binding and reference
     for e in mapping.values() {
         visit_all_named_references_in_element(e, |nr| fixup_reference(nr, &mapping));

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -194,6 +194,7 @@ fn duplicate_element_with_mapping(
             .iter()
             .map(|b| duplicate_binding(b, mapping, root_component, priority_delta))
             .collect(),
+        init_code: elem.init_code.clone(),
         property_analysis: elem.property_analysis.clone(),
         children: elem
             .children
@@ -265,7 +266,6 @@ fn duplicate_sub_component(
         embedded_file_resources: component_to_duplicate.embedded_file_resources.clone(),
         root_constraints: component_to_duplicate.root_constraints.clone(),
         child_insertion_point: component_to_duplicate.child_insertion_point.clone(),
-        setup_code: component_to_duplicate.setup_code.clone(),
         used_types: Default::default(),
         popup_windows: Default::default(),
         exported_global_names: component_to_duplicate.exported_global_names.clone(),

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -31,6 +31,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 base_type: std::mem::take(&mut elem.base_type),
                 bindings: std::mem::take(&mut elem.bindings),
                 property_analysis: std::mem::take(&mut elem.property_analysis),
+                init_code: std::mem::take(&mut elem.init_code),
                 children: std::mem::take(&mut elem.children),
                 property_declarations: std::mem::take(&mut elem.property_declarations),
                 named_references: Default::default(),

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1455,7 +1455,8 @@ impl ErasedComponentBox {
         generativity::make_guard!(guard);
         let compo_box = self.unerase(guard);
         let instance_ref = compo_box.borrow_instance();
-        for extra_init_code in self.0.component_type.original.setup_code.borrow().iter() {
+        for extra_init_code in self.0.component_type.original.root_element.borrow().init_code.iter()
+        {
             eval::eval_expression(
                 extra_init_code,
                 &mut eval::EvalLocalContext::from_component_instance(instance_ref),

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1455,7 +1455,8 @@ impl ErasedComponentBox {
         generativity::make_guard!(guard);
         let compo_box = self.unerase(guard);
         let instance_ref = compo_box.borrow_instance();
-        for extra_init_code in self.0.component_type.original.root_element.borrow().init_code.iter()
+        for extra_init_code in
+            self.0.component_type.original.root_element.borrow().init_code.borrow().iter()
         {
             eval::eval_expression(
                 extra_init_code,


### PR DESCRIPTION
This also matches the `init_code` naming in the llr component and prepares for allowing user code in that code block.