### PR TITLE
LSP: fix document outline with vscode

### DIFF
--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -1208,24 +1208,18 @@ fn get_document_symbols(
 
     let inner_components = doc.inner_components.clone();
     let inner_structs = doc.inner_structs.clone();
-    let doc_node = doc.node.as_ref();
 
     let mut r = inner_components
         .iter()
         .filter_map(|c| {
             let root_element = c.root_element.borrow();
-            let node = root_element.node.as_ref();
-            let id = &c.id;
-
-            let selection_range = doc_node?
-                .Component()
-                .map(|cc| cc.DeclaredIdentifier())
-                .find(|di| &di.text().to_string().trim() == id)
-                .map(|di| offset_mapper.map_node(&di));
+            let element_node = root_element.node.as_ref()?;
+            let component_node = syntax_nodes::Component::new(element_node.parent()?)?;
+            let selection_range = offset_mapper.map_node(&component_node.DeclaredIdentifier());
 
             Some(DocumentSymbol {
-                range: offset_mapper.map_node(node?),
-                selection_range: selection_range?,
+                range: offset_mapper.map_node(&component_node),
+                selection_range,
                 name: c.id.clone(),
                 kind: if c.is_global() {
                     lsp_types::SymbolKind::OBJECT


### PR DESCRIPTION
Currently, the reported range is the range of the root element, which doesn't include the name of the component itself.
While the Name of the component itself is used as the selection range. Vscode assrts that the selection range is within the range:

```
ERR selectionRange must be contained in fullRange: Error: selectionRange must be contained in fullRange
```

So use the full component range for the range instead