### PR TITLE
Fix panic when resetting the model to a smaller model in a ListView

### DIFF
--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -984,6 +984,9 @@ impl<C: RepeatedComponent + 'static> Repeater<C> {
             let mut idx = new_offset;
             let components_begin = new_offset - inner.offset;
             for c in &mut inner.components[components_begin..] {
+                if idx >= row_count {
+                    break;
+                }
                 if c.0 == RepeatedComponentState::Dirty {
                     if c.1.is_none() {
                         c.1 = Some(init());

--- a/tests/cases/models/listview_model_change.slint
+++ b/tests/cases/models/listview_model_change.slint
@@ -12,11 +12,11 @@
 import { ListView } from "std-widgets.slint";
 
 TestCase := Window {
-    width: 100px;
-    height: 100px;
+    width: 300px;
+    height: 300px;
 
     property<length> viewport-height: lv.viewport-height;
-    property<[length]> fixed-height-model: [100px];
+    property<[length]> fixed-height-model: [100px, 0px];
 
     lv := ListView {
         for fixed-height in fixed-height-model: Rectangle {


### PR DESCRIPTION
Regresison in 1162ebbb79f819c5fe58ed383cad850bae51e856: Before that commit, the vew would never have more items than the model since the model would communicate what items to remove. But now, it is possible that the model has less elements than the view currently displays from the previous model, so we need to account for that.