### PR TITLE
accessibility: Do not freeze trying to find items at position

### DIFF
--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -510,13 +510,9 @@ cpp! {{
 
         QAccessibleInterface *childAt(int x, int y) const override {
             for (int i = 0; i < childCount(); ++i)  {
-                auto c = child(i)->childAt(x, y);
-                if (c) return c;
-            }
-
-            auto r = rect();
-            if (r.contains(x, y)) {
-                return const_cast<QAccessibleInterface *>(static_cast<const QAccessibleInterface *>(this));
+                auto c = child(i);
+                auto r = c->rect();
+                if (r.contains(x, y)) return c;
             }
             return nullptr;
         }


### PR DESCRIPTION
Never return this from childAt(...), which seems obvious in retrospect. Qt loops till it childAt returns a nullptr, which my implementation never did as the leave-most element would return itself over and over again.

The screen reader on Linux works rather differently from the one on Windows... that never triggered this code path at all!

Fixes: #2195