### PR TITLE
internal: Remove the winit dependency from the renderers in the winit backend

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -46,6 +46,7 @@ scoped-tls-hkt = "0.1"
 winit = { version = "0.27.5", default-features = false }
 dark-light = "0.2.2"
 instant = "0.1"
+raw-window-handle = { version = "0.5" }
 
 # For the FemtoVG renderer
 femtovg = { version = "0.3.7", optional = true, default-features = false, features = ["image-loading"] }
@@ -68,7 +69,6 @@ send_wrapper = "0.6.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { version = "0.10", optional = true, features = ["memmap", "fontconfig"] }
 glutin = { version = "0.30", default-features = false, features = ["egl", "wgl"] }
-raw-window-handle = { version = "0.5" }
 
 # For the FemtoVG renderer
 [target.'cfg(target_family = "windows")'.dependencies]

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -67,8 +67,7 @@ send_wrapper = "0.6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { version = "0.10", optional = true, features = ["memmap", "fontconfig"] }
-glutin = { version = "0.30", default-features = false }
-glutin-winit = { version = "0.2.1" }
+glutin = { version = "0.30", default-features = false, features = ["egl", "wgl"] }
 raw-window-handle = { version = "0.5" }
 
 # For the FemtoVG renderer

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -187,7 +187,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WinitWindow for GLWindow<Rende
         };
 
         self.pending_redraw.set(false);
-        self.renderer.render(&window.canvas, self);
+        self.renderer.render(&window.canvas);
 
         self.pending_redraw.get()
     }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -39,7 +39,7 @@ mod renderer {
         fn create_canvas(&self, window_builder: winit::window::WindowBuilder) -> Self::Canvas;
         fn release_canvas(&self, canvas: Self::Canvas);
 
-        fn render(&self, canvas: &Self::Canvas, window: &dyn WindowAdapter);
+        fn render(&self, canvas: &Self::Canvas);
 
         fn default_font_size() -> LogicalLength;
     }

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -17,8 +17,6 @@ use i_slint_core::renderer::Renderer;
 use i_slint_core::window::{WindowAdapter, WindowInner};
 use i_slint_core::Brush;
 
-use crate::WindowSystemName;
-
 type PhysicalLength = euclid::Length<f32, PhysicalPx>;
 type PhysicalRect = euclid::Rect<f32, PhysicalPx>;
 type PhysicalSize = euclid::Size2D<f32, PhysicalPx>;
@@ -64,7 +62,7 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
 
         let rendering_metrics_collector = RenderingMetricsCollector::new(
             self.window_adapter_weak.clone(),
-            &format!("FemtoVG renderer (windowing system: {})", window.winsys_name()),
+            &format!("FemtoVG renderer (windowing system: {})", crate::winsys_name(&*window)),
         );
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -133,13 +133,14 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
         })
     }
 
-    fn render(&self, canvas: &FemtoVGCanvas, window_adapter: &dyn WindowAdapter) {
+    fn render(&self, canvas: &FemtoVGCanvas) {
         let size = canvas.window.inner_size();
         let width = size.width;
         let height = size.height;
 
         canvas.opengl_context.make_current();
 
+        let window_adapter = self.window_adapter_weak.upgrade().unwrap();
         let window = WindowInner::from_pub(window_adapter.window());
 
         window.draw_contents(|components| {
@@ -178,6 +179,8 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
                 canvas
                     .with_graphics_api(|api| callback.notify(RenderingState::BeforeRendering, &api))
             }
+
+            let window_adapter = self.window_adapter_weak.upgrade().unwrap();
 
             let mut item_renderer = self::itemrenderer::GLItemRenderer::new(
                 canvas,

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -17,8 +17,6 @@ use i_slint_core::lengths::{
 use i_slint_core::window::{WindowAdapter, WindowInner};
 use i_slint_core::Brush;
 
-use crate::WindowSystemName;
-
 type PhysicalLength = euclid::Length<f32, PhysicalPx>;
 type PhysicalRect = euclid::Rect<f32, PhysicalPx>;
 type PhysicalSize = euclid::Size2D<f32, PhysicalPx>;
@@ -68,7 +66,7 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
             self.window_adapter_weak.clone(),
             &format!(
                 "Skia renderer (windowing system: {}; skia backend {}; surface: {} bpp)",
-                surface.window().winsys_name(),
+                crate::winsys_name(&surface.window()),
                 surface.name(),
                 surface.bits_per_pixel()
             ),

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -94,7 +94,8 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
         });
     }
 
-    fn render(&self, canvas: &Self::Canvas, window_adapter: &dyn WindowAdapter) {
+    fn render(&self, canvas: &Self::Canvas) {
+        let window_adapter = self.window_adapter_weak.upgrade().unwrap();
         let window_inner = WindowInner::from_pub(window_adapter.window());
 
         canvas.surface.render(|skia_canvas, gr_context| {
@@ -119,6 +120,8 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
                 }
 
                 let mut box_shadow_cache = Default::default();
+
+                let window_adapter = self.window_adapter_weak.upgrade().unwrap();
 
                 let mut item_renderer = itemrenderer::SkiaRenderer::new(
                     skia_canvas,

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -34,7 +34,7 @@ impl<const BUFFER_COUNT: usize> super::WinitCompatibleRenderer for SoftwareRende
 
     fn release_canvas(&self, _canvas: Self::Canvas) {}
 
-    fn render(&self, canvas: &SwCanvas, _: &dyn WindowAdapter) {
+    fn render(&self, canvas: &SwCanvas) {
         let size = canvas.window.inner_size();
         let width = size.width as usize;
         let height = size.height as usize;


### PR DESCRIPTION
This prepares for the ability to move renderers into a separate crate and let them have their own API, for advanced embedding of Slint.