### PR TITLE
vscode extension: polish the `slint!` macro integration

### DIFF
--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -190,7 +190,7 @@ export function activate(context: vscode.ExtensionContext) {
             let content_str;
             if (uri === previewUrl) {
                 content_str = event.document.getText();
-                if (uri.endsWith(".rs")) {
+                if (event.document.languageId == "rust") {
                     content_str = extract_rust_macro(content_str)
                 }
             } else {
@@ -245,14 +245,20 @@ async function getDocumentSource(url: string): Promise<string> {
     let x = vscode.workspace.textDocuments.find(
         (d) => d.uri.toString() === url,
     );
-    let source = x ? x.getText() : new TextDecoder().decode(
-        await vscode.workspace.fs.readFile(Uri.parse(url)),
-    );
-
-    if (url.endsWith(".rs")) {
-        source = extract_rust_macro(source);
+    let source;
+    if (x) {
+        source = x.getText();
+        if (x.languageId == "rust") {
+            source = extract_rust_macro(source);
+        }
+    } else {
+        source = new TextDecoder().decode(
+            await vscode.workspace.fs.readFile(Uri.parse(url)),
+        );
+        if (url.endsWith(".rs")) {
+            source = extract_rust_macro(source);
+        }
     }
-
     return source;
 }
 

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -231,7 +231,7 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
         if (this._view === null) {
             return;
         }
-        if (language !== "slint") {
+        if (language !== "slint" && language != "rust") {
             this._view?.webview.postMessage({
                 command: "show_welcome",
                 message: "The active editor does not contain a Slint file.",

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -464,10 +464,10 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
     rh.register::<DocumentHighlightRequest, _>(|_params, _ctx| async move {
         let document_cache = &mut _ctx.document_cache.borrow_mut();
         let uri = _params.text_document_position_params.text_document.uri;
-        let offset_mapper = document_cache.offset_to_position_mapper(&uri)?;
         if let Some((tk, _off)) =
             token_descr(document_cache, &uri, &_params.text_document_position_params.position)
         {
+            let offset_mapper = document_cache.offset_to_position_mapper(&uri)?;
             let p = tk.parent();
             #[cfg(feature = "preview")]
             if p.kind() == SyntaxKind::QualifiedName


### PR DESCRIPTION
 - Make the browser extention preview work
 - Enable the properties tab on rust files
 - Only call `offset_to_position_mapper` if the token is valid, otherwise we might get an error visible in the UI.