### PR TITLE
fix(readme): table of virtual keyboard example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -126,7 +126,7 @@ A Rust and C++ example that shows how render SixtyFPS on top of graphical effect
 ### [`virtual keyboard`](./virtual_keyboard)
 
 | `.slint` Design | Rust Source | C++ Source |
-| --- | --- |
+| --- | --- | --- |
 | [`main_window.slint`](./virtual_keyboard/ui/main_window.slint) | [`main.rs`](./virtual_keyboard/rust/main.rs) | [`main.cpp`](./virtual_keyboard/cpp/main.cpp) |
 
 A Rust and C++ example that shows how to implement a custom virtual keyboard in Slint. For more details check out the [Readme](./virtual_keyboard).


### PR DESCRIPTION
Changes the current examples README from

![image](https://user-images.githubusercontent.com/98030270/233758701-1b1d3b85-811f-4e34-93d8-e183e178114c.png)

to

![image](https://user-images.githubusercontent.com/98030270/233758691-383cd90e-fcbc-4297-b837-53a9d89c77f9.png)
