### PR TITLE
Fix live-preview in docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ rust-version = "1.66"
 resvg = { version= "0.32.0", default-features = false, features = ["text"] }
 fontdb = { version = "0.13.1", default-features = false }
 yeslogic-fontconfig-sys = { version = "3.2.0", features = ["dlopen"] }
+send_wrapper = { version = "0.6.0" }
 
 [profile.release]
 lto = true

--- a/api/wasm-interpreter/Cargo.toml
+++ b/api/wasm-interpreter/Cargo.toml
@@ -20,6 +20,7 @@ highlight = ["slint-interpreter/highlight"]
 
 [dependencies]
 slint-interpreter = { path = "../../internal/interpreter", default-features = false, features = ["std", "backend-winit", "renderer-winit-femtovg", "compat-1-0"] }
+send_wrapper = { workspace = true }
 
 vtable = { version = "0.1.6", path="../../helper_crates/vtable" }
 

--- a/docs/resources/slint-docs-preview.html
+++ b/docs/resources/slint-docs-preview.html
@@ -25,7 +25,7 @@
             div.innerHTML = "<pre style='color: red; background-color:#fee; margin:0'>" + p.innerHTML + "</pre>";
         }
         if (component !== undefined) {
-            let instance = component.create(canvas_id);
+            let instance = await component.create(canvas_id);
             instance.show();
             all_instances.push(instance);
         }
@@ -81,13 +81,23 @@
 
     async function run() {
         await slint.default();
+
+        try {
+            slint.run_event_loop();
+            // this will trigger a JS exception, so this line will never be reached!
+        } catch (e) {
+            // The winit event loop, when targeting wasm, throws a JavaScript exception to break out of
+            // Rust without running any destructors. Don't rethrow the exception but swallow it, as
+            // this is no error and we truly want to resolve the promise of this function by returning
+            // the model markers.
+        }
+
         let selector = ["code.language-slint", ".rustdoc pre.language-slint", "div.highlight-slint div.highlight", "div.highlight-slint\\,no-auto-preview div.highlight"]
             .map((sel) => `${sel}:not([class*=slint\\,ignore]):not([class*=slint\\,no-preview])`).join(",");
         var elements = document.querySelectorAll(selector);
         for (var i = 0; i < elements.length; ++i) {
             await create_click_to_play_and_edit_buttons(elements[i]);
         }
-        slint.run_event_loop();
     }
     run();
 

--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -239,9 +239,13 @@ function getPreviewHtml(slint_wasm_interpreter_url: Uri): string {
             if (current_instance !== null) {
                 current_instance = component.create_with_existing_window(current_instance);
             } else {
-                current_instance = component.create("slint_canvas");
+                try {
+                    slint.run_event_loop();
+                } catch (e) {
+                    // ignore winit event loop exception
+                }
+                current_instance = await component.create("slint_canvas");
                 current_instance.show();
-                slint.run_event_loop();
             }
             current_instance?.set_design_mode(design_mode);
             current_instance?.on_element_selected(element_selected);
@@ -354,7 +358,7 @@ function initPreviewPanel(
                     );
                     const outside_uri = Uri.parse(
                         uriMapping.get(d.url) ??
-                            Uri.file(inside_uri.fsPath).toString(),
+                        Uri.file(inside_uri.fsPath).toString(),
                     );
                     if (outside_uri.scheme !== "invalid") {
                         vscode.window.showTextDocument(outside_uri, {

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -64,7 +64,7 @@ rgb = { version = "0.8.27", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap", "ClipboardEvent", "DataTransfer"] }
 wasm-bindgen = { version = "0.2" }
-send_wrapper = "0.6.0"
+send_wrapper = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.30", optional = true, default-features = false, features = ["egl", "wgl"] }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -566,10 +566,9 @@ pub fn run() -> Result<(), corelib::platform::PlatformError> {
                 windows_with_pending_redraw_requests.clear();
                 ALL_WINDOWS.with(|windows| {
                     for (window_id, window_weak) in windows.borrow().iter() {
-                        if window_weak
-                            .upgrade()
-                            .map_or(false, |window| window.take_pending_redraw())
-                        {
+                        if window_weak.upgrade().map_or(false, |window| {
+                            window.is_shown() && window.take_pending_redraw()
+                        }) {
                             if let Err(insert_pos) =
                                 windows_with_pending_redraw_requests.binary_search(window_id)
                             {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -495,6 +495,14 @@ impl WindowAdapterSealed for WinitWindowAdapter {
             }
         }
 
+        // In wasm a request_redraw() issued before show() results in a draw() even when the window
+        // isn't visible, as opposed to regular windowing systems. The compensate for the lost draw,
+        // explicitly render the first frame on show().
+        #[cfg(target_arch = "wasm32")]
+        if self.pending_redraw.get() {
+            self.draw()?;
+        };
+
         Ok(())
     }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -746,6 +746,19 @@ pub enum EventLoopError {
     NoEventLoopProvider,
 }
 
+impl core::fmt::Display for EventLoopError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            EventLoopError::EventLoopTerminated => {
+                f.write_str("The event loop was already terminated")
+            }
+            EventLoopError::NoEventLoopProvider => {
+                f.write_str("The Slint platform do not provide an event loop")
+            }
+        }
+    }
+}
+
 /// The platform encountered a fatal error.
 ///
 /// This error typically indicates an issue with initialization or connecting to the windowing system.

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -275,8 +275,6 @@ class PreviewerBackend {
             // It's not enough for the canvas element to exist, in order to extract a webgl rendering
             // context, the element needs to be attached to the window's dom.
             if (this.#instance == null) {
-                this.#instance = component.create(this.canvas_id!); // eslint-disable-line
-                this.#instance.show();
                 try {
                     if (!is_event_loop_running) {
                         slint_preview.run_event_loop();
@@ -289,6 +287,8 @@ class PreviewerBackend {
                     // the model markers.
                     is_event_loop_running = true; // Assume the winit caused the exception and that the event loop is up now
                 }
+                this.#instance = await component.create(this.canvas_id!); // eslint-disable-line
+                this.#instance.show();
             } else {
                 this.#instance = component.create_with_existing_window(
                     this.#instance,


### PR DESCRIPTION
This requires two changes:

- An API change in the wasm interpreter (needs careful review)
- A workaround for winit's delivery of draw events