### PR TITLE
ListView: Warn when we have other elements than just a `for`

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1126,6 +1126,23 @@ impl Element {
             }
         }
 
+        if r.borrow().base_type.to_string() == "ListView" {
+            let mut seen_for = false;
+            for se in node.children() {
+                if se.kind() == SyntaxKind::RepeatedElement && !seen_for {
+                    seen_for = true;
+                } else if matches!(
+                    se.kind(),
+                    SyntaxKind::SubElement
+                        | SyntaxKind::ConditionalElement
+                        | SyntaxKind::RepeatedElement
+                        | SyntaxKind::ChildrenPlaceholder
+                ) {
+                    diag.push_warning("A ListView can just have a single 'for' as children. Anything else is not supported".into(), &se)
+                }
+            }
+        }
+
         r
     }
 

--- a/internal/compiler/tests/syntax/elements/listview.slint
+++ b/internal/compiler/tests/syntax/elements/listview.slint
@@ -1,0 +1,35 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+import { ListView  } from "std-widgets.slint";
+
+Foo := Rectangle {
+    ListView {
+        @children
+//      ^warning{A ListView can just have a single 'for' as children. Anything else is not supported}
+    }
+}
+
+Bar := Rectangle {
+    Foo { Text {} }
+    ListView {
+        Text {}
+//      ^warning{A ListView can just have a single 'for' as children. Anything else is not supported}
+    }
+    ListView {
+        Text { }
+//      ^warning{A ListView can just have a single 'for' as children. Anything else is not supported}
+        for x in 2: Rectangle {}
+        Text { }
+//      ^warning{A ListView can just have a single 'for' as children. Anything else is not supported}
+        for x in 2: Rectangle {}
+//      ^warning{A ListView can just have a single 'for' as children. Anything else is not supported}
+    }
+
+    ListView { for x in 2: Rectangle {} }
+    ListView {
+        for x in 2: Rectangle {}
+        for x in 2: Rectangle {}
+//      ^warning{A ListView can just have a single 'for' as children. Anything else is not supported}
+    }
+}

--- a/internal/compiler/widgets/fluent-base/std-widgets.slint
+++ b/internal/compiler/widgets/fluent-base/std-widgets.slint
@@ -496,7 +496,7 @@ export ListView := ScrollView {
     @children
 }
 
-export StandardListView := ListView {
+StandardListViewBase := ListView {
     property<[StandardListViewItem]> model;
     property<int> current-item: -1;
     for item[idx] in model : Rectangle {
@@ -516,6 +516,9 @@ export StandardListView := ListView {
             clicked => { current-item = idx; }
         }
     }
+}
+
+export StandardListView := StandardListViewBase {
     FocusScope {
         key-pressed(event) => {
             if (event.text == Key.UpArrow && current-item > 0) {

--- a/internal/compiler/widgets/material-base/widget-listview.slint
+++ b/internal/compiler/widgets/material-base/widget-listview.slint
@@ -10,8 +10,7 @@ export ListView := ScrollView {
     @children
 }
 
-// Like `ListView`, but with a default delegate, and a `model` property which is a model of type `StandardListViewItem`.
-export StandardListView := ListView {
+StandardListViewBase := ListView {
     in property<[StandardListViewItem]> model;
     in-out property<int> current-item: -1;
 
@@ -20,7 +19,10 @@ export StandardListView := ListView {
         text: item.text;
         clicked => { current-item = idx; }
     }
+}
 
+// Like `ListView`, but with a default delegate, and a `model` property which is a model of type `StandardListViewItem`.
+export StandardListView := StandardListViewBase {
     FocusScope {
         key-pressed(event) => {
             if (event.text == Key.UpArrow && current-item > 0) {

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -115,7 +115,7 @@ export ListView := ScrollView {
     @children
 }
 
-export StandardListView := ListView {
+StandardListViewBase := ListView {
     in property<[StandardListViewItem]> model;
     in-out property<int> current-item: -1;
     for item[i] in model : NativeStandardListViewItem {
@@ -127,6 +127,9 @@ export StandardListView := ListView {
             clicked => { current-item = i; }
         }
     }
+}
+
+export StandardListView := StandardListViewBase {
     FocusScope {
         key-pressed(event) => {
             if (event.text == Key.UpArrow && current-item > 0) {


### PR DESCRIPTION
This is not supported right now, the other elements will not be part of the layout, and two `for` will be in the same listview, creating bad situation with the scrollbar.

This is a warning since it would be a breaking change to make it an error.

For example, we used a FocusScope in the StandardListView implementation so I had to go trough one level of indirection

CC: #860