### PR TITLE
nodejs: slint image object with loadFromPath

### DIFF
--- a/api/node/lib/index.ts
+++ b/api/node/lib/index.ts
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+import { threadId } from "worker_threads";
+
 // Load the native library with `process.dlopen` instead of with `require`.
 // This is only done for autotest that do not require nom or neon_cli to
 // copy the lib to its right place
@@ -51,6 +53,25 @@ class Component {
 
     send_keyboard_string_sequence(s: String) {
         this.comp.send_keyboard_string_sequence(s)
+    }
+}
+
+// Defines an image object.
+class SlintImage {
+    private _path: string | undefined;
+
+    private constructor() {}
+
+    // Creates an image from path.
+    public static loadFromPath(path: string): SlintImage {
+        let image = new SlintImage();
+        image._path = path;
+
+        return image;
+    }
+
+    get path(): string | undefined {
+        return this._path;
     }
 }
 
@@ -300,6 +321,7 @@ class ArrayModel<T> implements Model<T> {
 module.exports = {
     private_api: native,
     ArrayModel: ArrayModel,
+    Image: SlintImage,
     Timer: {
         singleShot: native.singleshot_timer,
     },

--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -198,7 +198,12 @@ fn to_eval_value<'cx>(
             }
         },
         Type::Image => {
-            let path = val.to_string(cx)?.value();
+            let path = if let Ok(obj) = val.downcast::<JsObject>() {
+                obj.get(cx, "path")?.to_string(cx)?.value()
+            } else {
+                val.to_string(cx)?.value()
+            };
+
             Ok(Value::Image(
                 i_slint_core::graphics::Image::load_from_path(std::path::Path::new(&path))
                     .or_else(|_| cx.throw_error(format!("cannot load image {:?}", path)))?,


### PR DESCRIPTION
This is the first step introducing an image object in the nodejs port. At next step in a following PR the image class should be extended to can be created from something like an `ImaeData` object to allow to create an image from an pixel buffer compare [from_rgb8](https://docs.rs/slint/1.0.0/slint/struct.Image.html#method.from_rgb8) method in Rust.

This is a non breaking change because it still supports to set only a string to an image:

```js
my_window.image = "path/to/my/image.png";
```