### PR TITLE
Fix const detection with two ways binding

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -524,8 +524,8 @@ fn propagate_is_set_on_aliases(component: &Rc<Component>, reverse_aliases: &mut 
     }
 
     fn mark_alias(alias: &NamedReference) {
+        alias.mark_as_set();
         if !alias.is_externally_modified() {
-            alias.mark_as_set();
             if let Some(bind) = alias.element().borrow().bindings.get(alias.name()) {
                 propagate_alias(&bind.borrow())
             }

--- a/tests/cases/bindings/change_sub_property_indirection_issue2185.slint
+++ b/tests/cases/bindings/change_sub_property_indirection_issue2185.slint
@@ -1,0 +1,59 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+component Buggy {
+    in-out property<string> magic: "Nope";
+    property<bool> condition: false;
+
+    public function change_condition() {
+        condition = !condition;
+    }
+
+    HorizontalLayout {
+        if root.condition: TouchArea {
+            property <string> innermagic <=> root.magic;
+            clicked => { self.innermagic = "Hello"; }
+            horizontal-stretch: 1;
+        }
+
+        Rectangle {
+            background: red;
+            TouchArea {
+                clicked => { change-condition() }
+            }
+        }
+    }
+}
+
+
+component TestCase {
+    width: 300px;
+    height: 100px;
+
+    public function change_condition() {
+        b.change-condition();
+    }
+
+    b := Buggy {
+        magic: "Hi";
+    }
+
+    out property <string> magic: b.magic;
+}
+
+
+/*
+
+```rust
+let instance = TestCase::new();
+assert_eq!(instance.get_magic(), slint::SharedString::from("Hi"));
+instance.invoke_change_condition();
+instance.invoke_change_condition();
+instance.invoke_change_condition();
+assert_eq!(instance.get_magic(), slint::SharedString::from("Hi"));
+slint_testing::send_mouse_click(&instance, 10., 10.);
+assert_eq!(instance.get_magic(), slint::SharedString::from("Hello"));
+```
+
+
+*/


### PR DESCRIPTION
The const detection for two way binding was not detecting change if one of the property was set to a const value in a component using it.

This would cause the compiler to generate call set_content on one of the property in a two way bindings, and later, the "const sentinel" be present in the dependency list, causing crash.

To avoid segfault for similar bug in the future, added added an assert! in the property system to detect that.

Fixes #2185