### PR TITLE
Fix panic in the interpreter when evaluating `init` in a layout

### DIFF
--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -227,7 +227,6 @@ fn box_layout_data(
                     window_adapter,
                     Default::default(),
                 );
-                instance.run_setup_code();
                 instance
             });
             let component_vec = rep.0.as_ref().components_vec();
@@ -286,7 +285,6 @@ fn repeater_indices(children: &[ElementRc], component: InstanceRef) -> Vec<u32> 
                     window_adapter,
                     Default::default(),
                 );
-                instance.run_setup_code();
                 instance
             });
             let component_vec = rep.0.as_ref().components_vec();

--- a/tests/cases/callbacks/init_layout.slint
+++ b/tests/cases/callbacks/init_layout.slint
@@ -1,0 +1,53 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// Verify that the init callback is invoked in the correct order
+
+export global InitOrder := {
+    property <string> observed-order: "start";
+}
+
+
+TestCase := Rectangle {
+    width: 300phx;
+    height: 300phx;
+    init => {
+        InitOrder.observed-order += "|root";
+    }
+
+
+    HorizontalLayout {
+        for i in ["hello", "world"]: Rectangle {
+            preferred-width: 10px;
+            init => {
+                InitOrder.observed-order +="|" + i;
+            }
+        }
+    }
+
+    property <string> expected_order: "start|root|hello|world";
+
+    property <bool> test: root.preferred-width == 20px && InitOrder.observed-order == expected_order;
+}
+
+/*
+```rust
+let instance = TestCase::new();
+
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+
+
+*/


### PR DESCRIPTION
The repeater code already call the init code, so we shouldn't call it twice.