### PR TITLE
LSP: complete the first import right before the first component

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -840,6 +840,13 @@ impl NodeOrToken {
             _ => None,
         }
     }
+
+    pub fn text_range(&self) -> rowan::TextRange {
+        match self {
+            NodeOrToken::Node(n) => n.text_range(),
+            NodeOrToken::Token(t) => t.text_range(),
+        }
+    }
 }
 
 impl Spanned for SyntaxNode {


### PR DESCRIPTION
So this doesn't break the slint! macro (add the import at the beginning of the rust file)