### PR TITLE
Fix the slide_puzzle canvas size on wasm

### DIFF
--- a/examples/slide_puzzle/Cargo.toml
+++ b/examples/slide_puzzle/Cargo.toml
@@ -30,6 +30,6 @@ slint-build = { path = "../../api/rs/build" }
 
 #wasm# [target.'cfg(target_arch = "wasm32")'.dependencies]
 #wasm# wasm-bindgen = { version = "0.2" }
-#wasm# web-sys = { version = "0.3", features=["console"] }
+#wasm# web-sys = { version = "0.3", features=["console", "Element", "HtmlCollection"] }
 #wasm# console_error_panic_hook = "0.1.5"
 #wasm# getrandom = { version = "0.2.2", features = ["js"] }


### PR DESCRIPTION
Since winit can't handle resize from the CSS or JS, work it around in the demo by calling set_size on the slint window.

Also fix slint_size panicking not working on wasm as the map_state was mutably borrowed by the set_size, and this may recurse into other functions (eg, draw) causing a panic. So don't keep the state borrowed when calling winit.

Another fix is fixing the initialization size of the window item when the initial size is set with set_size

Fixes #547