### PR TITLE
tools: Unshare some code

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -104,7 +104,8 @@
         }
     },
     "dependencies": {
-        "vscode-languageclient": "^7.0.0"
+        "vscode-languageclient": "^7.0.0",
+        "vscode-languageserver": "^8.0.2"
     },
     "files": [
         "bin/slint-lsp-*"
@@ -132,8 +133,6 @@
         "path-browserify": "^1.0.1",
         "ts-loader": "^9.4.1",
         "typescript": "^4.9.3",
-        "vscode-languageclient": "^7.0.0",
-        "vscode-languageserver": "^8.0.2",
         "vscode-test": "^1.6.1",
         "webpack": "^5.75.0",
         "webpack-cli": "^4.10.0"

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -3,11 +3,11 @@
 
 // This file contains the common code for both the normal and the browser extension
 
-import { Property, SetBindingResponse } from "../../../tools/online_editor/src/shared/properties";
 import {
-    change_property,
-    query_properties,
-} from "../../../tools/online_editor/src/shared/properties_client";
+    Property,
+    PropertyQuery,
+} from "../../../tools/online_editor/src/shared/properties";
+import { change_property, query_properties } from "./properties_client";
 
 import * as vscode from "vscode";
 import { BaseLanguageClient } from "vscode-languageclient";
@@ -74,7 +74,6 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
                     break;
                 case "change_property":
                     change_property(
-                        client,
                         data.document,
                         data.element_range,
                         data.property_name,
@@ -238,7 +237,7 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
         // So retry once with 2s delay...
         // Ideally we could use the progress messages from the LSP to find out when to retry,
         // but we do not have those yet.
-        query_properties(client, uri, { line: line, character: character })
+        query_properties(uri, { line: line, character: character })
             .then((p: PropertyQuery) => {
                 const msg = {
                     command: "set_properties",
@@ -249,7 +248,7 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
             .catch(() =>
                 setTimeout(
                     () =>
-                        query_properties(client, uri, {
+                        query_properties(uri, {
                             line: line,
                             character: character,
                         }),

--- a/editors/vscode/src/properties_client.ts
+++ b/editors/vscode/src/properties_client.ts
@@ -1,0 +1,48 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import {
+    PropertyQuery,
+    SetBindingResponse,
+} from "../../../tools/online_editor/src/shared/properties";
+
+import {
+    OptionalVersionedTextDocumentIdentifier,
+    Position as LspPosition,
+    Range as LspRange,
+    URI as LspURI,
+    WorkspaceEdit,
+} from "vscode-languageserver-types";
+
+import * as vscode from "vscode";
+
+export type WorkspaceEditor = (_we: WorkspaceEdit) => boolean;
+export type SetPropertiesHelper = (_p: PropertyQuery) => void;
+
+export async function change_property(
+    doc: OptionalVersionedTextDocumentIdentifier,
+    element_range: LspRange,
+    property_name: string,
+    current_text: string,
+    dry_run: boolean,
+): Promise<SetBindingResponse> {
+    return vscode.commands.executeCommand(
+        "setBinding",
+        doc,
+        element_range,
+        property_name,
+        current_text,
+        dry_run,
+    );
+}
+
+export async function query_properties(
+    uri: LspURI,
+    position: LspPosition,
+): Promise<PropertyQuery> {
+    return vscode.commands.executeCommand(
+        "queryProperties",
+        { uri: uri.toString() },
+        position,
+    );
+}

--- a/tools/online_editor/src/properties_client.ts
+++ b/tools/online_editor/src/properties_client.ts
@@ -1,12 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import { PropertyQuery, SetBindingResponse } from "./properties";
+import { PropertyQuery, SetBindingResponse } from "./shared/properties";
 
-import {
-    ExecuteCommandRequest,
-    ExecuteCommandParams,
-} from "vscode-languageserver-protocol";
 import {
     OptionalVersionedTextDocumentIdentifier,
     Position as LspPosition,
@@ -14,6 +10,10 @@ import {
     URI as LspURI,
     WorkspaceEdit,
 } from "vscode-languageserver-types";
+import {
+    ExecuteCommandRequest,
+    ExecuteCommandParams,
+} from "vscode-languageserver-protocol";
 
 import { BaseLanguageClient } from "vscode-languageclient";
 

--- a/tools/online_editor/src/properties_widget.ts
+++ b/tools/online_editor/src/properties_widget.ts
@@ -7,10 +7,7 @@ import { GotoPositionCallback } from "./text";
 import { LspPosition, LspURI } from "./lsp_integration";
 
 import { PropertyQuery, PropertiesView } from "./shared/properties";
-import {
-    change_property,
-    query_properties,
-} from "./shared/properties_client";
+import { change_property, query_properties } from "./properties_client";
 
 import { Message } from "@lumino/messaging";
 import { Widget } from "@lumino/widgets";


### PR DESCRIPTION
Do not interact with the language server directly in vscode, but use vscode.commands.executeCommand(...) instead. The online_editor will of course need to continue to interact with the language server directy, so this unshares a bit of code. It is not too much and straight forward code, so that is not too bad.