### PR TITLE
Fix missing window title when using Slint on Wayland

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -19,7 +19,7 @@ path = "lib.rs"
 # Note, these features need to be kept in sync (along with their defaults) in
 # the C++ crate's CMakeLists.txt
 [features]
-wayland = ["winit/wayland", "glutin/wayland", "glutin-winit/wayland", "copypasta/wayland", "i-slint-renderer-skia?/wayland"]
+wayland = ["winit/wayland", "winit/wayland-csd-adwaita", "glutin/wayland", "glutin-winit/wayland", "copypasta/wayland", "i-slint-renderer-skia?/wayland"]
 x11 = ["winit/x11", "glutin/x11", "glutin/glx", "glutin-winit/x11", "glutin-winit/glx", "copypasta/x11", "i-slint-renderer-skia?/x11"]
 renderer-winit-femtovg = ["i-slint-renderer-femtovg"]
 renderer-winit-skia = ["i-slint-renderer-skia"]


### PR DESCRIPTION
Winit defaults to sctk-adwaita with ab_glyph rendering. Pick the same default when the wayland feature is enabled on our end.

This is a stop-gap. In the future we should try to implement the window decoration rendering ourselves.

Fixes #2188