### PR TITLE
Improve LSP autocompletion formatting

### DIFF
--- a/tools/lsp/completion.rs
+++ b/tools/lsp/completion.rs
@@ -58,11 +58,11 @@ pub(crate) fn completion_at(
                             c.insert_text = Some(format!("{}: $1;", c.label))
                         }
                         Some(CompletionItemKind::METHOD) => {
-                            c.insert_text = Some(format!("{} => {{ $1 }}", c.label))
+                            c.insert_text = Some(format!("{} => {{$1}}", c.label))
                         }
                         Some(CompletionItemKind::CLASS) => {
                             available_types.insert(c.label.clone());
-                            c.insert_text = Some(format!("{} {{ $1 }}", c.label))
+                            c.insert_text = Some(format!("{} {{$1}}", c.label))
                         }
                         _ => (),
                     }


### PR DESCRIPTION
Spaces are no longer inserted around the cursor when user autocompletes a component or a callback handler.

These spaces result in a spurious whitespace and misaligned curly braces right after the user presses enter. Since most components and callback handlers are multi-line, this often requires additional keystrokes to fix.

The problem is present even in Slint's own examples. Such as examples/gallery/ui/side_bar.slint - line 127

![Code_CWESOzOZ3m](https://user-images.githubusercontent.com/104767/220758332-22b54e6d-5f02-4972-bb63-5bff7862ebe8.gif)
