### PR TITLE
Remove persistent renderer dependency on the WindowAdapter

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -256,6 +256,8 @@ public:
         }
     }
 
+    const cbindgen_private::WindowAdapterRcOpaque &handle() const { return inner; }
+
 private:
     cbindgen_private::WindowAdapterRcOpaque inner;
 };

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -55,6 +55,15 @@ using cbindgen_private::ItemWeak;
 using cbindgen_private::TraversalOrder;
 }
 
+#if !defined(DOXYGEN)
+namespace experimental {
+namespace platform {
+class SkiaRenderer;
+class SoftwareRenderer;
+}
+}
+#endif
+
 namespace private_api {
 using ItemTreeNode = cbindgen_private::ItemTreeNode;
 using ItemArrayEntry =
@@ -256,9 +265,9 @@ public:
         }
     }
 
-    const cbindgen_private::WindowAdapterRcOpaque &handle() const { return inner; }
-
 private:
+    friend class slint::experimental::platform::SkiaRenderer;
+    friend class slint::experimental::platform::SoftwareRenderer;
     cbindgen_private::WindowAdapterRcOpaque inner;
 };
 

--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -55,9 +55,7 @@ private:
         cbindgen_private::slint_window_adapter_new(
                 this, [](void *wa) { delete reinterpret_cast<const WindowAdapter *>(wa); },
                 [](void *wa) {
-                    return reinterpret_cast<const WindowAdapter *>(wa)
-                            ->renderer()
-                            .renderer_handle();
+                    return reinterpret_cast<WindowAdapter *>(wa)->renderer().renderer_handle();
                 },
                 [](void *wa) { reinterpret_cast<const WindowAdapter *>(wa)->show(); },
                 [](void *wa) { reinterpret_cast<const WindowAdapter *>(wa)->hide(); },
@@ -97,7 +95,7 @@ public:
 
     /// Re-implement this function to provide a reference to the renderer for use with the window
     /// adapter.
-    virtual AbstractRenderer &renderer() const = 0;
+    virtual AbstractRenderer &renderer() = 0;
 
     /// Return the slint::Window associated with this window.
     ///

--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -213,8 +213,7 @@ public:
                 std::size_t pixel_stride) const
     {
         cbindgen_private::slint_software_renderer_render_rgb8(
-                inner, &window.window_handle().handle(), buffer.data(), buffer.size(),
-                pixel_stride);
+                inner, &window.window_handle().inner, buffer.data(), buffer.size(), pixel_stride);
     }
 };
 
@@ -319,7 +318,7 @@ public:
 
     void render(const Window &window, PhysicalSize size) const
     {
-        cbindgen_private::slint_skia_renderer_render(inner, &window.window_handle().handle(), size);
+        cbindgen_private::slint_skia_renderer_render(inner, &window.window_handle().inner, size);
     }
 
     void resize(PhysicalSize size) const

--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -188,6 +188,12 @@ class SoftwareRenderer : public AbstractRenderer
 {
     mutable cbindgen_private::SoftwareRendererOpaque inner;
 
+    /// \private
+    cbindgen_private::RendererPtr renderer_handle() const override
+    {
+        return cbindgen_private::slint_software_renderer_handle(inner);
+    }
+
 public:
     virtual ~SoftwareRenderer() { cbindgen_private::slint_software_renderer_drop(inner); };
     SoftwareRenderer(const SoftwareRenderer &) = delete;
@@ -195,12 +201,6 @@ public:
     SoftwareRenderer(int max_buffer_age)
     {
         inner = cbindgen_private::slint_software_renderer_new(max_buffer_age);
-    }
-
-    /// \private
-    cbindgen_private::RendererPtr renderer_handle() const override
-    {
-        return cbindgen_private::slint_software_renderer_handle(inner);
     }
 
     /// Render the window scene into a pixel buffer
@@ -299,6 +299,12 @@ class SkiaRenderer : public AbstractRenderer
 {
     mutable cbindgen_private::SkiaRendererOpaque inner;
 
+    /// \private
+    cbindgen_private::RendererPtr renderer_handle() const override
+    {
+        return cbindgen_private::slint_skia_renderer_handle(inner);
+    }
+
 public:
     virtual ~SkiaRenderer() { cbindgen_private::slint_skia_renderer_drop(inner); }
     SkiaRenderer(const SkiaRenderer &) = delete;
@@ -308,12 +314,6 @@ public:
     SkiaRenderer(const NativeWindowHandle &window_handle, PhysicalSize initial_size)
     {
         inner = cbindgen_private::slint_skia_renderer_new(window_handle.inner, initial_size);
-    }
-
-    /// \private
-    cbindgen_private::RendererPtr renderer_handle() const override
-    {
-        return cbindgen_private::slint_skia_renderer_handle(inner);
     }
 
     void render(const Window &window, PhysicalSize size) const

--- a/api/cpp/tests/manual/platform_native/appview.cpp
+++ b/api/cpp/tests/manual/platform_native/appview.cpp
@@ -17,7 +17,7 @@ namespace slint_platform = slint::experimental::platform;
 struct MyPlatform : public slint_platform::Platform
 {
     mutable std::unique_ptr<MyWindowAdapter> the_window;
-    std::unique_ptr<slint_platform::AbstractWindowAdapter> create_window_adapter() const override
+    std::unique_ptr<slint_platform::WindowAdapter> create_window_adapter() const override
     {
         return std::move(the_window);
     }

--- a/api/cpp/tests/manual/platform_native/windowadapter_win.h
+++ b/api/cpp/tests/manual/platform_native/windowadapter_win.h
@@ -23,7 +23,7 @@ struct MyWindowAdapter : public slint_platform::WindowAdapter
 {
     HWND hwnd;
     Geometry geometry = { 0, 0, 600, 300 };
-    std::unique_ptr<slint_platform::SkiaRenderer> m_renderer;
+    std::optional<slint_platform::SkiaRenderer> m_renderer;
 
     MyWindowAdapter(HWND winId)
     {
@@ -56,14 +56,13 @@ struct MyWindowAdapter : public slint_platform::WindowAdapter
                               NULL // Additional application data
         );
 
-        m_renderer = std::make_unique<slint_platform::SkiaRenderer>(
-                slint_platform::NativeWindowHandle::from_win32(hwnd, hInstance),
-                slint::PhysicalSize({ 600, 300 }));
+        m_renderer.emplace(slint_platform::NativeWindowHandle::from_win32(hwnd, hInstance),
+                           slint::PhysicalSize({ 600, 300 }));
 
         SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)this);
     }
 
-    slint_platform::AbstractRenderer &renderer() const override { return *m_renderer.get(); }
+    slint_platform::AbstractRenderer &renderer() override { return m_renderer.value(); }
 
     slint::PhysicalSize physical_size() const override
     {

--- a/api/cpp/tests/manual/platform_qt/main.cpp
+++ b/api/cpp/tests/manual/platform_qt/main.cpp
@@ -51,17 +51,16 @@ static slint_platform::NativeWindowHandle window_handle_for_qt_window(QWindow *w
 
 class MyWindow : public QWindow, public slint_platform::WindowAdapter
 {
-    std::unique_ptr<slint_platform::SkiaRenderer> m_renderer;
+    std::optional<slint_platform::SkiaRenderer> m_renderer;
 
 public:
     MyWindow(QWindow *parentWindow = nullptr) : QWindow(parentWindow)
     {
-        m_renderer = std::make_unique<slint_platform::SkiaRenderer>(
-                window_handle_for_qt_window(this),
-                slint::PhysicalSize({ uint32_t(width()), uint32_t(height()) }));
+        m_renderer.emplace(window_handle_for_qt_window(this),
+                           slint::PhysicalSize({ uint32_t(width()), uint32_t(height()) }));
     }
 
-    slint_platform::AbstractRenderer &renderer() const override { return *m_renderer.get(); }
+    slint_platform::AbstractRenderer &renderer() override { return m_renderer.value(); }
 
     /*void keyEvent(QKeyEvent *event) override
     {

--- a/api/cpp/tests/manual/platform_qt/main.cpp
+++ b/api/cpp/tests/manual/platform_qt/main.cpp
@@ -54,11 +54,11 @@ class MyWindow : public QWindow, public slint_platform::WindowAdapter<slint_plat
 
 public:
     MyWindow(QWindow *parentWindow = nullptr)
-        : QWindow(parentWindow),
-          slint_platform::WindowAdapter<slint_platform::SkiaRenderer>(
-                  window_handle_for_qt_window(this),
-                  slint::PhysicalSize({ uint32_t(width()), uint32_t(height()) }))
+        : QWindow(parentWindow), slint_platform::WindowAdapter<slint_platform::SkiaRenderer>()
     {
+        set_renderer(std::make_unique<slint_platform::SkiaRenderer>(
+                window_handle_for_qt_window(this),
+                slint::PhysicalSize({ uint32_t(width()), uint32_t(height()) })));
     }
 
     /*void keyEvent(QKeyEvent *event) override
@@ -71,7 +71,7 @@ public:
         slint_platform::update_timers_and_animations();
 
         auto windowSize = slint::PhysicalSize({ uint32_t(width()), uint32_t(height()) });
-        renderer().render(windowSize);
+        renderer().render(window(), windowSize);
 
         if (has_active_animations()) {
             requestUpdate();

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -24,15 +24,11 @@ pub enum SlintUserEvent {
 }
 
 mod renderer {
-    use std::rc::Weak;
-
     use i_slint_core::api::PhysicalSize;
     use i_slint_core::platform::PlatformError;
-    use i_slint_core::window::WindowAdapter;
 
     pub(crate) trait WinitCompatibleRenderer {
         fn new(
-            window_adapter_weak: &Weak<dyn WindowAdapter>,
             window_builder: winit::window::WindowBuilder,
             #[cfg(target_arch = "wasm32")] canvas_id: &str,
         ) -> Result<(Self, winit::window::Window), PlatformError>
@@ -42,7 +38,11 @@ mod renderer {
         fn show(&self) -> Result<(), PlatformError>;
         fn hide(&self) -> Result<(), PlatformError>;
 
-        fn render(&self, size: PhysicalSize) -> Result<(), PlatformError>;
+        fn render(
+            &self,
+            window: &i_slint_core::api::Window,
+            size: PhysicalSize,
+        ) -> Result<(), PlatformError>;
 
         fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer;
 

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -1,12 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use std::rc::Weak;
-
 use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::Renderer;
-use i_slint_core::window::WindowAdapter;
 use i_slint_renderer_femtovg::FemtoVGRenderer;
 
 mod glcontext;
@@ -17,7 +14,6 @@ pub struct GlutinFemtoVGRenderer {
 
 impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn new(
-        window_adapter_weak: &Weak<dyn WindowAdapter>,
         window_builder: winit::window::WindowBuilder,
         #[cfg(target_arch = "wasm32")] canvas_id: &str,
     ) -> Result<(Self, winit::window::Window), PlatformError> {
@@ -30,7 +26,7 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
             )
         })?;
 
-        let renderer = FemtoVGRenderer::new(window_adapter_weak, opengl_context)?;
+        let renderer = FemtoVGRenderer::new(opengl_context)?;
 
         Ok((Self { renderer }, winit_window))
     }
@@ -43,8 +39,12 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
         self.renderer.hide()
     }
 
-    fn render(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
-        self.renderer.render(size)
+    fn render(
+        &self,
+        window: &i_slint_core::api::Window,
+        size: PhysicalWindowSize,
+    ) -> Result<(), PlatformError> {
+        self.renderer.render(window, size)
     }
 
     fn as_core_renderer(&self) -> &dyn Renderer {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -1,11 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint-ui.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-use std::rc::Weak;
-
 use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::platform::PlatformError;
-use i_slint_core::window::WindowAdapter;
 
 pub struct SkiaRenderer {
     renderer: i_slint_renderer_skia::SkiaRenderer,
@@ -13,7 +10,6 @@ pub struct SkiaRenderer {
 
 impl super::WinitCompatibleRenderer for SkiaRenderer {
     fn new(
-        window_adapter_weak: &Weak<dyn WindowAdapter>,
         window_builder: winit::window::WindowBuilder,
     ) -> Result<(Self, winit::window::Window), PlatformError> {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
@@ -38,7 +34,6 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
         })?;
 
         let renderer = i_slint_renderer_skia::SkiaRenderer::new(
-            window_adapter_weak.clone(),
             &winit_window,
             &winit_window,
             PhysicalWindowSize::new(width, height),
@@ -55,8 +50,12 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
         self.renderer.hide()
     }
 
-    fn render(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
-        self.renderer.render(size)
+    fn render(
+        &self,
+        window: &i_slint_core::api::Window,
+        size: PhysicalWindowSize,
+    ) -> Result<(), PlatformError> {
+        self.renderer.render(window, size)
     }
 
     fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -153,7 +153,6 @@ impl WinitWindowAdapter {
             )
             .and_then(|builder| {
                 R::new(
-                    &(self_weak.clone() as _),
                     builder,
                     #[cfg(target_arch = "wasm32")]
                     canvas_id,
@@ -277,7 +276,8 @@ impl WinitWindowAdapter {
         self.pending_redraw.set(false);
 
         let renderer = self.renderer();
-        renderer.render(physical_size_to_slint(&self.winit_window().inner_size()))?;
+        renderer
+            .render(self.window(), physical_size_to_slint(&self.winit_window().inner_size()))?;
 
         Ok(self.pending_redraw.get())
     }


### PR DESCRIPTION
Make it possible to construct the renderer without the window adapter.

This is a step towards disentangling these a little further. The renderer still must be set when `MyApp::create()` is called, i.e. `WindowAdapter`'s `renderer()` must return a valid reference after the adapter has been created, but this doesn't all have
to happen within `Rc::new_cyclic` anymore.