### PR TITLE
online editor: Improve waiting for setup to complete

### DIFF
--- a/tools/online_editor/src/lsp.ts
+++ b/tools/online_editor/src/lsp.ts
@@ -90,8 +90,7 @@ export class LspWaiter {
         const pp = this.#previewer_promise!;
         this.#previewer_promise = null;
 
-        await pp;
-        const worker = await lp;
+        const [_, worker] = await Promise.all([pp, lp]);
 
         return Promise.resolve(new Lsp(worker, this.#previewer_port));
     }


### PR DESCRIPTION
The code used to sometimes throw a strange exception indicating that the previewer WASM module was not fully up yet when used.

Fix the LspWaiter to really wait for both LSP WASM web worker and WASM previewer to report back that they are fully up. Previously it only waited for the Lsp, which surprisingly often works on my machine.