### PR TITLE
Prospective fix for VS code extension not working on Debian Bullseye

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             toolchain: x86_64-unknown-linux-gnu
             binary_built: slint-lsp
             target_dir:


### PR DESCRIPTION
Don't build on Ubuntu 22.04, use 20.04 instead, to avoid requiring a newer glibc version. Ubuntu 20.04 is based on Bullseye.

cc #2163