### PR TITLE
stm32h7: Move peripherals initialization to the init() function

### DIFF
--- a/examples/mcu-board-support/stm32h735g.rs
+++ b/examples/mcu-board-support/stm32h735g.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;
+use core::cell::RefCell;
 pub use cortex_m_rt::entry;
 use defmt_rtt as _;
 use embedded_display_controller::{DisplayController, DisplayControllerLayer};
@@ -38,24 +39,24 @@ pub fn init() {
         .expect("backend already initialized");
 }
 
-#[derive(Default)]
-struct StmBackend {
-    window:
-        core::cell::RefCell<Option<Rc<slint::platform::software_renderer::MinimalSoftwareWindow>>>,
-    timer: once_cell::unsync::OnceCell<hal::timer::Timer<pac::TIM2>>,
-}
-impl slint::platform::Platform for StmBackend {
-    fn create_window_adapter(
-        &self,
-    ) -> Result<Rc<dyn slint::platform::WindowAdapter>, slint::PlatformError> {
-        let window = slint::platform::software_renderer::MinimalSoftwareWindow::new(
-            slint::platform::software_renderer::RepaintBufferType::SwappedBuffers,
-        );
-        self.window.replace(Some(window.clone()));
-        Ok(window)
-    }
+#[link_section = ".frame_buffer"]
+static mut FB1: [TargetPixel; DISPLAY_WIDTH * DISPLAY_HEIGHT] =
+    [software_renderer::Rgb565Pixel(0); DISPLAY_WIDTH * DISPLAY_HEIGHT];
+#[link_section = ".frame_buffer"]
+static mut FB2: [TargetPixel; DISPLAY_WIDTH * DISPLAY_HEIGHT] =
+    [software_renderer::Rgb565Pixel(0); DISPLAY_WIDTH * DISPLAY_HEIGHT];
 
-    fn run_event_loop(&self) -> Result<(), slint::PlatformError> {
+struct StmBackend {
+    window: RefCell<Option<Rc<slint::platform::software_renderer::MinimalSoftwareWindow>>>,
+    scb: RefCell<cortex_m::peripheral::SCB>,
+    delay: RefCell<stm32h7xx_hal::delay::Delay>,
+    timer: hal::timer::Timer<pac::TIM2>,
+    layer: RefCell<stm32h7xx_hal::ltdc::LtdcLayer1>,
+    touch_i2c: RefCell<stm32h7xx_hal::i2c::I2c<stm32h7xx_hal::device::I2C4>>,
+}
+
+impl Default for StmBackend {
+    fn default() -> Self {
         let mut cp = cortex_m::Peripherals::take().unwrap();
         let dp = pac::Peripherals::take().unwrap();
 
@@ -195,12 +196,6 @@ impl slint::platform::Platform for StmBackend {
         led_green.set_low();
         */
 
-        #[link_section = ".frame_buffer"]
-        static mut FB1: [TargetPixel; DISPLAY_WIDTH * DISPLAY_HEIGHT] =
-            [software_renderer::Rgb565Pixel(0); DISPLAY_WIDTH * DISPLAY_HEIGHT];
-        #[link_section = ".frame_buffer"]
-        static mut FB2: [TargetPixel; DISPLAY_WIDTH * DISPLAY_HEIGHT] =
-            [software_renderer::Rgb565Pixel(0); DISPLAY_WIDTH * DISPLAY_HEIGHT];
         // SAFETY the init function is only called once (as enforced by Peripherals::take)
         let (fb1, fb2) = unsafe { (&mut FB1, &mut FB2) };
 
@@ -285,18 +280,44 @@ impl slint::platform::Platform for StmBackend {
         // Init Timer
         let mut timer = dp.TIM2.tick_timer(10000.Hz(), ccdr.peripheral.TIM2, &ccdr.clocks);
         timer.listen(hal::timer::Event::TimeOut);
-        self.timer.set(timer).unwrap();
 
         // Init Touch screen
         let scl =
             gpiof.pf14.into_alternate::<4>().set_open_drain().speed(High).internal_pull_up(true);
         let sda =
             gpiof.pf15.into_alternate::<4>().set_open_drain().speed(High).internal_pull_up(true);
-        let mut touch_i2c =
-            dp.I2C4.i2c((scl, sda), 100u32.kHz(), ccdr.peripheral.I2C4, &ccdr.clocks);
+        let touch_i2c = dp.I2C4.i2c((scl, sda), 100u32.kHz(), ccdr.peripheral.I2C4, &ccdr.clocks);
 
-        let mut ft5336 = ft5336::Ft5336::new(&mut touch_i2c, 0x70 >> 1, &mut delay).unwrap();
+        Self {
+            window: RefCell::default(),
+            scb: RefCell::new(cp.SCB),
+            delay: RefCell::new(delay),
+            timer,
+            layer: RefCell::new(layer),
+            touch_i2c: RefCell::new(touch_i2c),
+        }
+    }
+}
+
+impl slint::platform::Platform for StmBackend {
+    fn create_window_adapter(
+        &self,
+    ) -> Result<Rc<dyn slint::platform::WindowAdapter>, slint::PlatformError> {
+        let window = slint::platform::software_renderer::MinimalSoftwareWindow::new(
+            slint::platform::software_renderer::RepaintBufferType::SwappedBuffers,
+        );
+        self.window.replace(Some(window.clone()));
+        Ok(window)
+    }
+
+    fn run_event_loop(&self) -> Result<(), slint::PlatformError> {
+        let mut touch_i2c = self.touch_i2c.borrow_mut();
+
+        let mut delay = self.delay.borrow_mut();
+        let mut ft5336 = ft5336::Ft5336::new(&mut *touch_i2c, 0x70 >> 1, &mut *delay).unwrap();
         ft5336.init(&mut touch_i2c);
+
+        let (fb1, fb2) = unsafe { (&mut FB1, &mut FB2) };
 
         let mut displayed_fb: &mut [TargetPixel] = fb1;
         let mut work_fb: &mut [TargetPixel] = fb2;
@@ -312,9 +333,10 @@ impl slint::platform::Platform for StmBackend {
 
             if let Some(window) = self.window.borrow().clone() {
                 window.draw_if_needed(|renderer| {
+                    let mut layer = self.layer.borrow_mut();
                     while layer.is_swap_pending() {}
                     renderer.render(work_fb, DISPLAY_WIDTH);
-                    cp.SCB.clean_dcache_by_slice(work_fb);
+                    self.scb.borrow_mut().clean_dcache_by_slice(work_fb);
                     // Safety: the frame buffer has the right size
                     unsafe { layer.swap_framebuffer(work_fb.as_ptr() as *const u8) };
                     // Swap the buffer pointer so we will work now on the second buffer
@@ -357,7 +379,7 @@ impl slint::platform::Platform for StmBackend {
 
     fn duration_since_start(&self) -> core::time::Duration {
         // FIXME! the timer can overflow
-        let val = self.timer.get().map_or(0, |t| t.counter() / 10);
+        let val = self.timer.counter() / 10;
         core::time::Duration::from_millis(val.into())
     }
 


### PR DESCRIPTION
This will allow for initializing other peripherals such as the RNG and using them before run_event_loop().