### PR TITLE
online editor: Fix race on querying the properties from the LSP

### DIFF
--- a/tools/online_editor/src/properties_widget.ts
+++ b/tools/online_editor/src/properties_widget.ts
@@ -77,9 +77,15 @@ export class PropertiesWidget extends Widget {
         }
     }
 
-    position_changed(uri: LspURI, _: number, position: LspPosition) {
+    position_changed(uri: LspURI, version: number, position: LspPosition) {
         query_properties(this.#language_client, uri, position)
             .then((r: PropertyQuery) => {
+                if (r.source_version < version) {
+                    setTimeout(() => {
+                        this.position_changed(uri, version, position);
+                    }, 100);
+                    return;
+                }
                 this.#propertiesView.set_properties(r);
             })
             .catch(() => {


### PR DESCRIPTION
When removing a property binding, the editor notified the Properties Widget before the LSP was updated. So the LSP continued to provide the old data on the Property Widgets request. So the removed property binding was still shown as set.

Work around this by polling the LSP till it returns a source version we expect (or something newer). This should be save enough I hope.