### PR TITLE
Fix memory corruption when loading encoded embedded images in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project are documented in this file.
 ### C++
 
 - macOS: Fixed `install_name` for `libslint_cpp.dylib` use `@rpath` instead of absolute paths to the build directory.
+- Fixed memory corruption when embedding images in generated C++ code.
 
 ### LSP
 

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -75,7 +75,7 @@ fn default_config() -> cbindgen::Config {
         defines: [
             ("target_pointer_width = 64".into(), "SLINT_TARGET_64".into()),
             ("target_pointer_width = 32".into(), "SLINT_TARGET_32".into()),
-            ("target_arch = wasm32".into(), "SLINT_CPP_NEVER_WASM".into()), // Disable any wasm guarded code in C++, too - so that there are no gaps in enums.
+            ("target_arch = wasm32".into(), "SLINT_TARGET_WASM".into()), // Disable any wasm guarded code in C++, too - so that there are no gaps in enums.
         ]
         .iter()
         .cloned()

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -75,6 +75,7 @@ fn default_config() -> cbindgen::Config {
         defines: [
             ("target_pointer_width = 64".into(), "SLINT_TARGET_64".into()),
             ("target_pointer_width = 32".into(), "SLINT_TARGET_32".into()),
+            ("target_arch = wasm32".into(), "SLINT_CPP_NEVER_WASM".into()), // Disable any wasm guarded code in C++, too - so that there are no gaps in enums.
         ]
         .iter()
         .cloned()


### PR DESCRIPTION
The ImageCacheKey enum has a gap when not targeting wasm:

```
pub enum ImageCacheKey {
    /// This variant indicates that no image cache key can be created for the image.
    /// For example this is the case for programmatically created images.
    Invalid,
    /// The image is identified by its path on the file system.
    Path(SharedString),
    /// The image is identified by a URL.
    #[cfg(target_arch = "wasm32")]
    URL(SharedString),
    /// The image is identified by the static address of its encoded data.
    EmbeddedData(usize),
}
```

In the C++ generated header, that cfg was not mapped, and thus the URL variant was always there, while in a regular slint-cpp build it's not. Consequently tag value 2 in Rust was used to represent the EmbeddedData variant, while in the C++ generated code that become variant 3 and 2 was interpreted as a URL. So the receiving code in C++ tried to interpret the cache key as URL variant, while Rust created it as EmbeddedData.