### PR TITLE
Refactoring: Pass the size to to the render function

### DIFF
--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -55,7 +55,7 @@ macro_rules! get_size {
 
 macro_rules! fn_render {
     ($this:ident $dpr:ident $size:ident $painter:ident $widget:ident $initial_state:ident => $($tt:tt)*) => {
-        fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer, item_rc: &ItemRc) -> RenderingResult {
+        fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer, item_rc: &ItemRc, size: LogicalSize) -> RenderingResult {
             let $dpr: f32 = backend.scale_factor();
 
             let active: bool = backend.window().active();
@@ -69,7 +69,12 @@ macro_rules! fn_render {
             });
 
             if let Some(painter) = backend.as_any().and_then(|any| <dyn std::any::Any>::downcast_mut::<QPainterPtr>(any)) {
-                let $size: qttypes::QSize = get_size!(self);
+                let width = size.width * $dpr;
+                let height = size.height * $dpr;
+                if width < 1. || height < 1. {
+                    return Default::default();
+                };
+                let $size = qttypes::QSize { width: width as _, height: height as _ };
                 let $this = self;
                 painter.save();
                 let $widget = cpp!(unsafe [painter as "QPainterPtr*"] -> * const () as "QWidget*" {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -500,7 +500,7 @@ fn from_qt_button(qt_button: u32) -> PointerEventButton {
 macro_rules! check_geometry {
     ($size:expr) => {{
         let size = $size;
-        if size.width <= 0. || size.height <= 0. {
+        if size.width < 1. || size.height < 1. {
             return Default::default();
         };
         qttypes::QRectF { x: 0., y: 0., width: size.width as _, height: size.height as _ }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -162,6 +162,7 @@ pub struct ItemVTable {
         core::pin::Pin<VRef<ItemVTable>>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult,
 }
 
@@ -239,6 +240,7 @@ impl Item for Empty {
         self: Pin<&Self>,
         _backend: &mut ItemRendererRef,
         _self_rc: &ItemRc,
+        _size: LogicalSize,
     ) -> RenderingResult {
         RenderingResult::ContinueRenderingChildren
     }
@@ -326,8 +328,9 @@ impl Item for Rectangle {
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        (*backend).draw_rectangle(self, self_rc);
+        (*backend).draw_rectangle(self, self_rc, size);
         RenderingResult::ContinueRenderingChildren
     }
 }
@@ -417,8 +420,9 @@ impl Item for BorderRectangle {
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        (*backend).draw_border_rectangle(self, self_rc);
+        (*backend).draw_border_rectangle(self, self_rc, size);
         RenderingResult::ContinueRenderingChildren
     }
 }
@@ -605,6 +609,7 @@ impl Item for TouchArea {
         self: Pin<&Self>,
         _backend: &mut ItemRendererRef,
         _self_rc: &ItemRc,
+        _size: LogicalSize,
     ) -> RenderingResult {
         RenderingResult::ContinueRenderingChildren
     }
@@ -727,6 +732,7 @@ impl Item for FocusScope {
         self: Pin<&Self>,
         _backend: &mut ItemRendererRef,
         _self_rc: &ItemRc,
+        _size: LogicalSize,
     ) -> RenderingResult {
         RenderingResult::ContinueRenderingChildren
     }
@@ -826,8 +832,9 @@ impl Item for Clip {
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        (*backend).visit_clip(self, self_rc)
+        (*backend).visit_clip(self, self_rc, size)
     }
 }
 
@@ -912,8 +919,9 @@ impl Item for Opacity {
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        backend.visit_opacity(self, self_rc)
+        backend.visit_opacity(self, self_rc, size)
     }
 }
 
@@ -1027,8 +1035,9 @@ impl Item for Layer {
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        backend.visit_layer(self, self_rc)
+        backend.visit_layer(self, self_rc, size)
     }
 }
 
@@ -1116,6 +1125,7 @@ impl Item for Rotate {
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
         _self_rc: &ItemRc,
+        _size: LogicalSize,
     ) -> RenderingResult {
         let origin =
             LogicalVector::from_lengths(self.rotation_origin_x(), self.rotation_origin_y());
@@ -1240,6 +1250,7 @@ impl Item for WindowItem {
         self: Pin<&Self>,
         _backend: &mut ItemRendererRef,
         _self_rc: &ItemRc,
+        _size: LogicalSize,
     ) -> RenderingResult {
         RenderingResult::ContinueRenderingChildren
     }
@@ -1360,8 +1371,9 @@ impl Item for BoxShadow {
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        (*backend).draw_box_shadow(self, self_rc);
+        (*backend).draw_box_shadow(self, self_rc, size);
         RenderingResult::ContinueRenderingChildren
     }
 }

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -140,10 +140,10 @@ impl Item for Flickable {
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
         _self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        let geometry = self.geometry();
         (*backend).combine_clip(
-            LogicalRect::new(LogicalPoint::default(), geometry.size),
+            LogicalRect::new(LogicalPoint::default(), size),
             LogicalLength::zero(),
             LogicalLength::zero(),
         );

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -109,8 +109,9 @@ impl Item for ImageItem {
         self: Pin<&Self>,
         backend: &mut &mut dyn ItemRenderer,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        (*backend).draw_image(self, self_rc);
+        (*backend).draw_image(self, self_rc, size);
         RenderingResult::ContinueRenderingChildren
     }
 }
@@ -214,8 +215,9 @@ impl Item for ClippedImage {
         self: Pin<&Self>,
         backend: &mut &mut dyn ItemRenderer,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        (*backend).draw_clipped_image(self, self_rc);
+        (*backend).draw_clipped_image(self, self_rc, size);
         RenderingResult::ContinueRenderingChildren
     }
 }

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -120,13 +120,14 @@ impl Item for Path {
         self: Pin<&Self>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
         let clip = self.clip();
         if clip {
             (*backend).save_state();
-            (*backend).combine_clip(self.geometry(), LogicalLength::zero(), LogicalLength::zero());
+            (*backend).combine_clip(size.into(), LogicalLength::zero(), LogicalLength::zero());
         }
-        (*backend).draw_path(self, self_rc);
+        (*backend).draw_path(self, self_rc, size);
         if clip {
             (*backend).restore_state();
         }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -163,8 +163,9 @@ impl Item for Text {
         self: Pin<&Self>,
         backend: &mut &mut dyn ItemRenderer,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        (*backend).draw_text(self, self_rc);
+        (*backend).draw_text(self, self_rc, size);
         RenderingResult::ContinueRenderingChildren
     }
 }
@@ -577,8 +578,9 @@ impl Item for TextInput {
         self: Pin<&Self>,
         backend: &mut &mut dyn ItemRenderer,
         self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
-        (*backend).draw_text_input(self, self_rc);
+        (*backend).draw_text_input(self, self_rc, size);
         RenderingResult::ContinueRenderingChildren
     }
 }

--- a/internal/core/lengths.rs
+++ b/internal/core/lengths.rs
@@ -80,3 +80,9 @@ impl<T: Copy, U> RectLengths for euclid::Rect<T, U> {
         self.size_length().height_length()
     }
 }
+
+/// Convert from the api size to the internal size
+/// (This doesn't use the `From` trait because it would expose the conversion to euclid in the public API)
+pub fn logical_size_from_api(size: crate::api::LogicalSize) -> LogicalSize {
+    size.to_euclid()
+}

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -11,7 +11,7 @@ mod fonts;
 use crate::api::Window;
 use crate::graphics::{IntRect, PixelFormat, SharedImageBuffer, SharedPixelBuffer};
 use crate::item_rendering::ItemRenderer;
-use crate::items::{ImageFit, Item, ItemRc, TextOverflow};
+use crate::items::{ImageFit, ItemRc, TextOverflow};
 use crate::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector, PhysicalPx, PointLengths,
     RectLengths, ScaleFactor, SizeLengths,
@@ -1248,8 +1248,13 @@ struct RenderState {
 }
 
 impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'a, T> {
-    fn draw_rectangle(&mut self, rect: Pin<&crate::items::Rectangle>, _: &ItemRc) {
-        let geom = LogicalRect::new(LogicalPoint::default(), rect.geometry().size_length());
+    fn draw_rectangle(
+        &mut self,
+        rect: Pin<&crate::items::Rectangle>,
+        _: &ItemRc,
+        size: LogicalSize,
+    ) {
+        let geom = LogicalRect::from(size);
         if self.should_draw(&geom) {
             let clipped = match geom.intersection(&self.current_state.clip) {
                 Some(geom) => geom,
@@ -1369,8 +1374,13 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
         }
     }
 
-    fn draw_border_rectangle(&mut self, rect: Pin<&crate::items::BorderRectangle>, _: &ItemRc) {
-        let geom = LogicalRect::new(LogicalPoint::default(), rect.geometry().size_length());
+    fn draw_border_rectangle(
+        &mut self,
+        rect: Pin<&crate::items::BorderRectangle>,
+        _: &ItemRc,
+        size: LogicalSize,
+    ) {
+        let geom = LogicalRect::from(size);
         if self.should_draw(&geom) {
             let mut border = rect.border_width();
             let radius = rect.border_radius();
@@ -1480,9 +1490,8 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
         }
     }
 
-    fn draw_image(&mut self, image: Pin<&crate::items::ImageItem>, _: &ItemRc) {
-        let geom =
-            LogicalRect::new(LogicalPoint::default(), image.as_ref().geometry().size_length());
+    fn draw_image(&mut self, image: Pin<&crate::items::ImageItem>, _: &ItemRc, size: LogicalSize) {
+        let geom = LogicalRect::from(size);
         if self.should_draw(&geom) {
             let source = image.source();
             self.draw_image_impl(
@@ -1495,8 +1504,13 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
         }
     }
 
-    fn draw_clipped_image(&mut self, image: Pin<&crate::items::ClippedImage>, _: &ItemRc) {
-        let geom = LogicalRect::new(LogicalPoint::default(), image.geometry().size_length());
+    fn draw_clipped_image(
+        &mut self,
+        image: Pin<&crate::items::ClippedImage>,
+        _: &ItemRc,
+        size: LogicalSize,
+    ) {
+        let geom = LogicalRect::from(size);
         if self.should_draw(&geom) {
             let source = image.source();
 
@@ -1523,12 +1537,12 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
         }
     }
 
-    fn draw_text(&mut self, text: Pin<&crate::items::Text>, _: &ItemRc) {
+    fn draw_text(&mut self, text: Pin<&crate::items::Text>, _: &ItemRc, size: LogicalSize) {
         let string = text.text();
         if string.trim().is_empty() {
             return;
         }
-        let geom = LogicalRect::new(LogicalPoint::default(), text.geometry().size_length());
+        let geom = LogicalRect::from(size);
         if !self.should_draw(&geom) {
             return;
         }
@@ -1590,9 +1604,14 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
         }
     }
 
-    fn draw_text_input(&mut self, text_input: Pin<&crate::items::TextInput>, _: &ItemRc) {
+    fn draw_text_input(
+        &mut self,
+        text_input: Pin<&crate::items::TextInput>,
+        _: &ItemRc,
+        size: LogicalSize,
+    ) {
         let string = text_input.text();
-        let geom = LogicalRect::new(LogicalPoint::default(), text_input.geometry().size_length());
+        let geom = LogicalRect::from(size);
         if !self.should_draw(&geom) {
             return;
         }
@@ -1651,13 +1670,16 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
     }
 
     #[cfg(feature = "std")]
-    fn draw_path(&mut self, path: Pin<&crate::items::Path>, _: &ItemRc) {
-        path.geometry();
+    fn draw_path(&mut self, _path: Pin<&crate::items::Path>, _: &ItemRc, _size: LogicalSize) {
         // TODO
     }
 
-    fn draw_box_shadow(&mut self, box_shadow: Pin<&crate::items::BoxShadow>, _: &ItemRc) {
-        box_shadow.geometry();
+    fn draw_box_shadow(
+        &mut self,
+        _box_shadow: Pin<&crate::items::BoxShadow>,
+        _: &ItemRc,
+        _size: LogicalSize,
+    ) {
         // TODO
     }
 

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -10,7 +10,6 @@ use std::rc::{Rc, Weak};
 
 use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::graphics::{euclid, rendering_metrics_collector::RenderingMetricsCollector};
-use i_slint_core::items::Item;
 use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PhysicalPx, ScaleFactor,
 };
@@ -176,9 +175,12 @@ impl FemtoVGRenderer {
             match window_background_brush {
                 Some(Brush::SolidColor(..)) | None => {}
                 Some(brush @ _) => {
-                    if let Some(window_item) = window.window_item() {
-                        item_renderer.draw_rect(window_item.as_pin_ref().geometry(), brush);
-                    }
+                    item_renderer.draw_rect(
+                        i_slint_core::lengths::logical_size_from_api(
+                            size.to_logical(window.scale_factor()),
+                        ),
+                        brush,
+                    );
                 }
             }
 

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -8,11 +8,10 @@ use i_slint_core::graphics::boxshadowcache::BoxShadowCache;
 use i_slint_core::graphics::euclid::num::Zero;
 use i_slint_core::graphics::euclid::{self, Vector2D};
 use i_slint_core::item_rendering::{ItemCache, ItemRenderer};
-use i_slint_core::items::Item;
 use i_slint_core::items::{ImageFit, ImageRendering, ItemRc, Layer, Opacity, RenderingResult};
 use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalPx, LogicalRect, LogicalSize, LogicalVector, PhysicalPx,
-    RectLengths, ScaleFactor,
+    RectLengths, ScaleFactor, SizeLengths,
 };
 use i_slint_core::window::WindowInner;
 use i_slint_core::{items, Brush, Color, Property};
@@ -273,8 +272,8 @@ impl<'a> SkiaRenderer<'a> {
 
 impl<'a> SkiaRenderer<'a> {
     /// Draws a `Rectangle` using the `GLItemRenderer`.
-    pub fn draw_rect(&mut self, rect: LogicalRect, brush: Brush) {
-        let geometry = PhysicalRect::new(PhysicalPoint::default(), rect.size * self.scale_factor);
+    pub fn draw_rect(&mut self, size: LogicalSize, brush: Brush) {
+        let geometry = PhysicalRect::from(size * self.scale_factor);
         if geometry.is_empty() {
             return;
         }
@@ -293,16 +292,18 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         &mut self,
         rect: std::pin::Pin<&i_slint_core::items::Rectangle>,
         _self_rc: &i_slint_core::items::ItemRc,
+        size: LogicalSize,
     ) {
-        self.draw_rect(rect.geometry(), rect.background());
+        self.draw_rect(size, rect.background());
     }
 
     fn draw_border_rectangle(
         &mut self,
         rect: std::pin::Pin<&i_slint_core::items::BorderRectangle>,
         _self_rc: &i_slint_core::items::ItemRc,
+        size: LogicalSize,
     ) {
-        let mut geometry = item_rect(rect, self.scale_factor);
+        let mut geometry = PhysicalRect::from(size * self.scale_factor);
         if geometry.is_empty() {
             return;
         }
@@ -392,8 +393,9 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         &mut self,
         image: std::pin::Pin<&i_slint_core::items::ImageItem>,
         self_rc: &i_slint_core::items::ItemRc,
+        size: LogicalSize,
     ) {
-        let geometry = item_rect(image, self.scale_factor);
+        let geometry = PhysicalRect::from(size * self.scale_factor);
         if geometry.is_empty() {
             return;
         }
@@ -415,8 +417,9 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         &mut self,
         image: std::pin::Pin<&i_slint_core::items::ClippedImage>,
         self_rc: &i_slint_core::items::ItemRc,
+        size: LogicalSize,
     ) {
-        let geometry = item_rect(image, self.scale_factor);
+        let geometry = PhysicalRect::from(size * self.scale_factor);
         if geometry.is_empty() {
             return;
         }
@@ -445,9 +448,10 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         &mut self,
         text: std::pin::Pin<&i_slint_core::items::Text>,
         _self_rc: &i_slint_core::items::ItemRc,
+        size: LogicalSize,
     ) {
-        let max_width = text.width() * self.scale_factor;
-        let max_height = text.height() * self.scale_factor;
+        let max_width = size.width_length() * self.scale_factor;
+        let max_height = size.height_length() * self.scale_factor;
 
         if max_width.get() <= 0. || max_height.get() <= 0. {
             return;
@@ -485,9 +489,10 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         &mut self,
         text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
         _self_rc: &i_slint_core::items::ItemRc,
+        size: LogicalSize,
     ) {
-        let max_width = text_input.width() * self.scale_factor;
-        let max_height = text_input.height() * self.scale_factor;
+        let max_width = size.width_length() * self.scale_factor;
+        let max_height = size.height_length() * self.scale_factor;
 
         if max_width.get() <= 0. || max_height.get() <= 0. {
             return;
@@ -565,8 +570,9 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         &mut self,
         path: std::pin::Pin<&i_slint_core::items::Path>,
         item_rc: &i_slint_core::items::ItemRc,
+        size: LogicalSize,
     ) {
-        let geometry = item_rect(path, self.scale_factor);
+        let geometry = PhysicalRect::from(size * self.scale_factor);
 
         let (physical_offset, skpath): (crate::euclid::Vector2D<f32, PhysicalPx>, _) =
             match self.path_cache.get_or_update_cache_entry(item_rc, || {
@@ -641,6 +647,7 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         &mut self,
         box_shadow: std::pin::Pin<&i_slint_core::items::BoxShadow>,
         self_rc: &i_slint_core::items::ItemRc,
+        _size: LogicalSize,
     ) {
         let offset = LogicalPoint::from_lengths(box_shadow.offset_x(), box_shadow.offset_y())
             * self.scale_factor;
@@ -809,7 +816,12 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         None
     }
 
-    fn visit_opacity(&mut self, opacity_item: Pin<&Opacity>, item_rc: &ItemRc) -> RenderingResult {
+    fn visit_opacity(
+        &mut self,
+        opacity_item: Pin<&Opacity>,
+        item_rc: &ItemRc,
+        _size: LogicalSize,
+    ) -> RenderingResult {
         let opacity = opacity_item.opacity();
         if Opacity::need_layer(item_rc, opacity) {
             self.canvas.save_layer_alpha(None, (opacity * 255.) as u32);
@@ -831,7 +843,12 @@ impl<'a> ItemRenderer for SkiaRenderer<'a> {
         }
     }
 
-    fn visit_layer(&mut self, layer_item: Pin<&Layer>, self_rc: &ItemRc) -> RenderingResult {
+    fn visit_layer(
+        &mut self,
+        layer_item: Pin<&Layer>,
+        self_rc: &ItemRc,
+        _size: LogicalSize,
+    ) -> RenderingResult {
         if layer_item.cache_rendering_hint() {
             self.render_and_blend_layer(self_rc)
         } else {
@@ -857,11 +874,6 @@ pub fn to_skia_point(point: PhysicalPoint) -> skia_safe::Point {
 
 pub fn to_skia_size(size: &PhysicalSize) -> skia_safe::Size {
     skia_safe::Size::new(size.width, size.height)
-}
-
-fn item_rect<Item: items::Item>(item: Pin<&Item>, scale_factor: ScaleFactor) -> PhysicalRect {
-    let geometry = item.geometry();
-    PhysicalRect::new(PhysicalPoint::default(), geometry.size * scale_factor)
 }
 
 pub fn to_skia_color(col: &Color) -> skia_safe::Color {

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -14,7 +14,6 @@ use i_slint_core::api::{
 use i_slint_core::graphics::euclid::{self, Vector2D};
 use i_slint_core::graphics::rendering_metrics_collector::RenderingMetricsCollector;
 use i_slint_core::item_rendering::ItemCache;
-use i_slint_core::items::Item;
 use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PhysicalPx, ScaleFactor,
 };
@@ -170,9 +169,12 @@ impl<
                 match window_background_brush {
                     Some(Brush::SolidColor(..)) | None => {}
                     Some(brush @ _) => {
-                        if let Some(window_item) = window_inner.window_item() {
-                            item_renderer.draw_rect(window_item.as_pin_ref().geometry(), brush);
-                        }
+                        item_renderer.draw_rect(
+                            i_slint_core::lengths::logical_size_from_api(
+                                size.to_logical(window_inner.scale_factor()),
+                            ),
+                            brush,
+                        );
                     }
                 }
 


### PR DESCRIPTION
So that we don't need to query the geometry multiple time, and this pave the way to not have the geometry in the items

Part of #1932

As a drive by, fix the clipping of the Path element which incorrectly offseted the clip by (x,y).
Similar fixes happen in the Clip element in some renderer, but that didn't have effect because x and y are always 0 for the Clip element