### PR TITLE
Compiler: Mapping between offset and line/column positions in `SourceFile`

### DIFF
--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -520,3 +520,53 @@ impl BuildDiagnostics {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_source_file_offset_line_column_mapping() {
+        let content = r#"import { LineEdit, Button, Slider, HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+component MainWindow inherits Window {
+    property <duration> total-time: slider.value * 1s;
+
+    callback tick(duration);
+    VerticalBox {
+        HorizontalBox {
+            padding-left: 0;
+            Text { text: "Elapsed Time:"; }
+            Rectangle {
+                Rectangle {
+                    height: 100%;
+                    background: lightblue;
+                }
+            }
+        }
+    }
+
+
+}
+
+
+    "#.to_string();
+        let sf = SourceFileInner::new(PathBuf::from("foo.slint"), content.clone());
+
+        let mut line = 1;
+        let mut column = 1;
+        for offset in 0..content.len() {
+            let b = *content.as_bytes().get(offset).unwrap();
+
+            assert_eq!(sf.offset(line, column), offset);
+            assert_eq!(sf.line_column(offset), (line, column));
+
+            if b == b'\n' {
+                line += 1;
+                column = 1;
+            } else {
+                column += 1;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I am attempting to simplify the LSP by removing the line/column <-> offset mapper for files used there.

I got into strange problems doing so and was able to track them down to how the `SourceFile` handles that mapping. So fix it and add a proper test so that we can finally rely on this basic functionality working.