### PR TITLE
Fix crash when using repeaters in C++ on 32-bit architectures

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -1352,7 +1352,7 @@ public:
         viewport_height->set(h);
     }
 
-    uintptr_t visit(TraversalOrder order, private_api::ItemVisitorRefMut visitor) const
+    uint64_t visit(TraversalOrder order, private_api::ItemVisitorRefMut visitor) const
     {
         for (std::size_t i = 0; i < inner->data.size(); ++i) {
             int index = order == TraversalOrder::BackToFront ? i : inner->data.size() - 1 - i;


### PR DESCRIPTION
The abort in the repeated item traversal is represented as 64-bit unsigned value with all bits set, not just 32-bits.

Fixes #2039