### PR TITLE
Fix resizing a ListView to empty height would make all items invisible even if resized back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Fixed compiler panic when binding `Path`'s `commands` property to the field of a model entry.
 - Qt renderer: Fixed support for horizontal alignment in `TextInput`.
 - Winit backend: Fix detect of dark color scheme in some circumstances.
+- ListView: fix resizing a ListView to empty height would make all items invisible even if resized back (#2545)
 
 ### Slint Language
 
@@ -84,7 +85,7 @@ All notable changes to this project are documented in this file.
 ### Tooling
 
  - LSP: don't add spaces when auto-completing elements or callbacks, leads to better formatting.
- - The online editor was renamed to SlintPad. 
+ - The online editor was renamed to SlintPad.
 
 ## [0.3.5] - 2023-02-21
 

--- a/internal/compiler/widgets/native/std-widgets-impl.slint
+++ b/internal/compiler/widgets/native/std-widgets-impl.slint
@@ -14,6 +14,8 @@ export component ScrollView {
     in property <bool> enabled <=> native.enabled;
     preferred-height: 100%;
     preferred-width: 100%;
+    min-height: native.min-height;
+    min-width: native.min-width;
 
     native := NativeScrollView {
         vertical-max: fli.viewport-height > fli.height ? fli.viewport-height - fli.height : 0phx;

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1028,6 +1028,10 @@ impl<C: RepeatedComponent + 'static> Repeater<C> {
                 inner.components.splice(idx - new_offset.., core::iter::empty());
             }
 
+            if inner.components.is_empty() {
+                break;
+            }
+
             // Now re-compute some coordinate such a way that the scrollbar are adjusted.
             inner.cached_item_height = (y - new_offset_y) / inner.components.len() as Coord;
             inner.anchor_y = inner.cached_item_height * inner.offset as Coord;


### PR DESCRIPTION
The problem is that we would end up with a division by zero and the NaN value would be cached as the average item height

Fixes #2545