### PR TITLE
Parser: fix parsing of "public function" in release mode

### DIFF
--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -140,7 +140,7 @@ pub fn parse_qualified_name(p: &mut impl Parser) -> bool {
 fn parse_export(p: &mut impl Parser) -> bool {
     debug_assert_eq!(p.peek().as_str(), "export");
     let mut p = p.start_node(SyntaxKind::ExportsList);
-    p.consume(); // "export"
+    p.expect(SyntaxKind::Identifier); // "export"
     if p.test(SyntaxKind::LBrace) {
         loop {
             parse_export_specifier(&mut *p);
@@ -219,7 +219,7 @@ fn parse_export_specifier(p: &mut impl Parser) -> bool {
 fn parse_import_specifier(p: &mut impl Parser) -> bool {
     debug_assert_eq!(p.peek().as_str(), "import");
     let mut p = p.start_node(SyntaxKind::ImportSpecifier);
-    p.consume(); // "import"
+    p.expect(SyntaxKind::Identifier); // "import"
     if p.peek().kind != SyntaxKind::StringLiteral {
         if !parse_import_identifier_list(&mut *p) {
             return false;

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -148,7 +148,7 @@ fn parse_sub_element(p: &mut impl Parser) {
 fn parse_repeated_element(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "for");
     let mut p = p.start_node(SyntaxKind::RepeatedElement);
-    p.consume(); // "for"
+    p.expect(SyntaxKind::Identifier); // "for"
     if p.nth(0).kind() == SyntaxKind::Identifier {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
         p.expect(SyntaxKind::Identifier);
@@ -182,7 +182,7 @@ fn parse_repeated_element(p: &mut impl Parser) {
 fn parse_if_element(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "if");
     let mut p = p.start_node(SyntaxKind::ConditionalElement);
-    p.consume(); // "if"
+    p.expect(SyntaxKind::Identifier); // "if"
     parse_expression(&mut *p);
     if !p.expect(SyntaxKind::Colon) {
         drop(p.start_node(SyntaxKind::SubElement).start_node(SyntaxKind::Element));
@@ -298,7 +298,7 @@ fn parse_two_way_binding(p: &mut impl Parser) {
 fn parse_callback_declaration(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "callback");
     let mut p = p.start_node(SyntaxKind::CallbackDeclaration);
-    p.consume(); // "callback"
+    p.expect(SyntaxKind::Identifier); // "callback"
     {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
         p.expect(SyntaxKind::Identifier);
@@ -394,7 +394,7 @@ fn parse_property_declaration(p: &mut impl Parser) {
 fn parse_property_animation(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "animate");
     let mut p = p.start_node(SyntaxKind::PropertyAnimation);
-    p.consume(); // animate
+    p.expect(SyntaxKind::Identifier); // animate
     if p.nth(0).kind() == SyntaxKind::Star {
         p.consume();
     } else {
@@ -436,7 +436,7 @@ fn parse_property_animation(p: &mut impl Parser) {
 fn parse_states(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "states");
     let mut p = p.start_node(SyntaxKind::States);
-    p.consume(); // "states"
+    p.expect(SyntaxKind::Identifier); // "states"
     p.expect(SyntaxKind::LBracket);
     while parse_state(&mut *p) {}
     p.expect(SyntaxKind::RBracket);
@@ -508,7 +508,7 @@ fn parse_state(p: &mut impl Parser) -> bool {
 fn parse_transitions(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "transitions");
     let mut p = p.start_node(SyntaxKind::Transitions);
-    p.consume(); // "transitions"
+    p.expect(SyntaxKind::Identifier); // "transitions"
     p.expect(SyntaxKind::LBracket);
     while p.nth(0).kind() != SyntaxKind::RBracket && parse_transition(&mut *p) {}
     p.expect(SyntaxKind::RBracket);
@@ -575,7 +575,7 @@ fn parse_function(p: &mut impl Parser) {
         p.consume()
     }
     debug_assert_eq!(p.peek().as_str(), "function");
-    p.consume(); // "function"
+    p.expect(SyntaxKind::Identifier); // "function"
     {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
         p.expect(SyntaxKind::Identifier);

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -309,7 +309,7 @@ fn parse_template_string(p: &mut impl Parser) {
     debug_assert!(p.nth(0).as_str().ends_with("\\{"));
     {
         let mut p = p.start_node(SyntaxKind::Expression);
-        p.consume();
+        p.expect(SyntaxKind::StringLiteral);
     }
     loop {
         parse_expression(&mut *p);


### PR DESCRIPTION
`consume()` does not advance whitespace, while `peek()` does.  And the `peek()` in the debug_assert meant that the behavior was different in release and debug mode.
Use `expect` instead of consume as it skip over white space

