### PR TITLE
slintpad: Reload if service worker does not come up

### DIFF
--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -36,6 +36,12 @@ import {
 
 function resolveControllerReady(resolve: () => void, count: number) {
     count += 1;
+    if (count >= 5) {
+        // Force a reload! We do not have any state yet, so we do not need to
+        // be creative to make the browser notice that we have an active
+        // service worker.
+        window.location.reload();
+    }
     if (navigator.serviceWorker.controller) {
         console.info(`Controller ready after ${count} attempts`);
         resolve();


### PR DESCRIPTION
Apparently browsers do not set a controlling service worker when force-reloading a page. Work around this by reloading the page.

We run into this issue only while the load screen is still up. So we have no state to take care of or anything, so go for the simplest thinkable "fix": Reload the page.