### PR TITLE
Set MSRV to 1.66

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,13 +21,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2022]
-        rust_version: [stable, "1.64"]
+        rust_version: [stable, "1.66"]
         include:
           - os: windows-2022
             extra_args: "--exclude slint-node --exclude test-driver-nodejs"
         exclude:
           - os: macos-11
-            rust_version: "1.64"
+            rust_version: "1.66"
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
+ - Minimum Rust version is now 1.66.
  - Deprecated functions and enums were removed
  - `PointerEventButton::None` was renamed `PointerEventButton::Other`
  - In the Rust API, more functions now return Result, and the return value needs to be unwrap()'ed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ default-members = [
 resolver="2"
 
 [workspace.package]
-rust-version = "1.64"
+rust-version = "1.66"
 
 [profile.release]
 lto = true

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Corrosion)
 
 list(PREPEND CMAKE_MODULE_PATH ${Corrosion_SOURCE_DIR}/cmake)
-find_package(Rust 1.64 REQUIRED MODULE)
+find_package(Rust 1.66 REQUIRED MODULE)
 
 option(SLINT_FEATURE_COMPILER "Enable support for compiling .slint files to C++ ahead of time" ON)
 

--- a/api/rs/slint/README.md
+++ b/api/rs/slint/README.md
@@ -63,4 +63,4 @@ cargo run --release --bin printerdemo
 
 ### Minimum Supported Rust Version
 
- This crate's minimum supported `rustc` version is 1.64.
+ This crate's minimum supported `rustc` version is 1.66.

--- a/docs/building.md
+++ b/docs/building.md
@@ -7,7 +7,7 @@ This page explains how to build and test Slint.
 ### Installing Rust
 
 Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). If you already
-have Rust installed, make sure that it's at least version 1.64 or newer. You can check which version you have installed
+have Rust installed, make sure that it's at least version 1.66 or newer. You can check which version you have installed
 by running `rustc --version`.
 
 Once this is done, you should have the `rustc` compiler and the `cargo` build system installed in your path.

--- a/docs/tutorial/cpp/src/getting_started.md
+++ b/docs/tutorial/cpp/src/getting_started.md
@@ -6,7 +6,7 @@ In this tutorial, we use C++ as the host programming language. We also support o
 You will need a development environment that can compile C++20 with CMake 3.21.
 We don't provide binaries of Slint yet, so we will use the CMake integration that will automatically build
 the tools and library from source. Since it's implemented in the Rust programming language, this means that
-you also need to install a Rust compiler (1.64). You can easily install a Rust compiler
+you also need to install a Rust compiler (1.66 or newer). You can easily install a Rust compiler
 following the instruction from [the Rust website](https://www.rust-lang.org/learn/get-started).
 We're going to use `cmake`'s builtin FetchContent module to fetch the source code of Slint.
 

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -57,8 +57,8 @@ linked_hash_set = "0.1.4"
 # for processing and embedding the rendered image (texture)
 image = { version = "0.24", optional = true }
 tiny-skia = { version = "0.8.2", optional = true }
-resvg = { version = "0.28.0", optional = true }
-usvg = { version = "0.28.0", optional = true }
+resvg = { version = "0.29.0", optional = true }
+usvg = { version = "0.29.0", optional = true }
 # font embedding
 fontdb = { version = "0.12", features = ["fontconfig"], optional = true }
 fontdue = { version = "0.7.1", optional = true }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -77,8 +77,8 @@ integer-sqrt = { version = "0.1.5" }
 image = { version = "0.24.0", optional = true, default-features = false, features = [ "png", "jpeg" ] }
 clru = { version = "0.6.0", optional = true }
 
-resvg = { version= "0.28.0", optional = true, default-features = false }
-usvg = { version= "0.28.0", optional = true, default-features = false }
+resvg = { version= "0.29.0", optional = true, default-features = false }
+usvg = { version= "0.29.0", optional = true, default-features = false }
 tiny-skia = { version= "0.8.2", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
- the new version of resvg needs 1.65
- the memoffset crate can do const offset from Rust 1.65, which means we could get rid of our const field offset macro which is probably contributing to slow builds.
- `let else` is in 1.65 and it is good to use that.  (also GAT)

Technically there is not much we need from 1.66 (released 2022-12-15):
 - `wrapping_add_signed` is nice, but also simple to do ourselves.
 - I thought we could use `Span::source_text` to help with the dashes detection of identifier. But that is actually not helping.
 - I don't think we would use any other new feature of 1.66

1.67 Also doesn't have so many interesting feature, and is a bit too recent anyway.

We could just use 1.65, but I think since we want to be conservative with MSRV changes in the future, I think we can simply go with 1.66