### PR TITLE
Pure functions and callback: ensure that property bindings don't have side effects

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,6 +259,7 @@ jobs:
     - name: test
       # Skip a few tests that rely on private renamed properties.
       # Skip the tests which makes two way binding to output property (these are warning in previous version)
+      # Skip the test that use impure functions in property bindings (this is also warning in previous version)
       # Skip the example that did not exist or that are broken
       run: |
         cargo test --bin test-driver-interpreter -- \
@@ -271,5 +272,7 @@ jobs:
                   --skip test_interpreter_crashes_layout_deleted_item \
                   --skip test_interpreter_focus_focus_change_subcompo \
                   --skip test_interpreter_focus_focus_change_through_signal \
+                  --skip test_interpreter_crashes_issue1271_set_in_if \
+                  --skip test_interpreter_models_assign_equal_model \
                   --skip example_carousel \
                   --skip example_fancy_demo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
+ - Warning when calling non-pure function or callback from pure context (eg: a property binding).
+   callbacks and function can be annotated with `pure`
+
 ### Added
+
  - LSP: support of Slint features (auto-complete, preview, ...) in `slint!{}` macro in rust files
  - Support for software renderer without pre-rendered font at compile time
 

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -442,6 +442,31 @@ Example := Rectangle {
 }
 ```
 
+## Purity
+
+Slint's property evaluation is lazy and "reactive", which means that property bindings are only evaluated when they are used, and the value is cached.
+If any of the dependent properties change, the binding will be re-evaluated the next time the property is queried.
+Binding evaluation should be "pure", meaning that it should not have any side effects.
+For example, evaluating a binding should not change any other properties.
+Side effects are problematic because it is not always clear when they will happen.
+Lazy evaluation may change their order or affect whether they happen at all.
+In addition, changes to properties while their binding is being evaluated may result in unexpected behavior.
+
+For this reason, bindings are required to be pure. The Slint compiler checks that code in pure contexts has no side effects.
+Pure contexts includes binding expressions, bodies of pure functions, and bodies of pure callback handlers.
+In such a context, it is not allowed to change a property, or call a non-pure callback or function.
+
+Callbacks and public functions can be annotated with the `pure` keyword.
+Private functions can also be annotated with `pure`, otherwise their purity is automatically inferred.
+
+```slint,no-preview
+Example := Rectangle {
+    pure callback foo() -> int;
+    public pure function bar(x: int) -> int
+    { return x + foo(); }
+}
+```
+
 ## Expressions
 
 Expressions are a powerful way to declare relationships and connections in your user interface. They

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -940,7 +940,7 @@ It is possible to re-expose a callback or properties from a global using the two
 ```slint,no-preview
 global Logic := {
     property <int> the-value;
-    callback magic-operation(int) -> int;
+    pure callback magic-operation(int) -> int;
 }
 
 SomeComponent := Text {
@@ -952,7 +952,7 @@ export MainWindow := Window {
     // re-expose the global properties such that the native code
     // can access or modify them
     property the-value <=> Logic.the-value;
-    callback magic-operation <=> Logic.magic-operation;
+    pure callback magic-operation <=> Logic.magic-operation;
 
     SomeComponent {}
 }

--- a/docs/recipes/recipes.md
+++ b/docs/recipes/recipes.md
@@ -393,7 +393,7 @@ connected to the native code.
 import { HorizontalBox, VerticalBox, LineEdit } from "std-widgets.slint";
 
 export global Logic := {
-    callback to-upper-case(string) -> string;
+    pure callback to-upper-case(string) -> string;
     // You can collect other global properties here
 }
 
@@ -486,7 +486,7 @@ import { HorizontalBox, Button } from "std-widgets.slint";
 
 export global Tr := {
     // Do the translation of the first argument, with an array of string as supstitution
-    callback gettext(string, [string]) -> string;
+    pure callback gettext(string, [string]) -> string;
 
     // A default implementation that returns the original string for preview purposes.
     gettext(text, _) => { return text; }

--- a/examples/7guis/booker.slint
+++ b/examples/7guis/booker.slint
@@ -5,10 +5,10 @@ import { LineEdit, Button, ComboBox, VerticalBox } from "std-widgets.slint";
 
 Booker := Window {
     // returns true if the string parameter is a valid date
-    callback validate-date(string) -> bool;
+    pure callback validate-date(string) -> bool;
     validate-date(_) => { true }
     // returns true if the first date is before the second date and they are both valid
-    callback compare-date(string, string) -> bool;
+    pure callback compare-date(string, string) -> bool;
     compare-date(a, b) => { a <= b }
     property <bool> message-visible;
     VerticalBox {

--- a/examples/imagefilter/main.rs
+++ b/examples/imagefilter/main.rs
@@ -17,7 +17,7 @@ slint::slint! {
 
         property original-image <=> original.source;
         property filters <=> filter-combo.model;
-        callback filter-image(int) -> image;
+        pure callback filter-image(int) -> image;
 
         HorizontalBox {
             VerticalBox {

--- a/examples/plotter/plotter.slint
+++ b/examples/plotter/plotter.slint
@@ -8,7 +8,7 @@ export MainWindow := Window {
     preferred-width: 800px;
     preferred-height: 600px;
 
-    callback render_plot(float /* pitch */, float /* yaw */, float /* amplitude */) -> image;
+    pure callback render_plot(float /* pitch */, float /* yaw */, float /* amplitude */) -> image;
 
     property <float> pitch: 0.15;
     property <float> yaw: 0.5;

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -403,6 +403,7 @@ impl ElementType {
                                 resolved_name,
                                 property_type: Type::Invalid,
                                 property_visibility: PropertyVisibility::Private,
+                                declared_pure: None,
                                 is_local_to_component: false,
                             }
                         } else {
@@ -413,6 +414,7 @@ impl ElementType {
                         resolved_name,
                         property_type: p.ty.clone(),
                         property_visibility: p.property_visibility,
+                        declared_pure: None,
                         is_local_to_component: false,
                     },
                 }
@@ -429,6 +431,7 @@ impl ElementType {
                     resolved_name,
                     property_type,
                     property_visibility: PropertyVisibility::InOut,
+                    declared_pure: None,
                     is_local_to_component: false,
                 }
             }
@@ -436,6 +439,7 @@ impl ElementType {
                 resolved_name: Cow::Borrowed(name),
                 property_type: Type::Invalid,
                 property_visibility: PropertyVisibility::Private,
+                declared_pure: None,
                 is_local_to_component: false,
             },
         }
@@ -690,6 +694,7 @@ pub struct PropertyLookupResult<'a> {
     pub resolved_name: std::borrow::Cow<'a, str>,
     pub property_type: Type,
     pub property_visibility: PropertyVisibility,
+    pub declared_pure: Option<bool>,
     /// True if the property is part of the the current component (for visibility purposes)
     pub is_local_to_component: bool,
 }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use itertools::Itertools;
 
-use crate::expression_tree::{Expression, Unit};
+use crate::expression_tree::{BuiltinFunction, Expression, Unit};
 use crate::object_tree::{Component, PropertyVisibility};
 use crate::parser::syntax_nodes;
 use crate::typeregister::TypeRegister;
@@ -512,17 +512,17 @@ impl ElementType {
         })
     }
 
-    pub fn lookup_member_function(&self, name: &str) -> Expression {
+    pub fn lookup_member_function(&self, name: &str) -> Option<BuiltinFunction> {
         match self {
             Self::Builtin(builtin) => builtin
                 .member_functions
                 .get(name)
                 .cloned()
-                .unwrap_or_else(|| crate::typeregister::reserved_member_function(name)),
+                .or_else(|| crate::typeregister::reserved_member_function(name)),
             Self::Component(component) => {
                 component.root_element.borrow().base_type.lookup_member_function(name)
             }
-            _ => Expression::Invalid,
+            _ => None,
         }
     }
 
@@ -672,7 +672,7 @@ pub struct BuiltinElement {
     /// Non-item type do not have reserved properties (x/width/rowspan/...) added to them  (eg: PropertyAnimation)
     pub is_non_item_type: bool,
     pub accepts_focus: bool,
-    pub member_functions: HashMap<String, Expression>,
+    pub member_functions: HashMap<String, BuiltinFunction>,
     pub is_global: bool,
     pub default_size_binding: DefaultSizeBinding,
     /// When true this is an internal type not shown in the auto-completion

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -68,9 +68,9 @@ pub fn lower_expression(
             llr_Expression::NumberLiteral(unit.normalize(*n))
         }
         tree_Expression::BoolLiteral(b) => llr_Expression::BoolLiteral(*b),
-        tree_Expression::CallbackReference(nr)
+        tree_Expression::CallbackReference(nr, _)
         | tree_Expression::PropertyReference(nr)
-        | tree_Expression::FunctionReference(nr) => {
+        | tree_Expression::FunctionReference(nr, _) => {
             llr_Expression::PropertyReference(ctx.map_property_reference(nr))
         }
         tree_Expression::BuiltinFunctionReference(_, _) => panic!(),
@@ -120,17 +120,19 @@ pub fn lower_expression(
                 let arguments = arguments.iter().map(|e| lower_expression(e, ctx)).collect::<_>();
                 llr_Expression::BuiltinFunctionCall { function: *f, arguments }
             }
-            tree_Expression::CallbackReference(nr) => {
+            tree_Expression::CallbackReference(nr, _) => {
                 let arguments = arguments.iter().map(|e| lower_expression(e, ctx)).collect::<_>();
                 llr_Expression::CallBackCall { callback: ctx.map_property_reference(nr), arguments }
             }
-            tree_Expression::FunctionReference(nr) => {
+            tree_Expression::FunctionReference(nr, _) => {
                 let arguments = arguments.iter().map(|e| lower_expression(e, ctx)).collect::<_>();
                 llr_Expression::FunctionCall { function: ctx.map_property_reference(nr), arguments }
             }
             _ => panic!("not calling a function"),
         },
-        tree_Expression::SelfAssignment { lhs, rhs, op } => lower_assignment(lhs, rhs, *op, ctx),
+        tree_Expression::SelfAssignment { lhs, rhs, op, .. } => {
+            lower_assignment(lhs, rhs, *op, ctx)
+        }
         tree_Expression::BinaryExpression { lhs, rhs, op } => llr_Expression::BinaryExpression {
             lhs: Box::new(lower_expression(lhs, ctx)),
             rhs: Box::new(lower_expression(rhs, ctx)),

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -442,6 +442,7 @@ fn expression_from_reference(
 ) -> Expression {
     match ty {
         Type::Callback { .. } => Expression::CallbackReference(n, node.clone()),
+        Type::InferredCallback => Expression::CallbackReference(n, node.clone()),
         Type::Function { .. } => Expression::FunctionReference(n, node.clone()),
         _ => Expression::PropertyReference(n),
     }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -23,7 +23,7 @@ mod ensure_window;
 mod flickable;
 mod focus_item;
 pub mod generate_item_indices;
-mod infer_aliases_types;
+pub mod infer_aliases_types;
 mod inlining;
 mod lower_accessibility;
 mod lower_layout;

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -35,6 +35,7 @@ mod lower_tabwidget;
 mod materialize_fake_properties;
 mod move_declarations;
 mod optimize_useless_rectangles;
+mod purity_check;
 mod remove_aliases;
 mod remove_unused_properties;
 mod repeater_component;
@@ -74,11 +75,7 @@ pub async fn run_passes(
 
     let global_type_registry = type_loader.global_type_registry.clone();
     let root_component = &doc.root_component;
-    infer_aliases_types::resolve_aliases(doc, diag);
-    resolving::resolve_expressions(doc, type_loader, diag);
-    check_expressions::check_expressions(doc, diag);
-    check_rotation::check_rotation(doc, diag);
-    unique_id::check_unique_id(doc, diag);
+    run_import_passes(doc, type_loader, diag);
     check_public_api::check_public_api(doc, diag);
 
     collect_subcomponents::collect_subcomponents(root_component);
@@ -268,6 +265,7 @@ pub fn run_import_passes(
     infer_aliases_types::resolve_aliases(doc, diag);
     resolving::resolve_expressions(doc, type_loader, diag);
     check_expressions::check_expressions(doc, diag);
+    purity_check::purity_check(doc, diag);
     check_rotation::check_rotation(doc, diag);
     unique_id::check_unique_id(doc, diag);
 }

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -335,8 +335,8 @@ fn recurse_expression(expr: &Expression, vis: &mut impl FnMut(&PropertyPath)) {
     expr.visit(|sub| recurse_expression(sub, vis));
     match expr {
         Expression::PropertyReference(r)
-        | Expression::CallbackReference(r)
-        | Expression::FunctionReference(r) => vis(&r.clone().into()),
+        | Expression::CallbackReference(r, _)
+        | Expression::FunctionReference(r, _) => vis(&r.clone().into()),
         Expression::LayoutCacheAccess { layout_cache_prop, .. } => {
             vis(&layout_cache_prop.clone().into())
         }

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -497,6 +497,7 @@ fn lower_dialog_layout(
                                             "clicked",
                                         )),
                                         visibility: PropertyVisibility::InOut,
+                                        pure: None,
                                     });
                             }
                         }

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -215,9 +215,9 @@ fn expression_for_property(element: &ElementRc, name: &str) -> ExpressionForProp
                     // Check that the expresison is valid in the new scope
                     let mut has_invalid = false;
                     e.expression.visit_recursive(&mut |ex| match ex {
-                        Expression::CallbackReference(nr)
+                        Expression::CallbackReference(nr, _)
                         | Expression::PropertyReference(nr)
-                        | Expression::FunctionReference(nr) => {
+                        | Expression::FunctionReference(nr, _) => {
                             let e = nr.element();
                             if !Rc::ptr_eq(&e, &element)
                                 && Weak::ptr_eq(

--- a/internal/compiler/passes/purity_check.rs
+++ b/internal/compiler/passes/purity_check.rs
@@ -1,0 +1,94 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use crate::diagnostics::BuildDiagnostics;
+use crate::expression_tree::Expression;
+
+/// Check that pure expression only call pure functions
+pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnostics) {
+    for component in &doc.inner_components {
+        crate::object_tree::recurse_elem_including_sub_components_no_borrow(
+            component,
+            &(),
+            &mut |elem, &()| {
+                crate::object_tree::visit_element_expressions(elem, |expr, name, _| {
+                    if let Some(name) = name {
+                        let lookup = elem.borrow().lookup_property(name);
+                        if lookup.declared_pure.unwrap_or(false)
+                            || lookup.property_type.is_property_type()
+                        {
+                            ensure_pure(expr, Some(diag));
+                        }
+                    } else {
+                        // model expression must be pure
+                        ensure_pure(expr, Some(diag));
+                    };
+                })
+            },
+        )
+    }
+}
+
+fn ensure_pure(expr: &Expression, mut diag: Option<&mut BuildDiagnostics>) -> bool {
+    let mut r = true;
+    expr.visit_recursive(&mut |e| match e {
+        Expression::CallbackReference(nr, node) => {
+            if !nr.element().borrow().lookup_property(nr.name()).declared_pure.unwrap_or(false) {
+                if let Some(diag) = diag.as_deref_mut() {
+                    diag.push_error(format!("Cannot call impure callback '{}'", nr.name()), node);
+                }
+                r = false;
+            }
+        }
+        Expression::FunctionReference(nr, node) => {
+            match nr.element().borrow().lookup_property(nr.name()).declared_pure {
+                Some(true) => return,
+                Some(false) => {
+                    if let Some(diag) = diag.as_deref_mut() {
+                        diag.push_error(
+                            format!("Cannot call impure function '{}'", nr.name(),),
+                            node,
+                        );
+                    }
+                    r = false;
+                }
+                None => {
+                    if !ensure_pure(
+                        &nr.element()
+                            .borrow()
+                            .bindings
+                            .get(nr.name())
+                            .expect("private function must be local and defined")
+                            .borrow()
+                            .expression,
+                        None,
+                    ) {
+                        if let Some(diag) = diag.as_deref_mut() {
+                            diag.push_error(
+                                format!("Cannot call impure function '{}'", nr.name(),),
+                                node,
+                            );
+                        }
+                        r = false;
+                    }
+                }
+            }
+        }
+        Expression::BuiltinFunctionReference(func, node) => {
+            if !func.is_pure() {
+                if let Some(diag) = diag.as_deref_mut() {
+                    diag.push_error("Cannot call impure function".into(), node);
+                }
+                r = false;
+            }
+        }
+        Expression::SelfAssignment { node, .. } => {
+            if let Some(diag) = diag.as_deref_mut() {
+                diag.push_error("Cannot assign in a pure context".into(), node);
+            }
+            r = false;
+        }
+        _ => (),
+    });
+    r
+}

--- a/internal/compiler/passes/purity_check.rs
+++ b/internal/compiler/passes/purity_check.rs
@@ -11,17 +11,21 @@ pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnost
             component,
             &(),
             &mut |elem, &()| {
+                let level = match elem.borrow().is_legacy_syntax {
+                    true => crate::diagnostics::DiagnosticLevel::Warning,
+                    false => crate::diagnostics::DiagnosticLevel::Error,
+                };
                 crate::object_tree::visit_element_expressions(elem, |expr, name, _| {
                     if let Some(name) = name {
                         let lookup = elem.borrow().lookup_property(name);
                         if lookup.declared_pure.unwrap_or(false)
                             || lookup.property_type.is_property_type()
                         {
-                            ensure_pure(expr, Some(diag));
+                            ensure_pure(expr, Some(diag), level);
                         }
                     } else {
                         // model expression must be pure
-                        ensure_pure(expr, Some(diag));
+                        ensure_pure(expr, Some(diag), level);
                     };
                 })
             },
@@ -29,13 +33,21 @@ pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnost
     }
 }
 
-fn ensure_pure(expr: &Expression, mut diag: Option<&mut BuildDiagnostics>) -> bool {
+fn ensure_pure(
+    expr: &Expression,
+    mut diag: Option<&mut BuildDiagnostics>,
+    level: crate::diagnostics::DiagnosticLevel,
+) -> bool {
     let mut r = true;
     expr.visit_recursive(&mut |e| match e {
         Expression::CallbackReference(nr, node) => {
             if !nr.element().borrow().lookup_property(nr.name()).declared_pure.unwrap_or(false) {
                 if let Some(diag) = diag.as_deref_mut() {
-                    diag.push_error(format!("Cannot call impure callback '{}'", nr.name()), node);
+                    diag.push_diagnostic(
+                        format!("Call of impure callback '{}'", nr.name()),
+                        node,
+                        level,
+                    );
                 }
                 r = false;
             }
@@ -45,9 +57,10 @@ fn ensure_pure(expr: &Expression, mut diag: Option<&mut BuildDiagnostics>) -> bo
                 Some(true) => return,
                 Some(false) => {
                     if let Some(diag) = diag.as_deref_mut() {
-                        diag.push_error(
-                            format!("Cannot call impure function '{}'", nr.name(),),
+                        diag.push_diagnostic(
+                            format!("Call of impure function '{}'", nr.name(),),
                             node,
+                            level,
                         );
                     }
                     r = false;
@@ -62,11 +75,13 @@ fn ensure_pure(expr: &Expression, mut diag: Option<&mut BuildDiagnostics>) -> bo
                             .borrow()
                             .expression,
                         None,
+                        level,
                     ) {
                         if let Some(diag) = diag.as_deref_mut() {
-                            diag.push_error(
-                                format!("Cannot call impure function '{}'", nr.name(),),
+                            diag.push_diagnostic(
+                                format!("Call of impure function '{}'", nr.name()),
                                 node,
+                                level,
                             );
                         }
                         r = false;
@@ -77,14 +92,14 @@ fn ensure_pure(expr: &Expression, mut diag: Option<&mut BuildDiagnostics>) -> bo
         Expression::BuiltinFunctionReference(func, node) => {
             if !func.is_pure() {
                 if let Some(diag) = diag.as_deref_mut() {
-                    diag.push_error("Cannot call impure function".into(), node);
+                    diag.push_diagnostic("Call of impure function".into(), node, level);
                 }
                 r = false;
             }
         }
         Expression::SelfAssignment { node, .. } => {
             if let Some(diag) = diag.as_deref_mut() {
-                diag.push_error("Cannot assign in a pure context".into(), node);
+                diag.push_diagnostic("Assignment in a pure context".into(), node, level);
             }
             r = false;
         }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -746,6 +746,7 @@ impl Expression {
             lhs: Box::new(lhs),
             rhs: Box::new(rhs.maybe_convert_to(expected_ty, &rhs_n, ctx.diag)),
             op,
+            node: Some(NodeOrToken::Node(node.into())),
         }
     }
 
@@ -1063,7 +1064,10 @@ fn continue_lookup_within_element(
         if let Some(x) = it.next() {
             ctx.diag.push_error("Cannot access fields of callback".into(), &x)
         }
-        Expression::CallbackReference(NamedReference::new(elem, &lookup_result.resolved_name))
+        Expression::CallbackReference(
+            NamedReference::new(elem, &lookup_result.resolved_name),
+            Some(NodeOrToken::Token(second)),
+        )
     } else if matches!(lookup_result.property_type, Type::Function { .. }) {
         if !lookup_result.is_local_to_component
             && lookup_result.property_visibility == PropertyVisibility::Private
@@ -1083,7 +1087,10 @@ fn continue_lookup_within_element(
                     .into(),
             }
         } else {
-            Expression::FunctionReference(NamedReference::new(elem, &lookup_result.resolved_name))
+            Expression::FunctionReference(
+                NamedReference::new(elem, &lookup_result.resolved_name),
+                Some(NodeOrToken::Token(second)),
+            )
         }
     } else {
         let mut err = |extra: &str| {
@@ -1295,7 +1302,7 @@ pub fn resolve_two_way_binding(
             }
             Some(n)
         }
-        Expression::CallbackReference(n) => {
+        Expression::CallbackReference(n, _) => {
             if ctx.property_type != Type::InferredCallback && ty != ctx.property_type {
                 ctx.diag.push_error("Cannot bind to a callback".into(), &node);
                 None

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1072,13 +1072,15 @@ fn continue_lookup_within_element(
         } else if let Some(x) = it.next() {
             ctx.diag.push_error("Cannot access fields of a function".into(), &x)
         }
-        let member = elem.borrow().base_type.lookup_member_function(&lookup_result.resolved_name);
-        if !matches!(member, Expression::Invalid) {
+        if let Some(f) =
+            elem.borrow().base_type.lookup_member_function(&lookup_result.resolved_name)
+        {
             // builtin member function
             Expression::MemberFunction {
                 base: Box::new(Expression::ElementReference(Rc::downgrade(elem))),
                 base_node: Some(NodeOrToken::Node(node.into())),
-                member: Box::new(member),
+                member: Expression::BuiltinFunctionReference(f, Some(second.to_source_location()))
+                    .into(),
             }
         } else {
             Expression::FunctionReference(NamedReference::new(elem, &lookup_result.resolved_name))

--- a/internal/compiler/tests/syntax/analysis/binding_loop_function.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_function.slint
@@ -5,7 +5,7 @@ Compo1 := Rectangle {
 
     property <int> a : aa();
 //                    ^error{The binding for the property 'a' is part of a binding loop}
-    callback aa() -> int;
+    pure callback aa() -> int;
 
     function factorial(n: int) -> int {
 //  ^error{The binding for the property 'factorial' is part of a binding loop}
@@ -14,7 +14,7 @@ Compo1 := Rectangle {
 
 
     property <int> b;
-    public function bb() -> int { return b; }
+    public pure function bb() -> int { return b; }
 //  ^error{The binding for the property 'bb' is part of a binding loop}
 }
 

--- a/internal/compiler/tests/syntax/focus/focus_not_called.slint
+++ b/internal/compiler/tests/syntax/focus/focus_not_called.slint
@@ -15,4 +15,5 @@ X := Rectangle {
     x: edit.focus;
 //    ^error{Cannot convert function\(element ref\) -> void to length}
 //     ^^error{'edit.focus' must be called. Did you forgot the '\(\)'\?}
+//          ^^^error{Cannot call impure function}
 }

--- a/internal/compiler/tests/syntax/focus/focus_not_called.slint
+++ b/internal/compiler/tests/syntax/focus/focus_not_called.slint
@@ -15,5 +15,5 @@ X := Rectangle {
     x: edit.focus;
 //    ^error{Cannot convert function\(element ref\) -> void to length}
 //     ^^error{'edit.focus' must be called. Did you forgot the '\(\)'\?}
-//          ^^^error{Cannot call impure function}
+//          ^^^warning{Call of impure function}
 }

--- a/internal/compiler/tests/syntax/functions/functions_call.slint
+++ b/internal/compiler/tests/syntax/functions/functions_call.slint
@@ -34,5 +34,5 @@ Xxx := Rectangle {
     }
 
     callback xx <=> foo;
-//                 ^error{Cannot bind to a function}
+//  ^error{Binding to callback 'xx' must bind to another callback}
 }

--- a/internal/compiler/tests/syntax/functions/functions_purity.slint
+++ b/internal/compiler/tests/syntax/functions/functions_purity.slint
@@ -16,44 +16,44 @@ component Foo {
     pure function f3() {
         f2();
         f1();
-//      ^error{Cannot call impure function 'f1'}
+//      ^error{Call of impure function 'f1'}
 
         prop /= 5;
-//      ^error{Cannot assign in a pure context}
+//      ^error{Assignment in a pure context}
     }
     public function f4() {}
 
 
     pure function f5() {
         f1();
-//      ^error{Cannot call impure function 'f1'}
+//      ^error{Call of impure function 'f1'}
         f2(); // ok, private function auto-detected as pure
         f3();
         f4();
-//      ^error{Cannot call impure function 'f4'}
+//      ^error{Call of impure function 'f4'}
         c1();
-//      ^error{Cannot call impure callback 'c1'}
+//      ^error{Call of impure callback 'c1'}
         c2();
     }
 
     c1 => { f2() }
     c2 => {
         c1();
-//      ^error{Cannot call impure callback 'c1'}
+//      ^error{Call of impure callback 'c1'}
     }
 
 
     property <int> p1: f2();
     property <int> p2: {
         p1 = 42;
-//      ^error{Cannot assign in a pure context}
+//      ^error{Assignment in a pure context}
         42
     };
     property <int> p3: {
         pw.show();
-//         ^error{Cannot call impure function}
+//         ^error{Call of impure function}
         fs.focus();
-//         ^error{Cannot call impure function}
+//         ^error{Call of impure function}
         42
     };
 
@@ -70,7 +70,83 @@ component Bar {
     f := Foo {
         c2 => {
             self.c1();
-//               ^error{Cannot call impure callback 'c1'}
+//               ^error{Call of impure callback 'c1'}
+        }
+    }
+}
+
+
+
+
+
+Foo_Legacy := Rectangle {
+    property <int> prop;
+    callback c1;
+    pure callback c2;
+
+    function f1() {
+        prop = 1;
+    }
+    function f2() -> int { 42 }
+
+    pure function f3() {
+        f2();
+        f1();
+//      ^warning{Call of impure function 'f1'}
+
+        prop /= 5;
+//      ^warning{Assignment in a pure context}
+    }
+    public function f4() {}
+
+
+    pure function f5() {
+        f1();
+//      ^warning{Call of impure function 'f1'}
+        f2(); // ok, private function auto-detected as pure
+        f3();
+        f4();
+//      ^warning{Call of impure function 'f4'}
+        c1();
+//      ^warning{Call of impure callback 'c1'}
+        c2();
+    }
+
+    c1 => { f2() }
+    c2 => {
+        c1();
+//      ^warning{Call of impure callback 'c1'}
+    }
+
+
+    property <int> p1: f2();
+    property <int> p2: {
+        p1 = 42;
+//      ^warning{Assignment in a pure context}
+        42
+    };
+    property <int> p3: {
+        pw.show();
+//         ^warning{Call of impure function}
+        fs.focus();
+//         ^warning{Call of impure function}
+        42
+    };
+
+    pw := PopupWindow {}
+    fs := FocusScope {}
+}
+
+
+Bar_Legacy := Rectangle {
+    pure callback xc1 <=> f.c1;
+//  ^error{Purity of callbacks 'xc1' and 'f.c1' doesn't match}
+    callback xc2 <=> f.c2;
+//  ^error{Purity of callbacks 'xc2' and 'f.c2' doesn't match}
+    f := Foo {
+        c2 => {
+            self.c1();
+//               ^warning{Call of impure callback 'c1'}
         }
     }
 }

--- a/internal/compiler/tests/syntax/functions/functions_purity.slint
+++ b/internal/compiler/tests/syntax/functions/functions_purity.slint
@@ -61,3 +61,16 @@ component Foo {
     fs := FocusScope {}
 }
 
+
+component Bar {
+    pure callback xc1 <=> f.c1;
+//  ^error{Purity of callbacks 'xc1' and 'f.c1' doesn't match}
+    callback xc2 <=> f.c2;
+//  ^error{Purity of callbacks 'xc2' and 'f.c2' doesn't match}
+    f := Foo {
+        c2 => {
+            self.c1();
+//               ^error{Cannot call impure callback 'c1'}
+        }
+    }
+}

--- a/internal/compiler/tests/syntax/functions/functions_purity.slint
+++ b/internal/compiler/tests/syntax/functions/functions_purity.slint
@@ -1,0 +1,63 @@
+
+
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+component Foo {
+    property <int> prop;
+    callback c1;
+    pure callback c2;
+
+    function f1() {
+        prop = 1;
+    }
+    function f2() -> int { 42 }
+
+    pure function f3() {
+        f2();
+        f1();
+//      ^error{Cannot call impure function 'f1'}
+
+        prop /= 5;
+//      ^error{Cannot assign in a pure context}
+    }
+    public function f4() {}
+
+
+    pure function f5() {
+        f1();
+//      ^error{Cannot call impure function 'f1'}
+        f2(); // ok, private function auto-detected as pure
+        f3();
+        f4();
+//      ^error{Cannot call impure function 'f4'}
+        c1();
+//      ^error{Cannot call impure callback 'c1'}
+        c2();
+    }
+
+    c1 => { f2() }
+    c2 => {
+        c1();
+//      ^error{Cannot call impure callback 'c1'}
+    }
+
+
+    property <int> p1: f2();
+    property <int> p2: {
+        p1 = 42;
+//      ^error{Cannot assign in a pure context}
+        42
+    };
+    property <int> p3: {
+        pw.show();
+//         ^error{Cannot call impure function}
+        fs.focus();
+//         ^error{Cannot call impure function}
+        42
+    };
+
+    pw := PopupWindow {}
+    fs := FocusScope {}
+}
+

--- a/internal/compiler/tests/syntax/lookup/callback_alias3.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias3.slint
@@ -13,15 +13,14 @@ Xxx := Rectangle {
     }
 
     callback colr <=> foo.background;
-//                   ^error{The property does not have the same type as the bound property}
+//  ^error{Binding to callback 'colr' must bind to another callback}
     property propr <=> foo.hello;
-//                 ^error{Cannot bind to a callback}
-//  ^^error{Could not infer type of property 'propr'}
+//  ^error{Could not infer type of property 'propr'}
 
     callback loop1 <=> loop2;
     callback loop3 <=> loop1;
 //                     ^error{Unknown unqualified identifier 'loop1'}
-//                    ^^error{The expression in a two way binding must be a property reference}
+//  ^^error{Binding to callback 'loop3' must bind to another callback}
     callback loop2 <=> loop3;
 
     Sub {

--- a/internal/compiler/tests/syntax/lookup/two_way_binding.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding.slint
@@ -18,7 +18,7 @@ X := Rectangle {
     border_color <=> blue;
 //  ^error{The expression in a two way binding must be a property reference}
     border_width <=> 4px + 4px;
-//  ^error{The expression in a two way binding must be a property reference}
+//                  ^error{The expression in a two way binding must be a property reference}
 
     xx := Rectangle {
         x: 42phx;

--- a/internal/compiler/tests/syntax/lookup/two_way_binding_infer.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding_infer.slint
@@ -10,13 +10,12 @@ X := Rectangle {
     property infer_loop3 <=> infer_loop;
 //  ^error{Could not infer type of property 'infer-loop3'}
 //                           ^^error{Unknown unqualified identifier 'infer_loop'}
-//                       ^^^error{The expression in a two way binding must be a property reference}
 
     property infer_error <=> r.infer_error;
 //  ^error{Could not infer type of property 'infer-error'}
     r := Rectangle {
         property infer_error <=> 0;
-//                           ^error{The expression in a two way binding must be a property reference}
+//                              ^error{The expression in a two way binding must be a property reference}
 //      ^^error{Could not infer type of property 'infer-error'}
     }
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
-use crate::expression_tree::{BuiltinFunction, Expression};
+use crate::expression_tree::BuiltinFunction;
 use crate::langtype::{
     BuiltinElement, BuiltinPropertyInfo, ElementType, Enumeration, PropertyLookupResult, Type,
 };
@@ -171,17 +171,15 @@ pub fn reserved_property(name: &str) -> PropertyLookupResult {
 }
 
 /// These member functions are injected in every time
-pub fn reserved_member_function(name: &str) -> Expression {
+pub fn reserved_member_function(name: &str) -> Option<BuiltinFunction> {
     for (m, e) in [
-        ("focus", Expression::BuiltinFunctionReference(BuiltinFunction::SetFocusItem, None)), // match for callable "focus" property
-    ]
-    .iter()
-    {
-        if *m == name {
-            return e.clone();
+        ("focus", BuiltinFunction::SetFocusItem), // match for callable "focus" property
+    ] {
+        if m == name {
+            return Some(e);
         }
     }
-    Expression::Invalid
+    None
 }
 
 #[derive(Debug, Default)]
@@ -254,10 +252,10 @@ impl TypeRegister {
                     "show".into(),
                     BuiltinPropertyInfo::new(BuiltinFunction::ShowPopupWindow.ty()),
                 );
-                Rc::get_mut(b).unwrap().member_functions.insert(
-                    "show".into(),
-                    Expression::BuiltinFunctionReference(BuiltinFunction::ShowPopupWindow, None),
-                );
+                Rc::get_mut(b)
+                    .unwrap()
+                    .member_functions
+                    .insert("show".into(), BuiltinFunction::ShowPopupWindow);
             }
             _ => unreachable!(),
         };

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -141,6 +141,7 @@ pub fn reserved_property(name: &str) -> PropertyLookupResult {
                 resolved_name: name.into(),
                 is_local_to_component: false,
                 property_visibility: crate::object_tree::PropertyVisibility::InOut,
+                declared_pure: None,
             };
         }
     }
@@ -156,6 +157,7 @@ pub fn reserved_property(name: &str) -> PropertyLookupResult {
                             resolved_name: format!("{}-{}", pre, suf).into(),
                             is_local_to_component: false,
                             property_visibility: crate::object_tree::PropertyVisibility::InOut,
+                            declared_pure: None,
                         };
                     }
                 }
@@ -167,6 +169,7 @@ pub fn reserved_property(name: &str) -> PropertyLookupResult {
         property_type: Type::Invalid,
         is_local_to_component: false,
         property_visibility: crate::object_tree::PropertyVisibility::Private,
+        declared_pure: None,
     }
 }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -212,7 +212,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
             v
         }
         Expression::FunctionCall { function, arguments, source_location: _ } => match &**function {
-            Expression::FunctionReference(nr) => {
+            Expression::FunctionReference(nr, _) => {
                 let args = arguments.iter().map(|e| eval_expression(e, local_context)).collect::<Vec<_>>();
                 generativity::make_guard!(guard);
                 match enclosing_component_instance_for_element(&nr.element(), local_context.component_instance, guard) {
@@ -225,14 +225,14 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     },
                 }
             }
-            Expression::CallbackReference(nr) => {
+            Expression::CallbackReference(nr, _) => {
                 let args = arguments.iter().map(|e| eval_expression(e, local_context)).collect::<Vec<_>>();
                 invoke_callback(local_context.component_instance, &nr.element(), nr.name(), &args).unwrap()
             }
             Expression::BuiltinFunctionReference(f, _) => call_builtin_function(*f, arguments, local_context),
             _ => panic!("call of something not a callback: {function:?}"),
         }
-        Expression::SelfAssignment { lhs, rhs, op } => {
+        Expression::SelfAssignment { lhs, rhs, op, .. } => {
             let rhs = eval_expression(&**rhs, local_context);
             eval_assignment(lhs, *op, rhs, local_context);
             Value::Void

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -148,6 +148,7 @@ pub(crate) fn add_highlight_items(doc: &Document) {
             expose_in_public_api: false,
             is_alias: None,
             visibility: PropertyVisibility::Input,
+            pure: None,
         },
     );
     doc.root_component.root_element.borrow_mut().property_analysis.borrow_mut().insert(

--- a/tests/cases/callbacks/callback_alias.slint
+++ b/tests/cases/callbacks/callback_alias.slint
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 Foo := Rectangle {
-    callback hallo_alias <=> xxx.hallo;
+    pure callback hallo_alias <=> xxx.hallo;
     callback clicked <=> are.clicked;
     xxx := Rectangle {
-        callback hallo(int) -> int;
+        pure callback hallo(int) -> int;
         hallo(a) => { return a + 88; }
     }
 
@@ -14,8 +14,8 @@ Foo := Rectangle {
 
 TestCase := Rectangle {
 
-    callback foo1_alias <=> foo1.hallo_alias;
-    callback foo2_alias <=> foo2.hallo_alias;
+    pure callback foo1_alias <=> foo1.hallo_alias;
+    pure callback foo2_alias <=> foo2.hallo_alias;
 
     callback foo1_clicked <=> foo1.clicked;
 

--- a/tests/cases/callbacks/functions.slint
+++ b/tests/cases/callbacks/functions.slint
@@ -9,7 +9,7 @@ global G := {
 }
 
 SubCompo := Rectangle {
-    public function hello() -> color { red }
+    public pure function hello() -> color { red }
 }
 
 TestCase := Rectangle {

--- a/tests/cases/callbacks/return_value.slint
+++ b/tests/cases/callbacks/return_value.slint
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 TestCase := Rectangle {
-    callback test_func(int) -> int;
-    callback test_func2(string, int) -> string;
+    pure callback test_func(int) -> int;
+    pure callback test_func2(string, int) -> string;
     test_func2(str, val) => { str + "=" + (val + some_value) }
 
     property <int> test_prop: 4 + test_func(2);

--- a/tests/cases/globals/global_accessor_api.slint
+++ b/tests/cases/globals/global_accessor_api.slint
@@ -11,7 +11,7 @@ struct MyStruct := { x:int, y: int, }
 global InternalGlobal := {
     property <int> hello: 42;
     property <MyStruct> my_struct;
-    callback sum(int, int)->int;
+    pure callback sum(int, int)->int;
 }
 
 export { InternalGlobal as PublicGlobal }

--- a/tests/cases/globals/global_callback.slint
+++ b/tests/cases/globals/global_callback.slint
@@ -3,9 +3,9 @@
 
 global Glo := {
     property <int> hello: 42;
-    callback sum(int, int) -> int;
-    callback mul(int, int) -> int;
-    callback calculate_profit() -> int;
+    pure callback sum(int, int) -> int;
+    pure callback mul(int, int) -> int;
+    pure callback calculate_profit() -> int;
     calculate_profit() => { return 1000; }
 }
 
@@ -16,8 +16,8 @@ ExtraComp := Rectangle {
 
 
 TestCase := Window {
-    callback sum <=> Glo.sum;
-    callback mul <=> Glo.mul;
+    pure callback sum <=> Glo.sum;
+    pure callback mul <=> Glo.mul;
 
     x := ExtraComp {}
     property<int> five: x.five;

--- a/tests/cases/layout/geometry_center_by_default.slint
+++ b/tests/cases/layout/geometry_center_by_default.slint
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 global G {
-    callback is-center(length, length, length) -> bool;
-    is-center(pos, size, parent) => {
+    public pure function is-center(pos: length, size: length, parent: length) -> bool {
         return abs(pos / 1px - (parent - size) / 2px) < 0.001;
     }
 }

--- a/tests/cases/types/object.slint
+++ b/tests/cases/types/object.slint
@@ -18,8 +18,8 @@ TestCase := Rectangle {
         foo.b += 8 + obj_conversion2.b;
     }
 
-    callback return_object() -> { aa: { bb: int } };
-    return_object => { return { aa: { bb: { cc: 42 }.cc } }; }
+    function return_object() -> { aa: { bb: int } }
+    { return { aa: { bb: { cc: 42 }.cc } }; }
     property <bool> test: return_object().aa.bb == 42 && obj_binop_merge;
 
 }

--- a/tests/cases/types/structs2.slint
+++ b/tests/cases/types/structs2.slint
@@ -15,7 +15,7 @@ TestCase := Rectangle {
     cb1(foo) => { return { b: foo.a.member+1 }; }
 
     property<Foo2> xx;
-    callback cb2(Foo2, Foo2)->Foo2;
+    pure callback cb2(Foo2, Foo2)->Foo2;
     property<Foo2> xx2: cb2(xx, xx);
 
 

--- a/tools/lsp/completion.rs
+++ b/tools/lsp/completion.rs
@@ -453,8 +453,8 @@ fn completion_item_from_expression(str: &str, lookup_result: LookupResult) -> Co
             let mut c = CompletionItem::new_simple(str.to_string(), expression.ty().to_string());
             c.kind = match expression {
                 Expression::BoolLiteral(_) => Some(CompletionItemKind::CONSTANT),
-                Expression::CallbackReference(_) => Some(CompletionItemKind::METHOD),
-                Expression::FunctionReference(_) => Some(CompletionItemKind::FUNCTION),
+                Expression::CallbackReference(..) => Some(CompletionItemKind::METHOD),
+                Expression::FunctionReference(..) => Some(CompletionItemKind::FUNCTION),
                 Expression::PropertyReference(_) => Some(CompletionItemKind::PROPERTY),
                 Expression::BuiltinFunctionReference(..) => Some(CompletionItemKind::FUNCTION),
                 Expression::BuiltinMacroReference(..) => Some(CompletionItemKind::FUNCTION),

--- a/tools/lsp/goto.rs
+++ b/tools/lsp/goto.rs
@@ -71,9 +71,9 @@ pub fn goto_definition(
                         } => e.upgrade()?.borrow().node.clone()?.into(),
                         LookupResult::Expression {
                             expression:
-                                Expression::CallbackReference(nr)
+                                Expression::CallbackReference(nr, _)
                                 | Expression::PropertyReference(nr)
-                                | Expression::FunctionReference(nr),
+                                | Expression::FunctionReference(nr, _),
                             ..
                         } => {
                             let mut el = nr.element();

--- a/tools/syntax_updater/experiments/lookup_changes.rs
+++ b/tools/syntax_updater/experiments/lookup_changes.rs
@@ -127,8 +127,8 @@ fn fully_qualify_property_access(
             Some(LookupResult::Expression {
                 expression:
                     Expression::PropertyReference(nr)
-                    | Expression::CallbackReference(nr)
-                    | Expression::FunctionReference(nr),
+                    | Expression::CallbackReference(nr, _)
+                    | Expression::FunctionReference(nr, _),
                 ..
             }) => {
                 if let Some(new_name) = state.lookup_change.property_mappings.get(&nr) {

--- a/tools/syntax_updater/experiments/lookup_changes.rs
+++ b/tools/syntax_updater/experiments/lookup_changes.rs
@@ -253,7 +253,10 @@ fn move_properties_to_root(
     Ok(true)
 }
 
-fn with_lookup_ctx<R>(state: &crate::State, f: impl FnOnce(&mut LookupCtx) -> R) -> Option<R> {
+pub(crate) fn with_lookup_ctx<R>(
+    state: &crate::State,
+    f: impl FnOnce(&mut LookupCtx) -> R,
+) -> Option<R> {
     let mut build_diagnostics = Default::default();
     let tr = &state.current_doc.as_ref()?.local_registry;
     let mut lookup_context = LookupCtx::empty_context(tr, &mut build_diagnostics);

--- a/tools/syntax_updater/experiments/purity.rs
+++ b/tools/syntax_updater/experiments/purity.rs
@@ -1,0 +1,66 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+use crate::Cli;
+use i_slint_compiler::langtype::Type;
+
+use i_slint_compiler::parser::{syntax_nodes, NodeOrToken, SyntaxKind, SyntaxNode};
+use std::io::Write;
+
+pub(crate) fn fold_node(
+    node: &SyntaxNode,
+    file: &mut impl Write,
+    state: &mut crate::State,
+    _args: &Cli,
+) -> std::io::Result<bool> {
+    if let Some(s) = syntax_nodes::CallbackDeclaration::new(node.clone()) {
+        if state.current_elem.as_ref().map_or(false, |e| e.borrow().is_legacy_syntax)
+            && s.child_text(SyntaxKind::Identifier).as_deref() != Some("pure")
+        {
+            if s.ReturnType().is_some() {
+                write!(file, "pure ")?;
+            } else if let Some(twb) = s.TwoWayBinding() {
+                let nr = super::lookup_changes::with_lookup_ctx(state, |lookup_ctx| {
+                    lookup_ctx.property_type = Type::InferredCallback;
+                    let r = i_slint_compiler::passes::resolving::resolve_two_way_binding(
+                        twb, lookup_ctx,
+                    );
+                    r
+                })
+                .flatten();
+
+                if let Some(nr) = nr {
+                    let lk = nr.element().borrow().lookup_property(nr.name());
+                    if lk.declared_pure == Some(true) {
+                        write!(file, "pure ")?;
+                    } else if let Type::Callback { return_type, .. } = lk.property_type {
+                        if return_type.is_some() {
+                            write!(file, "pure ")?;
+                        }
+                    }
+                }
+            }
+        }
+    } else if let Some(s) = syntax_nodes::Function::new(node.clone()) {
+        if state.current_elem.as_ref().map_or(false, |e| e.borrow().is_legacy_syntax)
+            && s.ReturnType().is_some()
+        {
+            let (mut pure, mut public) = (false, false);
+            for t in s
+                .children_with_tokens()
+                .filter_map(NodeOrToken::into_token)
+                .filter(|t| t.kind() == SyntaxKind::Identifier)
+            {
+                match t.text() {
+                    "pure" => pure = true,
+                    "public" => public = true,
+                    _ => (),
+                }
+            }
+            if !pure && public {
+                write!(file, "pure ")?;
+            }
+        }
+    }
+    Ok(false)
+}


### PR DESCRIPTION
As of now, there is only two failling test that will need to be fixed

TODO:
 - [x]  Only make it a hard error with the new syntax
 - [ ] add an escape hatch ?