### PR TITLE
Fix links on the intro page of the Slint Language Documentation

### DIFF
--- a/docs/langref/conf.py
+++ b/docs/langref/conf.py
@@ -33,7 +33,7 @@ version = "1.0.0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["myst_parser", "sphinx_markdown_tables"]
+extensions = ["myst_parser", "sphinx_markdown_tables", "sphinx.ext.autosectionlabel"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/langref/index.rst
+++ b/docs/langref/index.rst
@@ -17,8 +17,8 @@ The Slint design markup language describes extensible graphical user interfaces.
 - Declare animations on properties and states to make the user interface feel alive.
 - Build your own re-usable components and share them in `.slint` module files.
 - Define data structures and models and access them from programming languages.
-- Build highly customized user interfaces with the [builtin elements](builtin_elements.md)
-  and pre-built [widgets](widgets.md) provided.
+- Build highly customized user interfaces with the :ref:`builtin elements <Builtin Elements>`
+  and pre-built :ref:`widgets <Widgets>` provided.
 
 Architecture
 ------------


### PR DESCRIPTION
Use rst references instead of markdown syntax for links. Also enable the extension to generate targets automatically.