### PR TITLE
Fixed missing items compilation error in the generated code related to public functions (#2655).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### General
+
+ * Fixed missing items compilation error in the generated code related to public functions (#2655).
+
 ### Rust
 
 - Added `slint::Image::load_from_svg_data(buffer: &[u8])` to load SVGs from memory.

--- a/cspell.json
+++ b/cspell.json
@@ -93,6 +93,7 @@
         "SPDX",
         "streetsidesoftware",
         "struct",
+        "structs",
         "tabwidget",
         "testcase",
         "textedit",

--- a/internal/compiler/passes/collect_structs.rs
+++ b/internal/compiler/passes/collect_structs.rs
@@ -94,6 +94,12 @@ fn visit_named_object(ty: &Type, visitor: &mut impl FnMut(&String, &Type)) {
                 visit_named_object(a, visitor);
             }
         }
+        Type::Function { return_type, args } => {
+            visit_named_object(return_type, visitor);
+            for a in args {
+                visit_named_object(a, visitor);
+            }
+        }
         _ => {}
     }
 }

--- a/tests/cases/types/functions.slint
+++ b/tests/cases/types/functions.slint
@@ -1,0 +1,32 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// Test that structs work if they are only referenced by functions
+
+struct Foo1 { member: int, }
+struct Foo2 { a: Foo1 }
+struct Foo3 { b: int }
+
+TestCase := TouchArea {
+    // Based on Issue #2655
+    public function fn1(foo2: Foo2) -> Foo3 {
+      return { b: foo2.a.member+1 };
+    }
+}
+
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.invoke_fn1(Foo2{ a: Foo1{ member: 123 } }).b, 124);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert_eq(instance.invoke_fn1(Foo2{ Foo1{ 123 } }).b, 124);
+```
+
+*/


### PR DESCRIPTION
Fixed missing items compilation error in the generated code related to public functions (#2655).

I manually "mutation tested" the change against `cargo test test-driver-cpp` and `cargo test test-driver-rust`

`cargo test test-driver-nodejs` shouldn't actually make a difference with this change, though.