### PR TITLE
Add a feature to enable system fonts with the software renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this project are documented in this file.
    as well as support for the "primary" clipboard on X11 and wayland (select to copy, and middle click to paste)
  - C++ API to create `slint::Image` from raw pixel data
  - Software renderer: support for linear-gradients
+ - Added a `software-renderer-systemfonts` feature to the Rust crate, to enable the use of fonts from the operating system
+   for text rendering with the software renderer.
 
 ### Fixed
 

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -45,6 +45,9 @@ libm = ["i-slint-core/libm"]
 ## of the [log](https://crates.io/crates/log) crate instead of just `println!()`.
 log = ["dep:log"]
 
+## This feature enables the software renderer to pick up fonts from the operating system for text rendering.
+software-renderer-systemfonts = ["i-slint-core/software-renderer-systemfonts"]
+
 ## Slint uses internally some `thread_local` state.
 ##
 ## When the `std` feature is enabled, Slint can use [`std::thread_local!`], but when in a `#![no_std]`

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -24,7 +24,7 @@ x11 = ["winit/x11", "glutin/x11", "glutin/glx", "glutin-winit/x11", "glutin-wini
 renderer-winit-femtovg = ["i-slint-renderer-femtovg"]
 renderer-winit-skia = ["i-slint-renderer-skia"]
 renderer-winit-skia-opengl = ["renderer-winit-skia", "i-slint-renderer-skia/opengl"]
-renderer-winit-software = ["softbuffer", "imgref", "rgb", "i-slint-core/systemfonts"]
+renderer-winit-software = ["softbuffer", "imgref", "rgb", "i-slint-core/software-renderer-systemfonts"]
 rtti = ["i-slint-core/rtti"]
 default = []
 

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -31,7 +31,7 @@ unsafe-single-threaded = []
 
 unicode = ["unicode-script", "unicode-linebreak"]
 
-systemfonts = ["fontdb", "rustybuzz", "fontdue"]
+software-renderer-systemfonts = ["fontdb", "rustybuzz", "fontdue"]
 
 image-decoders = ["image", "clru"]
 svg = ["resvg", "usvg", "tiny-skia"]

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -344,7 +344,7 @@ impl Renderer for SoftwareRenderer {
         fonts::register_bitmap_font(font_data);
     }
 
-    #[cfg(feature = "systemfonts")]
+    #[cfg(feature = "software-renderer-systemfonts")]
     fn register_font_from_memory(
         &self,
         data: &'static [u8],
@@ -352,7 +352,7 @@ impl Renderer for SoftwareRenderer {
         self::fonts::systemfonts::register_font_from_memory(data)
     }
 
-    #[cfg(feature = "systemfonts")]
+    #[cfg(feature = "software-renderer-systemfonts")]
     fn register_font_from_path(
         &self,
         path: &std::path::Path,
@@ -1569,7 +1569,7 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
 
                 self.draw_text_paragraph(paragraph, physical_clip, offset, color);
             }
-            #[cfg(feature = "systemfonts")]
+            #[cfg(feature = "software-renderer-systemfonts")]
             fonts::Font::VectorFont(vf) => {
                 let layout = fonts::text_layout_for_font(&vf, &font_request, self.scale_factor);
 

--- a/internal/core/software_renderer/fonts.rs
+++ b/internal/core/software_renderer/fonts.rs
@@ -46,16 +46,16 @@ pub trait GlyphRenderer {
 pub(super) const DEFAULT_FONT_SIZE: LogicalLength = LogicalLength::new(12 as Coord);
 
 mod pixelfont;
-#[cfg(feature = "systemfonts")]
+#[cfg(feature = "software-renderer-systemfonts")]
 pub mod vectorfont;
 
-#[cfg(feature = "systemfonts")]
+#[cfg(feature = "software-renderer-systemfonts")]
 pub mod systemfonts;
 
 #[derive(derive_more::From)]
 pub enum Font {
     PixelFont(pixelfont::PixelFont),
-    #[cfg(feature = "systemfonts")]
+    #[cfg(feature = "software-renderer-systemfonts")]
     VectorFont(vectorfont::VectorFont),
 }
 
@@ -77,7 +77,7 @@ pub fn match_font(request: &FontRequest, scale_factor: ScaleFactor) -> Font {
     let font = match bitmap_font {
         Some(bitmap_font) => bitmap_font,
         None => {
-            #[cfg(feature = "systemfonts")]
+            #[cfg(feature = "software-renderer-systemfonts")]
             if let Some(vectorfont) = systemfonts::match_font(request, scale_factor) {
                 return vectorfont.into();
             }
@@ -86,9 +86,9 @@ pub fn match_font(request: &FontRequest, scale_factor: ScaleFactor) -> Font {
             {
                 fallback_bitmap_font
             } else {
-                #[cfg(feature = "systemfonts")]
+                #[cfg(feature = "software-renderer-systemfonts")]
                 return systemfonts::fallbackfont(request.pixel_size, scale_factor).into();
-                #[cfg(not(feature = "systemfonts"))]
+                #[cfg(not(feature = "software-renderer-systemfonts"))]
                 panic!("No font fallback found. The software renderer requires enabling the `EmbedForSoftwareRenderer` option when compiling slint files.")
             }
         }
@@ -140,7 +140,7 @@ pub fn text_size(
                 max_width.map(|max_width| (max_width.cast() * scale_factor).cast()),
             )
         }
-        #[cfg(feature = "systemfonts")]
+        #[cfg(feature = "software-renderer-systemfonts")]
         Font::VectorFont(vf) => {
             let layout = text_layout_for_font(&vf, &font_request, scale_factor);
             layout.text_size(


### PR DESCRIPTION
If we have a file system, then we can allow users of the software
renderer to support text rendering by from fonts served by the file
system.

cc #2100