### PR TITLE
Fix visibility on drop shadow

### DIFF
--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -137,6 +137,7 @@ pub async fn run_passes(
             &global_type_registry.borrow(),
             diag,
         );
+        visible::handle_visible(component, &global_type_registry.borrow());
         lower_shadows::lower_shadow_properties(component, &doc.local_registry, diag);
         lower_property_to_element::lower_property_to_element(
             component,
@@ -163,7 +164,6 @@ pub async fn run_passes(
             diag,
         );
         clip::handle_clip(component, &global_type_registry.borrow(), diag);
-        visible::handle_visible(component, &global_type_registry.borrow());
         if compiler_config.accessibility {
             lower_accessibility::lower_accessibility_properties(component, diag);
         }


### PR DESCRIPTION
`visible:false` would't hide the drop shadow

Fixes: #1460