### PR TITLE
Fix missing navigation sidebar in the slint language docs

### DIFF
--- a/docs/language/conf.py
+++ b/docs/language/conf.py
@@ -33,7 +33,7 @@ version = "1.0.0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["myst_parser", "sphinx_markdown_tables", "sphinx.ext.autosectionlabel"]
+extensions = ["myst_parser", "sphinx_markdown_tables", "sphinx.ext.autosectionlabel", "sphinxcontrib.jquery"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
The navigation sidebar requires jquery, which from Sphinx >= 6.0 needs to be bundled via a separate extension. In the C++ docs Sphinx remains at version 4.5.0 (due to exhale), but the slint language site doesn't need exhale (no C++) and thus Pip ends up picking a newer Sphinx version.