### PR TITLE
Fix support on GLX displays with FemtoVG

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -19,8 +19,8 @@ path = "lib.rs"
 # Note, these features need to be kept in sync (along with their defaults) in
 # the C++ crate's CMakeLists.txt
 [features]
-wayland = ["winit/wayland", "glutin/wayland", "copypasta/wayland", "i-slint-renderer-skia?/wayland"]
-x11 = ["winit/x11", "glutin/x11", "glutin/glx", "copypasta/x11", "i-slint-renderer-skia?/x11"]
+wayland = ["winit/wayland", "glutin/wayland", "glutin-winit/wayland", "copypasta/wayland", "i-slint-renderer-skia?/wayland"]
+x11 = ["winit/x11", "glutin/x11", "glutin/glx", "glutin-winit/x11", "glutin-winit/glx", "copypasta/x11", "i-slint-renderer-skia?/x11"]
 renderer-winit-femtovg = ["i-slint-renderer-femtovg"]
 renderer-winit-skia = ["i-slint-renderer-skia"]
 renderer-winit-skia-opengl = ["renderer-winit-skia", "i-slint-renderer-skia/opengl"]
@@ -66,6 +66,7 @@ send_wrapper = "0.6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.30", optional = true, default-features = false, features = ["egl", "wgl"] }
+glutin-winit = { version = "0.3.0", optional = true, default-features = false, features = ["egl", "wgl"] }
 i-slint-renderer-femtovg = { version = "=1.0.0", path = "../../renderers/femtovg", optional = true, features = ["diskfonts"] }
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -548,12 +548,8 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWind
                 window_builder.with_canvas(Some(canvas.clone()))
             };
 
-            let winit_window = Rc::new(crate::event_loop::with_window_target(|event_loop| {
-                window_builder.build(event_loop.event_loop_target()).unwrap()
-            }));
-
-            self_.renderer.show(
-                &winit_window,
+            let winit_window = self_.renderer.show(
+                window_builder,
                 #[cfg(target_arch = "wasm32")]
                 &self_.canvas_id,
             );

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -29,9 +29,9 @@ mod renderer {
 
         fn show(
             &self,
-            window: &Rc<winit::window::Window>,
+            window_builder: winit::window::WindowBuilder,
             #[cfg(target_arch = "wasm32")] canvas_id: &str,
-        );
+        ) -> Rc<winit::window::Window>;
         fn hide(&self);
 
         fn render(&self, size: PhysicalSize);

--- a/internal/backends/winit/renderer/femtovg/glcontext.rs
+++ b/internal/backends/winit/renderer/femtovg/glcontext.rs
@@ -114,6 +114,8 @@ impl OpenGLContext {
 
         let surface = unsafe { gl_display.create_window_surface(&gl_config, &attrs)? };
 
+        // Align the GL layer to the top-left, so that resizing only invalidates the bottom/right
+        // part of the window.
         #[cfg(target_os = "macos")]
         if let raw_window_handle::RawWindowHandle::AppKit(raw_window_handle::AppKitWindowHandle {
             ns_view,

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -17,9 +17,15 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
         Self { renderer: i_slint_renderer_skia::SkiaRenderer::new(window_adapter_weak.clone()) }
     }
 
-    fn show(&self, window: &Rc<winit::window::Window>) {
+    fn show(&self, window_builder: winit::window::WindowBuilder) -> Rc<winit::window::Window> {
+        let window = Rc::new(crate::event_loop::with_window_target(|event_loop| {
+            window_builder.build(event_loop.event_loop_target()).unwrap()
+        }));
+
         let size: winit::dpi::PhysicalSize<u32> = window.inner_size();
         self.renderer.show(window.clone(), PhysicalWindowSize::new(size.width, size.height));
+
+        window
     }
 
     fn hide(&self) {

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -28,10 +28,16 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
         }
     }
 
-    fn show(&self, window: &Rc<winit::window::Window>) {
+    fn show(&self, window_builder: winit::window::WindowBuilder) -> Rc<winit::window::Window> {
+        let window = Rc::new(crate::event_loop::with_window_target(|event_loop| {
+            window_builder.build(event_loop.event_loop_target()).unwrap()
+        }));
+
         *self.canvas.borrow_mut() = Some(unsafe {
             softbuffer::GraphicsContext::new(window.as_ref(), window.as_ref()).unwrap()
         });
+
+        window
     }
 
     fn hide(&self) {

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -240,6 +240,8 @@ impl OpenGLSurface {
             })
             .unwrap();
 
+        // Align the GL layer to the top-left, so that resizing only invalidates the bottom/right
+        // part of the window.
         #[cfg(target_os = "macos")]
         if let raw_window_handle::RawWindowHandle::AppKit(raw_window_handle::AppKitWindowHandle {
             ns_view,


### PR DESCRIPTION
In order for GLX support to work, we need to create the X11 window with the same visual as in the GLX configuration. That requires delaying the creation of the window.

This is done in four parts:

- The window builder is re-introduced in the winit backend create internal renderer interface.
- The glcontext helper code for wasm was moved into a separate function (less indentation).
- The loop over different display preferences was replaced with a preference to the "window system native GL interface" over EGL, which should achieve the same as the fix for #2162. Upstream glutin defaults to this and so do various downstream projects.
- Use glutin-winit for the actual display selection.

This covers the FemtoVG bits of #2269