### PR TITLE
Fix rendering of LineEdit's placeholder text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project are documented in this file.
  - Added `select-all()`, `cut()`, `copy()`, and `paste() to `TextInput`, `LineEdit`, and `TextEdit`.
  - Added functions on color: `transparentize`, `mix`, and `with-alpha`.
  - Added a `close()` function and a `close-on-click` boolean property to `PopupWindow`.
+ - Fixed `LineEdit`'s placeholder text not being rendered with the same font attributes as regular `LineEdit` text.
 
 ### Rust
 

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -38,6 +38,10 @@ export component LineEditInner inherits Rectangle {
         height: 100%; width: 100%;
         vertical-alignment: center;
         text: (root.text == "" && input.preedit-text == "") ? root.placeholder-text : "";
+        font-size: input.font-size;
+        font-italic: input.font-italic;
+        font-weight: input.font-weight;
+        font-family: input.font-family;
     }
     input := TextInput {
         property <length> computed_x;


### PR DESCRIPTION
Use the same font attributes as for the inner `TextInput`.

Fixes #2829