### PR TITLE
First stage of cleaning up the export handling of the slint root component

### DIFF
--- a/examples/carousel/ui/carousel_demo.slint
+++ b/examples/carousel/ui/carousel_demo.slint
@@ -5,7 +5,7 @@ import { Carousel } from "carousel.slint";
 import { Card } from "card.slint";
 import { Theme } from "theme.slint";
 
-component MainWindow inherits Window {
+export component MainWindow inherits Window {
     private property<[{ title: string, image: image}]> navigation-items: [
        { title: "Settings", image: @image-url("svg/settings_black.svg") },
        { title: "Home", image: @image-url("svg/home_black.svg") },

--- a/examples/gallery/ui/gallery_settings.slint
+++ b/examples/gallery/ui/gallery_settings.slint
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-global GallerySettings  {
+export global GallerySettings  {
     in property<bool> widgets-disabled: false;
 }

--- a/examples/opengl_underlay/scene.slint
+++ b/examples/opengl_underlay/scene.slint
@@ -4,7 +4,7 @@
 import { ScrollView, Button, CheckBox, SpinBox, Slider, GroupBox, LineEdit, StandardListView,
     ComboBox, HorizontalBox, VerticalBox, GridBox, TabWidget, TextEdit, AboutSixtyFPS } from "std-widgets.slint";
 
-component App inherits Window {
+export component App inherits Window {
     preferred-width: 500px;
     preferred-height: 600px;
     title: "Slint OpenGL Underlay Example";

--- a/examples/printerdemo_old/ui/print_page.slint
+++ b/examples/printerdemo_old/ui/print_page.slint
@@ -4,7 +4,7 @@
 import { SpinBox, Button, CheckBox, Slider, GroupBox, StandardListView, GridBox } from "std-widgets.slint";
 import { Label, Page, Preview } from "common.slint";
 
-component PrintPage inherits Page {
+export component PrintPage inherits Page {
 
      layout := GridLayout {
         padding-left: 40px;

--- a/examples/printerdemo_old/ui/printerdemo.slint
+++ b/examples/printerdemo_old/ui/printerdemo.slint
@@ -54,7 +54,7 @@ struct InkLevel  {
     level: float,
 }
 
-component MainWindow inherits Window {
+export component MainWindow inherits Window {
     callback quit();
 
     width: 800px;

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -268,6 +268,7 @@ fn duplicate_sub_component(
 ) -> Rc<Component> {
     debug_assert!(component_to_duplicate.parent_element.upgrade().is_some());
     let new_component = Component {
+        node: component_to_duplicate.node.clone(),
         id: component_to_duplicate.id.clone(),
         root_element: duplicate_element_with_mapping(
             &component_to_duplicate.root_element,

--- a/internal/compiler/tests/syntax/accessibility/accessible_properties.slint
+++ b/internal/compiler/tests/syntax/accessibility/accessible_properties.slint
@@ -19,7 +19,7 @@ Button3 := Rectangle {
     }
 }
 
-Test := Window {
+export Test := Window {
 
     Button1 { }
     Button1 { accessible-description: "ok"; } // ok because Button1 has a role

--- a/internal/compiler/tests/syntax/analysis/binding_loop1.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop1.slint
@@ -14,7 +14,7 @@ WithStates := Rectangle {
     ]
 }
 
-Test := Rectangle {
+export Test := Rectangle {
 
     property <int> a: 45 + root.b;
     //               ^error{The binding for the property 'a' is part of a binding loop}

--- a/internal/compiler/tests/syntax/analysis/binding_loop2.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop2.slint
@@ -35,7 +35,7 @@ T4 := Rectangle {
     property <length> my_property <=> x;
 }
 
-App := Rectangle {
+export App := Rectangle {
 
 
     VerticalLayout {

--- a/internal/compiler/tests/syntax/analysis/binding_loop_function.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_function.slint
@@ -18,7 +18,7 @@ Compo1 := Rectangle {
 //  ^error{The binding for the property 'bb' is part of a binding loop}
 }
 
-App := Rectangle {
+export App := Rectangle {
     cc := Compo1 {
         aa() => { return self.a; }
 //      ^error{The binding for the property 'aa' is part of a binding loop}

--- a/internal/compiler/tests/syntax/analysis/binding_loop_issue_772.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_issue_772.slint
@@ -6,7 +6,7 @@ Alias := Rectangle {
     property <int> ps_width <=> viewport_width;
 }
 
-Foo := Rectangle {
+export Foo := Rectangle {
     property <int> base-prop: alias.viewport_width;
     //                       ^error{The binding for the property 'base-prop' is part of a binding loop}
 

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout.slint
@@ -19,7 +19,7 @@ TC := Rectangle {
 }
 
 
-Test := Rectangle {
+export Test := Rectangle {
     VerticalLayout {
 //  ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}  // FIXME: That's an internal property, but people might understand
 //  ^^error{The binding for the property 'min-width' is part of a binding loop}

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout2.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout2.slint
@@ -26,7 +26,7 @@ Wrap := Rectangle {
     property <bool> test: square.width == square.height;
 }
 
-Test := Rectangle {
+export Test := Rectangle {
     property <image> source;
     GridLayout {
 //  ^error{The binding for the property 'layout-cache-h' is part of a binding loop}

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout3.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout3.slint
@@ -22,7 +22,7 @@ Compo := Rectangle {
 
 }
 
-Foo := Rectangle {
+export Foo := Rectangle {
     Compo {
 //  ^error{The binding for the property 'preferred-width' is part of a binding loop}
         the_text: self.preferred-width / 1px;

--- a/internal/compiler/tests/syntax/analysis/binding_loop_self.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_self.slint
@@ -5,7 +5,7 @@
 
 Key := Rectangle { property <int> pos; property <int> num_elements; }
 
-Test := Rectangle {
+export Test := Rectangle {
     Rectangle {
         property <int> num_elements;
         num-elements: 4;

--- a/internal/compiler/tests/syntax/basic/animate.slint
+++ b/internal/compiler/tests/syntax/basic/animate.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
 
     animate x {
         duration: 1000ms;

--- a/internal/compiler/tests/syntax/basic/arithmetic_op.slint
+++ b/internal/compiler/tests/syntax/basic/arithmetic_op.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     property<duration> p1: 3s + 1ms;
     property<int> p2: 3s + 1;
 //                        ^error{Cannot convert float to duration}

--- a/internal/compiler/tests/syntax/basic/array.slint
+++ b/internal/compiler/tests/syntax/basic/array.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Test := Window {
+export Test := Window {
     a: [,];
 //      ^error{invalid expression}
 }

--- a/internal/compiler/tests/syntax/basic/assign.slint
+++ b/internal/compiler/tests/syntax/basic/assign.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     TouchArea {
         clicked => { root.x = 1phx; }
     }

--- a/internal/compiler/tests/syntax/basic/box_shadow.slint
+++ b/internal/compiler/tests/syntax/basic/box_shadow.slint
@@ -5,7 +5,7 @@ Foo := Rectangle {
     drop-shadow-color: red;
 }
 
-SuperSimple := Window {
+export SuperSimple := Window {
     drop-shadow-color: #00000080;
 //                    ^warning{The drop-shadow-color property cannot be used on the root element, the shadow will not be visible}
 

--- a/internal/compiler/tests/syntax/basic/children_placeholder.slint
+++ b/internal/compiler/tests/syntax/basic/children_placeholder.slint
@@ -33,7 +33,7 @@ TestBox2 := Rectangle {
 //  ^error{The @children placeholder can only appear once in an element hierarchy}
 }
 
-Final := TestBox {
+export Final := TestBox {
     Rectangle {
         @children
 //      ^error{children placeholder not allowed in the final component}

--- a/internal/compiler/tests/syntax/basic/children_placeholder_2.slint
+++ b/internal/compiler/tests/syntax/basic/children_placeholder_2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Final := Window {
+export Final := Window {
     VerticalLayout {
         @children
 //      ^error{children placeholder not allowed in the final component}

--- a/internal/compiler/tests/syntax/basic/clip.slint
+++ b/internal/compiler/tests/syntax/basic/clip.slint
@@ -3,7 +3,7 @@
 
 MyTouchArea := TouchArea { }
 
-SubElements := Rectangle {
+export SubElements := Rectangle {
     Rectangle {
         clip: 42;
 //           ^error{Cannot convert float to bool}

--- a/internal/compiler/tests/syntax/basic/comments.slint
+++ b/internal/compiler/tests/syntax/basic/comments.slint
@@ -4,7 +4,7 @@
 // comment
 
 // line comment
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     /* block comment */
     background: green;
 

--- a/internal/compiler/tests/syntax/basic/comparison_operator.slint
+++ b/internal/compiler/tests/syntax/basic/comparison_operator.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     property<bool> zz: aa > bb == cc
 //                             ^error{Use parentheses to disambiguate equality expression on the same level}
                 < dd;

--- a/internal/compiler/tests/syntax/basic/condition_operator.slint
+++ b/internal/compiler/tests/syntax/basic/condition_operator.slint
@@ -26,7 +26,7 @@ SuperSimple := Rectangle {
 }
 
 
-Test2 := Rectangle {
+export Test2 := Rectangle {
     background: {
 //             ^error{Cannot convert void to brush}
         if (true) {

--- a/internal/compiler/tests/syntax/basic/dialog.slint
+++ b/internal/compiler/tests/syntax/basic/dialog.slint
@@ -47,7 +47,7 @@ MyDialog4 := Dialog {
     }
 }
 
-Test := Rectangle {
+export Test := Rectangle {
     MyDiag1 {}
     MyDiag2 {}
     MyDiag3 {}

--- a/internal/compiler/tests/syntax/basic/dialog2.slint
+++ b/internal/compiler/tests/syntax/basic/dialog2.slint
@@ -3,8 +3,8 @@
 
 import { StandardButton } from "std-widgets.slint";
 
-Test := Dialog {
-//     ^error{A Dialog must have a single child element that is not StandardButton}
+export Test := Dialog {
+//            ^error{A Dialog must have a single child element that is not StandardButton}
     StandardButton { kind: ok; }
     StandardButton { }
 //  ^error{The `kind` property of the StandardButton in a Dialog must be set}

--- a/internal/compiler/tests/syntax/basic/double_binding.slint
+++ b/internal/compiler/tests/syntax/basic/double_binding.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-X := Rectangle {
+export X := Rectangle {
 
     x: 42phx;
     x: 32phx;

--- a/internal/compiler/tests/syntax/basic/double_color.slint
+++ b/internal/compiler/tests/syntax/basic/double_color.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     background: green;
     background: red;
 //  ^error{Duplicated property}

--- a/internal/compiler/tests/syntax/basic/duplicated_id.slint
+++ b/internal/compiler/tests/syntax/basic/duplicated_id.slint
@@ -26,7 +26,7 @@ SubElement := Rectangle {
 //          ^error{duplicated element id 'hello'}
 }
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
 
     unique := Rectangle {
         foo := SubElement { }

--- a/internal/compiler/tests/syntax/basic/easing.slint
+++ b/internal/compiler/tests/syntax/basic/easing.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-X := Rectangle {
+export X := Rectangle {
     animate x { easing: ease-in; }
     animate y { easing: foo; }
     //                  ^error{Unknown unqualified identifier 'foo'}

--- a/internal/compiler/tests/syntax/basic/easing_not_called.slint
+++ b/internal/compiler/tests/syntax/basic/easing_not_called.slint
@@ -3,7 +3,7 @@
 
 // Cannot be put in the easing.slint test because it is in a different pass
 
-X := Rectangle {
+export X := Rectangle {
     property <int> g; animate g { easing: cubic-bezier; }
     //                                    ^error{must be called}
 }

--- a/internal/compiler/tests/syntax/basic/for.slint
+++ b/internal/compiler/tests/syntax/basic/for.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     background: green;
 
     for xx Text {}

--- a/internal/compiler/tests/syntax/basic/image.slint
+++ b/internal/compiler/tests/syntax/basic/image.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-SubElements := Rectangle {
+export SubElements := Rectangle {
 
     background: blue;
 

--- a/internal/compiler/tests/syntax/basic/inline_component.slint
+++ b/internal/compiler/tests/syntax/basic/inline_component.slint
@@ -7,7 +7,7 @@ Inline1 := Rectangle {
     }
 }
 
-SubElements := Rectangle {
+export SubElements := Rectangle {
     Inline1 {
         background: yellow;
         invalid: yellow;

--- a/internal/compiler/tests/syntax/basic/item_as_property.slint
+++ b/internal/compiler/tests/syntax/basic/item_as_property.slint
@@ -19,7 +19,7 @@ Comp := Rectangle {
 //                    ^error{'Rectangle' is not a valid type}
 }
 
-Foo := Rectangle {
+export Foo := Rectangle {
     xx := Rectangle { }
     Comp {
         r: xx;

--- a/internal/compiler/tests/syntax/basic/layout.slint
+++ b/internal/compiler/tests/syntax/basic/layout.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-X := Rectangle {
+export X := Rectangle {
 
     lay := GridLayout {
         property<string> foo: "hello";

--- a/internal/compiler/tests/syntax/basic/layout2.slint
+++ b/internal/compiler/tests/syntax/basic/layout2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-X := Rectangle {
+export X := Rectangle {
 
     lay := GridLayout {
         property<string> foo: "hello";

--- a/internal/compiler/tests/syntax/basic/linear-gradient.slint
+++ b/internal/compiler/tests/syntax/basic/linear-gradient.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-X := Rectangle {
+export X := Rectangle {
     property<brush> g1: @linear-gradient();
 //                      ^error{Expected angle expression}
     property<brush> g2: @linear-gradient(to left, blue, red);

--- a/internal/compiler/tests/syntax/basic/minmax.slint
+++ b/internal/compiler/tests/syntax/basic/minmax.slint
@@ -6,7 +6,7 @@ global Plop :=  {
 //                    ^error{Builtin function must be called}
 }
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     property <int> a: max + max() + max(45, "hello");
 //                    ^error{Builtin function must be called}
 //                          ^^error{Needs at least one argument}

--- a/internal/compiler/tests/syntax/basic/object_in_binding.slint
+++ b/internal/compiler/tests/syntax/basic/object_in_binding.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-H := Rectangle {
+export H := Rectangle {
     x: {foo: "42"};
 //    ^error{Cannot convert \{ foo: string,\} to length}
     y: [ 45, 45, 45, 45 ];

--- a/internal/compiler/tests/syntax/basic/opacity.slint
+++ b/internal/compiler/tests/syntax/basic/opacity.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-SuperSimple := Window {
+export SuperSimple := Window {
 
     opacity: 0.5;
 //          ^warning{The opacity property cannot be used on the root element, it will not be applied}

--- a/internal/compiler/tests/syntax/basic/parse_error.slint
+++ b/internal/compiler/tests/syntax/basic/parse_error.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     88;
 //  ^error{Parse error}
     * / - + // no error there as this is already reported in the previous line

--- a/internal/compiler/tests/syntax/basic/path.slint
+++ b/internal/compiler/tests/syntax/basic/path.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     Path {
         LineTo { x: 100; y: 0; }
         LineTo { x: 100; y: 0; }

--- a/internal/compiler/tests/syntax/basic/path_commands.slint
+++ b/internal/compiler/tests/syntax/basic/path_commands.slint
@@ -8,7 +8,7 @@ Test2 := Path {
     //       ^error{Error parsing SVG commands}
 }
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     Path {
         width: 100px;
         height: 100px;

--- a/internal/compiler/tests/syntax/basic/path_for.slint
+++ b/internal/compiler/tests/syntax/basic/path_for.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     Path {
         MoveTo {
         x: 0;

--- a/internal/compiler/tests/syntax/basic/percent.slint
+++ b/internal/compiler/tests/syntax/basic/percent.slint
@@ -12,7 +12,7 @@ Foo := Rectangle {
 //    ^error{conversion from percentage to length is only possible for the properties width and height}
 }
 
-X := Rectangle {
+export X := Rectangle {
     height: 30%;
 //         ^error{Cannot find parent property to apply relative length}
     Foo {

--- a/internal/compiler/tests/syntax/basic/popup.slint
+++ b/internal/compiler/tests/syntax/basic/popup.slint
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-X := PopupWindow {
-//  ^error{PopupWindow cannot be the top level}
+export X := PopupWindow {
+//         ^error{PopupWindow cannot be the top level}
 
     Rectangle {
 

--- a/internal/compiler/tests/syntax/basic/property_animation.slint
+++ b/internal/compiler/tests/syntax/basic/property_animation.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     animate x {
         duration: 1000ms;
     }

--- a/internal/compiler/tests/syntax/basic/property_declaration.slint
+++ b/internal/compiler/tests/syntax/basic/property_declaration.slint
@@ -5,7 +5,7 @@ Comp := Rectangle {
     callback pressed;
 }
 
-Test := Comp {
+export Test := Comp {
     property<int> foo;
     foo: 100;
     property<NonExistent> bar;

--- a/internal/compiler/tests/syntax/basic/property_declaration_in_component.slint
+++ b/internal/compiler/tests/syntax/basic/property_declaration_in_component.slint
@@ -5,7 +5,7 @@ Comp := Rectangle {
     property<int> prop;
 }
 
-Test := Rectangle {
+export Test := Rectangle {
     Comp {
         prop: 45;
     }

--- a/internal/compiler/tests/syntax/basic/radial-gradient.slint
+++ b/internal/compiler/tests/syntax/basic/radial-gradient.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-X := Rectangle {
+export X := Rectangle {
     property<brush> g1: @radial-gradient();
 //                      ^error{Expected 'circle': currently, only @radial-gradient\(circle, ...\) are supported}
     property<brush> g2: @radial-gradient(circle at 100%, #333, #333 50%, #eee 75%, #333 75%);

--- a/internal/compiler/tests/syntax/basic/return.slint
+++ b/internal/compiler/tests/syntax/basic/return.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-X := Rectangle {
+export X := Rectangle {
     background: {
         return 42;
 //      ^error{Cannot convert float to brush}

--- a/internal/compiler/tests/syntax/basic/rotation.slint
+++ b/internal/compiler/tests/syntax/basic/rotation.slint
@@ -47,7 +47,7 @@ Ex2 := Rectangle {
 }
 
 
-Ex3 := Rectangle {
+export Ex3 := Rectangle {
     i1 := Image {
 //       ^error{Elements with rotation properties cannot have children elements}
         Rectangle {}

--- a/internal/compiler/tests/syntax/basic/self_assign.slint
+++ b/internal/compiler/tests/syntax/basic/self_assign.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     TouchArea {
         clicked => { root.x += 1phx; }
     }

--- a/internal/compiler/tests/syntax/basic/signal.slint
+++ b/internal/compiler/tests/syntax/basic/signal.slint
@@ -5,7 +5,7 @@ Base := Rectangle {
     callback blah;
 }
 
-SubElements := Rectangle {
+export SubElements := Rectangle {
     callback foobar;
     callback foobar;
 //          ^error{Duplicated callback declaration}    

--- a/internal/compiler/tests/syntax/basic/states_transitions.slint
+++ b/internal/compiler/tests/syntax/basic/states_transitions.slint
@@ -87,7 +87,7 @@ component NewSyntax {
 
 }
 
-component OldInNewSyntax {
+export component OldInNewSyntax {
     property<bool> checked;
     property <int> border;
     property <color> color;

--- a/internal/compiler/tests/syntax/basic/states_transitions2.slint
+++ b/internal/compiler/tests/syntax/basic/states_transitions2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     property<bool> checked;
     property <int> border;
     animate background { }

--- a/internal/compiler/tests/syntax/basic/strings.slint
+++ b/internal/compiler/tests/syntax/basic/strings.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Test := Window {
+export Test := Window {
     Text {
         text: "hel\lo";
         //    ^error{Cannot parse string literal}

--- a/internal/compiler/tests/syntax/basic/sub_elements.slint
+++ b/internal/compiler/tests/syntax/basic/sub_elements.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-SubElements := Rectangle {
+export SubElements := Rectangle {
 
     Rectangle {
         background: yellow;

--- a/internal/compiler/tests/syntax/basic/supersimple.slint
+++ b/internal/compiler/tests/syntax/basic/supersimple.slint
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     	background: green;
 }

--- a/internal/compiler/tests/syntax/basic/svg_path.slint
+++ b/internal/compiler/tests/syntax/basic/svg_path.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     Path {
         commands: "M 350 300 L 550 300 ";
         LineTo { x: 10; y: 100; }

--- a/internal/compiler/tests/syntax/basic/type_declaration.slint
+++ b/internal/compiler/tests/syntax/basic/type_declaration.slint
@@ -30,7 +30,7 @@ global MyType := {
 
 }
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     MyType {
 //  ^error{Cannot create an instance of a global component}
         ccc: "hello";

--- a/internal/compiler/tests/syntax/basic/unknown_item.slint
+++ b/internal/compiler/tests/syntax/basic/unknown_item.slint
@@ -3,7 +3,7 @@
 
 struct Struct := { def: int, }
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     DoesNotExist {
 //  ^error{Unknown type DoesNotExist}
     }

--- a/internal/compiler/tests/syntax/callbacks/init.slint
+++ b/internal/compiler/tests/syntax/callbacks/init.slint
@@ -8,7 +8,7 @@ global Singleton := {
 //  ^error{A global component cannot have an 'init' callback}
 }
 
-Test := Rectangle {
+export Test := Rectangle {
     callback init;
 //          ^error{Cannot override callback 'init'}
 }

--- a/internal/compiler/tests/syntax/elements/listview.slint
+++ b/internal/compiler/tests/syntax/elements/listview.slint
@@ -10,7 +10,7 @@ Foo := Rectangle {
     }
 }
 
-Bar := Rectangle {
+export Bar := Rectangle {
     Foo { Text {} }
     ListView {
         Text {}

--- a/internal/compiler/tests/syntax/elements/tabwidget.slint
+++ b/internal/compiler/tests/syntax/elements/tabwidget.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 import { TabWidget  } from "std-widgets.slint";
-Test1 := Rectangle {
+export Test1 := Rectangle {
     TabWidget {
         Rectangle {}
 //      ^error{Rectangle is not allowed within TabWidget. Only Tab are valid children}

--- a/internal/compiler/tests/syntax/elements/tabwidget2.slint
+++ b/internal/compiler/tests/syntax/elements/tabwidget2.slint
@@ -3,7 +3,7 @@
 
 import { TabWidget  } from "std-widgets.slint";
 
-Test2 := Rectangle {
+export Test2 := Rectangle {
     TabWidget {
         Tab {
             visible: false;

--- a/internal/compiler/tests/syntax/elements/tabwidget3.slint
+++ b/internal/compiler/tests/syntax/elements/tabwidget3.slint
@@ -7,5 +7,5 @@ Test3 := Rectangle {
     }
 }
 
-Foo := TabWidget { }
-//    ^error{Unknown type TabWidget. \(The type exist as an internal type, but cannot be accessed in this scope\)}
+export Foo := TabWidget { }
+//           ^error{Unknown type TabWidget. \(The type exist as an internal type, but cannot be accessed in this scope\)}

--- a/internal/compiler/tests/syntax/exports/root_compo_export.slint
+++ b/internal/compiler/tests/syntax/exports/root_compo_export.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+component Button {
+
+}
+
+  component App {
+//^warning{Component is implicitly marked for export. This is deprecated and it should be explicitly exported}    
+    Button {}
+}
+

--- a/internal/compiler/tests/syntax/exports/single_global_missing_export.slint
+++ b/internal/compiler/tests/syntax/exports/single_global_missing_export.slint
@@ -1,0 +1,7 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+  global Settings {
+//^warning{Global singleton is implicitly marked for export. This is deprecated and it should be explicitly exported}
+    in-out property <bool> active;
+}

--- a/internal/compiler/tests/syntax/focus/focus_invalid.slint
+++ b/internal/compiler/tests/syntax/focus/focus_invalid.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-X := Rectangle {
+export X := Rectangle {
     forward-focus: nothingness;
     //             ^error{Unknown unqualified identifier}
 }

--- a/internal/compiler/tests/syntax/focus/focus_not_called.slint
+++ b/internal/compiler/tests/syntax/focus/focus_not_called.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-X := Rectangle {
+export X := Rectangle {
     edit := TextInput { }
     TouchArea {
         clicked => {

--- a/internal/compiler/tests/syntax/focus/initial_focus_non_input.slint
+++ b/internal/compiler/tests/syntax/focus/initial_focus_non_input.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-X := Rectangle {
+export X := Rectangle {
     forward-focus: someRect;
 //                ^error{element is not focusable}
 

--- a/internal/compiler/tests/syntax/functions/functions.slint
+++ b/internal/compiler/tests/syntax/functions/functions.slint
@@ -7,7 +7,7 @@ Abc := Rectangle {
     function par() {}
 }
 
-Xxx := Rectangle {
+export Xxx := Rectangle {
     function fooo(a: int, a: int) -> int { return a; }
 //                        ^error{Duplicated argument name 'a'}
 

--- a/internal/compiler/tests/syntax/functions/functions_call.slint
+++ b/internal/compiler/tests/syntax/functions/functions_call.slint
@@ -10,7 +10,7 @@ Comp := Rectangle {
     public function f2() {}
 }
 
-Xxx := Rectangle {
+export Xxx := Rectangle {
     function foo(a: int) -> string { return a; }
 
     comp := Comp {}

--- a/internal/compiler/tests/syntax/functions/functions_purity.slint
+++ b/internal/compiler/tests/syntax/functions/functions_purity.slint
@@ -138,7 +138,7 @@ Foo_Legacy := Rectangle {
 }
 
 
-Bar_Legacy := Rectangle {
+export Bar_Legacy := Rectangle {
     pure callback xc1 <=> f.c1;
 //  ^error{Purity of callbacks 'xc1' and 'f.c1' doesn't match}
     callback xc2 <=> f.c2;

--- a/internal/compiler/tests/syntax/imports/cyclic_import.slint
+++ b/internal/compiler/tests/syntax/imports/cyclic_import.slint
@@ -3,7 +3,7 @@
 
 import { Rec12 } from "../../typeloader/recursive_import1.slint";
 //                    ^error{No exported type called 'Rec12' found in ".*recursive_import1.slint"}
-Blah := Rec12 {
-//     ^error{Unknown type Rec12}
+export Blah := Rec12 {
+//            ^error{Unknown type Rec12}
     width: 100px;
 }

--- a/internal/compiler/tests/syntax/imports/deprecated_import.slint
+++ b/internal/compiler/tests/syntax/imports/deprecated_import.slint
@@ -5,7 +5,7 @@ import { LineEdit } from "sixtyfps_widgets.60";
 //                       ^warning{"sixtyfps_widgets\.60" was renamed "std-widgets\.slint". Use of the old file name is deprecated}
 
 
-Blah := Window {
+export Blah := Window {
     LineEdit {} // Not an error
     Button {} // Not imported
 //  ^error{Unknown type Button}

--- a/internal/compiler/tests/syntax/imports/error_in_import.slint
+++ b/internal/compiler/tests/syntax/imports/error_in_import.slint
@@ -3,7 +3,7 @@
 
 import { X } from "../../typeloader/incpath/should_fail2.slint";
 
-Foo := Rectangle {
+export Foo := Rectangle {
     x:= X {
         hello: 42;
         meh: 12;

--- a/internal/compiler/tests/syntax/imports/error_in_import2.slint
+++ b/internal/compiler/tests/syntax/imports/error_in_import2.slint
@@ -3,6 +3,6 @@
 
 import { Y } from "../../typeloader/incpath/should_fail3.slint";
 
-Foo := Rectangle {
+export Foo := Rectangle {
 
 }

--- a/internal/compiler/tests/syntax/imports/error_in_import3.slint
+++ b/internal/compiler/tests/syntax/imports/error_in_import3.slint
@@ -3,7 +3,7 @@
 
 import { Z } from "../../typeloader/incpath/should_fail4.slint";
 
-Foo := Rectangle {
+export Foo := Rectangle {
     Z {
         property <int> b: b1;
     }

--- a/internal/compiler/tests/syntax/imports/import_error2.slint
+++ b/internal/compiler/tests/syntax/imports/import_error2.slint
@@ -5,6 +5,6 @@ import { SomeRect } from "../../typeloader/incpath/local_helper_type.slint";
 import "../../typeloader/incpath/local_helper_type.slint";
 //     ^error{Import names are missing. Please specify which types you would like to import}
 
-X := Rectangle {
+export X := Rectangle {
 
 }

--- a/internal/compiler/tests/syntax/imports/import_errors.slint
+++ b/internal/compiler/tests/syntax/imports/import_errors.slint
@@ -19,6 +19,6 @@ import "myimage.png";
 import ".";
 //     ^error{Unsupported foreign import ".*"}
 
-X := Rectangle {
+export X := Rectangle {
 
 }

--- a/internal/compiler/tests/syntax/imports/import_parse_error5.slint
+++ b/internal/compiler/tests/syntax/imports/import_parse_error5.slint
@@ -5,6 +5,6 @@ import { NotExported } from "../../typeloader/incpath/local_helper_type.slint";
 import { } from "../../typeloader/incpath/local_helper_type.slint";
 //       ^error{Import names are missing. Please specify which types you would like to import}
 
-X := Rectangle {
+export X := Rectangle {
 
 }

--- a/internal/compiler/tests/syntax/imports/invalid_export.slint
+++ b/internal/compiler/tests/syntax/imports/invalid_export.slint
@@ -10,6 +10,6 @@ export { Image as Plop }
 export { string as Boob }
 //      ^error{Cannot export 'string' because it is not a component}
 
-Hello := Plop {
-//      ^error{Unknown type Plop}
+export Hello := Plop {
+//             ^error{Unknown type Plop}
 }

--- a/internal/compiler/tests/syntax/imports/visibility_errors.slint
+++ b/internal/compiler/tests/syntax/imports/visibility_errors.slint
@@ -5,7 +5,7 @@ import { SomeRect } from "../../typeloader/incpath/local_helper_type.slint";
 
 import { X } from "../../typeloader/incpath/should_fail.slint";
 
-Blah := X {
+export Blah := X {
     width: 100px;
 //  ^error{Unknown property width in X}
 }

--- a/internal/compiler/tests/syntax/layout/if_in_grid.slint
+++ b/internal/compiler/tests/syntax/layout/if_in_grid.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Test := Rectangle {
+export Test := Rectangle {
     property <bool> condition;
 
     GridLayout {

--- a/internal/compiler/tests/syntax/layout/min_max_conflict.slint
+++ b/internal/compiler/tests/syntax/layout/min_max_conflict.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Test := Rectangle {
+export Test := Rectangle {
 
     GridLayout {
         Rectangle {

--- a/internal/compiler/tests/syntax/lookup/array_index.slint
+++ b/internal/compiler/tests/syntax/lookup/array_index.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Hello := Rectangle {
+export Hello := Rectangle {
 
     property <int> aa: 45;
     property <{o:[int], c:string}> bb;

--- a/internal/compiler/tests/syntax/lookup/callback_alias.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Xxx := Rectangle {
+export Xxx := Rectangle {
 
     foo := Rectangle {
         callback hello(int) -> int;

--- a/internal/compiler/tests/syntax/lookup/callback_alias2.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Xxx := Rectangle {
+export Xxx := Rectangle {
 
     foo := Rectangle {
         callback hello(int) -> int;

--- a/internal/compiler/tests/syntax/lookup/callback_alias3.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias3.slint
@@ -6,7 +6,7 @@ Sub := Rectangle {
     callback compute_alias <=> compute;
 }
 
-Xxx := Rectangle {
+export Xxx := Rectangle {
 
     foo := Rectangle {
         callback hello(int) -> int;

--- a/internal/compiler/tests/syntax/lookup/callback_return.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_return.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Xxx := Rectangle {
+export Xxx := Rectangle {
     callback plop() -> string;
     plop => {}
 //  ^error{Cannot convert void to string}

--- a/internal/compiler/tests/syntax/lookup/color.slint
+++ b/internal/compiler/tests/syntax/lookup/color.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 
-X := Rectangle {
+export X := Rectangle {
     Rectangle {
         background: blue;
     }

--- a/internal/compiler/tests/syntax/lookup/conversion.slint
+++ b/internal/compiler/tests/syntax/lookup/conversion.slint
@@ -15,7 +15,7 @@ global Glob := {
     property <relative-font-size> rem_allowed: 42rem;
 }
 
-X := Rectangle {
+export X := Rectangle {
 
     t := Text {
         x: "hello";

--- a/internal/compiler/tests/syntax/lookup/dashes.slint
+++ b/internal/compiler/tests/syntax/lookup/dashes.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Xxx := Rectangle {
+export Xxx := Rectangle {
 
     my-rect := Rectangle {
         border-width: 44px;

--- a/internal/compiler/tests/syntax/lookup/deprecated_property.slint
+++ b/internal/compiler/tests/syntax/lookup/deprecated_property.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Xxx := Rectangle {
+export Xxx := Rectangle {
     color: white;
 //  ^warning{The property 'color' has been deprecated. Please use 'background' instead}
 

--- a/internal/compiler/tests/syntax/lookup/enum.slint
+++ b/internal/compiler/tests/syntax/lookup/enum.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Text {
+export TestCase := Text {
     // allow unqualified enum when we can infer the type from the property assigned to
     horizontal-alignment: right;
 

--- a/internal/compiler/tests/syntax/lookup/for_lookup.slint
+++ b/internal/compiler/tests/syntax/lookup/for_lookup.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Hello := Rectangle {
+export Hello := Rectangle {
 
     aaa := Text{ text: "aaa";
         bbb := Text{ text: "bbb"; }

--- a/internal/compiler/tests/syntax/lookup/global.slint
+++ b/internal/compiler/tests/syntax/lookup/global.slint
@@ -16,7 +16,7 @@ global my_lowercase := {
 }
 
 
-X := Rectangle {
+export X := Rectangle {
     x: MyGlobal.custom_prop;
     background: MyGlobal.blue;
 //                       ^error{'MyGlobal' does not have a property 'blue'}

--- a/internal/compiler/tests/syntax/lookup/if.slint
+++ b/internal/compiler/tests/syntax/lookup/if.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Hello := Rectangle {
+export Hello := Rectangle {
 
     width: 100phx;
     height: 100phx;

--- a/internal/compiler/tests/syntax/lookup/property.slint
+++ b/internal/compiler/tests/syntax/lookup/property.slint
@@ -15,7 +15,7 @@ Comp := Rectangle {
 }
 
 
-X := Rectangle {
+export X := Rectangle {
     width: 50phx;
     height: width;
 

--- a/internal/compiler/tests/syntax/lookup/signal_arg.slint
+++ b/internal/compiler/tests/syntax/lookup/signal_arg.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Xxx := Rectangle {
+export Xxx := Rectangle {
     callback plop(string, color, int);
     callback plop2(string, color, int);
     property <color> glop_col;

--- a/internal/compiler/tests/syntax/lookup/two_way_binding.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding.slint
@@ -8,7 +8,7 @@ global G := {
 //                         ^error{The property does not have the same type as the bound property}
 }
 
-X := Rectangle {
+export X := Rectangle {
 
     property <brush> my_color <=> self.background;
     x <=> y;

--- a/internal/compiler/tests/syntax/lookup/two_way_binding_infer.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding_infer.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-X := Rectangle {
+export X := Rectangle {
 
     property infer_loop <=> infer_loop2;
 //  ^error{Could not infer type of property 'infer-loop'}

--- a/internal/compiler/tests/syntax/new_syntax/input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output.slint
@@ -55,7 +55,7 @@ OldCompo := Rectangle {
     }
 }
 
-component Foo inherits Rectangle {
+export component Foo inherits Rectangle {
 
     c1 := OldCompo {
         inout2: 42;

--- a/internal/compiler/tests/syntax/new_syntax/input_output2.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output2.slint
@@ -69,7 +69,7 @@ component A inherits Compo {
 //          ^error{Unknown unqualified identifier 'priv1'}
 }
 
-component Foo inherits Rectangle {
+export component Foo inherits Rectangle {
 
     in property <[int]> input_model;
 

--- a/internal/compiler/tests/syntax/new_syntax/new_component.slint
+++ b/internal/compiler/tests/syntax/new_syntax/new_component.slint
@@ -22,7 +22,7 @@ component Bar {
     @children
 }
 
-component Baz {
+export component Baz {
     Bar {
         Foo {}
     }

--- a/internal/compiler/tests/syntax/new_syntax/new_lookup.slint
+++ b/internal/compiler/tests/syntax/new_syntax/new_lookup.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-component Compo inherits Text {
+export component Compo inherits Text {
 
     property <string> background: text;
 //                                ^error{Unknown unqualified identifier 'text'. Did you mean 'self.text'?}

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -293,7 +293,7 @@ component C11 {
     }
 }
 
-Legacy1 := Rectangle {
+export Legacy1 := Rectangle {
     b1:= Button {}
     in property in1 <=> b1.pressed;
 //                  ^warning{Link to a output property is deprecated}

--- a/internal/compiler/tests/syntax/parse_error/children_placeholder0.slint
+++ b/internal/compiler/tests/syntax/parse_error/children_placeholder0.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Final := Window {
+export Final := Window {
     VerticalLayout {
         @
     }

--- a/internal/compiler/tests/syntax/parse_error/if0.slint
+++ b/internal/compiler/tests/syntax/parse_error/if0.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Window {
+export TestCase := Window {
     if  //
     Foo { }
     //  ^error{expected ':'}

--- a/internal/compiler/tests/syntax/parse_error/if1.slint
+++ b/internal/compiler/tests/syntax/parse_error/if1.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Window {
+export TestCase := Window {
     if (
 
   }

--- a/internal/compiler/tests/syntax/parse_error/if2.slint
+++ b/internal/compiler/tests/syntax/parse_error/if2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Window {
+export TestCase := Window {
     if () :
 //      ^error{invalid expression}
 

--- a/internal/compiler/tests/syntax/parse_error/if3.slint
+++ b/internal/compiler/tests/syntax/parse_error/if3.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Window {
+export TestCase := Window {
     if goo
 
   }

--- a/internal/compiler/tests/syntax/parse_error/if4.slint
+++ b/internal/compiler/tests/syntax/parse_error/if4.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Window {
+export TestCase := Window {
     if (true false) : Rectangle { }
 //           ^error{Syntax error: expected '\)'}
 //           ^^error{expected ':'}

--- a/internal/compiler/tests/syntax/parse_error/property1.slint
+++ b/internal/compiler/tests/syntax/parse_error/property1.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Window {
+export TestCase := Window {
     ta := TouchArea { }
 
     Rectangle {

--- a/internal/compiler/tests/syntax/parse_error/property2.slint
+++ b/internal/compiler/tests/syntax/parse_error/property2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Window {
+export TestCase := Window {
     ta := TouchArea { }
 
     Rectangle {

--- a/internal/compiler/tests/syntax/parse_error/state1.slint
+++ b/internal/compiler/tests/syntax/parse_error/state1.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     property<bool> checked;
     property <int> border;
     states [

--- a/internal/compiler/tests/syntax/parse_error/state2.slint
+++ b/internal/compiler/tests/syntax/parse_error/state2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     states [
 
   }

--- a/internal/compiler/tests/syntax/parse_error/state3.slint
+++ b/internal/compiler/tests/syntax/parse_error/state3.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     states [
         checked when true: {
             foo

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -232,22 +232,22 @@ fn self_test() -> std::io::Result<()> {
     // this should succeed
     assert!(process(
         r#"
-Foo := Rectangle { x: 0px; }
+export Foo := Rectangle { x: 0px; }
     "#
     )?);
 
     // unless we expected an error
     assert!(!process(
         r#"
-Foo := Rectangle { x: 0px; }
-//     ^error{i want an error}
+export Foo := Rectangle { x: 0px; }
+//            ^error{i want an error}
     "#
     )?);
 
     // An error should fail
     assert!(!process(
         r#"
-Foo := Rectangle foo { x:0px; }
+export Foo := Rectangle foo { x:0px; }
     "#
     )?);
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -749,7 +749,7 @@ impl ComponentInstance {
     /// ```
     /// use slint_interpreter::{ComponentDefinition, ComponentCompiler, Value, SharedString};
     /// let code = r#"
-    ///     MyWin := Window {
+    ///     export MyWin := Window {
     ///         property <int> my_property: 42;
     ///     }
     /// "#;

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -43,7 +43,7 @@ This example load a `.slint` from a string and set some properties:
 use slint_interpreter::{ComponentDefinition, ComponentCompiler, Value, SharedString, ComponentHandle};
 
 let code = r#"
-    MyWin := Window {
+    export MyWin := Window {
         property <string> my_name;
         Text {
             text: "Hello, " + my_name;

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -6,7 +6,7 @@ fn reuse_window() {
     i_slint_backend_testing::init();
     use crate::{ComponentCompiler, ComponentHandle, SharedString, Value};
     let code = r#"
-        MainWindow := Window {
+        export MainWindow := Window {
             property<string> text_text: "foo";
             property<string> text_alias: input.text;
             input := TextInput {

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -1470,8 +1470,10 @@ mod tests {
 
     #[test]
     fn test_reload_document_valid_contents() {
-        let (_, url, diag) =
-            loaded_document_cache("fluent", r#"component Main inherits Rectangle { }"#.into());
+        let (_, url, diag) = loaded_document_cache(
+            "fluent",
+            r#"export component Main inherits Rectangle { }"#.into(),
+        );
 
         assert!(diag.len() == 1); // Only one URL is known
         let diagnostics = diag.get(&url).expect("URL not found in result");

--- a/tools/online_editor/src/editor_widget.ts
+++ b/tools/online_editor/src/editor_widget.ts
@@ -33,7 +33,7 @@ import { commands } from "vscode";
 import { StandaloneServices, ICodeEditorService } from "vscode/services";
 
 const hello_world = `import { Button, VerticalBox } from "std-widgets.slint";
-component Demo {
+export component Demo {
     VerticalBox {
         alignment: start;
         Text {


### PR DESCRIPTION
We implicitly export the last component of a .slint file to the generator. Issue a warning when that happens and suggest to export it explicitly.