### PR TITLE
Fix panic when the binding loop is caused by accessing the same component twice

### DIFF
--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout4.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout4.slint
@@ -1,0 +1,39 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+component Foo {
+//            ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+//            ^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+    HorizontalLayout {
+//  ^error{The binding for the property 'layout-cache' is part of a binding loop}
+//  ^^error{The binding for the property 'width' is part of a binding loop}
+//  ^^^error{The binding for the property 'width' is part of a binding loop}
+//  ^^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+//  ^^^^^error{The binding for the property 'layout-cache' is part of a binding loop}
+//  ^^^^^^error{The binding for the property 'width' is part of a binding loop}
+//  ^^^^^^^error{The binding for the property 'width' is part of a binding loop}
+//  ^^^^^^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+
+        Text {
+            text: "hello";
+            font_size: self.width / 2.5;
+//                    ^error{The binding for the property 'font-size' is part of a binding loop}
+//                    ^^error{The binding for the property 'font-size' is part of a binding loop}
+        }
+    }
+}
+
+component Bar {
+    HorizontalLayout {
+//  ^error{The binding for the property 'layout-cache' is part of a binding loop}
+//  ^^error{The binding for the property 'width' is part of a binding loop}
+//  ^^^error{The binding for the property 'width' is part of a binding loop}
+        Foo {}
+        Foo {}
+    }
+}
+
+export component Apps inherits Window {
+    Bar {}
+}
+


### PR DESCRIPTION
The component properties might be accessed through different paths so we may still reach a case where we have to borrow something that is already borrowed