### PR TITLE
LSP: don't throw a protocol error when a symbol can't be renamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented in this file.
 
 ### LSP
 
+- Don't throw a protocol error when using the rename function on a symbol that can't be renamed
 - Always auto-complete widgets from the style even if no widgets is imported
 - Don't auto-complete reserved properties or sub components for globals
 

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -567,7 +567,7 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
                 )));
             }
         };
-        Err("This symbol cannot be renamed. (Only element id can be renamed at the moment)".into())
+        Ok(None)
     });
 }
 


### PR DESCRIPTION
I misread the spec that we should return an error if there is nothing to rename. We should just return None instead.

This means that the editor will no longer show an error message when this happens (and also that we can rename stuff in rust code without getting annoying error)

Technicly, we could still return an error if the user tries to rename a property or so, but i don't think its worth it