### PR TITLE
Speed up Linux builds

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -71,7 +71,6 @@ i-slint-renderer-femtovg = { version = "=1.0.0", path = "../../renderers/femtovg
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
 i-slint-renderer-femtovg = { version = "=1.0.0", path = "../../renderers/femtovg", optional = true, features = ["fontconfig"] }
-dark-light = "1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # For GL rendering

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -7,6 +7,5 @@ fn main() {
     // Setup cfg aliases
     cfg_aliases! {
        enable_skia_renderer: { any(feature = "renderer-winit-skia", feature = "renderer-winit-skia-opengl")},
-       use_winit_theme: { any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32") },
     }
 }

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -729,19 +729,14 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWind
         self.dark_color_scheme
             .get_or_init(|| {
                 Box::pin(Property::new({
-                    cfg_if::cfg_if! {
-                        if #[cfg(use_winit_theme)] {
-                            self.borrow_mapped_window().and_then(|mapped_window| {
-                                mapped_window
-                                    .winit_window
-                                    .theme()
-                                    .map(|theme| theme == winit::window::Theme::Dark)
-                            })
-                            .unwrap_or_default()
-                        } else {
-                            dark_light::detect() == dark_light::Mode::Dark
-                        }
-                    }
+                    self.borrow_mapped_window()
+                        .and_then(|mapped_window| {
+                            mapped_window
+                                .winit_window
+                                .theme()
+                                .map(|theme| theme == winit::window::Theme::Dark)
+                        })
+                        .unwrap_or_default()
                 }))
             })
             .as_ref()


### PR DESCRIPTION
Remove the dark-light dependency, as it significantly slows down the build on Linux. On Windows/Mac/Web it's not needed. On Linux Desktop, folks are likely going to have Qt installed - where this works - and on Embedded Linux the assumption is that it's not running as Linux Desktop.

On Linux the number of dependencies for `-p slint` goes down from 418 to
328. Build time on my machine goes from 1 minute down to ~50 seconds.