### PR TITLE
Fix support for multiple import statements from the same path

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -118,7 +118,7 @@ impl Document {
                 node.ImportSpecifier()
                     .last()
                     .and_then(|import| {
-                        crate::typeloader::ImportedName::extract_imported_names(&[import]).pop()
+                        crate::typeloader::ImportedName::extract_imported_names(&[import]).next()
                     })
                     .and_then(|import| local_registry.lookup_element(&import.internal_name).ok())
                     .and_then(|c| match c {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -118,7 +118,7 @@ impl Document {
                 node.ImportSpecifier()
                     .last()
                     .and_then(|import| {
-                        crate::typeloader::ImportedName::extract_imported_names(&[import]).next()
+                        crate::typeloader::ImportedName::extract_imported_names(&import).next()
                     })
                     .and_then(|import| local_registry.lookup_element(&import.internal_name).ok())
                     .and_then(|c| match c {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -118,8 +118,9 @@ impl Document {
                 node.ImportSpecifier()
                     .last()
                     .and_then(|import| {
-                        crate::typeloader::ImportedName::extract_imported_names(&import)
-                            .and_then(|it| it.last())
+                        crate::typeloader::ImportedName::extract_imported_names(&[import])
+                            .last()
+                            .cloned()
                     })
                     .and_then(|import| local_registry.lookup_element(&import.internal_name).ok())
                     .and_then(|c| match c {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -118,7 +118,7 @@ impl Document {
                 node.ImportSpecifier()
                     .last()
                     .and_then(|import| {
-                        crate::typeloader::ImportedName::extract_imported_names(&import).next()
+                        crate::typeloader::ImportedName::extract_imported_names(&import).last()
                     })
                     .and_then(|import| local_registry.lookup_element(&import.internal_name).ok())
                     .and_then(|c| match c {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -118,9 +118,7 @@ impl Document {
                 node.ImportSpecifier()
                     .last()
                     .and_then(|import| {
-                        crate::typeloader::ImportedName::extract_imported_names(&[import])
-                            .last()
-                            .cloned()
+                        crate::typeloader::ImportedName::extract_imported_names(&[import]).pop()
                     })
                     .and_then(|import| local_registry.lookup_element(&import.internal_name).ok())
                     .and_then(|c| match c {

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -229,7 +229,6 @@ fn parse_import_specifier(p: &mut impl Parser) -> bool {
 /// ```test,ImportIdentifierList
 /// { Type1 }
 /// { Type2, Type3 }
-/// { }
 /// { Type as Alias1, Type as AnotherAlias }
 /// ```
 fn parse_import_identifier_list(p: &mut impl Parser) -> bool {
@@ -237,8 +236,9 @@ fn parse_import_identifier_list(p: &mut impl Parser) -> bool {
     if !p.expect(SyntaxKind::LBrace) {
         return false;
     }
-    if p.test(SyntaxKind::RBrace) {
-        return true;
+    if p.peek().kind == SyntaxKind::RBrace {
+        p.error("Import names are missing. Please specify which types you would like to import");
+        return false;
     }
     loop {
         parse_import_identifier(&mut *p);

--- a/internal/compiler/tests/syntax/imports/import_error2.slint
+++ b/internal/compiler/tests/syntax/imports/import_error2.slint
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import { SomeRect } from "../../typeloader/incpath/local_helper_type.slint";
+import "../../typeloader/incpath/local_helper_type.slint";
+//     ^error{Import names are missing. Please specify which types you would like to import}
+
+X := Rectangle {
+
+}

--- a/internal/compiler/tests/syntax/imports/import_parse_error4.slint
+++ b/internal/compiler/tests/syntax/imports/import_parse_error4.slint
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import { } from yo;
-//              ^error{Expected plain string literal}
+import { Foo } from yo;
+//                  ^error{Expected plain string literal}

--- a/internal/compiler/tests/syntax/imports/import_parse_error5.slint
+++ b/internal/compiler/tests/syntax/imports/import_parse_error5.slint
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import { NotExported } from "../../typeloader/incpath/local_helper_type.slint";
+import { } from "../../typeloader/incpath/local_helper_type.slint";
+//       ^error{Import names are missing. Please specify which types you would like to import}
+
+X := Rectangle {
+
+}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -37,13 +37,14 @@ pub struct ImportedName {
 
 impl ImportedName {
     pub fn extract_imported_names(imports: &[syntax_nodes::ImportSpecifier]) -> Vec<ImportedName> {
-        let mut imported_names = Vec::new();
-        for import in imports {
-            if let Some(import_identifiers) = import.ImportIdentifierList() {
-                imported_names.extend(import_identifiers.ImportIdentifier().map(Self::from_node));
-            }
-        }
-        imported_names
+        imports
+            .iter()
+            .flat_map(|import| {
+                import.ImportIdentifierList().into_iter().flat_map(|import_identifiers| {
+                    import_identifiers.ImportIdentifier().map(Self::from_node)
+                })
+            })
+            .collect::<Vec<_>>()
     }
 
     pub fn from_node(importident: syntax_nodes::ImportIdentifier) -> Self {

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -27,7 +27,7 @@ pub struct ImportedTypes {
     pub file: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ImportedName {
     // name of export to match in the other file
     pub external_name: String,

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -450,7 +450,7 @@ impl TypeLoader {
 
             Some(ImportedTypes {
                 import_token: import_uri,
-                imported_types: import.clone(),
+                imported_types: import,
                 file: path_to_import,
             })
         })

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -39,10 +39,9 @@ impl ImportedName {
     pub fn extract_imported_names(imports: &[syntax_nodes::ImportSpecifier]) -> Vec<ImportedName> {
         imports
             .iter()
-            .flat_map(|import| {
-                import.ImportIdentifierList().into_iter().flat_map(|import_identifiers| {
-                    import_identifiers.ImportIdentifier().map(Self::from_node)
-                })
+            .filter_map(|import| import.ImportIdentifierList())
+            .flat_map(|import_identifiers| {
+                import_identifiers.ImportIdentifier().map(Self::from_node)
             })
             .collect::<Vec<_>>()
     }

--- a/tests/cases/imports/import_multi.slint
+++ b/tests/cases/imports/import_multi.slint
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import { ExportedA } from "./exported_component.slint";
+import { ExportedB } from "./exported_component.slint";
+
+TestCase := Rectangle {
+    ExportedA {}
+    ExportedB {}
+}


### PR DESCRIPTION
Importing multiple types from the same file with multiple import statements would produce an error, while this should work:

```
import { SomeType } from "somefile.slint";
import { AnotherType } from "somefile.slint";
```