### PR TITLE
Specify target platform for esbuild calls for vs code extension

### DIFF
--- a/editors/vscode/esbuild.js
+++ b/editors/vscode/esbuild.js
@@ -78,7 +78,7 @@ esbuild
         entryPoints: ["src/propertiesView.ts"],
         bundle: true,
         outfile: "out/propertiesView.js",
-        platform: "node",
+        platform: "browser",
         format: "iife",
     })
     .catch(() => process.exit(1));

--- a/editors/vscode/esbuild.js
+++ b/editors/vscode/esbuild.js
@@ -41,6 +41,7 @@ esbuild
         external: ["vscode"],
         outfile: "out/browser.js",
         format: "cjs",
+        platform: "browser",
     })
     .catch(() => process.exit(1));
 
@@ -50,6 +51,7 @@ esbuild
         bundle: true,
         outfile: "out/browserServerMain.js",
         format: "iife",
+        platform: "browser",
         plugins: [wasmPlugin],
     })
     .catch(() => process.exit(1));
@@ -66,6 +68,7 @@ esbuild
             "fs",
         ],
         outfile: "out/extension.js",
+        platform: "node",
         format: "cjs",
     })
     .catch(() => process.exit(1));
@@ -75,6 +78,7 @@ esbuild
         entryPoints: ["src/propertiesView.ts"],
         bundle: true,
         outfile: "out/propertiesView.js",
+        platform: "node",
         format: "iife",
     })
     .catch(() => process.exit(1));


### PR DESCRIPTION
This patch has no effect on the currently generated output (apart from a dummy few lines in out/extension.js), but may help to avoid issues in the future like we had last week, where esbuild processed an import from "vscode-languageclient" and due to browser mode it picked the browser version of the languageclient for out/extension.js that's running in the node environment.