### PR TITLE
Remove workaround for running tests on Linux

### DIFF
--- a/api/cpp/tests/CMakeLists.txt
+++ b/api/cpp/tests/CMakeLists.txt
@@ -19,12 +19,6 @@ macro(slint_test NAME)
     )
     add_test(NAME test_${NAME} COMMAND test_${NAME})
 
-    # Somehow the wrong relative rpath ends up in the binary, requiring us to change the
-    # working directory.
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        set_property(TEST test_${NAME} PROPERTY WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-    endif()
-
     if(MSVC)
         target_compile_options(test_${NAME} PRIVATE /W3)
     else()


### PR DESCRIPTION
With the latest Corrosion update test binaries don’t depend on libslint_cpp.so with path anymore that contains a slash. Therefore rpath kicks in and this workaround should not be needed anymore.

Plus, this gives us test coverage for rpath.