### PR TITLE
Do not panic if the document contains a global but no normal component

### DIFF
--- a/api/rs/slint/tests/simple_macro.rs
+++ b/api/rs/slint/tests/simple_macro.rs
@@ -12,4 +12,5 @@ fn simple_window() {
 fn empty_stuff() {
     slint!();
     slint!(struct Hei := { abcd: bool });
+    slint!(global G := { });
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -287,7 +287,7 @@ mod cpp_ast {
 }
 
 use crate::expression_tree::{BuiltinFunction, EasingCurve};
-use crate::langtype::{NativeClass, Type};
+use crate::langtype::{ElementType, NativeClass, Type};
 use crate::layout::Orientation;
 use crate::llr::{
     self, EvaluationContext as llr_EvaluationContext, ParentCtx as llr_ParentCtx,
@@ -581,6 +581,14 @@ pub fn generate(doc: &Document) -> impl std::fmt::Display {
         if let Type::Struct { fields, name: Some(name), node: Some(_) } = ty {
             generate_struct(&mut file, name, fields);
         }
+    }
+
+    if matches!(
+        doc.root_component.root_element.borrow().base_type,
+        ElementType::Error | ElementType::Global
+    ) {
+        // empty document, nothing to generate
+        return file;
     }
 
     let llr = llr::lower_to_item_tree::lower_to_item_tree(&doc.root_component);

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -132,11 +132,6 @@ fn set_primitive_property_value(ty: &Type, value_expression: TokenStream) -> Tok
 
 /// Generate the rust code for the given component.
 pub fn generate(doc: &Document) -> TokenStream {
-    if matches!(doc.root_component.root_element.borrow().base_type, ElementType::Error) {
-        // empty document, nothing to generate
-        return TokenStream::default();
-    }
-
     let (structs_ids, structs): (Vec<_>, Vec<_>) = doc
         .root_component
         .used_types
@@ -151,6 +146,14 @@ pub fn generate(doc: &Document) -> TokenStream {
             }
         })
         .unzip();
+
+    if matches!(
+        doc.root_component.root_element.borrow().base_type,
+        ElementType::Error | ElementType::Global
+    ) {
+        // empty document, nothing to generate
+        return TokenStream::default();
+    }
 
     let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(&doc.root_component);
 


### PR DESCRIPTION
Fixes #2005

(Unfortunately, we can't make a driver test for this becasue the behavior with the interpreter is different than with the compilers. The interpreter errors out, while the compiler should just generate nothing)