### PR TITLE
Declare the Slint VS code extension as stable

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -16,7 +16,6 @@
     "categories": [
         "Programming Languages"
     ],
-    "preview": true,
     "activationEvents": [
         "onLanguage:slint",
         "onLanguage:rust",

--- a/scripts/prepare_vscode_nightly.sh
+++ b/scripts/prepare_vscode_nightly.sh
@@ -25,7 +25,8 @@ git show HEAD:./package.json | jq --arg nightly_version "${nightly_version}" '
 .version = $nightly_version |
 .name += "-nightly" |
 .displayName += " (Nightly)" |
-.description += " (Nightly)"' > package.json
+.description += " (Nightly)" |
+. + {"preview": true}' > package.json
 
 cat >README.md <<EOT
 # Slint for Visual Studio Code Nightly


### PR DESCRIPTION
... and not preview anymore.