### PR TITLE
Better error message when trying to use private property in native code

### DIFF
--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -60,6 +60,7 @@ pub struct GlobalComponent {
     pub init_values: Vec<Option<BindingExpression>>,
     pub const_properties: Vec<bool>,
     pub public_properties: PublicProperties,
+    pub private_properties: PrivateProperties,
     /// true if we should expose the global in the generated API
     pub exported: bool,
     /// The extra names under which this component should be accessible
@@ -305,6 +306,7 @@ pub struct ItemTree {
 #[derive(Debug)]
 pub struct PublicComponent {
     pub public_properties: PublicProperties,
+    pub private_properties: PrivateProperties,
     pub item_tree: ItemTree,
     pub sub_components: Vec<Rc<SubComponent>>,
     pub globals: Vec<GlobalComponent>,
@@ -375,3 +377,4 @@ pub struct PublicProperty {
     pub read_only: bool,
 }
 pub type PublicProperties = Vec<PublicProperty>;
+pub type PrivateProperties = Vec<(String, Type)>;

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -46,6 +46,7 @@ pub fn lower_to_item_tree(component: &Rc<Component>) -> PublicComponent {
             })
             .collect(),
         public_properties,
+        private_properties: component.private_properties.borrow().clone(),
     };
     super::optim_passes::run_passes(&root);
     root
@@ -655,6 +656,7 @@ fn lower_global(
         init_values,
         const_properties,
         public_properties,
+        private_properties: global.private_properties.borrow().clone(),
         exported: !global.exported_global_names.borrow().is_empty(),
         aliases: global.global_aliases(),
         is_builtin,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -287,6 +287,10 @@ pub struct Component {
     /// if it is a global singleton and exported.
     pub exported_global_names: RefCell<Vec<ExportedName>>,
 
+    /// The list of properties (name and type) declared as private in the component.
+    /// This is used to issue better error in the generated code if the property is used.
+    pub private_properties: RefCell<Vec<(String, Type)>>,
+
     /// This is the main entry point for the code generators. Such a component
     /// should have the full API, etc.
     pub is_root_component: Cell<bool>,

--- a/internal/compiler/passes/check_public_api.rs
+++ b/internal/compiler/passes/check_public_api.rs
@@ -27,7 +27,9 @@ fn check_public_api_component(root_component: &Rc<Component>, diag: &mut BuildDi
     let mut pa = root_elem.property_analysis.borrow_mut();
     root_elem.property_declarations.iter_mut().for_each(|(n, d)| {
         if d.property_type.ok_for_public_api() {
-            if d.visibility != PropertyVisibility::Private {
+            if d.visibility == PropertyVisibility::Private {
+                root_component.private_properties.borrow_mut().push((n.clone(), d.property_type.clone()));
+            } else {
                 d.expose_in_public_api = true;
                 if d.visibility != PropertyVisibility::Output {
                     pa.entry(n.to_string()).or_default().is_set = true;

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -308,6 +308,7 @@ fn duplicate_sub_component(
         popup_windows: Default::default(),
         exported_global_names: component_to_duplicate.exported_global_names.clone(),
         is_root_component: Default::default(),
+        private_properties: Default::default(),
     };
 
     let new_component = Rc::new(new_component);


### PR DESCRIPTION
If you declare a `property <int> foo;` in Slint, it will be private by default, and the getter/setter won't be generated, and it may be confusing as to why

With this change, it still generate private getter and setter so this gives a better hint what the problem is.

Replaces #2170

Example of error with C++
![image](https://user-images.githubusercontent.com/959326/227953643-9e5d40e9-4674-422f-a722-550bf4d9d39a.png)

Example of error with rust and build.rs
![image](https://user-images.githubusercontent.com/959326/227954468-8c3a1e62-7c73-4f63-bff6-dbd52b1454d4.png)

Example of error with Rust  macro (unfortunately a bit less useful)
![image](https://user-images.githubusercontent.com/959326/227953783-2717f80f-f2a8-47c3-860e-f032ee1e117b.png)

I'm not sure there is a way to test this