### PR TITLE
Parser: Nicer error when extra top-level semicolon

### DIFF
--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -23,6 +23,12 @@ pub fn parse_document(p: &mut impl Parser) -> bool {
             return true;
         }
 
+        if p.peek().kind() == SyntaxKind::Semicolon {
+            p.error("Extra semicolon. Remove this semicolon");
+            p.consume();
+            continue;
+        }
+
         match p.peek().as_str() {
             "export" => {
                 if !parse_export(&mut *p) {

--- a/internal/compiler/tests/syntax/basic/parse_error.slint
+++ b/internal/compiler/tests/syntax/basic/parse_error.slint
@@ -21,4 +21,13 @@ export SuperSimple := Rectangle {
         * .
 //      ^error{Parse error}
     }
-}
+  };
+// ^error{Extra semicolon. Remove this semicolon}
+
+struct F {};
+//         ^error{Extra semicolon. Remove this semicolon}
+
+export {F};
+//        ^error{Extra semicolon. Remove this semicolon}
+
+


### PR DESCRIPTION
Recover from extra semicolon

(As reported on mattermost)