### PR TITLE
cmake: Fix SLINT_EMBED_RESOURCES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 
 project(Slint LANGUAGES CXX)
 

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(Slint HOMEPAGE_URL "https://slint-ui.com/" LANGUAGES CXX)
 
 include(FeatureSummary)

--- a/api/cpp/README.md
+++ b/api/cpp/README.md
@@ -25,7 +25,7 @@ First you need to install the prerequisites:
 
 * Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). Once this is done,
   you should have the ```rustc``` compiler and the ```cargo``` build system installed in your path.
-* **[cmake](https://cmake.org/download/)** (3.23 or newer)
+* **[cmake](https://cmake.org/download/)** (3.21 or newer)
 * A C++ compiler that supports C++20 (e.g., **MSVC 2019 16.6** on Windows)
 
 You can include Slint in your CMake project using CMake's `FetchContent` feature. Insert the following snippet into your

--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -6,8 +6,9 @@ set(DEFAULT_SLINT_EMBED_RESOURCES as-absolute-path CACHE STRING
     "The default resource embedding option to pass to the Slint compiler")
 set_property(CACHE DEFAULT_SLINT_EMBED_RESOURCES PROPERTY STRINGS
     "as-absolute-path" "embed-files" "embed-for-software-renderer")
-define_property(TARGET PROPERTY SLINT_EMBED_RESOURCES
-    INITIALIZE_FROM_VARIABLE DEFAULT_SLINT_EMBED_RESOURCES)
+## This requires CMake 3.23 and does not work in 3.26 AFAICT.
+# define_property(TARGET PROPERTY SLINT_EMBED_RESOURCES
+#     INITIALIZE_FROM_VARIABLE DEFAULT_SLINT_EMBED_RESOURCES)
 
 function(SLINT_TARGET_SOURCES target)
     foreach (it IN ITEMS ${ARGN})
@@ -15,7 +16,9 @@ function(SLINT_TARGET_SOURCES target)
         get_filename_component(_SLINT_ABSOLUTE ${it} REALPATH BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
         get_property(_SLINT_STYLE GLOBAL PROPERTY SLINT_STYLE)
 
-        set(embed "$<TARGET_PROPERTY:${target},SLINT_EMBED_RESOURCES>")
+        set(t_prop "$<TARGET_PROPERTY:${target},SLINT_EMBED_RESOURCES>")
+        set(global_fallback "${DEFAULT_SLINT_EMBED_RESOURCES}")
+        set(embed "$<IF:$<STREQUAL:${t_prop},>,${global_fallback},${t_prop}>")
 
         if(CMAKE_GENERATOR STREQUAL "Ninja")
             # this code is inspired from the llvm source

--- a/api/cpp/docs/cmake.md
+++ b/api/cpp/docs/cmake.md
@@ -42,7 +42,7 @@ First you need to install the prerequisites:
 * Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). If you already
   have Rust installed, make sure that it's at least version 1.60 or newer. You can check which version you have installed
   by running `rustc --version`. Once this is done, you should have the ```rustc``` compiler and the ```cargo``` build system installed in your path.
-* **[cmake](https://cmake.org/download/)** (3.23 or newer)
+* **[cmake](https://cmake.org/download/)** (3.21 or newer)
 * A C++ compiler that supports C++20 (e.g., **MSVC 2019 16.6** on Windows)
 
 You can include Slint into your CMake project using CMake's

--- a/api/cpp/docs/getting_started.md
+++ b/api/cpp/docs/getting_started.md
@@ -15,7 +15,7 @@ target in two steps:
 A minimal CMake `CMakeLists.txt` file looks like this:
 
 ```cmake
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(my_application LANGUAGES CXX)
 
 # Note: Use find_package(Slint) instead of the following three commands,

--- a/docs/tutorial/cpp/src/CMakeLists.txt
+++ b/docs/tutorial/cpp/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 
 if (NOT TARGET Slint::Slint)
     find_package(Slint REQUIRED)

--- a/docs/tutorial/cpp/src/getting_started.md
+++ b/docs/tutorial/cpp/src/getting_started.md
@@ -14,7 +14,7 @@ In a new directory, we create a new `CMakeLists.txt` file.
 
 ```cmake
 # CMakeLists.txt
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(memory LANGUAGES CXX)
 
 include(FetchContent)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(SlintExamples LANGUAGES CXX)
 
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")

--- a/examples/carousel/cpp/CMakeLists.txt
+++ b/examples/carousel/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(slint_cpp_carousel LANGUAGES CXX)
 
 if (NOT TARGET Slint::Slint)

--- a/examples/gallery/CMakeLists.txt
+++ b/examples/gallery/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(slint_cpp_gallery LANGUAGES CXX)
 
 if (NOT TARGET Slint::Slint)

--- a/examples/iot-dashboard/CMakeLists.txt
+++ b/examples/iot-dashboard/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(slint_cpp_iot_dashboard LANGUAGES CXX)
 
 if (NOT TARGET Slint::Slint)

--- a/examples/memory/CMakeLists.txt
+++ b/examples/memory/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(memory LANGUAGES CXX)
 
 if (NOT TARGET Slint::Slint)

--- a/examples/opengl_underlay/CMakeLists.txt
+++ b/examples/opengl_underlay/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(opengl_cpp_underlay LANGUAGES CXX)
 
 if (NOT TARGET Slint::Slint)

--- a/examples/printerdemo/cpp/CMakeLists.txt
+++ b/examples/printerdemo/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(slint_cpp_printer_demo LANGUAGES CXX)
 
 if (NOT TARGET Slint::Slint)

--- a/examples/printerdemo/cpp_interpreted/CMakeLists.txt
+++ b/examples/printerdemo/cpp_interpreted/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(slint_cpp_interpreter_printer_demo LANGUAGES CXX)
 
 if (NOT TARGET Slint::Slint)

--- a/examples/printerdemo_old/cpp/CMakeLists.txt
+++ b/examples/printerdemo_old/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 
 if (NOT TARGET Slint::Slint)
     find_package(Slint REQUIRED)

--- a/examples/qt_viewer/CMakeLists.txt
+++ b/examples/qt_viewer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(qt_viewer LANGUAGES CXX)
 
 if (NOT TARGET Slint::Slint)

--- a/examples/todo/cpp/CMakeLists.txt
+++ b/examples/todo/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint-ui.com>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.21)
 project(slint_cpp_todo LANGUAGES CXX)
 
 if (NOT TARGET Slint::Slint)


### PR DESCRIPTION
* Do not use the `initialize_from_variable` feature introduced in cmake 3.23. Users report this does not work for them.
* Reset minimum cmake required to version 3.21