### PR TITLE
Reduce the likelihood of users declaring properties in the root but not seeing them in C++/Rust

### DIFF
--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -723,7 +723,7 @@ fn public_properties(
                 name: p.clone(),
                 ty: c.property_type.clone(),
                 prop: property_reference,
-                read_only: c.visibility == PropertyVisibility::Output,
+                read_only: c.visibility == Some(PropertyVisibility::Output),
             }
         })
         .collect()

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -384,7 +384,7 @@ pub struct PropertyDeclaration {
     pub expose_in_public_api: bool,
     /// Public API property exposed as an alias: it shouldn't be generated but instead forward to the alias.
     pub is_alias: Option<NamedReference>,
-    pub visibility: PropertyVisibility,
+    pub visibility: Option<PropertyVisibility>,
     /// For function or callback: whether it is declared as `pure` (None for private function for which this has to be deduced)
     pub pure: Option<bool>,
 }
@@ -831,11 +831,11 @@ impl Element {
                     _ => (),
                 }
             }
-            let visibility = visibility.unwrap_or_else(|| {
+            let visibility = visibility.or_else(|| {
                 if is_legacy_syntax {
-                    PropertyVisibility::InOut
+                    Some(PropertyVisibility::InOut)
                 } else {
-                    PropertyVisibility::Private
+                    None
                 }
             });
 
@@ -908,7 +908,7 @@ impl Element {
                     PropertyDeclaration {
                         property_type: Type::InferredCallback,
                         node: Some(sig_decl.into()),
-                        visibility: PropertyVisibility::InOut,
+                        visibility: Some(PropertyVisibility::InOut),
                         pure,
                         ..Default::default()
                     },
@@ -955,7 +955,7 @@ impl Element {
                 PropertyDeclaration {
                     property_type: Type::Callback { return_type, args },
                     node: Some(sig_decl.into()),
-                    visibility: PropertyVisibility::InOut,
+                    visibility: Some(PropertyVisibility::InOut),
                     pure,
                     ..Default::default()
                 },
@@ -1033,7 +1033,7 @@ impl Element {
                 PropertyDeclaration {
                     property_type: Type::Function { return_type, args },
                     node: Some(func.into()),
-                    visibility,
+                    visibility: Some(visibility),
                     pure,
                     ..Default::default()
                 },
@@ -1377,7 +1377,7 @@ impl Element {
             |p| PropertyLookupResult {
                 resolved_name: name.into(),
                 property_type: p.property_type.clone(),
-                property_visibility: p.visibility,
+                property_visibility: p.visibility.unwrap_or_default(),
                 declared_pure: p.pure,
                 is_local_to_component: true,
             },

--- a/internal/compiler/passes/check_public_api.rs
+++ b/internal/compiler/passes/check_public_api.rs
@@ -27,11 +27,19 @@ fn check_public_api_component(root_component: &Rc<Component>, diag: &mut BuildDi
     let mut pa = root_elem.property_analysis.borrow_mut();
     root_elem.property_declarations.iter_mut().for_each(|(n, d)| {
         if d.property_type.ok_for_public_api() {
-            if d.visibility != PropertyVisibility::Private {
-                d.expose_in_public_api = true;
-                if d.visibility != PropertyVisibility::Output {
-                    pa.entry(n.to_string()).or_default().is_set = true;
+            if let Some(visibility) = d.visibility {
+                if visibility != PropertyVisibility::Private {
+                    d.expose_in_public_api = true;
+                    if visibility != PropertyVisibility::Output {
+                        pa.entry(n.to_string()).or_default().is_set = true;
+                    }
                 }
+            } else {
+                diag.push_diagnostic(
+                    format!("Properties in the root component exposed to native code must be annotated with in, out, in-out, or private"),
+                    &d.node,
+                    DiagnosticLevel::Warning
+               );
             }
         } else {
             diag.push_diagnostic(

--- a/internal/compiler/passes/check_public_api.rs
+++ b/internal/compiler/passes/check_public_api.rs
@@ -36,7 +36,7 @@ fn check_public_api_component(root_component: &Rc<Component>, diag: &mut BuildDi
                 }
             } else {
                 diag.push_diagnostic(
-                    format!("Properties in the root component exposed to native code must be annotated with in, out, in-out, or private"),
+                    format!("Properties are private by default. If you want to use them from native code, use in, out or in-out. Use private to suppress this warning"),
                     &d.node,
                     DiagnosticLevel::Warning
                );

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -492,7 +492,7 @@ fn lower_dialog_layout(
                                             layout_child,
                                             "clicked",
                                         )),
-                                        visibility: PropertyVisibility::InOut,
+                                        visibility: Some(PropertyVisibility::InOut),
                                         pure: None,
                                     });
                             }

--- a/internal/compiler/tests/syntax/new_syntax/new_lookup.slint
+++ b/internal/compiler/tests/syntax/new_syntax/new_lookup.slint
@@ -3,8 +3,8 @@
 
 export component Compo inherits Text {
 
-    property <string> background: text;
-//                                ^error{Unknown unqualified identifier 'text'. Did you mean 'self.text'?}
+    private property <string> background: text;
+//                                        ^error{Unknown unqualified identifier 'text'. Did you mean 'self.text'?}
 
     Rectangle {
         background: background;

--- a/internal/compiler/tests/syntax/new_syntax/root_compo_props.slint
+++ b/internal/compiler/tests/syntax/new_syntax/root_compo_props.slint
@@ -7,7 +7,7 @@ component Unrelated {
 
 export component Compo {
     property <string> i-forgot;
-//  ^warning{Properties in the root component exposed to native code must be annotated with in, out, in-out, or private}
+//  ^warning{Properties are private by default. If you want to use them from native code, use in, out or in-out. Use private to suppress this warning}
 
     in-out property <string> ok;
 

--- a/internal/compiler/tests/syntax/new_syntax/root_compo_props.slint
+++ b/internal/compiler/tests/syntax/new_syntax/root_compo_props.slint
@@ -1,0 +1,16 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+component Unrelated {
+    property <string> private-by-default;    
+}
+
+export component Compo {
+    property <string> i-forgot;
+//  ^warning{Properties in the root component exposed to native code must be annotated with in, out, in-out, or private}
+
+    in-out property <string> ok;
+
+    Unrelated {  }
+}
+

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -796,7 +796,8 @@ impl ComponentInstance {
 
         if !decl.expose_in_public_api {
             return Err(SetPropertyError::NoSuchProperty);
-        } else if decl.visibility == i_slint_compiler::object_tree::PropertyVisibility::Output {
+        } else if decl.visibility == Some(i_slint_compiler::object_tree::PropertyVisibility::Output)
+        {
             return Err(SetPropertyError::AccessDenied);
         }
 

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -147,7 +147,7 @@ pub(crate) fn add_highlight_items(doc: &Document) {
             node: None,
             expose_in_public_api: false,
             is_alias: None,
-            visibility: PropertyVisibility::Input,
+            visibility: Some(PropertyVisibility::Input),
             pure: None,
         },
     );

--- a/tools/lsp/properties.rs
+++ b/tools/lsp/properties.rs
@@ -87,8 +87,10 @@ fn property_is_editable(property: &PropertyDeclaration, is_local_element: bool) 
         // Filter away the callbacks
         return false;
     }
-    if matches!(property.visibility, PropertyVisibility::Output | PropertyVisibility::Private)
-        && !is_local_element
+    if matches!(
+        property.visibility.unwrap_or_default(),
+        PropertyVisibility::Output | PropertyVisibility::Private
+    ) && !is_local_element
     {
         // Skip properties that cannot be set because of visibility rules
         return false;


### PR DESCRIPTION
Require that properties in the root component are annotated with private, in, in-out, or out.