### PR TITLE
Parser: don't have the whitespace as part of an expression

### DIFF
--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -32,6 +32,7 @@ use super::prelude::*;
 /// "foo".bar.something().something.xx({a: 1.foo}.a)
 /// ```
 pub fn parse_expression(p: &mut impl Parser) -> bool {
+    p.peek(); // consume the whitespace so they aren't part of the Expression node
     parse_expression_helper(p, OperatorPrecedence::Default)
 }
 

--- a/internal/compiler/tests/syntax/basic/assign.slint
+++ b/internal/compiler/tests/syntax/basic/assign.slint
@@ -14,7 +14,7 @@ export SuperSimple := Rectangle {
     }
     TouchArea {
         clicked => { x = "string"; }
-//                      ^error{Cannot convert string to length}
+//                       ^error{Cannot convert string to length}
     }
 
     TouchArea {

--- a/internal/compiler/tests/syntax/basic/condition_operator.slint
+++ b/internal/compiler/tests/syntax/basic/condition_operator.slint
@@ -7,17 +7,17 @@ export SuperSimple := Rectangle {
 //                     ^error{Cannot convert float to color}
 
     property<int> c3: area.pressed ? 123 : #456;
-//                                        ^error{Cannot convert color to float}
+//                                         ^error{Cannot convert color to float}
 //                   ^^error{Cannot convert void to int}
 
     property<int> c4: area.pressed ? 123ms : 123;
-//                                          ^error{Cannot convert float to duration}
+//                                           ^error{Cannot convert float to duration}
 //                   ^^error{Cannot convert void to int}
 
     property <length> c5: true ? 123px : 0;
 
     property<duration> c6: area.pressed ? 123ms : 123;
-//                                               ^error{Cannot convert float to duration}
+//                                                ^error{Cannot convert float to duration}
 //                        ^^error{Cannot convert void to duration}
 
 

--- a/internal/compiler/tests/syntax/basic/self_assign.slint
+++ b/internal/compiler/tests/syntax/basic/self_assign.slint
@@ -14,7 +14,7 @@ export SuperSimple := Rectangle {
     }
     TouchArea {
         clicked => { x += "string"; }
-//                       ^error{Cannot convert string to length}
+//                        ^error{Cannot convert string to length}
     }
 
     TouchArea {
@@ -59,7 +59,7 @@ export SuperSimple := Rectangle {
 
     TouchArea {
         clicked => { height /= height; }
-//                            ^error{Cannot convert length to float}
+//                             ^error{Cannot convert length to float}
     }
 
 }

--- a/internal/compiler/tests/syntax/lookup/for_lookup.slint
+++ b/internal/compiler/tests/syntax/lookup/for_lookup.slint
@@ -37,7 +37,7 @@ export Hello := Rectangle {
     }
 
     for aaa in aaa.text: Rectangle {
-//            ^error{Cannot convert string to model}
+//             ^error{Cannot convert string to model}
     }
 
     for plop in [1,2,3,4]: Rectangle {

--- a/internal/compiler/tests/syntax/lookup/if.slint
+++ b/internal/compiler/tests/syntax/lookup/if.slint
@@ -22,7 +22,7 @@ export Hello := Rectangle {
     }
 
     if (width) : Rectangle {
-//    ^error{Cannot convert length to bool}
+//     ^error{Cannot convert length to bool}
 
     }
 }

--- a/internal/compiler/tests/syntax/lookup/signal_arg.slint
+++ b/internal/compiler/tests/syntax/lookup/signal_arg.slint
@@ -11,7 +11,7 @@ export Xxx := Rectangle {
         x = 42 + hello;
 //      ^error{Assignment needs to be done on a property}
         width = x;
-//             ^error{Cannot convert string to length}
+//              ^error{Cannot convert string to length}
         plop("hallo", #fff, 42);
         plop("hallo", #fff,);
 //      ^error{The callback or function expects 3 arguments, but 2 are provided}

--- a/internal/compiler/tests/syntax/lookup/two_way_binding.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding.slint
@@ -18,7 +18,7 @@ export X := Rectangle {
     border_color <=> blue;
 //  ^error{The expression in a two way binding must be a property reference}
     border_width <=> 4px + 4px;
-//                  ^error{The expression in a two way binding must be a property reference}
+//                   ^error{The expression in a two way binding must be a property reference}
 
     xx := Rectangle {
         x: 42phx;

--- a/internal/compiler/tests/syntax/lookup/two_way_binding_infer.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding_infer.slint
@@ -15,7 +15,7 @@ export X := Rectangle {
 //  ^error{Could not infer type of property 'infer-error'}
     r := Rectangle {
         property infer_error <=> 0;
-//                              ^error{The expression in a two way binding must be a property reference}
+//                               ^error{The expression in a two way binding must be a property reference}
 //      ^^error{Could not infer type of property 'infer-error'}
     }
 

--- a/tools/fmt/fmt.rs
+++ b/tools/fmt/fmt.rs
@@ -902,6 +902,19 @@ A := B {
     }
 
     #[test]
+    fn if_element() {
+        assert_formatting(
+            r#"
+component A {  if condition : Text {  }  }
+        "#,
+            r#"
+component A {
+    if condition: Text { }
+}"#,
+        );
+    }
+
+    #[test]
     fn array() {
         assert_formatting(
             r#"


### PR DESCRIPTION
That way the error for an expression is at a better location, and this also prevent the formater that removes space in expressions to remove the spaces before the expression that shouldn't be removed