### PR TITLE
Add a lifetime to ModelPeer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
+ - In the rust API, a lifetime parameter was added to `slint::ModelPeer`
+
 ### Added
 
 ### Fixed

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -13,6 +13,7 @@ use crate::lengths::{LogicalLength, RectLengths};
 use crate::{Coord, Property, SharedString, SharedVector};
 pub use adapters::{FilterModel, MapModel, SortModel};
 use alloc::boxed::Box;
+use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
 use core::pin::Pin;
@@ -22,7 +23,6 @@ use euclid::num::{Ceil, Floor};
 pub use model_peer::*;
 use once_cell::unsync::OnceCell;
 use pin_project::pin_project;
-use pin_weak::rc::{PinWeak, Rc};
 
 mod adapters;
 mod model_peer;


### PR DESCRIPTION
ModelPeer is a short lived object which is just used to register a view to a ModelNotify.
Using a life time allow to save a heap allocation.

closes #1953