### PR TITLE
Fix rendering of the Qt platform example with high-dpi

### DIFF
--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -140,6 +140,15 @@ public:
         }
     }
 
+    /// Notifies the platform about a change in the device pixel ratio.
+    void dispatch_scale_factor_change_event(float factor)
+    {
+        private_api::assert_main_thread();
+        if (was_initialized) {
+            cbindgen_private::slint_windowrc_dispatch_scale_factor_change_event(&self, factor);
+        }
+    }
+
     /// Returns true if the window is currently animating
     bool has_active_animations() const
     {

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn slint_windowrc_has_active_animations(
     window_adapter.window().has_active_animations()
 }
 
-/// Dispatch a key pressed or release event
+/// Dispatch resize event
 #[no_mangle]
 pub unsafe extern "C" fn slint_windowrc_dispatch_resize_event(
     handle: *const WindowAdapterRcOpaque,
@@ -150,6 +150,18 @@ pub unsafe extern "C" fn slint_windowrc_dispatch_resize_event(
     window_adapter.window().dispatch_event(i_slint_core::platform::WindowEvent::Resized {
         size: i_slint_core::api::LogicalSize { width, height },
     });
+}
+
+/// Dispatch scale factor change event
+#[no_mangle]
+pub unsafe extern "C" fn slint_windowrc_dispatch_scale_factor_change_event(
+    handle: *const WindowAdapterRcOpaque,
+    scale_factor: f32,
+) {
+    let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
+    window_adapter
+        .window()
+        .dispatch_event(i_slint_core::platform::WindowEvent::ScaleFactorChanged { scale_factor });
 }
 
 #[no_mangle]


### PR DESCRIPTION
- Provide a C++ platform event for the scale factor change and send it
- Report the correct logical and physical sizes to Slint