### PR TITLE
Bump MSRV to 1.64 and fix CI that checks it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,13 +21,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2022]
-        rust_version: [stable, "1.60"]
+        rust_version: [stable, "1.64"]
         include:
           - os: windows-2022
             extra_args: "--exclude slint-node --exclude test-driver-nodejs"
         exclude:
           - os: macos-11
-            rust_version: "1.60"
+            rust_version: "1.64"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,7 @@ jobs:
       id: node-install
     - uses: ./.github/actions/setup-rust
       with:
+        toolchain: ${{ matrix.rust_version }}
         key: x-v2-${{ steps.node-install.outputs.node-version }} # the cache key consists of a manually bumpable version and the node version, as the cached rustc artifacts contain linking information where to find node.lib, which is in a versioned directory.
     - name: Build
       run: cargo build --verbose --all-features --workspace ${{ matrix.extra_args }} --exclude test-driver-cpp --exclude mcu-board-support --exclude printerdemo_mcu --exclude carousel  # mcu backend requires nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Changed
+
+ - Minimum rust version is now 1.64.
+
 ## [0.3.2] - 2022-11-28
 
 ### Changed

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Corrosion)
 
 list(PREPEND CMAKE_MODULE_PATH ${Corrosion_SOURCE_DIR}/cmake)
-find_package(Rust 1.60 REQUIRED MODULE)
+find_package(Rust 1.64 REQUIRED MODULE)
 
 option(SLINT_FEATURE_COMPILER "Enable support for compiling .slint files to C++ ahead of time" ON)
 

--- a/api/rs/slint/README.md
+++ b/api/rs/slint/README.md
@@ -63,4 +63,4 @@ cargo run --release --bin printerdemo
 
 ### Minimum Supported Rust Version
 
- This crate's minimum supported `rustc` version is 1.60.
+ This crate's minimum supported `rustc` version is 1.64.

--- a/docs/building.md
+++ b/docs/building.md
@@ -7,7 +7,7 @@ This page explains how to build and test Slint.
 ### Installing Rust
 
 Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). If you already
-have Rust installed, make sure that it's at least version 1.60 or newer. You can check which version you have installed
+have Rust installed, make sure that it's at least version 1.64 or newer. You can check which version you have installed
 by running `rustc --version`.
 
 Once this is done, you should have the `rustc` compiler and the `cargo` build system installed in your path.

--- a/docs/tutorial/cpp/src/getting_started.md
+++ b/docs/tutorial/cpp/src/getting_started.md
@@ -6,7 +6,7 @@ In this tutorial, we use C++ as the host programming language. We also support o
 You will need a development environment that can compile C++20 with CMake 3.19.
 We do not provide binaries of Slint yet, so we will use the CMake integration that will automatically build
 the tools and library from source. Since it is implemented in the Rust programming language, this means that
-you also need to install a Rust compiler (1.60). You can easily install a Rust compiler
+you also need to install a Rust compiler (1.64). You can easily install a Rust compiler
 following the instruction from [the Rust website](https://www.rust-lang.org/learn/get-started).
 We are going to use `cmake`'s builtin FetchContent module to fetch the source code of Slint.
 


### PR DESCRIPTION
The refactoring of the CI broke our check that we test the build with an earlier Rust version. This PR restores that and bumps the MSRV to 1.64 - that's the minimum that the Rust Skia bindings need for the `core::ffi::c_*` types.