### PR TITLE
Fix run-time panic when combining forward-focus with text rendering in no_std environments

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -220,6 +220,31 @@ pub struct UsedSubTypes {
     pub sub_components: Vec<Rc<Component>>,
 }
 
+#[derive(Debug, Default, Clone)]
+pub struct InitCode {
+    // Code from init callbacks collected from elements
+    pub constructor_code: Vec<Expression>,
+    /// Code to set the initial focus via forward-focus on the Window
+    pub focus_setting_code: Vec<Expression>,
+    /// Code to register embedded fonts.
+    pub font_registration_code: Vec<Expression>,
+}
+
+impl InitCode {
+    pub fn iter(&self) -> impl Iterator<Item = &Expression> {
+        self.font_registration_code
+            .iter()
+            .chain(self.focus_setting_code.iter())
+            .chain(self.constructor_code.iter())
+    }
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Expression> {
+        self.font_registration_code
+            .iter_mut()
+            .chain(self.focus_setting_code.iter_mut())
+            .chain(self.constructor_code.iter_mut())
+    }
+}
+
 /// A component is a type in the language which can be instantiated,
 /// Or is materialized for repeated expression.
 #[derive(Default, Debug)]
@@ -251,9 +276,7 @@ pub struct Component {
     /// we can preserve the order across multiple inlining passes.
     pub inlined_init_code: RefCell<BTreeMap<usize, Expression>>,
 
-    /// Code to be inserted into the constructor, such as font registration, focus setting or
-    /// init callback code collected from elements.
-    pub init_code: RefCell<Vec<Expression>>,
+    pub init_code: RefCell<InitCode>,
 
     /// The list of used extra types used (recursively) by this root component.
     /// (This only make sense on the root component)

--- a/internal/compiler/passes/collect_custom_fonts.rs
+++ b/internal/compiler/passes/collect_custom_fonts.rs
@@ -56,11 +56,11 @@ pub fn collect_custom_fonts<'a>(
         Box::new(|font_path| Expression::StringLiteral(font_path.clone()))
     };
 
-    root_component.init_code.borrow_mut().extend(all_fonts.into_iter().map(|font_path| {
-        Expression::FunctionCall {
+    root_component.init_code.borrow_mut().font_registration_code.extend(all_fonts.into_iter().map(
+        |font_path| Expression::FunctionCall {
             function: Box::new(registration_function.clone()),
             arguments: vec![prepare_font_registration_argument(font_path)],
             source_location: None,
-        }
-    }));
+        },
+    ));
 }

--- a/internal/compiler/passes/collect_init_code.rs
+++ b/internal/compiler/passes/collect_init_code.rs
@@ -19,7 +19,11 @@ pub fn collect_init_code(component: &Rc<Component>) {
         }
 
         if let Some(init_callback) = elem.borrow_mut().bindings.remove("init") {
-            component.init_code.borrow_mut().push(init_callback.into_inner().expression);
+            component
+                .init_code
+                .borrow_mut()
+                .constructor_code
+                .push(init_callback.into_inner().expression);
         }
     });
 }

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -216,7 +216,7 @@ pub fn embed_glyphs<'a>(
             },
         );
 
-        component.init_code.borrow_mut().push(Expression::FunctionCall {
+        component.init_code.borrow_mut().font_registration_code.push(Expression::FunctionCall {
             function: Box::new(Expression::BuiltinFunctionReference(
                 BuiltinFunction::RegisterBitmapFont,
                 None,

--- a/internal/compiler/passes/focus_item.rs
+++ b/internal/compiler/passes/focus_item.rs
@@ -119,7 +119,7 @@ pub fn determine_initial_focus_item(component: &Rc<Component>, diag: &mut BuildD
             source_location: None,
         };
 
-        component.init_code.borrow_mut().push(setup_code);
+        component.init_code.borrow_mut().focus_setting_code.push(setup_code);
     }
 }
 

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -54,6 +54,7 @@ pub fn inline(doc: &Document, inline_selection: InlineSelection) {
         doc.root_component
             .init_code
             .borrow_mut()
+            .constructor_code
             .splice(0..0, doc.root_component.inlined_init_code.borrow().values().cloned());
     }
 }
@@ -177,15 +178,17 @@ fn inline_element(
         .borrow()
         .values()
         .cloned()
-        .chain(inlined_component.init_code.borrow().iter().map(|setup_code_expr| {
-            // Fix up any property references from within already collected init code.
-            let mut new_setup_code = setup_code_expr.clone();
-            visit_named_references_in_expression(&mut new_setup_code, &mut |nr| {
-                fixup_reference(nr, &mapping)
-            });
-            fixup_element_references(&mut new_setup_code, &mapping);
-            new_setup_code
-        }))
+        .chain(inlined_component.init_code.borrow().constructor_code.iter().map(
+            |constructor_code_expr| {
+                // Fix up any property references from within already collected init code.
+                let mut new_constructor_code = constructor_code_expr.clone();
+                visit_named_references_in_expression(&mut new_constructor_code, &mut |nr| {
+                    fixup_reference(nr, &mapping)
+                });
+                fixup_element_references(&mut new_constructor_code, &mapping);
+                new_constructor_code
+            },
+        ))
         .collect();
 
     root_component


### PR DESCRIPTION
As outlined in #2199, there may be ways to trigger text layout code through forward-focus before embedded fonts are registered. To fix this, this patch replaces the init_code vector, which had the SetFocusItem code before the font registration, with three explicit vectors for focus setup code, code from init callbacks, and initial focus, and defines the order in one central place in the copmiler (visit_init_code).

Fixes #2199