### PR TITLE
Second stage of cleaning up the export handling of the slint root component

### DIFF
--- a/docs/recipes/recipes.md
+++ b/docs/recipes/recipes.md
@@ -966,7 +966,7 @@ export component SideBar inherits Rectangle {
     ]
 }
 
-component SideBarTest inherits Window {
+export component SideBarTest inherits Window {
     preferred-width: 700px;
     min-height: 400px;
 

--- a/internal/compiler/tests/syntax/basic/children_placeholder.slint
+++ b/internal/compiler/tests/syntax/basic/children_placeholder.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-NotInIf := Rectangle {
+export NotInIf := Rectangle {
     if true: Rectangle {
         @children
 //      ^error{The @children placeholder cannot appear in a conditional element}
     }
 }
 
-NotInFor := Rectangle {
+export NotInFor := Rectangle {
     HorizontalLayout {
         for xxx in 12: Rectangle {
             VerticalLayout {
@@ -25,7 +25,7 @@ TestBox := Rectangle {
 //  ^error{The @children placeholder can only appear once in an element}
 }
 
-TestBox2 := Rectangle {
+export TestBox2 := Rectangle {
     Rectangle {
         @children
     }

--- a/internal/compiler/tests/syntax/basic/condition_operator.slint
+++ b/internal/compiler/tests/syntax/basic/condition_operator.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-SuperSimple := Rectangle {
+export SuperSimple := Rectangle {
     background: area.pressed ? green : blue;
     property<color> c2: area.pressed ? 123 : 456;
 //                     ^error{Cannot convert float to color}

--- a/internal/compiler/tests/syntax/basic/rotation.slint
+++ b/internal/compiler/tests/syntax/basic/rotation.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Ex1 := Rectangle {
+export Ex1 := Rectangle {
     Rectangle {
         rotation-origin-x: width / 2;
         rotation-angle: 45deg;
@@ -25,7 +25,7 @@ ImageWithChild := Image {
     Rectangle {}
 }
 
-Ex2 := Rectangle {
+export Ex2 := Rectangle {
     Image {
 //  ^error{Elements with rotation properties cannot have children elements}
         rotation-angle: 45deg;

--- a/internal/compiler/tests/syntax/basic/states_transitions.slint
+++ b/internal/compiler/tests/syntax/basic/states_transitions.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-TestCase := Rectangle {
+export TestCase := Rectangle {
     property<bool> checked;
     property <int> border;
     states [
@@ -46,7 +46,7 @@ TestCase := Rectangle {
 }
 
 
-component NewSyntax {
+export component NewSyntax {
     property<bool> checked;
     property <int> border;
     property <color> color;

--- a/internal/compiler/tests/syntax/elements/tabwidget3.slint
+++ b/internal/compiler/tests/syntax/elements/tabwidget3.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-Test3 := Rectangle {
+export Test3 := Rectangle {
     TabWidget {
 //  ^error{Unknown type TabWidget. \(The type exist as an internal type, but cannot be accessed in this scope\)}
     }

--- a/internal/compiler/tests/syntax/exports/root_compo_export2.slint
+++ b/internal/compiler/tests/syntax/exports/root_compo_export2.slint
@@ -1,0 +1,7 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+  component App {
+//^warning{Component is implicitly marked for export. This is deprecated and it should be explicitly exported}    
+}
+

--- a/internal/compiler/tests/syntax/exports/unused_compo.slint
+++ b/internal/compiler/tests/syntax/exports/unused_compo.slint
@@ -1,0 +1,13 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+component Used {
+}
+
+export component Ok {
+    Used {}
+}
+
+  component Unused {
+//^warning{Component is neither used nor exported}
+}

--- a/internal/compiler/tests/syntax/functions/functions_purity.slint
+++ b/internal/compiler/tests/syntax/functions/functions_purity.slint
@@ -3,7 +3,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-component Foo {
+export component Foo {
     property <int> prop;
     callback c1;
     pure callback c2;
@@ -62,7 +62,7 @@ component Foo {
 }
 
 
-component Bar {
+export component Bar {
     pure callback xc1 <=> f.c1;
 //  ^error{Purity of callbacks 'xc1' and 'f.c1' doesn't match}
     callback xc2 <=> f.c2;
@@ -79,7 +79,7 @@ component Bar {
 
 
 
-Foo_Legacy := Rectangle {
+export Foo_Legacy := Rectangle {
     property <int> prop;
     callback c1;
     pure callback c2;

--- a/internal/compiler/tests/syntax/lookup/global.slint
+++ b/internal/compiler/tests/syntax/lookup/global.slint
@@ -7,7 +7,7 @@ global MyGlobal := {
     color_prop: red;
 }
 
-SomeComp := Rectangle {
+export SomeComp := Rectangle {
     property<length> foo;
 }
 

--- a/internal/compiler/tests/syntax/new_syntax/input_output2.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output2.slint
@@ -64,7 +64,7 @@ OldCompo := Rectangle {
     }
 }
 
-component A inherits Compo {
+export component A inherits Compo {
     input1: priv1;
 //          ^error{Unknown unqualified identifier 'priv1'}
 }

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-component Button {
+export component Button {
     in property<bool> enabled : true;
     out property <bool> pressed;
     in-out property <bool> checked;
     callback clicked();
 }
 
-component C1 {
+export component C1 {
     out property <bool> out;
     in property <bool> in;
     in-out property <bool> inout;
@@ -45,7 +45,7 @@ component C1 {
 }
 
 
-  component C2 {
+  export component C2 {
     out property <bool> out;
     in property <bool> in;
     in-out property <bool> inout;
@@ -76,7 +76,7 @@ component C1 {
     }
 }
 
-component C3 {
+export component C3 {
     out property <bool> out;
     in property <bool> in;
     in-out property <bool> inout;
@@ -106,7 +106,7 @@ component C3 {
 }
 
 
-component C5 {
+export component C5 {
     out property <bool> out;
     in property <bool> in;
     in-out property <bool> inout;
@@ -122,7 +122,7 @@ component C5 {
     Button { enabled <=> priv; }
 }
 
-component C6 {
+export component C6 {
     out property <bool> out;
     in property <bool> in;
     in-out property <bool> inout;
@@ -147,7 +147,7 @@ component C6 {
     }
 }
 
-component C7 {
+export component C7 {
     b1 := Button {
         clicked => {
             self.enabled = !self.enabled;
@@ -190,7 +190,7 @@ component C7 {
     }
 }
 
-component C8 {
+export component C8 {
     out property <bool> out1;
     out property <bool> out2;
     out property <bool> out3;
@@ -212,7 +212,7 @@ component C8 {
     }
 }
 
-component C9 {
+export component C9 {
     in property <bool> in1;
     in property <bool> in2;
     in property <bool> in3;
@@ -239,7 +239,7 @@ component C9 {
 }
 
 
-component C10 {
+export component C10 {
     in-out property <bool> inout1;
     in-out property <bool> inout2;
     in-out property <bool> inout3;
@@ -266,7 +266,7 @@ component C10 {
     }
 }
 
-component C11 {
+export component C11 {
     property <bool> priv1;
     property <bool> priv2;
     property <bool> priv3;

--- a/tests/cases/bindings/two_way_deep.slint
+++ b/tests/cases/bindings/two_way_deep.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-export LineEdit := Rectangle {
+LineEdit := Rectangle {
     property <string> text <=> ti.text;
     ti := TextInput {  }
 }
@@ -14,7 +14,7 @@ LiTest := Rectangle {
     property <bool> test_li: li1.text == "li1" && li3.text == "li4";
 }
 
-TestCase := Window {
+export TestCase := Window {
 
     li := LiTest {  }
 

--- a/tests/cases/bindings/two_way_priority.slint
+++ b/tests/cases/bindings/two_way_priority.slint
@@ -1,20 +1,20 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-export OpacityTwoWay := Rectangle {
+OpacityTwoWay := Rectangle {
     property <float> sub_opacity <=> rect.opacity;
     rect := Rectangle {
         opacity: 0.75;
     }
 }
 
-export Compo := Rectangle {
+Compo := Rectangle {
     preferred-height: 10px;
     property<int> foo <=> self.bar;
     property<int> bar: 120;
 }
 
-TestCase := Window {
+export TestCase := Window {
     compo0 := Compo { foo: compo1.foo + 20; }
     compo1 := Compo {}
     compo2 := Compo { foo: compo1.foo + 10; }

--- a/tests/cases/exports/export_root.slint
+++ b/tests/cases/exports/export_root.slint
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+export component Ok {
+    in-out property <bool> test: true;
+}
+
+component Ko {
+    in-out property <bool> test: false;
+}


### PR DESCRIPTION
Commit 24dcef5fed2b53e6d1f65ba0fb5db9de9d657bf2 added a warning for the implicit export of last component. For 1.0, this commit makes it so that the root component is determined by the last export in the file.