### PR TITLE
Wasm: don't print fake keys in input box

### DIFF
--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -219,5 +219,9 @@ fn event_text(e: &web_sys::KeyboardEvent) -> Option<SharedString> {
     }
     i_slint_common::for_each_special_keys!(check_non_printable_code);
 
-    return Some(key.into());
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(first_char) if chars.next().is_none() => Some(first_char.into()),
+        _ => None,
+    }
 }


### PR DESCRIPTION
We should only forward keys that are a single character. Other ones are just virtual keys that should't be processed.

This regressed in commit 32d2ba7

Fix #2327