### PR TITLE
Polish the online editor welcome screen

### DIFF
--- a/tools/online_editor/src/welcome_widget.ts
+++ b/tools/online_editor/src/welcome_widget.ts
@@ -18,16 +18,16 @@ export class WelcomeWidget extends Widget {
       <a href="https://slint-ui.com/"><img src="https://slint-ui.com/logo/slint-logo-simple-light.svg"></a>
       </center>
 
-      <p>Slint is a GUI toolkit to develop native graphical user interface for embedded and desktop platform.
-      It does that using a domain specific language to describe the interface.
-      More information on <a href="https://slint-ui.com/">our Homepage</a></p>
+      <p>Slint is a toolkit to efficiently develop fluid graphical user interfaces for
+      any display: embedded devices and desktop applications. It comes with a custom markup language for user
+      interfaces. This language is easy to learn, to read and write, and provides a powerful way to describe
+      graphical elements. For more details, check out the <a href="https://slint-ui.com/docs/slint">Slint Language Documentation</a>.</p>
 
-      <p>This Online Editor is allowing to quickly try out Slint code snippets and see the preview.
-      It also enables feature like auto-completion, smart navigation, and such.</p>
-      <p>Similar features are also available in <a href="https://marketplace.visualstudio.com/items?itemName=Slint.slint">our Visual Studio Code extension</a>
-      (also available as a web extension for the <a href="https://vscode.dev/">web version of vscode</a>)</p>
+      <p>Use this Online Editor to quickly try out Slint code snippets, with auto-completion, code navigation, and live-preview.</p>
+      <p>The same features are also available in the <a href="https://marketplace.visualstudio.com/items?itemName=Slint.slint">Visual Studio Code extension</a>,
+      which runs in your local VS code installation as well as in the <a href="https://vscode.dev/">Visual Studio Code for the Web</a>.</p>
 
-      <p>This Online Editor is licensed under the GNU GPLv3. <a href="https://github.com/slint-ui/slint/tree/master/tools/online_editor">Sources</a>.
+      <p>This Online Editor is licensed under the GNU GPLv3. The source code is located in our <a href="https://github.com/slint-ui/slint/tree/master/tools/online_editor">GitHub repository</a>.
       </div>
       `;
         node.appendChild(content);


### PR DESCRIPTION
- To describe the product, use the same text as we use in the README and on the blog.
- Use complete sentences.
- Replace "XXX is allowing to YYY" with actionable "Use XXX to YYY".
- Connect to VS Code extension and web extension into one sentence, instead of a sub-sentence entirely in parentheses.
- Link to the Slint Language documentation, instead of the generic home page.