### PR TITLE
docs: Correct debug(string) returns "void"

### DIFF
--- a/docs/language/src/builtins/functions.md
+++ b/docs/language/src/builtins/functions.md
@@ -27,6 +27,6 @@ export component Example inherits Window {
 }
 ```
 
-## `debug(string) -> string`
+## `debug(...)`
 
-The debug function take a string as an argument and prints it
+The debug function can take one or multiple values as arguments, prints them, and returns nothing.


### PR DESCRIPTION
Additional enhancement might be to have a `stringify(string) -> string` builtin function to make it possible to print values like `3px` easily for debugging animations and math code.