### PR TITLE
Clean up password character substitution handling

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -675,10 +675,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
             TextWrap::WordWrap => key_generated::Qt_TextFlag_TextWordWrap,
         };
 
-        let mut visual_representation = text_input.visual_representation();
-
-        visual_representation
-            .apply_password_character_substitution(text_input, Some(qt_password_character));
+        let visual_representation = text_input.visual_representation(Some(qt_password_character));
 
         let text = &visual_representation.text;
         let mut string: qttypes::QString = text.as_str().into();
@@ -1817,10 +1814,7 @@ impl Renderer for QtWindow {
             text_input.font_request(&WindowInner::from_pub(&self.window).window_adapter()),
         );
 
-        let mut visual_representation = text_input.visual_representation();
-
-        visual_representation
-            .apply_password_character_substitution(text_input, Some(qt_password_character));
+        let visual_representation = text_input.visual_representation(Some(qt_password_character));
 
         let string = qttypes::QString::from(visual_representation.text.as_str());
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -678,7 +678,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
         let mut visual_representation = text_input.visual_representation();
 
         visual_representation
-            .apply_password_character_substitution(text_input, qt_password_character);
+            .apply_password_character_substitution(text_input, Some(qt_password_character));
 
         let text = &visual_representation.text;
         let mut string: qttypes::QString = text.as_str().into();
@@ -1820,7 +1820,7 @@ impl Renderer for QtWindow {
         let mut visual_representation = text_input.visual_representation();
 
         visual_representation
-            .apply_password_character_substitution(text_input, qt_password_character);
+            .apply_password_character_substitution(text_input, Some(qt_password_character));
 
         let string = qttypes::QString::from(visual_representation.text.as_str());
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -681,7 +681,7 @@ pub struct TextInputVisualRepresentation {
 impl TextInputVisualRepresentation {
     /// If the given `TextInput` renders a password, then all characters in this `TextInputVisualRepresentation` are replaced
     /// with the given password character and the selection/preedit-ranges/cursor position are adjusted.
-    pub fn apply_password_character_substitution(
+    fn apply_password_character_substitution(
         &mut self,
         text_input: Pin<&TextInput>,
         password_character_fn: Option<fn() -> char>,
@@ -1075,7 +1075,10 @@ impl TextInput {
         }
     }
 
-    pub fn visual_representation(self: Pin<&Self>) -> TextInputVisualRepresentation {
+    pub fn visual_representation(
+        self: Pin<&Self>,
+        password_character_fn: Option<fn() -> char>,
+    ) -> TextInputVisualRepresentation {
         let mut text: String = self.text().into();
 
         let preedit_text = self.preedit_text();
@@ -1109,14 +1112,16 @@ impl TextInput {
             (preedit_range, selection_range, cursor_position)
         };
 
-        TextInputVisualRepresentation {
+        let mut repr = TextInputVisualRepresentation {
             text,
             preedit_range,
             selection_range,
             cursor_position,
             text_without_password: None,
             password_character: Default::default(),
-        }
+        };
+        repr.apply_password_character_substitution(self, password_character_fn);
+        repr
     }
 }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -680,7 +680,8 @@ pub struct TextInputVisualRepresentation {
 
 impl TextInputVisualRepresentation {
     /// If the given `TextInput` renders a password, then all characters in this `TextInputVisualRepresentation` are replaced
-    /// with the given password character and the selection/preedit-ranges/cursor position are adjusted.
+    /// with the password character and the selection/preedit-ranges/cursor position are adjusted.
+    /// If `password_character_fn` is Some, it is called lazily to query the password character, otherwise a default is used.
     fn apply_password_character_substitution(
         &mut self,
         text_input: Pin<&TextInput>,

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -712,6 +712,8 @@ impl TextInputVisualRepresentation {
         self.password_character = password_character;
     }
 
+    /// Use this function to make a byte offset in the text used for rendering back to a byte offset in the
+    /// TextInput's text. The offsets might differ for example for password text input fields.
     pub fn map_byte_offset_from_byte_offset_in_visual_text(&self, byte_offset: usize) -> usize {
         if let Some(text_without_password) = self.text_without_password.as_ref() {
             text_without_password
@@ -1076,6 +1078,9 @@ impl TextInput {
         }
     }
 
+    /// Returns a [`TextInputVisualRepresentation`] struct that contains all the fields necessary for rendering the text input,
+    /// after making adjustments such as applying a substitution of characters for password input fields, or making sure
+    /// that the selection start is always less or equal than the selection end.
     pub fn visual_representation(
         self: Pin<&Self>,
         password_character_fn: Option<fn() -> char>,

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -684,13 +684,13 @@ impl TextInputVisualRepresentation {
     pub fn apply_password_character_substitution(
         &mut self,
         text_input: Pin<&TextInput>,
-        password_character_fn: fn() -> char,
+        password_character_fn: Option<fn() -> char>,
     ) {
         if !matches!(text_input.input_type(), InputType::Password) {
             return;
         }
 
-        let password_character = password_character_fn();
+        let password_character = password_character_fn.map_or('●', |f| f());
 
         let text = &mut self.text;
         let fixup_range = |r: &mut core::ops::Range<usize>| {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -682,25 +682,27 @@ impl TextInputVisualRepresentation {
     pub fn apply_password_character_substitution(
         &mut self,
         text_input: Pin<&TextInput>,
-        password_character: &str,
+        password_character_fn: fn() -> char,
     ) {
         if !matches!(text_input.input_type(), InputType::Password) {
             return;
         }
 
+        let password_character = password_character_fn();
+
         let text = &mut self.text;
         let fixup_range = |r: &mut core::ops::Range<usize>| {
             if !core::ops::Range::is_empty(&r) {
-                r.start = text[..r.start].chars().count() * password_character.len();
-                r.end = text[..r.end].chars().count() * password_character.len();
+                r.start = text[..r.start].chars().count() * password_character.len_utf8();
+                r.end = text[..r.end].chars().count() * password_character.len_utf8();
             }
         };
         fixup_range(&mut self.preedit_range);
         fixup_range(&mut self.selection_range);
         if let Some(cursor_pos) = self.cursor_position.as_mut() {
-            *cursor_pos = text[..*cursor_pos].chars().count() * password_character.len();
+            *cursor_pos = text[..*cursor_pos].chars().count() * password_character.len_utf8();
         }
-        *text = String::from(password_character.repeat(text.chars().count()));
+        *text = core::iter::repeat(password_character).take(text.chars().count()).collect();
     }
 }
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -372,9 +372,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
             None => return,
         };
 
-        let mut visual_representation = text_input.visual_representation();
-
-        visual_representation.apply_password_character_substitution(text_input, None);
+        let visual_representation = text_input.visual_representation(None);
 
         let (min_select, max_select) = if !visual_representation.preedit_range.is_empty() {
             (visual_representation.preedit_range.start, visual_representation.preedit_range.end)

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -374,7 +374,8 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
 
         let mut visual_representation = text_input.visual_representation();
 
-        visual_representation.apply_password_character_substitution(text_input, PASSWORD_CHARACTER);
+        visual_representation
+            .apply_password_character_substitution(text_input, || PASSWORD_CHARACTER);
 
         let (min_select, max_select) = if !visual_representation.preedit_range.is_empty() {
             (visual_representation.preedit_range.start, visual_representation.preedit_range.end)

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -23,8 +23,8 @@ use i_slint_core::window::WindowInner;
 use i_slint_core::{Brush, Color, ImageInner, Property, SharedString};
 
 use super::images::{Texture, TextureCacheKey};
+use super::PhysicalSize;
 use super::{fonts, PhysicalLength, PhysicalPoint, PhysicalRect};
-use super::{PhysicalSize, PASSWORD_CHARACTER};
 
 type FemtovgBoxShadowCache = BoxShadowCache<ItemGraphicsCacheEntry>;
 
@@ -374,8 +374,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
 
         let mut visual_representation = text_input.visual_representation();
 
-        visual_representation
-            .apply_password_character_substitution(text_input, || PASSWORD_CHARACTER);
+        visual_representation.apply_password_character_substitution(text_input, None);
 
         let (min_select, max_select) = if !visual_representation.preedit_range.is_empty() {
             (visual_representation.preedit_range.start, visual_representation.preedit_range.end)

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -30,7 +30,7 @@ mod fonts;
 mod images;
 mod itemrenderer;
 
-const PASSWORD_CHARACTER: &str = "●";
+const PASSWORD_CHARACTER: char = '●';
 
 /// Use the FemtoVG renderer when implementing a custom Slint platform where you deliver events to
 /// Slint and want the scene to be rendered using OpenGL and the FemtoVG renderer.
@@ -254,7 +254,9 @@ impl Renderer for FemtoVGRenderer {
             matches!(text_input.input_type(), i_slint_core::items::InputType::Password);
         let password_string;
         let actual_text = if is_password {
-            password_string = PASSWORD_CHARACTER.repeat(text.chars().count());
+            password_string = core::iter::repeat(PASSWORD_CHARACTER)
+                .take(text.chars().count())
+                .collect::<String>();
             password_string.as_str()
         } else {
             text.as_str()
@@ -290,7 +292,7 @@ impl Renderer for FemtoVGRenderer {
 
         if is_password {
             text.char_indices()
-                .nth(result / PASSWORD_CHARACTER.len())
+                .nth(result / PASSWORD_CHARACTER.len_utf8())
                 .map_or(text.len(), |(r, _)| r)
         } else {
             result

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -248,9 +248,7 @@ impl Renderer for FemtoVGRenderer {
             )
         });
 
-        let mut visual_representation = text_input.visual_representation();
-
-        visual_representation.apply_password_character_substitution(text_input, None);
+        let visual_representation = text_input.visual_representation(None);
 
         let paint = font.init_paint(text_input.letter_spacing() * scale_factor, Default::default());
         let text_context =

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -30,8 +30,6 @@ mod fonts;
 mod images;
 mod itemrenderer;
 
-const PASSWORD_CHARACTER: char = '●';
-
 /// Use the FemtoVG renderer when implementing a custom Slint platform where you deliver events to
 /// Slint and want the scene to be rendered using OpenGL and the FemtoVG renderer.
 pub struct FemtoVGRenderer {
@@ -252,8 +250,7 @@ impl Renderer for FemtoVGRenderer {
 
         let mut visual_representation = text_input.visual_representation();
 
-        visual_representation
-            .apply_password_character_substitution(text_input, || PASSWORD_CHARACTER);
+        visual_representation.apply_password_character_substitution(text_input, None);
 
         let paint = font.init_paint(text_input.letter_spacing() * scale_factor, Default::default());
         let text_context =

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -506,8 +506,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
 
         let mut visual_representation = text_input.visual_representation();
 
-        visual_representation
-            .apply_password_character_substitution(text_input, || crate::PASSWORD_CHARACTER);
+        visual_representation.apply_password_character_substitution(text_input, None);
 
         let selection = if !visual_representation.preedit_range.is_empty() {
             Some(super::textlayout::Selection {

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -507,7 +507,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         let mut visual_representation = text_input.visual_representation();
 
         visual_representation
-            .apply_password_character_substitution(text_input, crate::PASSWORD_CHARACTER);
+            .apply_password_character_substitution(text_input, || crate::PASSWORD_CHARACTER);
 
         let selection = if !visual_representation.preedit_range.is_empty() {
             Some(super::textlayout::Selection {

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -504,9 +504,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         let mut text_style = skia_safe::textlayout::TextStyle::new();
         text_style.set_foreground_color(&paint);
 
-        let mut visual_representation = text_input.visual_representation();
-
-        visual_representation.apply_password_character_substitution(text_input, None);
+        let visual_representation = text_input.visual_representation(None);
 
         let selection = if !visual_representation.preedit_range.is_empty() {
             Some(super::textlayout::Selection {

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -31,8 +31,6 @@ mod cached_image;
 mod itemrenderer;
 mod textlayout;
 
-const PASSWORD_CHARACTER: char = '●';
-
 #[cfg(target_os = "macos")]
 mod metal_surface;
 
@@ -274,8 +272,7 @@ impl<NativeWindowWrapper> i_slint_core::renderer::Renderer for SkiaRenderer<Nati
 
         let mut visual_representation = text_input.visual_representation();
 
-        visual_representation
-            .apply_password_character_substitution(text_input, || PASSWORD_CHARACTER);
+        visual_representation.apply_password_character_substitution(text_input, None);
 
         let font_request = text_input.font_request(&window_adapter);
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -270,9 +270,7 @@ impl<NativeWindowWrapper> i_slint_core::renderer::Renderer for SkiaRenderer<Nati
             return 0;
         }
 
-        let mut visual_representation = text_input.visual_representation();
-
-        visual_representation.apply_password_character_substitution(text_input, None);
+        let visual_representation = text_input.visual_representation(None);
 
         let font_request = text_input.font_request(&window_adapter);
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -31,7 +31,7 @@ mod cached_image;
 mod itemrenderer;
 mod textlayout;
 
-const PASSWORD_CHARACTER: &str = "●";
+const PASSWORD_CHARACTER: char = '●';
 
 #[cfg(target_os = "macos")]
 mod metal_surface;
@@ -277,7 +277,9 @@ impl<NativeWindowWrapper> i_slint_core::renderer::Renderer for SkiaRenderer<Nati
             matches!(text_input.input_type(), i_slint_core::items::InputType::Password);
         let password_string;
         let actual_text = if is_password {
-            password_string = PASSWORD_CHARACTER.repeat(text.chars().count());
+            password_string = core::iter::repeat(PASSWORD_CHARACTER)
+                .take(text.chars().count())
+                .collect::<String>();
             password_string.as_str()
         } else {
             text.as_str()
@@ -312,7 +314,7 @@ impl<NativeWindowWrapper> i_slint_core::renderer::Renderer for SkiaRenderer<Nati
 
         if is_password {
             text.char_indices()
-                .nth(byte_offset / PASSWORD_CHARACTER.len())
+                .nth(byte_offset / PASSWORD_CHARACTER.len_utf8())
                 .map_or(text.len(), |(r, _)| r)
         } else {
             byte_offset


### PR DESCRIPTION
Centralize the handling of the password character substitution in corelib, instead of duplicating it in the backends.