### PR TITLE
Fix the memory game tutorial

### DIFF
--- a/docs/tutorial/rust/src/main_multiple_tiles.rs
+++ b/docs/tutorial/rust/src/main_multiple_tiles.rs
@@ -64,7 +64,7 @@ export component MainWindow inherits Window {
     width: 326px;
     height: 326px;
 
-    property <[TileData]> memory_tiles: [
+    in property <[TileData]> memory_tiles: [
         { image: @image-url("icons/at.png") },
         { image: @image-url("icons/balance-scale.png") },
         { image: @image-url("icons/bicycle.png") },

--- a/docs/tutorial/rust/src/main_polishing_the_tile.rs
+++ b/docs/tutorial/rust/src/main_polishing_the_tile.rs
@@ -27,6 +27,7 @@ component MemoryTile inherits Rectangle {
     // Left curtain
     Rectangle {
         background: #193076;
+        x: 0px;
         width: open_curtain ? 0px : (parent.width / 2);
         height: parent.height;
         animate width { duration: 250ms; easing: ease-in; }


### PR DESCRIPTION
Fix mis-rendering and build problems in native code when accessing property that was unintentionally private.

Fixes #2496