### PR TITLE
Don't match builtin type purely on it's base type name

### DIFF
--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -22,7 +22,7 @@ pub fn lower_popups(
         component,
         &None,
         &mut |elem, parent_element: &Option<ElementRc>| {
-            let is_popup = elem.borrow().base_type.to_string() == "PopupWindow";
+            let is_popup = matches!(&elem.borrow().base_type, ElementType::Builtin(base_type) if base_type.name == "PopupWindow");
             if is_popup {
                 lower_popup_window(elem, parent_element.as_ref(), &window_type, diag);
             }

--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -21,15 +21,10 @@ fn create_box_shadow_element(
     type_register: &TypeRegister,
     diag: &mut BuildDiagnostics,
 ) -> Option<Element> {
-    if matches!(sibling_element.borrow().native_class(), Some(native)
-       if native.class_name != "Rectangle" && native.class_name != "BorderRectangle" && native.class_name != "Clip")
-    {
+    if matches!(sibling_element.borrow().builtin_type(), Some(b) if b.name != "Rectangle") {
         for (shadow_prop_name, shadow_prop_binding) in shadow_property_bindings {
             diag.push_error(
-                format!(
-                    "The {} property is only supported on Rectangle and Clip elements right now",
-                    shadow_prop_name
-                ),
+                format!("The {shadow_prop_name} property is only supported on Rectangle elements right now"),
                 &shadow_prop_binding,
             );
         }

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -38,7 +38,7 @@ pub async fn lower_tabwidget(
         type_loader.global_type_registry.borrow().lookup_element("Rectangle").unwrap();
 
     recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
-        if elem.borrow().base_type.to_string() == "TabWidget" {
+        if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "TabWidget") {
             process_tabwidget(
                 elem,
                 ElementType::Component(tabwidget_impl.clone()),
@@ -59,6 +59,11 @@ fn process_tabwidget(
     rectangle_type: &ElementType,
     diag: &mut BuildDiagnostics,
 ) {
+    if matches!(&elem.borrow_mut().base_type, ElementType::Builtin(_)) {
+        // That's the TabWidget re-exported from the style, it doesn't need to be processed
+        return;
+    }
+
     elem.borrow_mut().base_type = tabwidget_impl;
     let mut children = std::mem::take(&mut elem.borrow_mut().children);
     let num_tabs = children.len();

--- a/internal/compiler/tests/syntax/basic/box_shadow.slint
+++ b/internal/compiler/tests/syntax/basic/box_shadow.slint
@@ -11,7 +11,7 @@ SuperSimple := Window {
 
     Text {
         drop-shadow-color: black;
-//                        ^error{The drop-shadow-color property is only supported on Rectangle and Clip elements right now}
+//                        ^error{The drop-shadow-color property is only supported on Rectangle elements right now}
     }
 
     Foo {}

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -320,6 +320,13 @@ impl TypeRegister {
         })
     }
 
+    pub fn lookup_builtin_element(&self, name: &str) -> Option<ElementType> {
+        self.parent_registry.as_ref().map_or_else(
+            || self.elements.get(name).cloned(),
+            |p| p.borrow().lookup_builtin_element(name),
+        )
+    }
+
     pub fn lookup_qualified<Member: AsRef<str>>(&self, qualified: &[Member]) -> Type {
         if qualified.len() != 1 {
             return Type::Invalid;

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -203,7 +203,7 @@ pub(crate) fn add_highlight_items(doc: &Document) {
             root_element: Rc::new(RefCell::new(Element {
                 enclosing_component: comp.clone(),
                 id: "$Highlight".into(),
-                base_type: doc.local_registry.lookup_element("Rectangle").unwrap(),
+                base_type: doc.local_registry.lookup_builtin_element("Rectangle").unwrap(),
                 bindings,
                 ..Default::default()
             })),

--- a/tests/cases/lookup/renamed_elements.slint
+++ b/tests/cases/lookup/renamed_elements.slint
@@ -1,0 +1,27 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+PopupWindow := Rectangle {}
+Rectangle := Image {}
+TabWidget := Text {}
+VerticalLayout := PopupWindow {}
+
+
+TestCase := Window {
+    HorizontalLayout {
+        pw := PopupWindow {
+            background: orangered;
+        }
+        Rectangle {
+            colorize: red;
+        }
+        TabWidget {
+            text: "hello";
+            TouchArea { clicked => { parent.text = "world"; } }
+        }
+        VerticalLayout {
+            background: pw.background;
+        }
+    }
+}


### PR DESCRIPTION
Make sure this is the actual builtin type we are looking at and not a re-defined component

Doesn't work for ListView unfortunately because ListView is not a builtin type

CC #861