### PR TITLE
Femtovg: fix panic when rendering layer or shadow with negative size

### DIFF
--- a/internal/core/graphics/boxshadowcache.rs
+++ b/internal/core/graphics/boxshadowcache.rs
@@ -64,9 +64,14 @@ impl BoxShadowOptions {
         if color.alpha() == 0 {
             return None;
         }
+        let width = box_shadow.width() * scale_factor;
+        let height = box_shadow.height() * scale_factor;
+        if width.get() < 1. || height.get() < 1. {
+            return None;
+        }
         Some(Self {
-            width: box_shadow.width() * scale_factor,
-            height: box_shadow.height() * scale_factor,
+            width,
+            height,
             color,
             blur: box_shadow.blur() * scale_factor, // This effectively becomes the blur radius, so scale to physical pixels
             radius: box_shadow.border_radius() * scale_factor,

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1038,7 +1038,7 @@ impl<'a> GLItemRenderer<'a> {
 
         let cache_entry = self.graphics_cache.get_or_update_cache_entry(item_rc, || {
             ItemGraphicsCacheEntry::Texture({
-                let size = (layer_logical_size_fn() * self.scale_factor).ceil().cast();
+                let size = (layer_logical_size_fn() * self.scale_factor).ceil().try_cast()?;
 
                 let layer_image = existing_layer_texture
                     .and_then(|layer_texture| {


### PR DESCRIPTION
Reproducer:

```
export component Test {
    width: 200px;
    height: 200px;
    Rectangle {
        clip: true;
        background: red;
        border-radius: 5px;
        height: -12px; //<- negative size
        width: 100%;
        Rectangle { background: green; }
        drop-shadow-color: #8888;
        drop-shadow-blur: 5px;
    }
}

```