### PR TITLE
LSP: auto-complete at the document root

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -636,7 +636,9 @@ impl Parser for DefaultParser<'_> {
     fn consume(&mut self) {
         let t = self.current_token();
         self.builder.token(t.kind.into(), t.text.as_str());
-        self.cursor += 1;
+        if t.kind != SyntaxKind::Eof {
+            self.cursor += 1;
+        }
     }
 
     /// Reports an error at the current token location

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -19,33 +19,38 @@ pub fn parse_document(p: &mut impl Parser) -> bool {
     let mut p = p.start_node(SyntaxKind::Document);
 
     loop {
-        if p.nth(0).kind() == SyntaxKind::Eof {
+        if p.test(SyntaxKind::Eof) {
             return true;
         }
 
         match p.peek().as_str() {
             "export" => {
                 if !parse_export(&mut *p) {
-                    return false;
+                    break;
                 }
             }
             "import" => {
                 if !parse_import_specifier(&mut *p) {
-                    return false;
+                    break;
                 }
             }
             "struct" => {
                 if !parse_struct_declaration(&mut *p) {
-                    return false;
+                    break;
                 }
             }
             _ => {
                 if !parse_component(&mut *p) {
-                    return false;
+                    break;
                 }
             }
         }
     }
+    // Always consume the whole document
+    while !p.test(SyntaxKind::Eof) {
+        p.consume()
+    }
+    false
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -59,10 +59,16 @@ pub fn parse_document(p: &mut impl Parser) -> bool {
 /// component C inherits D { }
 /// ```
 pub fn parse_component(p: &mut impl Parser) -> bool {
-    let mut p = p.start_node(SyntaxKind::Component);
     let simple_component = p.nth(1).kind() == SyntaxKind::ColonEqual;
     let is_global = !simple_component && p.peek().as_str() == "global";
     let is_new_component = !simple_component && p.peek().as_str() == "component";
+    if !is_global && !simple_component && !is_new_component {
+        p.error(
+            "Parse error: expected a top-level item such as a component, a struct, or a global",
+        );
+        return false;
+    }
+    let mut p = p.start_node(SyntaxKind::Component);
     if is_global || is_new_component {
         p.consume();
     }

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -252,15 +252,15 @@ fn parse_import_specifier(p: &mut impl Parser) -> bool {
 /// { Type1 }
 /// { Type2, Type3 }
 /// { Type as Alias1, Type as AnotherAlias }
+/// {}
 /// ```
 fn parse_import_identifier_list(p: &mut impl Parser) -> bool {
     let mut p = p.start_node(SyntaxKind::ImportIdentifierList);
     if !p.expect(SyntaxKind::LBrace) {
         return false;
     }
-    if p.peek().kind == SyntaxKind::RBrace {
-        p.error("Import names are missing. Please specify which types you would like to import");
-        return false;
+    if p.test(SyntaxKind::RBrace) {
+        return true;
     }
     loop {
         parse_import_identifier(&mut *p);

--- a/internal/compiler/tests/syntax/imports/import_error2.slint
+++ b/internal/compiler/tests/syntax/imports/import_error2.slint
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 import { SomeRect } from "../../typeloader/incpath/local_helper_type.slint";
-import "../../typeloader/incpath/local_helper_type.slint";
-//     ^error{Import names are missing. Please specify which types you would like to import}
+  import "../../typeloader/incpath/local_helper_type.slint";
+//^error{Import names are missing. Please specify which types you would like to import}
 
 export X := Rectangle {
 

--- a/internal/compiler/tests/syntax/imports/import_errors.slint
+++ b/internal/compiler/tests/syntax/imports/import_errors.slint
@@ -10,8 +10,8 @@ import { NotExported } from "../../typeloader/incpath/local_helper_type.slint";
 import { Nothing } from "";
 //                      ^error{Unexpected empty import url}
 
-import "../../typeloader/incpath/local_helper_type.slint";
-//     ^error{Import names are missing. Please specify which types you would like to import}
+  import "../../typeloader/incpath/local_helper_type.slint";
+//^error{Import names are missing. Please specify which types you would like to import}
 
 import "myimage.png";
 //     ^error{Unsupported foreign import "myimage.png"}

--- a/internal/compiler/tests/syntax/imports/import_parse_error5.slint
+++ b/internal/compiler/tests/syntax/imports/import_parse_error5.slint
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 import { NotExported } from "../../typeloader/incpath/local_helper_type.slint";
-import { } from "../../typeloader/incpath/local_helper_type.slint";
-//       ^error{Import names are missing. Please specify which types you would like to import}
+//                          ^error{No exported type called 'NotExported' found}
+  import { } from "../../typeloader/incpath/local_helper_type.slint";
+//^error{Import names are missing. Please specify which types you would like to import}
 
 export X := Rectangle {
 

--- a/internal/compiler/tests/syntax/parse_error/export0.slint
+++ b/internal/compiler/tests/syntax/parse_error/export0.slint
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
 export -
-//     ^error{expected Identifier}
+//     ^error{Parse error: expected a top-level item such as a component, a struct, or a global}

--- a/internal/compiler/tests/syntax/parse_error/if0.slint
+++ b/internal/compiler/tests/syntax/parse_error/if0.slint
@@ -7,4 +7,4 @@ export TestCase := Window {
     //  ^error{expected ':'}
     //  ^^error{Parse error}
   }
-//^error{expected Identifier}
+//^error{Parse error: expected a top-level item such as a component, a struct, or a global}

--- a/internal/compiler/tests/syntax/parse_error/state1.slint
+++ b/internal/compiler/tests/syntax/parse_error/state1.slint
@@ -14,7 +14,7 @@ export TestCase := Rectangle {
             border: 42;
         }
     ]
-//  ^error{expected Identifier}
+//  ^error{Parse error: expected a top-level item such as a component, a struct, or a global}
 
     transitions [
         in pressed: {

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -174,7 +174,7 @@ impl TypeLoader {
                                 if imported_types.peek().is_some() {
                                     Self::register_imported_types(doc, &import, imported_types, registry_to_populate, &mut state.diag);
                                 } else {
-                                    state.diag.push_error("Import names are missing. Please specify which types you would like to import".into(), &import.import_uri_token);
+                                    state.diag.push_error("Import names are missing. Please specify which types you would like to import".into(), &import.import_uri_token.parent());
                                 }
                                 None
                             }

--- a/tools/fmt/fmt.rs
+++ b/tools/fmt/fmt.rs
@@ -128,7 +128,12 @@ fn fold(
     match n {
         NodeOrToken::Node(n) => format_node(&n, writer, state),
         NodeOrToken::Token(t) => {
-            if t.kind() == SyntaxKind::Whitespace {
+            if t.kind() == SyntaxKind::Eof {
+                if state.skip_all_whitespace {
+                    writer.with_new_content(t, "\n")?;
+                }
+                return Ok(());
+            } else if t.kind() == SyntaxKind::Whitespace {
                 if state.skip_all_whitespace && !state.after_comment {
                     writer.with_new_content(t, "")?;
                     return Ok(());
@@ -683,14 +688,14 @@ mod tests {
 
     #[test]
     fn basic_formatting() {
-        assert_formatting("A:=Text{}", "A := Text { }");
+        assert_formatting("A:=Text{}", "A := Text { }\n");
     }
 
     #[test]
     fn components() {
         assert_formatting(
             "component   A   {}  export component  B  inherits  Text {  }",
-            "component A { }\n\nexport component B inherits Text { }",
+            "component A { }\n\nexport component B inherits Text { }\n",
         );
     }
 
@@ -710,7 +715,8 @@ mod tests {
             /*y*/ {
     // c
               Foo/*aa*/ /*bb*/ { }
-}"#,
+}
+"#,
         );
     }
 
@@ -733,7 +739,8 @@ Main := Window {
 
     pure callback some-fn({x: int}, string);
     in property <int> foo: 42;
-}"#,
+}
+"#,
         );
     }
 
@@ -749,13 +756,14 @@ Main := Parent {
     Child {
         some-prop: parent.foo - 60px;
     }
-}"#,
+}
+"#,
         );
     }
 
     #[test]
     fn space_with_braces() {
-        assert_formatting("Main := Window{}", "Main := Window { }");
+        assert_formatting("Main := Window{}", "Main := Window { }\n");
         // Also in a child
         assert_formatting(
             r#"
@@ -763,7 +771,8 @@ Main := Window{Child{}}"#,
             r#"
 Main := Window {
     Child { }
-}"#,
+}
+"#,
         );
         assert_formatting(
             r#"
@@ -773,7 +782,8 @@ Main := VerticalLayout {
     HorizontalLayout {
         prop: 3;
     }
-}"#,
+}
+"#,
         );
     }
 
@@ -800,7 +810,8 @@ Main := Some {
     j: 3 >= 4;
     k: 3 && 4;
     l: 3 || 4;
-}"#,
+}
+"#,
         );
 
         assert_formatting(
@@ -825,7 +836,8 @@ Main := Some {
     m: 3 + 8;
     m: 3 + 8;
     m: 3 + 8;
-}"#,
+}
+"#,
         );
     }
 
@@ -844,7 +856,8 @@ A := Some {
     Text {
         x: 3px;
     }
-}"#,
+}
+"#,
         );
     }
 
@@ -863,7 +876,8 @@ A := B {
     C {
         @children
     }
-}"#,
+}
+"#,
         );
     }
 
@@ -878,7 +892,8 @@ A := B {
     for c in root.d: T {
         e: c.attr;
     }
-}"#,
+}
+"#,
         );
     }
 
@@ -897,7 +912,8 @@ A := B {
     for number [index] in [1, 2, 3]: C {
         d: number * index;
     }
-}"#,
+}
+"#,
         );
     }
 
@@ -910,7 +926,8 @@ component A {  if condition : Text {  }  }
             r#"
 component A {
     if condition: Text { }
-}"#,
+}
+"#,
         );
     }
 
@@ -923,7 +940,8 @@ A := B { c: [1,2,3]; }
             r#"
 A := B {
     c: [1, 2, 3];
-}"#,
+}
+"#,
         );
         assert_formatting(
             r#"
@@ -932,7 +950,8 @@ A := B { c: [    1    ]; }
             r#"
 A := B {
     c: [1];
-}"#,
+}
+"#,
         );
         assert_formatting(
             r#"
@@ -941,7 +960,8 @@ A := B { c:   [    ]  ; }
             r#"
 A := B {
     c: [];
-}"#,
+}
+"#,
         );
         assert_formatting(
             r#"
@@ -956,7 +976,8 @@ A := B { c:   [
             r#"
 A := B {
     c: [1, 2];
-}"#,
+}
+"#,
         );
     }
 
@@ -978,7 +999,8 @@ component FooBar {
         dummy1 when a == true: {}
     ]
 
-}"#,
+}
+"#,
         );
     }
 }

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -1051,7 +1051,7 @@ fn get_document_and_offset<'a>(
         + pos.character;
 
     let doc = document_cache.documents.get_document(&text_document_uri.to_file_path().ok()?)?;
-    doc.node.as_ref()?.text_range().contains(o.into()).then_some((doc, o))
+    doc.node.as_ref()?.text_range().contains_inclusive(o.into()).then_some((doc, o))
 }
 
 fn element_contains(element: &i_slint_compiler::object_tree::ElementRc, offset: u32) -> bool {
@@ -1091,7 +1091,7 @@ fn token_descr(
 
     let mut taf = node.token_at_offset(o.into());
     let token = match (taf.next(), taf.next()) {
-        (None, _) => return None,
+        (None, _) => node.last_token()?,
         (Some(t), None) => t,
         (Some(l), Some(r)) => match (l.kind(), r.kind()) {
             // Prioritize identifier


### PR DESCRIPTION
this include changes to the parser so auto-completion can work in the top-level even if the document is empty or has errors.