### PR TITLE
Fixes access to unset layout property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - Qt renderer: Fixed support for horizontal alignment in `TextInput`.
 - Winit backend: Fix detect of dark color scheme in some circumstances.
 - ListView: fix resizing a ListView to empty height would make all items invisible even if resized back (#2545)
+- Fixed compiler panic when accessing unset layout properties such as `spacing` or `alignment` (#2483)
 
 ### Slint Language
 

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -115,14 +115,11 @@ fn lower_element_layout(
         let prev_base = std::mem::replace(&mut elem.base_type, type_register.empty_type());
         elem.default_fill_parent = (true, true);
         // Create fake properties for the layout properties
-        for p in elem.bindings.keys() {
-            if !elem.base_type.lookup_property(p).is_valid()
-                && !elem.property_declarations.contains_key(p)
+        for (p, ty) in prev_base.property_list() {
+            if !elem.base_type.lookup_property(&p).is_valid()
+                && !elem.property_declarations.contains_key(&p)
             {
-                let ty = prev_base.lookup_property(p).property_type;
-                if ty != Type::Invalid {
-                    elem.property_declarations.insert(p.into(), ty.into());
-                }
+                elem.property_declarations.insert(p, ty.into());
             }
         }
     }

--- a/tests/cases/issues/issue_2483_access_spacing.slint
+++ b/tests/cases/issues/issue_2483_access_spacing.slint
@@ -1,0 +1,17 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+export component Test {
+    VerticalLayout {
+        spacing: 1px;
+
+        hl :=  HorizontalLayout {
+            Rectangle {
+                // At first I didn't see that there was an HorizontalLayout in-between in the original code.
+                width: 20px - parent.spacing;
+            }
+        }
+
+        property <bool> test: hl.preferred-width == 20px;
+    }
+}


### PR DESCRIPTION
The previous code was only re-creating the layout properties for these that had a binding, but that wasn't done if the property was just read, leading to access to non-existing properties later.

Fixes #2483