### PR TITLE
Qt TabWidget: clip the tabbar to fix the breeze style

### DIFF
--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -278,10 +278,13 @@ export component TabBarImpl {
     accessible-role: tab;
     accessible-delegate-focus: root.current;
 
-    HorizontalLayout {
-        spacing: 0px; // Qt renders Tabs next to each other and renders "spacing" as part of the tab itself
-        alignment: NativeStyleMetrics.tab-bar-alignment;
-        @children
+    Rectangle {
+        clip: true; // The breeze style draws outside of the tab bar, which is clip by default with Qt
+        HorizontalLayout {
+            spacing: 0px; // Qt renders Tabs next to each other and renders "spacing" as part of the tab itself
+            alignment: NativeStyleMetrics.tab-bar-alignment;
+            @children
+        }
     }
 
     fs := FocusScope {


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/959326/228892097-87405845-2c4d-4f7a-8271-117bae0155eb.png)


After: 
![image](https://user-images.githubusercontent.com/959326/228892429-b47e6cdf-cb68-44f4-aafd-45c9e8fc492d.png)
