### PR TITLE
Fix doc rendering of remaining callbacks

### DIFF
--- a/docs/language/src/builtins/elements.md
+++ b/docs/language/src/builtins/elements.md
@@ -583,7 +583,7 @@ When not part of a layout, its width or height defaults to 100% of the parent el
 ### Callbacks
 
 -   **`accepted()`**: Invoked when enter key is pressed.
--   **`cursor-position-changed(_[`Point`](structs.md#point)_)**: The cursor was moved to the new (x, y) position.
+-   **`cursor-position-changed(`[_`Point`_](structs.md#point)`)`**: The cursor was moved to the new (x, y) position.
 -   **`edited()`**: Invoked when the text has changed because the user modified it.
 
 ### Example
@@ -677,7 +677,7 @@ When not part of a layout, its width or height default to 100% of the parent ele
 
 -   **`clicked()`**: Invoked when clicked: The mouse is pressed, then released on this element.
 -   **`moved()`**: The mouse has been moved. This will only be called if the mouse is also pressed.
--   **`pointer-event(`_[`PointerEvent`](structs.md#pointerevent)_`)`**: Invoked when a button was pressed or released.
+-   **`pointer-event(`[_`PointerEvent`_](structs.md#pointerevent)`)`**: Invoked when a button was pressed or released.
 
 ### Example
 

--- a/docs/language/src/builtins/widgets.md
+++ b/docs/language/src/builtins/widgets.md
@@ -102,7 +102,7 @@ A button that, when clicked, opens a popup to select a value.
 
 ### Callbacks
 
--   **`selected(_string_)`**: A value was selected from the combo box. The argument is the currently selected value.
+-   **`selected(`_`string`_`)`**: A value was selected from the combo box. The argument is the currently selected value.
 
 ### Example
 
@@ -171,8 +171,8 @@ a widget able to handle several lines of text.
 
 ### Callbacks
 
--   **`accepted(_string_)`**: Enter was pressed
--   **`edited(_string_)`**: Emitted when the text has changed because the user modified it
+-   **`accepted(`_`string`_`)`**: Enter was pressed
+-   **`edited(`_`string`_`)`**: Emitted when the text has changed because the user modified it
 
 ### Example
 
@@ -405,8 +405,8 @@ Same as [`ListView`](#listview), and in addition:
 
 ### Callbacks
 
--   **`sort-ascending(_int_)`**: Emitted if the model should be sorted by the given column in ascending order.
--   **`sort-descending(_int_)`**: Emitted if the model should be sorted by the given column in descending order.
+-   **`sort-ascending(`_`int`_`)`**: Emitted if the model should be sorted by the given column in ascending order.
+-   **`sort-descending(`_`int`_`)`**: Emitted if the model should be sorted by the given column in descending order.
 
 ### Example
 
@@ -501,7 +501,7 @@ shortcut will be implemented in a future version: <https://github.com/slint-ui/s
 
 ### Callbacks
 
--   **`edited(_string_)`**: Emitted when the text has changed because the user modified it
+-   **`edited(`_`string`_`)`**: Emitted when the text has changed because the user modified it
 
 ### Example
 


### PR DESCRIPTION
- Don't show a literal underscore.
- Close the code fence so that the markdown link turns into a real link.