### PR TITLE
swrenderer: fix image drawing when the image is not stretched to the geometry

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -211,9 +211,9 @@ pub fn register_window(id: winit::window::WindowId, window: Rc<dyn WinitWindow>)
 }
 
 pub fn unregister_window(id: winit::window::WindowId) {
-    ALL_WINDOWS.with(|windows| {
+    let _ = ALL_WINDOWS.try_with(|windows| {
         windows.borrow_mut().remove(&id);
-    })
+    });
 }
 
 fn window_by_id(id: winit::window::WindowId) -> Option<Rc<dyn WinitWindow>> {

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1013,6 +1013,7 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
 
         let renderer_clip_in_source_rect_space = (self.current_state.clip.cast()
             * self.scale_factor)
+            .translate(-image_fit_offset)
             .scale(1. / source_to_target_x, 1. / source_to_target_y);
         match image_inner {
             ImageInner::None => (),


### PR DESCRIPTION
This would cause some of the image to be drawn outside of the clip
region, which may even lead to panics

(Fix changing pages in the energy monitor demo)