### PR TITLE
Fix use the meta key causing characters to appear in TextInput elements

### DIFF
--- a/internal/common/key_codes.rs
+++ b/internal/common/key_codes.rs
@@ -28,9 +28,10 @@ macro_rules! for_each_special_keys {
 '\u{0015}'  # ShiftR      #                         # RShift       ;
 '\u{0016}'  # ControlR    #                         # RControl     ;
 
-// meta defines the macos command key (check DOM_VK_META on https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)
-'\u{00E0}'  # Meta        # Qt_Key_Key_Control      # LWin         ;
-'\u{00E1}'  # MetaR       #                         # RWin         ;
+// Use custom codes instead of DOM_VK_META for meta, because the Mozilla defined code is a regular character (E0; LATIN SMALL LETTER A WITH GRAVE)
+// which makes those keys appear as text.
+'\u{0017}'  # Meta        # Qt_Key_Key_Control      # LWin         ;
+'\u{0018}'  # MetaR       #                         # RWin         ;
 
 '\u{F700}'	# UpArrow     # Qt_Key_Key_Up           # Up           ;
 '\u{F701}'	# DownArrow   # Qt_Key_Key_Down         # Down         ;

--- a/tests/cases/text/control_keys_input.slint
+++ b/tests/cases/text/control_keys_input.slint
@@ -1,0 +1,33 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+TestCase := Window {
+    width: 100phx;
+    height: 100phx;
+    ti := TextInput { 
+    }
+
+    property <bool> input_focused: ti.has_focus;
+    property <string> text <=> ti.text;
+}
+
+/*
+```rust
+use slint::Key;
+
+let instance = TestCase::new();
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_input_focused());
+assert!(instance.get_text().is_empty());
+
+for code in [Key::Shift, Key::ShiftR, Key::Alt, Key::AltGr, Key::Control, Key::ControlR, Key::Meta, Key::MetaR] {
+    slint_testing::send_keyboard_char(&instance, code.into(), true);
+    assert!(instance.get_text().is_empty());
+    slint_testing::send_keyboard_char(&instance, code.into(), false);
+    assert!(instance.get_text().is_empty());
+}
+
+slint_testing::send_keyboard_char(&instance, 'a', true);
+assert_eq!(instance.get_text(), "a");
+```
+*/

--- a/tests/cases/text/keyboard_modifiers.slint
+++ b/tests/cases/text/keyboard_modifiers.slint
@@ -30,15 +30,7 @@ TestCase := Window {
 
 /*
 ```rust
-
-const SHIFT_CODE: char = '\u{0010}';
-const SHIFTR_CODE: char = '\u{0015}';
-const ALT_CODE: char = '\u{0012}';
-const ALTGR_CODE: char = '\u{0013}';
-const CONTROL_CODE: char = '\u{0011}';
-const CONTROLR_CODE: char = '\u{0016}';
-const META_CODE: char = '\u{00E0}';
-const METAR_CODE: char = '\u{00E1}';
+use slint::Key;
 
 let instance = TestCase::new();
 slint_testing::send_mouse_click(&instance, 5., 5.);
@@ -51,7 +43,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, SHIFT_CODE, true);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), true);
@@ -59,7 +51,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, SHIFTR_CODE, true);
+slint_testing::send_keyboard_char(&instance, Key::ShiftR.into(), true);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), true);
@@ -67,7 +59,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, SHIFT_CODE, false);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), true);
@@ -75,7 +67,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, SHIFTR_CODE, false);
+slint_testing::send_keyboard_char(&instance, Key::ShiftR.into(), false);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -83,7 +75,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, ALT_CODE, true);
+slint_testing::send_keyboard_char(&instance, Key::Alt.into(), true);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -91,7 +83,7 @@ assert_eq!(instance.get_alt_modifier(), true);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, ALTGR_CODE, true);
+slint_testing::send_keyboard_char(&instance, Key::AltGr.into(), true);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -100,7 +92,7 @@ assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
 // AltGr does not set the alt modifier
-slint_testing::send_keyboard_char(&instance, ALT_CODE, false);
+slint_testing::send_keyboard_char(&instance, Key::Alt.into(), false);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -108,7 +100,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, ALTGR_CODE, false);
+slint_testing::send_keyboard_char(&instance, Key::AltGr.into(), false);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -116,7 +108,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, CONTROL_CODE, true);
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -124,7 +116,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), true);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, CONTROLR_CODE, true);
+slint_testing::send_keyboard_char(&instance, Key::ControlR.into(), true);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -132,7 +124,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), true);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, CONTROL_CODE, false);
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), false);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -140,7 +132,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), true);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, CONTROLR_CODE, false);
+slint_testing::send_keyboard_char(&instance, Key::ControlR.into(), false);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -148,7 +140,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), false);
 
-slint_testing::send_keyboard_char(&instance, META_CODE, true);
+slint_testing::send_keyboard_char(&instance, Key::Meta.into(), true);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -156,7 +148,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), true);
 
-slint_testing::send_keyboard_char(&instance, METAR_CODE, true);
+slint_testing::send_keyboard_char(&instance, Key::MetaR.into(), true);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -164,7 +156,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), true);
 
-slint_testing::send_keyboard_char(&instance, META_CODE, false);
+slint_testing::send_keyboard_char(&instance, Key::Meta.into(), false);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);
@@ -172,7 +164,7 @@ assert_eq!(instance.get_alt_modifier(), false);
 assert_eq!(instance.get_control_modifier(), false);
 assert_eq!(instance.get_meta_modifier(), true);
 
-slint_testing::send_keyboard_char(&instance, METAR_CODE, false);
+slint_testing::send_keyboard_char(&instance, Key::MetaR.into(), false);
 slint_testing::send_keyboard_char(&instance, 'a', true);
 slint_testing::send_keyboard_char(&instance, 'a', false);
 assert_eq!(instance.get_shift_modifier(), false);

--- a/tests/cases/text/keyboard_modifiers.slint
+++ b/tests/cases/text/keyboard_modifiers.slint
@@ -6,8 +6,6 @@ TestCase := Window {
     height: 100phx;
     ti := FocusScope { 
         key-pressed(event) => {
-            debug("pressy");
-            debug(event.modifiers.shift);
             shift_modifier = event.modifiers.shift;
             alt_modifier = event.modifiers.alt;
             control_modifier = event.modifiers.control;


### PR DESCRIPTION
This was a regression from 61c39b5fa18c7ad352b7279d1cc1f20841d9327f. We
now send key events also for keys that change the modifier state. Our
existing encoding uses characters in the control character category, so
the existing code in TextInput ignores them correctly. However for meta
we were using LATIN SMALL LETTER A WITH GRAVE, which is not CC category.

Deviate from the Mozilla encoding here, as there's little value to it
and there's much value to not showing the character and using the same
existing code for exclusion.