### PR TITLE
Fix FemtoVG's drawing of the border rectangle with non-opaque borders (#2079)

### DIFF
--- a/internal/core/graphics/brush.rs
+++ b/internal/core/graphics/brush.rs
@@ -69,6 +69,22 @@ impl Brush {
         }
     }
 
+    /// Returns true if this brush is fully opaque
+    ///
+    /// ```
+    /// # use i_slint_core::graphics::*;
+    /// assert!(!Brush::default().is_opaque());
+    /// assert!(!Brush::SolidColor(Color::from_argb_u8(25, 255, 128, 140)).is_opaque());
+    /// assert!(Brush::SolidColor(Color::from_rgb_u8(128, 140, 210)).is_opaque());
+    /// ```
+    pub fn is_opaque(&self) -> bool {
+        match self {
+            Brush::SolidColor(c) => c.alpha() == 255,
+            Brush::LinearGradient(g) => g.stops().all(|s| s.color.alpha() == 255),
+            Brush::RadialGradient(g) => g.stops().all(|s| s.color.alpha() == 255),
+        }
+    }
+
     /// Returns a new version of this brush that has the brightness increased
     /// by the specified factor. This is done by calling [`Color::brighter`] on
     /// all the colors of this brush.


### PR DESCRIPTION
Also fix the border radius to be the outer radius of the rectangle

FemtoVG renderer part of #1988 (minus clipping)

#1988's testcase before:

<img width="417" alt="before" src="https://user-images.githubusercontent.com/1486/213411397-e66fbb6d-b8e4-4b2c-9693-25998bcd3368.png">

and with this patch:

<img width="417" alt="after" src="https://user-images.githubusercontent.com/1486/213411432-c593d3cd-4448-4b12-93c7-d95aaaee1dde.png">
