### PR TITLE
energy monitor: optimize memory usage for small size

### DIFF
--- a/examples/energy-monitor/ui/small_main.slint
+++ b/examples/energy-monitor/ui/small_main.slint
@@ -10,19 +10,20 @@ export component SmallMain {
         current-index <=> MenuOverviewAdapter.current-page;
         page-count: MenuOverviewAdapter.count;
 
-        Overview {
+        // check current-index for virtualization
+        if(i-navigation.current-index <= 1) : Overview {
             index: 0;
             current-index: i-navigation.current-index;
         }
-        Usage { 
+        if(i-navigation.current-index >= 0 && i-navigation.current-index <= 2) : Usage { 
             index: 1;
             current-index: i-navigation.current-index;
         }
-        Balance {
+        if(i-navigation.current-index >= 1 && i-navigation.current-index <= 3) : Balance {
             index: 2;
             current-index: i-navigation.current-index;
         }
-        Weather {
+        if(i-navigation.current-index >= 2 && i-navigation.current-index <= 4) : Weather {
             index: 3; 
             current-index: i-navigation.current-index;
         }
@@ -44,7 +45,7 @@ export component SmallMain {
         menu-width: parent.width - 8px;
         menu-height: parent.height - 14px;  
 
-        i-menu-page := MenuPage {
+        if(i-menu.open) : MenuPage {
             page-changed => {  
                 i-menu.hide();
             }
@@ -52,10 +53,6 @@ export component SmallMain {
             close => {
                 i-menu.hide();
             }
-        }
-
-        opend => {
-            i-menu-page.current-index = 0;
         }
     }
 }

--- a/examples/energy-monitor/ui/small_main.slint
+++ b/examples/energy-monitor/ui/small_main.slint
@@ -10,7 +10,7 @@ export component SmallMain {
         current-index <=> MenuOverviewAdapter.current-page;
         page-count: MenuOverviewAdapter.count;
 
-        // check current-index for virtualization
+        // check current-index to generate only displayed items
         if(i-navigation.current-index <= 1) : Overview {
             index: 0;
             current-index: i-navigation.current-index;

--- a/examples/energy-monitor/ui/widgets/menu.slint
+++ b/examples/energy-monitor/ui/widgets/menu.slint
@@ -5,7 +5,6 @@ import { Theme } from "../theme.slint";
 import { MenuButton } from "menu_button.slint";
 
 export component Menu {
-    private property <bool> open;
     private property <int> container-visibility;
 
     callback opend();
@@ -17,6 +16,7 @@ export component Menu {
     in property <bool> stays-open;
     in property <length> menu-width <=> i-menu-container.width;
     in property <length> menu-height <=> i-menu-container.height;
+    out property <bool> open;
 
     if(open) : Rectangle {
         background: Theme.palette.pure-black;


### PR DESCRIPTION
* reduce memory usage for the small size view
* use virtualization on navigation items
* generate menu content only if menu is opened
* works now again on the Pico