### PR TITLE
StandardTableView: Remove the editable feature for now

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -567,4 +567,4 @@ The `StandardListViewItem` is used to display items in the `StandardListView` an
 ### Properties
 
 * **`text`** (*string*): Describes the text of the item.
-* **`editable`** (*bool*): If set to `true` the text of the item can be changed by text editing.
+

--- a/examples/gallery/main.cpp
+++ b/examples/gallery/main.cpp
@@ -18,7 +18,7 @@ int main()
             slint::SharedString text("item");
             text = text + slint::SharedString::from_number(c) + slint::SharedString(".")
                     + slint::SharedString::from_number(r);
-            items->push_back(slint::StandardListViewItem { text, c == 1 });
+            items->push_back(slint::StandardListViewItem { text });
         }
 
         row_data->push_back(items);

--- a/examples/gallery/main.rs
+++ b/examples/gallery/main.rs
@@ -27,10 +27,7 @@ pub fn main() {
         let items = Rc::new(VecModel::default());
 
         for c in 1..5 {
-            items.push(StandardListViewItem {
-                text: format!("Item {r}.{c}").into(),
-                editable: c == 1,
-            });
+            items.push(StandardListViewItem { text: format!("Item {r}.{c}").into() });
         }
 
         row_data.push(items.into());

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -400,7 +400,6 @@ PropertyAnimation := _ {
 export struct StandardListViewItem := {
     //-name:slint::StandardListViewItem
     text: string,
-    editable: bool,
 }
 
 export struct TableColumn := {

--- a/internal/compiler/widgets/fluent-base/widget-table-view.slint
+++ b/internal/compiler/widgets/fluent-base/widget-table-view.slint
@@ -185,17 +185,7 @@ export component StandardTableView {
                         max-width: (index < columns.length && columns[index].width >= 1px) ? max(columns[index].min-width, columns[index].width) : 100000px;
 
                         Rectangle {
-                            // height: 100%;
-                            line-edit := LineEditInner {
-                                opacity: self.has-focus ? 1.0 : 0.0;
-                                visible: cell.editable;
-                                text: cell.text;
-                                edited => {
-                                    cell.text = self.text;
-                                }
-                            }
-
-                            if(!cell.editable || !line-edit.has-focus) : Text {
+                            Text {
                                 width: 100%;
                                 height: 100%;
                                 overflow: elide;

--- a/internal/compiler/widgets/material-base/widget-table-view.slint
+++ b/internal/compiler/widgets/material-base/widget-table-view.slint
@@ -181,16 +181,7 @@ export component StandardTableView {
                         max-width: (index < columns.length && columns[index].width >= 1px) ? max(columns[index].min-width, columns[index].width) : 100000px;
 
                         Rectangle {
-                            line-edit := LineEditInner {
-                                opacity: self.has-focus ? 1.0 : 0.0;
-                                visible: cell.editable;
-                                text: cell.text;
-                                edited => {
-                                    cell.text = self.text;
-                                }
-                            }
-
-                            if(!cell.editable || !line-edit.has-focus) : Text {
+                            Text {
                                 width: 100%;
                                 height: 100%;
                                 overflow: elide;

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -317,19 +317,7 @@ export component StandardTableView {
                             preferred-width: self.min-width;
                             max-width: (index < columns.length && columns[index].width >= 1px) ? max(columns[index].min-width, columns[index].width) : 100000px;
                             HorizontalLayout {
-                                if cell.editable : NativeStandardListViewItem {
-                                    index: i;
-                                    //is-selected: root.current-item == i;
-                                    has-hover: row-ta.has-hover;
-
-                                    LineEditInner {
-                                        text: cell.text;
-                                        edited => {
-                                            cell.text = self.text;
-                                        }
-                                    }
-                                }
-                                if !cell.editable : NativeStandardListViewItem {
+                                NativeStandardListViewItem {
                                     item: cell;
                                     index: i;
                                     //is-selected: root.current-item == i;

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1121,20 +1121,17 @@ impl<C: RepeatedComponent + 'static> Repeater<C> {
 pub struct StandardListViewItem {
     /// The text content of the item.
     pub text: SharedString,
-
-    /// If set to `true` the text can be edited by the user.
-    pub editable: bool,
 }
 
 impl From<SharedString> for StandardListViewItem {
     fn from(value: SharedString) -> Self {
-        StandardListViewItem { text: value, editable: false }
+        StandardListViewItem { text: value }
     }
 }
 
 impl From<&str> for StandardListViewItem {
     fn from(value: &str) -> Self {
-        StandardListViewItem { text: value.into(), editable: false }
+        StandardListViewItem { text: value.into() }
     }
 }
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -250,7 +250,7 @@ macro_rules! declare_value_struct_conversion {
     };
 }
 
-declare_value_struct_conversion!(struct i_slint_core::model::StandardListViewItem { text, editable });
+declare_value_struct_conversion!(struct i_slint_core::model::StandardListViewItem { text });
 declare_value_struct_conversion!(struct i_slint_core::model::TableColumn { title, min_width, horizontal_stretch, sort_order, width });
 declare_value_struct_conversion!(struct i_slint_core::properties::StateInfo { current_state, previous_state, change_time });
 declare_value_struct_conversion!(struct i_slint_core::input::KeyboardModifiers { control, alt, shift, meta });


### PR DESCRIPTION
This commit can be reverted when we want to introduce it again. There is a few bugs with the editable property:
 - The text is not in sync with the model if the model changes after an edit. (can be seen by making an edit and then sort)
 - The highlight of the current row doesn't work properly
 - We should probably only edit on double click or some shortcut instead of just clicking
 - The editable field exist but does nothing for the StandardListView