### PR TITLE
Fix in/out/private property on global

### DIFF
--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -71,6 +71,15 @@ impl<'a> LookupCtx<'a> {
     pub fn is_legacy_component(&self) -> bool {
         self.component_scope.first().map_or(false, |e| e.borrow().is_legacy_syntax)
     }
+
+    /// True if the element is in the same component as the scope
+    pub fn is_local_element(&self, elem: &ElementRc) -> bool {
+        Option::zip(
+            elem.borrow().enclosing_component.upgrade(),
+            self.component_scope.first().and_then(|x| x.borrow().enclosing_component.upgrade()),
+        )
+        .map_or(true, |(x, y)| Rc::ptr_eq(&x, &y))
+    }
 }
 
 pub enum LookupResult {

--- a/internal/compiler/tests/syntax/new_syntax/input_output2.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output2.slint
@@ -1,6 +1,21 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+global Glo {
+    property <int> priv1: 34;
+    in property <int> in1: 11;
+    out property <int> out1: 33;
+    private property <int> priv2: 55;
+    in-out property <int> inout1: 2;
+
+    callback foo(int);
+    foo(x) => {
+        out1 = 42;
+        in1 = 55;
+//      ^error{Assignment on a input property}
+    }
+}
+
 component Compo inherits Rectangle {
     property <int> priv1: 42;
     private property <int> priv2: priv1;
@@ -90,6 +105,13 @@ component Foo inherits Rectangle {
             input_model[42] += 12;
 //          ^error{Self assignment on a input property}
 
+            Glo.out1 = Glo.in1;
+//          ^error{Assignment on a output property}
+            Glo.inout1 = Glo.priv1;
+//                           ^error{'priv1' is private}
+            Glo.priv2 = Glo.out1;
+//              ^error{'priv2' is private}
+            Glo.in1 = 32;
         }
     }
 }


### PR DESCRIPTION
This is technicly a breking change. But this is also a bug and it was only allowed since 0.3.2, so it is probably fine.

The problem is that any property access to a global was considered as being local.
Now, change that so that property access to a global object is no longer local, and other components can't access private property anymore