### PR TITLE
C++: Enable /bigobj by default when building with MSVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project are documented in this file.
 - Fixed memory corruption when embedding images in generated C++ code.
 - Add support for dispatching key press and key release events to `slint::Window` via `dispatch_key_*_event`. This replaces
   the experimental `slint::experimental::platform::WindowAdapter::dispatch_key_event`.
+- MSVC: /bigobj is enabled by default as compile option when linking against the Slint CMake target, removing the need
+  for users who run into linking issues to add that to their build.
 
 ### LSP
 

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -59,6 +59,9 @@ add_library(Slint INTERFACE)
 add_library(Slint::Slint ALIAS Slint)
 target_link_libraries(Slint INTERFACE slint-cpp)
 target_compile_features(Slint INTERFACE cxx_std_20)
+if (MSVC)
+    target_compile_options(Slint INTERFACE /bigobj)
+endif()
 
 function(define_cargo_feature cargo-feature description default)
     # turn foo-bar into SLINT_FEATURE_FOO_BAR

--- a/examples/gallery/CMakeLists.txt
+++ b/examples/gallery/CMakeLists.txt
@@ -9,8 +9,5 @@ if (NOT TARGET Slint::Slint)
 endif()
 
 add_executable(gallery main.cpp)
-if (MSVC)
-    target_compile_options(gallery PRIVATE /bigobj)
-endif()
 target_link_libraries(gallery PRIVATE Slint::Slint)
 slint_target_sources(gallery gallery.slint)

--- a/examples/printerdemo/cpp/CMakeLists.txt
+++ b/examples/printerdemo/cpp/CMakeLists.txt
@@ -9,8 +9,5 @@ if (NOT TARGET Slint::Slint)
 endif()
 
 add_executable(printerdemo main.cpp)
-if (MSVC)
-    target_compile_options(printerdemo PRIVATE /bigobj)
-endif()
 target_link_libraries(printerdemo PRIVATE Slint::Slint)
 slint_target_sources(printerdemo ../ui/printerdemo.slint)

--- a/examples/printerdemo/cpp_interpreted/CMakeLists.txt
+++ b/examples/printerdemo/cpp_interpreted/CMakeLists.txt
@@ -12,7 +12,4 @@ add_executable(printerdemo_interpreted main.cpp)
 target_compile_definitions(printerdemo_interpreted PRIVATE
    SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"
 )
-if (MSVC)
-    target_compile_options(printerdemo_interpreted PRIVATE /bigobj)
-endif()
 target_link_libraries(printerdemo_interpreted PRIVATE Slint::Slint)

--- a/examples/virtual_keyboard/cpp/CMakeLists.txt
+++ b/examples/virtual_keyboard/cpp/CMakeLists.txt
@@ -9,8 +9,5 @@ if (NOT TARGET Slint::Slint)
 endif()
 
 add_executable(virtual_keyboard main.cpp)
-if (MSVC)
-    target_compile_options(virtual_keyboard PRIVATE /bigobj)
-endif()
 target_link_libraries(virtual_keyboard PRIVATE Slint::Slint)
 slint_target_sources(virtual_keyboard ../ui/main_window.slint)


### PR DESCRIPTION
Large C++ files generated from .slint files can cause link problems with MSVC. When that happens, MSVC itself suggests /bigobj as remedy.

It's not apparent that there's a downside to using this option, apart from backwaords binary compatibility - which is not a concern for us.

The discussion at https://developercommunity.visualstudio.com/t/Enable-bigobj-by-default/1031214 suggests that perhaps this will become the default one day.

To simplify our examples and avoid users running into this, let's enable it by default.