### PR TITLE
LSP: Support for the `slint!` macro in rust files

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -19,6 +19,7 @@
     "preview": true,
     "activationEvents": [
         "onLanguage:slint",
+        "onLanguage:rust",
         "onWebviewPanel:slint-preview",
         "onView:slint.propertiesView"
     ],
@@ -43,6 +44,16 @@
                 "language": "slint",
                 "scopeName": "source.slint",
                 "path": "./slint.tmLanguage.json"
+            },
+            {
+                "injectTo": [
+                    "source.rust"
+                ],
+                "scopeName": "source.rust.slint",
+                "path": "./slint.injection.json",
+                "embeddedLanguages": {
+                    "source.slint": "slint"
+                }
             }
         ],
         "commands": [

--- a/editors/vscode/slint.injection.json
+++ b/editors/vscode/slint.injection.json
@@ -1,0 +1,37 @@
+{
+    "scopeName": "source.rust.slint",
+    "injectionSelector": "L:source.rust",
+    "patterns": [
+        {
+            "include": "#slint-macro"
+        }
+    ],
+    "repository": {
+        "slint-macro": {
+            "name": "source.slint",
+            "begin": "slint\\s*!\\s*\\{",
+            "end": "}",
+            "patterns": [
+                {
+                    "include": "source.slint"
+                },
+                {
+                    "include": "#inner_block"
+                }
+            ]
+        },
+        "inner_block": {
+            "name": "source.slint",
+            "begin": "{",
+            "end": "}",
+            "patterns": [
+                {
+                    "include": "source.slint"
+                },
+                {
+                    "include": "#inner_block"
+                }
+            ]
+        }
+    }
+}

--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -26,7 +26,7 @@ let properties_provider: PropertiesViewProvider;
 function startClient(context: vscode.ExtensionContext) {
     //let args = vscode.workspace.getConfiguration('slint').get<[string]>('lsp-args');
 
-    const documentSelector = [{ language: "slint" }];
+    const documentSelector = [{ language: "slint" }, { language: "rust" }];
 
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -149,7 +149,7 @@ function startClient(context: vscode.ExtensionContext) {
     };
 
     let clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: "file", language: "slint" }],
+        documentSelector: [{ language: "slint" }, { language: "rust" }],
         middleware: {
             handleWorkDoneProgress: (
                 token: ProgressToken,


### PR DESCRIPTION
So preview, auto-completion, and many features works out of the box within rust files

<img width="865" alt="image" src="https://user-images.githubusercontent.com/959326/208200533-526c401c-12fa-4f2f-b20d-0d59b0c06487.png">

Colors presentation and syntax coloration don't work, i don't know why.
Properties tab don't work because we don't query the LSP for Rust files.