### PR TITLE
Fixed: regression mcu simulator misisng OpenGLContext

### DIFF
--- a/examples/carousel/rust/main.rs
+++ b/examples/carousel/rust/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 #![cfg_attr(feature = "mcu-board-support", no_std)]
-#![cfg_attr(all(feature = "mcu-board-support", not(simulator)), no_main)]
+#![cfg_attr(all(feature = "mcu-board-support", not(feature = "simulator")), no_main)]
 
 #[cfg(feature = "mcu-board-support")]
 extern crate alloc;
@@ -23,7 +23,7 @@ pub fn main() {
     MainWindow::new().run()
 }
 
-#[cfg(all(feature = "mcu-board-support", not(feature = "simulator")))]
+#[cfg(feature = "mcu-board-support")]
 #[mcu_board_support::entry]
 fn main() -> ! {
     mcu_board_support::init();

--- a/examples/carousel/rust/main.rs
+++ b/examples/carousel/rust/main.rs
@@ -23,7 +23,7 @@ pub fn main() {
     MainWindow::new().run()
 }
 
-#[cfg(feature = "mcu-board-support")]
+#[cfg(all(feature = "mcu-board-support", not(feature = "simulator")))]
 #[mcu_board_support::entry]
 fn main() -> ! {
     mcu_board_support::init();

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -26,6 +26,7 @@ renderer-winit-skia-opengl = ["skia-safe/gl", "glow", "unicode-segmentation"]
 renderer-winit-software = ["femtovg", "imgref", "rgb"]
 rtti = ["i-slint-core/rtti"]
 default = []
+simulator = []
 
 [dependencies]
 i-slint-core = { version = "=0.3.2", path = "../../../internal/core" }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -13,9 +13,9 @@ use std::rc::Rc;
 
 mod glwindow;
 use glwindow::*;
-#[cfg(any(feature = "renderer-winit-femtovg", skia_backend_opengl))]
+#[cfg(any(feature = "renderer-winit-femtovg", feature = "renderer-winit-software", skia_backend_opengl))]
 mod glcontext;
-#[cfg(any(feature = "renderer-winit-femtovg", skia_backend_opengl))]
+#[cfg(any(feature = "renderer-winit-femtovg", feature = "renderer-winit-software", skia_backend_opengl))]
 use glcontext::*;
 pub(crate) mod event_loop;
 mod renderer {

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -13,9 +13,17 @@ use std::rc::Rc;
 
 mod glwindow;
 use glwindow::*;
-#[cfg(any(feature = "renderer-winit-femtovg", feature = "renderer-winit-software", skia_backend_opengl))]
+#[cfg(any(
+    feature = "renderer-winit-femtovg",
+    feature = "renderer-winit-software",
+    skia_backend_opengl
+))]
 mod glcontext;
-#[cfg(any(feature = "renderer-winit-femtovg", feature = "renderer-winit-software", skia_backend_opengl))]
+#[cfg(any(
+    feature = "renderer-winit-femtovg",
+    feature = "renderer-winit-software",
+    skia_backend_opengl
+))]
 use glcontext::*;
 pub(crate) mod event_loop;
 mod renderer {


### PR DESCRIPTION
* Fixed missing `glcontext` use for `renderer-winit-software` feature which the simulator depends on. 