### PR TITLE
Add support for manually closing PopupWindows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project are documented in this file.
  - Added boolean `font-italic` property to `Text` and `TextInput`.
  - Added `select-all()`, `cut()`, `copy()`, and `paste() to `TextInput`, `LineEdit`, and `TextEdit`.
  - Added functions on color: `transparentize`, `mix`, and `with-alpha`.
+ - Added a `close()` function and a `close-on-click` boolean property to `PopupWindow`.
 
 ### Rust
 

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -331,6 +331,7 @@ fn gen_corelib(
             "slint_windowrc_set_focus_item",
             "slint_windowrc_set_component",
             "slint_windowrc_show_popup",
+            "slint_windowrc_close_popup",
             "slint_windowrc_set_rendering_notifier",
             "slint_windowrc_request_redraw",
             "slint_windowrc_on_close_requested",

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -161,12 +161,15 @@ public:
     }
 
     template<typename Component, typename Parent>
-    void show_popup(const Parent *parent_component, cbindgen_private::Point p,
+    void show_popup(const Parent *parent_component, cbindgen_private::Point p, bool close_on_click,
                     cbindgen_private::ItemRc parent_item) const
     {
         auto popup = Component::create(parent_component).into_dyn();
-        cbindgen_private::slint_windowrc_show_popup(&inner, &popup, p, &parent_item);
+        cbindgen_private::slint_windowrc_show_popup(&inner, &popup, p, close_on_click,
+                                                    &parent_item);
     }
+
+    void close_popup() const { cbindgen_private::slint_windowrc_close_popup(&inner); }
 
     template<std::invocable<RenderingState, GraphicsAPI> F>
     std::optional<SetRenderingNotifierError> set_rendering_notifier(F callback) const

--- a/docs/language/src/builtins/elements.md
+++ b/docs/language/src/builtins/elements.md
@@ -495,9 +495,15 @@ Use this element to show a popup window like a tooltip or a popup menu.
 
 Note: It isn't allowed to access properties of elements within the popup from outside of the `PopupWindow`.
 
+### Properties
+
+-   **`close-on-click`** (_in_ _bool_): By default, a PopupWindow closes when the user clicks. Set this
+    to false to prevent that behavior and close it manually using the `close()` function. (default value: true)
+
 ### Functions
 
 -   **`show()`** Show the popup on the screen.
+-   **`close()`** Closes the popup. Use this if you set the `close-on-click` property to false.
 
 ### Example
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -387,6 +387,7 @@ export component PopupWindow {
     in property <length> anchor_y;
     in property <length> anchor_height;
     in property <length> anchor_width;*/
+    in property <bool> close-on-click: true;
     //show() is hardcoded in typeregister.rs
 }
 

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -39,6 +39,7 @@ pub enum BuiltinFunction {
     Pow,
     SetFocusItem,
     ShowPopupWindow,
+    ClosePopupWindow,
     /// A function that belongs to an item (such as TextInput's select-all function).
     ItemMemberFunction(String),
     /// the "42".to_float()
@@ -123,10 +124,12 @@ impl BuiltinFunction {
                 return_type: Box::new(Type::Void),
                 args: vec![Type::ElementReference],
             },
-            BuiltinFunction::ShowPopupWindow => Type::Function {
-                return_type: Box::new(Type::Void),
-                args: vec![Type::ElementReference],
-            },
+            BuiltinFunction::ShowPopupWindow | BuiltinFunction::ClosePopupWindow => {
+                Type::Function {
+                    return_type: Box::new(Type::Void),
+                    args: vec![Type::ElementReference],
+                }
+            }
             BuiltinFunction::ItemMemberFunction(..) => Type::Function {
                 return_type: Box::new(Type::Void),
                 args: vec![Type::ElementReference],
@@ -225,7 +228,7 @@ impl BuiltinFunction {
             | BuiltinFunction::Pow
             | BuiltinFunction::ATan => true,
             BuiltinFunction::SetFocusItem => false,
-            BuiltinFunction::ShowPopupWindow => false,
+            BuiltinFunction::ShowPopupWindow | BuiltinFunction::ClosePopupWindow => false,
             BuiltinFunction::ItemMemberFunction(..) => false,
             BuiltinFunction::StringToFloat | BuiltinFunction::StringIsFloat => true,
             BuiltinFunction::ColorBrighter
@@ -276,7 +279,7 @@ impl BuiltinFunction {
             | BuiltinFunction::Pow
             | BuiltinFunction::ATan => true,
             BuiltinFunction::SetFocusItem => false,
-            BuiltinFunction::ShowPopupWindow => false,
+            BuiltinFunction::ShowPopupWindow | BuiltinFunction::ClosePopupWindow => false,
             BuiltinFunction::ItemMemberFunction(..) => false,
             BuiltinFunction::StringToFloat | BuiltinFunction::StringIsFloat => true,
             BuiltinFunction::ColorBrighter

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2744,7 +2744,7 @@ fn compile_builtin_function_call(
             format!("{}.text_input_focused()", access_window_field(ctx))
         }
         BuiltinFunction::ShowPopupWindow => {
-            if let [llr::Expression::NumberLiteral(popup_index), x, y, llr::Expression::PropertyReference(parent_ref)] =
+            if let [llr::Expression::NumberLiteral(popup_index), x, y, close_on_click, llr::Expression::PropertyReference(parent_ref)] =
                 arguments
             {
                 let mut parent_ctx = ctx;
@@ -2764,12 +2764,17 @@ fn compile_builtin_function_call(
                 let parent_component = access_item_rc(parent_ref, ctx);
                 let x = compile_expression(x, ctx);
                 let y = compile_expression(y, ctx);
+                let close_on_click = compile_expression(close_on_click, ctx);
                 format!(
-                    "{window}.show_popup<{popup_window_id}>({component_access}, {{ static_cast<float>({x}), static_cast<float>({y}) }}, {{ {parent_component} }})"
+                    "{window}.show_popup<{popup_window_id}>({component_access}, {{ static_cast<float>({x}), static_cast<float>({y}) }}, {close_on_click}, {{ {parent_component} }})"
                 )
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {:?}", arguments)
             }
+        }
+        BuiltinFunction::ClosePopupWindow => {
+            let window = access_window_field(ctx);
+            format!("{window}.close_popup()")
         }
         BuiltinFunction::ItemMemberFunction(name) => {
             if let [llr::Expression::PropertyReference(pr)] = arguments {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2233,7 +2233,7 @@ fn compile_builtin_function_call(
             }
         }
         BuiltinFunction::ShowPopupWindow => {
-            if let [Expression::NumberLiteral(popup_index), x, y, Expression::PropertyReference(parent_ref)] =
+            if let [Expression::NumberLiteral(popup_index), x, y, close_on_click, Expression::PropertyReference(parent_ref)] =
                 arguments
             {
                 let mut parent_ctx = ctx;
@@ -2252,6 +2252,7 @@ fn compile_builtin_function_call(
                 let parent_component = access_item_rc(parent_ref, ctx);
                 let x = compile_expression(x, ctx);
                 let y = compile_expression(y, ctx);
+                let close_on_click = compile_expression(close_on_click, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
                 quote!(
                     slint::private_unstable_api::re_exports::WindowInner::from_pub(#window_adapter_tokens.window()).show_popup(
@@ -2261,12 +2262,19 @@ fn compile_builtin_function_call(
                             instance.into()
                         }),
                         Point::new(#x as slint::private_unstable_api::re_exports::Coord, #y as slint::private_unstable_api::re_exports::Coord),
+                        #close_on_click,
                         #parent_component
                     )
                 )
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {:?}", arguments)
             }
+        }
+        BuiltinFunction::ClosePopupWindow => {
+            let window_adapter_tokens = access_window_adapter_field(ctx);
+            quote!(
+                slint::private_unstable_api::re_exports::WindowInner::from_pub(#window_adapter_tokens.window()).close_popup()
+            )
         }
         BuiltinFunction::ItemMemberFunction(name) => {
             if let [Expression::PropertyReference(pr)] = arguments {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2255,7 +2255,11 @@ fn compile_builtin_function_call(
                 let window_adapter_tokens = access_window_adapter_field(ctx);
                 quote!(
                     slint::private_unstable_api::re_exports::WindowInner::from_pub(#window_adapter_tokens.window()).show_popup(
-                        &VRc::into_dyn(#popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone()).into()),
+                        &VRc::into_dyn({
+                            let instance = #popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone());
+                            #popup_window_id::user_init(slint::private_unstable_api::re_exports::VRc::map(instance.clone(), |x| x));
+                            instance.into()
+                        }),
                         Point::new(#x as slint::private_unstable_api::re_exports::Coord, #y as slint::private_unstable_api::re_exports::Coord),
                         #parent_component
                     )

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -355,7 +355,13 @@ fn lower_show_popup(args: &[tree_Expression], ctx: &ExpressionContext) -> llr_Ex
         );
         llr_Expression::BuiltinFunctionCall {
             function: BuiltinFunction::ShowPopupWindow,
-            arguments: vec![llr_Expression::NumberLiteral(popup_index as _), x, y, item_ref],
+            arguments: vec![
+                llr_Expression::NumberLiteral(popup_index as _),
+                x,
+                y,
+                llr_Expression::BoolLiteral(popup.close_on_click),
+                item_ref,
+            ],
         }
     } else {
         panic!("invalid arguments to ShowPopupWindow");

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -87,7 +87,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::Log => 10,
         BuiltinFunction::Pow => 10,
         BuiltinFunction::SetFocusItem => isize::MAX,
-        BuiltinFunction::ShowPopupWindow => isize::MAX,
+        BuiltinFunction::ShowPopupWindow | BuiltinFunction::ClosePopupWindow => isize::MAX,
         BuiltinFunction::ItemMemberFunction(..) => isize::MAX,
         BuiltinFunction::StringToFloat => 50,
         BuiltinFunction::StringIsFloat => 50,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -203,6 +203,7 @@ pub struct PopupWindow {
     pub component: Rc<Component>,
     pub x: NamedReference,
     pub y: NamedReference,
+    pub close_on_click: bool,
     pub parent_element: ElementRc,
 }
 

--- a/internal/compiler/passes/collect_init_code.rs
+++ b/internal/compiler/passes/collect_init_code.rs
@@ -26,4 +26,7 @@ pub fn collect_init_code(component: &Rc<Component>) {
                 .push(init_callback.into_inner().expression);
         }
     });
+    for popup in component.popup_windows.borrow().iter() {
+        collect_init_code(&popup.component);
+    }
 }

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -344,6 +344,7 @@ fn duplicate_popup(
     PopupWindow {
         x: p.x.clone(),
         y: p.y.clone(),
+        close_on_click: p.close_on_click.clone(),
         component: duplicate_sub_component(&p.component, &parent, mapping, priority_delta),
         parent_element: mapping
             .get(&element_key(p.parent_element.clone()))

--- a/internal/compiler/tests/syntax/elements/popup.slint
+++ b/internal/compiler/tests/syntax/elements/popup.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+
+export Bar := Rectangle {
+    in property <bool> external;
+    PopupWindow {
+        close-on-click: true;
+    }
+    PopupWindow {
+        close-on-click: root.external;
+//                      ^error{The close-on-click property only supports constants at the moment}        
+    }
+}

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -259,7 +259,16 @@ impl TypeRegister {
                     .unwrap()
                     .member_functions
                     .insert("show".into(), BuiltinFunction::ShowPopupWindow);
+                Rc::get_mut(b).unwrap().properties.insert(
+                    "close".into(),
+                    BuiltinPropertyInfo::new(BuiltinFunction::ClosePopupWindow.ty()),
+                );
+                Rc::get_mut(b)
+                    .unwrap()
+                    .member_functions
+                    .insert("close".into(), BuiltinFunction::ClosePopupWindow);
             }
+
             _ => unreachable!(),
         };
 

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -1745,6 +1745,7 @@ impl<'a, 'id> InstanceRef<'a, 'id> {
 pub fn show_popup(
     popup: &object_tree::PopupWindow,
     pos: i_slint_core::graphics::Point,
+    close_on_click: bool,
     parent_comp: ComponentRefPin,
     parent_window_adapter: &Rc<dyn WindowAdapter>,
     parent_item: &ItemRc,
@@ -1757,6 +1758,7 @@ pub fn show_popup(
     WindowInner::from_pub(parent_window_adapter.window()).show_popup(
         &vtable::VRc::into_dyn(inst),
         pos,
+        close_on_click,
         parent_item,
     );
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -572,6 +572,7 @@ fn call_builtin_function(
                         x.try_into().unwrap(),
                         y.try_into().unwrap(),
                     ),
+                    popup.close_on_click,
                     component.borrow(),
                     window_adapter_ref(component).unwrap(),
                     &parent_item,
@@ -580,6 +581,18 @@ fn call_builtin_function(
             } else {
                 panic!("internal error: argument to SetFocusItem must be an element")
             }
+        }
+        BuiltinFunction::ClosePopupWindow => {
+            let component = match local_context.component_instance {
+                ComponentInstance::InstanceRef(c) => c,
+                ComponentInstance::GlobalComponent(_) => {
+                    panic!("Cannot show popup from a global component")
+                }
+            };
+
+            window_ref(component).unwrap().close_popup();
+
+            Value::Void
         }
         BuiltinFunction::ItemMemberFunction(name) => {
             if arguments.len() != 1 {

--- a/tests/cases/callbacks/init_popup.slint
+++ b/tests/cases/callbacks/init_popup.slint
@@ -1,0 +1,48 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+// Verify that the init callback is invoked in the correct order
+
+TestCase := Rectangle {
+    width: 300phx;
+    height: 300phx;
+
+    out property <bool> popup-created;
+
+    popup := PopupWindow {
+        init => {
+            root.popup-created = true;
+        }
+    }
+
+    TouchArea {
+        clicked => {
+            popup.show();
+        }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_popup_created());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert(instance.get_popup_created());
+```
+
+
+```js
+var instance = new slint.TestCase({});
+instance.send_mouse_click(5., 5.);
+assert(instance.popup_created);
+```
+
+
+*/

--- a/tests/cases/elements/popupwindow_close.slint
+++ b/tests/cases/elements/popupwindow_close.slint
@@ -152,7 +152,7 @@ slint_testing::send_mouse_click(&instance, 5., 5.);
 assert_eq(instance.get_click_count(), 1);
 ```
 
-```js
+```disable-because-nodejs-runs-with-qt-and-send-mouse-click-wont-send-to-popup-qwindow
 var instance = new slint.TestCase({});
 
 assert.equal(instance.click_count, 0);

--- a/tests/cases/elements/popupwindow_close.slint
+++ b/tests/cases/elements/popupwindow_close.slint
@@ -1,0 +1,195 @@
+// Copyright © SixtyFPS GmbH <info@slint-ui.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+export component TestCase {
+    width: 300px;
+    height: 300px;
+
+    in-out property <bool> popup-created;
+    in-out property <int> click-count;
+    in-out property <int> popup-selector: 0;
+
+    default-popup := PopupWindow {
+        width: parent.width;
+        height: parent.height;
+        Text {
+            text: "I'm a default";
+        }
+        init => {
+            root.popup-created = true;
+        }        
+    }
+
+    self-closing-popup := PopupWindow {
+        close-on-click: false;
+        width: parent.width;
+        height: parent.height;
+        Text {
+            text: "I'm a self-closing popup";
+        }
+        TouchArea {
+            clicked => {
+                self-closing-popup.close();
+            }
+        }
+        init => {
+            root.popup-created = true;
+        }
+    }
+
+    never-closing-popup := PopupWindow {
+        close-on-click: false;
+        width: parent.width;
+        height: parent.height;
+        Text {
+            text: "I'm a popup that never closes";
+        }
+        TouchArea {
+            clicked => {
+            }
+        }
+        init => {
+            root.popup-created = true;
+        }
+    }
+
+    TouchArea {
+        clicked => {
+            root.click-count = root.click-count + 1;
+            if (root.popup-selector == 0) {
+                root.popup-selector = 3;
+                default-popup.show();
+            } else if (root.popup-selector == 1) {
+                root.popup-selector = 3;
+                self-closing-popup.show();
+            } else if (root.popup-selector == 2) {
+                root.popup-selector = 3;
+                never-closing-popup.show();
+            }
+        }
+    }
+}
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_click_count(), 0);
+assert_eq!(instance.get_popup_created(), false);
+
+instance.set_popup_selector(0);
+instance.set_popup_created(false);
+instance.set_click_count(0);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_click_count(), 1);
+assert_eq!(instance.get_popup_created(), true);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_click_count(), 1);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_click_count(), 2);
+
+instance.set_popup_selector(1);
+instance.set_popup_created(false);
+instance.set_click_count(0);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_click_count(), 1);
+assert_eq!(instance.get_popup_created(), true);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_click_count(), 1);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_click_count(), 2);
+
+instance.set_popup_selector(2);
+instance.set_popup_created(false);
+instance.set_click_count(0);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_click_count(), 1);
+assert_eq!(instance.get_popup_created(), true);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_click_count(), 1);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_click_count(), 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert_eq(instance.get_click_count(), 0);
+assert_eq(instance.get_popup_created(), false);
+
+instance.set_popup_selector(0);
+instance.set_popup_created(false);
+instance.set_click_count(0);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_created(), true);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_click_count(), 1);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_click_count(), 2);
+
+instance.set_popup_selector(1);
+instance.set_popup_created(false);
+instance.set_click_count(0);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_created(), true);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_click_count(), 1);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_click_count(), 2);
+
+instance.set_popup_selector(2);
+instance.set_popup_created(false);
+instance.set_click_count(0);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_created(), true);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_click_count(), 1);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_click_count(), 1);
+```
+
+```js
+var instance = new slint.TestCase({});
+
+assert.equal(instance.click_count, 0);
+assert.equal(instance.popup_created, false);
+
+instance.popup_selector = 0;
+instance.popup_created = false;
+instance.click_count = 0;
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.click_count, 1);
+assert.equal(instance.popup_created, true);
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.click_count, 1);
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.click_count, 2);
+
+instance.popup_selector = 1;
+instance.popup_created = false;
+instance.click_count = 0;
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.click_count, 1);
+assert.equal(instance.popup_created, true);
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.click_count, 1);
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.click_count, 2);
+
+instance.popup_selector = 2;
+instance.popup_created = false;
+instance.click_count = 0;
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.click_count, 1);
+assert.equal(instance.popup_created, true);
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.click_count, 1);
+instance.send_mouse_click(5., 5.);
+assert.equal(instance.click_count, 1);
+```
+
+*/


### PR DESCRIPTION
This patch adds a `close()` function that can be called to close a popup window, and a `close-to-click` boolean that can be set to false to disable the default behavior.