### PR TITLE
Use click-to-play for preview of examples and recipes

### DIFF
--- a/docs/recipes/recipes.md
+++ b/docs/recipes/recipes.md
@@ -6,7 +6,7 @@ This page provides a collection of common use-cases and how to implement them us
 
 ### A clickable Button
 
-```slint
+```slint,no-auto-preview
 import { VerticalBox, Button } from "std-widgets.slint";
 export Recipe := Window {
     property <int> counter: 0;
@@ -127,7 +127,7 @@ is generated. For the callback, a function to set the callback is generated (`on
 
 ### Use property bindings to synchronize controls
 
-```slint
+```slint,no-auto-preview
 import { VerticalBox, Slider } from "std-widgets.slint";
 export Recipe := Window {
     VerticalBox {
@@ -150,7 +150,7 @@ code between the curly braces to a string.
 ### Animate the position of an element
 
 
-```slint
+```slint,no-auto-preview
 import { CheckBox } from "std-widgets.slint";
 export Recipe := Window {
     width: 200px;
@@ -190,7 +190,7 @@ changes: Either because the property is set in a callback, or if its binding val
 
 ### Animation Sequence
 
-```slint
+```slint,no-auto-preview
 import { CheckBox } from "std-widgets.slint";
 export Recipe := Window {
     width: 200px;
@@ -235,7 +235,7 @@ This example uses the `delay` property to make one animation run after another.
 
 ### Associate multiple property values with states
 
-```slint
+```slint,no-auto-preview
 import { HorizontalBox, VerticalBox, Button } from "std-widgets.slint";
 
 Circle := Rectangle {
@@ -283,7 +283,7 @@ export Recipe := Window {
 
 ### Transitions
 
-```slint
+```slint,no-auto-preview
 import { HorizontalBox, VerticalBox, Button } from "std-widgets.slint";
 
 Circle := Rectangle {
@@ -333,7 +333,7 @@ export Recipe := Window {
 
 ### Vertical
 
-```slint
+```slint,no-auto-preview
 import { VerticalBox, Button } from "std-widgets.slint";
 export Recipe := Window {
     VerticalBox {
@@ -346,7 +346,7 @@ export Recipe := Window {
 
 ### Horizontal
 
-```slint
+```slint,no-auto-preview
 import { HorizontalBox, Button } from "std-widgets.slint";
 export Recipe := Window {
     HorizontalBox {
@@ -359,7 +359,7 @@ export Recipe := Window {
 
 ### Grid
 
-```slint
+```slint,no-auto-preview
 import { GridBox, Button, Slider } from "std-widgets.slint";
 export Recipe := Window {
     GridBox {
@@ -559,7 +559,7 @@ fn main() {
 
 ### Custom Button
 
-```slint
+```slint,no-auto-preview
 Button := Rectangle {
     property text <=> txt.text;
     callback clicked <=> touch.clicked;
@@ -587,7 +587,7 @@ export Recipe := Window {
 
 ### ToggleSwitch
 
-```slint
+```slint,no-auto-preview
 export ToggleSwitch := Rectangle {
     callback toggled;
     property <string> text;
@@ -654,7 +654,7 @@ export Recipe := Window {
 This slider can be dragged from any point within itself, because the TouchArea is covering
 the whole widget.
 
-```slint
+```slint,no-auto-preview
 import { VerticalBox } from "std-widgets.slint";
 
 export MySlider := Rectangle {
@@ -715,7 +715,7 @@ This example show another implementation that has a draggable handle:
 The handle only moves when we click on that handle.
 The TouchArea is within the handle and moves with the handle.
 
-```slint
+```slint,no-auto-preview
 import { VerticalBox } from "std-widgets.slint";
 
 export MySlider := Rectangle {
@@ -769,7 +769,7 @@ export Recipe := Window {
 ### Custom Tabs
 
 Use this recipe as a basis to when you want to create your own custom tab widget.
-```slint
+```slint,no-auto-preview
 import { Button } from "std-widgets.slint";
 
 export Recipe := Window {
@@ -817,7 +817,7 @@ export Recipe := Window {
 
 Slint doesn't currently provide a table widget. It's possible to emulate it with a ListView:
 
-```slint
+```slint,no-auto-preview
 import { VerticalBox, ListView } from "std-widgets.slint";
 
 TableView := Rectangle {

--- a/docs/resources/slint-docs-highlight.html
+++ b/docs/resources/slint-docs-highlight.html
@@ -52,7 +52,7 @@
   };
 
   // Tags used in fenced code blocks
-  for (let tag of ["slint", "slint,no-preview", "slint,ignore"]) {
+  for (let tag of ["slint", "slint,no-preview", "slint,no-auto-preview", "slint,ignore"]) {
     hljs.registerLanguage(tag, highlight_slint);
   }
 

--- a/docs/resources/slint-docs-preview.html
+++ b/docs/resources/slint-docs-preview.html
@@ -31,20 +31,55 @@
         }
     }
 
+    async function create_preview(element, source_code) {
+        let div = document.createElement("div");
+        div.style = "float: right; padding:0; margin:0;";
+        element.prepend(div);
+        await render_or_error(source_code, div);
+    }
+
+    function should_show_automatic_preview(element) {
+        // The `no-auto-preview` doesn't map directly to a dedicated class but it is mangled differently
+        // between rustdoc and sphinx, so match fuzzy on the entire class list:
+        return !element.className.includes("no-auto-preview");
+    }
+
+    async function create_click_to_play_and_edit_buttons(element) {
+        let source = element.innerText;
+
+        let link_section = document.createElement("div");
+        element.append(link_section);
+
+        let edit_button = document.createElement("input");
+        edit_button.type = "button";
+        edit_button.value = "Edit 📝";
+        edit_button.onclick = () => {
+            window.open(`${editor_url}?snippet=${encodeURIComponent(source)}`, "_blank");
+        };
+        link_section.append(edit_button);
+
+        if (should_show_automatic_preview(element)) {
+            create_preview(element, source);
+        } else {
+            let play_button = document.createElement("input");
+            play_button.type = "button";
+            play_button.value = "Preview ▶️";
+            play_button.onclick = async () => {
+                play_button.remove();
+                create_preview(element, source);
+            };
+
+            link_section.prepend(play_button);
+        }
+    }
+
     async function run() {
         await slint.default();
         let selector = ["code.language-slint", ".rustdoc pre.language-slint", "div.highlight-slint"]
             .map((sel) => `${sel}:not([class*=slint\\,ignore]):not([class*=slint\\,no-preview])`).join(",");
         var elements = document.querySelectorAll(selector);
         for (var i = 0; i < elements.length; ++i) {
-            let source = elements[i].innerText;
-            let div = document.createElement("div");
-            div.style = "float: right; padding:0; margin:0;";
-            elements[i].prepend(div);
-            let link = document.createElement("div");
-            link.innerHTML = `<a href="${editor_url}?snippet=${encodeURIComponent(source)}" target="_blank">📝</a>`;
-            elements[i].append(link);
-            await render_or_error(source, div);
+            await create_click_to_play_and_edit_buttons(elements[i]);
         }
         slint.run_event_loop();
     }

--- a/docs/resources/slint-docs-preview.html
+++ b/docs/resources/slint-docs-preview.html
@@ -50,20 +50,21 @@
         let link_section = document.createElement("div");
         element.append(link_section);
 
-        let edit_button = document.createElement("input");
-        edit_button.type = "button";
-        edit_button.value = "Edit 📝";
-        edit_button.onclick = () => {
-            window.open(`${editor_url}?snippet=${encodeURIComponent(source)}`, "_blank");
-        };
+        let button_style = "padding: 5px 10px 5px 10px; text-decoration: none;"
+
+        let edit_button = document.createElement("a");
+        edit_button.style = button_style;
+        edit_button.href = `${editor_url}?snippet=${encodeURIComponent(source)}`;
+        edit_button.target = "_blank";
+        edit_button.innerText = "Edit 📝";
         link_section.append(edit_button);
 
         if (should_show_automatic_preview(element)) {
             create_preview(element, source);
         } else {
-            let play_button = document.createElement("input");
-            play_button.type = "button";
-            play_button.value = "Preview ▶️";
+            let play_button = document.createElement("a");
+            play_button.style = button_style;
+            play_button.innerText = "Preview ▶️";
             play_button.onclick = async () => {
                 play_button.remove();
                 create_preview(element, source);

--- a/tests/doctests/build.rs
+++ b/tests/doctests/build.rs
@@ -31,9 +31,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         while let Some(begin) = rest.find(BEGIN_MARKER) {
             rest = rest[begin..].strip_prefix(BEGIN_MARKER).unwrap();
 
-            // Permit `slint,no-preview` but skip `slint,ignore` and others.
+            // Permit `slint,no-preview` and `slint,no-auto-preview` but skip `slint,ignore` and others.
             rest = match rest.split_once('\n') {
-                Some((",no-preview", rest)) => rest,
+                Some((",no-preview", rest)) | Some((",no-auto-preview", rest)) => rest,
                 Some(("", _)) => rest,
                 _ => continue,
             };


### PR DESCRIPTION
By using a persistent WebGL context for reach (small) preview, we hit the browser imposed limits on the number of GL contexts quickly.
This change replaces the automatically loaded preview with a click-to-play approach, by using two buttons:
- one to show the preview
- one to launch the example in the online editor (button, instead of link, to avoid highlight on hover)