### PR TITLE
language doc: Improve structure, fix links

### DIFF
--- a/docs/language/conf.py
+++ b/docs/language/conf.py
@@ -21,7 +21,7 @@ import textwrap
 
 # -- Project information -----------------------------------------------------
 
-project = "Slint Book"
+project = "Slint Language Documentation"
 copyright = "2023, info@slint-ui.com"
 author = "Slint Developers <info@slint-ui.com>"
 

--- a/docs/language/genindex.rst
+++ b/docs/language/genindex.rst
@@ -1,6 +1,0 @@
-.. Copyright © SixtyFPS GmbH <info@slint-ui.com>
-.. SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
-
-===========
-Slint Index
-===========

--- a/docs/language/index.rst
+++ b/docs/language/index.rst
@@ -28,7 +28,7 @@ is compiled to native code.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Slint Language Concepts
+   :caption: Concepts
 
    src/concepts/intro.md
    src/concepts/file.md
@@ -40,7 +40,7 @@ is compiled to native code.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Slint Language Reference
+   :caption: Reference
 
    src/comments.md
    src/identifiers.md
@@ -60,7 +60,7 @@ is compiled to native code.
 
 .. toctree::
    :maxdepth: 4
-   :caption: Slint Language Builtins
+   :caption: Builtins
 
    src/builtin_callbacks.md
    src/builtin_elements.md

--- a/docs/language/index.rst
+++ b/docs/language/index.rst
@@ -34,9 +34,9 @@ is compiled to native code.
    src/concepts/file.md
    src/concepts/layouting.md
    src/concepts/container.md
-   src/concepts/purity.md
    src/concepts/focus.md
    src/concepts/fonts.md
+   src/concepts/purity.md
 
 .. toctree::
    :maxdepth: 2

--- a/docs/language/src/brushes.md
+++ b/docs/language/src/brushes.md
@@ -1,4 +1,4 @@
-# Colors and Brushes
+## Colors and Brushes
 
 Color literals follow the syntax of CSS:
 
@@ -17,7 +17,7 @@ draw the outline.
 CSS Color names are only in scope in expressions of type `color` or `brush`. Otherwise, you can access
 colors from the `Colors` namespace.
 
-## Methods
+### Methods
 
 All colors and brushes define the following methods:
 
@@ -33,7 +33,7 @@ All colors and brushes define the following methods:
     For example if the factor is .5 (or for example 50%) the returned color is 50% darker. Negative factors
     increase the brightness.
 
-## Linear Gradients
+### Linear Gradients
 
 Linear gradients describe smooth, colorful surfaces. They're specified using an angle and a series of
 color stops. The colors will be linearly interpolated between the stops, aligned to an imaginary line
@@ -63,7 +63,7 @@ export component Example inherits Window {
 }
 ```
 
-## Radial Gradients
+### Radial Gradients
 
 Linear gradiants are like real gradiant but the colors is interpolated in a circle instead of
 along a line. To describe a readial gradiant, use the `@radial-gradient` macro with the following signature:

--- a/docs/language/src/brushes.md
+++ b/docs/language/src/brushes.md
@@ -42,7 +42,7 @@ that is rotated by the specified angle. This is called a linear gradient and is 
 
 **`@linear-gradient(angle, color percentage, color percentage, ...)`**
 
-The first parameter to the macro is an angle (see [Types](#types)). The gradient line's starting point
+The first parameter to the macro is an angle (see [Types](types.md)). The gradient line's starting point
 will be rotated by the specified value.
 
 Following the initial angle is one or multiple color stops, describe as a space separated pair of a

--- a/docs/language/src/builtin_elements.md
+++ b/docs/language/src/builtin_elements.md
@@ -506,7 +506,7 @@ The FocusScope exposes callback to intercept the pressed key when it has focus.
 
 The KeyEvent has a text property which is a character of the key entered.
 When a non-printable key is pressed, the character will be either a control character,
-or it will be mapped to a private unicode character. The mapping of these non-printable, special characters is available in the [`Key`](#key) namespace
+or it will be mapped to a private unicode character. The mapping of these non-printable, special characters is available in the [`Key`](builtin_namespaces.md#key) namespace
 
 ### Properties
 
@@ -685,7 +685,7 @@ When not part of a layout, its width or height defaults to 100% of the parent el
 -   **`read-only`** (_bool_): When set to `true`, text editing via keyboard and mouse is disabled but
     selecting text is still enabled as well as editing text programatically (default value: `false`)
 -   **`wrap`** (_enum [`TextWrap`](builtin_enums.md#textwrap)_): The way the text input wraps. Only makes sense when `single-line` is false. (default: no-wrap)
--   **`input-type`** (_enum [`InputType`](builtin_enums.md#InputType)_): The way to allow special input viewing properties such as password fields (default value: `text`).
+-   **`input-type`** (_enum [`InputType`](builtin_enums.md#inputtype)_): The way to allow special input viewing properties such as password fields (default value: `text`).
 
 ### Methods
 

--- a/docs/language/src/builtin_namespaces.md
+++ b/docs/language/src/builtin_namespaces.md
@@ -2,7 +2,7 @@
 
 The following namespaces provide access to common constants such as special keys or named colors.
 
-## `Colors` Namespace
+## `Colors`
 
 Use the colors namespace to select colors by their name. For example you can use `Colors.aquamarine` or `Colors.bisque`.
 The entire list of names is very long. You can find a complete list in the [CSS Specification](https://www.w3.org/TR/css-color-3/#svg-color).
@@ -19,9 +19,9 @@ The fourth value, if present, is an alpha value between 0 and 1.
 
 Unlike in CSS, the commas are mandatory.
 
-## `Key` Namespace
+## `Key`
 
-Use the constants in the `Key` namespace to handle pressing of keys that don't have a printable character. Check the value of [`KeyEvent`](#keyevent)'s `text` property
+Use the constants in the `Key` namespace to handle pressing of keys that don't have a printable character. Check the value of [`KeyEvent`](builtin_structs.md#keyevent)'s `text` property
 against the constants below.
 
 -   **`Backspace`**
@@ -78,7 +78,7 @@ against the constants below.
 -   **`Stop`**
 -   **`Menu`**
 
-## `Math` Namespace
+## `Math`
 
 These functions are available both in the global scope and in the `Math` namespace.
 

--- a/docs/language/src/callbacks.md
+++ b/docs/language/src/callbacks.md
@@ -46,7 +46,7 @@ export component Example inherits Rectangle {
 }
 ```
 
-## Callback aliases
+## Aliases
 
 It is possible to declare callback aliases in a similar way to two-way bindings:
 

--- a/docs/language/src/properties.md
+++ b/docs/language/src/properties.md
@@ -2,7 +2,7 @@
 
 All elements have properties. Built-in elements come with common properties such
 as color or dimensional properties. You can assign values or entire
-[expressions](#expressions) to them:
+[expressions](expressions.md) to them:
 
 ```slint,no-preview
 export component Example inherits Window {

--- a/docs/language/src/widgets.md
+++ b/docs/language/src/widgets.md
@@ -181,7 +181,7 @@ A widget used to enter a single line of text
 -   **`enabled`**: (_bool_): Defaults to true. When false, nothing can be entered
 -   **`read-only`** (_bool_): When set to `true`, text editing via keyboard and mouse is disabled but
     selecting text is still enabled as well as editing text programatically (default value: `false`)
--   **`input-type`** (_enum [`InputType`](builtin_enums.md#InputType)_): The way to allow special input viewing properties such as password fields (default value: `text`).
+-   **`input-type`** (_enum [`InputType`](builtin_enums.md#inputtype)_): The way to allow special input viewing properties such as password fields (default value: `text`).
 -   **`horizontal-alignment`** (_enum [`TextHorizontalAlignment`](builtin_enums.md#texthorizontalalignment)_): The horizontal alignment of the text.
 
 ### Callbacks


### PR DESCRIPTION
This re-organizes the structure a little to what I think makes more sense. There's more to be done I think, but this is a start.

Also this PR fixes a bunch of links, shortens titles, and removes the non-existent index.