### PR TITLE
Fix panic parsing invalid linear grandient

### DIFF
--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -468,7 +468,7 @@ impl Expression {
             let (before, rest) = stops.split_at_mut(start);
             let pos =
                 rest.iter().position(|s| !matches!(s.1, Expression::Invalid)).unwrap_or(rest.len());
-            if pos > 0 {
+            if pos > 0 && pos < rest.len() {
                 let (middle, after) = rest.split_at_mut(pos);
                 let begin = &before.last().expect("The first should never be invalid").1;
                 let end = &after.first().expect("The last should never be invalid").1;

--- a/internal/compiler/tests/syntax/basic/linear-gradient.slint
+++ b/internal/compiler/tests/syntax/basic/linear-gradient.slint
@@ -24,4 +24,7 @@ export X := Rectangle {
     property<brush> g12: @linear-gradient(2, blue 45%, red 88%);
 //                                        ^error{Cannot convert float to angle. Use an unit, or multiply by 1deg to convert explicitly}
     property<brush> g13: @linear-gradient(90deg + 0.5turn, true ? blue : red 45%, red 88% + 0.1);
+
+    property<brush> g14: @linear-gradient(-128deg, white, blue r);
+//                                                             ^error{Unknown unqualified identifier 'r'}
 }


### PR DESCRIPTION
If the last position expression is invalid due to an unrelated error, the code that tries to do the interpolation was panicking with the message "The last should never be invalid". (Because it assumed that invalid meant that it was not set, and we added a 100% for that last one if it wasn't set. But if it is set and invalid, this would error.)