### PR TITLE
Fix Skia's drawing of the border rectangle with non-opaque borders (#2079)

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -307,8 +307,6 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
             rect.border_width() * self.scale_factor
         };
 
-        let radius = rect.border_radius() * self.scale_factor;
-
         // Radius of rounded rect if we were to just fill the rectangle, without a border.
         let fill_radius = rect.border_radius() * self.scale_factor;
         // Skia's border radius on stroke is in the middle of the border. But we want it to be the radius of the rectangle itself.

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -328,7 +328,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
 
             let rounded_rect = skia_safe::RRect::new_rect_xy(
                 to_skia_rect(&geometry),
-                radius.get(),
+                stroke_border_radius.get(),
                 stroke_border_radius.get(),
             );
 
@@ -336,7 +336,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         } else {
             let background_rect = skia_safe::RRect::new_rect_xy(
                 to_skia_rect(&geometry),
-                radius.get(),
+                fill_radius.get(),
                 fill_radius.get(),
             );
 
@@ -348,7 +348,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
 
             let border_rect = skia_safe::RRect::new_rect_xy(
                 to_skia_rect(&geometry),
-                radius.get(),
+                stroke_border_radius.get(),
                 stroke_border_radius.get(),
             );
 


### PR DESCRIPTION
Also fix the border radius to be the outer radius of the rectangle

Skia renderer part of #1988 (minus clipping)

Before:
<img width="417" alt="before" src="https://user-images.githubusercontent.com/1486/213442879-ae025f1a-a146-4a2b-b2c7-bb18f42de1f5.png">

After:
<img width="417" alt="after" src="https://user-images.githubusercontent.com/1486/213442901-aa429cab-e1e5-4c9a-9bcb-f516984eb1c6.png">
