### PR TITLE
Prospective fix for panic when running material style under Wayland/Gnome

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1617,8 +1617,8 @@ impl WindowAdapterSealed for QtWindow {
         let max_size: qttypes::QSize = max_size.map_or_else(
             || qttypes::QSize { width: widget_size_max, height: widget_size_max },
             |LogicalSize { width, height, .. }| qttypes::QSize {
-                width: (width as u32).min(widget_size_max),
-                height: (height as u32).min(widget_size_max),
+                width: width as u32,
+                height: height as u32,
             },
         );
 

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -97,7 +97,12 @@ pub fn min_max_size_for_layout_constraints(
         && max_height > 0 as Coord
         && (max_width < i32::MAX as Coord || max_height < i32::MAX as Coord)
     {
-        Some(crate::lengths::LogicalSize::new(max_width, max_height))
+        // maximum widget size for Qt and a workaround for the winit api not allowing partial constraints
+        let window_size_max = 16_777_215 as Coord;
+        Some(crate::lengths::LogicalSize::new(
+            max_width.min(window_size_max),
+            max_height.min(window_size_max),
+        ))
     } else {
         None
     };


### PR DESCRIPTION
Avoid communicating partial window size constraints, where only one component is set.

In the provided example in the cc'ed bug report, when run with material style, it appears that there's a maximum height, but no maximum width.

While for example the wayland protocol allows for partial constraints, i.e. a max height but max width 0 means unlimited, the
winit API takes the Option for the size as a whole.

cc #2562