### PR TITLE
Fix C++ memory game tutorial not starting out of the box on Windows

### DIFF
--- a/api/cpp/README.md
+++ b/api/cpp/README.md
@@ -25,7 +25,7 @@ First you need to install the prerequisites:
 
 * Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). Once this is done,
   you should have the ```rustc``` compiler and the ```cargo``` build system installed in your path.
-* **[cmake](https://cmake.org/download/)** (3.19 or newer)
+* **[cmake](https://cmake.org/download/)** (3.21 or newer)
 * A C++ compiler that supports C++20 (e.g., **MSVC 2019 16.6** on Windows)
 
 You can include Slint in your CMake project using CMake's `FetchContent` feature. Insert the following snippet into your
@@ -103,7 +103,7 @@ After extracting the artifact or running the installer, you can place the `lib` 
 A typical example looks like this:
 
 ```cmake
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 project(my_application LANGUAGES CXX)
 
 # Note: Use find_package(Slint) instead of the following three commands, if you prefer the package
@@ -120,6 +120,10 @@ FetchContent_MakeAvailable(Slint)
 add_executable(my_application main.cpp)
 target_link_libraries(my_application PRIVATE Slint::Slint)
 slint_target_sources(my_application my_application_ui.slint)
+# On Windows, copy the Slint DLL next to the application binary so that it's found.
+if (WIN32)
+    add_custom_command(TARGET my_application POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:my_application> $<TARGET_FILE_DIR:my_application> COMMAND_EXPAND_LISTS)
+endif()
 ```
 
 The `slint_target_sources` cmake command allows you to add .slint files to your build. Finally it is

--- a/api/cpp/docs/cmake.md
+++ b/api/cpp/docs/cmake.md
@@ -34,7 +34,7 @@ First you need to install the prerequisites:
 * Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). If you already
   have Rust installed, make sure that it's at least version 1.60 or newer. You can check which version you have installed
   by running `rustc --version`. Once this is done, you should have the ```rustc``` compiler and the ```cargo``` build system installed in your path.
-* **[cmake](https://cmake.org/download/)** (3.19 or newer)
+* **[cmake](https://cmake.org/download/)** (3.21 or newer)
 * A C++ compiler that supports C++20 (e.g., **MSVC 2019 16.6** on Windows)
 
 You can include Slint in your CMake project using CMake's [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html) feature.

--- a/api/cpp/docs/getting_started.md
+++ b/api/cpp/docs/getting_started.md
@@ -28,6 +28,10 @@ FetchContent_MakeAvailable(Slint)
 add_executable(my_application main.cpp)
 slint_target_sources(my_application my_application_ui.slint)
 target_link_libraries(my_application PRIVATE Slint::Slint)
+# On Windows, copy the Slint DLL next to the application binary so that it's found.
+if (WIN32)
+    add_custom_command(TARGET my_application POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:my_application> $<TARGET_FILE_DIR:my_application> COMMAND_EXPAND_LISTS)
+endif()
 ```
 
 Suppose `my_application_ui.slint` was a "Hello World" like this:

--- a/docs/building.md
+++ b/docs/building.md
@@ -40,7 +40,7 @@ environment variable `RUST_FONTCONFIG_DLOPEN=on`. This can be useful for [cross-
 
 To use Slint from C++, the following extra dependencies are needed:
 
-- **[cmake](https://cmake.org/download/)** (3.19 or newer)
+- **[cmake](https://cmake.org/download/)** (3.21 or newer)
 - A C++ compiler that supports C++20 (e.g., **MSVC 2022 17.3** on Windows, or **GCC 10**)
 
 ### Node.js API (optional)

--- a/docs/tutorial/cpp/src/getting_started.md
+++ b/docs/tutorial/cpp/src/getting_started.md
@@ -3,7 +3,7 @@
 In this tutorial, we use C++ as the host programming language. We also support other programming languages like
 [Rust](https://slint-ui.com/docs/rust/slint/) or [JavaScript](https://slint-ui.com/docs/node/).
 
-You will need a development environment that can compile C++20 with CMake 3.19.
+You will need a development environment that can compile C++20 with CMake 3.21.
 We do not provide binaries of Slint yet, so we will use the CMake integration that will automatically build
 the tools and library from source. Since it is implemented in the Rust programming language, this means that
 you also need to install a Rust compiler (1.64). You can easily install a Rust compiler
@@ -14,7 +14,7 @@ In a new directory, we create a new `CMakeLists.txt` file.
 
 ```cmake
 # CMakeLists.txt
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 project(memory LANGUAGES CXX)
 
 include(FetchContent)
@@ -29,6 +29,10 @@ FetchContent_MakeAvailable(Slint)
 add_executable(memory_game main.cpp)
 target_link_libraries(memory_game PRIVATE Slint::Slint)
 slint_target_sources(memory_game memory.slint)
+# On Windows, copy the Slint DLL next to the application binary so that it's found.
+if (WIN32)
+    add_custom_command(TARGET memory_game POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:memory_game> $<TARGET_FILE_DIR:memory_game> COMMAND_EXPAND_LISTS)
+endif()
 ```
 
 This should look familiar to people familiar with CMake. We see that this CMakeLists.txt
@@ -64,13 +68,7 @@ If you are on Linux or macOS, you can run the program:
 
 and a window will appear with the green "Hello World" greeting.
 
-If you are stepping through this tutorial on a Windows machine, you need to add the `bin` sub-directory into your `%PATH%`:
-
-```sh
-set PATH=%CD%\bin;%PATH%
-```
-
-so that Windows to can find the Slint run-time library. Then you can run it with
+If you are stepping through this tutorial on a Windows machine, you can run it with
 
 ```sh
 memory_game


### PR DESCRIPTION
After commit 3e5aa212d5954ac9b171a043c52088ca292e292a the Slint DLLs aren't placed in the `bin/` directory by default anymore. Since the tutorial builds Slint as an external sub-project, it is entirely isolated and the CMAKE_*_OUTPUT_DIRECTORY variables do not propagate. On macOS and Linux, the program still runs due to rpath. On Windows, the instructions said to put `bin` into `%PATH%`, but that doesn't work anymore, the dll is now in `_deps/slint-build`.

Instead of adjusting `%PATH%`, this change adjusts the documentation to recommend the use of a custom command on Windows using $<TARGET_RUNTIME_DLLS:tgt> to copy the DLL across. This is guarded with WIN32 due to https://gitlab.kitware.com/cmake/cmake/-/issues/23543 , where the proposed solution requires CMake 3.26 (not released yet).
