### PR TITLE
femtovg: Speedup TextEdit with many lines

### DIFF
--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -3,6 +3,7 @@
 
 // cspell:ignore Noto fontconfig
 
+use core::num::NonZeroUsize;
 use femtovg::TextContext;
 use i_slint_core::graphics::euclid;
 use i_slint_core::graphics::FontRequest;
@@ -249,10 +250,14 @@ impl Default for FontCache {
             })
             .collect();
 
+        let text_context = TextContext::default();
+        text_context.resize_shaped_words_cache(NonZeroUsize::new(10_000_000).unwrap());
+        text_context.resize_shaping_run_cache(NonZeroUsize::new(1_000_000).unwrap());
+
         Self {
             loaded_fonts: HashMap::new(),
             loaded_font_coverage: HashMap::new(),
-            text_context: Default::default(),
+            text_context,
             available_fonts: font_db,
             available_families,
             #[cfg(all(

--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -109,8 +109,11 @@ impl Font {
         let mut start = 0;
         if let Some(max_width) = max_width {
             while start < text.len() {
-                let index =
-                    self.text_context.break_text(max_width.get(), &text[start..], &paint).unwrap();
+                let max_line_index = text[start..].find('\n').map_or(text.len(), |i| i + 1 + start);
+                let index = self
+                    .text_context
+                    .break_text(max_width.get(), &text[start..max_line_index], &paint)
+                    .unwrap();
                 if index == 0 {
                     break;
                 }
@@ -708,7 +711,10 @@ pub(crate) fn layout_text_lines(
     let mut start = 0;
     'lines: while start < string.len() && y + font_height <= max_height {
         if wrap && (!elide || y + font_height * 2. <= max_height) {
-            let index = text_context.break_text(max_width.get(), &string[start..], paint).unwrap();
+            let max_line_index = string[start..].find('\n').map_or(string.len(), |i| i + 1 + start);
+            let index = text_context
+                .break_text(max_width.get(), &string[start..max_line_index], paint)
+                .unwrap();
             if index == 0 {
                 // FIXME the word is too big to be shown, but we should still break, ideally
                 break;


### PR DESCRIPTION
Increase the cache font cache size, otherwise, the cache is trashed with already moderate text size causing TextEdit to become quickly very slow (unusable) when the text becomes a bit big.

Also prevent to be O(N²) in the number of new lines while calling break_text.

Big text are still bit slow  slow but at least now it is usable