### PR TITLE
Tweak AboutSlint

### DIFF
--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -87,7 +87,7 @@ export component TextEdit inherits ScrollView {
     }
 }
 
-export component AboutSlint inherits Rectangle {
+export component AboutSlint {
     VerticalLayout {
         padding: 12px;
         spacing: 8px;
@@ -101,6 +101,7 @@ export component AboutSlint inherits Rectangle {
         Image {
             source: StyleMetrics.dark-color-scheme ? @image-url("slint-logo-dark.svg") : @image-url("slint-logo-light.svg");
             preferred-width: 256px;
+            min-height: 48px;
         }
         Text {
             text: "Version 1.0.0\nhttps://slint-ui.com/";


### PR DESCRIPTION
- Don't publicly inherit from Rectangle - let's keep that as an implementation detail
- Provide a minimum height for the image, to avoid that it becomes invisible (for example in `export component Example { VerticalLayout { AboutSlint { } } }`