### PR TITLE
Add a title tag to SlintPad

### DIFF
--- a/tools/online_editor/index.html
+++ b/tools/online_editor/index.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="/styles/index.css" />
+        <title>SlintPad</title>
         <script id="inline-sw">
             if ("serviceWorker" in navigator) {
                 window.addEventListener("load", () => {


### PR DESCRIPTION
preview.html has one as well. This could be enhanced in the future to include a project name, etc. - but it's common to have a title nowadays instead of just the (long) url in the tab title in the browser :)