### PR TITLE
Fix SLINT_EMBED_RESOURCES environment variable

### DIFF
--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -93,8 +93,8 @@ impl CompilerConfiguration {
                 panic!("SLINT_EMBED_RESOURCES has incorrect value. Must be either unset, 'true' or 'false'")
             });
             match var {
-                true => EmbedResourcesKind::OnlyBuiltinResources,
-                false => EmbedResourcesKind::EmbedAllResources,
+                true => EmbedResourcesKind::EmbedAllResources,
+                false => EmbedResourcesKind::OnlyBuiltinResources,
             }
         } else {
             match output_format {


### PR DESCRIPTION
The logic was inverted: Setting to true should embed everything, while false should be the same as if it's not set: Only embed built-in resources (as always).