### PR TITLE
Add support for reacting to dark/light mode theme changes with winit

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -44,7 +44,6 @@ once_cell = "1.5"
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
 winit = { version = "0.28.1", default-features = false }
-dark-light = "1.0"
 instant = "0.1"
 raw-window-handle = { version = "0.5", features = ["alloc"] }
 scopeguard =  { version = "1.1.0", default-features = false }
@@ -80,6 +79,9 @@ winapi = { version = "0.3", optional = true, features = ["dwrite"] }
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
 libc = { version = "0.2", optional = true }
 yeslogic-fontconfig-sys = { version = "3.2", optional = true }
+
+[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
+dark-light = "1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # For GL rendering

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -7,6 +7,8 @@ fn main() {
     // Setup cfg aliases
     cfg_aliases! {
        enable_skia_renderer: { any(feature = "renderer-winit-skia", feature = "renderer-winit-skia-opengl")},
+       // Upgrade to wasm once https://github.com/rust-windowing/winit/pull/2687 is merged & released.
+       use_winit_theme: { any(target_family = "windows", target_os = "macos", target_os = "ios") },
     }
 
     println!("cargo:rerun-if-env-changed=RUST_FONTCONFIG_DLOPEN");

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -49,6 +49,9 @@ pub trait WinitWindow: WindowAdapter {
     /// Returns true if request_redraw() was called since the last event loop iteration
     /// and resets the state back to false.
     fn take_pending_redraw(&self) -> bool;
+
+    /// Notify the window if the system theme has changed from light to dark mode
+    fn set_dark_color_scheme(&self, dark_mode: bool);
 }
 
 /// The Default, and the selection clippoard
@@ -434,6 +437,9 @@ fn process_window_event(
                 runtime_window.set_window_item_geometry(LogicalSize::new(size.width, size.height));
                 runtime_window.set_scale_factor(scale_factor as f32);
             }
+        }
+        WindowEvent::ThemeChanged(theme) => {
+            window.set_dark_color_scheme(theme == winit::window::Theme::Dark)
         }
         _ => {}
     }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -49,7 +49,7 @@ glutin = { version = "0.30", default-features = false, features = ["egl", "wgl"]
 winit = { version = "0.28.1", optional = true, default-features = false }
 
 [target.'cfg(target_family = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["dwrite", "d3d12", "dxgi", "dxgi1_2", "dxgi1_3", "dxgi1_4", "d3d12sdklayers", "synchapi", "winbase"] }
+winapi = { version = "0.3", features = ["impl-default", "dwrite", "d3d12", "dxgi", "dxgi1_2", "dxgi1_3", "dxgi1_4", "d3d12sdklayers", "synchapi", "winbase"] }
 skia-safe = { version = "0.58", features = ["d3d"] }
 wio = { version = "0.2.2" }
 


### PR DESCRIPTION
On macOS and Windows, use winit's `Window::theme()` instead of dark-light, to detect the theme.

Always react to WindowEvent::ThemeChange. It's delivered on macOS, Windows, and the web.