### PR TITLE
energy-monitor: Move the about page from the settings menu to a top-level page on its own

### DIFF
--- a/examples/energy-monitor/ui/mid_main.slint
+++ b/examples/energy-monitor/ui/mid_main.slint
@@ -6,10 +6,10 @@ import { Images } from "images.slint";
 import { Theme } from "theme.slint";
 import { Menu, PageScrollView, PageContainer } from "widgets/widgets.slint";
 import { MenuPage } from "pages/pages.slint";
-import { Balance, Overview, Usage, UsageAdapter, Weather } from "pages/pages.slint";
+import { Balance, Overview, Usage, UsageAdapter, Weather, About } from "pages/pages.slint";
 
 export component MidMain {
-    private property <int> page-count: 4;
+    private property <int> page-count: 5;
     private property <length> item-width: i-page-scroll-view.viewport-width / page-count;
     private property <length> max-viewport-x: i-page-scroll-view.width - i-page-scroll-view.viewport-width;
 
@@ -54,6 +54,14 @@ export component MidMain {
 
                     clicked => {
                         show-page(3);
+                    }
+                }
+
+                PageContainer {
+                    About {}
+
+                    clicked => {
+                        show-page(4);
                     }
                 }
 

--- a/examples/energy-monitor/ui/pages/about.slint
+++ b/examples/energy-monitor/ui/pages/about.slint
@@ -1,34 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import { Theme } from "../../theme.slint";
-import { Images } from "../../images.slint";
-import { Page } from "../page.slint";
-import { IconButton } from "../../widgets/widgets.slint";
+import { Theme } from "../theme.slint";
+import { Images } from "../images.slint";
+import { Page } from "page.slint";
+import { IconButton } from "../widgets/widgets.slint";
+import { GroupBox } from "../widgets/group_box.slint";
 
 export component About inherits Page {
-    callback back <=> i-back-button.clicked;
-
-    padding-left: 0;
-    padding-right: 0;
-
-    VerticalLayout {
-        padding-left: Theme.spaces.medium;
-        padding-right: Theme.spaces.medium;
-        padding-top: Theme.spaces.medium;
-        padding-bottom: Theme.spaces.large;
-        spacing: Theme.spaces.medium;
-
-        HorizontalLayout {
-            vertical-stretch: 0;
-            alignment: start;
-
-            i-back-button := IconButton {
-                horizontal-stretch: 0;
-                icon: Images.arrow-left;
-            }
-        }
-
+    GroupBox {
         VerticalLayout {
             vertical-stretch: 1;
             spacing: Theme.spaces.medium;

--- a/examples/energy-monitor/ui/pages/menu_page/menu_overview.slint
+++ b/examples/energy-monitor/ui/pages/menu_page/menu_overview.slint
@@ -3,7 +3,6 @@
 
 import { Theme } from "../../theme.slint";
 import { Images } from "../../images.slint";
-import { About } from "about.slint";
 import { Page } from "../page.slint";
 import { IconButton, ListView } from "../../widgets/widgets.slint";
 
@@ -13,6 +12,7 @@ export global MenuOverviewAdapter {
         { text: "Usage"},
         { text: "Balance"},
         { text: "Weather"},
+        { text: "About"},
     ];
     in-out property <int> current-page;
     out property <int> count: model.length;

--- a/examples/energy-monitor/ui/pages/menu_page/menu_page.slint
+++ b/examples/energy-monitor/ui/pages/menu_page/menu_page.slint
@@ -1,7 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-import { About } from "about.slint";
 import { MenuOverviewAdapter } from "menu_overview.slint";
 import { Settings, SettingsAdapter } from "settings.slint";
 import { Theme } from "../../theme.slint";
@@ -34,21 +33,8 @@ export component MenuPage {
         if(current-index == 0) : Settings {
             width: root.width;
 
-            show-about => {
-                current-index = 1;
-            }
-
             close => {
                 root.close();
-            }
-        }
-
-       if(current-index == 1) : About {
-            x: root.width;
-            width: root.width;
-
-            back => {
-                back();
             }
         }
 

--- a/examples/energy-monitor/ui/pages/menu_page/settings.slint
+++ b/examples/energy-monitor/ui/pages/menu_page/settings.slint
@@ -3,7 +3,6 @@
 
 import { Theme } from "../../theme.slint";
 import { Images } from "../../images.slint";
-import { About } from "about.slint";
 import { Page } from "../page.slint";
 import { IconButton, CheckBox, RadioButton, Switch, ScrollView, Item, ItemGroupBox } from "../../widgets/widgets.slint";
 
@@ -38,7 +37,6 @@ export global SettingsAdapter {
 
 export component Settings inherits Page {
     callback close();
-    callback show-about <=> i-back-button.clicked;
     callback check-radio-option <=> SettingsAdapter.check-radio-option;
 
     // fuctions
@@ -64,16 +62,6 @@ export component Settings inherits Page {
         padding-top: Theme.spaces.medium;
         padding-bottom: Theme.spaces.large;
         spacing: Theme.spaces.medium;
-
-        HorizontalLayout {
-            vertical-stretch: 0;
-            alignment: end;
-
-            i-back-button := IconButton {
-                horizontal-stretch: 0;
-                icon: Images.information;
-            }
-        }
 
         // spacer
         ScrollView {

--- a/examples/energy-monitor/ui/pages/pages.slint
+++ b/examples/energy-monitor/ui/pages/pages.slint
@@ -8,6 +8,7 @@ import { Weather, WeatherAdapter } from "weather.slint";
 import { Page } from "page.slint";
 import { Dashboard } from "dashboard.slint";
 import { MenuPage, MenuPageAdapter, MenuOverviewAdapter, SettingsAdapter } from "menu_page/menu_page.slint";
+import { About } from "about.slint";
 
 export { Balance, BalanceAdapter }
 export { Overview, OverviewAdapter }
@@ -16,3 +17,4 @@ export { Weather, WeatherAdapter }
 export { Page }
 export { Dashboard }
 export { MenuPage, MenuPageAdapter, MenuOverviewAdapter, SettingsAdapter }
+export { About }

--- a/examples/energy-monitor/ui/small_main.slint
+++ b/examples/energy-monitor/ui/small_main.slint
@@ -3,7 +3,7 @@
 
 import { Theme } from "theme.slint";
 import { Navigation, MenuButton, Menu, Value } from "widgets/widgets.slint";
-import { Balance, Overview, Usage, UsageAdapter, Weather, MenuPage, MenuOverviewAdapter } from "pages/pages.slint";
+import { Balance, Overview, Usage, UsageAdapter, Weather, MenuPage, MenuOverviewAdapter, About } from "pages/pages.slint";
 
 export component SmallMain {
     i-navigation := Navigation {
@@ -25,6 +25,10 @@ export component SmallMain {
         }
         if(i-navigation.current-index >= 2 && i-navigation.current-index <= 4 && !i-menu.open) : Weather {
             index: 3;
+            current-index: i-navigation.current-index;
+        }
+        if(i-navigation.current-index >= 3 && i-navigation.current-index <= 5 && !i-menu.open) : About {
+            index: 4;
             current-index: i-navigation.current-index;
         }
 


### PR DESCRIPTION
This way it's much more discoverable.