### PR TITLE
Add support for `CMAKE_*_OUTPUT_DIRECTORY` variables for Slint build artefacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,7 @@ jobs:
         buildWithCMakeArgs: '--config Debug'
     - name: ctest
       working-directory: ${{ runner.workspace }}/cppbuild
-      run: ctest --verbose
+      run: ctest --verbose -C Debug
     - name: cpack
       working-directory: ${{ runner.workspace }}/cppbuild
       run: cmake --build . --config Debug --target package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,17 +14,21 @@ option(BUILD_TESTING "Build tests" OFF)
 add_feature_info(BUILD_TESTING BUILD_TESTING "configure whether to build the test suite")
 include(CTest)
 
+# Place all compiled examples into the same bin directory
+# on Windows, where we'll also put the dll
+if (WIN32)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin/debug)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin/release)
+endif()
+
 add_subdirectory(api/cpp/)
 
 option(SLINT_BUILD_EXAMPLES "Build Slint Examples" OFF)
 add_feature_info(SLINT_BUILD_EXAMPLES SLINT_BUILD_EXAMPLES "configure whether to build the examples")
 
 if(SLINT_BUILD_EXAMPLES)
-    # Place all compiled examples into the same bin directory
-    # on Windows, where we'll also put the dll
-    if (WIN32)
-        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-    endif()
     add_subdirectory(examples)
     if(BUILD_TESTING)
         add_subdirectory(docs/tutorial/cpp/src/)

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.3.0
+    GIT_TAG f03517a98ccd69dd33ce115ac0d63aab5cc4398a
 )
 FetchContent_MakeAvailable(Corrosion)
 

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -259,11 +259,6 @@ if(WIN32)
     if(GENERATOR_IS_MULTI_CONFIG)
         set(config_subdir_genex "$<CONFIG>/")
     endif()
-
-    add_custom_target(Slint_dll_convenience ALL DEPENDS slint-cpp-shared
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        $<TARGET_FILE:slint-cpp-shared>
-        ${CMAKE_BINARY_DIR}/bin/${config_subdir_genex}$<TARGET_FILE_NAME:slint-cpp-shared>)
 endif()
 
 if(SLINT_FEATURE_COMPILER)

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -377,7 +377,7 @@ if(BUILD_TESTING)
         target_compile_definitions(test_${NAME} PRIVATE
             SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"
         )
-        add_test(test_${NAME} ${CMAKE_CURRENT_BINARY_DIR}/test_${NAME})
+        add_test(NAME test_${NAME} COMMAND test_${NAME})
 
         # Somehow the wrong relative rpath ends up in the binary, requiring us to change the
         # working directory.


### PR DESCRIPTION
Upgrade to a newer version of Corrosion that implements this and remove our workarounds.

Closes #1025