### PR TITLE
Docs: Disable a few preview 

### DIFF
--- a/docs/recipes/recipes.md
+++ b/docs/recipes/recipes.md
@@ -46,7 +46,7 @@ In this first example, you see the basics of the Slint language:
 
 This example increments the counter using native code, instead with the slint language.
 
-```slint
+```slint,no-preview
 import { VerticalBox, Button } from "std-widgets.slint";
 export Recipe := Window {
     property <int> counter: 0;
@@ -481,7 +481,7 @@ Meanwhile, you can make your design translatable with a global callback, some na
 
 Example using gettext:
 
-```slint
+```slint,no-preview
 import { HorizontalBox, Button } from "std-widgets.slint";
 
 export global Tr := {

--- a/docs/resources/slint-docs-preview.html
+++ b/docs/resources/slint-docs-preview.html
@@ -34,7 +34,7 @@
     async function run() {
         await slint.default();
         let selector = ["code.language-slint", ".rustdoc pre.language-slint", "div.highlight-slint"]
-            .map((sel) => `${sel}:not([class*=slint\\,ignore]):not([class*=slint\\,no_run])`).join(",");
+            .map((sel) => `${sel}:not([class*=slint\\,ignore]):not([class*=slint\\,no-preview])`).join(",");
         var elements = document.querySelectorAll(selector);
         for (var i = 0; i < elements.length; ++i) {
             let source = elements[i].innerText;


### PR DESCRIPTION
1. Fix the no-preview tag
2. disable some preview in the recipes

This makes the recipes preview work again on chromium.

This is a bakup in the event that we don't make the preview only enable.

That said, the commit 1. should probably be merged anyway in the release.
How about commit 2. ? these preview don't really make sense without the native code.