### PR TITLE
Feature: Add copy/paste listener on Wasm

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -61,7 +61,7 @@ imgref = { version = "1.6.1", optional = true }
 rgb = { version = "0.8.27", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3", features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap"] }
+web-sys = { version = "0.3", features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap", "Navigator", "Clipboard", "ClipboardEvent"] }
 wasm-bindgen = { version = "0.2" }
 send_wrapper = "0.6.0"
 

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -20,10 +20,12 @@
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 
+use core::pin::Pin;
 use i_slint_core::input::{KeyEventType, KeyInputEvent};
 use i_slint_core::platform::WindowEvent;
 use i_slint_core::window::{WindowAdapter, WindowInner};
 use i_slint_core::SharedString;
+use std::ops::Deref;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::convert::FromWasmAbi;
 use wasm_bindgen::JsCast;
@@ -45,8 +47,9 @@ impl WasmInputHelper {
         window_adapter: Weak<dyn WindowAdapter>,
         canvas: web_sys::HtmlCanvasElement,
     ) -> Self {
-        let input = web_sys::window()
-            .unwrap()
+        let window = web_sys::window().unwrap();
+        let clipboard = window.navigator().clipboard().unwrap();
+        let input = window
             .document()
             .unwrap()
             .create_element("input")
@@ -66,6 +69,58 @@ impl WasmInputHelper {
         let mut h = Self { input, canvas: canvas.clone() };
 
         let shared_state = Rc::new(RefCell::new(WasmInputState::default()));
+
+        let win = window_adapter.clone();
+        let clip = clipboard.clone();
+        let closure_copy = Closure::wrap(Box::new(move |e: web_sys::ClipboardEvent| {
+            if let Some(window_adapter) = win.upgrade() {
+                e.prevent_default();
+                let mut item = window_adapter.window().0.focus_item.borrow().clone().upgrade();
+                if let Some(focus_item) = item.clone() {
+                    if let Some(text_input) =
+                        focus_item.downcast::<i_slint_core::items::TextInput>()
+                    {
+                        unsafe {
+                            let copied_text = Pin::new_unchecked(text_input.deref()).text();
+                            web_sys::console::log_1(&format!("T {:?}", copied_text).into());
+                            clip.write_text(copied_text.as_str());
+                        }
+                    }
+                }
+            }
+        }) as Box<dyn Fn(_)>);
+        window.add_event_listener_with_callback("copy", closure_copy.as_ref().unchecked_ref());
+        closure_copy.forget();
+
+        let win = window_adapter.clone();
+        let closure_paste = Closure::wrap(Box::new(move |e: web_sys::ClipboardEvent| {
+            web_sys::console::log_1(&format!("TT {:?}", "123123").into());
+            if let Some(window_adapter) = win.upgrade() {
+                e.prevent_default();
+                let mut item = window_adapter.window().0.focus_item.borrow().clone().upgrade();
+                if let Some(focus_item) = item.clone() {
+                    if let Some(text_input) =
+                        focus_item.downcast::<i_slint_core::items::TextInput>()
+                    {
+                        let copy = Closure::wrap(Box::new(move |result: wasm_bindgen::JsValue| {
+                            let focus_item_clone = focus_item.clone();
+                            unsafe {
+                                Pin::new_unchecked(text_input.deref()).insert(
+                                    &result.as_string().unwrap(),
+                                    &window_adapter,
+                                    &focus_item_clone,
+                                );
+                            }
+                        })
+                            as Box<dyn FnMut(wasm_bindgen::JsValue)>);
+                        clipboard.read_text().then(&copy);
+                        copy.forget();
+                    }
+                }
+            }
+        }) as Box<dyn Fn(_)>);
+        window.add_event_listener_with_callback("paste", closure_paste.as_ref().unchecked_ref());
+        closure_paste.forget();
 
         let win = window_adapter.clone();
         h.add_event_listener("blur", move |_: web_sys::Event| {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -287,7 +287,7 @@ pub enum SetRenderingNotifierError {
 /// scene of a component. It provides API to control windowing system specific aspects such
 /// as the position on the screen.
 #[repr(transparent)]
-pub struct Window(pub(crate) WindowInner);
+pub struct Window(pub WindowInner);
 
 /// This enum describes whether a Window is allowed to be hidden when the user tries to close the window.
 /// It is the return type of the callback provided to [Window::on_close_requested].

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -7,7 +7,6 @@ This module contains the builtin text related items.
 When adding an item or a property, it needs to be kept in sync with different place.
 Lookup the [`crate::items`] module documentation.
 */
-
 use super::{
     InputType, Item, ItemConsts, ItemRc, KeyEventResult, KeyEventType, PointArg,
     PointerEventButton, RenderingResult, TextHorizontalAlignment, TextOverflow,
@@ -35,7 +34,6 @@ use core::pin::Pin;
 use euclid::num::Ceil;
 use i_slint_core_macros::*;
 use unicode_segmentation::UnicodeSegmentation;
-
 /// The implementation of the `Text` element
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]
@@ -485,6 +483,7 @@ impl Item for TextInput {
                             return KeyEventResult::EventAccepted;
                         }
                         StandardShortcut::Copy => {
+                            // 111
                             self.copy(Clipboard::DefaultClipboard);
                             return KeyEventResult::EventAccepted;
                         }
@@ -954,7 +953,7 @@ impl TextInput {
         anchor_pos != cursor_pos
     }
 
-    fn insert(
+    pub fn insert(
         self: Pin<&Self>,
         text_to_insert: &str,
         window_adapter: &Rc<dyn WindowAdapter>,
@@ -1026,6 +1025,7 @@ impl TextInput {
             return;
         }
         let text = self.text();
+        #[cfg(not(target_arch = "wasm32"))]
         crate::platform::PLATFORM_INSTANCE.with(|p| {
             if let Some(backend) = p.get() {
                 backend.set_clipboard_text(&text[anchor..cursor], clipboard);
@@ -1039,6 +1039,7 @@ impl TextInput {
         self_rc: &ItemRc,
         clipboard: Clipboard,
     ) {
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(text) = crate::platform::PLATFORM_INSTANCE
             .with(|p| p.get().and_then(|p| p.clipboard_text(clipboard)))
         {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -264,7 +264,8 @@ pub struct WindowInner {
     mouse_input_state: Cell<MouseInputState>,
     pub(crate) modifiers: Cell<InternalKeyboardModifierState>,
 
-    focus_item: RefCell<crate::item_tree::ItemWeak>,
+    /// itemRC will retrieve on wasms
+    pub focus_item: RefCell<crate::item_tree::ItemWeak>,
     cursor_blinker: RefCell<pin_weak::rc::PinWeak<crate::input::TextCursorBlinker>>,
 
     pinned_fields: Pin<Box<WindowPinnedFields>>,


### PR DESCRIPTION
Fixes : #2515 

Added listener copy paste on Wasm side .
There is another option which we can listen on `keyup` event for `ctrl_key` boolean .
