### PR TITLE
dev: Ignore CHANGELOG.md from pre-commit hook checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# See https://prettier.io/docs/en/ignore.html
+CHANGELOG.md

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,7 +7,7 @@ Files: */slint-logo-*.svg */slint-logo-*.png
 Copyright: Copyright © SixtyFPS GmbH <info@slint-ui.com>
 License: CC-BY-ND-4.0
 
-Files: .clang-format .gitattributes .gitignore */.gitignore .dockerignore .pre-commit-config.yaml .vscode/* cspell.json rustfmt.toml .mailmap */.eslintrc.yml Cargo.lock
+Files: .clang-format .gitattributes .gitignore */.gitignore .dockerignore .prettierignore .pre-commit-config.yaml .vscode/* cspell.json rustfmt.toml .mailmap */.eslintrc.yml Cargo.lock
 Copyright: Copyright © SixtyFPS GmbH <info@slint-ui.com>
 License: GPL-3.0-only OR LicenseRef-Slint-commercial
 

--- a/cspell.json
+++ b/cspell.json
@@ -113,6 +113,7 @@
     "ignorePaths": [
         "api/cpp/docs/conf.py",
         "Cargo.toml",
+        "CHANGELOG.md",
         "cspell.json",
         ".github/workflows/*.yaml"
     ],

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -309,6 +309,7 @@ lazy_static! {
         ("\\.gitattributes$", LicenseLocation::NoLicense),
         ("\\.gitignore$", LicenseLocation::NoLicense),
         ("\\.dockerignore$", LicenseLocation::NoLicense),
+        ("\\.prettierignore$", LicenseLocation::NoLicense),
         ("\\.h$", LicenseLocation::Tag(LicenseTagStyle::c_style_comment_style())),
         ("\\.html$", LicenseLocation::NoLicense),
         ("\\.jpg$", LicenseLocation::NoLicense),


### PR DESCRIPTION
Makes it a bit easier to use pre-commit hook since I'm trying to group the changelog update, the code change, and the test case addition in the same commit for easier reference.

TODO: 
- [x] Fix CI check for license header for .prettierignore file. 