### PR TITLE
Update the neovim plugin

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -130,9 +130,9 @@ exists under the `language` server section:
 
 Follow step 1. of the Vim section to get support for `.slint` files.
 
-The easist way to use the language server itself in Neovim is via the `neovim/lsp-config`
+The easist way to use the language server itself in Neovim is via the `neovim/nvim-lspconfig`
 and `williamboman/nvim-lsp-installer` plugins. Once these are installed
-you can run `:LspInstallInfo` to install the `slint_lsp` binary (on Windows and Linux).
+you can run `:LspInstall slint_lsp` to install the lsp binary (on Windows and Linux).
 
 Once the slint_lsp language server is installed and running, you can triggger the live preview
 via the code actions. Unfortunately there are several ways to trigger these, so please check your


### PR DESCRIPTION
Replace the non-existent `neovim/lspconfig` plugin by `neovim/nvim-lspconfig`.