### PR TITLE
Fix build against macOS deployment target 10.10

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -147,7 +147,7 @@ public:
     template<typename Component>
     void set_component(const Component &c) const
     {
-        auto self_rc = c.self_weak.lock().value().into_dyn();
+        auto self_rc = (*c.self_weak.lock()).into_dyn();
         slint_windowrc_set_component(&inner, &self_rc);
     }
 
@@ -289,8 +289,10 @@ inline void dealloc(const ComponentVTable *, uint8_t *ptr, vtable::Layout layout
 #ifdef __cpp_sized_deallocation
     ::operator delete(reinterpret_cast<void *>(ptr), layout.size,
                       static_cast<std::align_val_t>(layout.align));
-#else
+#elif !defined(__APPLE__) || MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14
     ::operator delete(reinterpret_cast<void *>(ptr), static_cast<std::align_val_t>(layout.align));
+#else
+    ::operator delete(reinterpret_cast<void *>(ptr));
 #endif
 }
 

--- a/api/cpp/include/vtable.h
+++ b/api/cpp/include/vtable.h
@@ -10,7 +10,7 @@
 #include <atomic>
 
 #ifdef __APPLE__
-#include <AvailabilityMacros.h>
+#    include <AvailabilityMacros.h>
 #endif
 
 namespace vtable {
@@ -134,18 +134,45 @@ public:
         return VRc(inner);
     }
 
-    const X *operator->() const { return &inner->data; }
-    const X &operator*() const { return inner->data; }
-    X *operator->() { return &inner->data; }
-    X &operator*() { return inner->data; }
+    const X *operator->() const
+    {
+        return &inner->data;
+    }
+    const X &operator*() const
+    {
+        return inner->data;
+    }
+    X *operator->()
+    {
+        return &inner->data;
+    }
+    X &operator*()
+    {
+        return inner->data;
+    }
 
-    VRc<VTable, Dyn> into_dyn() const { return *reinterpret_cast<const VRc<VTable, Dyn> *>(this); }
+    VRc<VTable, Dyn> into_dyn() const
+    {
+        return *reinterpret_cast<const VRc<VTable, Dyn> *>(this);
+    }
 
-    VRef<VTable> borrow() const { return { inner->vtable, inner->data_ptr() }; }
+    VRef<VTable> borrow() const
+    {
+        return { inner->vtable, inner->data_ptr() };
+    }
 
-    friend bool operator==(const VRc &a, const VRc &b) { return a.inner == b.inner; }
-    friend bool operator!=(const VRc &a, const VRc &b) { return a.inner != b.inner; }
-    const VTable *vtable() const { return inner->vtable; }
+    friend bool operator==(const VRc &a, const VRc &b)
+    {
+        return a.inner == b.inner;
+    }
+    friend bool operator!=(const VRc &a, const VRc &b)
+    {
+        return a.inner != b.inner;
+    }
+    const VTable *vtable() const
+    {
+        return inner->vtable;
+    }
 };
 
 template<typename VTable, typename X = Dyn>

--- a/api/cpp/include/vtable.h
+++ b/api/cpp/include/vtable.h
@@ -9,6 +9,10 @@
 #include <optional>
 #include <atomic>
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 namespace vtable {
 
 template<typename T>
@@ -119,8 +123,12 @@ public:
     template<typename... Args>
     static VRc make(Args... args)
     {
+#if !defined(__APPLE__) || MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14
         auto mem = ::operator new(sizeof(VRcInner<VTable, X>),
                                   static_cast<std::align_val_t>(alignof(VRcInner<VTable, X>)));
+#else
+        auto mem = ::operator new(sizeof(VRcInner<VTable, X>));
+#endif
         auto inner = new (mem) VRcInner<VTable, X>;
         new (&inner->data) X(args...);
         return VRc(inner);

--- a/examples/iot-dashboard/dashboard.cpp
+++ b/examples/iot-dashboard/dashboard.cpp
@@ -36,7 +36,7 @@ std::string WidgetLocation::location_bindings() const
 {
     auto maybe_binding = [](std::string_view name, const auto &opt_value) -> std::string {
         if (opt_value.has_value()) {
-            return fmt::format("               {}: {};\n", name, opt_value.value());
+            return fmt::format("               {}: {};\n", name, *opt_value);
         } else {
             return "";
         }

--- a/examples/qt_viewer/qt_viewer.cpp
+++ b/examples/qt_viewer/qt_viewer.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
                 break;
 
             case slint::interpreter::Value::Type::Number:
-                ui.prop_value->setText(QString::number(val->to_number().value()));
+                ui.prop_value->setText(QString::number(*val->to_number()));
                 break;
 
             default:


### PR DESCRIPTION
- std::optional<T>::value() is not available, use operator * instead
- alignment allocation is also only available in 10.14 or newer