### PR TITLE
winit: Fix dark color scheme not always being detected correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 
 - Fixed compiler panic when binding `Path`'s `commands` property to the field of a model entry.
 - Qt renderer: Fixed support for horizontal alignment in `TextInput`.
+- Winit backend: Fix detect of dark color scheme in some circumstances.
 
 ### C++
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -611,6 +611,14 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed
             runtime_window.set_window_item_geometry(LogicalSize::new(s.width, s.height));
             let id = winit_window.id();
 
+            // Make sure the dark color scheme property is up-to-date, as it may have been queried earlier when
+            // the window wasn't mapped yet.
+            if let Some(dark_color_scheme_prop) = self_.dark_color_scheme.get() {
+                if let Some(theme) = winit_window.theme() {
+                    dark_color_scheme_prop.as_ref().set(theme == winit::window::Theme::Dark)
+                }
+            }
+
             self_.map_state.replace(GraphicsWindowBackendState::Mapped(MappedWindow {
                 constraints: Default::default(),
                 winit_window,


### PR DESCRIPTION
When the dark color scheme was queried before the window was mapped, we'd initialize it to false, but never update it to the actual theme value.

Fixes #2533