### PR TITLE
janitor: Fix C++ Windows build with Ninja

### DIFF
--- a/examples/gallery/CMakeLists.txt
+++ b/examples/gallery/CMakeLists.txt
@@ -9,5 +9,8 @@ if (NOT TARGET Slint::Slint)
 endif()
 
 add_executable(gallery main.cpp)
+if (MSVC)
+    target_compile_options(gallery PRIVATE /bigobj)
+endif()
 target_link_libraries(gallery PRIVATE Slint::Slint)
 slint_target_sources(gallery gallery.slint)

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -69,7 +69,11 @@ fn main() -> std::io::Result<()> {
             }
         }
         for resource in doc.root_component.embedded_file_resources.borrow().keys() {
-            write!(f, " {}", resource)?;
+            if !fileaccess::load_file(&std::path::Path::new(resource))
+                .map_or(false, |f| f.is_builtin())
+            {
+                write!(f, " {}", resource)?;
+            }
         }
 
         writeln!(f)?;


### PR DESCRIPTION
Use `/bigobj` with the gallery (as with the other demos) and fix ninja dependency file generation to exclude built-in image resource paths.