### PR TITLE
macOS: Fix installed libslint_cpp.dylib containing references to the build directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented in this file.
 
 - Fixed compiler panic when binding `Path`'s `commands` property to the field of a model entry.
 
+### C++
+
+- macOS: Fixed `install_name` for `libslint_cpp.dylib` use `@rpath` instead of absolute paths to the build directory.
+
 ## [1.0.0] - 2023-04-03
 
 ### General

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ if (WIN32)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin/debug)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin/release)
+elseif(APPLE)
+    # On macOS, the slint_cpp.dylib's install_name uses @rpath. CMake doesn't set BUILD_RPATH for
+    # imported targets though, so include the directory here by hand in the rpath used to build binaries
+    # in the build tree (such as our examples or tests).
+    set(CMAKE_BUILD_RPATH ${CMAKE_BINARY_DIR}/api/cpp)
 endif()
 
 add_subdirectory(api/cpp/)

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 cmake_minimum_required(VERSION 3.21)
-project(Slint HOMEPAGE_URL "https://slint-ui.com/" LANGUAGES CXX)
+project(Slint HOMEPAGE_URL "https://slint-ui.com/" LANGUAGES CXX VERSION 1.0.0)
 
 include(FeatureSummary)
 include(CMakeDependentOption)
@@ -26,6 +26,14 @@ endif()
 
 corrosion_import_crate(MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../Cargo.toml"
     CRATES slint-cpp ${slint_compiler_crate})
+
+if (APPLE)
+    # corrosion could provide the Cargo.toml package version as a CMake target property.
+    corrosion_add_target_local_rustflags(slint-cpp -Clink-arg=-Wl,-install_name,@rpath/libslint_cpp.dylib,-current_version,${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR},-compatibility_version,${PROJECT_VERSION_MAJOR}.0)
+    # Set this one to false again explicitely because Corrosion will starting setting this property to true by default.
+    set_target_properties(slint-cpp-shared PROPERTIES IMPORTED_NO_SONAME 0)
+    set_target_properties(slint-cpp-shared PROPERTIES IMPORTED_SONAME libslint_cpp.dylib)
+endif()
 
 set_property(
     TARGET slint-cpp


### PR DESCRIPTION
Thanks to @jschwe, there's a way to instruct corrosion to supply link flags that set the install name and work around cargo/rustc behavior.

Fixes #2075