### PR TITLE
internal: remove per-item cache fields

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -117,11 +117,11 @@ public:
 
     bool dark_color_scheme() const { return slint_windowrc_dark_color_scheme(&inner); }
 
-    template<typename Component, typename ItemArray>
-    void unregister_component(Component *c, ItemArray items) const
+    template<typename Component>
+    void unregister_component(Component *c) const
     {
         cbindgen_private::slint_unregister_component(
-                vtable::VRef<ComponentVTable> { &Component::static_vtable, c }, items, &inner);
+                vtable::VRef<ComponentVTable> { &Component::static_vtable, c }, &inner);
     }
 
     void set_focus_item(const ComponentRc &component_rc, uintptr_t item_index)

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -25,8 +25,8 @@ use i_slint_core::graphics::Color;
 use i_slint_core::input::{
     FocusEvent, InputEventFilterResult, InputEventResult, KeyEvent, KeyEventResult, MouseEvent,
 };
-use i_slint_core::item_rendering::{CachedRenderingData, ItemRenderer};
-use i_slint_core::items::{Item, ItemConsts, ItemRc, ItemVTable, RenderingResult, VoidArg};
+use i_slint_core::item_rendering::ItemRenderer;
+use i_slint_core::items::{Item, ItemRc, ItemVTable, RenderingResult, VoidArg};
 use i_slint_core::layout::{LayoutInfo, Orientation};
 use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize};
 #[cfg(feature = "rtti")]

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -118,7 +118,6 @@ pub struct NativeButton {
     pub enabled: Property<bool>,
     pub standard_button_kind: Property<StandardButtonKind>,
     pub is_standard_button: Property<bool>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl NativeButton {
@@ -368,11 +367,6 @@ impl Item for NativeButton {
             qApp->style()->drawControl(QStyle::CE_PushButton, &option, painter->get(), widget);
         });
     }
-}
-
-impl ItemConsts for NativeButton {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -18,7 +18,6 @@ pub struct NativeCheckBox {
     pub toggled: Callback<VoidArg>,
     pub text: Property<SharedString>,
     pub checked: Property<bool>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for NativeCheckBox {
@@ -160,11 +159,6 @@ impl Item for NativeCheckBox {
             qApp->style()->drawControl(QStyle::CE_CheckBox, &option, painter->get(), widget);
         });
     }
-}
-
-impl ItemConsts for NativeCheckBox {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -17,7 +17,6 @@ pub struct NativeComboBox {
     pub pressed: Property<bool>,
     pub is_open: Property<bool>,
     pub current_value: Property<SharedString>,
-    pub cached_rendering_data: CachedRenderingData,
     pub open_popup: Callback<VoidArg>,
 }
 
@@ -155,11 +154,6 @@ impl Item for NativeComboBox {
     }
 }
 
-impl ItemConsts for NativeComboBox {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
 fn slint_get_NativeComboBoxVTable() -> NativeComboBoxVTable for NativeComboBox
 }
@@ -172,7 +166,6 @@ pub struct NativeComboBoxPopup {
     pub y: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for NativeComboBoxPopup {
@@ -261,11 +254,6 @@ impl Item for NativeComboBoxPopup {
             style->drawControl(QStyle::CE_ShapedFrame, &option, painter->get(), widget);
         });
     }
-}
-
-impl ItemConsts for NativeComboBoxPopup {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -15,7 +15,6 @@ pub struct NativeGroupBox {
     pub height: Property<LogicalLength>,
     pub enabled: Property<bool>,
     pub title: Property<SharedString>,
-    pub cached_rendering_data: CachedRenderingData,
     pub native_padding_left: Property<LogicalLength>,
     pub native_padding_right: Property<LogicalLength>,
     pub native_padding_top: Property<LogicalLength>,
@@ -235,11 +234,6 @@ impl Item for NativeGroupBox {
             qApp->style()->drawComplexControl(QStyle::CC_GroupBox, &option, painter->get(), widget);
         });
     }
-}
-
-impl ItemConsts for NativeGroupBox {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -14,7 +14,6 @@ pub struct NativeLineEdit {
     pub y: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
     pub native_padding_left: Property<LogicalLength>,
     pub native_padding_right: Property<LogicalLength>,
     pub native_padding_top: Property<LogicalLength>,
@@ -156,11 +155,6 @@ impl Item for NativeLineEdit {
             qApp->style()->drawPrimitive(QStyle::PE_PanelLineEdit, &option, painter->get(), widget);
         });
     }
-}
-
-impl ItemConsts for NativeLineEdit {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -16,7 +16,6 @@ pub struct NativeStandardListViewItem {
     pub item: Property<i_slint_core::model::StandardListViewItem>,
     pub index: Property<i32>,
     pub is_selected: Property<bool>,
-    pub cached_rendering_data: CachedRenderingData,
     pub has_hover: Property<bool>,
 }
 
@@ -148,11 +147,6 @@ impl Item for NativeStandardListViewItem {
             engine->setSystemClip(old_clip);
         });
     }
-}
-
-impl ItemConsts for NativeStandardListViewItem {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -19,7 +19,6 @@ pub struct NativeScrollView {
     pub vertical_max: Property<LogicalLength>,
     pub vertical_page_size: Property<LogicalLength>,
     pub vertical_value: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
     pub native_padding_left: Property<LogicalLength>,
     pub native_padding_right: Property<LogicalLength>,
     pub native_padding_top: Property<LogicalLength>,
@@ -426,11 +425,6 @@ impl Item for NativeScrollView {
             initial_state
         );
     }
-}
-
-impl ItemConsts for NativeScrollView {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -30,7 +30,6 @@ pub struct NativeSlider {
     pub value: Property<f32>,
     pub minimum: Property<f32>,
     pub maximum: Property<f32>,
-    pub cached_rendering_data: CachedRenderingData,
     data: Property<NativeSliderData>,
     pub changed: Callback<FloatArg>,
 }
@@ -245,11 +244,6 @@ impl Item for NativeSlider {
             style->drawComplexControl(QStyle::CC_Slider, &option, painter->get(), widget);
         });
     }
-}
-
-impl ItemConsts for NativeSlider {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -25,7 +25,6 @@ pub struct NativeSpinBox {
     pub value: Property<i32>,
     pub minimum: Property<i32>,
     pub maximum: Property<i32>,
-    pub cached_rendering_data: CachedRenderingData,
     data: Property<NativeSpinBoxData>,
 }
 
@@ -285,11 +284,6 @@ impl Item for NativeSpinBox {
             (*painter)->drawText(text_rect, QString::number(value));
         });
     }
-}
-
-impl ItemConsts for NativeSpinBox {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -15,7 +15,6 @@ pub struct NativeTabWidget {
     pub y: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
     pub content_min_height: Property<LogicalLength>,
     pub content_min_width: Property<LogicalLength>,
     pub tabbar_preferred_height: Property<LogicalLength>,
@@ -316,11 +315,6 @@ impl Item for NativeTabWidget {
     }
 }
 
-impl ItemConsts for NativeTabWidget {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
 fn slint_get_NativeTabWidgetVTable() -> NativeTabWidgetVTable for NativeTabWidget
 }
@@ -341,7 +335,6 @@ pub struct NativeTab {
     pub current_focused: Property<i32>,
     pub tab_index: Property<i32>,
     pub num_tabs: Property<i32>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for NativeTab {
@@ -528,11 +521,6 @@ impl Item for NativeTab {
             qApp->style()->drawControl(QStyle::CE_TabBarTab, &option, painter->get(), widget);
         });
     }
-}
-
-impl ItemConsts for NativeTab {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1908,11 +1908,7 @@ impl Renderer for QtWindow {
         LogicalLength::new(default_font_size as f32)
     }
 
-    fn free_graphics_resources(
-        &self,
-        component: ComponentRef,
-        _items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'_>>>,
-    ) {
+    fn free_graphics_resources(&self, component: ComponentRef) {
         // Invalidate caches:
         self.cache.component_destroyed(component);
     }

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1591,11 +1591,7 @@ impl WindowAdapterSealed for QtWindow {
         self.tree_structure_changed.replace(true);
     }
 
-    fn unregister_component<'a>(
-        &self,
-        _component: ComponentRef,
-        _: &mut dyn Iterator<Item = Pin<ItemRef<'a>>>,
-    ) {
+    fn unregister_component<'a>(&self, _component: ComponentRef) {
         self.tree_structure_changed.replace(true);
     }
 

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -442,11 +442,7 @@ impl Renderer for FemtoVGRenderer {
         self::fonts::DEFAULT_FONT_SIZE
     }
 
-    fn free_graphics_resources(
-        &self,
-        component: i_slint_core::component::ComponentRef,
-        _items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'_>>>,
-    ) {
+    fn free_graphics_resources(&self, component: i_slint_core::component::ComponentRef) {
         let canvas = if self.canvas.borrow().is_some() {
             std::cell::Ref::map(self.canvas.borrow(), |canvas_opt| canvas_opt.as_ref().unwrap())
         } else {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1201,10 +1201,8 @@ fn generate_item_tree(
 
     let mut destructor = vec!["auto self = this;".to_owned()];
 
-    destructor.push(format!(
-        "{}->m_window.window_handle().unregister_component(self, item_array());",
-        root_access
-    ));
+    destructor
+        .push(format!("{}->m_window.window_handle().unregister_component(self);", root_access));
 
     target_struct.members.push((
         Access::Public,

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1335,7 +1335,7 @@ fn generate_item_tree(
             fn drop(self: core::pin::Pin<&mut #inner_component_id>) {
                 use slint::private_unstable_api::re_exports::*;
                 new_vref!(let vref : VRef<ComponentVTable> for Component = self.as_ref().get_ref());
-                slint::private_unstable_api::re_exports::unregister_component(self.as_ref(), vref, Self::item_array(), self.window_adapter.get().unwrap());
+                slint::private_unstable_api::re_exports::unregister_component(vref, self.window_adapter.get().unwrap());
             }
         }
 

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -133,15 +133,9 @@ pub fn register_component<Base>(
 }
 
 /// Free the backend graphics resources allocated by the component's items.
-pub fn unregister_component<Base>(
-    base: core::pin::Pin<&Base>,
-    component: ComponentRef,
-    item_array: &[vtable::VOffset<Base, ItemVTable, vtable::AllowPin>],
-    window_adapter: &Rc<dyn WindowAdapter>,
-) {
+pub fn unregister_component(component: ComponentRef, window_adapter: &Rc<dyn WindowAdapter>) {
     window_adapter.renderer().free_graphics_resources(component);
-    window_adapter
-        .unregister_component(component, &mut item_array.iter().map(|item| item.apply_pin(base)));
+    window_adapter.unregister_component(component);
 }
 
 #[cfg(feature = "ffi")]
@@ -171,15 +165,9 @@ pub(crate) mod ffi {
     #[no_mangle]
     pub unsafe extern "C" fn slint_unregister_component(
         component: ComponentRefPin,
-        item_array: Slice<vtable::VOffset<u8, ItemVTable, vtable::AllowPin>>,
         window_handle: *const crate::window::ffi::WindowAdapterRcOpaque,
     ) {
         let window_adapter = &*(window_handle as *const Rc<dyn WindowAdapter>);
-        super::unregister_component(
-            core::pin::Pin::new_unchecked(&*(component.as_ptr() as *const u8)),
-            core::pin::Pin::into_inner(component),
-            item_array.as_slice(),
-            window_adapter,
-        )
+        super::unregister_component(core::pin::Pin::into_inner(component), window_adapter)
     }
 }

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -139,10 +139,7 @@ pub fn unregister_component<Base>(
     item_array: &[vtable::VOffset<Base, ItemVTable, vtable::AllowPin>],
     window_adapter: &Rc<dyn WindowAdapter>,
 ) {
-    window_adapter.renderer().free_graphics_resources(
-        component,
-        &mut item_array.iter().map(|item| item.apply_pin(base)),
-    );
+    window_adapter.renderer().free_graphics_resources(component);
     window_adapter
         .unregister_component(component, &mut item_array.iter().map(|item| item.apply_pin(base)));
 }

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -6,15 +6,11 @@
     Graphics Abstractions.
 
     This module contains the abstractions and convenience types used for rendering.
-
-    The run-time library also makes use of [RenderingCache] to store the rendering primitives
-    created by the backend in a type-erased manner.
 */
 extern crate alloc;
 use crate::lengths::LogicalLength;
 use crate::Coord;
 use crate::SharedString;
-use alloc::boxed::Box;
 
 pub use euclid;
 /// 2D Rectangle
@@ -52,28 +48,6 @@ pub mod rendering_metrics_collector;
 
 #[cfg(feature = "box-shadow-cache")]
 pub mod boxshadowcache;
-
-/// CachedGraphicsData allows the graphics backend to store an arbitrary piece of data associated with
-/// an item, which is typically computed by accessing properties. The dependency_tracker is used to allow
-/// for a lazy computation. Typically back ends store either compute intensive data or handles that refer to
-/// data that's stored in GPU memory.
-pub struct CachedGraphicsData<T> {
-    /// The backend specific data.
-    pub data: T,
-    /// The property tracker that should be used to evaluate whether the primitive needs to be re-created
-    /// or not.
-    pub dependency_tracker: Option<core::pin::Pin<Box<crate::properties::PropertyTracker>>>,
-}
-
-impl<T> CachedGraphicsData<T> {
-    /// Creates a new TrackingRenderingPrimitive by evaluating the provided update_fn once, storing the returned
-    /// rendering primitive and initializing the dependency tracker.
-    pub fn new(update_fn: impl FnOnce() -> T) -> Self {
-        let dependency_tracker = Box::pin(crate::properties::PropertyTracker::default());
-        let data = dependency_tracker.as_ref().evaluate(update_fn);
-        Self { data, dependency_tracker: Some(dependency_tracker) }
-    }
-}
 
 /// FontRequest collects all the developer-configurable properties for fonts, such as family, weight, etc.
 /// It is submitted as a request to the platform font system (i.e. CoreText on macOS) and in exchange the

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -75,61 +75,6 @@ impl<T> CachedGraphicsData<T> {
     }
 }
 
-/// The RenderingCache, in combination with CachedGraphicsData, allows back ends to store data that's either
-/// intensive to compute or has bad CPU locality. Back ends typically keep a RenderingCache instance and use
-/// the item's cached_rendering_data() integer as index in the vec_arena::Arena.
-///
-/// This is used only for the [`crate::item_rendering::PartialRenderingCache`]
-pub struct RenderingCache<T> {
-    slab: slab::Slab<CachedGraphicsData<T>>,
-    generation: usize,
-}
-
-impl<T> Default for RenderingCache<T> {
-    fn default() -> Self {
-        Self { slab: Default::default(), generation: 1 }
-    }
-}
-
-impl<T> RenderingCache<T> {
-    /// Returns the generation of the cache. The generation starts at 1 and is increased
-    /// whenever the cache is cleared, for example when the GL context is lost.
-    pub fn generation(&self) -> usize {
-        self.generation
-    }
-
-    /// Retrieves a mutable reference to the cached graphics data at index.
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut CachedGraphicsData<T>> {
-        self.slab.get_mut(index)
-    }
-
-    /// Returns true if a cache entry exists for the given index.
-    pub fn contains(&self, index: usize) -> bool {
-        self.slab.contains(index)
-    }
-
-    /// Inserts data into the cache and returns the index for retrieval later.
-    pub fn insert(&mut self, data: CachedGraphicsData<T>) -> usize {
-        self.slab.insert(data)
-    }
-
-    /// Retrieves an immutable reference to the cached graphics data at index.
-    pub fn get(&self, index: usize) -> Option<&CachedGraphicsData<T>> {
-        self.slab.get(index)
-    }
-
-    /// Removes the cached graphics data at the given index.
-    pub fn remove(&mut self, index: usize) -> CachedGraphicsData<T> {
-        self.slab.remove(index)
-    }
-
-    /// Removes all entries from the cache and increases the cache's generation count, so
-    /// that stale index access can be avoided.
-    pub fn clear(&mut self) {
-        self.slab.clear();
-        self.generation += 1;
-    }
-}
 /// FontRequest collects all the developer-configurable properties for fonts, such as family, weight, etc.
 /// It is submitted as a request to the platform font system (i.e. CoreText on macOS) and in exchange the
 /// backend returns a `Box<dyn Font>`.

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -4,7 +4,6 @@
 #![warn(missing_docs)]
 //! module for rendering the tree of items
 
-use super::graphics::RenderingCache;
 use super::items::*;
 use crate::component::ComponentRc;
 use crate::graphics::CachedGraphicsData;
@@ -16,52 +15,11 @@ use crate::lengths::{
 };
 use crate::Coord;
 use alloc::boxed::Box;
-use core::cell::{Cell, RefCell};
+use core::cell::RefCell;
 use core::pin::Pin;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 use vtable::VRc;
-
-/// This structure must be present in items that are Rendered and contains information.
-/// Used by the backend.
-#[derive(Default, Debug)]
-#[repr(C)]
-pub struct CachedRenderingData {
-    /// Used and modified by the backend, should be initialized to 0 by the user code
-    pub(crate) cache_index: Cell<usize>,
-    /// Used and modified by the backend, should be initialized to 0 by the user code.
-    /// The backend compares this generation against the one of the cache to verify
-    /// the validity of the cache_index field.
-    pub(crate) cache_generation: Cell<usize>,
-}
-
-impl CachedRenderingData {
-    /// This function can be used to remove an entry from the rendering cache for a given item, if it
-    /// exists, i.e. if any data was ever cached. This is typically called by the graphics backend's
-    /// implementation of the release_item_graphics_cache function.
-    pub fn release<T>(&self, cache: &mut RenderingCache<T>) -> Option<T> {
-        if self.cache_generation.get() == cache.generation() {
-            let index = self.cache_index.get();
-            self.cache_generation.set(0);
-            Some(cache.remove(index).data)
-        } else {
-            None
-        }
-    }
-
-    /// Return the value if it is in the cache
-    pub fn get_entry<'a, T>(
-        &self,
-        cache: &'a mut RenderingCache<T>,
-    ) -> Option<&'a mut crate::graphics::CachedGraphicsData<T>> {
-        let index = self.cache_index.get();
-        if self.cache_generation.get() == cache.generation() {
-            cache.get_mut(index)
-        } else {
-            None
-        }
-    }
-}
 
 /// A per-item cache.
 ///

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -25,7 +25,6 @@ use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
     KeyEventResult, KeyEventType, MouseEvent,
 };
-use crate::item_rendering::CachedRenderingData;
 pub use crate::item_tree::ItemRc;
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{
@@ -112,12 +111,6 @@ pub struct ItemVTable {
     /// Returns the geometry of this item (relative to its parent item)
     pub geometry: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>) -> LogicalRect,
 
-    /// offset in bytes from the *const ItemImpl.
-    /// isize::MAX  means None
-    #[allow(non_upper_case_globals)]
-    #[field_offset(CachedRenderingData)]
-    pub cached_rendering_data_offset: usize,
-
     /// We would need max/min/preferred size, and all layout info
     pub layout_info: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
@@ -178,7 +171,6 @@ pub struct Empty {
     pub y: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for Empty {
@@ -244,13 +236,6 @@ impl Item for Empty {
     }
 }
 
-impl ItemConsts for Empty {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        Empty,
-        CachedRenderingData,
-    > = Empty::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_EmptyVTable() -> EmptyVTable for Empty
 }
@@ -265,7 +250,6 @@ pub struct Rectangle {
     pub y: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for Rectangle {
@@ -332,13 +316,6 @@ impl Item for Rectangle {
     }
 }
 
-impl ItemConsts for Rectangle {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        Rectangle,
-        CachedRenderingData,
-    > = Rectangle::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_RectangleVTable() -> RectangleVTable for Rectangle
 }
@@ -356,7 +333,6 @@ pub struct BorderRectangle {
     pub border_width: Property<LogicalLength>,
     pub border_radius: Property<LogicalLength>,
     pub border_color: Property<Brush>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for BorderRectangle {
@@ -423,13 +399,6 @@ impl Item for BorderRectangle {
     }
 }
 
-impl ItemConsts for BorderRectangle {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        BorderRectangle,
-        CachedRenderingData,
-    > = BorderRectangle::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_BorderRectangleVTable() -> BorderRectangleVTable for BorderRectangle
 }
@@ -459,8 +428,6 @@ pub struct TouchArea {
     pub clicked: Callback<VoidArg>,
     pub moved: Callback<VoidArg>,
     pub pointer_event: Callback<PointerEventArg>,
-    /// FIXME: remove this
-    pub cached_rendering_data: CachedRenderingData,
     /// true when we are currently grabbing the mouse
     grabbed: Cell<bool>,
 }
@@ -610,13 +577,6 @@ impl Item for TouchArea {
     }
 }
 
-impl ItemConsts for TouchArea {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        TouchArea,
-        CachedRenderingData,
-    > = TouchArea::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_TouchAreaVTable() -> TouchAreaVTable for TouchArea
 }
@@ -634,8 +594,6 @@ pub struct FocusScope {
     pub has_focus: Property<bool>,
     pub key_pressed: Callback<KeyEventArg, EventResult>,
     pub key_released: Callback<KeyEventArg, EventResult>,
-    /// FIXME: remove this
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for FocusScope {
@@ -730,13 +688,6 @@ impl Item for FocusScope {
     }
 }
 
-impl ItemConsts for FocusScope {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        FocusScope,
-        CachedRenderingData,
-    > = FocusScope::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_FocusScopeVTable() -> FocusScopeVTable for FocusScope
 }
@@ -752,7 +703,6 @@ pub struct Clip {
     pub height: Property<LogicalLength>,
     pub border_radius: Property<LogicalLength>,
     pub border_width: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
     pub clip: Property<bool>,
 }
 
@@ -829,11 +779,6 @@ impl Item for Clip {
     }
 }
 
-impl ItemConsts for Clip {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Clip, CachedRenderingData> =
-        Clip::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_ClipVTable() -> ClipVTable for Clip
 }
@@ -849,7 +794,6 @@ pub struct Opacity {
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
     pub opacity: Property<f32>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for Opacity {
@@ -942,13 +886,6 @@ impl Opacity {
     }
 }
 
-impl ItemConsts for Opacity {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        Opacity,
-        CachedRenderingData,
-    > = Opacity::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_OpacityVTable() -> OpacityVTable for Opacity
 }
@@ -964,7 +901,6 @@ pub struct Layer {
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
     pub cache_rendering_hint: Property<bool>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for Layer {
@@ -1030,13 +966,6 @@ impl Item for Layer {
     }
 }
 
-impl ItemConsts for Layer {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        Layer,
-        CachedRenderingData,
-    > = Layer::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_LayerVTable() -> LayerVTable for Layer
 }
@@ -1053,7 +982,6 @@ pub struct Rotate {
     pub rotation_origin_y: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for Rotate {
@@ -1124,13 +1052,6 @@ impl Item for Rotate {
     }
 }
 
-impl ItemConsts for Rotate {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        Rotate,
-        CachedRenderingData,
-    > = Rotate::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_RotateVTable() -> RotateVTable for Rotate
 }
@@ -1176,7 +1097,6 @@ pub struct WindowItem {
     pub default_font_family: Property<SharedString>,
     pub default_font_size: Property<LogicalLength>,
     pub default_font_weight: Property<i32>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for WindowItem {
@@ -1271,11 +1191,6 @@ impl WindowItem {
     }
 }
 
-impl ItemConsts for WindowItem {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 declare_item_vtable! {
     fn slint_get_WindowItemVTable() -> WindowItemVTable for WindowItem
 }
@@ -1296,7 +1211,6 @@ pub struct BoxShadow {
     pub offset_y: Property<LogicalLength>,
     pub color: Property<Color>,
     pub blur: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for BoxShadow {
@@ -1361,11 +1275,6 @@ impl Item for BoxShadow {
         (*backend).draw_box_shadow(self, self_rc);
         RenderingResult::ContinueRenderingChildren
     }
-}
-
-impl ItemConsts for BoxShadow {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -8,14 +8,11 @@
 
 //! The `Flickable` item
 
-use super::{
-    Item, ItemConsts, ItemRc, ItemRendererRef, KeyEventResult, PointerEventButton, RenderingResult,
-};
+use super::{Item, ItemRc, ItemRendererRef, KeyEventResult, PointerEventButton, RenderingResult};
 use crate::animations::{EasingCurve, Instant};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent, MouseEvent,
 };
-use crate::item_rendering::CachedRenderingData;
 use crate::items::{Empty, PropertyAnimation};
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{
@@ -51,9 +48,6 @@ pub struct Flickable {
     pub viewport: Empty,
     pub interactive: Property<bool>,
     data: FlickableDataBox,
-
-    /// FIXME: remove this
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for Flickable {
@@ -149,11 +143,6 @@ impl Item for Flickable {
         );
         RenderingResult::ContinueRenderingChildren
     }
-}
-
-impl ItemConsts for Flickable {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
-        Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 #[repr(C)]

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -7,12 +7,11 @@ This module contains the builtin image related items.
 When adding an item or a property, it needs to be kept in sync with different place.
 Lookup the [`crate::items`] module documentation.
 */
-use super::{ImageFit, ImageRendering, Item, ItemConsts, ItemRc, RenderingResult};
+use super::{ImageFit, ImageRendering, Item, ItemRc, RenderingResult};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
     KeyEventResult, MouseEvent,
 };
-use crate::item_rendering::CachedRenderingData;
 use crate::item_rendering::ItemRenderer;
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize};
@@ -37,7 +36,6 @@ pub struct ImageItem {
     pub height: Property<LogicalLength>,
     pub image_fit: Property<ImageFit>,
     pub image_rendering: Property<ImageRendering>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for ImageItem {
@@ -114,13 +112,6 @@ impl Item for ImageItem {
     }
 }
 
-impl ItemConsts for ImageItem {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        ImageItem,
-        CachedRenderingData,
-    > = ImageItem::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
@@ -138,7 +129,6 @@ pub struct ClippedImage {
     pub source_clip_y: Property<i32>,
     pub source_clip_width: Property<i32>,
     pub source_clip_height: Property<i32>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for ClippedImage {
@@ -213,11 +203,4 @@ impl Item for ClippedImage {
         (*backend).draw_clipped_image(self, self_rc);
         RenderingResult::ContinueRenderingChildren
     }
-}
-
-impl ItemConsts for ClippedImage {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        ClippedImage,
-        CachedRenderingData,
-    > = ClippedImage::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -8,13 +8,12 @@ When adding an item or a property, it needs to be kept in sync with different pl
 Lookup the [`crate::items`] module documentation.
 */
 
-use super::{FillRule, Item, ItemConsts, ItemRc, ItemRendererRef, RenderingResult};
+use super::{FillRule, Item, ItemRc, ItemRendererRef, RenderingResult};
 use crate::graphics::{Brush, PathData, PathDataIterator};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
     KeyEventResult, MouseEvent,
 };
-use crate::item_rendering::CachedRenderingData;
 
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{
@@ -49,7 +48,6 @@ pub struct Path {
     pub viewbox_width: Property<f32>,
     pub viewbox_height: Property<f32>,
     pub clip: Property<bool>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for Path {
@@ -162,9 +160,4 @@ impl Path {
         elements_iter.fit(bounds_width.get() as _, bounds_height.get() as _, maybe_viewbox);
         (offset, elements_iter)
     }
-}
-
-impl ItemConsts for Path {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Path, CachedRenderingData> =
-        Path::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -9,16 +9,16 @@ Lookup the [`crate::items`] module documentation.
 */
 
 use super::{
-    InputType, Item, ItemConsts, ItemRc, KeyEventResult, KeyEventType, PointArg,
-    PointerEventButton, RenderingResult, TextHorizontalAlignment, TextOverflow,
-    TextVerticalAlignment, TextWrap, VoidArg,
+    InputType, Item, ItemRc, KeyEventResult, KeyEventType, PointArg, PointerEventButton,
+    RenderingResult, TextHorizontalAlignment, TextOverflow, TextVerticalAlignment, TextWrap,
+    VoidArg,
 };
 use crate::graphics::{Brush, Color, FontRequest};
 use crate::input::{
     key_codes, FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
     KeyboardModifiers, MouseEvent, StandardShortcut, TextShortcut,
 };
-use crate::item_rendering::{CachedRenderingData, ItemRenderer};
+use crate::item_rendering::ItemRenderer;
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
 #[cfg(feature = "rtti")]
@@ -53,7 +53,6 @@ pub struct Text {
     pub y: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
-    pub cached_rendering_data: CachedRenderingData,
 }
 
 impl Item for Text {
@@ -167,11 +166,6 @@ impl Item for Text {
     }
 }
 
-impl ItemConsts for Text {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<Text, CachedRenderingData> =
-        Text::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
-}
-
 impl Text {
     pub fn font_request(self: Pin<&Self>, window: &WindowInner) -> FontRequest {
         let window_item = window.window_item();
@@ -242,7 +236,6 @@ pub struct TextInput {
     pub preedit_text: Property<SharedString>,
     pub preedit_selection_start: Property<i32>, // byte offset, relative to cursor
     pub preedit_selection_end: Property<i32>,   // byte offset, relative to cursor
-    pub cached_rendering_data: CachedRenderingData,
     // The x position where the cursor wants to be.
     // It is not updated when moving up and down even when the line is shorter.
     preferred_x_pos: core::cell::Cell<Coord>,
@@ -544,13 +537,6 @@ impl Item for TextInput {
         (*backend).draw_text_input(self, self_rc);
         RenderingResult::ContinueRenderingChildren
     }
-}
-
-impl ItemConsts for TextInput {
-    const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        TextInput,
-        CachedRenderingData,
-    > = TextInput::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 pub enum TextCursorDirection {

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -38,12 +38,7 @@ pub trait Renderer {
     ) -> LogicalRect;
 
     /// Clear the caches for the items that are being removed
-    fn free_graphics_resources(
-        &self,
-        _component: ComponentRef,
-        _items: &mut dyn Iterator<Item = Pin<crate::items::ItemRef<'_>>>,
-    ) {
-    }
+    fn free_graphics_resources(&self, _component: ComponentRef) {}
 
     /// Mark a given region as dirty regardless whether the items actually are dirty.
     ///

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1394,12 +1394,7 @@ impl<const MAX_BUFFER_AGE: usize> crate::window::WindowAdapterSealed
         &self.renderer
     }
 
-    fn unregister_component<'a>(
-        &self,
-        _component: crate::component::ComponentRef,
-        _items: &mut dyn Iterator<Item = Pin<crate::items::ItemRef<'a>>>,
-    ) {
-    }
+    fn unregister_component<'a>(&self, _component: crate::component::ComponentRef) {}
 }
 
 impl<const MAX_BUFFER_AGE: usize> WindowAdapter for MinimalSoftwareWindow<MAX_BUFFER_AGE> {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -79,12 +79,7 @@ pub trait WindowAdapterSealed {
 
     /// This function is called by the generated code when a component and therefore its tree of items are destroyed. The
     /// implementation typically uses this to free the underlying graphics resources cached via [`crate::graphics::RenderingCache`].
-    fn unregister_component<'a>(
-        &self,
-        _component: ComponentRef,
-        _items: &mut dyn Iterator<Item = Pin<ItemRef<'a>>>,
-    ) {
-    }
+    fn unregister_component<'a>(&self, _component: ComponentRef) {}
 
     /// Create a window for a popup.
     ///

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -220,12 +220,7 @@ impl<'id> Drop for ErasedComponentBox {
         let unerase = self.unerase(guard);
         let instance_ref = unerase.borrow_instance();
         if let Some(window_adapter) = eval::window_adapter_ref(instance_ref) {
-            i_slint_core::component::unregister_component(
-                instance_ref.instance,
-                vtable::VRef::new(self),
-                instance_ref.component_type.item_array.as_slice(),
-                window_adapter,
-            );
+            i_slint_core::component::unregister_component(vtable::VRef::new(self), window_adapter);
         }
     }
 }

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -366,11 +366,7 @@ impl<NativeWindowWrapper> i_slint_core::renderer::Renderer for SkiaRenderer<Nati
         self::textlayout::DEFAULT_FONT_SIZE
     }
 
-    fn free_graphics_resources(
-        &self,
-        component: i_slint_core::component::ComponentRef,
-        _items: &mut dyn Iterator<Item = std::pin::Pin<i_slint_core::items::ItemRef<'_>>>,
-    ) {
+    fn free_graphics_resources(&self, component: i_slint_core::component::ComponentRef) {
         let canvas = if self.canvas.borrow().is_some() {
             std::cell::Ref::map(self.canvas.borrow(), |canvas_opt| canvas_opt.as_ref().unwrap())
         } else {


### PR DESCRIPTION
All the renderers are storing their caches such as textures, fonts, etc. for items in the separate per-component-per-item hash table, except for the partial renderer. This change ports the partial renderer over and removes the now unnecessary fields and data structures.