### PR TITLE
Fix embedding of images referenced in globals

### DIFF
--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -98,13 +98,6 @@ pub async fn run_passes(
     inlining::inline(doc, inlining::InlineSelection::InlineOnlyRequiredComponents);
     collect_subcomponents::collect_subcomponents(root_component);
 
-    embed_images::embed_images(
-        root_component,
-        compiler_config.embed_resources,
-        compiler_config.scale_factor,
-        diag,
-    );
-
     for component in (root_component.used_types.borrow().sub_components.iter())
         .chain(std::iter::once(root_component))
     {
@@ -217,6 +210,13 @@ pub async fn run_passes(
 
     // collect globals once more: After optimizations we might have less globals
     collect_globals::collect_globals(doc, diag);
+
+    embed_images::embed_images(
+        root_component,
+        compiler_config.embed_resources,
+        compiler_config.scale_factor,
+        diag,
+    );
 
     match compiler_config.embed_resources {
         #[cfg(feature = "software-renderer")]

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -20,8 +20,13 @@ pub fn embed_images(
 ) {
     let global_embedded_resources = &component.embedded_file_resources;
 
-    for component in
-        component.used_types.borrow().sub_components.iter().chain(std::iter::once(component))
+    for component in component
+        .used_types
+        .borrow()
+        .sub_components
+        .iter()
+        .chain(component.used_types.borrow().globals.iter())
+        .chain(std::iter::once(component))
     {
         visit_all_expressions(component, |e, _| {
             embed_images_from_expression(


### PR DESCRIPTION
When doing builds that require image embedding (such as for WASM), it's crucial to also visit the globals (after they've been collected) to catch all image references.