### PR TITLE
Fix tutorial "running in browser" example html tag typo

### DIFF
--- a/docs/tutorial/rust/src/running_in_a_browser.md
+++ b/docs/tutorial/rust/src/running_in_a_browser.md
@@ -57,7 +57,7 @@ file. The Slint runtime expects the `<canvas>` element to have the id `id = "can
 <html>
   <body>
     <!-- canvas required by the Slint runtime -->
-    <canvas id="canvas">>/canvas>
+    <canvas id="canvas"></canvas>
     <script type="module">
       // import the generated file.
       import init from './pkg/memory.js';


### PR DESCRIPTION
Hi, there was an incorrect html  `<canvas id="canvas">>/canvas>`