### PR TITLE
C++ docs: Fix red warning in generated HTML for file and namespace listings

### DIFF
--- a/api/cpp/docs/conf.py
+++ b/api/cpp/docs/conf.py
@@ -58,6 +58,7 @@ exhale_args = {
     ),
     "doxygenStripFromPath": "..",
     "createTreeView": True,
+    "kindsWithContentsDirectives": [],
     "exhaleExecutesDoxygen": True,
     "exhaleDoxygenStdin": """INPUT = ../../api/cpp/include generated_include
 EXCLUDE_SYMBOLS = slint::cbindgen_private* slint::private_api* vtable* slint::testing* SLINT_DECL_ITEM


### PR DESCRIPTION
The Furo theme by default generates a "on this page" contents list in the right column. The breathe output for C++ namespace and file pages also includes a ::contents:: RST directive, to summarize the available headings. The duplication of these two is warned about by furo with a big fat red warning.

Solve this by not making breathe generate the contents directive anymore. According to

https://exhale.readthedocs.io/en/latest/reference/configs.html?highlight=contentsspecifier#exhale.configs.kindsWithContentsDirectives

it's by default used for files and namespace, so make it empty in our config.

Fixes #2505