### PR TITLE
Make it possible to use more than png and jpeg with Slint C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project are documented in this file.
  - Fluent style: Adjust disabled scrollbar background color
  - Fix panics in the compiler (#2312, #2274, #2319)
  - winit backend: Fix rendering when moving windows between monitors with different scale factor (#2282)
+ - C++: Support all image formats the Rust image-rs crate supports, not just png and jpeg.
 
 
 ## [0.3.5] - 2023-02-21

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -45,6 +45,8 @@ i-slint-renderer-skia = { version = "=1.0.0", path="../../internal/renderers/ski
 i-slint-core = { version = "=1.0.0", path="../../internal/core", features = ["ffi"] }
 slint-interpreter = { version = "=1.0.0", path="../../internal/interpreter", default-features = false, features = ["ffi", "compat-1-0"], optional = true }
 raw-window-handle = { version = "0.5", optional = true }
+# Enable image-rs' default features to make all image formats to C++ users
+image = { version = "0.24.0" }
 
 [build-dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Enable all the image formats the image-rs crate enables by default.