### PR TITLE
swr: implement text_input_byte_offset_for_position

### DIFF
--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -327,7 +327,6 @@ impl Renderer for SoftwareRenderer {
         let height = (text_input.height().cast() * scale_factor).cast();
 
         let pos = (pos.cast() * scale_factor).cast();
-        let pos = PhysicalPoint::from_lengths(pos.x_length(), pos.y_length());
 
         match font {
             fonts::Font::PixelFont(pf) => {
@@ -345,7 +344,8 @@ impl Renderer for SoftwareRenderer {
                     single_line: false,
                 };
 
-                return paragraph.byte_offset_for_position((pos.x_length(), pos.y_length()), pf.height());
+                return paragraph
+                    .byte_offset_for_position((pos.x_length(), pos.y_length()), pf.height());
             }
             #[cfg(feature = "software-renderer-systemfonts")]
             fonts::Font::VectorFont(vf) => {
@@ -363,7 +363,8 @@ impl Renderer for SoftwareRenderer {
                     single_line: false,
                 };
 
-                return paragraph.byte_offset_for_position((pos.x_length(), pos.y_length()), vf.height());
+                return paragraph
+                    .byte_offset_for_position((pos.x_length(), pos.y_length()), vf.height());
             }
         };
     }

--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -256,22 +256,22 @@ impl<'a, Font: AbstractFont> TextParagraphLayout<'a, Font> {
     /// Returns the bytes offset for the given position
     pub fn byte_offset_for_position(
         &self,
-        pos: (Font::Length, Font::Length),
+        (pos_x, pos_y): (Font::Length, Font::Length),
         font_height: Font::Length,
     ) -> usize {
         let byte_offset = 0;
         let two = Font::LengthPrimitive::one() + Font::LengthPrimitive::one();
 
         match self.layout_lines(|glyphs, _, line_y, line| {
-            if pos.1 > line_y + font_height {
+            if pos_y > line_y + font_height {
                 return core::ops::ControlFlow::Continue(());
             }
 
             while let Some(positioned_glyph) = glyphs.next() {
-                if pos.0 >= positioned_glyph.x
-                    && pos.0 <= positioned_glyph.x + positioned_glyph.advance
+                if pos_x >= positioned_glyph.x
+                    && pos_x <= positioned_glyph.x + positioned_glyph.advance
                 {
-                    if pos.0 < positioned_glyph.x + positioned_glyph.advance / two {
+                    if pos_x < positioned_glyph.x + positioned_glyph.advance / two {
                         return core::ops::ControlFlow::Break(positioned_glyph.text_byte_offset);
                     } else if let Some(next_glyph) = glyphs.next() {
                         return core::ops::ControlFlow::Break(next_glyph.text_byte_offset);

--- a/internal/core/textlayout/shaping.rs
+++ b/internal/core/textlayout/shaping.rs
@@ -44,7 +44,8 @@ pub trait TextShaper {
         + euclid::num::Zero
         + euclid::num::One
         + core::convert::From<i16>
-        + Copy;
+        + Copy
+        + core::fmt::Debug;
     type Length: euclid::num::Zero
         + core::ops::AddAssign
         + core::ops::Add<Output = Self::Length>
@@ -54,7 +55,8 @@ pub trait TextShaper {
         + Copy
         + core::cmp::PartialOrd
         + core::ops::Mul<Self::LengthPrimitive, Output = Self::Length>
-        + core::ops::Div<Self::LengthPrimitive, Output = Self::Length>;
+        + core::ops::Div<Self::LengthPrimitive, Output = Self::Length>
+        + core::fmt::Debug;
     // Shapes the given string and emits the result into the given glyphs buffer.
     fn shape_text<GlyphStorage: core::iter::Extend<Glyph<Self::Length>>>(
         &self,


### PR DESCRIPTION
* implement text_input_byte_offset_for_position for SoftwareRenderer
* add byte_offset_for_position to TextParagraphLayout

# Note

Place text cursor by mouse should work now. Navigate with arrow up and down keys is a little bit buggy but can be done in a flowing PR.