### PR TITLE
Fix panics in the software renderer system font

### DIFF
--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -676,7 +676,7 @@ impl SharedBufferCommand {
                 }
             }
             SharedBufferData::AlphaMap { data, width } => SceneTexture {
-                data: &data[begin * 4..],
+                data: &data[begin..],
                 stride: *width,
                 format: PixelFormat::AlphaMap,
                 source_size: self.source_rect.size,

--- a/internal/core/textlayout/glyphclusters.rs
+++ b/internal/core/textlayout/glyphclusters.rs
@@ -74,7 +74,7 @@ impl<'a, Length: Copy + Clone + Zero + core::ops::AddAssign> Iterator
 
             self.glyph_index += 1;
 
-            if self.glyph_index >= self.shaped_text.glyphs.len() {
+            if self.glyph_index >= current_run.glyph_range.end {
                 cluster_byte_offset = current_run.byte_range.end;
                 break;
             }

--- a/internal/core/textlayout/shaping.rs
+++ b/internal/core/textlayout/shaping.rs
@@ -156,9 +156,10 @@ impl<'a> Iterator for ShapeBoundaries<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct TextRun {
     pub byte_range: Range<usize>,
-    //pub glyph_range: Range<usize>,
+    pub glyph_range: Range<usize>,
     // TODO: direction, etc.
 }
 
@@ -198,10 +199,7 @@ impl<Length> ShapeBuffer<Length> {
 
                 let run = TextRun {
                     byte_range: Range { start: *run_start, end: run_end },
-                    //glyph_range: Range {
-                    //     start: glyphs_start,
-                    //     end: glyph_buffer.borrow().as_ref().len(),
-                    // },
+                    glyph_range: Range { start: glyphs_start, end: glyphs.len() },
                 };
                 *run_start = run_end;
 


### PR DESCRIPTION
Two bugs:
 - There was an extra `* 4` that caused panic when the Text was clipped
 - There was a bug in glyph handling when the text is being split in several runs