### PR TITLE
Docs: Remove the sentence that say one need to use nightly

### DIFF
--- a/api/rs/slint/mcu.md
+++ b/api/rs/slint/mcu.md
@@ -17,14 +17,7 @@ and the curated list of [Awesome Embedded Rust](https://github.com/rust-embedded
 crates, tools, and training materials. These resources should guide you through the initial setup. Many include a "hello world" example
 to get started with your device.
 
-Slint requires a custom global memory allocator in a bare metal environment with `#![no_std]`.
-The Rust team hasn't yet stabilized this feature, so only the nightly version
-of the Rust compiler will support it. See
-[#51540](https://github.com/rust-lang/rust/issues/51540) or
-[#66741](https://github.com/rust-lang/rust/issues/66741) for tracking issues.
-
-Note: The rust compiler version 1.68 should have all features needed by Slint
-stabilized. We have not tested this setup extensively yet though.
+Slint requires a global memory allocator in a bare metal environment with `#![no_std]`.
 
 The following sections assume that your setup is complete and you have a non-graphical skeleton Rust program running on your MCU.
 


### PR DESCRIPTION
Rust 1.68 will be released by the time we do the next release