### PR TITLE
SoftwareRenderer: render texture with opacity and color alpha channel

### DIFF
--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -597,7 +597,7 @@ struct SceneTexture<'a> {
     stride: u16,
     source_size: PhysicalSize,
     color: Color,
-    alpha: u8
+    alpha: u8,
 }
 
 struct SharedBufferCommand {
@@ -605,7 +605,7 @@ struct SharedBufferCommand {
     /// The source rectangle that is mapped into this command span
     source_rect: PhysicalRect,
     colorize: Color,
-    alpha: u8
+    alpha: u8,
 }
 
 impl SharedBufferCommand {
@@ -620,7 +620,7 @@ impl SharedBufferCommand {
                 format: PixelFormat::Rgb,
                 source_size: self.source_rect.size,
                 color: self.colorize,
-                alpha:self.alpha
+                alpha: self.alpha,
             },
             SharedImageBuffer::RGBA8(b) => SceneTexture {
                 data: &b.as_bytes()[begin * 4..],
@@ -628,7 +628,7 @@ impl SharedBufferCommand {
                 format: PixelFormat::Rgba,
                 source_size: self.source_rect.size,
                 color: self.colorize,
-                alpha: self.alpha
+                alpha: self.alpha,
             },
             SharedImageBuffer::RGBA8Premultiplied(b) => SceneTexture {
                 data: &b.as_bytes()[begin * 4..],
@@ -636,7 +636,7 @@ impl SharedBufferCommand {
                 format: PixelFormat::RgbaPremultiplied,
                 source_size: self.source_rect.size,
                 color: self.colorize,
-                alpha:self.alpha
+                alpha: self.alpha,
             },
         }
     }
@@ -866,7 +866,7 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
         image_fit: ImageFit,
         colorize: Color,
     ) {
-        let alpha = self.current_state.alpha_u8();
+        let alpha_u16 = self.current_state.alpha_u8() as u16;
         let image_inner: &ImageInner = source.into();
         let size: euclid::default::Size2D<u32> = source_rect.size.cast();
         let phys_size = geom.size_length().cast() * self.scale_factor;
@@ -934,6 +934,8 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
                             + source_rect.origin.y as usize
                             - t.rect.origin.y as usize;
                         let stride = t.rect.width() as u16 * t.format.bpp() as u16;
+                        let t_alpha_u16 = t.color.alpha() as u16;
+
                         self.processor.process_texture(
                             target_rect.cast(),
                             SceneTexture {
@@ -944,7 +946,13 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
                                 source_size: clipped_relative_source_rect.size.ceil().cast(),
                                 format: t.format,
                                 color: if colorize.alpha() > 0 { colorize } else { t.color },
-                                alpha: self.current_state.alpha_u8()
+                                alpha: if colorize.alpha() > 0 {
+                                    (((alpha_u16 * colorize.alpha() as u16) / 255
+                                        * t_alpha_u16 as u16)
+                                        / 255) as u8
+                                } else {
+                                    ((alpha_u16 * t_alpha_u16) / 255) as u8
+                                },
                             },
                         );
                     }
@@ -984,7 +992,9 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
                                     )
                                     .cast(),
                                 colorize,
-                                alpha
+                                alpha: ((self.current_state.alpha_u8() as u16
+                                    * colorize.alpha() as u16)
+                                    / 255) as u8,
                             },
                         );
                     }
@@ -1250,6 +1260,7 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
                             source_size: geometry.size,
                             format: PixelFormat::AlphaMap,
                             color,
+                            alpha: self.current_state.alpha_u8(),
                         },
                     );
                 }

--- a/internal/core/software_renderer/draw_functions.rs
+++ b/internal/core/software_renderer/draw_functions.rs
@@ -20,7 +20,7 @@ pub(super) fn draw_texture_line(
     texture: &super::SceneTexture,
     line_buffer: &mut [impl TargetPixel],
 ) {
-    let super::SceneTexture { data, format, stride, source_size, color } = *texture;
+    let super::SceneTexture { data, format, stride, source_size, color, alpha } = *texture;
     let source_size = source_size.cast::<usize>();
     let span_size = span.size.cast::<usize>();
     let bpp = format.bpp();

--- a/internal/core/software_renderer/draw_functions.rs
+++ b/internal/core/software_renderer/draw_functions.rs
@@ -26,6 +26,7 @@ pub(super) fn draw_texture_line(
     let bpp = format.bpp();
     let y = (line - span.origin.y_length()).cast::<usize>();
     let y_pos = (y.get() * source_size.height / span_size.height) * stride as usize;
+
     for (x, pix) in line_buffer
         [span.origin.x as usize..(span.origin.x_length() + span.size.width_length()).get() as usize]
         .iter_mut()
@@ -39,7 +40,7 @@ pub(super) fn draw_texture_line(
                 continue;
             }
             PixelFormat::Rgba => {
-                let alpha = data[pos + 3];
+                let alpha = ((data[pos + 3] as u16 * alpha as u16) / 255) as u8;
                 PremultipliedRgbaColor::premultiply(if color.alpha() == 0 {
                     Color::from_argb_u8(alpha, data[pos + 0], data[pos + 1], data[pos + 2])
                 } else {
@@ -47,7 +48,7 @@ pub(super) fn draw_texture_line(
                 })
             }
             PixelFormat::RgbaPremultiplied => {
-                let alpha = data[pos + 3];
+                let alpha = ((data[pos + 3] as u16 * alpha as u16) / 255) as u8;
                 if color.alpha() == 0 {
                     PremultipliedRgbaColor {
                         alpha,
@@ -65,7 +66,7 @@ pub(super) fn draw_texture_line(
                 }
             }
             PixelFormat::AlphaMap => PremultipliedRgbaColor::premultiply(Color::from_argb_u8(
-                data[pos],
+                ((data[pos] as u16 * alpha as u16) / 255) as u8,
                 color.red(),
                 color.green(),
                 color.blue(),


### PR DESCRIPTION
Now the element opacity and alpha channel of texture color and colorize will be used on rendering with the software renderer. 