### PR TITLE
Transitions can now be declared within the states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project are documented in this file.
  - Added support for the implicitly declared `init` callback that can be used to run code when
    an element or component is instantiated.
  - Properties can be annotated with `in`, `out`, `in-out`, or `private`.
+ - Transitions can now be declared directly within the state
  - Online editor: The property view can now edit properties
  - LSP preview: highlight the selected element in the preview
  - LSP: Added a setting to change the style and the include paths

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -820,18 +820,15 @@ Example := Window {
         disabled when !is-enabled : {
             background: gray; // same as root.background: gray;
             text.color: white;
+            out {
+                animate * { duration: 800ms; }
+            }
         }
         down when pressed : {
             background: blue;
-        }
-    ]
-
-    transitions [
-        in down : {
-            animate color { duration: 300ms; }
-        }
-        out disabled : {
-            animate * { duration: 800ms; }
+            in {
+                animate color { duration: 300ms; }
+            }
         }
     ]
 }

--- a/docs/recipes/recipes.md
+++ b/docs/recipes/recipes.md
@@ -297,19 +297,16 @@ export Recipe := Window {
         left-aligned when b1.pressed: {
             circle1.x: 0px; circle1.y: 40px;
             circle2.x: 0px; circle2.y: 0px;
+            in {
+                animate circle1.x, circle2.x { duration: 250ms; }
+            }
+            out {
+                animate circle1.x, circle2.x { duration: 500ms; }
+            }
         }
         right-aligned when !b1.pressed: {
             circle1.x: 170px; circle1.y: 70px;
             circle2.x: 170px; circle2.y: 00px;
-        }
-    ]
-
-    transitions [
-        in left-aligned: {
-            animate circle1.x, circle2.x { duration: 250ms; }
-        }
-        out left-aligned: {
-            animate circle1.x, circle2.x { duration: 500ms; }
         }
     ]
 

--- a/examples/printerdemo/ui/ink_page.slint
+++ b/examples/printerdemo/ui/ink_page.slint
@@ -39,14 +39,12 @@ export InkPage := Page {
                     states [
                         inactive when !root.page-visible : {
                             height: 0;
-                        }
-                    ]
-                    transitions [
-                        out inactive : {
-                            animate height { duration: 750ms; easing: ease-in-out; }
-                        }
-                        in inactive : {
-                            animate height { duration: 200ms; easing: ease-in; }
+                            out {
+                                animate height { duration: 750ms; easing: ease-in-out; }
+                            }
+                            in {
+                                animate height { duration: 200ms; easing: ease-in; }
+                            }
                         }
                     ]
                 }

--- a/examples/printerdemo/ui/printer_queue.slint
+++ b/examples/printerdemo/ui/printer_queue.slint
@@ -127,16 +127,15 @@ NarrowPrintQueueElement := Rectangle {
         expanded when expanded : {
             height: layout.min-height;
             expanded-opacity: 1;
-        }
-    ]
-    transitions [
-        in expanded : {
-            animate height { duration: 200ms; easing: ease; }
-            animate expanded-opacity { duration: 200ms; }
-        }
-        out expanded : {
-            animate height { duration: 200ms; easing: ease; }
-            animate expanded-opacity { duration: 200ms; }
+
+            in {
+                animate height { duration: 200ms; easing: ease; }
+                animate expanded-opacity { duration: 200ms; }
+            }
+            out {
+                animate height { duration: 200ms; easing: ease; }
+                animate expanded-opacity { duration: 200ms; }
+            }
         }
     ]
 

--- a/examples/printerdemo_mcu/ui/ink_page.slint
+++ b/examples/printerdemo_mcu/ui/ink_page.slint
@@ -39,18 +39,16 @@ export InkPage := Page {
                     states [
                         inactive when !root.page-visible : {
                             height: 2px;
-                        }
-                    ]
-                    transitions [
-                        out inactive : {
-                            animate height {
-                                duration: 750ms;
-                                delay: 50ms;
-                                easing: ease-in-out;
+                            out {
+                                animate height {
+                                    duration: 750ms;
+                                    delay: 50ms;
+                                    easing: ease-in-out;
+                                }
                             }
-                        }
-                        in inactive : {
-                            animate height { duration: 200ms; easing: ease-in; }
+                            in {
+                                animate height { duration: 200ms; easing: ease-in; }
+                            }
                         }
                     ]
                 }

--- a/examples/printerdemo_mcu/ui/printer_queue.slint
+++ b/examples/printerdemo_mcu/ui/printer_queue.slint
@@ -127,18 +127,18 @@ NarrowPrintQueueElement := Rectangle {
         expanded when expanded : {
             height: layout.min-height;
             expanded-opacity: 1;
+            in {
+                animate height { duration: 200ms; easing: ease; }
+                animate expanded-opacity { duration: 200ms; }
+            }
+            out {
+                animate height { duration: 200ms; easing: ease; }
+                animate expanded-opacity { duration: 200ms; }
+            }
         }
     ]
-    transitions [
-        in expanded : {
-            animate height { duration: 200ms; easing: ease; }
-            animate expanded-opacity { duration: 200ms; }
-        }
-        out expanded : {
-            animate height { duration: 200ms; easing: ease; }
-            animate expanded-opacity { duration: 200ms; }
-        }
-    ]
+
+
 
     TouchArea {
         clicked => {

--- a/examples/slide_puzzle/slide_puzzle.slint
+++ b/examples/slide_puzzle/slide_puzzle.slint
@@ -91,19 +91,16 @@ Checkbox := Rectangle {
             clip.width: root.width;
             checkbox-rect.border-color: checked-color;
             checkbox-rect.border-width: root.width;
+            in {
+                animate clip.width { duration: 200ms; easing: ease-in; }
+                animate checkbox-rect.border-width { duration: 100ms; easing: ease-out; }
+            }
+            out {
+                animate clip.width { duration: 100ms; easing: ease; }
+                animate checkbox-rect.border-width { duration: 200ms; easing: ease-in-out; }
+                animate checkbox-rect.border-color { duration: 200ms; easing: cubic-bezier(1,1,1,0); }
+            }
         }
-    ]
-    transitions [
-        in checked : {
-            animate clip.width { duration: 200ms; easing: ease-in; }
-            animate checkbox-rect.border-width { duration: 100ms; easing: ease-out; }
-        }
-        out checked : {
-            animate clip.width { duration: 100ms; easing: ease; }
-            animate checkbox-rect.border-width { duration: 200ms; easing: ease-in-out; }
-            animate checkbox-rect.border-color { duration: 200ms; easing: cubic-bezier(1,1,1,0); }
-        }
-
     ]
 }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1116,9 +1116,14 @@ impl Element {
             r.borrow_mut().states.push(s);
         }
 
-        for trs in node.Transitions().flat_map(|s| s.Transition()) {
-            let trans = Transition::from_node(trs, &r, tr, diag);
-            r.borrow_mut().transitions.push(trans);
+        for ts in node.Transitions() {
+            if !is_legacy_syntax {
+                diag.push_error("'transitions' block are no longer supported. Use 'in {...}' and 'out {...}' directly in the state definition".into(), &ts);
+            }
+            for trs in ts.Transition() {
+                let trans = Transition::from_node(trs, &r, tr, diag);
+                r.borrow_mut().transitions.push(trans);
+            }
         }
 
         r

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1925,7 +1925,7 @@ impl Transition {
         diag: &mut BuildDiagnostics,
     ) -> Transition {
         if let Some(star) = trs.child_token(SyntaxKind::Star) {
-            diag.push_error("TODO: catch-all not yet implemented".into(), &star);
+            diag.push_error("catch-all not yet implemented".into(), &star);
         };
         Transition {
             is_out: parser::identifier_text(&trs).unwrap_or_default() == "out",

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -386,13 +386,13 @@ declare_syntax! {
         /// `states: [...]`
         States -> [*State],
         /// The DeclaredIdentifier is the state name. The Expression, if any, is the condition.
-        State -> [DeclaredIdentifier, ?Expression, *StatePropertyChange],
+        State -> [DeclaredIdentifier, ?Expression, *StatePropertyChange, *Transition],
         /// binding within a state
         StatePropertyChange -> [ QualifiedName, BindingExpression ],
         /// `transitions: [...]`
         Transitions -> [*Transition],
         /// There is an identifier "in" or "out", the DeclaredIdentifier is the state name
-        Transition -> [DeclaredIdentifier, *PropertyAnimation],
+        Transition -> [?DeclaredIdentifier, *PropertyAnimation],
         /// Export a set of declared components by name
         ExportsList -> [ *ExportSpecifier, ?Component, *StructDeclaration ],
         /// Declare the first identifier to be exported, either under its name or instead

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -5,6 +5,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::diagnostics::SourceLocation;
+use crate::diagnostics::Spanned;
 use crate::expression_tree::*;
 use crate::langtype::ElementType;
 use crate::langtype::Type;
@@ -136,7 +137,12 @@ fn lower_transitions_in_element(
         let state = states_id.get(&transition.state_id).unwrap_or_else(|| {
             diag.push_error(
                 format!("State '{}' does not exist", transition.state_id),
-                &transition.node,
+                transition
+                    .node
+                    .DeclaredIdentifier()
+                    .as_ref()
+                    .map(|x| x as &dyn Spanned)
+                    .unwrap_or(&transition.node as &dyn Spanned),
             );
             &0
         });

--- a/internal/compiler/tests/syntax/basic/states_transitions.slint
+++ b/internal/compiler/tests/syntax/basic/states_transitions.slint
@@ -44,3 +44,90 @@ TestCase := Rectangle {
     touch := TouchArea {}
 
 }
+
+
+component NewSyntax {
+    property<bool> checked;
+    property <int> border;
+    property <color> color;
+    states [
+        checked when checked: {
+            color: blue; // same as root.color
+            text.color: red;
+            border: 42;
+        }
+        pressed when touch.pressed: {
+            color: green;
+            border: 88;
+            text.foo.bar: 0;
+///         ^error{'text.foo.bar' is not a valid property}
+            colour: yellow;
+///         ^error{'colour' is not a valid property}
+            fox.color: yellow;
+///         ^error{'fox' is not a valid element id}
+            text.fox: yellow;
+///         ^error{'fox' not found in 'text'}
+
+            in  {
+                animate * { duration: 88ms; }
+                animate color { duration: 88ms; }
+            }
+            out {
+                animate color, foo.x { duration: 300ms; }
+///                           ^error{'foo' is not a valid element id}
+                animate border { duration: 120ms; }
+                animate color, text.text { duration: 300ms; }
+///                           ^error{'text.text' is not a property that can be animated}
+            }
+        }
+    ]
+
+    text := Text {}
+    touch := TouchArea {}
+
+}
+
+component OldInNewSyntax {
+    property<bool> checked;
+    property <int> border;
+    property <color> color;
+    states [
+        checked when checked: {
+            color: blue; // same as root.color
+            text.color: red;
+            border: 42;
+        }
+        pressed when touch.pressed: {
+            color: green;
+            border: 88;
+            text.foo.bar: 0;
+///         ^error{'text.foo.bar' is not a valid property}
+            colour: yellow;
+///         ^error{'colour' is not a valid property}
+            fox.color: yellow;
+///         ^error{'fox' is not a valid element id}
+            text.fox: yellow;
+///         ^error{'fox' not found in 'text'}
+        }
+    ]
+
+    transitions [
+/// ^error{'transitions' block are no longer supported. Use 'in \{...\}' and 'out \{...\}' directly in the state definition}
+        in pressed: {
+            animate * { duration: 88ms; }
+            animate color { duration: 88ms; }
+        }
+        out pressed: {
+            animate color, foo.x { duration: 300ms; }
+///                       ^error{'foo' is not a valid element id}
+            animate border { duration: 120ms; }
+            animate color, text.text { duration: 300ms; }
+///                       ^error{'text.text' is not a property that can be animated}
+
+        }
+    ]
+
+    text := Text {}
+    touch := TouchArea {}
+
+}

--- a/tools/syntax_updater/experiments/transitions.rs
+++ b/tools/syntax_updater/experiments/transitions.rs
@@ -1,0 +1,56 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use crate::Cli;
+use i_slint_compiler::parser::{syntax_nodes, SyntaxKind, SyntaxNode};
+use std::io::Write;
+
+pub(crate) fn fold_node(
+    node: &SyntaxNode,
+    file: &mut impl Write,
+    state: &mut crate::State,
+    args: &Cli,
+) -> std::io::Result<bool> {
+    if let Some(s) = syntax_nodes::State::new(node.clone()) {
+        if let Some(element) = state.current_elem.clone() {
+            let state_id = i_slint_compiler::parser::normalize_identifier(
+                s.DeclaredIdentifier().to_string().as_str(),
+            );
+            if !element.borrow().transitions.is_empty() {
+                for c in node.children_with_tokens() {
+                    if c.kind() == SyntaxKind::RBrace {
+                        let whitespace = c
+                            .as_token()
+                            .and_then(|t| t.prev_token())
+                            .filter(|t| t.kind() == SyntaxKind::Whitespace);
+                        for t in element.borrow().transitions.clone() {
+                            if t.state_id == state_id {
+                                for c in t.node.children_with_tokens() {
+                                    if !matches!(
+                                        c.kind(),
+                                        SyntaxKind::DeclaredIdentifier | SyntaxKind::Colon,
+                                    ) {
+                                        crate::visit_node_or_token(c, file, state, args)?;
+                                    }
+                                }
+                                if let Some(ws) = whitespace.as_ref() {
+                                    write!(file, "{ws}")?
+                                }
+                            }
+                        }
+                    }
+                    crate::visit_node_or_token(c, file, state, args)?;
+                }
+                return Ok(true);
+            }
+        }
+    }
+    if node.kind() == SyntaxKind::Transitions {
+        if let Some(element) = state.current_elem.clone() {
+            if !element.borrow().transitions.is_empty() {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}

--- a/tools/syntax_updater/main.rs
+++ b/tools/syntax_updater/main.rs
@@ -20,6 +20,7 @@ mod experiments {
     pub(super) mod input_output_properties;
     pub(super) mod lookup_changes;
     pub(super) mod new_component_declaration;
+    pub(super) mod transitions;
 }
 
 #[derive(clap::Parser)]
@@ -96,6 +97,7 @@ fn process_rust_file(source: String, mut file: impl Write, args: &Cli) -> std::i
         source_slice = &source_slice[idx - 1..];
 
         let mut diag = BuildDiagnostics::default();
+        diag.enable_experimental = true;
         let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, &mut diag);
         let len = syntax_node.text_range().end().into();
         visit_node(syntax_node, &mut file, &mut State::default(), args)?;
@@ -125,6 +127,7 @@ fn process_markdown_file(source: String, mut file: impl Write, args: &Cli) -> st
         source_slice = &source_slice[code_end..];
 
         let mut diag = BuildDiagnostics::default();
+        diag.enable_experimental = true;
         let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, &mut diag);
         let len = syntax_node.text_range().end().into();
         visit_node(syntax_node, &mut file, &mut State::default(), args)?;
@@ -149,6 +152,7 @@ fn process_file(
     }
 
     let mut diag = BuildDiagnostics::default();
+    diag.enable_experimental = true;
     let syntax_node = i_slint_compiler::parser::parse(source.clone(), Some(path), &mut diag);
     let len = syntax_node.node.text_range().end().into();
     let mut state = State::default();
@@ -289,6 +293,9 @@ fn fold_node(
         return Ok(true);
     }
     if experiments::geometry_changes::fold_node(node, file, state, args)? {
+        return Ok(true);
+    }
+    if experiments::transitions::fold_node(node, file, state, args)? {
         return Ok(true);
     }
     Ok(false)


### PR DESCRIPTION
CC: #1850

The current implementation enable this regardless of the new and old syntax, and try to move away from the old way of declaring transition.

Should we deprecate the old transitions syntax?  IMHO not right now as it would just cause churn before we move to the new syntax.
Should we forbid the old transitions syntax with the new syntax? IMHO yes.