### PR TITLE
CI: Use opt_level="s" for WASM binaries

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -216,6 +216,8 @@ jobs:
     - name: Install wasm-pack
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
     - name: Build package and optionally publish to Visual Studio Marketplace
+      env:
+        CARGO_PROFILE_RELEASE_OPT_LEVEL: "s"
       id: publishToVSCM
       uses: HaaLeo/publish-vscode-extension@v1
       with:

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -24,9 +24,13 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build slint-wasm-interpreter
+        env:
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: "s"
         run: npm run build:wasm_preview-release
         working-directory: tools/online_editor
       - name: Build slint-wasm-lsp
+        env:
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: "s"
         run: npm run build:wasm_lsp-release
         working-directory: tools/online_editor
 


### PR DESCRIPTION
This significantly reduces their size (about 40% when I try that locally), which should reduce download times and traffic from the online editor.

My first attempt tried to force this for all builds, but failed as we do not always set up NPM in CI. So this time I focus on the CI only.