### PR TITLE
Fix panic when binding Path's commands property to a model entry's field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### General
+
+- Fixed compiler panic when binding `Path`'s `commands` property to the field of a model entry.
+
 ## [1.0.0] - 2023-04-03
 
 ### General

--- a/internal/compiler/tests/syntax/basic/path_commands.slint
+++ b/internal/compiler/tests/syntax/basic/path_commands.slint
@@ -32,4 +32,9 @@ export TestCase := Rectangle {
     }
 
     Test2 {}
+
+    property <[{commands: string}]> model: [{commands: "M 0 0 L 0 100 A 1 1 0 0 0 100 100 L 100 0 Z"}];
+    for entry in model: Path {
+        commands: entry.commands; // Don't panic
+    }
 }


### PR DESCRIPTION
Fixes #2466