### PR TITLE
clippy: Disable more clippy warnings in generated rust code

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -303,6 +303,8 @@ pub fn generate(doc: &Document) -> TokenStream {
         #[allow(clippy::approx_constant)] // We may get those from .slint inputs!
         #[allow(clippy::eq_op)] // The generated code will compare/subtract/etc. equal values
         #[allow(clippy::cmp_owned)] // The generated code will do this
+        #[allow(clippy::redundant_clone)] // TODO: We clone properties more often then needed
+                                          // according to clippy!
         mod #compo_module {
             use slint::private_unstable_api::re_exports::*;
             #(#structs)*


### PR DESCRIPTION
`eq_op` is a clippy error by default, so we should make sure these never reach the users.

The others are just clippy warnings, so not that important.

I expect we need to discuss whether just suppressing the diagnostics is fine or whether we need to improve the code generator to not trigger these.