### PR TITLE
docs: Fix up link to slint language ref in rust docs on slint-ui

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -297,6 +297,10 @@ jobs:
             cp -a ../target/cppdocs/html/* snapshots/$target_branch/docs/cpp/
             mkdir -p snapshots/$target_branch/docs/rust
             cp -a ../target/doc/* snapshots/$target_branch/docs/rust/
+
+            # Fix up link to Slint language reference
+            sed -i "s!https://slint-ui.com/releases/.*/doc/slint!../../slint!" snapshots/$target_branch/docs/rust/slint/index.html
+
             mkdir -p snapshots/$target_branch/docs/tutorial/rust
             cp -a ../docs/tutorial/rust/book/html/* snapshots/$target_branch/docs/tutorial/rust
             mkdir -p snapshots/$target_branch/docs/tutorial/cpp


### PR DESCRIPTION
This link must work on crates.io and on slint-ui.com. For crates.io we only have released versions of slint and need a full link to the language reference of exactly this version (built out of the information available when running cargo doc).

On slint-ui a relative link works best.

So this patch generates the absolute link needed for crates.io unconditionally and makes slint-ui update it to a relative link when publishing the docs.