### PR TITLE
Fix crash when a state condition is detected as constant

### DIFF
--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -411,7 +411,10 @@ pub fn for_each_const_properties(component: &Rc<Component>, mut f: impl FnMut(&E
                 e.borrow()
                     .property_declarations
                     .iter()
-                    .filter(|(_, x)| x.property_type.is_property_type())
+                    .filter(|(_, x)| {
+                        x.property_type.is_property_type() &&
+                            !matches!( &x.property_type, crate::langtype::Type::Struct { name: Some(name), .. } if name.ends_with("::StateInfo"))
+                    })
                     .map(|(k, _)| k.clone()),
             );
             match &e.clone().borrow().base_type {

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -668,7 +668,7 @@ unsafe fn mark_dependencies_dirty(dependencies: *mut DependencyListHead) {
 
         assert!(
             !core::ptr::eq(
-                binding.dependencies.as_ptr() as *const u32,
+                *(binding.dependencies.as_ptr() as *mut *const u32),
                 (&CONSTANT_PROPERTY_SENTINEL) as *const u32,
             ),
             "Const property marked as dirty"

--- a/tests/cases/crashes/issue_2274_const_state_crash.slint
+++ b/tests/cases/crashes/issue_2274_const_state_crash.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+export component TestCase  {
+    width: 300px;
+    height: 300px;
+    r:= Rectangle {
+       property <bool> scrolling: false;
+
+       states [
+           active when scrolling : {
+               opacity: 1;
+               out {
+                   animate opacity { duration: 800ms; }
+               }
+           }
+           inactive when !scrolling : {
+               opacity: 0;
+           }
+       ]
+   }
+
+   out property rect_opacity <=> r.opacity;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_rect_opacity(), 0.0);
+slint_testing::mock_elapsed_time(600);
+assert_eq!(instance.get_rect_opacity(), 0.0);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_rect_opacity(), 0.0);
+slint_testing::mock_elapsed_time(600);
+assert_eq(instance.get_rect_opacity(), 0.0);
+```
+
+*/


### PR DESCRIPTION
States are never constant because the generated state binding depend on the time as it register the time it was set for the pottential animation

Also adjust the assert so it assert correctly which the right message

Fixes: #2274