### PR TITLE
Fix resizing of the preview in SlintPad after selecting a new demo

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -433,7 +433,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed
 
                     if canvas
                         .dataset()
-                        .get("slint-auto-resize-to-preferred")
+                        .get("slintAutoResizeToPreferred")
                         .and_then(|val_str| val_str.parse().ok())
                         .unwrap_or_default()
                     {


### PR DESCRIPTION
I misread the spec about the name conversion for the DOMStringMap used in JS for the dataset attribute and the name used in the DOM.
Both, the setting in preview_widget.ts as well as
reading it in windowadapter.rs counts as JavaScript access, so use camel case.

The old variant happened to work in Safari.

Amends 43234dafc50a043ef53b65be635c71cbd1bf490f