### PR TITLE
Attempt at making the C/C++ ABI more robust

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -296,9 +296,9 @@ pub struct Window(pub(crate) WindowInner);
 pub enum CloseRequestResponse {
     /// The Window will be hidden (default action)
     #[default]
-    HideWindow,
+    HideWindow = 0,
     /// The close request is rejected and the window will be kept shown.
-    KeepWindowShown,
+    KeepWindowShown = 1,
 }
 
 impl Window {

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -275,18 +275,18 @@ pub struct StaticTextures {
 /// ImageCacheKey encapsulates the different ways of indexing images in the
 /// cache of decoded images.
 #[derive(PartialEq, Eq, Debug, Hash, Clone)]
-#[repr(C)]
+#[repr(u8)]
 pub enum ImageCacheKey {
     /// This variant indicates that no image cache key can be created for the image.
     /// For example this is the case for programmatically created images.
-    Invalid,
+    Invalid = 0,
     /// The image is identified by its path on the file system.
-    Path(SharedString),
+    Path(SharedString) = 1,
     /// The image is identified by a URL.
     #[cfg(target_arch = "wasm32")]
-    URL(SharedString),
+    URL(SharedString) = 2,
     /// The image is identified by the static address of its encoded data.
-    EmbeddedData(usize),
+    EmbeddedData(usize) = 3,
 }
 
 impl ImageCacheKey {

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -252,14 +252,14 @@ impl From<InternalKeyboardModifierState> for KeyboardModifiers {
 pub enum KeyEventType {
     /// A key on a keyboard was pressed.
     #[default]
-    KeyPressed,
+    KeyPressed = 0,
     /// A key on a keyboard was released.
-    KeyReleased,
+    KeyReleased = 1,
     /// The input method updates the currently composed text. The KeyEvent's text field is the pre-edit text and
     /// composition_selection specifies the placement of the cursor within the pre-edit text.
-    UpdateComposition,
+    UpdateComposition = 2,
     /// The input method replaces the currently composed text with the final result of the composition.
-    CommitComposition,
+    CommitComposition = 3,
 }
 
 /// Represents a key event sent by the windowing system.

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -83,38 +83,38 @@ impl From<LangType> for ValueType {
 /// ```
 #[derive(Clone, Default)]
 #[non_exhaustive]
-#[repr(C)]
+#[repr(u8)]
 pub enum Value {
     /// There is nothing in this value. That's the default.
     /// For example, a function that do not return a result would return a Value::Void
     #[default]
-    Void,
+    Void = 0,
     /// An `int` or a `float` (this is also used for unit based type such as `length` or `angle`)
-    Number(f64),
+    Number(f64) = 1,
     /// Correspond to the `string` type in .slint
-    String(SharedString),
+    String(SharedString) = 2,
     /// Correspond to the `bool` type in .slint
-    Bool(bool),
+    Bool(bool) = 3,
     /// Correspond to the `image` type in .slint
-    Image(Image),
+    Image(Image) = 4,
     /// A model (that includes array in .slint)
-    Model(ModelRc<Value>),
+    Model(ModelRc<Value>) = 5,
     /// An object
-    Struct(Struct),
+    Struct(Struct) = 6,
     /// Correspond to `brush` or `color` type in .slint.  For color, this is then a [`Brush::SolidColor`]
-    Brush(Brush),
+    Brush(Brush) = 7,
     #[doc(hidden)]
     /// The elements of a path
-    PathData(PathData),
+    PathData(PathData) = 8,
     #[doc(hidden)]
     /// An easing curve
-    EasingCurve(i_slint_core::animations::EasingCurve),
+    EasingCurve(i_slint_core::animations::EasingCurve) = 9,
     #[doc(hidden)]
     /// An enumeration, like `TextHorizontalAlignment::align_center`, represented by `("TextHorizontalAlignment", "align_center")`.
     /// FIXME: consider representing that with a number?
-    EnumerationValue(String, String),
+    EnumerationValue(String, String) = 10,
     #[doc(hidden)]
-    LayoutCache(SharedVector<f32>),
+    LayoutCache(SharedVector<f32>) = 11,
 }
 
 impl Value {


### PR DESCRIPTION
Even if there's a cfg gap in an enum (say cfg(feature = "svg")), don't let that break the ABI.

See also 004dce6c0bf3c6f49004d720a0b2ec0626a22962