### PR TITLE
Fix slide puzzle not scaling to the browser viewport

### DIFF
--- a/examples/slide_puzzle/slide_puzzle.slint
+++ b/examples/slide_puzzle/slide_puzzle.slint
@@ -215,6 +215,11 @@ export component MainWindow inherits Window {
     animate pieces-spacing { duration: 500ms; easing: ease-out; }
 
     Image {
+        // For the wasm build we want the puzzle to resize with the browser viewport, as per CSS in index.html.
+        // Our winit backend preserves the CSS set size if there's no preferred size set on the Slint window.
+        // This image propagates its preferred size and that means the window won't scale. By positioning it
+        // manually, the preferred size is ignored.
+        x: 0; y: 0;
         height: 100%; width: 100%;
         // https://commons.wikimedia.org/wiki/File:Berlin_potsdamer_platz.jpg Belappetit, CC BY-SA 3.0
         source: @image-url("berlin.jpg");


### PR DESCRIPTION
With commit b55ec6894aac2ad58a4dbf414ee3c22b25878c19 the preferred size of the background image of the slide puzzle demo propagates to the Window, which causes the web build of the winit backend to use the window's preferred size instead of the 100% viewport width/height set via CSS.

Work around it via manual positioning.