### PR TITLE
Flickable: capture the event if the flickable can flick even if it is at the end

### DIFF
--- a/tests/cases/elements/flickable_in_flickable.slint
+++ b/tests/cases/elements/flickable_in_flickable.slint
@@ -56,11 +56,9 @@ instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPo
 assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 0.);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 198.0) });
-// (still not above threshold : 200 - 198 < threshold)
 assert_eq!(instance.get_inner_x(), 0.);
-assert_eq!(instance.get_outer_y(), 0.);
+assert_eq!(instance.get_outer_y(), 2.);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 170.0) });
-//instance.run();
 assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 30.);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(150.0, 150.0) });
@@ -80,17 +78,17 @@ slint_testing::mock_elapsed_time(1000);
 assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 500.);
 
-// Now, try to go to the right and the bottom at the same time: we should go to the right because that's the only option
+// Now, try to go to the right
 instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(100.0, 100.0), button: PointerEventButton::Left });
 slint_testing::mock_elapsed_time(16);
 assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 500.);
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(90.0, 90.0) });
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(90.0, 100.0) });
 slint_testing::mock_elapsed_time(120); // we need to wait enough because of the delay in the outer one
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(90.0, 90.0) });
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(90.0, 100.0) });
 assert_eq!(instance.get_inner_x(), 10.);
 assert_eq!(instance.get_outer_y(), 500.);
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(20.0, 90.0) });
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(20.0, 100.0) });
 slint_testing::mock_elapsed_time(16);
 assert_eq!(instance.get_inner_x(), 80.);
 assert_eq!(instance.get_outer_y(), 500.);


### PR DESCRIPTION
When scrolling the printer demo, I often end up closing or opening element i don't want to because we reached the end and therefore it is not scrolling and forwarding the event