### PR TITLE
online editor: Fix incomplete information from LSP after opening a demo

### DIFF
--- a/tools/online_editor/src/editor_widget.ts
+++ b/tools/online_editor/src/editor_widget.ts
@@ -142,6 +142,10 @@ class EditorPaneWidget extends Widget {
 
         this.#client = this.setup_editor(this.contentNode, lsp);
 
+        lsp.file_reader = (url) => {
+            return this.read_from_url(url);
+        };
+
         monaco.editor.onDidCreateModel((model) =>
             this.add_model_listener(model),
         );


### PR DESCRIPTION
This sets up the file reader, which has gone missing in action at some point.

We used to open the main file of the printer demo. That trriggered loading of all the helper files, but they all came back empty. So any LSP request that came in got errors as the code was incomplete.

Afterwards the editor loads the files anyway, telling the LSP about the loaded file each time, filling in the missing information. So after all files are open in the editor, the information in the LSP is complete and all LSP commands return proper information going forward.