### PR TITLE
vscode: Update version requirements

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/slint-ui/slint"
     },
     "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.70.0"
     },
     "categories": [
         "Programming Languages"
@@ -122,7 +122,7 @@
         "@types/glob": "^7.2.0",
         "@types/mocha": "^8.2.3",
         "@types/node": "^12.20.55",
-        "@types/vscode": "^1.73.1",
+        "@types/vscode": "1.70.0",
         "@typescript-eslint/eslint-plugin": "^5.44.0",
         "@typescript-eslint/parser": "^5.44.0",
         "esbuild": "^0.14.54",


### PR DESCRIPTION
I just noticed that I had broken the package build before by updating the types downloaded for vscode. Those types need to be in sync with the vscode engine version!

Hard-code both to 1.70 for now, I think that is old enough to cover most installaions of VSCode (which tend to be very new in my experience).