### PR TITLE
online_editor: Fix firefox

### DIFF
--- a/tools/online_editor/package.json
+++ b/tools/online_editor/package.json
@@ -38,7 +38,7 @@
         "path-browserify": "^1.0.1",
         "rimraf": "^4.1.2",
         "typescript": "^4.9.4",
-        "vite": "^4.0.4",
+        "vite": "^4.1.1",
         "vscode-languageserver": "^8.0.2",
         "vscode-languageserver-protocol": "^3.17.2"
     }

--- a/tools/online_editor/src/lsp.ts
+++ b/tools/online_editor/src/lsp.ts
@@ -66,7 +66,7 @@ export class LspWaiter {
 
         const worker = new Worker(
             new URL("worker/lsp_worker.ts", import.meta.url),
-            { type: "module" },
+            // { type: "module" }, // Do not force ES modules in web worker!
         );
         this.#lsp_promise = new Promise<Worker>((resolve) => {
             worker.onmessage = (m) => {

--- a/tools/online_editor/src/worker/lsp_worker.ts
+++ b/tools/online_editor/src/worker/lsp_worker.ts
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+import "./shim.js";
+
 import slint_init, * as slint_lsp from "@lsp/slint_lsp_wasm.js";
 import { InitializeParams, InitializeResult } from "vscode-languageserver";
 import {

--- a/tools/online_editor/src/worker/shim.js
+++ b/tools/online_editor/src/worker/shim.js
@@ -1,0 +1,17 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// UGLY HACK: Vite does produce invalid code when packaging a web worker as
+// iife, see https://github.com/vitejs/vite/issues/9879
+//
+// We need to produce iife, otherwise firefox will not be supported :-/
+//
+// The issue is that the generated code uses `document` which does not exist
+// on a web worker. So we just add one with all the needed values for this to
+// work and make sure it gets imported before its needed...
+
+let assets = new URL("assets/", location.origin);
+
+self.document = {
+    baseURI: assets,
+};

--- a/tools/online_editor/vite.config.js
+++ b/tools/online_editor/vite.config.js
@@ -22,7 +22,7 @@ export default defineConfig(({ command, _mode }) => {
             target: "safari14",
         },
         worker: {
-            format: "es",
+            format: "iife",
         },
     };
 


### PR DESCRIPTION
Firefox does not handle modules in web workers yet, but that is what we asked vite to build (to work around a compatibility issue after upgrading to vite 4). So Chrome worked, but Firefox did not.

This PR adds a pretty ugly work around to that problem.

The good news is: Firefox will apparently be able to handle modules in web workers starting with 111, so let's hope we do not need this for too long!