### PR TITLE
LSP: Add `toggleDesignMode` command

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -62,13 +62,8 @@
                 "category": "Slint"
             },
             {
-                "command": "slint.enableDesignMode",
-                "title": "Enable Design Mode in Slint Preview",
-                "category": "Slint"
-            },
-            {
-                "command": "slint.disableDesignMode",
-                "title": "Disable Design Mode in Slint Preview",
+                "command": "slint.toggleDesignMode",
+                "title": "Toggle Design Mode in Slint Preview (experimental)",
                 "category": "Slint"
             },
             {

--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -28,8 +28,8 @@ function startClient(context: vscode.ExtensionContext) {
             );
             return true;
         },
-        (args: any) => {
-            wasm_preview.setDesignMode(args[0]);
+        (_) => {
+            wasm_preview.toggleDesignMode();
             return true;
         },
     );

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -83,7 +83,7 @@ export function setServerStatus(
 
 export function languageClientOptions(
     showPreview: (args: any) => boolean,
-    setDesignMode: (args: any) => boolean,
+    toggleDesignMode: (args: any) => boolean,
 ): LanguageClientOptions {
     return {
         documentSelector: [{ language: "slint" }, { language: "rust" }],
@@ -93,8 +93,8 @@ export function languageClientOptions(
                     if (showPreview(args)) {
                         return;
                     }
-                } else if (command == "slint/setDesignMode") {
-                    if (setDesignMode(args)) {
+                } else if (command == "slint/toggleDesignMode") {
+                    if (toggleDesignMode(args)) {
                         return;
                     }
                 }
@@ -138,13 +138,8 @@ export function activate(
         }),
     );
     context.subscriptions.push(
-        vscode.commands.registerCommand("slint.enableDesignMode", function () {
-            lsp_commands.setDesignMode(true);
-        }),
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand("slint.disableDesignMode", function () {
-            lsp_commands.setDesignMode(false);
+        vscode.commands.registerCommand("slint.toggleDesignMode", function () {
+            lsp_commands.toggleDesignMode();
         }),
     );
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -148,13 +148,13 @@ function startClient(context: vscode.ExtensionContext) {
             }
             return false;
         },
-        (args: any) => {
+        (_) => {
             if (
                 vscode.workspace
                     .getConfiguration("slint")
                     .get<boolean>("preview.providedByEditor")
             ) {
-                wasm_preview.setDesignMode(args[0]);
+                wasm_preview.toggleDesignMode();
                 return true;
             }
             return false;

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -222,6 +222,11 @@ struct PreviewState {
 }
 thread_local! {static PREVIEW_STATE: std::cell::RefCell<PreviewState> = Default::default();}
 
+pub fn design_mode() -> bool {
+    let cache = CONTENT_CACHE.get_or_init(Default::default).lock().unwrap();
+    cache.design_mode
+}
+
 pub fn set_design_mode(sender: crate::ServerNotifier, enable: bool) {
     let mut cache = CONTENT_CACHE.get_or_init(Default::default).lock().unwrap();
     cache.design_mode = enable;

--- a/tools/slintpad/src/shared/lsp_commands.ts
+++ b/tools/slintpad/src/shared/lsp_commands.ts
@@ -43,6 +43,10 @@ export async function setDesignMode(
     return vscode.commands.executeCommand("slint/setDesignMode", enable);
 }
 
+export async function toggleDesignMode(): Promise<SetBindingResponse> {
+    return vscode.commands.executeCommand("slint/toggleDesignMode");
+}
+
 export async function setBinding(
     doc: OptionalVersionedTextDocumentIdentifier,
     element_range: LspRange,


### PR DESCRIPTION
Add a toggle command to the LS and use them in VSCode.

Keep the existing set_design_mode commands for Slintpad, as it is easier for the state stored on the web site and in the WASM side to go out of sync. This is not an issue in VS Code at this point.

This PR is #2626 with the actual code implementing the code lens removed.