### PR TITLE
Add support for re-exporting types from other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 ### Added
 
  - Added support for declaring functions in the language.
+ - Add support for re-exporting types from other files using `export * from "./other_file.slint";`.
 
 ### Fixed
 

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -1031,6 +1031,32 @@ App := Rectangle {
 
 Elements, globals and structs can be exported and imported.
 
+### Module Syntax
+
+The following syntax is supported for importing types:
+
+```slint,ignore
+import { export1 } from "module.slint";
+import { export1, export2 } from "module.slint";
+import { export1 as alias1 } from "module.slint";
+import { export1, export2 as alias2, /* ... */ } from "module.slint";
+```
+
+The following syntax is supported for exporting types:
+
+```slint,ignore
+// Export declarations
+export MyButton := Rectangle { /* ... */ }
+
+// Export lists
+MySwitch := Rectangle { /* ... */ }
+export { MySwitch };
+export { MySwitch as Alias1, MyButton as Alias2 };
+
+// Re-export all types from other module
+export * from "other_module.slint";
+```
+
 ## Focus Handling
 
 Certain elements such as ```TextInput``` accept not only input from the mouse/finger but

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -160,12 +160,13 @@ pub async fn compile_syntax_node(
         return (crate::object_tree::Document::default(), diagnostics);
     }
 
-    let foreign_imports =
+    let (foreign_imports, reexports) =
         loader.load_dependencies_recursively(&doc_node, &mut diagnostics, &type_registry).await;
 
     let doc = crate::object_tree::Document::from_node(
         doc_node,
         foreign_imports,
+        reexports,
         &mut diagnostics,
         &type_registry,
     );

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2068,7 +2068,7 @@ impl ExportedName {
 }
 
 #[derive(Default, Debug, derive_more::Deref)]
-pub struct Exports(pub Vec<(ExportedName, Either<Rc<Component>, Type>)>);
+pub struct Exports(Vec<(ExportedName, Either<Rc<Component>, Type>)>);
 
 impl Exports {
     pub fn from_node(
@@ -2224,6 +2224,13 @@ impl Exports {
                 }
             }
         }
+    }
+
+    pub fn find(&self, name: &str) -> Option<Either<Rc<Component>, Type>> {
+        self.0
+            .binary_search_by(|(exported_name, _)| exported_name.as_str().cmp(name))
+            .ok()
+            .map(|index| self.0[index].1.clone())
     }
 }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2214,8 +2214,11 @@ impl Exports {
         for export in other_exports {
             match self.0.binary_search_by(|entry| entry.0.cmp(&export.0)) {
                 Ok(_) => {
-                    diag.push_error(
-                        format!("re-export '{}' is already exported in this file", &*export.0),
+                    diag.push_warning(
+                        format!(
+                            "'{}' is already exported in this file; it will not be re-exported",
+                            &*export.0
+                        ),
                         &export.0.name_ident,
                     );
                 }

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -396,12 +396,14 @@ declare_syntax! {
         /// There is an identifier "in" or "out", the DeclaredIdentifier is the state name
         Transition -> [?DeclaredIdentifier, *PropertyAnimation],
         /// Export a set of declared components by name
-        ExportsList -> [ *ExportSpecifier, ?Component, *StructDeclaration ],
+        ExportsList -> [ *ExportSpecifier, ?Component, *StructDeclaration, *ExportModule ],
         /// Declare the first identifier to be exported, either under its name or instead
         /// under the name of the second identifier.
         ExportSpecifier -> [ ExportIdentifier, ?ExportName ],
         ExportIdentifier -> [],
         ExportName -> [],
+        /// `export * from "foo"`. The import uri is stored as string literal.
+        ExportModule -> [],
         /// import { foo, bar, baz } from "blah"; The import uri is stored as string literal.
         ImportSpecifier -> [ ?ImportIdentifierList ],
         ImportIdentifierList -> [ *ImportIdentifier ],

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -164,7 +164,7 @@ fn parse_export(p: &mut impl Parser) -> bool {
         }
     } else if p.peek().as_str() == "struct" {
         parse_struct_declaration(&mut *p)
-    } else if p.peek().as_str() == "*" {
+    } else if p.peek().kind == SyntaxKind::Star {
         let mut p = p.start_node(SyntaxKind::ExportModule);
         p.consume(); // *
         if p.peek().as_str() != "from" {

--- a/internal/compiler/passes/check_public_api.rs
+++ b/internal/compiler/passes/check_public_api.rs
@@ -10,7 +10,7 @@ use crate::object_tree::{Component, Document, PropertyVisibility};
 
 pub fn check_public_api(doc: &Document, diag: &mut BuildDiagnostics) {
     check_public_api_component(&doc.root_component, diag);
-    for (export_name, e) in &doc.exports.0 {
+    for (export_name, e) in &*doc.exports {
         if let Some(c) = e.as_ref().left() {
             if c.is_global() {
                 // This global will become part of the public API.

--- a/internal/compiler/passes/collect_globals.rs
+++ b/internal/compiler/passes/collect_globals.rs
@@ -16,7 +16,7 @@ pub fn collect_globals(doc: &Document, _diag: &mut BuildDiagnostics) {
     doc.root_component.used_types.borrow_mut().globals.clear();
     let mut set = HashSet::new();
     let mut sorted_globals = vec![];
-    for (_, ty) in &doc.exports.0 {
+    for (_, ty) in &*doc.exports {
         if let Some(c) = ty.as_ref().left() {
             if c.is_global() {
                 if set.insert(ByAddress(c.clone())) {

--- a/internal/compiler/tests/syntax/exports/reexport_duplicate.slint
+++ b/internal/compiler/tests/syntax/exports/reexport_duplicate.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+export * from "../../typeloader/incpath/local_helper_type.slint";
+//     ^error{re-export 'SomeRect' is already exported in this file}
+
+export * from "../../typeloader/incpath/dependency_from_incpath.slint";
+export * from "../../typeloader/incpath/dependency_from_incpath.slint";
+//     ^error{re-export 'AnotherType' is already exported in this file}
+
+
+export SomeRect := Rectangle {}

--- a/internal/compiler/tests/syntax/exports/reexport_duplicate.slint
+++ b/internal/compiler/tests/syntax/exports/reexport_duplicate.slint
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 export * from "../../typeloader/incpath/local_helper_type.slint";
-//     ^error{re-export 'SomeRect' is already exported in this file}
+//     ^warning{'SomeRect' is already exported in this file; it will not be re-exported}
 
 export * from "../../typeloader/incpath/dependency_from_incpath.slint";
+//     ^error{re-exporting modules is only allowed once per file}
 export * from "../../typeloader/incpath/dependency_from_incpath.slint";
-//     ^error{re-export 'AnotherType' is already exported in this file}
+//     ^error{re-exporting modules is only allowed once per file}
 
 
 export SomeRect := Rectangle {}

--- a/internal/compiler/tests/syntax/imports/import_errors.slint
+++ b/internal/compiler/tests/syntax/imports/import_errors.slint
@@ -10,7 +10,7 @@ import { NotExported } from "../../typeloader/incpath/local_helper_type.slint";
 import { Nothing } from "";
 //                      ^error{Unexpected empty import url}
 
-import "invalid_export.slint";
+import "../../typeloader/incpath/local_helper_type.slint";
 //     ^error{Import names are missing. Please specify which types you would like to import}
 
 import "myimage.png";

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -230,13 +230,7 @@ impl TypeLoader {
 
         let doc = self.all_documents.docs.get(&doc_path).unwrap();
 
-        doc.exports.0.iter().find_map(|(export_name, ty)| {
-            if type_name == export_name.as_str() {
-                ty.clone().left()
-            } else {
-                None
-            }
-        })
+        doc.exports.find(type_name).and_then(|compo_or_type| compo_or_type.left())
     }
 
     /// Append a possibly relative path to a base path. Returns the data if it resolves to a built-in (compiled-in)
@@ -396,13 +390,7 @@ impl TypeLoader {
         build_diagnostics: &mut BuildDiagnostics,
     ) {
         for import_name in imported_types {
-            let imported_type = doc.exports.0.iter().find_map(|(export_name, ty)| {
-                if import_name.external_name == export_name.as_str() {
-                    Some(ty.clone())
-                } else {
-                    None
-                }
-            });
+            let imported_type = doc.exports.find(&import_name.external_name);
 
             let imported_type = match imported_type {
                 Some(ty) => ty,

--- a/internal/compiler/widgets/fluent-dark/std-widgets.slint
+++ b/internal/compiler/widgets/fluent-dark/std-widgets.slint
@@ -1,16 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-} from "../fluent-base/std-widgets.slint";
-
-export {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-}
+export * from "../fluent-base/std-widgets.slint";

--- a/internal/compiler/widgets/fluent-light/std-widgets.slint
+++ b/internal/compiler/widgets/fluent-light/std-widgets.slint
@@ -1,16 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-} from "../fluent-base/std-widgets.slint";
-
-export {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-}
+export * from "../fluent-base/std-widgets.slint";

--- a/internal/compiler/widgets/fluent/std-widgets.slint
+++ b/internal/compiler/widgets/fluent/std-widgets.slint
@@ -1,16 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-} from "../fluent-base/std-widgets.slint";
-
-export {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-}
+export * from "../fluent-base/std-widgets.slint";

--- a/internal/compiler/widgets/material-dark/std-widgets.slint
+++ b/internal/compiler/widgets/material-dark/std-widgets.slint
@@ -1,16 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-} from "../material-base/std-widgets.slint";
-
-export {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-}
+export * from "../material-base/std-widgets.slint";

--- a/internal/compiler/widgets/material-light/std-widgets.slint
+++ b/internal/compiler/widgets/material-light/std-widgets.slint
@@ -1,16 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-} from "../material-base/std-widgets.slint";
-
-export {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-}
+export * from "../material-base/std-widgets.slint";

--- a/internal/compiler/widgets/material/std-widgets.slint
+++ b/internal/compiler/widgets/material/std-widgets.slint
@@ -1,16 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-} from "../material-base/std-widgets.slint";
-
-export {
-    StyleMetrics, ScrollView, Button, StandardButton, TextEdit,
-    AboutSlint, AboutSlint as AboutSixtyFPS, CheckBox, SpinBox, Slider, GroupBox, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, ListView, StandardListView, ComboBox,
-    VerticalBox, HorizontalBox, GridBox
-}
+export * from "../material-base/std-widgets.slint";

--- a/tests/cases/imports/reexport.slint
+++ b/tests/cases/imports/reexport.slint
@@ -1,0 +1,9 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+//include_path: ../../helper_components
+import { TestButton, ColorButton } from "re_export_all.slint";
+TestCase := Rectangle {
+    TestButton {}
+    ColorButton {}
+}

--- a/tests/helper_components/re_export_all.slint
+++ b/tests/helper_components/re_export_all.slint
@@ -1,0 +1,5 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+export * from "./test_button.slint";
+

--- a/tools/lsp/completion.rs
+++ b/tools/lsp/completion.rs
@@ -147,7 +147,7 @@ pub(crate) fn completion_at(
                         }
                     };
 
-                    for (exported_name, ty) in &doc.exports.0 {
+                    for (exported_name, ty) in &*doc.exports {
                         if available_types.contains(&exported_name.name) {
                             continue;
                         }

--- a/tools/syntax_updater/main.rs
+++ b/tools/syntax_updater/main.rs
@@ -168,7 +168,7 @@ fn process_file(
     let dependency_registry = Rc::new(RefCell::new(
         i_slint_compiler::typeregister::TypeRegister::new(&type_loader.global_type_registry),
     ));
-    let foreign_imports = spin_on::spin_on(type_loader.load_dependencies_recursively(
+    let (foreign_imports, reexports) = spin_on::spin_on(type_loader.load_dependencies_recursively(
         &doc,
         &mut diag,
         &dependency_registry,
@@ -176,6 +176,7 @@ fn process_file(
     let current_doc = crate::object_tree::Document::from_node(
         doc,
         foreign_imports,
+        reexports,
         &mut diag,
         &dependency_registry,
     );


### PR DESCRIPTION
The `export * from "./other_file.slint"` syntax takes all the exports from that file and re-exports them. This simplifies our style wrapper code.

As a bonus this also cleans up some of the export handling in the compiler.