### PR TITLE
Move `WindowEvent`, `PointerEventButton` and `Key` to the `platform` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
  - Disallow overrides or duplicated declarations of callbacks. Previously they were silently overwritten,
    now an error is produced.
  - The name "init" is now a reserved name in callbacks and properties.
+ - Deprecated `slint::WindowEvent` and `slint::PointerEventButton` and moved them to the `slint::platform` module.
 
 ### Added
 
@@ -22,7 +23,7 @@ All notable changes to this project are documented in this file.
  - Added `Window::is_visible`
  - Added `From<char>` for `SharedString` in Rust.
  - Added `KeyPressed` and `KeyReleased` variants to `slint::WindowEvent` in Rust, along
-   with `slint::Key`, for use by custom platform backends.
+   with `slint::platform::Key`, for use by custom platform backends.
  - Added support for the implicitly declared `init` callback that can be used to run code when
    an element or component is instantiated.
  - Properties can be annotated with `in`, `out`, `in-out`, or `private`.

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -253,6 +253,14 @@ pub use i_slint_core::sharedvector::SharedVector;
 pub use i_slint_core::timers::{Timer, TimerMode};
 pub use i_slint_core::{format, string::SharedString};
 
+#[deprecated(note = "Use platform::PointerEventButton instead")]
+/// Deprecated type alias for [`slint::platform::PointerEventButton`](`crate::platform::PointerEventButton`).
+pub type PointerEventButton = crate::platform::PointerEventButton;
+
+#[deprecated(note = "Use platform::WindowEvent instead")]
+/// Deprecated type alias for [`slint::platform::WindowEvent`](`crate::platform::WindowEvent`).
+pub type WindowEvent = crate::platform::WindowEvent;
+
 pub mod private_unstable_api;
 
 /// Enters the main event loop. This is necessary in order to receive

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -5,7 +5,6 @@
 
 use cpp::*;
 use euclid::approxeq::ApproxEq;
-use i_slint_core::api::WindowEvent;
 use i_slint_core::component::{ComponentRc, ComponentRef};
 use i_slint_core::graphics::euclid::num::Zero;
 use i_slint_core::graphics::rendering_metrics_collector::{
@@ -22,6 +21,7 @@ use i_slint_core::layout::Orientation;
 use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector, PhysicalPx, ScaleFactor,
 };
+use i_slint_core::platform::WindowEvent;
 use i_slint_core::window::{WindowAdapter, WindowAdapterSealed, WindowInner};
 use i_slint_core::{Coord, ImageInner, PathData, Property, SharedString};
 use items::{ImageFit, TextHorizontalAlignment, TextVerticalAlignment};

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -268,8 +268,8 @@ fn process_window_event(
                 ch
             };
 
-            window.window().dispatch_event(corelib::api::WindowEvent::KeyPressed { text });
-            window.window().dispatch_event(corelib::api::WindowEvent::KeyReleased { text });
+            window.window().dispatch_event(corelib::platform::WindowEvent::KeyPressed { text });
+            window.window().dispatch_event(corelib::platform::WindowEvent::KeyReleased { text });
         }
         WindowEvent::Focused(have_focus) => {
             let have_focus = have_focus || window.input_method_focused();
@@ -300,10 +300,10 @@ fn process_window_event(
             if let Some(ch) = key_code.and_then(key_codes::winit_key_to_char) {
                 window.window().dispatch_event(match input.state {
                     winit::event::ElementState::Pressed => {
-                        corelib::api::WindowEvent::KeyPressed { text: ch }
+                        corelib::platform::WindowEvent::KeyPressed { text: ch }
                     }
                     winit::event::ElementState::Released => {
-                        corelib::api::WindowEvent::KeyReleased { text: ch }
+                        corelib::platform::WindowEvent::KeyReleased { text: ch }
                     }
                 });
             };

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -20,8 +20,8 @@
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 
-use i_slint_core::api::WindowEvent;
 use i_slint_core::input::{KeyEventType, KeyInputEvent};
+use i_slint_core::platform::WindowEvent;
 use i_slint_core::window::{WindowAdapter, WindowInner};
 use i_slint_core::SharedString;
 use wasm_bindgen::closure::Closure;
@@ -203,7 +203,7 @@ fn event_text(e: &web_sys::KeyboardEvent) -> Option<char> {
 
     let key = e.key();
 
-    use i_slint_core::api::Key;
+    use i_slint_core::platform::Key;
 
     macro_rules! check_non_printable_code {
         ($($char:literal # $name:ident # $($_qt:ident)|* # $($_winit:ident)|* ;)*) => {

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -20,8 +20,8 @@ use core::pin::Pin;
 
 /// A mouse or touch event
 ///
-/// The only difference with [`crate::api::WindowEvent`] us that it uses untyped `Point`
-/// TODO: merge with api::WindowEvent
+/// The only difference with [`crate::platform::WindowEvent`] us that it uses untyped `Point`
+/// TODO: merge with platform::WindowEvent
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(missing_docs)]
@@ -138,10 +138,10 @@ pub mod key_codes {
             #[repr(C)]
             /// The `Key` enum is used to map a specific key by name e.g. `Key::Control` to an
             /// internal used unicode representation. The enum is convertible to [`std::char`] and [`slint::SharedString`](`crate::SharedString`).
-            /// Use this with [`slint::WindowEvent`](`crate::api::WindowEvent`) to supply key events to Slint's platform abstraction.
+            /// Use this with [`slint::platform::WindowEvent`](`crate::platform::WindowEvent`) to supply key events to Slint's platform abstraction.
             ///
             /// ```
-            /// let slint_key_code: char = slint::Key::Tab.into();
+            /// let slint_key_code: char = slint::platform::Key::Tab.into();
             /// assert_eq!(slint_key_code, '\t')
             /// ```
             pub enum Key {

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -5,8 +5,8 @@
 #![warn(missing_docs)]
 #![allow(unsafe_code)]
 
-use crate::api::WindowEvent;
 use crate::input::{key_codes::Key, MouseEvent};
+use crate::platform::WindowEvent;
 use crate::Coord;
 
 /// Slint animations do not use real time, but use a mocked time.

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -39,7 +39,7 @@ TestCase := Window {
 
 ```rust
 // Test that basic scrolling works, and that releasing the mouse animates
-use slint::{WindowEvent, PointerEventButton, LogicalPosition};
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
 let instance = TestCase::new();
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(300.0, 100.0) });
 slint_testing::mock_elapsed_time(5000);
@@ -81,7 +81,7 @@ assert_eq!(instance.get_clicked(), 0);
 
 ```rust
 // Test interaction with inner mouse area
-use slint::{WindowEvent, PointerEventButton, LogicalPosition};
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
 let instance = TestCase::new();
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(175.0, 175.0) });
 assert!(!instance.get_inner_ta_pressed());

--- a/tests/cases/elements/flickable3.slint
+++ b/tests/cases/elements/flickable3.slint
@@ -33,7 +33,7 @@ TestCase := Window {
 /*
 ```rust
 // Test that mouse exit events are dispatched while scrolling
-use slint::{WindowEvent, LogicalPosition};
+use slint::{platform::WindowEvent, LogicalPosition};
 let instance = TestCase::new();
 // Vertical
 assert_eq!(instance.get_t1_has_hover(), false);

--- a/tests/cases/elements/flickable_in_flickable.slint
+++ b/tests/cases/elements/flickable_in_flickable.slint
@@ -32,7 +32,7 @@ TestCase := Window {
 /*
 
 ```rust
-use slint::{WindowEvent, PointerEventButton, LogicalPosition};
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
 let instance = TestCase::new();
 
 // First, try to scroll up

--- a/tests/cases/text/control_keys_input.slint
+++ b/tests/cases/text/control_keys_input.slint
@@ -13,7 +13,7 @@ TestCase := Window {
 
 /*
 ```rust
-use slint::Key;
+use slint::platform::Key;
 
 let instance = TestCase::new();
 slint_testing::send_mouse_click(&instance, 5., 5.);

--- a/tests/cases/text/keyboard_modifiers.slint
+++ b/tests/cases/text/keyboard_modifiers.slint
@@ -30,7 +30,7 @@ TestCase := Window {
 
 /*
 ```rust
-use slint::Key;
+use slint::platform::Key;
 
 let instance = TestCase::new();
 slint_testing::send_mouse_click(&instance, 5., 5.);


### PR DESCRIPTION
For `Key` this is a move, as it is a new type. For `WindowEvent` and `PointerEventButton` deprecated aliases are provided.