### PR TITLE
winit: Fix rendering when moving windows between monitors with different scale factor

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -431,11 +431,13 @@ fn process_window_event(
             };
             runtime_window.process_mouse_input(ev);
         }
-        WindowEvent::ScaleFactorChanged { scale_factor, new_inner_size: size } => {
+        WindowEvent::ScaleFactorChanged { scale_factor, new_inner_size } => {
             if std::env::var("SLINT_SCALE_FACTOR").is_err() {
-                let size = size.to_logical(scale_factor);
+                let size = new_inner_size.to_logical(scale_factor);
                 runtime_window.set_window_item_geometry(LogicalSize::new(size.width, size.height));
                 runtime_window.set_scale_factor(scale_factor as f32);
+                // Resize the underlying graphics surface
+                window.resize_event(*new_inner_size);
             }
         }
         WindowEvent::ThemeChanged(theme) => {


### PR DESCRIPTION
Adjust the size of the underlying graphics surface to avoid rendering artefacts.

Fixes #2282