### PR TITLE
Fix panic when accessing a global from init that's not used otherwise

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2056,6 +2056,11 @@ pub fn visit_all_named_references(
             compo
         },
     );
+    component
+        .init_code
+        .borrow_mut()
+        .iter_mut()
+        .for_each(|expr| visit_named_references_in_expression(expr, vis));
 }
 
 /// Visit all expression in this component and sub components

--- a/tests/cases/callbacks/init.slint
+++ b/tests/cases/callbacks/init.slint
@@ -3,6 +3,8 @@
 
 // Verify that the init callback is invoked in the correct order
 
+import { ExportedGlobal } from "../../helper_components/export_globals.slint";
+
 export global InitOrder := {
     property <string> observed-order: "start";
 }
@@ -45,6 +47,7 @@ TestCase := Rectangle {
     height: 300phx;
     init => {
         InitOrder.observed-order += "|root";
+        ExportedGlobal.foo += 1;
     }
     Sub1 {
         init => {


### PR DESCRIPTION
Make sure to visit the named references in the init code, when collecting globals.

Fixes #2312