### PR TITLE
Add public API to allow platforms to report the window scale factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 ### Rust
 
  - Added `slint::Image::load_from_svg_data(buffer: &[u8])` to load SVGs from memory.
+ - Added `slint::platform::WindowEvent::ScaleFactorChanged` to allow backends to report the current window scale factor.
 
 ### LSP
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -158,6 +158,7 @@ pub fn init() {
 /// This module contains functions useful for unit tests
 mod for_unit_test {
     use i_slint_core::api::ComponentHandle;
+    use i_slint_core::platform::WindowEvent;
     pub use i_slint_core::tests::slint_mock_elapsed_time as mock_elapsed_time;
     use i_slint_core::window::WindowInner;
     use i_slint_core::SharedString;
@@ -220,7 +221,7 @@ mod for_unit_test {
         component: &Component,
         factor: f32,
     ) {
-        WindowInner::from_pub(component.window()).set_scale_factor(factor)
+        component.window().dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor: factor });
     }
 }
 

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -443,7 +443,11 @@ fn process_window_event(
             if std::env::var("SLINT_SCALE_FACTOR").is_err() {
                 let size = new_inner_size.to_logical(scale_factor);
                 runtime_window.set_window_item_geometry(LogicalSize::new(size.width, size.height));
-                runtime_window.set_scale_factor(scale_factor as f32);
+                window.window().dispatch_event(
+                    i_slint_core::platform::WindowEvent::ScaleFactorChanged {
+                        scale_factor: scale_factor as f32,
+                    },
+                );
                 // Resize the underlying graphics surface
                 window.resize_event(*new_inner_size)?;
             }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -21,7 +21,7 @@ use corelib::items::MouseCursor;
 
 use corelib::layout::Orientation;
 use corelib::lengths::{LogicalLength, LogicalSize};
-use corelib::platform::PlatformError;
+use corelib::platform::{PlatformError, WindowEvent};
 use corelib::window::{WindowAdapter, WindowAdapterSealed, WindowInner};
 use corelib::Property;
 use corelib::{graphics::*, Coord};
@@ -186,10 +186,10 @@ impl WinitWindowAdapter {
 
             let scale_factor = std::env::var("SLINT_SCALE_FACTOR")
                 .ok()
-                .and_then(|x| x.parse::<f64>().ok())
+                .and_then(|x| x.parse::<f32>().ok())
                 .filter(|f| *f > 0.)
-                .unwrap_or_else(|| self_rc.winit_window().scale_factor());
-            WindowInner::from_pub(&self_rc.window()).set_scale_factor(scale_factor as _);
+                .unwrap_or_else(|| self_rc.winit_window().scale_factor() as f32);
+            self_rc.window().dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor });
 
             Ok(self_rc as _)
         }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -466,6 +466,9 @@ impl Window {
                     ..Default::default()
                 })
             }
+            crate::platform::WindowEvent::ScaleFactorChanged { scale_factor } => {
+                self.0.set_scale_factor(scale_factor);
+            }
         }
     }
 

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -210,7 +210,7 @@ pub fn duration_until_next_timer_update() -> Option<core::time::Duration> {
 pub use crate::input::key_codes::Key;
 pub use crate::input::PointerEventButton;
 
-/// A event that describes user input.
+/// A event that describes user input or windowing system events.
 ///
 /// Slint backends typically receive events from the windowing system, translate them to this
 /// enum and deliver to the scene of items via [`slint::Window::dispatch_event()`](`crate::api::Window::dispatch_event()`).
@@ -268,6 +268,15 @@ pub enum WindowEvent {
         /// let _ = slint::platform::WindowEvent::KeyReleased { text: slint::platform::Key::Shift.into() };
         /// ```
         text: SharedString,
+    },
+    /// The window's scale factor has changed. This can happen for example when the display's resolution
+    /// changes, the user selects a new scale factor in the system settings, or the window is moved to a
+    /// different screen.
+    /// Platform implementations should dispatch this event also right after the initial window creation,
+    /// to set the initial scale factor the windowing system provided for the window.
+    ScaleFactorChanged {
+        /// The window system provided scale factor to map logical pixels to physical pixels.
+        scale_factor: f32,
     },
 }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -799,7 +799,7 @@ impl WindowInner {
     }
 
     /// Sets the scale factor for the window. This is set by the backend or for testing.
-    pub fn set_scale_factor(&self, factor: f32) {
+    pub(crate) fn set_scale_factor(&self, factor: f32) {
         self.pinned_fields.scale_factor.set(factor)
     }
 


### PR DESCRIPTION
Add WindowEvent::ScaleFactorChanged and made set_scale_factor on WindowInner private.

This achieves what #2486 tried to do, but using the clean platform window event interface.