### PR TITLE
Remove the OpenGL dependency for renderer-winit-software

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,7 @@ panic = "abort"
 
 [profile.dev]
 panic = "abort"
+
+[patch.crates-io]
+# Pull in fix for https://github.com/john01dav/softbuffer/issues/22
+softbuffer = { git = "https://github.com/slint-ui/softbuffer", branch = "simon/macos-scale-fix" }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -61,7 +61,6 @@ i-slint-renderer-skia = { version = "=0.3.3", path = "../../renderers/skia", opt
 
 # For the software renderer
 softbuffer = { version = "0.1.1", optional = true }
-raw-window-handle-old = { package = "raw-window-handle", version = "0.4.1", features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["console", "WebGlContextAttributes", "CanvasRenderingContext2d", "HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "CssStyleDeclaration", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent"] }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -24,7 +24,7 @@ x11 = ["winit/x11", "glutin/x11", "copypasta/x11", "i-slint-renderer-skia?/x11"]
 renderer-winit-femtovg = ["femtovg", "fontdb", "libc", "yeslogic-fontconfig-sys", "winapi", "dwrote", "imgref", "unicode-script", "ttf-parser", "rgb", "i-slint-core/box-shadow-cache"]
 renderer-winit-skia = ["i-slint-renderer-skia"]
 renderer-winit-skia-opengl = ["renderer-winit-skia", "i-slint-renderer-skia/opengl"]
-renderer-winit-software = ["femtovg", "imgref", "rgb"]
+renderer-winit-software = ["softbuffer", "imgref", "rgb"]
 rtti = ["i-slint-core/rtti"]
 default = []
 
@@ -59,6 +59,10 @@ rgb = { version = "0.8.27", optional = true }
 # For the Skia renderer
 i-slint-renderer-skia = { version = "=0.3.3", path = "../../renderers/skia", optional = true }
 
+# For the software renderer
+softbuffer = { version = "0.1.1", optional = true }
+raw-window-handle-old = { package = "raw-window-handle", version = "0.4.1", features = ["alloc"] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["console", "WebGlContextAttributes", "CanvasRenderingContext2d", "HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "CssStyleDeclaration", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent"] }
 wasm-bindgen = { version = "0.2" }
@@ -66,7 +70,7 @@ send_wrapper = "0.6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { version = "0.10", optional = true, features = ["memmap", "fontconfig"] }
-glutin = { version = "0.30", default-features = false, features = ["egl", "wgl"] }
+glutin = { version = "0.30", optional = true, default-features = false, features = ["egl", "wgl"] }
 
 # For the FemtoVG renderer
 [target.'cfg(target_family = "windows")'.dependencies]

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -82,7 +82,7 @@ impl<const MAX_BUFFER_AGE: usize> super::WinitCompatibleRenderer
         let mut softbuffer_buffer = Vec::with_capacity(width * height * 4);
         softbuffer_buffer.extend(
             buffer
-                .iter()
+                .into_iter()
                 .map(|pixel| ((pixel.r as u32) << 16) | ((pixel.g as u32) << 8) | (pixel.b as u32)),
         );
 


### PR DESCRIPTION
Use softbuffer to bring pixels produced by the software renderer to the screen.