### PR TITLE
Avoid an empty forecast if there's an issue with the weather api

### DIFF
--- a/examples/energy-monitor/src/controllers/weather.rs
+++ b/examples/energy-monitor/src/controllers/weather.rs
@@ -32,15 +32,6 @@ async fn weather_worker_loop(window_weak: Weak<MainWindow>) {
         return;
     }
 
-    // place holders
-    window_weak
-        .upgrade_in_event_loop(|window| {
-            window.global::<WeatherAdapter>().set_week_model(
-                VecModel::from_slice(&vec![BarTileModel::default(); FORECAST_DAYS as usize]).into(),
-            );
-        })
-        .unwrap();
-
     let lat = lat();
     let long = long();
 
@@ -80,7 +71,9 @@ async fn weather_worker_loop(window_weak: Weak<MainWindow>) {
         }
     }
 
-    display_forecast(window_weak.clone(), forecast_days);
+    if !forecast_days.is_empty() {
+        display_forecast(window_weak.clone(), forecast_days);
+    }
 }
 
 async fn current_forecast(


### PR DESCRIPTION
In case we fail to retrieve a forecast, don't empty the current forecast shown. After all, this is just a demo, not a forecast that anybody should rely on. Therefore it's better to show something than have an empty widget :)