### PR TITLE
Always generate the native struct for exported struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project are documented in this file.
  - Calling public function from native code
  - Fixed crash when using repeaters in C++ on 32-bit architectures
  - conversion of array literal containing struct with array litteral (#2023)
+ - struct exported by the main file are always generated in native code (#594)
 
 ## [0.3.3] - 2022-12-16
 

--- a/internal/compiler/passes/collect_structs.rs
+++ b/internal/compiler/passes/collect_structs.rs
@@ -13,6 +13,12 @@ use std::rc::Rc;
 pub fn collect_structs(doc: &Document) {
     let mut hash = BTreeMap::new();
 
+    for (name, exp) in doc.exports.iter() {
+        if let Some(ty) = exp.as_ref().right() {
+            hash.insert(String::clone(name), ty.clone());
+        }
+    }
+
     for component in (doc.root_component.used_types.borrow().sub_components.iter())
         .chain(std::iter::once(&doc.root_component))
     {

--- a/tests/cases/types/structs.slint
+++ b/tests/cases/types/structs.slint
@@ -7,6 +7,10 @@ export struct Player := {
     energy_level: float,
 }
 
+export struct Unused {
+    foo: int,
+}
+
 TestCase := Rectangle {
     property<Player> player_1: {name : "Player1", score: 12, energy_level: 80% };
     property<Player> player_2: {name : "Player2", score: 24, energy_level: 40% };
@@ -36,6 +40,9 @@ instance.set_player_2(super_player.clone());
 assert_eq!(instance.get_player_2(), super_player);
 
 assert_eq!(instance.get_player_2_score(), 99);
+
+
+let _ = Unused { foo: 42 };
 ```
 
 ```cpp
@@ -51,6 +58,9 @@ instance.set_player_2(super_player);
 assert_eq(instance.get_player_2().name, "Super Player");
 
 assert_eq(instance.get_player_2_score(), 99);
+
+Unused _unused { .foo = 42 };
+(void)_unused;
 ```
 
 ```js


### PR DESCRIPTION
Fixes #594