### PR TITLE
Add work-in-progress support for the ESP32-S3-Box

### DIFF
--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -19,7 +19,8 @@ path = "lib.rs"
 [features]
 pico-st7789 = ["slint/unsafe-single-threaded", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "fugit", "cortex-m", "display-interface", "st7789", "defmt", "defmt-rtt", "shared-bus", "slint/libm", "embedded-dma", "embedded-graphics", "euclid/libm"]
 stm32h735g = ["slint/unsafe-single-threaded", "embedded-hal", "cortex-m/critical-section-single-core", "cortex-m-rt","alloc-cortex-m", "embedded-time", "cortex-m", "stm32h7xx-hal/stm32h735", "defmt", "defmt-rtt", "embedded-display-controller", "ft5336", "panic-probe", "slint/libm"]
-esp32-s2-kaluga-1 = ["slint/unsafe-single-threaded", "esp32s2-hal", "embedded-hal", "xtensa-lx-rt", "esp-alloc", "esp-println", "display-interface", "display-interface-spi", "st7789", "slint/libm"]
+esp32-s2-kaluga-1 = ["slint/unsafe-single-threaded", "esp32s2-hal", "embedded-hal", "xtensa-lx-rt/esp32s2", "esp-alloc", "esp-println/esp32s2", "display-interface", "display-interface-spi", "st7789", "slint/libm"]
+esp32-s3-box = ["slint/unsafe-single-threaded", "esp32s3-hal", "embedded-hal", "xtensa-lx-rt/esp32s3", "esp-alloc", "esp-println/esp32s3", "esp-backtrace/esp32s3", "display-interface", "display-interface-spi", "mipidsi", "embedded-graphics", "slint/libm"]
 
 [dependencies]
 slint = { version = "=0.3.2", path = "../../api/rs/slint", default-features = false, features = ["compat-0-3-0"] }
@@ -52,10 +53,14 @@ embedded-display-controller = { version = "0.1.0", optional = true }
 ft5336 = { version = "0.1", git = "https://github.com/bobgates/ft5336", rev = "293730a225a68b6364857602f8fb62fd0beb8a26", optional = true }
 
 esp32s2-hal = { version = "0.2", optional = true }
-xtensa-lx-rt = { version = "0.13", features = ["esp32s2"], optional = true }
+esp32s3-hal = { version = "0.1", optional = true }
+xtensa-lx-rt = { version = "0.13", optional = true }
 display-interface-spi = { version = "0.4", optional = true }
 esp-alloc = { version = "0.1", optional = true }
-esp-println = { version = "0.3.0", features = ["esp32s2"], optional = true }
+esp-println = { version = "0.3.0", optional = true }
+esp-backtrace = { version = "0.2.0", optional = true, features = ["panic-handler", "print-uart"] }
+
+mipidsi = { version = "0.3.0", optional = true }
 
 defmt-rtt = { version = "0.4.0", optional = true }
 defmt = { version = "0.3.0", optional = true }

--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -174,6 +174,9 @@ CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-run --chip STM32H735IGKx" cargo
  * ESP Rust Toolchain: https://esp-rs.github.io/book/dependencies/installing-rust.html#xtensa-esp32-esp32-s2-esp32-s3
  * `espflash`: Install via `cargo install espflash`.
 
+When flashing, with `esplash`, you will be prompted to select a USB port. If this port is always the same, then you can also pass it as a parameter on the command line to avoid the prompt. For example if
+`/dev/ttyUSB1` is the device file for your port, the command line changes to `espflash --monitor /dev/ttyUSB1 path/to/binary/to/flash_and_monitor`.
+
 #### ESP32-S2-Kaluga-1
 
 
@@ -181,7 +184,7 @@ To compile and run the demo:
 
 ```sh
 cargo +esp build -p printerdemo_mcu --target xtensa-esp32s2-none-elf --no-default-features --features=mcu-board-support/esp32-s2-kaluga-1 --release --config examples/mcu-board-support/esp32_s2_kaluga_1/cargo-config.toml
-espflash --monitor /dev/ttyUSB1 target/xtensa-esp32s2-none-elf/release/printerdemo_mcu
+espflash --monitor target/xtensa-esp32s2-none-elf/release/printerdemo_mcu
 ```
 
 The device needs to be connected with the two USB cables (one for power, one for data)

--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -170,7 +170,7 @@ CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-run --chip STM32H735IGKx" cargo
 ### ESP32-S2-Kaluga-1
 
 A esp toolchain is required: https://esp-rs.github.io/book/dependencies/installing-rust.html#xtensa-esp32-esp32-s2-esp32-s3
-Also `cargo instal espflash`
+Also `cargo install espflash`
 
 To compile and run the demo:
 

--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -167,10 +167,15 @@ Using [probe-run](https://github.com/knurling-rs/probe-run) (`cargo install prob
 CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-run --chip STM32H735IGKx" cargo +nightly run -p printerdemo_mcu --no-default-features  --features=mcu-board-support/stm32h735g --target=thumbv7em-none-eabihf --release
 ```
 
-### ESP32-S2-Kaluga-1
+### ESP32
 
-A esp toolchain is required: https://esp-rs.github.io/book/dependencies/installing-rust.html#xtensa-esp32-esp32-s2-esp32-s3
-Also `cargo install espflash`
+#### Prerequisites
+
+ * ESP Rust Toolchain: https://esp-rs.github.io/book/dependencies/installing-rust.html#xtensa-esp32-esp32-s2-esp32-s3
+ * `espflash`: Install via `cargo install espflash`.
+
+#### ESP32-S2-Kaluga-1
+
 
 To compile and run the demo:
 
@@ -181,3 +186,11 @@ espflash --monitor /dev/ttyUSB1 target/xtensa-esp32s2-none-elf/release/printerde
 
 The device needs to be connected with the two USB cables (one for power, one for data)
 
+#### ESP32-S3-Box (Experimental)
+
+To compile and run the demo:
+
+```sh
+cargo +esp build -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box --release --config examples/mcu-board-support/esp32_s3_box/cargo-config.toml
+espflash --monitor target/xtensa-esp32s3-none-elf/release/printerdemo_mcu
+```

--- a/examples/mcu-board-support/esp32_s3_box.rs
+++ b/examples/mcu-board-support/esp32_s3_box.rs
@@ -1,0 +1,195 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use core::cell::RefCell;
+use display_interface_spi::SPIInterfaceNoCS;
+use embedded_hal::digital::v2::OutputPin;
+use esp32s3_hal::{
+    clock::ClockControl,
+    pac::Peripherals,
+    prelude::*,
+    spi::{Spi, SpiMode},
+    systimer::SystemTimer,
+    timer::TimerGroup,
+    Delay, Rtc, IO,
+};
+use esp_alloc::EspHeap;
+use esp_backtrace as _;
+use mipidsi::{Display, DisplayOptions, Orientation};
+pub use xtensa_lx_rt::entry;
+
+#[alloc_error_handler]
+fn oom(layout: core::alloc::Layout) -> ! {
+    panic!("Out of memory {:?}", layout);
+}
+
+#[global_allocator]
+static ALLOCATOR: EspHeap = EspHeap::empty();
+
+pub fn init() {
+    const HEAP_SIZE: usize = 250 * 1024;
+    static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
+    unsafe { ALLOCATOR.init(&mut HEAP as *mut u8, core::mem::size_of_val(&HEAP)) }
+    slint::platform::set_platform(Box::new(EspBackend::default()))
+        .expect("backend already initialized");
+}
+
+#[derive(Default)]
+struct EspBackend {
+    window: RefCell<Option<Rc<slint::platform::software_renderer::MinimalSoftwareWindow<1>>>>,
+}
+
+impl slint::platform::Platform for EspBackend {
+    fn create_window_adapter(&self) -> Rc<dyn slint::platform::WindowAdapter> {
+        let window = slint::platform::software_renderer::MinimalSoftwareWindow::new();
+        self.window.replace(Some(window.clone()));
+        window
+    }
+
+    fn duration_since_start(&self) -> core::time::Duration {
+        core::time::Duration::from_millis(
+            SystemTimer::now() / (SystemTimer::TICKS_PER_SECOND / 1000),
+        )
+    }
+
+    fn run_event_loop(&self) {
+        let peripherals = Peripherals::take().unwrap();
+        let mut system = peripherals.SYSTEM.split();
+        let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
+        let mut rtc = Rtc::new(peripherals.RTC_CNTL);
+        let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+        let mut wdt0 = timer_group0.wdt;
+        let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+        let mut wdt1 = timer_group1.wdt;
+
+        rtc.rwdt.disable();
+        wdt0.disable();
+        wdt1.disable();
+
+        let mut delay = Delay::new(&clocks);
+        let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+        let sclk = io.pins.gpio7;
+        let mosi = io.pins.gpio6;
+
+        let spi = Spi::new_no_cs_no_miso(
+            peripherals.SPI2,
+            sclk,
+            mosi,
+            4u32.MHz(),
+            SpiMode::Mode0,
+            &mut system.peripheral_clock_control,
+            &clocks,
+        );
+
+        let dc = io.pins.gpio4.into_push_pull_output();
+        let rst = io.pins.gpio48.into_push_pull_output();
+
+        let di = SPIInterfaceNoCS::new(spi, dc);
+        let mut display = Display::ili9342c_rgb565(di, rst);
+
+        display
+            .init(
+                &mut delay,
+                DisplayOptions {
+                    orientation: Orientation::PortraitInverted(false),
+                    ..DisplayOptions::default()
+                },
+            )
+            .unwrap();
+
+        let mut backlight = io.pins.gpio45.into_push_pull_output();
+        backlight.set_high().unwrap();
+
+        let mut buffer_provider = DrawBuffer {
+            display,
+            buffer: &mut [slint::platform::software_renderer::Rgb565Pixel(0); 320],
+        };
+
+        self.window.borrow().as_ref().unwrap().set_size(slint::PhysicalSize::new(320, 240));
+
+        loop {
+            slint::platform::update_timers_and_animations();
+
+            if let Some(window) = self.window.borrow().clone() {
+                window.draw_if_needed(|renderer| {
+                    renderer.render_by_line(&mut buffer_provider);
+                });
+                if window.has_active_animations() {
+                    continue;
+                }
+            }
+            // TODO
+        }
+    }
+
+    fn debug_log(&self, arguments: core::fmt::Arguments) {
+        esp_println::println!("{}", arguments);
+    }
+}
+
+struct DrawBuffer<'a, Display> {
+    display: Display,
+    buffer: &'a mut [slint::platform::software_renderer::Rgb565Pixel],
+}
+
+impl<
+        DI: display_interface::WriteOnlyDataCommand,
+        RST: OutputPin<Error = core::convert::Infallible>,
+        MODEL: mipidsi::models::Model<ColorFormat = embedded_graphics::pixelcolor::Rgb565>,
+    > slint::platform::software_renderer::LineBufferProvider
+    for &mut DrawBuffer<'_, Display<DI, RST, MODEL>>
+{
+    type TargetPixel = slint::platform::software_renderer::Rgb565Pixel;
+
+    fn process_line(
+        &mut self,
+        line: usize,
+        range: core::ops::Range<usize>,
+        render_fn: impl FnOnce(&mut [slint::platform::software_renderer::Rgb565Pixel]),
+    ) {
+        let buffer = &mut self.buffer[range.clone()];
+
+        render_fn(buffer);
+
+        // We send empty data just to get the device in the right window
+        self.display
+            .set_pixels(
+                range.start as u16,
+                line as _,
+                range.end as u16,
+                line as u16,
+                buffer.iter().map(|x| embedded_graphics::pixelcolor::raw::RawU16::new(x.0).into()),
+            )
+            .unwrap();
+    }
+}
+
+// FIXME: implement properly upstream
+#[no_mangle]
+extern "C" fn fmaxf(a: f32, b: f32) -> f32 {
+    if a > b {
+        a
+    } else {
+        b
+    }
+}
+#[no_mangle]
+extern "C" fn fminf(a: f32, b: f32) -> f32 {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+#[no_mangle]
+extern "C" fn fmodf() {
+    unimplemented!("fmodf");
+}
+#[no_mangle]
+extern "C" fn fmod(a: f64, b: f64) -> f64 {
+    ((a as u32) % (b as u32)) as f64
+}

--- a/examples/mcu-board-support/esp32_s3_box/cargo-config.toml
+++ b/examples/mcu-board-support/esp32_s3_box/cargo-config.toml
@@ -1,0 +1,18 @@
+# Copyright © SixtyFPS GmbH <info@slint-ui.com>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+[target.xtensa-esp32s3-none-elf]
+runner = "espflash --monitor"
+
+[build]
+rustflags = [
+    "-C", "force-frame-pointers",
+    "-C",
+    "link-arg=-nostartfiles",
+    "-C",
+    "link-arg=-Wl,-Tlinkall.x",
+]
+target = "xtensa-esp32s3-none-elf"
+
+[unstable]
+build-std = ["core", "alloc"]

--- a/examples/mcu-board-support/lib.rs
+++ b/examples/mcu-board-support/lib.rs
@@ -7,7 +7,12 @@
 #![doc(html_logo_url = "https://slint-ui.com/logo/slint-logo-square-light.svg")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(
-    any(feature = "pico-st7789", feature = "stm32h735g", feature = "esp32-s2-kaluga-1"),
+    any(
+        feature = "pico-st7789",
+        feature = "stm32h735g",
+        feature = "esp32-s2-kaluga-1",
+        feature = "esp32-s3-box"
+    ),
     feature(alloc_error_handler)
 )]
 
@@ -28,12 +33,23 @@ mod esp32_s2_kaluga_1;
 #[cfg(feature = "esp32-s2-kaluga-1")]
 pub use esp32_s2_kaluga_1::*;
 
+#[cfg(feature = "esp32-s3-box")]
+mod esp32_s3_box;
+#[cfg(feature = "esp32-s3-box")]
+pub use esp32_s3_box::*;
+
 #[cfg(not(any(
     feature = "pico-st7789",
     feature = "stm32h735g",
-    feature = "esp32-s2-kaluga-1"
+    feature = "esp32-s2-kaluga-1",
+    feature = "esp32-s3-box"
 )))]
 pub use i_slint_core_macros::identity as entry;
 
-#[cfg(not(any(feature = "pico-st7789", feature = "stm32h735g", feature = "esp32-s2-kaluga-1")))]
+#[cfg(not(any(
+    feature = "pico-st7789",
+    feature = "stm32h735g",
+    feature = "esp32-s2-kaluga-1",
+    feature = "esp32-s3-box"
+)))]
 pub fn init() {}


### PR DESCRIPTION
This is a work-in-progress port of support for the ESP32-S3-Box MCU for the mcu-board-support crate, based on the S2-Kaluga implementation. It only supports screen output, but no touch or button input yet.