### PR TITLE
winit: Add API to access the winit window and event loop

### DIFF
--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -21,7 +21,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(feature = "i-slint-backend-winit")] {
         use i_slint_backend_winit as default_backend;
         fn create_default_backend() -> Box<dyn Platform + 'static> {
-            Box::new(i_slint_backend_winit::Backend::new(None))
+            Box::new(i_slint_backend_winit::Backend::new())
         }
     } else {
 
@@ -51,7 +51,7 @@ cfg_if::cfg_if! {
                 #[cfg(all(feature = "i-slint-backend-qt", not(no_qt)))]
                 "qt" => return Ok(Box::new(i_slint_backend_qt::Backend)),
                 #[cfg(feature = "i-slint-backend-winit")]
-                "winit" => return Ok(Box::new(i_slint_backend_winit::Backend::new((!_renderer.is_empty()).then(|| _renderer)))),
+                "winit" => return Ok(Box::new(i_slint_backend_winit::Backend::new_with_renderer_by_name((!_renderer.is_empty()).then(|| _renderer)))),
                 _ => {},
             }
 

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -79,3 +79,15 @@ cocoa = { version = "0.24.0" }
 
 [build-dependencies]
 cfg_aliases = "0.1.0"
+
+[dev-dependencies]
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-0", "backend-winit", "renderer-winit-software"] }
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "--html-in-header",
+  "docs/resources/slint-docs-preview.html",
+  "--html-in-header",
+  "docs/resources/slint-docs-highlight.html",
+]
+features = ["wayland", "renderer-winit-software"]

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -88,17 +88,37 @@ cfg_if::cfg_if! {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn use_modules() {}
 
+#[doc(hidden)]
 pub type NativeWidgets = ();
+#[doc(hidden)]
 pub type NativeGlobals = ();
+#[doc(hidden)]
 pub const HAS_NATIVE_STYLE: bool = false;
+#[doc(hidden)]
 pub mod native_widgets {}
 
+#[doc = concat!("This struct implements the Slint Platform trait. Use this in conjuction with [`slint::platform::set_platform`](https://slint-ui.com/releases/", env!("CARGO_PKG_VERSION"), "/docs/rust/slint/platform/fn.set_platform.html) to initialize.")]
+/// Slint to use winit for all windowing system interaction.
+///
+/// ```rust
+/// # use i_slint_backend_winit::Backend;
+/// slint::platform::set_platform(Box::new(Backend::new()));
+/// ```
 pub struct Backend {
     window_factory_fn: fn() -> Rc<dyn WindowAdapter>,
 }
 
 impl Backend {
-    pub fn new(renderer_name: Option<&str>) -> Self {
+    #[doc = concat!("Creates a new winit backend with the default renderer that's compiled in. See the [backend documentation](https://slint-ui.com/releases/", env!("CARGO_PKG_VERSION"), "/docs/rust/slint/index.html#backends) for")]
+    /// details on how to select the default renderer.
+    pub fn new() -> Self {
+        Self::new_with_renderer_by_name(None)
+    }
+
+    #[doc = concat!("Creates a new winit backend with the renderer specified by name. See the [backend documentation](https://slint-ui.com/releases/", env!("CARGO_PKG_VERSION"), "/docs/rust/slint/index.html#backends) for")]
+    /// details on how to select the default renderer.
+    /// If the renderer name is `None` or the name is not recognized, the default renderer is selected.
+    pub fn new_with_renderer_by_name(renderer_name: Option<&str>) -> Self {
         let window_factory_fn = match renderer_name {
             #[cfg(feature = "renderer-winit-femtovg")]
             Some("gl") | Some("femtovg") => {

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -241,8 +241,12 @@ pub fn with_event_loop_window_target<R>(
     })
 }
 
+mod private {
+    pub trait WinitWindowAccessorSealed {}
+}
+
 #[doc = concat!("This helper trait can be used to obtain access to the [`winit::window::Window`] for a given [`slint::Window`](https://slint-ui.com/releases/", env!("CARGO_PKG_VERSION"), "/docs/rust/slint/struct.window).")]
-pub trait WinitWindowAccessor {
+pub trait WinitWindowAccessor: private::WinitWindowAccessorSealed {
     /// Returns true if a [`winit::window::Window`] exists for this window. This is the case if the window is
     /// backed by this winit backend and is shown on the screen.
     fn has_winit_window(&self) -> bool;
@@ -264,6 +268,8 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
         winit_window_rc_for_window(self).as_ref().map(|w| callback(w))
     }
 }
+
+impl private::WinitWindowAccessorSealed for i_slint_core::api::Window {}
 
 fn winit_window_rc_for_window(
     window: &i_slint_core::api::Window,

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -177,8 +177,9 @@ impl WasmInputHelper {
             crate::event_loop::GLOBAL_PROXY.with(|global_proxy| {
                 if let Ok(mut x) = global_proxy.try_borrow_mut() {
                     if let Some(proxy) = &mut *x {
-                        let _ = proxy
-                            .send_event(crate::event_loop::CustomEvent::WakeEventLoopWorkaround);
+                        let _ = proxy.send_event(crate::SlintUserEvent::CustomEvent {
+                            event: crate::event_loop::CustomEvent::WakeEventLoopWorkaround,
+                        });
                     }
                 }
             });

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -306,9 +306,9 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed
             self_.with_window_handle(&mut |window| {
                 let window_id = window.id();
                 crate::event_loop::with_window_target(|event_loop| {
-                    event_loop.event_loop_proxy().send_event(
-                        crate::event_loop::CustomEvent::UpdateWindowProperties(window_id),
-                    )
+                    event_loop.event_loop_proxy().send_event(crate::SlintUserEvent::CustomEvent {
+                        event: crate::event_loop::CustomEvent::UpdateWindowProperties(window_id),
+                    })
                 })
                 .ok();
             });
@@ -656,9 +656,9 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed
                 existing_blinker.stop();
             }*/
             crate::event_loop::with_window_target(|event_loop| {
-                event_loop
-                    .event_loop_proxy()
-                    .send_event(crate::event_loop::CustomEvent::WindowHidden)
+                event_loop.event_loop_proxy().send_event(crate::SlintUserEvent::CustomEvent {
+                    event: crate::event_loop::CustomEvent::WindowHidden,
+                })
             })
             .ok(); // It's okay to call hide() even after the event loop is closed. We don't need the logic for quitting the event loop anymore at this point.
             Ok(())


### PR DESCRIPTION
This API requires using the i_slint_backend crate, which won't follow semver. But it's a way out for a couple of use-cases where semver doesn't matter.