### PR TITLE
Fix rendering of border widths with FemtoVG and Skia

### DIFF
--- a/internal/backends/winit/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/winit/renderer/femtovg/itemrenderer.rs
@@ -112,9 +112,8 @@ fn adjust_rect_and_border_for_inner_drawing(
     *border_width = border_width.min(rect.width_length() / 2.);
     // adjust the size so that the border is drawn within the geometry
 
-    let half_border_size = PhysicalSize::from_lengths(*border_width / 2., *border_width / 2.);
-    rect.origin += half_border_size;
-    rect.size -= half_border_size;
+    rect.origin += PhysicalSize::from_lengths(*border_width / 2., *border_width / 2.);
+    rect.size -= PhysicalSize::from_lengths(*border_width, *border_width);
 }
 
 fn item_rect<Item: items::Item>(item: Pin<&Item>, scale_factor: ScaleFactor) -> PhysicalRect {

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -794,9 +794,8 @@ fn adjust_rect_and_border_for_inner_drawing(
     *border_width = border_width.min(rect.width_length() / 2.);
     // adjust the size so that the border is drawn within the geometry
 
-    let half_border_size = PhysicalSize::from_lengths(*border_width / 2., *border_width / 2.);
-    rect.origin += half_border_size;
-    rect.size -= half_border_size;
+    rect.origin += PhysicalSize::from_lengths(*border_width / 2., *border_width / 2.);
+    rect.size -= PhysicalSize::from_lengths(*border_width, *border_width);
 }
 
 /// Changes the source or the destination rectangle to respect the image fit


### PR DESCRIPTION
Commit f66a2a577532bccb5db5b35743e2d5613e9357ea and dc048a11dbb4c0b31ef2818ae8444d59f696a6d2 introduced the regression of issue #1985 where in adjust_rect_and_border_for_inner_drawing instead of subtracting the entire border width from the size, only half of it was subtracted,
leaving an inner area of the rectangle visible.

Fixes #1985