### PR TITLE
LSP: fix error location

### DIFF
--- a/api/wasm-interpreter/src/lib.rs
+++ b/api/wasm-interpreter/src/lib.rs
@@ -128,7 +128,7 @@ pub async fn compile_from_string_with_style(
         let error_obj = js_sys::Object::new();
         js_sys::Reflect::set(&error_obj, &message_key, &JsValue::from_str(&d.message()))?;
         js_sys::Reflect::set(&error_obj, &line_key, &JsValue::from_f64(line as f64))?;
-        js_sys::Reflect::set(&error_obj, &column_key, &JsValue::from_f64(column as f64))?;
+        js_sys::Reflect::set(&error_obj, &column_key, &JsValue::from_f64(column as f64 + 1.))?;
         js_sys::Reflect::set(&error_obj, &file_key, &filename_js)?;
         js_sys::Reflect::set(&error_obj, &level_key, &JsValue::from_f64(d.level() as i8 as f64))?;
         array.push(&error_obj);

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -716,7 +716,7 @@ pub struct Diagnostic {
     source_file: SharedString,
     /// The line within the source file. Line numbers start at 1.
     line: usize,
-    /// The column within the source file. Column numbers start at 1.
+    /// The column within the source file. Column numbers start at 0.
     column: usize,
     /// The level of the diagnostic, such as a warning or an error.
     level: DiagnosticLevel,

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -155,10 +155,7 @@ pub fn to_lsp_diag(d: &i_slint_compiler::diagnostics::Diagnostic) -> lsp_types::
 }
 
 fn to_range(span: (usize, usize)) -> lsp_types::Range {
-    let pos = lsp_types::Position::new(
-        (span.0 as u32).saturating_sub(1),
-        (span.1 as u32).saturating_sub(1),
-    );
+    let pos = lsp_types::Position::new((span.0 as u32).saturating_sub(1), span.1 as u32);
     lsp_types::Range::new(pos, pos)
 }
 


### PR DESCRIPTION
Commit 893983e8d320bd248c47f3d57292d432ec4ded69 fixed Diagnostic::line_column to make the column 0-based instead of 1-based. But the LSP was not adjusted yet. This makes sure the error is reported in the right location

Also adjust a couple of more place.
The C++ slint::interpreter::Diagnostic documentation was changed to be consistent with the Rust documentation and new behavior