### PR TITLE
Fix the fancy demo because of its use of `@children`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -258,6 +258,7 @@ jobs:
     - name: test
       # Skip a few tests that rely on private renamed properties.
       # Skip the tests which makes two way binding to output property (these are warning in previous version)
+      # Skip the example that did not exist or that are broken
       run: |
         cargo test --bin test-driver-interpreter -- \
                   --skip test_interpreter_text_cursor_move \
@@ -268,4 +269,6 @@ jobs:
                   --skip test_interpreter_text_text_change \
                   --skip test_interpreter_crashes_layout_deleted_item \
                   --skip test_interpreter_focus_focus_change_subcompo \
-                  --skip test_interpreter_focus_focus_change_through_signal
+                  --skip test_interpreter_focus_focus_change_through_signal \
+                  --skip example_carousel \
+                  --skip example_fancy_demo

--- a/examples/fancy_demo/main.slint
+++ b/examples/fancy_demo/main.slint
@@ -32,18 +32,16 @@ MdiWindow := Rectangle {
         property <length> open-width: l.preferred-width;
         property <length> open-height: l.preferred-height;
         width: l.preferred-width;
-        height: l.preferred-height;
+        height: l.preferred-height - hidden.preferred-height;
 
         states [
             open when is-open : {
                 width: open-width;
                 height: open-height;
                 expand.angle: 0deg;
+                in { animate width, height, expand.angle { duration: 150ms; easing: ease; } }
+                out { animate width, height, expand.angle { duration: 150ms; easing: ease; } }
             }
-        ]
-        transitions [
-            in open : { animate width, height, expand.angle { duration: 150ms; easing: ease; } }
-            out open : { animate width, height, expand.angle { duration: 150ms; easing: ease; } }
         ]
 
         clip: true;
@@ -104,7 +102,8 @@ MdiWindow := Rectangle {
                     }
                 }
             }
-            if is-open : VerticalLayout {
+            hidden := VerticalLayout {
+                visible: is-open;
                 Rectangle {
                     height: window.border-width;
                     background: window.border-color;

--- a/tests/driver/interpreter/main.rs
+++ b/tests/driver/interpreter/main.rs
@@ -31,6 +31,10 @@ test_example!(example_memory, "memory/memory.slint");
 test_example!(example_slide_puzzle, "slide_puzzle/slide_puzzle.slint");
 test_example!(example_todo, "todo/ui/todo.slint");
 test_example!(example_gallery, "gallery/gallery.slint");
+test_example!(example_fancy_demo, "fancy_demo/main.slint");
+test_example!(example_bash_sysinfo, "bash/sysinfo.slint");
+test_example!(example_carousel, "carousel/ui/carousel_demo.slint");
+test_example!(example_iot_dashboard, "iot-dashboard/main.slint");
 
 fn main() {
     println!("Nothing to see here, please run me through cargo test :)");


### PR DESCRIPTION
Commit 53090ab489bd718d4f1f3f6ea9ec3a73588d9a5d forbid the use of
`@children` in repeater and conditional elements because it can cause
problem in the cases where the element is referenced (which is not the
case in the fancy demo)

We could try to still allow this case, but it is easier to just fix the
demo.