### PR TITLE
Fix support for transparent Windows on Wayland

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -468,7 +468,7 @@ impl<Renderer: WinitCompatibleRenderer + 'static> WindowAdapterSealed
                 GraphicsWindowBackendState::Mapped(_) => return Ok(()),
             };
 
-            let mut window_builder = winit::window::WindowBuilder::new();
+            let mut window_builder = winit::window::WindowBuilder::new().with_transparent(true);
 
             let runtime_window = WindowInner::from_pub(&self_.window);
             let component_rc = runtime_window.component();


### PR DESCRIPTION
We must tell winit that we want a transparent surface by default, to avoid that winit sets an opaque region on the wayland surface.

In terms of the surface, we already prefer a GL config with a color buffer that supports transparency.