### PR TITLE
Try to improve the documentation for ModelRc

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -185,7 +185,7 @@ The follow table summarizes the entire mapping:
 | `relative-font-size` | `f32` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
 | structure | `struct` of the same name | |
 | anonymous object | anonymous tuple | The fields are in alphabetical order. |
-| array | [`ModelRc`] |  |
+| array | [`ModelRc`] | Arrays are mapped to models. This also applies to array fields in structures. |
 
 For user defined structures in the .slint, an extra struct is generated.
 For example, if the `.slint` contains
@@ -193,6 +193,7 @@ For example, if the `.slint` contains
 export struct MyStruct {
     foo: int,
     bar: string,
+    names: [string],
 }
 ```
 
@@ -203,6 +204,7 @@ The following struct would be generated:
 struct MyStruct {
     foo : i32,
     bar: slint::SharedString,
+    names: slint::ModelRc<slint::SharedString>,
 }
 ```
 

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -185,11 +185,11 @@ The follow table summarizes the entire mapping:
 | `relative-font-size` | `f32` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
 | structure | `struct` of the same name | |
 | anonymous object | anonymous tuple | The fields are in alphabetical order. |
-| array | [`ModelRc`] | Arrays are mapped to models. This also applies to array fields in structures. |
+| array | [`ModelRc`] | Arrays are represented as models, so that their contents can change dynamically. |
 
 For user defined structures in the .slint, an extra struct is generated.
 For example, if the `.slint` contains
-```slint,ignore
+```slint,no-preview
 export struct MyStruct {
     foo: int,
     bar: string,

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -503,18 +503,33 @@ impl Model for bool {
     }
 }
 
-/// A Reference counted [`Model`].
+/// ModelRc is a type alias for a reference counted implementation of the [`Model`] trait.
 ///
-/// The `ModelRc` struct holds something that implements the [`Model`] trait.
-/// This is used in `for` expressions in the .slint language.
-/// Array properties in the .slint language are holding a ModelRc.
+/// Models are used to represent sequences of the same data type. In `.slint` code those
+/// are represented using the `[T]` array syntax and typically used in `for` expressions,
+/// array properties, and array struct fields.
+///
 /// For example, a `property <[string]> foo` will be of type `ModelRc<SharedString>`
 /// and, behind the scenes, wraps a `Rc<dyn Model<Data = SharedString>>.`
 ///
-/// An empty model can be constructed with [`ModelRc::default()`].
-/// Use [`ModelRc::new()`] To construct a ModelRc from something that implements the
-/// [`Model`] trait.
-/// It is also possible to use the [`From`] trait to convert from `Rc<dyn Model>`.
+/// An array struct field will also be of type `ModelRc`:
+///
+/// ```slint,ignore
+/// export struct AddressBook {
+///     names: [string]
+/// }
+/// ```
+///
+/// When accessing `Addressbook` from Rust, the `names` field will be of type `ModelRc<SharedString>`.
+///
+/// There are several ways of constructing a ModelRc in Rust:
+///
+/// * An empty ModelRc can be constructed with [`ModelRc::default()`].
+/// * A `ModelRc` can be constructed from a slice using [`VecModel::from_slice`].
+/// * Use [`ModelRc::new()`] to construct a `ModelRc` from a type that implements the
+///   [`Model`] trait, such as [`VecModel`] or your own implementation.
+/// * If you have your model already in an `Rc`, then you can use the [`From`] trait
+///   to convert from `Rc<dyn Model<Data = T>>` to `ModelRc`.
 ///
 /// ## Example
 ///

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -503,7 +503,7 @@ impl Model for bool {
     }
 }
 
-/// ModelRc is a type alias for a reference counted implementation of the [`Model`] trait.
+/// ModelRc is a type wrapper for a reference counted implementation of the [`Model`] trait.
 ///
 /// Models are used to represent sequences of the same data type. In `.slint` code those
 /// are represented using the `[T]` array syntax and typically used in `for` expressions,
@@ -514,7 +514,7 @@ impl Model for bool {
 ///
 /// An array struct field will also be of type `ModelRc`:
 ///
-/// ```slint,ignore
+/// ```slint,no-preview
 /// export struct AddressBook {
 ///     names: [string]
 /// }


### PR DESCRIPTION
- Mention in the type mapping table as well as in ModelRc that ModelRc is also used for array struct fields.
- Use an itemized list for the different ways of constructing, with the from_slice variant being listed second.

cc #2787