### PR TITLE
Do not raise alerts abouts errors opening URLs the user did not explicitly open

### DIFF
--- a/tools/online_editor/src/index.ts
+++ b/tools/online_editor/src/index.ts
@@ -93,7 +93,7 @@ function create_open_menu(editor: EditorWidget): Menu {
         mnemonic: 1,
         execute: () => {
             const url = prompt("Please enter the URL to open");
-            editor.open_url(url);
+            editor.project_from_url(url);
         },
     });
 


### PR DESCRIPTION
Do not raise an alert for URLs the LSP/previewer requested. This prevents breaking the flow as the user types an import statement which the LSP/previewer then can not find.

Continue to alert about problems with URLs explicitly opened by the user. This is important so that we do not silently fail when trying to open a file from an URL.

Fixes: #2377