### PR TITLE
Slintpad: Fix editing in non-main files was getting ignored

### DIFF
--- a/tools/slintpad/src/editor_widget.ts
+++ b/tools/slintpad/src/editor_widget.ts
@@ -633,7 +633,7 @@ class EditorPaneWidget extends Widget {
         internal_uri: monaco.Uri,
         raise_alert: boolean,
     ): Promise<string> {
-        let model = monaco.editor.getModel(uri);
+        let model = monaco.editor.getModel(internal_uri);
         if (model != null) {
             return model.getValue();
         }
@@ -662,7 +662,7 @@ class EditorPaneWidget extends Widget {
             return "";
         }
 
-        model = monaco.editor.getModel(uri);
+        model = monaco.editor.getModel(internal_uri);
         if (model != null) {
             return model.getValue();
         }


### PR DESCRIPTION
We always grabbed a fresh copy from github instead of using the buffer found in the editor.

Fixes: #2630