### PR TITLE
Fix placeholder text rendered on top of cursor when empty LineEdit is focused

### DIFF
--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -19,13 +19,18 @@ export LineEditInner := Rectangle {
     min-width: max(50px, placeholder.min-width);
     clip: true;
     forward-focus: input;
+    placeholder := Text {
+        height: 100%; width: 100%;
+        vertical-alignment: center;
+        text: (root.text == "" && input.preedit-text == "") ? root.placeholder-text : "";
+    }
     input := TextInput {
         property <length> computed_x;
         x: min(0px, max(parent.width - width, computed_x));
         width: max(parent.width, preferred-width);
         height: 100%;
         color: enabled ? StyleMetrics.textedit-text-color : StyleMetrics.textedit-text-color-disabled;
-        cursor-position-changed(cpos) => {
+       cursor-position-changed(cpos) => {
             if (cpos.x + computed_x < StyleMetrics.layout-padding) {
                 computed_x = - cpos.x + StyleMetrics.layout-padding;
             } else if (cpos.x + computed_x > parent.width - StyleMetrics.layout-padding) {
@@ -36,11 +41,6 @@ export LineEditInner := Rectangle {
         edited => { root.edited(self.text); }
         vertical-alignment: center;
         single-line: true;
-    }
-    placeholder := Text {
-        height: 100%; width: 100%;
-        vertical-alignment: center;
-        text: (root.text == "" && input.preedit-text == "") ? root.placeholder-text : "";
     }
 }
 

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -30,7 +30,7 @@ export LineEditInner := Rectangle {
         width: max(parent.width, preferred-width);
         height: 100%;
         color: enabled ? StyleMetrics.textedit-text-color : StyleMetrics.textedit-text-color-disabled;
-       cursor-position-changed(cpos) => {
+        cursor-position-changed(cpos) => {
             if (cpos.x + computed_x < StyleMetrics.layout-padding) {
                 computed_x = - cpos.x + StyleMetrics.layout-padding;
             } else if (cpos.x + computed_x > parent.width - StyleMetrics.layout-padding) {

--- a/internal/compiler/widgets/material-base/widget-lineedit.slint
+++ b/internal/compiler/widgets/material-base/widget-lineedit.slint
@@ -35,6 +35,24 @@ export LineEdit := Rectangle {
 
         Rectangle {  
             clip: true;
+
+            placeholder := Text {
+                width: 100%;
+                height: 100%;
+                color: md.sys.color.outline-variant;
+                font-family: md.sys.typescale.body-large.font;
+                font-size: md.sys.typescale.body-large.size;
+                font-weight: md.sys.typescale.body-large.weight;
+                visible: false;
+                vertical-alignment: center;
+
+                states [
+                    empty when input.text == "" : {
+                        visible: true;
+                    }
+                ]
+            }
+
             input := TextInput {
                 property <length> computed_x;
                 property <length> padding-outer: layout.padding-left + layout.padding-right;
@@ -58,23 +76,6 @@ export LineEdit := Rectangle {
                         computed_x = parent.width - cpos.x - padding-outer;
                     }
                 }
-            }
-
-            placeholder := Text {
-                width: 100%;
-                height: 100%;
-                color: md.sys.color.outline-variant;
-                font-family: md.sys.typescale.body-large.font;
-                font-size: md.sys.typescale.body-large.size;
-                font-weight: md.sys.typescale.body-large.weight;
-                visible: false;
-                vertical-alignment: center;
-
-                states [
-                    empty when input.text == "" : {
-                        visible: true;
-                    }
-                ]
             }
         }    
     }


### PR DESCRIPTION
Don't draw the placeholder if the TextInput element has the focus.