### PR TITLE
WIP: Layouting: by default, still expand a component without constraint to its parent

### DIFF
--- a/docs/language/src/concepts/layouting.md
+++ b/docs/language/src/concepts/layouting.md
@@ -81,7 +81,8 @@ don't have content and default to fill their parent element when they do not hav
 
 Layouts are also defaulting to fill the parent, regardless of their own preferred size.
 
-Other elements (including custom ones without base) default to using their preferred size.
+Other elements (including custom ones without base) default to using the preferred size or the
+minimum size (whichever is bigger).
 
 ### Preferred size
 
@@ -89,7 +90,8 @@ The preferred size of elements can be specified with the `preferred-width` and `
 
 When not explicitly set, the preferred size depends on the children, and is the preferred size of the
 child that has the bigger preferred size, whose `x` and `y` property are not set.
-The preferred size is therefore computed from the child to the parent, just like other constraints (maximum and minimum size), unless explicitly overwritten.
+The preferred size is therefore computed from the child to the parent, just like other
+constraints (maximum and minimum size), unless explicitly overwritten.
 
 A special case is to set the preferred size to be the size of the parent using `100%` as value.
 For example,this component will use the size of the parent by default:
@@ -101,6 +103,8 @@ component MyComponent {
     // ...
 }
 ```
+
+If there is nothing specified explicitly or implicitly, the default is 100%
 
 ## Automatic Placement Using Layouts
 

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -16,7 +16,9 @@ use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{
     BindingExpression, BuiltinFunction, Expression, NamedReference, Unit,
 };
-use crate::langtype::{BuiltinElement, DefaultSizeBinding, PropertyLookupResult, Type};
+use crate::langtype::{
+    BuiltinElement, DefaultSizeBinding, ElementType, PropertyLookupResult, Type,
+};
 use crate::layout::{implicit_layout_info_call, LayoutConstraints, Orientation};
 use crate::object_tree::{Component, ElementRc};
 use std::collections::HashMap;
@@ -51,12 +53,14 @@ pub fn default_geometry(root_component: &Rc<Component>, diag: &mut BuildDiagnost
             if let Some(parent) = parent {
                 match builtin_type.default_size_binding {
                     DefaultSizeBinding::None => {
-                        if elem.borrow().default_fill_parent.0 {
+                        let no_constraint_defined = !has_layout_info_prop(elem)
+                            && !LayoutConstraints::new(elem, diag).has_explicit_restrictions();
+                        if no_constraint_defined || elem.borrow().default_fill_parent.0 {
                             w100 |= make_default_100(elem, parent, "width");
                         } else {
                             make_default_implicit(elem, "width");
                         }
-                        if elem.borrow().default_fill_parent.1 {
+                        if no_constraint_defined || elem.borrow().default_fill_parent.1 {
                             h100 |= make_default_100(elem, parent, "height");
                         } else {
                             make_default_implicit(elem, "height");
@@ -438,5 +442,17 @@ fn adjust_image_clip_rect(elem: &ElementRc, builtin: &Rc<BuiltinElement>) {
             .set_binding_if_not_set("source-clip-width".into(), || make_expr("width", x));
         elem.borrow_mut()
             .set_binding_if_not_set("source-clip-height".into(), || make_expr("height", y));
+    }
+}
+
+// return true if the element of its component base has a layout_info_prop define
+fn has_layout_info_prop(elem: &ElementRc) -> bool {
+    if elem.borrow().layout_info_prop.is_some() {
+        return true;
+    };
+    if let ElementType::Component(base) = &elem.borrow().base_type {
+        has_layout_info_prop(&base.root_element)
+    } else {
+        false
     }
 }

--- a/tests/cases/layout/default_fill.slint
+++ b/tests/cases/layout/default_fill.slint
@@ -86,7 +86,7 @@ export component TestCase inherits Rectangle {
     out property <bool> elem2_ok: elem2.width == 300phx && elem2.height == 200phx;
     out property <bool> elem3_ok: elem3.width == 300phx && elem3.height == 200phx / 2;
     out property <bool> elem4_ok: elem4.width == 30phx && elem4.height == 200phx;
-    out property <bool> empty1_ok: empty1.width == 0px && empty1.height == 0px && empty1.p == 0px;
+    out property <bool> empty1_ok: empty1.width == 300phx && empty1.height == 200phx && empty1.p == 500phx;
     out property <bool> empty2_ok: empty2.width == 30px && empty2.height == 20px && empty2.p == 50px;
     out property <bool> wid1_ok: wid1.width == 22px && wid1.height == 32px;
     out property <bool> wid2_ok: wid2.width == 10px && wid2.height == 70px;


### PR DESCRIPTION
if there is no constraint set, still default to the parent size


This was just some idea to help fixing the energy monitor demo. But it actually doesn't fix it because the involved component still have a Layout in it which sets some constraints.