### PR TITLE
C++: optimize SharedVector's iterator constructor

### DIFF
--- a/api/cpp/include/slint_sharedvector.h
+++ b/api/cpp/include/slint_sharedvector.h
@@ -60,9 +60,8 @@ struct SharedVector
     SharedVector(InputIt first, InputIt last)
         : SharedVector(SharedVector::with_capacity(std::distance(first, last)))
     {
-        for (auto it = first; it != last; ++it) {
-            push_back(*it);
-        }
+        std::uninitialized_copy(first, last, begin());
+        inner->size = inner->capacity;
     }
 
     /// Creates a new vector that is a copy of \a other.

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -237,4 +237,8 @@ TEST_CASE("SharedVector")
     SharedVector<int> vec4(5);
     REQUIRE(vec4.size() == 5);
     REQUIRE(vec4[3] == 0);
+
+    std::vector<SharedString> std_v(vec2.begin(), vec2.end());
+    SharedVector<SharedString> vec6(std_v.begin(), std_v.end());
+    REQUIRE(vec6 == vec2);
 }


### PR DESCRIPTION
Don't detach for every element.

Closes #2737