### PR TITLE
Fix compilation of Rust generated code when the generated code uses a return statement inside a block

### DIFF
--- a/tests/cases/expr/return.slint
+++ b/tests/cases/expr/return.slint
@@ -13,6 +13,14 @@ TestCase := Rectangle {
         return 100;
     }
 
+    in-out property <int> index: -1;
+    public function rust_fn_codegen_bug() -> bool {
+        return index != 0 && index != 1;
+    }
+    in-out property <bool> rust_binding_codegen_bug: {
+        return index != 42 && index != 42;
+    }
+
     callback test_signal;
     property <bool> block_signal;
     property <bool> signal_handled;


### PR DESCRIPTION
We cast the result of the body of functions or binding expressions to the target type via `as _`. When the code contains a return expression, that works fine, because `return`'s type is the never type, which can be coerced to a value of any type. However when the return statement is inside a sub-block, the type becomes `()`, for which the `as _` cast fails.

Work around this by attempting to detect the situation (return produces Type::Invalid) and omit the trailing cast.