### PR TITLE
Fix crash when using an int model in a repeater with a negative value

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -771,9 +771,9 @@ public:
 struct UIntModel : Model<int>
 {
     /// Constructs a new IntModel with \a d rows.
-    UIntModel(uint d) : data(d) { }
+    UIntModel(uint32_t d) : data(d) { }
     /// \private
-    uint data;
+    uint32_t data;
     /// \copydoc Model::row_count
     int row_count() const override { return data; }
     std::optional<int> row_data(int value) const override

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -775,7 +775,7 @@ struct IntModel : Model<int>
     /// \private
     int data;
     /// \copydoc Model::row_count
-    int row_count() const override { return data; }
+    int row_count() const override { return std::max(0, data); }
     std::optional<int> row_data(int value) const override
     {
         if (value >= row_count())

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -768,14 +768,14 @@ public:
 };
 
 /// Model to be used when we just want to repeat without data.
-struct IntModel : Model<int>
+struct UIntModel : Model<int>
 {
     /// Constructs a new IntModel with \a d rows.
-    IntModel(int d) : data(d) { }
+    UIntModel(uint d) : data(d) { }
     /// \private
-    int data;
+    uint data;
     /// \copydoc Model::row_count
-    int row_count() const override { return std::max(0, data); }
+    int row_count() const override { return data; }
     std::optional<int> row_data(int value) const override
     {
         if (value >= row_count())

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1466,7 +1466,7 @@ fn generate_sub_component(
         if repeated.model.ty(&ctx) == Type::Bool {
             // bool converts to int
             // FIXME: don't do a heap allocation here
-            model = format!("std::make_shared<slint::private_api::IntModel>({})", model)
+            model = format!("std::make_shared<slint::private_api::UIntModel>({})", model)
         }
 
         // FIXME: optimize  if repeated.model.is_constant()
@@ -2247,7 +2247,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                     format!("slint::SharedString::from_number({})", f)
                 }
                 (Type::Float32, Type::Model) | (Type::Int32, Type::Model) => {
-                    format!("std::make_shared<slint::private_api::IntModel>({})", f)
+                    format!("std::make_shared<slint::private_api::UIntModel>(std::max(0, {}))", f)
                 }
                 (Type::Array(_), Type::Model) => f,
                 (Type::Float32, Type::Color) => {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1785,7 +1785,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                     ))
                 }
                 (Type::Float32, Type::Model) | (Type::Int32, Type::Model) => {
-                    quote!(slint::private_unstable_api::re_exports::ModelRc::new(#f as usize))
+                    quote!(slint::private_unstable_api::re_exports::ModelRc::new(#f.max(Default::default()) as usize))
                 }
                 (Type::Float32, Type::Color) => {
                     quote!(slint::private_unstable_api::re_exports::Color::from_argb_encoded(#f as u32))

--- a/internal/interpreter/value_model.rs
+++ b/internal/interpreter/value_model.rs
@@ -47,7 +47,7 @@ impl Model for ValueModel {
                     0
                 }
             }
-            Value::Number(x) => *x as usize,
+            Value::Number(x) => x.max(Default::default()) as usize,
             Value::Void => 0,
             Value::Model(model_ptr) => model_ptr.row_count(),
             x => panic!("Invalid model {:?}", x),

--- a/tests/cases/models/negative_intmodel.slint
+++ b/tests/cases/models/negative_intmodel.slint
@@ -1,0 +1,54 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+
+TestCase := Rectangle {
+    width: 100phx;
+    height: 100phx;
+
+    property <int> creation-count: 0;
+
+    property <length> test-height: preferred-height;
+
+    property <int> neg-count: -10;
+
+    VerticalLayout {
+        for _ in neg-count: Rectangle {
+            preferred-height: 10px;
+            init => {
+                creation-count += 1;
+            }
+        }
+    }
+
+}
+
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert_eq(instance.get_creation_count(), 0);
+assert_eq(instance.get_test_height(), 0.);
+assert_eq(instance.get_creation_count(), 0);
+```
+
+
+```rust
+let instance = TestCase::new();
+
+assert_eq!(instance.get_creation_count(), 0);
+assert_eq!(instance.get_test_height(), 0.);
+assert_eq!(instance.get_creation_count(), 0);
+```
+
+```js
+var instance = new slint.TestCase();
+
+assert.equal(instance.creation_count, 0);
+assert.equal(instance.test_height, 0.);
+assert.equal(instance.creation_count, 0);
+```
+*/

--- a/tests/cases/models/negative_intmodel.slint
+++ b/tests/cases/models/negative_intmodel.slint
@@ -11,10 +11,10 @@ TestCase := Rectangle {
 
     property <length> test-height: preferred-height;
 
-    property <int> neg-count: -10;
+    property <int> repeater-count: -10;
 
     VerticalLayout {
-        for _ in neg-count: Rectangle {
+        for _ in repeater-count: Rectangle {
             preferred-height: 10px;
             init => {
                 creation-count += 1;
@@ -33,6 +33,9 @@ const TestCase &instance = *handle;
 assert_eq(instance.get_creation_count(), 0);
 assert_eq(instance.get_test_height(), 0.);
 assert_eq(instance.get_creation_count(), 0);
+instance.set_repeater_count(2);
+assert_eq(instance.get_test_height(), 20.);
+assert_eq(instance.get_creation_count(), 2);
 ```
 
 
@@ -42,6 +45,9 @@ let instance = TestCase::new();
 assert_eq!(instance.get_creation_count(), 0);
 assert_eq!(instance.get_test_height(), 0.);
 assert_eq!(instance.get_creation_count(), 0);
+instance.set_repeater_count(2);
+assert_eq!(instance.get_test_height(), 20.);
+assert_eq!(instance.get_creation_count(), 2);
 ```
 
 ```js
@@ -50,5 +56,8 @@ var instance = new slint.TestCase();
 assert.equal(instance.creation_count, 0);
 assert.equal(instance.test_height, 0.);
 assert.equal(instance.creation_count, 0);
+instance.repeater_count = 2;
+assert.equal(instance.test_height, 20.);
+assert.equal(instance.creation_count, 2);
 ```
 */


### PR DESCRIPTION
Make sure that we return an unsigned for row_count() in C++ and that we create the usize for the model in Rust capped to zero.

For the interpreter this "worked" by chance as casting a negative floating number to usize automatically caps at zero, and all values are stored as f64. For safety this patch applies the same fix though, to be on the safe side.