### PR TITLE
Fix compiler panic when an component's base is not inlined

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -35,7 +35,10 @@ pub fn inline(doc: &Document, inline_selection: InlineSelection) {
                 if match inline_selection {
                     InlineSelection::InlineAllComponents => true,
                     InlineSelection::InlineOnlyRequiredComponents => {
-                        component_requires_inlining(&c) || element_require_inlining(elem)
+                        component_requires_inlining(&c)
+                            || element_require_inlining(elem)
+                            // We always inline the root in case the element that instantiate this component needs full inlining
+                            || Rc::ptr_eq(elem, &component.root_element)
                     }
                 } {
                     inline_element(elem, &c, component);

--- a/tests/cases/subcomponents/no_children.slint
+++ b/tests/cases/subcomponents/no_children.slint
@@ -1,0 +1,52 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// Verify that two repeaters (if and for) are placed correctly in the item tree
+// and matched in the dyn_visit closure.
+// The two repeaters ended up being swapped and sub-component's repeater was
+// visisted when the Text's child's repeater should have been, resulting in
+// wrong rendering order. This is tested by clicking into the left half and
+// verifying that it did not hit the sub-component's repeater.
+
+component A inherits Rectangle {
+}
+component B inherits A {
+}
+
+
+export component TestCase  {
+    width: 300phx;
+    height: 300phx;
+    out property <bool> clicked;
+    B {
+        TouchArea { clicked => {root.clicked = true;} }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+assert!(!instance.get_clicked());
+slint_testing::send_mouse_click(&instance, 20., 5.);
+assert!(instance.get_clicked());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(!instance.get_clicked());
+slint_testing::send_mouse_click(&instance, 20., 5.);
+assert(instance.get_clicked());
+```
+
+
+```js
+var instance = new slint.TestCase({});
+assert(!instance.clicked);
+instance.send_mouse_click(20., 5.);
+assert(instance.clicked);
+```
+
+
+*/


### PR DESCRIPTION
An element with children must be fully inlined or the children array can't be easily computed.
But the code wouldn't work if the base of a component was not inlined