### PR TITLE
janitor: bump rust-version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ default-members = [
 
 resolver="2"
 
+[workspace.package]
+rust-version = "1.64"
+
 [profile.release]
 lto = true
 panic = "abort"

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -12,7 +12,7 @@ description = "Slint C++ integration"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
 publish = false
-rust-version = "1.60"
+rust-version.workspace = true
 # prefix used to convey path to generated includes to the C++ test driver
 links = "slint_cpp"
 

--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
 description = "Helper for Slint build script"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
-rust-version = "1.60"
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
 categories = ["gui", "rendering::engine"]
 keywords = ["gui", "toolkit", "graphics", "design", "ui"]
-rust-version = "1.60"
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/examples/7guis/Cargo.toml
+++ b/examples/7guis/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Slint Developers <info@slint-ui.com>"]
 edition = "2021"
 publish = false
 license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
-rust-version = "1.60"
+rust-version.workspace = true
 
 [[bin]]
 path = "booker.rs"

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -11,6 +11,7 @@ description = "OpenGL rendering backend for Slint"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
 build = "build.rs"
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
 description = "Internal Slint Compiler Library"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
-rust-version = "1.60"
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
 categories = ["gui", "development-tools"]
 keywords = ["gui", "ui", "toolkit", "graphics", "design"]
-rust-version = "1.60"
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
 categories = ["gui", "rendering::engine"]
 keywords = ["gui", "toolkit", "graphics", "design", "ui"]
-rust-version = "1.60"
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint-ui.com"
 categories = ["gui", "development-tools"]
 keywords = ["lsp"]
-rust-version = "1.60"
+rust-version.workspace = true
 
 [package.metadata.bundle]
 name = "Slint Live Preview"


### PR DESCRIPTION
* 1.64 for compiler and winit due to the ffi types
* 1.62 for the interpreter and core for the enum defaults