### PR TITLE
docs: Add previews to langref

### DIFF
--- a/docs/langref/book.toml
+++ b/docs/langref/book.toml
@@ -6,7 +6,6 @@ src = "src"
 title = "Slint Language Reference"
 
 [output.html]
-theme = "../tutorial/theme"
 
 [output.linkcheck]  # enable the "mdbook-linkcheck" renderer
 optional = true

--- a/docs/langref/theme/head.hbs
+++ b/docs/langref/theme/head.hbs
@@ -1,0 +1,1 @@
+../../resources/slint-docs-highlight-preview.html

--- a/docs/langref/theme/highlight.css
+++ b/docs/langref/theme/highlight.css
@@ -1,0 +1,1 @@
+/* Disabled as part of disabling mdbook's highlight.js version, see highlight.js */

--- a/docs/langref/theme/highlight.js
+++ b/docs/langref/theme/highlight.js
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// This file is empty to override and disable mdbook's built-in highlight.js
+// version, which does not include CMake support. Instead the appropriate version
+// of highlight.js is included via head.hbs

--- a/docs/resources/slint-docs-highlight-preview.html
+++ b/docs/resources/slint-docs-highlight-preview.html
@@ -1,0 +1,270 @@
+<!--
+    This file is used to add preview of the `.slint` snippets in the generated rustdoc documentation.
+    It can be injected via the `--html-in-header slint-docs-preview.html` option of rustdoc.
+-->
+<script type="module">
+    "use strict";
+    //import * as slint from 'https://slint-ui.com/releases/0.x.0/wasm-interpreter/slint_wasm_interpreter.js';
+    //const editor_url = "https://slint-ui.com/releases/0.x.0/editor/";
+    import * as slint from "https://slint-ui.com/snapshots/master/wasm-interpreter/slint_wasm_interpreter.js";
+    const editor_url = "https://slint-ui.com/snapshots/master/editor/";
+    // keep them alive
+    var all_instances = new Array();
+
+    async function render_or_error(source, div) {
+        let canvas_id = "canvas_" + Math.random().toString(36).substr(2, 9);
+        let canvas = document.createElement("canvas");
+        canvas.id = canvas_id;
+        div.appendChild(canvas);
+
+        let { component, error_string } = await slint.compile_from_string(
+            source,
+            "",
+        );
+        if (error_string != "") {
+            var text = document.createTextNode(error_string);
+            var p = document.createElement("pre");
+            p.appendChild(text);
+            div.innerHTML =
+                "<pre style='color: red; background-color:#fee; margin:0'>" +
+                p.innerHTML +
+                "</pre>";
+        }
+        if (component !== undefined) {
+            let instance = component.create(canvas_id);
+            instance.show();
+            all_instances.push(instance);
+        }
+    }
+
+    async function create_preview(element, source_code) {
+        let div = document.createElement("div");
+        div.style = "float: right; padding:0; margin:0;";
+        div.class = "slint-previewer";
+        element.prepend(div);
+        await render_or_error(source_code, div);
+    }
+
+    function should_show_automatic_preview(element) {
+        // The `no-auto-preview` doesn't map directly to a dedicated class but it is mangled differently
+        // between rustdoc and sphinx, so match fuzzy on the entire class list:
+        return !element.className.includes("no-auto-preview");
+    }
+
+    async function create_click_to_play_and_edit_buttons(element) {
+        if (
+            element.classList.contains("ignore") ||
+            element.classList.contains("no-preview")
+        ) {
+            return;
+        }
+
+        let source = element.innerText;
+
+        let link_section = document.createElement("div");
+        element.append(link_section);
+
+        let button_style = "text-decoration: none;";
+
+        let edit_button = document.createElement("a");
+        edit_button.style = button_style;
+        edit_button.href = `${editor_url}?snippet=${encodeURIComponent(
+            source,
+        )}`;
+        edit_button.target = "_blank";
+        edit_button.innerText = "Edit 📝";
+        link_section.append(edit_button);
+        link_section.style =
+            "padding-top: 8px; margin-top: 8px; border-top-style: solid;border-top-width: thin;";
+
+        if (should_show_automatic_preview(element)) {
+            create_preview(element, source);
+        } else {
+            let play_button = document.createElement("a");
+            // play_button.style = button_style;
+            play_button.innerText = "Preview ▶️";
+            play_button.onclick = async () => {
+                play_button.remove();
+                create_preview(element, source);
+            };
+
+            link_section.prepend(play_button);
+        }
+    }
+
+    async function run() {
+        await slint.default();
+        var elements = document.querySelectorAll("code.language-slint");
+        for (var i = 0; i < elements.length; ++i) {
+            await create_click_to_play_and_edit_buttons(elements[i]);
+        }
+        slint.run_event_loop();
+    }
+    run();
+
+    // Included markdown files may have links to other markdown files, which may not have been
+    // resolved by rustdoc. This helper locates such links and resolves them, assuming that each
+    // .md file gets its own sub-directory with an index.html.
+    function fix_markdown_links() {
+        for (let anchor of document.querySelectorAll(
+            'a[href$=".md"], a[href*=".md#"]',
+        )) {
+            let url = new URL(anchor.href);
+            let dir_separator = Math.max(url.pathname.lastIndexOf("/"), 0);
+            let base_name = url.pathname.slice(dir_separator + 1, -3);
+            let base_path = url.pathname.slice(0, dir_separator);
+            url.pathname = base_path + "/../" + base_name + "/index.html";
+            anchor.setAttribute("href", url);
+        }
+    }
+    fix_markdown_links();
+
+    // Select C++ blocks in rustdoc generated code and hide them, while opening the <details> of Rust snippets
+    // Similarly, in Sphinx generated HTML, hide Rust blocks and open C++.
+    function select_code_snippet_variants(options) {
+        // When the CSS has pseudo class becomes available, we can probably use that directly
+        // in a stylesheet instead of JS here.
+
+        let selector_for_language = (language) => {
+            return `details[data-snippet-language="${language}"]`;
+        };
+
+        for (let details_element_to_hide of document.querySelectorAll(
+            selector_for_language(options.hide),
+        )) {
+            details_element_to_hide.style = "display: none";
+        }
+
+        for (let details_element_to_show of document.querySelectorAll(
+            selector_for_language(options.show),
+        )) {
+            details_element_to_show.open = true;
+        }
+    }
+
+    const rustDoc =
+        document.querySelector('meta[name="generator"]')?.content == "rustdoc";
+    if (rustDoc) {
+        select_code_snippet_variants({ hide: "cpp", show: "rust" });
+    } else {
+        select_code_snippet_variants({ hide: "rust", show: "cpp" });
+    }
+</script>
+<!--
+    This file is used to add syntax highlighting of the `.slint` snippets in the generated rustdoc, sphinx and mdbook documentation.
+    It can be injected via the `--html-in-header slint-docs-highlight.html` option of rustdoc, is included via _templates/layout.html
+    in sphinx and via head.hbs in mdbook.
+-->
+<link
+    rel="stylesheet"
+    href="https://slint-ui.com/resources/highlightjs/11.0.1/default.min.css"
+/>
+<script src="https://slint-ui.com/resources/highlightjs/11.0.1/highlight.min.js"></script>
+<script>
+    function highlight_slint(hljs) {
+        const KEYWORDS = {
+            keyword:
+                "animate callback component export for function global if import in in-out inherits out parent private property public pure root self signal states struct transitions",
+            literal: "false true",
+            built_in:
+                "ArcTo Clip Close Colors CubicTo Flickable FocusScope GridLayout HorizontalLayout Image LineTo Math MoveTo Path PopupWindow QuadraticTo Rectangle Row Text TextInput TouchArea VerticalLayout Window animation-tick debug",
+            type: "bool duration easing float int length logical_length relative-font-size resource string",
+        };
+
+        return {
+            name: "slint",
+            case_insensitive: false,
+            keywords: KEYWORDS,
+            contains: [
+                hljs.QUOTE_STRING_MODE,
+                hljs.C_LINE_COMMENT_MODE,
+                hljs.C_BLOCK_COMMENT_MODE,
+                hljs.COMMENT("/\\*", "\\*/", {
+                    contains: ["self"],
+                }),
+                {
+                    className: "number",
+                    begin: "\\b\\d+(\\.\\d+)?(\\w+)?",
+                    relevance: 0,
+                },
+                {
+                    className: "title",
+                    begin: "\\b[_a-zA-Z][_\\-a-zA-Z0-9]* *:=",
+                },
+                {
+                    className: "symbol",
+                    begin: "\\b[_a-zA-Z][_\\-a-zA-Z0-9]*(:| *=>)",
+                },
+                {
+                    className: "built_in",
+                    begin: "\\b[_a-zA-Z][_\\-a-zA-Z0-9]*!",
+                },
+            ],
+            illegal: /@/,
+        };
+    }
+
+    // Tags used in fenced code blocks
+    for (let tag of [
+        "slint",
+        "slint,no-preview",
+        "slint,no-auto-preview",
+        "slint,ignore",
+    ]) {
+        hljs.registerLanguage(tag, highlight_slint);
+    }
+
+    window.addEventListener("DOMContentLoaded", () => {
+        const rustDoc =
+            document.querySelector('meta[name="generator"]')?.content ==
+            "rustdoc";
+        if (rustDoc) {
+            // Only highlight .slint blocks, leave the others to rustdoc
+            for (slintBlock of document.querySelectorAll(
+                "[class*=language-slint]",
+            )) {
+                hljs.highlightElement(slintBlock);
+            }
+
+            // Some of the rustdoc selectors require the pre element to have the rust class
+            for (codeBlock of document.querySelectorAll(
+                ".language-slint.hljs",
+            )) {
+                codeBlock.parentElement.classList.add("rust");
+            }
+
+            // Change the hljs generated classes to the rustdoc
+            // ones, so that the highlighting adjusts to the theme correctly.
+            const highlightJSToRustDoc = [
+                ["comment", "comment"],
+                ["number", "number"],
+                ["symbol", "struct"], // width:
+                ["keyword", "kw"],
+                ["built_in", "primitive"],
+                ["string", "string"],
+                ["title", "fnname"], // Foo :=
+                ["type", "type"],
+            ];
+
+            for ([hljs_class, rustdoc_class] of highlightJSToRustDoc) {
+                for (titleElement of document.querySelectorAll(
+                    `.hljs-${hljs_class}`,
+                )) {
+                    titleElement.classList.remove(`hljs-${hljs_class}`);
+                    titleElement.classList.add(rustdoc_class);
+                }
+            }
+        } else {
+            // For use with the mdbook Tutorial
+            hljs.highlightAll();
+
+            // The Sphinx/my_st generated HTML for code blocks does not use <code> tags, so highlight.js'
+            // default selector "pre code" does not match. Let's do it by hand:
+            for (block of document.querySelectorAll(
+                "div[class*=highlight-slint] div.highlight pre",
+            )) {
+                hljs.highlightElement(block);
+            }
+        }
+    });
+</script>

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -279,6 +279,7 @@ lazy_static! {
         // Path prefix matches:
         ("^api/cpp/docs/_static/", LicenseLocation::NoLicense),
         ("^api/cpp/docs/_templates/", LicenseLocation::NoLicense),
+        ("^docs/langref/theme/", LicenseLocation::NoLicense),
         ("^docs/tutorial/theme/", LicenseLocation::NoLicense),
         ("^editors/tree-sitter-slint/queries/", LicenseLocation::NoLicense), // liberal license
         ("^helper_crates/const-field-offset/", LicenseLocation::NoLicense), // liberal license


### PR DESCRIPTION
I added a line between the text area and the buttons.

I also tried to consume all the events that should go to the previewer only, but failed at that :-(