### PR TITLE
Fix loading of demos in SlintPad

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -61,7 +61,7 @@ imgref = { version = "1.6.1", optional = true }
 rgb = { version = "0.8.27", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3", features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent"] }
+web-sys = { version = "0.3", features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap"] }
 wasm-bindgen = { version = "0.2" }
 send_wrapper = "0.6.0"
 

--- a/internal/backends/winit/glwindow.rs
+++ b/internal/backends/winit/glwindow.rs
@@ -418,6 +418,28 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed for GLWind
                         winit_window.set_inner_size(new_size);
                     }
                 }
+
+                // Auto-resize to the preferred size if users (SlintPad) requests it
+                #[cfg(target_arch = "wasm32")]
+                {
+                    let canvas = self.renderer.html_canvas_element();
+
+                    if canvas
+                        .dataset()
+                        .get("slint-auto-resize-to-preferred")
+                        .and_then(|val_str| val_str.parse().ok())
+                        .unwrap_or_default()
+                    {
+                        let pref_width = constraints_horizontal.preferred_bounded();
+                        let pref_height = constraints_vertical.preferred_bounded();
+                        if pref_width > 0 as Coord || pref_height > 0 as Coord {
+                            winit_window.set_inner_size(winit::dpi::LogicalSize::new(
+                                pref_width,
+                                pref_height,
+                            ));
+                        };
+                    }
+                }
             }
         });
     }

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -214,6 +214,8 @@ export class PreviewWidget extends Widget {
         this.#canvas.style.position = "absolute";
         this.#canvas.style.imageRendering = "pixelated";
 
+        this.#canvas.dataset.slintAutoResizeToPreferred = "true";
+
         this.scrollNode.appendChild(this.#canvas);
 
         const update_scroll_size = () => {


### PR DESCRIPTION
Add a data attribute hack to force auto-resizing to the preferred size in SlintPad. Otherwise the initial size of the hello world will remain in effect when loading other demos.