### PR TITLE
Fix visitation of init code

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -161,6 +161,16 @@ fn analyze_element(
     for (_, nr) in &elem.borrow().accessibility_props.0 {
         process_property(&PropertyPath::from(nr.clone()), context, reverse_aliases, diag);
     }
+
+    if let Some(component) = elem.borrow().enclosing_component.upgrade() {
+        if Rc::ptr_eq(&component.root_element, elem) {
+            for e in component.init_code.borrow().iter() {
+                recurse_expression(e, &mut |prop| {
+                    process_property(prop, context, reverse_aliases, diag);
+                });
+            }
+        }
+    }
 }
 
 #[derive(Copy, Clone, dm::BitAnd, dm::BitOr, dm::BitAndAssign, dm::BitOrAssign)]

--- a/tests/cases/callbacks/init_access_base_compo.slint
+++ b/tests/cases/callbacks/init_access_base_compo.slint
@@ -1,0 +1,102 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// Verify that properties in the base type can be accessed from init
+
+
+component Foo inherits VerticalLayout {
+    in property<string> title: "OK";
+    Text {
+        text <=> root.title;
+    }
+}
+
+component Base {
+    out property <string> title: "OK";
+}
+
+component CompoWithCond  {
+    callback dontcrash();
+    dontcrash() => {}
+    VerticalLayout {
+        if (true) : Rectangle {
+            init => {
+                dontcrash();
+            }
+        }
+    }
+}
+
+
+export component TestCase inherits Rectangle {
+    width: 300phx;
+    height: 300phx;
+
+    property <bool> ok;
+    out property <string> test1: "KO";
+    out property <string> test2: "KO";
+
+    in property <bool> cond: false;
+
+    if cond: Base {
+        init => {
+            root.test1 = self.title;
+        }
+    }
+
+    if cond: Foo {
+        init => {
+            root.test2 = self.title;
+        }
+    }
+
+    l := VerticalLayout {
+        CompoWithCond {
+            dontcrash => {
+                root.ok = true;
+            }
+        }
+    }
+    out property <bool> test: l.preferred-width == 0px && ok;
+}
+
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_test1(), "KO");
+assert_eq!(instance.get_test2(), "KO");
+assert!(instance.get_test());
+instance.set_cond(true);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_test1(), "OK");
+assert_eq!(instance.get_test2(), "OK");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_test1(), "KO");
+assert_eq(instance.get_test2(), "KO");
+assert(instance.get_test());
+instance.set_cond(true);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_test1(), "OK");
+assert_eq(instance.get_test2(), "OK");
+```
+
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.test1, "KO");
+assert.equal(instance.test2, "KO");
+assert(instance.test);
+instance.cond = true;
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.test1, "OK");
+assert.equal(instance.test2, "OK");
+```
+
+
+*/


### PR DESCRIPTION
This patch merges the changes from #2344 and #2491 and do some cleanup

In particular, this visit the init code expression when visiting the root element expression

Closes #2344
Closes #2491
Fixes #2487