### PR TITLE
online editor: fix previous preview re-appearing unexpectedly

### DIFF
--- a/tools/online_editor/src/preview_widget.ts
+++ b/tools/online_editor/src/preview_widget.ts
@@ -134,10 +134,10 @@ export class PreviewWidget extends Widget {
         });
 
         if (component != null) {
+            // It's not enough for the canvas element to exist, in order to extract a webgl rendering
+            // context, the element needs to be attached to the window's dom.
+            await this.#ensure_attached_to_dom;
             if (this.#instance == null) {
-                // It's not enough for the canvas element to exist, in order to extract a webgl rendering
-                // context, the element needs to be attached to the window's dom.
-                await this.#ensure_attached_to_dom;
                 this.#instance = component.create(this.canvas_id);
                 this.#instance.show();
                 try {


### PR DESCRIPTION
After checking if the instance field is null, we await the promise that would guarantee DOM attachment.  While we await, the browser processes other microtasks, and we might end up in render() again. This time the instance field is also null, but the ensure_attached_to_dom promise is already resolved, so we would create the first slint component and the associated window. Later we would return from the first await. At this point the instance field is already set, so we should re-use the existing window, but since we're not checking anymore, we'll go ahead and create a second window on the same canvas element.

Fixes #1926