### PR TITLE
Doc: Fix table in C++ types mapping page

### DIFF
--- a/api/cpp/docs/types.md
+++ b/api/cpp/docs/types.md
@@ -3,25 +3,22 @@
 The types used for properties in `.slint` design markup each translate to specific types in C++.
 The follow table summarizes the entire mapping:
 
-```{eval-rst}
-==========================  ==================================  =======================================================================================================================================
- :code:`.slint` Type             C++ Type                        Note
-==========================  ==================================  =======================================================================================================================================
- :code:`int`                 :code:`int`
- :code:`float`               :code:`float`
- :code:`bool`                :code:`bool`
- :code:`string`              :cpp:class:`slint::SharedString`    A reference-counted string type that uses UTF-8 encoding and can be easily converted to a std::string_view or a :code:`const char *`.
- :code:`color`               :cpp:class:`slint::Color`
- :code:`brush`               :cpp:class:`slint::Brush`
- :code:`image`               :cpp:class:`slint::Image`
- :code:`physical_length`     :code:`float`                       The unit are physical pixels.
- :code:`length`              :code:`float`                       At run-time, logical lengths are automatically translated to physical pixels using the device pixel ratio.
- :code:`duration`            :code:`std::int64_t`                At run-time, durations are always represented as signed 64-bit integers with millisecond precision.
- :code:`angle`               :code:`float`                       The value in degrees.
- :code:`relative-font-size`  :code:`float`                       Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`.
- structure                   A :code:`class` of the same name    The order of the data member are in the lexicographic order of their name
-==========================  ==================================  =======================================================================================================================================
-```
+| :code:`.slint` Type        |     C++ Type                      | Note                                                                                                                                  |
+| -------------------------- |---------------------------------- |---------------------------------------------------------------------------------------------------------------------------------------|
+| :code:`int`                | :code:`int`
+| :code:`float`              | :code:`float`
+| :code:`bool`               | :code:`bool`
+| :code:`string`             | :cpp:class:`slint::SharedString`  | A reference-counted string type that uses UTF-8 encoding and can be easily converted to a std::string_view or a :code:`const char *`.
+| :code:`color`              | :cpp:class:`slint::Color`
+| :code:`brush`              | :cpp:class:`slint::Brush`
+| :code:`image`              | :cpp:class:`slint::Image`
+| :code:`physical_length`    | :code:`float`                     | The unit are physical pixels.
+| :code:`length`             | :code:`float`                     | At run-time, logical lengths are automatically translated to physical pixels using the device pixel ratio.
+| :code:`duration`           | :code:`std::int64_t`              | At run-time, durations are always represented as signed 64-bit integers with millisecond precision.
+| :code:`angle`              | :code:`float`                     | The value in degrees.
+| :code:`relative-font-size` | :code:`float`                     | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`.
+| structure                  | A :code:`class` of the same name  | The order of the data member are in the lexicographic order of their name
+
 ## Structures
 
 For user-defined structures in the .slint code, a `class` of the same name is generated with data member


### PR DESCRIPTION
I'm not sure if I did it exactly correct because I don't have the setup here to generate the docs.

Right now, on the official site, the table doesn't show up at all:
![image](https://user-images.githubusercontent.com/104767/211772887-a5657ca5-91f6-436c-a3cc-8ffeda9341b5.png)
