### PR TITLE
Tests: look at _all_ markdown files for slint snippets

### DIFF
--- a/api/cpp/docs/getting_started.md
+++ b/api/cpp/docs/getting_started.md
@@ -42,13 +42,13 @@ endif()
 
 Suppose `my_application_ui.slint` was a "Hello World" like this:
 
-```slint,ignore
+```slint,no-preview
 export component HelloWorld inherits Window {
     width: 400px;
     height: 400px;
 
     // Declare an alias that exposes the label's text property to C++
-    property my_label <=> label.text;
+    in property my_label <=> label.text;
 
     label := Text {
        y: parent.width / 2;

--- a/examples/virtual_keyboard/README.md
+++ b/examples/virtual_keyboard/README.md
@@ -18,9 +18,9 @@ It has three different building blocks:
 ## Example
 
 ```slint
-import { VirtualKeyboard } from "virtual_keyboard.slint"
+import { VirtualKeyboard } from "ui/virtual_keyboard.slint";
 
-export MainWindow inherits Window {
+export component MainWindow inherits Window {
     HorizontalLayout {
         TextInput {}
     }

--- a/tests/doctests/Cargo.toml
+++ b/tests/doctests/Cargo.toml
@@ -13,11 +13,9 @@ license = "GPL-3.0-only OR LicenseRef-Slint-commercial"
 path = "main.rs"
 name = "doctests"
 
-[dev-dependencies]
-i-slint-compiler = { path = "../../internal/compiler" }
-slint-interpreter = { path = "../../internal/interpreter", features = ["display-diagnostics"] }
-slint = { path = "../../api/rs/slint" }
+[build-dependencies]
+walkdir = "2"
 
-lazy_static = "1.4.0"
+[dev-dependencies]
+slint-interpreter = { path = "../../internal/interpreter", features = ["display-diagnostics"] }
 spin_on = "0.1"
-rand = "0.8"

--- a/tests/doctests/main.rs
+++ b/tests/doctests/main.rs
@@ -1,11 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+#![allow(uncommon_codepoints)]
+
 #[cfg(test)]
-fn do_test(snippet: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn do_test(snippet: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> {
     let mut compiler = slint_interpreter::ComponentCompiler::default();
-    let component =
-        spin_on::spin_on(compiler.build_from_source(snippet.into(), Default::default()));
+    let component = spin_on::spin_on(compiler.build_from_source(snippet.into(), path.into()));
 
     slint_interpreter::print_diagnostics(&compiler.diagnostics());
 


### PR DESCRIPTION
We were missing some which had errors

Fixes #2689
(Although the error for 2689 was in C++ and would not have been discovered by the test, better to have it parsed anyway)