### PR TITLE
Internal renderer API cleanups

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1529,10 +1529,8 @@ impl WindowAdapterSealed for QtWindow {
         let qt_platform_name = cpp! {unsafe [] -> qttypes::QString as "QString" {
             return QGuiApplication::platformName();
         }};
-        *self.rendering_metrics_collector.borrow_mut() = RenderingMetricsCollector::new(
-            self.self_weak.clone(),
-            &format!("Qt backend (platform {})", qt_platform_name),
-        );
+        *self.rendering_metrics_collector.borrow_mut() =
+            RenderingMetricsCollector::new(&format!("Qt backend (platform {})", qt_platform_name));
         Ok(())
     }
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1823,7 +1823,7 @@ impl WindowAdapterSealed for QtWindow {
 impl Renderer for QtWindow {
     fn text_size(
         &self,
-        font_request: i_slint_core::graphics::FontRequest,
+        font_request: FontRequest,
         text: &str,
         max_width: Option<LogicalLength>,
         _scale_factor: ScaleFactor,
@@ -1835,15 +1835,15 @@ impl Renderer for QtWindow {
         &self,
         text_input: Pin<&i_slint_core::items::TextInput>,
         pos: LogicalPoint,
+        font_request: FontRequest,
+        _scale_factor: ScaleFactor,
     ) -> usize {
         if pos.y < 0. {
             return 0;
         }
         let rect: qttypes::QRectF = check_geometry!(text_input.geometry().size);
         let pos = qttypes::QPointF { x: pos.x as _, y: pos.y as _ };
-        let font: QFont = get_font(
-            text_input.font_request(&WindowInner::from_pub(&self.window).window_adapter()),
-        );
+        let font: QFont = get_font(font_request);
 
         let visual_representation = text_input.visual_representation(Some(qt_password_character));
 
@@ -1897,11 +1897,11 @@ impl Renderer for QtWindow {
         &self,
         text_input: Pin<&i_slint_core::items::TextInput>,
         byte_offset: usize,
+        font_request: FontRequest,
+        _scale_factor: ScaleFactor,
     ) -> LogicalRect {
         let rect: qttypes::QRectF = check_geometry!(text_input.geometry().size);
-        let font: QFont = get_font(
-            text_input.font_request(&WindowInner::from_pub(&self.window).window_adapter()),
-        );
+        let font: QFont = get_font(font_request);
         let text = text_input.text();
         let mut string = qttypes::QString::from(text.as_str());
         let offset: u32 = utf8_byte_offset_to_utf16_units(text.as_str(), byte_offset) as _;

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -5,6 +5,7 @@
 #![doc(html_logo_url = "https://slint-ui.com/logo/slint-logo-square-light.svg")]
 
 use i_slint_core::graphics::euclid::{Point2D, Size2D};
+use i_slint_core::graphics::FontRequest;
 use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
 use i_slint_core::renderer::Renderer;
 use i_slint_core::window::WindowAdapter;
@@ -108,6 +109,8 @@ impl Renderer for TestingWindow {
         &self,
         text_input: Pin<&i_slint_core::items::TextInput>,
         pos: LogicalPoint,
+        _font_request: FontRequest,
+        _scale_factor: ScaleFactor,
     ) -> usize {
         let text_len = text_input.text().len();
         let result = pos.x / 10.;
@@ -119,6 +122,8 @@ impl Renderer for TestingWindow {
         &self,
         _text_input: Pin<&i_slint_core::items::TextInput>,
         byte_offset: usize,
+        _font_request: FontRequest,
+        _scale_factor: ScaleFactor,
     ) -> LogicalRect {
         LogicalRect::new(Point2D::new(byte_offset as f32 * 10., 0.), Size2D::new(1., 10.))
     }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -613,7 +613,14 @@ pub fn run() -> Result<(), corelib::platform::PlatformError> {
                 if *control_flow != ControlFlow::Exit
                     && ALL_WINDOWS.with(|windows| {
                         windows.borrow().iter().any(|(_, w)| {
-                            w.upgrade().map_or(false, |w| w.window().has_active_animations())
+                            w.upgrade()
+                                .and_then(|w| {
+                                    w.window().has_active_animations().then(|| {
+                                        w.request_redraw();
+                                        true
+                                    })
+                                })
+                                .unwrap_or_default()
                         })
                     })
                 {

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -1,15 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use std::cell::RefCell;
-use std::pin::Pin;
 use std::rc::Weak;
 
-use i_slint_core::api::{
-    GraphicsAPI, PhysicalSize as PhysicalWindowSize, RenderingNotifier, RenderingState,
-    SetRenderingNotifierError,
-};
-use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
+use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::Renderer;
 use i_slint_core::window::WindowAdapter;
@@ -18,39 +12,7 @@ use i_slint_renderer_femtovg::FemtoVGRenderer;
 mod glcontext;
 
 pub struct GlutinFemtoVGRenderer {
-    rendering_notifier: RefCell<Option<Box<dyn RenderingNotifier>>>,
     renderer: FemtoVGRenderer,
-    // Last field, so that it's dropped last and context exists and is current when destroying the FemtoVG canvas
-    opengl_context: glcontext::OpenGLContext,
-}
-
-impl GlutinFemtoVGRenderer {
-    #[cfg(not(target_arch = "wasm32"))]
-    fn with_graphics_api(
-        opengl_context: &glcontext::OpenGLContext,
-        callback: impl FnOnce(i_slint_core::api::GraphicsAPI<'_>),
-    ) -> Result<(), PlatformError> {
-        opengl_context.ensure_current()?;
-        let api = GraphicsAPI::NativeOpenGL {
-            get_proc_address: &|name| opengl_context.get_proc_address(name),
-        };
-        callback(api);
-        Ok(())
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn with_graphics_api(
-        opengl_context: &glcontext::OpenGLContext,
-        callback: impl FnOnce(i_slint_core::api::GraphicsAPI<'_>),
-    ) -> Result<(), PlatformError> {
-        let canvas_element_id = opengl_context.html_canvas_element().id();
-        let api = GraphicsAPI::WebGL {
-            canvas_element_id: canvas_element_id.as_str(),
-            context_type: "webgl",
-        };
-        callback(api);
-        Ok(())
-    }
 }
 
 impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
@@ -68,152 +30,33 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
             )
         })?;
 
-        let renderer = FemtoVGRenderer::new(
-            window_adapter_weak,
-            #[cfg(not(target_arch = "wasm32"))]
-            |name| opengl_context.get_proc_address(name) as *const _,
-            #[cfg(target_arch = "wasm32")]
-            &opengl_context.html_canvas_element(),
-        )?;
+        let renderer = FemtoVGRenderer::new(window_adapter_weak, opengl_context)?;
 
-        Ok((
-            Self { rendering_notifier: Default::default(), renderer, opengl_context },
-            winit_window,
-        ))
+        Ok((Self { renderer }, winit_window))
     }
 
     fn show(&self) -> Result<(), PlatformError> {
-        self.opengl_context.ensure_current()?;
-        self.renderer.show();
-
-        if let Some(callback) = self.rendering_notifier.borrow_mut().as_mut() {
-            Self::with_graphics_api(&self.opengl_context, |api| {
-                callback.notify(RenderingState::RenderingSetup, &api)
-            })?;
-        }
-
-        Ok(())
+        self.renderer.show()
     }
 
     fn hide(&self) -> Result<(), PlatformError> {
-        self.opengl_context.ensure_current()?;
-        if let Some(callback) = self.rendering_notifier.borrow_mut().as_mut() {
-            Self::with_graphics_api(&self.opengl_context, |api| {
-                callback.notify(RenderingState::RenderingTeardown, &api)
-            })?;
-        }
-        self.renderer.hide();
-
-        Ok(())
+        self.renderer.hide()
     }
 
     fn render(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
-        self.opengl_context.ensure_current()?;
-
-        self.renderer.render(
-            size,
-            self.rendering_notifier.borrow_mut().as_mut().map(|notifier_fn| {
-                || {
-                    Self::with_graphics_api(&self.opengl_context, |api| {
-                        notifier_fn.notify(RenderingState::BeforeRendering, &api)
-                    })
-                }
-            }),
-        )?;
-
-        if let Some(callback) = self.rendering_notifier.borrow_mut().as_mut() {
-            Self::with_graphics_api(&self.opengl_context, |api| {
-                callback.notify(RenderingState::AfterRendering, &api)
-            })?;
-        }
-
-        self.opengl_context.swap_buffers()
+        self.renderer.render(size)
     }
 
     fn as_core_renderer(&self) -> &dyn Renderer {
-        self
+        &self.renderer
     }
 
     fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
-        self.opengl_context.ensure_resized(size)
+        self.renderer.resize(size)
     }
 
     #[cfg(target_arch = "wasm32")]
     fn html_canvas_element(&self) -> web_sys::HtmlCanvasElement {
-        self.opengl_context.html_canvas_element()
-    }
-}
-
-impl Renderer for GlutinFemtoVGRenderer {
-    fn text_size(
-        &self,
-        font_request: i_slint_core::graphics::FontRequest,
-        text: &str,
-        max_width: Option<LogicalLength>,
-        scale_factor: ScaleFactor,
-    ) -> LogicalSize {
-        self.renderer.text_size(font_request, text, max_width, scale_factor)
-    }
-
-    fn text_input_byte_offset_for_position(
-        &self,
-        text_input: Pin<&i_slint_core::items::TextInput>,
-        pos: LogicalPoint,
-    ) -> usize {
-        self.renderer.text_input_byte_offset_for_position(text_input, pos)
-    }
-
-    fn text_input_cursor_rect_for_byte_offset(
-        &self,
-        text_input: Pin<&i_slint_core::items::TextInput>,
-        byte_offset: usize,
-    ) -> LogicalRect {
-        self.renderer.text_input_cursor_rect_for_byte_offset(text_input, byte_offset)
-    }
-
-    fn register_font_from_memory(
-        &self,
-        data: &'static [u8],
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        self.renderer.register_font_from_memory(data)
-    }
-
-    fn register_font_from_path(
-        &self,
-        path: &std::path::Path,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        self.renderer.register_font_from_path(path)
-    }
-
-    fn set_rendering_notifier(
-        &self,
-        callback: Box<dyn RenderingNotifier>,
-    ) -> std::result::Result<(), SetRenderingNotifierError> {
-        let mut notifier = self.rendering_notifier.borrow_mut();
-        if notifier.replace(callback).is_some() {
-            Err(SetRenderingNotifierError::AlreadySet)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn default_font_size(&self) -> LogicalLength {
-        self.renderer.default_font_size()
-    }
-
-    fn free_graphics_resources(
-        &self,
-        component: i_slint_core::component::ComponentRef,
-        _items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'_>>>,
-    ) -> Result<(), PlatformError> {
-        self.opengl_context.ensure_current()?;
-        self.renderer.free_graphics_resources(component, _items)
-    }
-}
-
-impl Drop for GlutinFemtoVGRenderer {
-    fn drop(&mut self) {
-        // Ensure the context is current before the renderer is destroyed
-        self.opengl_context.ensure_current().ok();
+        self.renderer.html_canvas_element()
     }
 }

--- a/internal/backends/winit/renderer/femtovg/glcontext.rs
+++ b/internal/backends/winit/renderer/femtovg/glcontext.rs
@@ -21,7 +21,7 @@ pub struct OpenGLContext {
     canvas: web_sys::HtmlCanvasElement,
 }
 
-impl i_slint_renderer_femtovg::OpenGLContextWrapper for OpenGLContext {
+unsafe impl i_slint_renderer_femtovg::OpenGLContextWrapper for OpenGLContext {
     #[cfg(target_arch = "wasm32")]
     fn html_canvas_element(&self) -> web_sys::HtmlCanvasElement {
         self.canvas.clone()

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -26,6 +26,8 @@ pub trait Renderer {
         &self,
         text_input: Pin<&crate::items::TextInput>,
         pos: LogicalPoint,
+        font_request: crate::graphics::FontRequest,
+        scale_factor: ScaleFactor,
     ) -> usize;
 
     /// That's the opposite of [`Self::text_input_byte_offset_for_position`]
@@ -35,6 +37,8 @@ pub trait Renderer {
         &self,
         text_input: Pin<&crate::items::TextInput>,
         byte_offset: usize,
+        font_request: crate::graphics::FontRequest,
+        scale_factor: ScaleFactor,
     ) -> LogicalRect;
 
     /// Clear the caches for the items that are being removed

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -311,16 +311,11 @@ impl Renderer for SoftwareRenderer {
         &self,
         text_input: Pin<&crate::items::TextInput>,
         pos: LogicalPoint,
+        font_request: crate::graphics::FontRequest,
+        scale_factor: ScaleFactor,
     ) -> usize {
-        let window_adapter = match self.window.upgrade() {
-            Some(window) => window,
-            None => return Default::default(),
-        };
-
-        let scale_factor = ScaleFactor::new(window_adapter.window().scale_factor()).cast();
         let visual_representation = text_input.visual_representation(None);
 
-        let font_request = text_input.font_request(&window_adapter);
         let font = fonts::match_font(&font_request, scale_factor);
 
         let width = (text_input.width().cast() * scale_factor).cast();
@@ -373,16 +368,11 @@ impl Renderer for SoftwareRenderer {
         &self,
         text_input: Pin<&crate::items::TextInput>,
         byte_offset: usize,
+        font_request: crate::graphics::FontRequest,
+        scale_factor: ScaleFactor,
     ) -> LogicalRect {
-        let window_adapter = match self.window.upgrade() {
-            Some(window) => window,
-            None => return Default::default(),
-        };
-
-        let scale_factor = ScaleFactor::new(window_adapter.window().scale_factor()).cast();
         let visual_representation = text_input.visual_representation(None);
 
-        let font_request = text_input.font_request(&window_adapter);
         let font = fonts::match_font(&font_request, scale_factor);
 
         let width = (text_input.width().cast() * scale_factor).cast();

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -35,7 +35,7 @@ mod itemrenderer;
 
 /// Trait that the FemtoVGRenderer uses to ensure that the OpenGL context is current, before running
 /// OpenGL commands. The trait also provides access to the symbols of the OpenGL implementation.
-pub trait OpenGLContextWrapper {
+pub unsafe trait OpenGLContextWrapper {
     /// Ensures that the GL context is current.
     fn ensure_current(&self) -> Result<(), PlatformError>;
     fn swap_buffers(&self) -> Result<(), PlatformError>;

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -35,6 +35,10 @@ mod itemrenderer;
 
 /// Trait that the FemtoVGRenderer uses to ensure that the OpenGL context is current, before running
 /// OpenGL commands. The trait also provides access to the symbols of the OpenGL implementation.
+///
+/// Safety: This trait is unsafe because an implementation of get_proc_address could return dangling
+/// pointers. In practice an implementation of this trait should just forward to the EGL/WGL/CGL
+/// C library that implements EGL/CGL/WGL.
 pub unsafe trait OpenGLContextWrapper {
     /// Ensures that the GL context is current.
     fn ensure_current(&self) -> Result<(), PlatformError>;

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -98,10 +98,8 @@ impl FemtoVGRenderer {
 
     /// Notifiers the renderer that the underlying window is becoming visible.
     pub fn show(&self) {
-        *self.rendering_metrics_collector.borrow_mut() = RenderingMetricsCollector::new(
-            self.window_adapter_weak.clone(),
-            &format!("FemtoVG renderer"),
-        );
+        *self.rendering_metrics_collector.borrow_mut() =
+            RenderingMetricsCollector::new(&format!("FemtoVG renderer"));
     }
 
     /// Notifiers the renderer that the underlying window will be hidden soon.

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -13,6 +13,7 @@ use i_slint_core::api::{
 };
 use i_slint_core::graphics::euclid::{self, Vector2D};
 use i_slint_core::graphics::rendering_metrics_collector::RenderingMetricsCollector;
+use i_slint_core::graphics::FontRequest;
 use i_slint_core::item_rendering::ItemCache;
 use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PhysicalPx, ScaleFactor,
@@ -224,16 +225,9 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
         &self,
         text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
         pos: LogicalPoint,
+        font_request: FontRequest,
+        scale_factor: ScaleFactor,
     ) -> usize {
-        let window_adapter = match self.window_adapter_weak.upgrade() {
-            Some(window) => window,
-            None => return 0,
-        };
-
-        let window = WindowInner::from_pub(window_adapter.window());
-
-        let scale_factor = ScaleFactor::new(window.scale_factor());
-
         let max_width = text_input.width() * scale_factor;
         let max_height = text_input.height() * scale_factor;
         let pos = pos * scale_factor;
@@ -243,8 +237,6 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
         }
 
         let visual_representation = text_input.visual_representation(None);
-
-        let font_request = text_input.font_request(&window_adapter);
 
         let (layout, layout_top_left) = textlayout::create_layout(
             font_request,
@@ -280,16 +272,9 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
         &self,
         text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
         byte_offset: usize,
+        font_request: FontRequest,
+        scale_factor: ScaleFactor,
     ) -> LogicalRect {
-        let window_adapter = match self.window_adapter_weak.upgrade() {
-            Some(window) => window,
-            None => return Default::default(),
-        };
-
-        let window = WindowInner::from_pub(window_adapter.window());
-
-        let scale_factor = ScaleFactor::new(window.scale_factor());
-
         let max_width = text_input.width() * scale_factor;
         let max_height = text_input.height() * scale_factor;
 
@@ -299,7 +284,6 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
 
         let string = text_input.text();
         let string = string.as_str();
-        let font_request = text_input.font_request(&window_adapter);
 
         let (layout, layout_top_left) = textlayout::create_layout(
             font_request,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -83,14 +83,11 @@ impl SkiaRenderer {
 
     /// Notifiers the renderer that the underlying window is becoming visible.
     pub fn show(&self) -> Result<(), PlatformError> {
-        *self.rendering_metrics_collector.borrow_mut() = RenderingMetricsCollector::new(
-            self.window_adapter_weak.clone(),
-            &format!(
-                "Skia renderer (skia backend {}; surface: {} bpp)",
-                self.surface.name(),
-                self.surface.bits_per_pixel()?
-            ),
-        );
+        *self.rendering_metrics_collector.borrow_mut() = RenderingMetricsCollector::new(&format!(
+            "Skia renderer (skia backend {}; surface: {} bpp)",
+            self.surface.name(),
+            self.surface.bits_per_pixel()?
+        ));
 
         if let Some(callback) = self.rendering_notifier.borrow_mut().as_mut() {
             self.surface


### PR DESCRIPTION
This series reduces the dependencies of the Renderers on the `Weak<dyn WindowAdapter>`, by adding the necessary state to the core `Renderer` trait functions and making the renderer metrics collector independent from the window adapter.

As a bonus, the wrapper around the FemtoVG renderer in the winit backend becomes much thinner.