### PR TITLE
MCU: Remove the `alloc_error_handler` feature

### DIFF
--- a/examples/mcu-board-support/esp32_s2_kaluga_1.rs
+++ b/examples/mcu-board-support/esp32_s2_kaluga_1.rs
@@ -14,11 +14,6 @@ use esp_alloc::EspHeap;
 use esp_println::println;
 pub use xtensa_lx_rt::entry;
 
-#[alloc_error_handler]
-fn oom(layout: core::alloc::Layout) -> ! {
-    panic!("Out of memory {:?}", layout);
-}
-
 #[inline(never)]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {

--- a/examples/mcu-board-support/esp32_s3_box.rs
+++ b/examples/mcu-board-support/esp32_s3_box.rs
@@ -20,11 +20,6 @@ use esp_backtrace as _;
 use mipidsi::{Display, DisplayOptions, Orientation};
 pub use xtensa_lx_rt::entry;
 
-#[alloc_error_handler]
-fn oom(layout: core::alloc::Layout) -> ! {
-    panic!("Out of memory {:?}", layout);
-}
-
 #[global_allocator]
 static ALLOCATOR: EspHeap = EspHeap::empty();
 

--- a/examples/mcu-board-support/lib.rs
+++ b/examples/mcu-board-support/lib.rs
@@ -6,15 +6,6 @@
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint-ui.com/logo/slint-logo-square-light.svg")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(
-    any(
-        feature = "pico-st7789",
-        feature = "stm32h735g",
-        feature = "esp32-s2-kaluga-1",
-        feature = "esp32-s3-box"
-    ),
-    feature(alloc_error_handler)
-)]
 
 extern crate alloc;
 

--- a/examples/mcu-board-support/pico_st7789.rs
+++ b/examples/mcu-board-support/pico_st7789.rs
@@ -28,11 +28,6 @@ use slint::platform::{PointerEventButton, WindowEvent};
 #[cfg(feature = "panic-probe")]
 use panic_probe as _;
 
-#[alloc_error_handler]
-fn oom(layout: core::alloc::Layout) -> ! {
-    panic!("Out of memory {:?}", layout);
-}
-
 mod display_interface_spi;
 
 const HEAP_SIZE: usize = 200 * 1024;

--- a/examples/mcu-board-support/stm32h735g.rs
+++ b/examples/mcu-board-support/stm32h735g.rs
@@ -18,10 +18,6 @@ use stm32h7xx_hal as hal; // global logger
 #[cfg(feature = "panic-probe")]
 use panic_probe as _;
 
-#[alloc_error_handler]
-fn oom(layout: core::alloc::Layout) -> ! {
-    panic!("Out of memory {:?}", layout);
-}
 use alloc_cortex_m::CortexMHeap;
 
 const HEAP_SIZE: usize = 200 * 1024;


### PR DESCRIPTION
`default_alloc_error_handler` is being stabilized in Rust 1.68, so current nightly don't need any unstable features anymore