### PR TITLE
winit: Clean up implementation of WinitWindowAdapter::show() and hide()

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -154,6 +154,39 @@ impl Backend {
     }
 }
 
+fn send_event_via_global_event_loop_proxy(
+    event: SlintUserEvent,
+) -> Result<(), i_slint_core::api::EventLoopError> {
+    #[cfg(not(target_arch = "wasm32"))]
+    crate::event_loop::GLOBAL_PROXY
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap()
+        .send_event(event)?;
+    #[cfg(target_arch = "wasm32")]
+    {
+        crate::event_loop::GLOBAL_PROXY.with(|global_proxy| {
+            let mut maybe_proxy = global_proxy.borrow_mut();
+            let proxy = maybe_proxy.get_or_insert_with(Default::default);
+            // Calling send_event is usually done by winit at the bottom of the stack,
+            // in event handlers, and thus winit might decide to process the event
+            // immediately within that stack.
+            // To prevent re-entrancy issues that might happen by getting the application
+            // event processed on top of the current stack, set winit in Poll mode so that
+            // events are queued and process on top of a clean stack during a requested animation
+            // frame a few moments later.
+            // This also allows batching multiple post_event calls and redraw their state changes
+            // all at once.
+            proxy.send_event(SlintUserEvent::CustomEvent {
+                event: CustomEvent::WakeEventLoopWorkaround,
+            })?;
+            proxy.send_event(event)?;
+            Ok(())
+        })?
+    }
+    Ok(())
+}
+
 impl i_slint_core::platform::Platform for Backend {
     fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
         (self.window_factory_fn)()
@@ -186,34 +219,7 @@ impl i_slint_core::platform::Platform for Backend {
                 event: Box<dyn FnOnce() + Send>,
             ) -> Result<(), i_slint_core::api::EventLoopError> {
                 let e = SlintUserEvent::CustomEvent { event: CustomEvent::UserEvent(event) };
-                #[cfg(not(target_arch = "wasm32"))]
-                crate::event_loop::GLOBAL_PROXY
-                    .get_or_init(Default::default)
-                    .lock()
-                    .unwrap()
-                    .send_event(e)?;
-                #[cfg(target_arch = "wasm32")]
-                {
-                    crate::event_loop::GLOBAL_PROXY.with(|global_proxy| {
-                        let mut maybe_proxy = global_proxy.borrow_mut();
-                        let proxy = maybe_proxy.get_or_insert_with(Default::default);
-                        // Calling send_event is usually done by winit at the bottom of the stack,
-                        // in event handlers, and thus winit might decide to process the event
-                        // immediately within that stack.
-                        // To prevent re-entrancy issues that might happen by getting the application
-                        // event processed on top of the current stack, set winit in Poll mode so that
-                        // events are queued and process on top of a clean stack during a requested animation
-                        // frame a few moments later.
-                        // This also allows batching multiple post_event calls and redraw their state changes
-                        // all at once.
-                        proxy.send_event(SlintUserEvent::CustomEvent {
-                            event: CustomEvent::WakeEventLoopWorkaround,
-                        })?;
-                        proxy.send_event(e)?;
-                        Ok(())
-                    })?
-                }
-                Ok(())
+                send_event_via_global_event_loop_proxy(e)
             }
         }
         Some(Box::new(Proxy))


### PR DESCRIPTION
show() used to create the window, which required access to the event loop (target), which in turn required workarounds like in #1603.  Since the winit window exists now in show(), we don't need this workaround anymore.

The same applies to hide(), we don't need an event loop target, all we need is the event loop proxy to dispatch a WindowHidden event.