### PR TITLE
Fix `FocusScope` click-to-focus behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented in this file.
 - Fixed compiler panic when binding `Path`'s `commands` property to the field of a model entry.
 - Qt renderer: Fixed support for horizontal alignment in `TextInput`.
 
+### Slint Language
+
+- Fixed parent `FocusScope` objects stealing the focus from inner `FocusScope`s when clicked.
+
 ### C++
 
 - macOS: Fixed `install_name` for `libslint_cpp.dylib` use `@rpath` instead of absolute paths to the build directory.

--- a/docs/language/src/builtins/elements.md
+++ b/docs/language/src/builtins/elements.md
@@ -143,6 +143,8 @@ or it will be mapped to a private unicode character. The mapping of these non-pr
 
 -   **`has-focus`** (_out_ _bool_): Is `true` when the element has keyboard
     focus.
+-   **`enabled`** (_in_ _bool_): When true, the `FocusScope` will make itself the focused element when clicked. Set this to false if you don't want the click-to-focus
+    behavior. A parent `FocusScope` will still receive key events from child `FocusScope`s that were rejected, even if `enabled` is set to false. (default value: true)
 
 ### Functions
 

--- a/docs/language/src/builtins/elements.md
+++ b/docs/language/src/builtins/elements.md
@@ -144,7 +144,8 @@ or it will be mapped to a private unicode character. The mapping of these non-pr
 -   **`has-focus`** (_out_ _bool_): Is `true` when the element has keyboard
     focus.
 -   **`enabled`** (_in_ _bool_): When true, the `FocusScope` will make itself the focused element when clicked. Set this to false if you don't want the click-to-focus
-    behavior. A parent `FocusScope` will still receive key events from child `FocusScope`s that were rejected, even if `enabled` is set to false. (default value: true)
+    behavior. Similarly, a disabled `FocusScope` does not accept the focus via tab focus traversal. A parent `FocusScope` will still receive key events from
+    child `FocusScope`s that were rejected, even if `enabled` is set to false. (default value: true)
 
 ### Functions
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -673,8 +673,10 @@ impl Item for FocusScope {
     ) -> InputEventResult {
         if self.enabled() && matches!(event, MouseEvent::Pressed { .. }) && !self.has_focus() {
             WindowInner::from_pub(window_adapter.window()).set_focus_item(self_rc);
+            InputEventResult::EventAccepted
+        } else {
+            InputEventResult::EventIgnored
         }
-        InputEventResult::EventIgnored
     }
 
     fn key_event(

--- a/tests/cases/focus/event_propagation_3.slint
+++ b/tests/cases/focus/event_propagation_3.slint
@@ -1,0 +1,40 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+export component TestCase inherits Window {
+    width: 100phx;
+    height: 100phx;
+    f1 := FocusScope {
+
+        f2 := FocusScope {
+            x: 50px;
+            y: 50px;
+            width: 50px;
+            height: 50px;
+        }
+    }
+
+    out property<bool> correct_focus: !f1.has_focus && f2.has_focus;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 70., 70.);
+assert!(instance.get_correct_focus());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 70., 70.);
+assert(instance.get_correct_focus());
+```
+
+```js
+var instance = new slint.TestCase();
+instance.send_mouse_click(70., 70.);
+assert(instance.correct_focus);
+
+```
+*/

--- a/tests/cases/focus/event_propagation_3.slint
+++ b/tests/cases/focus/event_propagation_3.slint
@@ -5,15 +5,26 @@ export component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
     f1 := FocusScope {
+        key-pressed(event) => {
+            r1 += event.text;
+            return accept;
+        }
 
         f2 := FocusScope {
             x: 50px;
             y: 50px;
             width: 50px;
             height: 50px;
+            key-pressed(event) => {
+                r2 += event.text;
+                reject
+            }
         }
     }
 
+    in property<bool> click-to-focus-on-outer <=> f1.enabled;
+    out property<string> r1;
+    out property<string> r2;
     out property<bool> correct_focus: !f1.has_focus && f2.has_focus;
 }
 
@@ -22,6 +33,10 @@ export component TestCase inherits Window {
 let instance = TestCase::new().unwrap();
 slint_testing::send_mouse_click(&instance, 70., 70.);
 assert!(instance.get_correct_focus());
+instance.set_click_to_focus_on_outer(false);
+slint_testing::send_keyboard_string_sequence(&instance, "ok");
+assert_eq!(instance.get_r1(), "ok");
+assert_eq!(instance.get_r2(), "ok");
 ```
 
 ```cpp
@@ -29,12 +44,19 @@ auto handle = TestCase::create();
 const TestCase &instance = *handle;
 slint_testing::send_mouse_click(&instance, 70., 70.);
 assert(instance.get_correct_focus());
+instance.set_click_to_focus_on_outer(false);
+slint_testing::send_keyboard_string_sequence(&instance, "ok");
+assert_eq(instance.get_r1(), "ok");
+assert_eq(instance.get_r2(), "ok");
 ```
 
 ```js
 var instance = new slint.TestCase();
 instance.send_mouse_click(70., 70.);
 assert(instance.correct_focus);
-
+instance.click_to_focus_on_outer = false;
+instance.send_keyboard_string_sequence("ok");
+assert.equal(instance.r1, "ok");
+assert.equal(instance.r2, "ok");
 ```
 */


### PR DESCRIPTION
Don't propagate the input event further. Also document the `enabled` property.