### PR TITLE
Fix application of Material Design's default font

### DIFF
--- a/internal/compiler/passes/apply_default_properties_from_style.rs
+++ b/internal/compiler/passes/apply_default_properties_from_style.rs
@@ -58,25 +58,31 @@ pub fn apply_default_properties_from_style(
                         .into(),
                         to: Type::Brush,
                     });
-                    if !matches!(
-                        style_metrics
-                            .root_element
-                            .borrow()
-                            .lookup_property("default-font-size")
-                            .property_type,
-                        Type::Invalid,
-                    ) {
-                        elem.set_binding_if_not_set("default-font-size".into(), || {
-                            Expression::Cast {
-                                from: Expression::PropertyReference(NamedReference::new(
-                                    &style_metrics.root_element,
-                                    "default-font-size",
-                                ))
-                                .into(),
-                                to: Type::LogicalLength,
-                            }
-                        });
-                    }
+
+                    let mut bind_style_property_if_exists = |property_name, property_type| {
+                        if !matches!(
+                            style_metrics
+                                .root_element
+                                .borrow()
+                                .lookup_property(property_name)
+                                .property_type,
+                            Type::Invalid,
+                        ) {
+                            elem.set_binding_if_not_set(property_name.into(), || {
+                                Expression::Cast {
+                                    from: Expression::PropertyReference(NamedReference::new(
+                                        &style_metrics.root_element,
+                                        property_name,
+                                    ))
+                                    .into(),
+                                    to: property_type,
+                                }
+                            });
+                        }
+                    };
+
+                    bind_style_property_if_exists("default-font-size", Type::LogicalLength);
+                    bind_style_property_if_exists("default-font-family", Type::String);
                 }
 
                 _ => {}

--- a/internal/compiler/widgets/material-base/md.slint
+++ b/internal/compiler/widgets/material-base/md.slint
@@ -22,7 +22,6 @@ struct Color := {
 
 // typo settings
 struct Label := {
-    font: string,
     size: length,
     weight: int
 }
@@ -79,27 +78,22 @@ export global md := {
 
         typescale: {
             label-large: {
-                font: "Roboto Medium",
                 size: 14px,
                 weight: 500
             },
             label-medium: {
-                font: "Roboto Medium",
                 size: 12px,
                 weight: 500
             },
             body-large: {
-                font: "Roboto Medium",
                 size: 14px,
                 weight: 400
             },
             body-small: {
-                font: "Roboto Regular",
                 size: 12px,
                 weight: 400
             },
             title-small: {
-                font: "Roboto Medium",
                 size: 14px,
                 weight: 500
             },

--- a/internal/compiler/widgets/material-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material-base/std-widgets-impl.slint
@@ -21,5 +21,7 @@ export global StyleMetrics := {
     property<color> textedit-text-color-disabled: md.sys.color.on-surface;
     property<bool> dark-color-scheme: md.dark-color-scheme;
 
+    property <string> default-font-family: "Roboto";
+
     property<brush> window-background: md.sys.color.background;
 }

--- a/internal/compiler/widgets/material-base/widget-lineedit.slint
+++ b/internal/compiler/widgets/material-base/widget-lineedit.slint
@@ -40,7 +40,6 @@ export LineEdit := Rectangle {
                 width: 100%;
                 height: 100%;
                 color: md.sys.color.outline-variant;
-                font-family: md.sys.typescale.body-large.font;
                 font-size: md.sys.typescale.body-large.size;
                 font-weight: md.sys.typescale.body-large.weight;
                 visible: false;
@@ -62,8 +61,6 @@ export LineEdit := Rectangle {
                 height: 100%;
                 color: md.sys.color.on-surface;
                 vertical-alignment: center;
-                // FIXME after Roboto font can be loaded
-                //font-family: md.sys.typescale.body-large.font;
                 font-size: md.sys.typescale.body-large.size;
                 font-weight: md.sys.typescale.body-large.weight;
     


### PR DESCRIPTION
Allow the style to override the font, use "Robot" as general font family for Material Design, and use it in the widgets gallery.