### PR TITLE
Disallow callback overrides and duplicated callback declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project are documented in this file.
  - In the interpreter, calling `set_property` or `get_property` on properties of the base no longer works.
  - Renamed the `Keys` namespace for use in `key-pressed`/`key-released` callbacks to `Key`. The
    old name continues to work.
+ - Disallow overrides or duplicated declarations of callbacks. Previously they were silently overwritten,
+   now an error is produced.
 
 ### Added
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -852,15 +852,23 @@ impl Element {
             let return_type = sig_decl
                 .ReturnType()
                 .map(|ret_ty| Box::new(type_from_node(ret_ty.Type(), diag, tr)));
-            r.property_declarations.insert(
-                name,
-                PropertyDeclaration {
-                    property_type: Type::Callback { return_type, args },
-                    node: Some(Either::Right(sig_decl)),
-                    visibility: PropertyVisibility::InOut,
-                    ..Default::default()
-                },
-            );
+            if r.property_declarations
+                .insert(
+                    name,
+                    PropertyDeclaration {
+                        property_type: Type::Callback { return_type, args },
+                        node: Some(Either::Right(sig_decl.clone())),
+                        visibility: PropertyVisibility::InOut,
+                        ..Default::default()
+                    },
+                )
+                .is_some()
+            {
+                diag.push_error(
+                    "Duplicated callback declaration".into(),
+                    &sig_decl.DeclaredIdentifier(),
+                );
+            }
         }
 
         for con_node in node.CallbackConnection() {

--- a/internal/compiler/tests/syntax/basic/item_as_property.slint
+++ b/internal/compiler/tests/syntax/basic/item_as_property.slint
@@ -15,7 +15,7 @@ Comp := Rectangle {
 
     callback cb1(Rectangle);
 //               ^error{'Rectangle' is not a valid type}
-    callback cb1() -> Rectangle;
+    callback cb2() -> Rectangle;
 //                    ^error{'Rectangle' is not a valid type}
 }
 

--- a/internal/compiler/tests/syntax/basic/signal.slint
+++ b/internal/compiler/tests/syntax/basic/signal.slint
@@ -1,6 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+Base := Rectangle {
+    callback blah;
+}
+
 SubElements := Rectangle {
     callback foobar;
     callback foobar;
@@ -37,4 +41,8 @@ SubElements := Rectangle {
     callback_with_arg(a, b, c, d) => { }
 //  ^error{'callback-with-arg' only has 2 arguments, but 4 were provided}
 
+    Base {
+        callback blah;
+//              ^error{Cannot override callback 'blah'}        
+    }
 }

--- a/internal/compiler/tests/syntax/basic/signal.slint
+++ b/internal/compiler/tests/syntax/basic/signal.slint
@@ -3,6 +3,8 @@
 
 SubElements := Rectangle {
     callback foobar;
+    callback foobar;
+//          ^error{Duplicated callback declaration}    
 
     callback callback_with_arg(int, string);
 


### PR DESCRIPTION
A duplicated callback would silently overwrite the previous declaration, which is counter-intuitive.