### PR TITLE
Don't recurse mark_dependencies_dirty if it was already marked

### DIFF
--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -674,7 +674,9 @@ unsafe fn mark_dependencies_dirty(dependencies: *mut DependencyListHead) {
             "Const property marked as dirty"
         );
 
-        mark_dependencies_dirty(binding.dependencies.as_ptr() as *mut DependencyListHead)
+        if !was_dirty {
+            mark_dependencies_dirty(binding.dependencies.as_ptr() as *mut DependencyListHead)
+        }
     });
 }
 


### PR DESCRIPTION
When updating multiple models between frames, it's possible that multiple bindings will be marked dirty many times. In diamond dependencies, marking one binding could also end up affecting another binding through multiple intermediate dependencies.
The process can then be quite expensive even for medium scenes.

If a binding is already marked dirty we can however assume that all of its dependencies are already marked dirty. This reduces the complexity of marking large dependency branches multiple times.