### PR TITLE
vscode: Trigger queryProperties less often

### DIFF
--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -180,6 +180,12 @@ export function activate(
     });
 
     vscode.workspace.onDidChangeTextDocument(async (ev) => {
+        if (
+            ev.document.languageId !== "slint" &&
+            ev.document.languageId !== "rust"
+        ) {
+            return;
+        }
         wasm_preview.refreshPreview(ev);
 
         // Send a request for properties information after passing through the


### PR DESCRIPTION
I somehow ended up in a situation where the Slint LSP logs was open and VSCode was logging data into that. While my cursor was in an editor with a .slint file open, the onDidChangeTextDocument events emitted by the slint log file triggered yet another attempt to `queryProperties` whenever the slint LS log changes due to e.g. reporting that a query properties request incoming.

This patch makes sure to ignore events from documents not containing slint or rust files.