### PR TITLE
Fix 32-bit C++ build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -210,6 +210,19 @@ jobs:
     - name: Check
       run: cargo check --target=thumbv6m-none-eabi -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789
 
+  ffi_32bit_build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/setup-rust
+      with:
+        target: armv7-unknown-linux-gnueabihf
+    - uses: baptiste0928/cargo-install@v1
+      with:
+        crate: cross
+    - name: Check
+      run: cross check --target=armv7-unknown-linux-gnueabihf -p slint-cpp --no-default-features --features=testing,interpreter
+
   docs:
     uses: ./.github/workflows/build_docs.yaml
 

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -17,7 +17,7 @@ pub struct ValueOpaque([usize; 8]);
 #[repr(C)]
 #[cfg(target_pointer_width = "32")]
 #[repr(align(8))]
-pub struct ValueOpaque([usize; 11]);
+pub struct ValueOpaque([usize; 9]);
 /// Asserts that ValueOpaque is as large as Value and has the same alignment, to make transmute safe.
 const _: [(); std::mem::size_of::<ValueOpaque>()] = [(); std::mem::size_of::<Value>()];
 const _: [(); std::mem::align_of::<ValueOpaque>()] = [(); std::mem::align_of::<Value>()];
@@ -710,7 +710,14 @@ pub struct Diagnostic {
 }
 
 #[repr(C)]
+#[cfg(target_pointer_width = "64")]
 pub struct ComponentCompilerOpaque([usize; 13]);
+
+#[repr(C)]
+#[cfg(target_pointer_width = "32")]
+#[repr(align(8))]
+pub struct ComponentCompilerOpaque([usize; 16]);
+
 /// Asserts that ComponentCompilerOpaque is as large as ComponentCompiler and has the same alignment, to make transmute safe.
 const _: [(); std::mem::size_of::<ComponentCompilerOpaque>()] =
     [(); std::mem::size_of::<ComponentCompiler>()];


### PR DESCRIPTION
Adjust sizes of opaque value and component compiler wrapper structs.

These have been out of sync for many releases (I stopped at v0.2.0, but it goes further AFAICS).