### PR TITLE
Fix font fallback in femtovg renderer.

### DIFF
--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -414,7 +414,10 @@ impl FontCache {
                     fallback_font.fontdb_face_id,
                 );
 
-                if matches!(coverage_result, GlyphCoverageCheckResult::Improved) {
+                if matches!(
+                    coverage_result,
+                    GlyphCoverageCheckResult::Improved | GlyphCoverageCheckResult::Complete
+                ) {
                     Some(fallback_font.femtovg_font_id)
                 } else {
                     None


### PR DESCRIPTION
When the coverage is complete, the fallback font is not chosen. This causes some minor mis-fallback, for example, incorrect weight for CJK characters.