### PR TITLE
Support negative numbers in `cubic-bezier(...)` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented in this file.
 
  * Fixed missing items compilation error in the generated code related to public functions (#2655).
 
+### Slint Language
+
+- Support negative numbers in `cubic-bezier(...)` function.
+
 ### Rust
 
 - Added `slint::Image::load_from_svg_data(buffer: &[u8])` to load SVGs from memory.

--- a/tests/cases/types/cubic-bezier.slint
+++ b/tests/cases/types/cubic-bezier.slint
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// Test that cubic-bezier() can accept negative numbers
+
+TestCase := Rectangle {
+    animate background {
+      easing: cubic-bezier(0.600, -0.280, 0.735, 0.045); // ease-in-back
+    }
+}


### PR DESCRIPTION
Required to support ease in back / bounce kinds of easings.

Tested with mutation testing alongside `cargo test test-driver-interpreter`.