### PR TITLE
Clean up debug info handling in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,8 @@ jobs:
     env:
       DYLD_FRAMEWORK_PATH: /Users/runner/work/slint/Qt/5.15.2/clang_64/lib
       QT_QPA_PLATFORM: offscreen
-      RUSTFLAGS: -D warnings -C debuginfo=0
+      RUSTFLAGS: -D warnings
+      CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_INCREMENTAL: false
       RUST_BACKTRACE: 1
     strategy:
@@ -50,10 +51,6 @@ jobs:
       if: matrix.os != 'windows-2022'
       run: |
           echo "SLINT_STYLE=native" >> $GITHUB_ENV
-    - name: Disable debug on Windows to save disk space
-      if: runner.os == 'Windows'
-      run: |
-          echo "CARGO_PROFILE_DEV_DEBUG=0" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append          
     - name: Set default style
       if: matrix.os == 'windows-2022'
       run: |


### PR DESCRIPTION
Apply `CARGO_PROFILE_DEV_DEBUG: 0` consistently to all our builds.

Amends 4fa1f885a93f826f3266f512d05aa18a43677274