### PR TITLE
Document and enable the in / out keywords with the old component syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented in this file.
 
  - When using a two way binding `foo <=> bar`, the default value will always be the one of `bar`.
    There was a warning about this change in previous versions (#1394)
- - `Window`'s `default-font-size` property is now always set to a non-zero value, provided by 
+ - `Window`'s `default-font-size` property is now always set to a non-zero value, provided by
    either the style or the backend.
  - In the interpreter, calling `set_property` or `get_property` on properties of the base no longer works.
  - Renamed the `Keys` namespace for use in `key-pressed`/`key-released` callbacks to `Key`. The
@@ -19,12 +19,13 @@ All notable changes to this project are documented in this file.
 ### Added
 
  - Added `material` style with `material-light` and `fluent-dark` as explicit styles
- - Added `Window::is_visible` 
+ - Added `Window::is_visible`
  - Added `From<char>` for `SharedString` in Rust.
  - Added `KeyPressed` and `KeyReleased` variants to `slint::WindowEvent` in Rust, along
    with `slint::Key`, for use by custom platform backends.
- - Added suppport for the implicitly declared `init` callback that can be used to run code when
+ - Added support for the implicitly declared `init` callback that can be used to run code when
    an element or component is instantiated.
+ - Properties can be annotated with `in`, `out`, `in-out`, or `private`.
 
 ### Fixed
 

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -162,6 +162,31 @@ Example := Rectangle {
 }
 ```
 
+You can annotate the properties with a qualifier that specifies how the property can be read and written.
+
+ * **`private`**: The property can only be accessed from within the component.
+ * **`in`**: The property is an input, it can be set and modified by the user of this component,
+   for example through bindings or by assignment in callbacks.
+   The component can provide a default binding, but it cannot overwrite it by a `background = #abc`
+   assignment
+ * **`out`**: An output property that can only be set by the component. It is read-only for the
+   users of the components.
+ * **`in-out`** (the default): The property can be read and modified by everyone.
+
+```slint,no-preview
+Button := Rectangle {
+    // this is meant to be set by the user of the component
+    in property <string> text;
+    // This property is meant to be read by the user of the component
+    out property <bool> pressed;
+    // This property is meant to both be changed by the user and the componet itself
+    in-out property <bool> checked;
+
+    // This property is internal to this component.
+    private property <bool> has-mouse;
+}
+```
+
 ### Bindings
 
 The expression on the right of a binding is automatically re-evaluated when the expression changes.

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -162,12 +162,12 @@ Example := Rectangle {
 }
 ```
 
-You can annotate the properties with a qualifier that specifies how the property can be read and written.
+You can annotate the properties with a qualifier that specifies how the property can be read and written:
 
  * **`private`**: The property can only be accessed from within the component.
- * **`in`**: The property is an input, it can be set and modified by the user of this component,
+ * **`in`**: The property is an input. It can be set and modified by the user of this component,
    for example through bindings or by assignment in callbacks.
-   The component can provide a default binding, but it cannot overwrite it by a `background = #abc`
+   The component can provide a default binding, but it cannot overwrite it by
    assignment
  * **`out`**: An output property that can only be set by the component. It is read-only for the
    users of the components.
@@ -175,11 +175,11 @@ You can annotate the properties with a qualifier that specifies how the property
 
 ```slint,no-preview
 Button := Rectangle {
-    // this is meant to be set by the user of the component
+    // This is meant to be set by the user of the component.
     in property <string> text;
-    // This property is meant to be read by the user of the component
+    // This property is meant to be read by the user of the component.
     out property <bool> pressed;
-    // This property is meant to both be changed by the user and the componet itself
+    // This property is meant to both be changed by the user and the component itself.
     in-out property <bool> checked;
 
     // This property is internal to this component.

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -336,12 +336,7 @@ fn parse_callback_declaration(p: &mut impl Parser) {
 /// ```
 fn parse_property_declaration(p: &mut impl Parser) {
     let checkpoint = p.checkpoint();
-    let mut reported_experimental = false;
     while matches!(p.peek().as_str(), "in" | "out" | "in-out" | "in_out" | "private") {
-        if !reported_experimental && !super::enable_experimental() {
-            p.error("the input/output keywords are experimental, set `SLINT_EXPERIMENTAL_SYNTAX` env variable to enable experimental syntax. See https://github.com/slint-ui/slint/issues/1750");
-        }
-        reported_experimental = true;
         p.consume();
     }
     if p.peek().as_str() != "property" {


### PR DESCRIPTION
But it still defaults to `in-out`