### PR TITLE
Fix TabWidget::current-index bindings

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -365,8 +365,7 @@ export TabWidget := _ {
     in property <length> width;
     in property <length> height;
 
-    in property <int> current-index;
-    in property <int> current-focused;
+    in-out property <int> current-index;
 
     //-disallow_global_types_as_child_elements
     Tab {}

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -147,9 +147,9 @@ fn process_tabwidget(
         "num-tabs".to_owned(),
         RefCell::new(Expression::NumberLiteral(num_tabs as _, Unit::None).into()),
     );
-    elem.borrow_mut().bindings.insert(
-        "current-index".to_owned(),
-        BindingExpression::new_two_way(NamedReference::new(&tabbar, "current")).into(),
+    tabbar.borrow_mut().bindings.insert(
+        "current".to_owned(),
+        BindingExpression::new_two_way(NamedReference::new(&elem, "current-index")).into(),
     );
     elem.borrow_mut().bindings.insert(
         "current-focused".to_owned(),

--- a/tests/cases/elements/tabwidget.slint
+++ b/tests/cases/elements/tabwidget.slint
@@ -7,11 +7,12 @@ TestCase := Window {
     preferred_height: 500px;
     preferred_width: 500px;
 
-    property <int> current_tab;
+    property <int> current_tab: tw.current-index;
 
     VerticalLayout {
         padding: 20px;
         tw := TabWidget {
+            current-index: 1;
             Tab {
                 title: "Hello";
                 Rectangle {
@@ -33,5 +34,5 @@ TestCase := Window {
         }
     }
 
-    property <bool> test: tw.vertical_stretch == 1 && tw.horizontal_stretch == 1 && tw.min_height > 200px ;
+    property <bool> test: tw.vertical_stretch == 1 && tw.horizontal_stretch == 1 && tw.min_height > 200px && current-tab == 1;
 }


### PR DESCRIPTION
The property set by the user was not kept because the binding went the wrong way.

Also remove the undocumented (and equaly not working) TabWidget::current-focused property from the public API