### PR TITLE
Fix signature of get_proc_address in Rust GraphicsAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ All notable changes to this project are documented in this file.
  - Renamed the `Keys` namespace for use in `key-pressed`/`key-released` callbacks to `Key`. The
    old name continues to work.
  - The style or the backend now always set a value for the `Window`'s `default-font-size` property.
+ - In the Rust API, the `GraphicsAPI`'s `NativeOpenGL` variant uses a function signature for `get_proc_address` that
+   takes a `&std::ffi::CStr` instead of a `&str` to match the native APIs and avoid unnecessary conversions.
 
 ### Added
 

--- a/examples/opengl_underlay/main.rs
+++ b/examples/opengl_underlay/main.rs
@@ -190,7 +190,7 @@ pub fn main() {
                 let context = match graphics_api {
                     #[cfg(not(target_arch = "wasm32"))]
                     slint::GraphicsAPI::NativeOpenGL { get_proc_address } => unsafe {
-                        glow::Context::from_loader_function(|s| get_proc_address(s))
+                        glow::Context::from_loader_function_cstr(|s| get_proc_address(s))
                     },
                     #[cfg(target_arch = "wasm32")]
                     slint::GraphicsAPI::WebGL { canvas_element_id, context_type } => {

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -70,8 +70,9 @@ impl super::WinitCompatibleRenderer for FemtoVGRenderer {
 
         #[cfg(not(target_arch = "wasm32"))]
         let gl_renderer = unsafe {
+            // TODO: use new_from_function_cstr with new FemtoVG release
             femtovg::renderer::OpenGl::new_from_function(|s| {
-                opengl_context.get_proc_address(s) as *const _
+                opengl_context.get_proc_address(&std::ffi::CString::new(s).unwrap()) as *const _
             })
             .unwrap()
         };

--- a/internal/backends/winit/renderer/femtovg/glcontext.rs
+++ b/internal/backends/winit/renderer/femtovg/glcontext.rs
@@ -150,9 +150,8 @@ impl OpenGLContext {
         }
     }
 
-    // TODO: fix this interface to also take a ffi::CStr so that we can avoid the allocation. Problem: It's in our public api.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn get_proc_address(&self, name: &str) -> *const std::ffi::c_void {
-        self.context.display().get_proc_address(&std::ffi::CString::new(name).unwrap())
+    pub fn get_proc_address(&self, name: &std::ffi::CStr) -> *const std::ffi::c_void {
+        self.context.display().get_proc_address(name)
     }
 }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -213,7 +213,7 @@ pub enum GraphicsAPI<'a> {
     /// The rendering is done using OpenGL.
     NativeOpenGL {
         /// Use this function pointer to obtain access to the OpenGL implementation - similar to `eglGetProcAddress`.
-        get_proc_address: &'a dyn Fn(&str) -> *const core::ffi::c_void,
+        get_proc_address: &'a dyn Fn(&core::ffi::CStr) -> *const core::ffi::c_void,
     },
     /// The rendering is done on a HTML Canvas element using WebGL.
     WebGL {

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -75,10 +75,7 @@ impl super::Surface for OpenGLSurface {
     fn with_graphics_api(&self, callback: impl FnOnce(GraphicsAPI<'_>)) {
         let api = GraphicsAPI::NativeOpenGL {
             get_proc_address: &|name| {
-                self.glutin_context
-                    .display()
-                    .get_proc_address(&std::ffi::CString::new(name).unwrap())
-                    as *const _
+                self.glutin_context.display().get_proc_address(name) as *const _
             },
         };
         callback(api)


### PR DESCRIPTION
Use a CStr instead of str, to avoid an extra CString allocation. The underlying operating system API for this expects a zero terminated C String.

Fixes #1943