### PR TITLE
C++: Warn when the return value of `slint::Image::load_from_path` is …

### DIFF
--- a/api/cpp/include/slint_image.h
+++ b/api/cpp/include/slint_image.h
@@ -112,7 +112,7 @@ public:
     Image() : data(Data::ImageInner_None()) { }
 
     /// Load an image from an image file
-    static Image load_from_path(const SharedString &file_path)
+    [[nodiscard]] static Image load_from_path(const SharedString &file_path)
     {
         Image img;
         cbindgen_private::types::slint_image_load_from_path(&file_path, &img.data);


### PR DESCRIPTION
…not used

Somebody recently accidentally wrote this code:

```cpp
slint::Image image;
image.load_from_path(...);
```

and that should have produced a warning.