### PR TITLE
Femtovg backend: fix text_input_cursor_rect_for_byte_offset for the last glyph

### DIFF
--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -397,8 +397,11 @@ impl Renderer for FemtoVGRenderer {
                         }
                     }
                     if let Some(last) = metrics.glyphs.last() {
-                        result = line_pos
-                            + PhysicalPoint::new(last.x + last.advance_x, last.y).to_vector();
+                        if line_text.ends_with('\n') {
+                            result = line_pos + euclid::vec2(0.0, last.y);
+                        } else {
+                            result = line_pos + euclid::vec2(last.x + last.advance_x, 0.0);
+                        }
                     }
                 }
             },


### PR DESCRIPTION
It was on the wrong line if not a \n, and on the wrong position if a \n