### PR TITLE
online-editor: Add "open from Link"

### DIFF
--- a/tools/online_editor/src/index.ts
+++ b/tools/online_editor/src/index.ts
@@ -83,6 +83,25 @@ function create_style_menu(editor: EditorWidget): Menu {
     return menu;
 }
 
+function create_open_menu(editor: EditorWidget): Menu {
+    const menu = new Menu({ commands });
+    menu.title.label = "Open";
+
+    commands.addCommand("slint:open_url", {
+        label: "Open Slint file from URL",
+        iconClass: "fa fa-link",
+        mnemonic: 1,
+        execute: () => {
+            const url = prompt("Please enter the URL to open");
+            editor.open_url(url);
+        },
+    });
+
+    menu.addItem({ command: "slint:open_url" });
+
+    return menu;
+}
+
 function create_share_menu(editor: EditorWidget): Menu {
     const menu = new Menu({ commands });
     menu.title.label = "Share";
@@ -394,6 +413,7 @@ function setup(lsp: Lsp) {
 
     const menu_bar = new MenuBar();
     menu_bar.id = "menuBar";
+    menu_bar.addMenu(create_open_menu(editor));
     menu_bar.addMenu(create_share_menu(editor));
     menu_bar.addMenu(create_build_menu());
     menu_bar.addMenu(create_demo_menu(editor));


### PR DESCRIPTION
Unfortunately this is not as useful as I had hoped: Download from pretty much every git hoster fails due to CORS. The big exception is github.com, which has raw.githubusercontent.com to work around this problem.

I added automatic conversion to raw links (which allow CORS!) from "normal" links to make this easier to use. Gists work, too, provided you paste the link you get when clicking on "Raw" for the specific file of the gist you want to view.