### PR TITLE
printerdemo: Improve category labels' visibility in night mode

### DIFF
--- a/examples/printerdemo/ui/common.slint
+++ b/examples/printerdemo/ui/common.slint
@@ -18,7 +18,7 @@ export global DemoPalette  {
     out property <color> page-background-color: root.night-mode ? #122F7B : white;
 
     out property <color> text-foreground-color: root.night-mode ? #F4F6FF : black;
-    out property <color> secondary-foreground-color: #6C6E7A; // FIXME: night mode
+    out property <color> secondary-foreground-color: root.night-mode ? #C1C3CA : #6C6E7A;
 
     out property <color> printer-action-background-color: root.night-mode ? root.main-background : white;
     out property <color> printer-queue-item-background-color: root.page-background-color;

--- a/examples/printerdemo_mcu/ui/common.slint
+++ b/examples/printerdemo_mcu/ui/common.slint
@@ -18,7 +18,7 @@ export global DemoPalette  {
     out property <color> page-background-color: root.night-mode ? #122F7B : white;
 
     out property <color> text-foreground-color: root.night-mode ? #F4F6FF : black;
-    out property <color> secondary-foreground-color: #6C6E7A; // FIXME: night mode
+    out property <color> secondary-foreground-color: root.night-mode ? #C1C3CA : #6C6E7A;
 
     out property <color> printer-action-background-color: root.night-mode ? root.main-background : white;
     out property <color> printer-queue-item-background-color: root.page-background-color;


### PR DESCRIPTION
Current:
![image](https://user-images.githubusercontent.com/5221601/222023518-a6c86d9c-5ed9-494b-9247-820605e2b0e6.png)

With this change:
![image](https://user-images.githubusercontent.com/5221601/222023606-85d188fc-9d05-4897-a807-72150226962f.png)
