### PR TITLE
Fix panic when invoking unused callback aliases with the interpreter

### DIFF
--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1280,23 +1280,26 @@ pub fn instantiate(
             if let Type::Function { .. } = property_type {
                 // function don't need initialization
             } else if let Type::Callback { .. } = property_type {
-                let expr = binding.expression.clone();
-                let component_type = component_type.clone();
-                if let Some(callback_offset) =
-                    component_type.custom_callbacks.get(prop_name).filter(|_| is_root)
-                {
-                    let callback = callback_offset.apply(instance_ref.as_ref());
-                    callback.set_handler(make_callback_eval_closure(expr, &self_weak));
-                } else {
-                    let item_within_component = &component_type.items[&elem.id];
-                    let item = item_within_component.item_from_component(instance_ref.as_ptr());
-                    if let Some(callback) = item_within_component.rtti.callbacks.get(prop_name) {
-                        callback.set_handler(
-                            item,
-                            Box::new(make_callback_eval_closure(expr, &self_weak)),
-                        );
+                if !matches!(binding.expression, Expression::Invalid) {
+                    let expr = binding.expression.clone();
+                    let component_type = component_type.clone();
+                    if let Some(callback_offset) =
+                        component_type.custom_callbacks.get(prop_name).filter(|_| is_root)
+                    {
+                        let callback = callback_offset.apply(instance_ref.as_ref());
+                        callback.set_handler(make_callback_eval_closure(expr, &self_weak));
                     } else {
-                        panic!("unknown callback {}", prop_name)
+                        let item_within_component = &component_type.items[&elem.id];
+                        let item = item_within_component.item_from_component(instance_ref.as_ptr());
+                        if let Some(callback) = item_within_component.rtti.callbacks.get(prop_name)
+                        {
+                            callback.set_handler(
+                                item,
+                                Box::new(make_callback_eval_closure(expr, &self_weak)),
+                            );
+                        } else {
+                            panic!("unknown callback {}", prop_name)
+                        }
                     }
                 }
             } else if let Some(PropertiesWithinComponent { offset, prop: prop_info, .. }) =

--- a/tests/cases/crashes/unused_callback_alias.slint
+++ b/tests/cases/crashes/unused_callback_alias.slint
@@ -1,0 +1,44 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+component TextInner inherits Text {
+    callback panic();
+    //init => { self.panic() }
+    text: "Click me";
+    TouchArea {
+        clicked => { root.panic(); }
+    }
+}
+
+component TextOuter {
+    callback panic <=> inner.panic;
+    inner := TextInner {
+        width: 100%;
+        height: 100%;
+    }
+}
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+    TextOuter { 
+    }
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 50., 50.);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 50., 50.);
+```
+
+```js
+var instance = new slint.TestCase();
+instance.send_mouse_click(50., 50.);
+```
+*/


### PR DESCRIPTION
Don't try to install a callback handler that captures an invalid expression. The llr pass has an invalid expression guard, and so does the rest of this handle_property_bindings_init callback.

Fixes #2319