### PR TITLE
FemtoVG and Skia renderer API cleanup

### DIFF
--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -323,9 +323,9 @@ public:
         inner = cbindgen_private::slint_skia_renderer_new(window_handle.inner, initial_size);
     }
 
-    void render(const Window &window, PhysicalSize size) const
+    void render(const Window &window) const
     {
-        cbindgen_private::slint_skia_renderer_render(inner, &window.window_handle().inner, size);
+        cbindgen_private::slint_skia_renderer_render(inner, &window.window_handle().inner);
     }
 
     void resize(PhysicalSize size) const

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -340,12 +340,10 @@ pub unsafe extern "C" fn slint_skia_renderer_resize(r: SkiaRendererOpaque, size:
 pub unsafe extern "C" fn slint_skia_renderer_render(
     r: SkiaRendererOpaque,
     window: *const WindowAdapterRcOpaque,
-    size: IntSize,
 ) {
     let window_adapter = &*(window as *const Rc<dyn WindowAdapter>);
     let r = &*(r as *const SkiaRenderer);
-    r.render(window_adapter.window(), PhysicalSize { width: size.width, height: size.height })
-        .unwrap();
+    r.render(window_adapter.window()).unwrap();
 }
 
 #[no_mangle]

--- a/api/cpp/tests/manual/platform_native/windowadapter_win.h
+++ b/api/cpp/tests/manual/platform_native/windowadapter_win.h
@@ -87,7 +87,7 @@ struct MyWindowAdapter : public slint_platform::WindowAdapter
 
     void render()
     {
-        m_renderer->render(window(), physical_size());
+        m_renderer->render(window());
         if (has_active_animations())
             request_redraw();
     }

--- a/api/cpp/tests/manual/platform_qt/main.cpp
+++ b/api/cpp/tests/manual/platform_qt/main.cpp
@@ -70,7 +70,7 @@ public:
     {
         slint_platform::update_timers_and_animations();
 
-        m_renderer->render(window(), physical_size());
+        m_renderer->render(window());
 
         if (has_active_animations()) {
             requestUpdate();

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -38,11 +38,7 @@ mod renderer {
         fn show(&self) -> Result<(), PlatformError>;
         fn hide(&self) -> Result<(), PlatformError>;
 
-        fn render(
-            &self,
-            window: &i_slint_core::api::Window,
-            size: PhysicalSize,
-        ) -> Result<(), PlatformError>;
+        fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError>;
 
         fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer;
 

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -40,7 +40,7 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     }
 
     fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
-        self.renderer.render(window, window.size())
+        self.renderer.render(window)
     }
 
     fn as_core_renderer(&self) -> &dyn Renderer {

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -39,12 +39,8 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
         self.renderer.hide()
     }
 
-    fn render(
-        &self,
-        window: &i_slint_core::api::Window,
-        size: PhysicalWindowSize,
-    ) -> Result<(), PlatformError> {
-        self.renderer.render(window, size)
+    fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
+        self.renderer.render(window, window.size())
     }
 
     fn as_core_renderer(&self) -> &dyn Renderer {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -51,7 +51,7 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
     }
 
     fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
-        self.renderer.render(window, window.size())
+        self.renderer.render(window)
     }
 
     fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -50,12 +50,8 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
         self.renderer.hide()
     }
 
-    fn render(
-        &self,
-        window: &i_slint_core::api::Window,
-        size: PhysicalWindowSize,
-    ) -> Result<(), PlatformError> {
-        self.renderer.render(window, size)
+    fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
+        self.renderer.render(window, window.size())
     }
 
     fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer {

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -49,11 +49,8 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
         Ok(())
     }
 
-    fn render(
-        &self,
-        window: &i_slint_core::api::Window,
-        size: PhysicalWindowSize,
-    ) -> Result<(), PlatformError> {
+    fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
+        let size = window.size();
         let width = size.width as usize;
         let height = size.height as usize;
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -226,8 +226,7 @@ impl WinitWindowAdapter {
         self.pending_redraw.set(false);
 
         let renderer = self.renderer();
-        renderer
-            .render(self.window(), physical_size_to_slint(&self.winit_window().inner_size()))?;
+        renderer.render(self.window())?;
 
         Ok(self.pending_redraw.get())
     }

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -150,10 +150,10 @@ impl FemtoVGRenderer {
     pub fn render(
         &self,
         window: &i_slint_core::api::Window,
-        size: PhysicalWindowSize,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         self.opengl_context.ensure_current()?;
 
+        let size = window.size();
         let width = size.width;
         let height = size.height;
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -111,8 +111,8 @@ impl SkiaRenderer {
     pub fn render(
         &self,
         window: &i_slint_core::api::Window,
-        size: PhysicalWindowSize,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
+        let size = window.size();
         let window_inner = WindowInner::from_pub(window);
 
         self.surface.render(size, |skia_canvas, gr_context| {


### PR DESCRIPTION
Remove the redundant size argument from `render()`.