### PR TITLE
Bump femtovg, rustybuzz, ttf-parser, and fontdb dependencies

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -50,9 +50,9 @@ raw-window-handle = { version = "0.5", features = ["alloc"] }
 scopeguard =  { version = "1.1.0", default-features = false }
 
 # For the FemtoVG renderer
-femtovg = { version = "0.4.0", optional = true }
-fontdb = { version = "0.10.0", optional = true, default-features = false }
-ttf-parser = { version = "0.17.0", optional = true } # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
+femtovg = { version = "0.6.0", optional = true }
+fontdb = { version = "0.12.0", optional = true, default-features = false }
+ttf-parser = { version = "0.18.0", optional = true } # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
 unicode-script = { version = "0.5.4", optional = true } # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
 imgref = { version = "1.6.1", optional = true }
 rgb = { version = "0.8.27", optional = true }
@@ -69,7 +69,7 @@ wasm-bindgen = { version = "0.2" }
 send_wrapper = "0.6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-fontdb = { version = "0.10", optional = true, features = ["memmap", "fontconfig"] }
+fontdb = { version = "0.12", optional = true, features = ["memmap", "fontconfig"] }
 glutin = { version = "0.30", optional = true, default-features = false, features = ["egl", "wgl"] }
 
 # For the FemtoVG renderer

--- a/internal/backends/winit/renderer/femtovg/fonts.rs
+++ b/internal/backends/winit/renderer/femtovg/fonts.rs
@@ -231,8 +231,13 @@ impl Default for FontCache {
             };
             font_db.set_sans_serif_family(default_sans_serif_family);
         }
-        let available_families =
-            font_db.faces().iter().map(|face_info| face_info.family.as_str().into()).collect();
+        let available_families = font_db
+            .faces()
+            .iter()
+            .flat_map(|face_info| {
+                face_info.families.first().map(|(family_name, _)| family_name.as_str().into())
+            })
+            .collect();
 
         Self {
             loaded_fonts: HashMap::new(),

--- a/internal/backends/winit/renderer/femtovg/fonts.rs
+++ b/internal/backends/winit/renderer/femtovg/fonts.rs
@@ -234,7 +234,7 @@ impl Default for FontCache {
         let available_families = font_db
             .faces()
             .iter()
-            .flat_map(|face_info| {
+            .filter_map(|face_info| {
                 face_info.families.first().map(|(family_name, _)| family_name.as_str().into())
             })
             .collect();

--- a/internal/backends/winit/renderer/femtovg/itemrenderer.rs
+++ b/internal/backends/winit/renderer/femtovg/itemrenderer.rs
@@ -1369,11 +1369,9 @@ impl<'a> GLItemRenderer<'a> {
                 let start: Point = transform.transform_point(start);
                 let end: Point = transform.transform_point(end);
 
-                let stops = gradient
-                    .stops()
-                    .map(|stop| (stop.position, to_femtovg_color(&stop.color)))
-                    .collect::<Vec<_>>();
-                femtovg::Paint::linear_gradient_stops(start.x, start.y, end.x, end.y, &stops)
+                let stops =
+                    gradient.stops().map(|stop| (stop.position, to_femtovg_color(&stop.color)));
+                femtovg::Paint::linear_gradient_stops(start.x, start.y, end.x, end.y, stops)
             }
             Brush::RadialGradient(gradient) => {
                 let path_bounds = path_bounding_box(&self.canvas, path);
@@ -1381,16 +1379,14 @@ impl<'a> GLItemRenderer<'a> {
                 let path_width = path_bounds.width();
                 let path_height = path_bounds.height();
 
-                let stops = gradient
-                    .stops()
-                    .map(|stop| (stop.position, to_femtovg_color(&stop.color)))
-                    .collect::<Vec<_>>();
+                let stops =
+                    gradient.stops().map(|stop| (stop.position, to_femtovg_color(&stop.color)));
                 femtovg::Paint::radial_gradient_stops(
                     path_width / 2.,
                     path_height / 2.,
                     0.,
                     (path_width + path_height) / 4.,
-                    &stops,
+                    stops,
                 )
             }
             _ => return None,

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -60,7 +60,7 @@ tiny-skia = { version = "0.8.2", optional = true }
 resvg = { version = "0.28.0", optional = true }
 usvg = { version = "0.28.0", optional = true }
 # font embedding
-fontdb = { version = "0.10", features = ["fontconfig"], optional = true }
+fontdb = { version = "0.12", features = ["fontconfig"], optional = true }
 fontdue = { version = "0.7.1", optional = true }
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -191,7 +191,14 @@ pub fn embed_glyphs<'a>(
     )
     .expect("internal error: fontdb returned a font that ttf-parser/fontdue could not parse");
                 embed_font(
-                    fontdb.face(face_id).unwrap().family.clone(),
+                    fontdb
+                        .face(face_id)
+                        .unwrap()
+                        .families
+                        .first()
+                        .expect("TrueType font without english family name encountered")
+                        .0
+                        .clone(),
                     font,
                     &pixel_sizes,
                     characters_seen.iter().cloned(),

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -87,16 +87,16 @@ wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = [ "HtmlImageElement" ] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-fontdb = { version = "0.10", optional = true, features = ["memmap", "fontconfig"] }
-rustybuzz = { version = "0.6.0", optional = true }
+fontdb = { version = "0.12", optional = true, features = ["memmap", "fontconfig"] }
+rustybuzz = { version = "0.7.0", optional = true }
 fontdue = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-0-3-0"] }
 i-slint-backend-testing = { path="../backends/testing" }
-rustybuzz = "0.6.0"
-ttf-parser = "0.17.0"
-fontdb = { version = "0.10.0" }
+rustybuzz = "0.7.0"
+ttf-parser = "0.18.0"
+fontdb = { version = "0.12.0" }
 
 image = { version = "0.24.0", default-features = false, features = [ "png" ] }
 pin-weak = "1"

--- a/internal/core/software_renderer/fonts/systemfonts.rs
+++ b/internal/core/software_renderer/fonts/systemfonts.rs
@@ -30,7 +30,11 @@ fn init_fontdb() -> FontDatabase {
             ],
             ..Default::default()
         }) {
-            db.set_sans_serif_family(db.face(fallback_id).unwrap().family.clone());
+            if let Some(family_name) =
+                db.face(fallback_id).unwrap().families.first().map(|(name, _)| name.clone())
+            {
+                db.set_sans_serif_family(family_name);
+            }
         }
     }
 

--- a/internal/core/software_renderer/fonts/vectorfont.rs
+++ b/internal/core/software_renderer/fonts/vectorfont.rs
@@ -104,7 +104,7 @@ impl TextShaper for VectorFont {
             .borrow()
             .with_face_data(self.id, |face_data, font_index| {
                 let face = rustybuzz::ttf_parser::Face::parse(face_data, font_index).unwrap();
-                let rb_face = rustybuzz::Face::from_face(face).unwrap();
+                let rb_face = rustybuzz::Face::from_face(face);
 
                 let glyph_buffer = rustybuzz::shape(&rb_face, &[], buffer);
 


### PR DESCRIPTION
Mostly bugfix changes upstream with some minor API changes. FemtoVG is no more limited to 24 gradient stops for the paint.