### PR TITLE
tools: Remove progress reporting for file loading

### DIFF
--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -107,17 +107,12 @@ impl ServerNotifier {
 
     pub async fn progress_reporter(
         &self,
-        token: Option<lsp_types::ProgressToken>,
+        token: lsp_types::ProgressToken,
         title: String,
         message: Option<String>,
         percentage: Option<u32>,
         cancellable: Option<bool>,
     ) -> Result<server_loop::ProgressReporter, Error> {
-        let token = if let Some(t) = token {
-            t
-        } else {
-            server_loop::ProgressReporter::create_server_side_token(self).await?
-        };
         server_loop::ProgressReporter::new(
             self.clone(),
             token,
@@ -312,17 +307,6 @@ async fn handle_notification(
     match &*req.method {
         DidOpenTextDocument::METHOD => {
             let params: DidOpenTextDocumentParams = serde_json::from_value(req.params)?;
-            let uri = params.text_document.uri.to_string();
-            let progress = ctx
-                .server_notifier
-                .progress_reporter(
-                    None,
-                    "Opening document".into(),
-                    Some(format!("opening: {}@{}", uri, params.text_document.version)),
-                    None,
-                    None,
-                )
-                .await?;
             reload_document(
                 &ctx.server_notifier,
                 params.text_document.text,
@@ -331,21 +315,9 @@ async fn handle_notification(
                 &mut ctx.document_cache.borrow_mut(),
             )
             .await?;
-            progress.finish(Some(format!("Updated: {}@{}", uri, params.text_document.version)))?;
         }
         DidChangeTextDocument::METHOD => {
             let mut params: DidChangeTextDocumentParams = serde_json::from_value(req.params)?;
-            let uri = params.text_document.uri.to_string();
-            let progress = ctx
-                .server_notifier
-                .progress_reporter(
-                    None,
-                    "Changing document".into(),
-                    Some(format!("Changing: {}@{}", uri, params.text_document.version)),
-                    None,
-                    None,
-                )
-                .await?;
             reload_document(
                 &ctx.server_notifier,
                 params.content_changes.pop().unwrap().text,
@@ -354,7 +326,6 @@ async fn handle_notification(
                 &mut ctx.document_cache.borrow_mut(),
             )
             .await?;
-            progress.finish(Some(format!("Updated: {}@{}", uri, params.text_document.version)))?;
         }
         DidChangeConfiguration::METHOD => {
             load_configuration(ctx).await?;

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -31,7 +31,6 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub type Error = Box<dyn std::error::Error>;
 
@@ -107,21 +106,6 @@ impl ProgressReporter {
         )?;
 
         Ok(Self { notifier, token: Some(token) })
-    }
-
-    pub async fn create_server_side_token(
-        notifier: &crate::ServerNotifier,
-    ) -> Result<lsp_types::ProgressToken, Error> {
-        static SERVER_SIDE_WORK_DONE_TOKEN: AtomicUsize = AtomicUsize::new(0);
-
-        let token_number = SERVER_SIDE_WORK_DONE_TOKEN.fetch_add(1, Ordering::SeqCst);
-        let token = lsp_types::NumberOrString::String(format!("slint/progress/{token_number}"));
-        notifier
-            .send_request::<lsp_types::request::WorkDoneProgressCreate>(
-                lsp_types::WorkDoneProgressCreateParams { token: token.clone() },
-            )?
-            .await?;
-        Ok(token)
     }
 
     pub fn update(

--- a/tools/online_editor/src/index.ts
+++ b/tools/online_editor/src/index.ts
@@ -370,6 +370,8 @@ function setup(lsp: Lsp) {
                 const properties = new PropertiesWidget();
 
                 properties.set_language_client(lsp.language_client);
+                const pos = editor.position;
+                properties.position_changed(pos.uri, pos.version, pos.position);
 
                 properties.on_goto_position = (uri, pos) => {
                     editor.goto_position(uri, pos);

--- a/tools/online_editor/src/shared/utils.ts
+++ b/tools/online_editor/src/shared/utils.ts
@@ -1,8 +1,0 @@
-// Copyright © SixtyFPS GmbH <info@slint-ui.com>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
-
-export function extract_uri_from_progress_message(input: string): string {
-    const start = input.indexOf(": ");
-    const end = input.lastIndexOf("@");
-    return input.slice(start + 2, end);
-}


### PR DESCRIPTION
Stop the LSP from reporting progress information on file loading. This caused problems with VSCode: First it triggered popups in the UI and secondly it caused problems for the LSP that was asked to process requests while calling back into the client.

Adapt the online editor and the two VSCode plugins to work with the updated code.

Note: I did leave in the progress reporting code that can be used to handle progress initiated by the _client_ side. That is just notifications which will not block the LSP in any way and we might need to support that at some point.

I did remove the Middleware code from the client side though that acted on the progress information.