### PR TITLE
Round values when converting from `f32` to `u8` in `RgbaColor`

### DIFF
--- a/internal/core/graphics/color.rs
+++ b/internal/core/graphics/color.rs
@@ -85,10 +85,10 @@ impl From<Color> for RgbaColor<f32> {
 impl From<RgbaColor<f32>> for Color {
     fn from(col: RgbaColor<f32>) -> Self {
         Self {
-            red: (col.red * 255.) as u8,
-            green: (col.green * 255.) as u8,
-            blue: (col.blue * 255.) as u8,
-            alpha: (col.alpha * 255.) as u8,
+            red: (col.red * 255.).round() as u8,
+            green: (col.green * 255.).round() as u8,
+            blue: (col.blue * 255.).round() as u8,
+            alpha: (col.alpha * 255.).round() as u8,
         }
     }
 }


### PR DESCRIPTION
Previously, the following assertion would fail:
```rust
// use i_slint_core::graphics::Color;
assert_eq!(Color::from_argba_encoded(0xff804000), Color::from_argba_f32(1.0, 0.5, 0.25, 0.0));
```

This happened because upon converting `RgbaColor<f32>` to `RgbaColor<u8>` the code discarded the fractional part of the calculated value by using `as u8` without calling `round()`. The previous behavior was preventing test cases (to be pushed to #2565) from passing.