### PR TITLE
winit: Fix panic when creating a window with an empty layout

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -34,11 +34,6 @@ pub trait WinitWindow: WindowAdapter {
     fn draw(&self) -> Result<bool, i_slint_core::platform::PlatformError>;
     fn with_window_handle(&self, callback: &mut dyn FnMut(&winit::window::Window));
     fn winit_window(&self) -> Option<Rc<winit::window::Window>>;
-    fn constraints(&self) -> (corelib::layout::LayoutInfo, corelib::layout::LayoutInfo);
-    fn set_constraints(
-        &self,
-        constraints: (corelib::layout::LayoutInfo, corelib::layout::LayoutInfo),
-    );
 
     /// Called by the event loop when a WindowEvent::Resized is received.
     fn resize_event(

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -373,7 +373,9 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWind
                 } else {
                     None
                 };
-                let max_inner_size = if max_width < i32::MAX as f32 || max_height < i32::MAX as f32
+                let max_inner_size = if max_width > 0.
+                    && max_height > 0.
+                    && (max_width < i32::MAX as f32 || max_height < i32::MAX as f32)
                 {
                     Some(winit::dpi::PhysicalSize::new(
                         (max_width * sf).min(65535.),
@@ -524,7 +526,10 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWind
                         winit::dpi::LogicalSize::new(layout_info_h.min, layout_info_v.min),
                     ))
                 }
-                if layout_info_h.max < Coord::MAX || layout_info_v.max < Coord::MAX {
+                if layout_info_h.max > Coord::zero()
+                    && layout_info_v.max > Coord::zero()
+                    && (layout_info_h.max < Coord::MAX || layout_info_v.max < Coord::MAX)
+                {
                     window_builder = window_builder.with_max_inner_size(into_size(
                         winit::dpi::LogicalSize::new(layout_info_h.max, layout_info_v.max),
                     ))

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -368,24 +368,30 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWind
 
                 let sf = self.window.scale_factor();
 
-                winit_window.set_resizable(true);
-                winit_window.set_min_inner_size(if min_width > 0. || min_height > 0. {
+                let min_inner_size = if min_width > 0. || min_height > 0. {
                     Some(winit::dpi::PhysicalSize::new(min_width * sf, min_height * sf))
                 } else {
                     None
-                });
-                winit_window.set_max_inner_size(
-                    if max_width < i32::MAX as f32 || max_height < i32::MAX as f32 {
-                        Some(winit::dpi::PhysicalSize::new(
-                            (max_width * sf).min(65535.),
-                            (max_height * sf).min(65535.),
-                        ))
+                };
+                let max_inner_size = if max_width < i32::MAX as f32 || max_height < i32::MAX as f32
+                {
+                    Some(winit::dpi::PhysicalSize::new(
+                        (max_width * sf).min(65535.),
+                        (max_height * sf).min(65535.),
+                    ))
+                } else {
+                    None
+                };
+                winit_window.set_min_inner_size(min_inner_size);
+                winit_window.set_max_inner_size(max_inner_size);
+                self.set_constraints((constraints_horizontal, constraints_vertical));
+                winit_window.set_resizable(
+                    if min_inner_size.is_some() && max_inner_size.is_some() {
+                        min_width < max_width || min_height < max_height
                     } else {
-                        None
+                        true
                     },
                 );
-                self.set_constraints((constraints_horizontal, constraints_vertical));
-                winit_window.set_resizable(min_width < max_width || min_height < max_height);
 
                 #[cfg(target_arch = "wasm32")]
                 {

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -78,6 +78,33 @@ impl core::ops::Add for LayoutInfo {
     }
 }
 
+/// Returns the logical min and max sizes given the provided layout constraints.
+pub fn min_max_size_for_layout_constraints(
+    constraints_horizontal: LayoutInfo,
+    constraints_vertical: LayoutInfo,
+) -> (Option<crate::lengths::LogicalSize>, Option<crate::lengths::LogicalSize>) {
+    let min_width = constraints_horizontal.min.min(constraints_horizontal.max) as f32;
+    let min_height = constraints_vertical.min.min(constraints_vertical.max) as f32;
+    let max_width = constraints_horizontal.max.max(constraints_horizontal.min) as f32;
+    let max_height = constraints_vertical.max.max(constraints_vertical.min) as f32;
+
+    let min_size = if min_width > 0. || min_height > 0. {
+        Some(crate::lengths::LogicalSize::new(min_width, min_height))
+    } else {
+        None
+    };
+    let max_size = if max_width > 0.
+        && max_height > 0.
+        && (max_width < i32::MAX as f32 || max_height < i32::MAX as f32)
+    {
+        Some(crate::lengths::LogicalSize::new(max_width, max_height))
+    } else {
+        None
+    };
+
+    (min_size, max_size)
+}
+
 /// Implement a saturating_add version for both possible value of Coord.
 /// So that adding the max value does not overflow
 trait Saturating {


### PR DESCRIPTION
Avoid conveying a maximum size of 0x0, mark a window as explicitly resizable (true or false) only if a min/max constraint is actually set, and do these things consistently between show() and apply_geometry_constraint().

Fixes #2413