### PR TITLE
Remove dark-light dependency on the web

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -43,7 +43,7 @@ lyon_path = "1.0"
 once_cell = "1.5"
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
-winit = { version = "0.28.1", default-features = false }
+winit = { version = "0.28.2", default-features = false }
 instant = "0.1"
 raw-window-handle = { version = "0.5", features = ["alloc"] }
 scopeguard =  { version = "1.1.0", default-features = false }
@@ -79,8 +79,6 @@ winapi = { version = "0.3", optional = true, features = ["dwrite"] }
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
 libc = { version = "0.2", optional = true }
 yeslogic-fontconfig-sys = { version = "3.2", optional = true }
-
-[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 dark-light = "1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -7,8 +7,7 @@ fn main() {
     // Setup cfg aliases
     cfg_aliases! {
        enable_skia_renderer: { any(feature = "renderer-winit-skia", feature = "renderer-winit-skia-opengl")},
-       // Upgrade to wasm once https://github.com/rust-windowing/winit/pull/2687 is merged & released.
-       use_winit_theme: { any(target_family = "windows", target_os = "macos", target_os = "ios") },
+       use_winit_theme: { any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32") },
     }
 
     println!("cargo:rerun-if-env-changed=RUST_FONTCONFIG_DLOPEN");

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -46,7 +46,7 @@ glow = { version = "0.12" }
 unicode-segmentation = { version = "1.8.0" }
 
 glutin = { version = "0.30", default-features = false, features = ["egl", "wgl"] }
-winit = { version = "0.28.1", optional = true, default-features = false }
+winit = { version = "0.28.2", optional = true, default-features = false }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["impl-default", "dwrite", "d3d12", "dxgi", "dxgi1_2", "dxgi1_3", "dxgi1_4", "d3d12sdklayers", "synchapi", "winbase"] }


### PR DESCRIPTION
winit 0.28.2 was released today, which supports `Window::theme()` on the web.