### PR TITLE
slintpad: Rework github access token management

### DIFF
--- a/tools/slintpad/src/dialogs.ts
+++ b/tools/slintpad/src/dialogs.ts
@@ -3,7 +3,9 @@
 
 export function modal_dialog(
     extra_class: string,
-    content: HTMLElement[],
+    content:
+        | HTMLElement[]
+        | ((_is_ready: (_ready: boolean) => void) => HTMLElement[]),
     trigger_text = "OK",
     trigger_action = () => {
         /**/
@@ -31,14 +33,24 @@ export function modal_dialog(
     const content_div = document.createElement("div");
     content_div.classList.add("dialog_content");
 
-    for (const c of content) {
+    const ok_button = document.createElement("button");
+
+    let content_elements: HTMLElement[] = [];
+    if (typeof content === "function") {
+        content_elements = content((r) => {
+            ok_button.disabled = !r;
+        });
+    } else {
+        content_elements = content;
+    }
+
+    for (const c of content_elements) {
         content_div.appendChild(c);
     }
 
     const button_div = document.createElement("div");
     button_div.classList.add("button_row");
 
-    const ok_button = document.createElement("button");
     ok_button.innerText = trigger_text;
     ok_button.onclick = () => {
         trigger_action();

--- a/tools/slintpad/src/github.ts
+++ b/tools/slintpad/src/github.ts
@@ -12,99 +12,100 @@ export function has_github_access_token(): boolean {
 }
 
 export async function manage_github_access(): Promise<boolean | null> {
-    let new_access_token = "";
-
-    const description_div = document.createElement("div");
-    description_div.classList.add("description_area");
-
-    const description = document.createElement("p");
-
-    description_div.appendChild(description);
-
-    const state_div = document.createElement("div");
-    state_div.classList.add("current_state");
-
-    const error_div = document.createElement("div");
-    error_div.classList.add("error_area");
-
-    const error = document.createElement("p");
-    error_div.appendChild(error);
-
-    const token_input = document.createElement("input");
-    token_input.classList.add("token_input");
-    token_input.type = "password";
-    token_input.autocomplete = "new-password";
-    token_input.onfocus = () => {
-        error.innerText = "";
-    };
-    token_input.onblur = () => {
-        set_state(token_input.value);
-    };
-
-    const logout_button = document.createElement("button");
-    logout_button.classList.add("logout");
-    logout_button.classList.add("button");
-
-    logout_button.innerText = "logout";
-
-    function set_state(nt: string) {
-        new_access_token = nt;
-        if (new_access_token !== "") {
-            if (
-                new_access_token.match(
-                    /^github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$/,
-                )
-            ) {
-                error.innerText = "";
-            } else {
-                new_access_token = "";
-                error.innerText = "Not a github personal access token";
-            }
-        }
-
-        if (new_access_token != "") {
-            token_input.placeholder = "<logged in>";
-            token_input.readOnly = true;
-            logout_button.disabled = false;
-
-            description.innerText =
-                "You currently have a github access token set up. Click on logout " +
-                "to invalidate the token.";
-        } else {
-            description.innerText =
-                "You currently do not have a github access token. Visit your github account, " +
-                "go to your settings, then developer settings and create a personal access " +
-                "token there with the permission to read and write Gists. Then paste it into " +
-                "the text field below.";
-            token_input.placeholder = "<logged out>";
-            token_input.readOnly = false;
-            logout_button.disabled = true;
-        }
-
-        token_input.value = "";
-    }
-
-    set_state(get_github_access_token() ?? "");
-
-    logout_button.onclick = () => {
-        set_state("");
-    };
-
-    state_div.appendChild(token_input);
-    state_div.appendChild(logout_button);
-
     return new Promise((resolve, _) => {
         let result: boolean | null = null;
 
+        let new_access_token = "";
+
+        const is_valid_token = (t: string) =>
+            t.match(/^github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$/);
+
         modal_dialog(
             "manage_github_dialog",
-            [description_div, state_div, error_div],
+            (ready_callback) => {
+                ready_callback(true);
+
+                const description_div = document.createElement("div");
+                description_div.classList.add("description_area");
+
+                const description = document.createElement("p");
+
+                description_div.appendChild(description);
+
+                const state_div = document.createElement("div");
+                state_div.classList.add("current_state");
+
+                const token_input = document.createElement("input");
+                token_input.classList.add("token_input");
+                token_input.type = "text";
+                token_input.pattern =
+                    "^github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$";
+                token_input.oninput = () => {
+                    const valid = token_input.reportValidity();
+                    ready_callback(valid);
+                    if (valid) {
+                        new_access_token = token_input.value;
+                    } else {
+                        new_access_token = "";
+                    }
+                };
+
+                const forget_button = document.createElement("button");
+                forget_button.classList.add("forget");
+                forget_button.classList.add("button");
+
+                forget_button.innerText = "forget token";
+
+                function set_state(nt: string) {
+                    new_access_token = nt;
+
+                    if (new_access_token != "") {
+                        token_input.style.display = "none";
+                        token_input.value = "";
+                        token_input.readOnly = true;
+                        forget_button.style.display = "block";
+
+                        description.innerText =
+                            "You have a github access token set up.";
+                    } else {
+                        description.innerHTML =
+                            "You have no github access token set up.<br>Visit your github account, " +
+                            "go to your settings, then developer settings and create a personal access " +
+                            "token there with the permission to read and write Gists. Then paste it into " +
+                            "the text field below.";
+                        token_input.placeholder =
+                            "Github personal access token";
+                        token_input.value = "";
+                        token_input.style.display = "block";
+                        token_input.readOnly = false;
+                        forget_button.style.display = "none";
+                    }
+
+                    token_input.value = "";
+                }
+
+                set_state(get_github_access_token() ?? "");
+
+                forget_button.onclick = () => {
+                    set_state("");
+                };
+
+                state_div.appendChild(token_input);
+                state_div.appendChild(forget_button);
+
+                return [description_div, state_div];
+            },
             "OK",
             () => {
-                localStorage.setItem(
-                    local_storage_key_github_token,
-                    new_access_token,
-                );
+                if (
+                    is_valid_token(new_access_token) ||
+                    new_access_token == ""
+                ) {
+                    localStorage.setItem(
+                        local_storage_key_github_token,
+                        new_access_token,
+                    );
+                }
                 result = has_github_access_token();
             },
             () => {

--- a/tools/slintpad/styles/content.css
+++ b/tools/slintpad/styles/content.css
@@ -211,17 +211,28 @@
 
 .dialog.manage_github_dialog .current_state {
     display: flex;
-    gap: 5px;
+}
+
+.dialog.manage_github_dialog .current_state .forget.button {
+    width: 100%;
 }
 
 .dialog.manage_github_dialog .current_state input {
     flex: 3 1 0;
 }
 
-.dialog.manage_github_dialog .error_area {
-    width: 300px;
-    height: 50px;
-    display: flex;
-    align-items: center;
-    color: var(--error-bg);
+.dialog.manage_github_dialog .current_state input + span {
+    padding-right: 30px;
+}
+
+.dialog.manage_github_dialog .current_state input:invalid + span::after {
+    position: absolute;
+    content: "✖";
+    padding-left: 5px;
+}
+
+.dialog.manage_github_dialog .current_state input:valid + span::after {
+    position: absolute;
+    content: "✓";
+    padding-left: 5px;
 }


### PR DESCRIPTION
Simplify the github token management dialog.

It's now either a plain text field or one big "forget" button. Imput validation is now to the browser.