### PR TITLE
LSP: Simplify the code

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -42,7 +42,7 @@ pub trait SyntaxNodeVerify {
     }
 }
 
-pub use rowan::TextRange;
+pub use rowan::{TextRange, TextSize};
 
 /// Check that a node has the assumed children
 #[cfg(test)]

--- a/tools/lsp/properties.rs
+++ b/tools/lsp/properties.rs
@@ -1,19 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use crate::server_loop::{DocumentCache, OffsetToPositionMapper};
+use crate::server_loop::DocumentCache;
 use crate::Error;
 
+use crate::util::{map_node, map_node_and_url, map_position, map_range};
 use i_slint_compiler::diagnostics::{BuildDiagnostics, Spanned};
 use i_slint_compiler::langtype::{ElementType, Type};
 use i_slint_compiler::object_tree::{Element, ElementRc, PropertyDeclaration, PropertyVisibility};
 use i_slint_compiler::parser::{syntax_nodes, Language, SyntaxKind};
-use rowan::TextRange;
 
 use std::collections::HashSet;
-
-#[cfg(target_arch = "wasm32")]
-use crate::wasm_prelude::*;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, PartialEq)]
 pub(crate) struct DefinitionInformation {
@@ -78,10 +75,6 @@ fn get_reserved_properties<'a>(
     })
 }
 
-fn source_file(element: &Element) -> Option<String> {
-    element.source_file().map(|sf| sf.path().to_string_lossy().to_string())
-}
-
 fn property_is_editable(property: &PropertyDeclaration, is_local_element: bool) -> bool {
     if !property.property_type.is_property_type() {
         // Filter away the callbacks
@@ -102,27 +95,20 @@ fn property_is_editable(property: &PropertyDeclaration, is_local_element: bool) 
 
 fn add_element_properties(
     element: &Element,
-    offset_to_position: &OffsetToPositionMapper,
     group: &str,
     is_local_element: bool,
     result: &mut Vec<PropertyInformation>,
 ) {
-    let file = source_file(element);
-
     result.extend(element.property_declarations.iter().filter_map(move |(name, value)| {
         if !property_is_editable(value, is_local_element) {
             return None;
         }
 
-        let type_node = value.type_node()?; // skip fake and materialized properties
-        let declared_at = file.as_ref().map(|file| {
-            let start_position = offset_to_position.map_node(&type_node).start;
-            let uri = lsp_types::Url::from_file_path(file).unwrap_or_else(|_| {
-                lsp_types::Url::parse("file:///)").expect("That should have been valid as URL!")
-            });
-
-            DeclarationInformation { uri, start_position }
-        });
+        let declared_at = value
+            .type_node()
+            .as_ref()
+            .and_then(|node| map_node_and_url(node))
+            .map(|(uri, range)| DeclarationInformation { uri, start_position: range.start });
         Some(PropertyInformation {
             name: name.clone(),
             type_name: value.property_type.to_string(),
@@ -202,12 +188,13 @@ fn right_extend(token: rowan::SyntaxToken<Language>) -> rowan::SyntaxToken<Langu
 fn find_expression_range(
     element: &syntax_nodes::Element,
     offset: u32,
-    offset_to_position: &OffsetToPositionMapper,
 ) -> Option<DefinitionInformation> {
     let mut selection_range = None;
     let mut expression_range = None;
     let mut expression_value = None;
     let mut property_definition_range = None;
+
+    let source_file = element.source_file()?;
 
     if let Some(token) = element.token_at_offset(offset.into()).right_biased() {
         for ancestor in token.parent_ancestors() {
@@ -236,9 +223,9 @@ fn find_expression_range(
         }
     }
     Some(DefinitionInformation {
-        property_definition_range: offset_to_position.map_range(property_definition_range?),
-        selection_range: offset_to_position.map_range(selection_range?),
-        expression_range: offset_to_position.map_range(expression_range?),
+        property_definition_range: map_range(source_file, property_definition_range?),
+        selection_range: map_range(source_file, selection_range?),
+        expression_range: map_range(source_file, expression_range?),
         expression_value: expression_value?,
     })
 }
@@ -261,27 +248,19 @@ fn find_property_binding_offset(element: &Element, property_name: &str) -> Optio
     None
 }
 
-fn insert_property_definitions(
-    element: &Element,
-    properties: &mut Vec<PropertyInformation>,
-    offset_to_position: &OffsetToPositionMapper,
-) {
+fn insert_property_definitions(element: &Element, properties: &mut Vec<PropertyInformation>) {
     if let Some(element_node) = element.node.as_ref() {
         for prop_info in properties {
             if let Some(offset) = find_property_binding_offset(element, prop_info.name.as_str()) {
-                prop_info.defined_at =
-                    find_expression_range(element_node, offset, offset_to_position);
+                prop_info.defined_at = find_expression_range(element_node, offset);
             }
         }
     }
 }
 
-fn get_properties(
-    element: &ElementRc,
-    offset_to_position: &OffsetToPositionMapper,
-) -> Vec<PropertyInformation> {
+fn get_properties(element: &ElementRc) -> Vec<PropertyInformation> {
     let mut result = Vec::new();
-    add_element_properties(&element.borrow(), offset_to_position, "", true, &mut result);
+    add_element_properties(&element.borrow(), "", true, &mut result);
 
     let mut current_element = element.clone();
 
@@ -292,13 +271,7 @@ fn get_properties(
         match base_type {
             ElementType::Component(c) => {
                 current_element = c.root_element.clone();
-                add_element_properties(
-                    &current_element.borrow(),
-                    offset_to_position,
-                    &c.id,
-                    false,
-                    &mut result,
-                );
+                add_element_properties(&current_element.borrow(), &c.id, false, &mut result);
                 continue;
             }
             ElementType::Builtin(b) => {
@@ -402,45 +375,42 @@ fn get_properties(
         break;
     }
 
-    insert_property_definitions(&element.borrow(), &mut result, offset_to_position);
+    insert_property_definitions(&element.borrow(), &mut result);
 
     result
 }
 
-fn find_block_range(element: &ElementRc) -> Option<TextRange> {
+fn find_block_range(element: &ElementRc) -> Option<lsp_types::Range> {
     let element = element.borrow();
     let node = element.node.as_ref();
 
     let open_brace = node?.child_token(SyntaxKind::LBrace)?;
     let close_brace = node?.child_token(SyntaxKind::RBrace)?;
 
-    Some(TextRange::new(open_brace.text_range().start(), close_brace.text_range().end()))
+    Some(lsp_types::Range::new(
+        map_position(node?.source_file()?, open_brace.text_range().start()),
+        map_position(node?.source_file()?, close_brace.text_range().end()),
+    ))
 }
 
-fn get_element_information(
-    element: &ElementRc,
-    offset_to_position: &OffsetToPositionMapper,
-) -> ElementInformation {
+fn get_element_information(element: &ElementRc) -> ElementInformation {
     let e = element.borrow();
 
     ElementInformation {
         id: e.id.clone(),
         type_name: e.base_type.to_string(),
-        range: e.node.as_ref().map(|n| offset_to_position.map_node(n)),
+        range: e.node.as_ref().and_then(|n| map_node(n)),
     }
 }
 
 pub(crate) fn query_properties(
-    document_cache: &mut DocumentCache,
     uri: &lsp_types::Url,
     source_version: i32,
     element: &ElementRc,
 ) -> Result<QueryPropertyResponse, crate::Error> {
-    let mapper = document_cache.offset_to_position_mapper(uri)?;
-
     Ok(QueryPropertyResponse {
-        properties: get_properties(element, &mapper),
-        element: Some(get_element_information(element, &mapper)),
+        properties: get_properties(element),
+        element: Some(get_element_information(element)),
         source_uri: uri.to_string(),
         source_version,
     })
@@ -584,12 +554,11 @@ fn create_workspace_edit_for_set_binding_on_known_property(
     uri: &lsp_types::Url,
     version: i32,
     element: &ElementRc,
-    offset_mapper: &OffsetToPositionMapper,
     properties: &[PropertyInformation],
     property_name: &str,
     new_expression: &str,
 ) -> Option<lsp_types::WorkspaceEdit> {
-    let block_range = find_block_range(element).map(|r| offset_mapper.map_range(r));
+    let block_range = find_block_range(element);
 
     find_insert_range_for_property(&block_range, properties, property_name).and_then(
         |(range, insert_type)| {
@@ -636,9 +605,6 @@ fn set_binding_on_known_property(
                 uri,
                 document_cache.document_version(uri)?,
                 element,
-                &document_cache
-                    .offset_to_position_mapper(uri)
-                    .expect("This URI is known at this point!"),
                 properties,
                 property_name,
                 new_expression,
@@ -707,8 +673,7 @@ pub(crate) fn set_binding(
         }
     };
 
-    let offset_mapper = document_cache.offset_to_position_mapper(uri)?;
-    let properties = get_properties(element, &offset_mapper);
+    let properties = get_properties(element);
     let property = match get_property_information(&properties, property_name) {
         Ok(p) => p,
         Err(e) => {
@@ -772,8 +737,8 @@ pub(crate) fn remove_binding(
     element: &ElementRc,
     property_name: &str,
 ) -> Result<lsp_types::WorkspaceEdit, Error> {
-    let offset_mapper = document_cache.offset_to_position_mapper(uri)?;
     let element = element.borrow();
+    let source_file = element.node.as_ref().and_then(|n| n.source_file());
 
     let range = find_property_binding_offset(&element, property_name)
         .and_then(|offset| element.node.as_ref()?.token_at_offset(offset.into()).right_biased())
@@ -817,7 +782,7 @@ pub(crate) fn remove_binding(
                             .unwrap_or(end)
                     };
 
-                    return Some(offset_mapper.map_range(rowan::TextRange::new(start, end)));
+                    return source_file.map(|sf| map_range(sf, rowan::TextRange::new(start, end)));
                 }
                 if ancestor.kind() == SyntaxKind::Element {
                     // There should have been a binding before the element!
@@ -860,7 +825,7 @@ mod tests {
     ) -> Option<(ElementRc, Vec<PropertyInformation>)> {
         let element =
             server_loop::element_at_position(dc, &url, &lsp_types::Position { line, character })?;
-        Some((element.clone(), get_properties(&element, &dc.offset_to_position_mapper(url).ok()?)))
+        Some((element.clone(), get_properties(&element)))
     }
 
     fn properties_at_position(
@@ -910,8 +875,7 @@ mod tests {
             server_loop::element_at_position(&mut dc, &url, &lsp_types::Position::new(33, 4))
                 .unwrap();
 
-        let result =
-            get_element_information(&element, &dc.offset_to_position_mapper(&url).unwrap());
+        let result = get_element_information(&element);
 
         let r = result.range.unwrap();
         assert_eq!(r.start.line, 32);
@@ -1550,7 +1514,7 @@ component MyComp {
             .to_string(),
         );
 
-        let (_, result) = properties_at_position_in_cache(11, 0, &mut dc, &url).unwrap();
+        let (_, result) = properties_at_position_in_cache(11, 1, &mut dc, &url).unwrap();
         assert_eq!(find_property(&result, "a1").unwrap().type_name, "int");
         assert_eq!(
             find_property(&result, "a1").unwrap().defined_at.as_ref().unwrap().expression_value,

--- a/tools/lsp/server_loop.rs
+++ b/tools/lsp/server_loop.rs
@@ -3,10 +3,12 @@
 
 // cSpell: ignore descr rfind
 
+use crate::util::{map_node, map_range, map_token};
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
 use crate::{completion, goto, semantic_tokens, util};
-use i_slint_compiler::diagnostics::{BuildDiagnostics, Spanned};
+
+use i_slint_compiler::diagnostics::BuildDiagnostics;
 use i_slint_compiler::langtype::Type;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{syntax_nodes, NodeOrToken, SyntaxKind, SyntaxNode, SyntaxToken};
@@ -33,44 +35,6 @@ use std::pin::Pin;
 use std::rc::Rc;
 
 pub type Error = Box<dyn std::error::Error>;
-
-/// Trim leading and trailing whitespace tokens from the `range`
-/// `token` must be the first token in that `range`.
-/// This should actually not be necessary (the parser should not
-/// add stray whitespace tokens), but it makes working with the LSP so
-/// much nicer that I want this here till we fix the parser.
-fn range_from_token(token: Option<SyntaxToken>, range: &rowan::TextRange) -> rowan::TextRange {
-    let mut current_token = token;
-    let mut start_pos = None;
-    let mut end_pos = None;
-
-    while let Some(ct) = current_token {
-        current_token = ct.next_token();
-
-        if ct.text_range().end() > range.end() {
-            break;
-        }
-        if ct.kind() != SyntaxKind::Whitespace {
-            let r = ct.text_range();
-            start_pos = Some(r.start());
-            end_pos = Some(r.end());
-            break;
-        }
-    }
-
-    while let Some(ct) = current_token {
-        current_token = ct.next_token();
-
-        if ct.text_range().end() > range.end() {
-            break;
-        }
-        if ct.kind() != SyntaxKind::Whitespace {
-            end_pos = Some(ct.text_range().end());
-        }
-    }
-
-    rowan::TextRange::new(start_pos.unwrap_or(range.start()), end_pos.unwrap_or(range.end()))
-}
 
 pub struct ProgressReporter {
     token: Option<lsp_types::ProgressToken>,
@@ -188,7 +152,6 @@ fn create_show_preview_command(pretty: bool, file: &str, component_name: &str) -
 
 pub struct DocumentCache {
     pub(crate) documents: TypeLoader,
-    newline_offsets: HashMap<Url, Rc<Vec<u32>>>,
     versions: HashMap<Url, i32>,
 }
 
@@ -196,75 +159,11 @@ impl DocumentCache {
     pub fn new(config: CompilerConfiguration) -> Self {
         let documents =
             TypeLoader::new(TypeRegister::builtin(), config, &mut BuildDiagnostics::default());
-        Self { documents, newline_offsets: Default::default(), versions: Default::default() }
-    }
-
-    fn newline_offsets_from_content(content: &str) -> Vec<u32> {
-        let mut ln_offs = 0;
-        content
-            .split('\n')
-            .map(|line| {
-                let r = ln_offs;
-                ln_offs += line.len() as u32 + 1;
-                r
-            })
-            .collect()
+        Self { documents, versions: Default::default() }
     }
 
     pub fn document_version(&self, target_uri: &lsp_types::Url) -> Option<i32> {
         self.versions.get(target_uri).cloned()
-    }
-
-    fn newline_offsets_of_url(&mut self, uri: &lsp_types::Url) -> Option<Rc<Vec<u32>>> {
-        let newline_offsets = match self.newline_offsets.entry(uri.clone()) {
-            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
-            std::collections::hash_map::Entry::Vacant(e) => {
-                let path = uri.to_file_path().ok()?;
-                let content =
-                    self.documents.get_document(&path)?.node.as_ref()?.source_file()?.source()?;
-                e.insert(Rc::new(Self::newline_offsets_from_content(content)))
-            }
-        };
-        Some(newline_offsets.clone())
-    }
-
-    pub fn offset_to_position_mapper(
-        &mut self,
-        uri: &Url,
-    ) -> Result<OffsetToPositionMapper, Error> {
-        self.newline_offsets_of_url(uri)
-            .map(OffsetToPositionMapper)
-            .ok_or_else(|| Into::<Error>::into("Document not found in cache"))
-    }
-}
-
-pub struct OffsetToPositionMapper(Rc<Vec<u32>>);
-
-impl OffsetToPositionMapper {
-    pub fn map_u32(&self, offset: u32) -> lsp_types::Position {
-        self.0.binary_search(&offset).map_or_else(
-            |line| {
-                if line == 0 {
-                    Position::new(0, offset)
-                } else {
-                    Position::new(line as u32 - 1, self.0.get(line - 1).map_or(0, |x| offset - *x))
-                }
-            },
-            |line| Position::new(line as u32, 0),
-        )
-    }
-
-    pub fn map(&self, s: rowan::TextSize) -> lsp_types::Position {
-        self.map_u32(s.into())
-    }
-
-    pub fn map_range(&self, r: rowan::TextRange) -> lsp_types::Range {
-        lsp_types::Range::new(self.map(r.start()), self.map(r.end()))
-    }
-
-    /// This strips leading/trailing whitespace tokens from the node
-    pub fn map_node(&self, n: &SyntaxNode) -> lsp_types::Range {
-        self.map_range(range_from_token(n.first_token(), &n.text_range()))
     }
 }
 
@@ -521,25 +420,24 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
         if let Some((tk, _off)) =
             token_descr(document_cache, &uri, &_params.text_document_position_params.position)
         {
-            let offset_mapper = document_cache.offset_to_position_mapper(&uri)?;
             let p = tk.parent();
             #[cfg(feature = "preview-api")]
             if p.kind() == SyntaxKind::QualifiedName
                 && p.parent().map_or(false, |n| n.kind() == SyntaxKind::Element)
             {
-                (ctx.preview.highlight)(&ctx, uri.to_file_path().ok(), _off)?;
-                let range = offset_mapper.map_range(p.text_range());
-                return Ok(Some(vec![lsp_types::DocumentHighlight { range, kind: None }]));
-            } else {
-                (ctx.preview.highlight)(&ctx, None, 0)?;
+                if let Some(range) = map_node(&p) {
+                    (ctx.preview.highlight)(&ctx, uri.to_file_path().ok(), _off)?;
+                    return Ok(Some(vec![lsp_types::DocumentHighlight { range, kind: None }]));
+                }
             }
 
             if let Some(value) = find_element_id_for_highlight(&tk, &p) {
+                (ctx.preview.highlight)(&ctx, None, 0)?;
                 return Ok(Some(
                     value
                         .into_iter()
                         .map(|r| lsp_types::DocumentHighlight {
-                            range: offset_mapper.map_range(r),
+                            range: map_range(&p.source_file, r),
                             kind: None,
                         })
                         .collect(),
@@ -556,12 +454,12 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
         if let Some((tk, _off)) =
             token_descr(&mut document_cache, &uri, &params.text_document_position.position)
         {
+            let p = tk.parent();
             if let Some(value) = find_element_id_for_highlight(&tk, &tk.parent()) {
-                let mapper = document_cache.offset_to_position_mapper(&uri)?;
                 let edits = value
                     .into_iter()
                     .map(|r| TextEdit {
-                        range: mapper.map_range(r),
+                        range: map_range(&p.source_file, r),
                         new_text: params.new_name.clone(),
                     })
                     .collect();
@@ -578,9 +476,7 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
         let uri = params.text_document.uri;
         if let Some((tk, _off)) = token_descr(&mut document_cache, &uri, &params.position) {
             if find_element_id_for_highlight(&tk, &tk.parent()).is_some() {
-                return Ok(Some(PrepareRenameResponse::Range(
-                    document_cache.offset_to_position_mapper(&uri)?.map_range(tk.text_range()),
-                )));
+                return Ok(map_token(&tk).map(|r| PrepareRenameResponse::Range(r)));
             }
         };
         Ok(None)
@@ -671,7 +567,7 @@ pub fn query_properties_command(
     };
 
     if let Some(element) = element_at_position(document_cache, &text_document_uri, &position) {
-        properties::query_properties(document_cache, &text_document_uri, source_version, &element)
+        properties::query_properties(&text_document_uri, source_version, &element)
             .map(|r| serde_json::to_value(r).expect("Failed to serialize property query result!"))
     } else {
         Ok(serde_json::to_value(properties::QueryPropertyResponse::no_element_response(
@@ -728,14 +624,14 @@ pub async fn set_binding_command(
                 format!("No element found at the given start position {:?}", &element_range.start)
             })?;
 
-        let offset_mapper = document_cache.offset_to_position_mapper(&uri)?;
-        let node_range = offset_mapper.map_node(
+        let node_range = map_node(
             element
                 .borrow()
                 .node
                 .as_ref()
                 .ok_or("The element was found, but had no range defined!")?,
-        );
+        )
+        .ok_or("Failed to map node")?;
 
         if node_range.start != element_range.start {
             return Err(format!(
@@ -794,7 +690,6 @@ pub async fn remove_binding_command(
     let edit = {
         let document_cache = &mut ctx.document_cache.borrow_mut();
         let uri = text_document.uri;
-        let offset_mapper = document_cache.offset_to_position_mapper(&uri)?;
 
         if let Some(source_version) = text_document.version {
             if let Some(current_version) = document_cache.document_version(&uri) {
@@ -814,13 +709,14 @@ pub async fn remove_binding_command(
                 format!("No element found at the given start position {:?}", &element_range.start)
             })?;
 
-        let node_range = offset_mapper.map_node(
+        let node_range = map_node(
             element
                 .borrow()
                 .node
                 .as_ref()
                 .ok_or("The element was found, but had no range defined!")?,
-        );
+        )
+        .ok_or("Failed to map node")?;
 
         if node_range.start != element_range.start {
             return Err(format!(
@@ -916,8 +812,6 @@ pub async fn reload_document_impl(
         };
     }
 
-    let newline_offsets = Rc::new(DocumentCache::newline_offsets_from_content(&content));
-    document_cache.newline_offsets.insert(uri.clone(), newline_offsets);
     document_cache.versions.insert(uri.clone(), version);
 
     let path_canon = dunce::canonicalize(&path).unwrap_or_else(|_| path.to_owned());
@@ -1092,10 +986,9 @@ fn get_document_and_offset<'a>(
     text_document_uri: &'a Url,
     pos: &'a Position,
 ) -> Option<(&'a i_slint_compiler::object_tree::Document, u32)> {
-    let o = document_cache.newline_offsets.get(text_document_uri)?.get(pos.line as usize)?
-        + pos.character;
-
     let doc = document_cache.documents.get_document(&text_document_uri.to_file_path().ok()?)?;
+    let o = doc.node.as_ref()?.source_file.offset(pos.line as usize + 1, pos.character as usize + 1)
+        as u32;
     doc.node.as_ref()?.text_range().contains_inclusive(o.into()).then_some((doc, o))
 }
 
@@ -1194,14 +1087,13 @@ fn get_document_color(
 ) -> Option<Vec<ColorInformation>> {
     let mut result = Vec::new();
     let uri = &text_document.uri;
-    let offset_mapper = document_cache.offset_to_position_mapper(uri).ok()?;
     let doc = document_cache.documents.get_document(&uri.to_file_path().ok()?)?;
-    let root_node = &doc.node.as_ref()?.node;
+    let root_node = doc.node.as_ref()?;
     let mut token = root_node.first_token()?;
     loop {
         if token.kind() == SyntaxKind::ColorLiteral {
             (|| -> Option<()> {
-                let range = offset_mapper.map_range(token.text_range());
+                let range = map_token(&token)?;
                 let col = i_slint_compiler::literals::parse_color_literal(token.text())?;
                 let shift = |s: u32| -> f32 { ((col >> s) & 0xff) as f32 / 255. };
                 result.push(ColorInformation {
@@ -1228,7 +1120,6 @@ fn get_document_symbols(
     text_document: &lsp_types::TextDocumentIdentifier,
 ) -> Option<DocumentSymbolResponse> {
     let uri = &text_document.uri;
-    let offset_mapper = document_cache.offset_to_position_mapper(uri).ok()?;
     let doc = document_cache.documents.get_document(&uri.to_file_path().ok()?)?;
 
     // DocumentSymbol doesn't implement default and some field depends on features or are deprecated
@@ -1246,10 +1137,10 @@ fn get_document_symbols(
             let root_element = c.root_element.borrow();
             let element_node = root_element.node.as_ref()?;
             let component_node = syntax_nodes::Component::new(element_node.parent()?)?;
-            let selection_range = offset_mapper.map_node(&component_node.DeclaredIdentifier());
+            let selection_range = map_node(&component_node.DeclaredIdentifier())?;
 
             Some(DocumentSymbol {
-                range: offset_mapper.map_node(&component_node),
+                range: map_node(&component_node)?,
                 selection_range,
                 name: c.id.clone(),
                 kind: if c.is_global() {
@@ -1257,7 +1148,7 @@ fn get_document_symbols(
                 } else {
                     lsp_types::SymbolKind::CLASS
                 },
-                children: gen_children(&c.root_element, &ds, &offset_mapper),
+                children: gen_children(&c.root_element, &ds),
                 ..ds.clone()
             })
         })
@@ -1265,8 +1156,8 @@ fn get_document_symbols(
 
     r.extend(inner_structs.iter().filter_map(|c| match c {
         Type::Struct { name: Some(name), node: Some(node), .. } => Some(DocumentSymbol {
-            range: offset_mapper.map_node(node.parent().as_ref()?),
-            selection_range: offset_mapper.map_node(node),
+            range: map_node(node.parent().as_ref()?)?,
+            selection_range: map_node(node)?,
             name: name.clone(),
             kind: lsp_types::SymbolKind::STRUCT,
             ..ds.clone()
@@ -1274,11 +1165,7 @@ fn get_document_symbols(
         _ => None,
     }));
 
-    fn gen_children(
-        elem: &ElementRc,
-        ds: &DocumentSymbol,
-        offset_mapper: &OffsetToPositionMapper,
-    ) -> Option<Vec<DocumentSymbol>> {
+    fn gen_children(elem: &ElementRc, ds: &DocumentSymbol) -> Option<Vec<DocumentSymbol>> {
         let r = elem
             .borrow()
             .children
@@ -1286,13 +1173,12 @@ fn get_document_symbols(
             .filter_map(|child| {
                 let e = child.borrow();
                 Some(DocumentSymbol {
-                    range: offset_mapper.map_node(e.node.as_ref()?),
-                    selection_range: offset_mapper
-                        .map_node(e.node.as_ref()?.QualifiedName().as_ref()?),
+                    range: map_node(e.node.as_ref()?)?,
+                    selection_range: map_node(e.node.as_ref()?.QualifiedName().as_ref()?)?,
                     name: e.base_type.to_string(),
                     detail: (!e.id.is_empty()).then(|| e.id.clone()),
                     kind: lsp_types::SymbolKind::VARIABLE,
-                    children: gen_children(child, ds, offset_mapper),
+                    children: gen_children(child, ds),
                     ..ds.clone()
                 })
             })
@@ -1319,7 +1205,6 @@ fn get_code_lenses(
 ) -> Option<Vec<CodeLens>> {
     if cfg!(feature = "preview-lense") {
         let uri = &text_document.uri;
-        let offset_mapper = document_cache.offset_to_position_mapper(uri).ok()?;
         let filepath = uri.to_file_path().ok()?;
         let doc = document_cache.documents.get_document(&filepath)?;
 
@@ -1330,7 +1215,7 @@ fn get_code_lenses(
         // Handle preview lens
         r.extend(inner_components.iter().filter(|c| !c.is_global()).filter_map(|c| {
             Some(CodeLens {
-                range: offset_mapper.map_range(c.root_element.borrow().node.as_ref()?.text_range()),
+                range: map_node(c.root_element.borrow().node.as_ref()?)?,
                 command: Some(create_show_preview_command(true, uri.as_str(), c.id.as_str())),
                 data: None,
             })
@@ -1479,23 +1364,6 @@ mod tests {
         let diagnostics = diag.get(&url).expect("URL not found in result");
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Some(lsp_types::DiagnosticSeverity::ERROR));
-    }
-
-    #[test]
-    fn test_reload_document_text_positions() {
-        let (mut dc, url, _) = loaded_document_cache(
-            "fluent",
-            // cspell:disable-next-line
-            "Thiß is not valid!\n and more...".into(),
-        );
-
-        let mapper = dc.offset_to_position_mapper(&url).unwrap();
-
-        assert_eq!(mapper.map_u32(0), lsp_types::Position { line: 0, character: 0 });
-        assert_eq!(mapper.map_u32(4), lsp_types::Position { line: 0, character: 4 });
-        assert_eq!(mapper.map_u32(5), lsp_types::Position { line: 0, character: 5 }); // TODO: Figure out whether this is actually correct...
-        assert_eq!(mapper.map_u32(1024), lsp_types::Position { line: 1, character: 1004 });
-        // TODO: This is nonsense!
     }
 
     #[test]


### PR DESCRIPTION
This removes the `OffsetToPositionMapper` and related code.

It also relies on a patch landed this week that makes sure `SyntaxNode`s will not start with whitespace.

This relies on #2653 being present!