### PR TITLE
Clean up the Skia renderer API

### DIFF
--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -64,11 +64,11 @@ pub struct SkiaRenderer {
 impl SkiaRenderer {
     /// Creates a new renderer is associated with the provided window adapter.
     pub fn new(
-        native_window: &impl raw_window_handle::HasRawWindowHandle,
-        native_display: &impl raw_window_handle::HasRawDisplayHandle,
+        window_handle: raw_window_handle::WindowHandle<'_>,
+        display_handle: raw_window_handle::DisplayHandle<'_>,
         size: PhysicalWindowSize,
     ) -> Result<Self, PlatformError> {
-        let surface = DefaultSurface::new(&native_window, &native_display, size)?;
+        let surface = DefaultSurface::new(window_handle, display_handle, size)?;
 
         Ok(Self {
             rendering_notifier: Default::default(),
@@ -350,8 +350,8 @@ impl i_slint_core::renderer::Renderer for SkiaRenderer {
 trait Surface {
     const SUPPORTS_GRAPHICS_API: bool;
     fn new(
-        window: &dyn raw_window_handle::HasRawWindowHandle,
-        display: &dyn raw_window_handle::HasRawDisplayHandle,
+        window_handle: raw_window_handle::WindowHandle<'_>,
+        display_handle: raw_window_handle::DisplayHandle<'_>,
         size: PhysicalWindowSize,
     ) -> Result<Self, PlatformError>
     where

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -8,6 +8,7 @@ use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use metal::MTLPixelFormat;
 use objc::{rc::autoreleasepool, runtime::YES};
 
+use raw_window_handle::HasRawWindowHandle;
 use skia_safe::gpu::mtl;
 
 use std::cell::RefCell;
@@ -22,8 +23,8 @@ impl super::Surface for MetalSurface {
     const SUPPORTS_GRAPHICS_API: bool = false;
 
     fn new(
-        window: &dyn raw_window_handle::HasRawWindowHandle,
-        _display: &dyn raw_window_handle::HasRawDisplayHandle,
+        window_handle: raw_window_handle::WindowHandle<'_>,
+        _display_handle: raw_window_handle::DisplayHandle<'_>,
         size: PhysicalWindowSize,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
         let device = metal::Device::system_default()
@@ -38,7 +39,7 @@ impl super::Surface for MetalSurface {
         layer.set_drawable_size(CGSize::new(size.width as f64, size.height as f64));
 
         unsafe {
-            let view = match window.raw_window_handle() {
+            let view = match window_handle.raw_window_handle() {
                 raw_window_handle::RawWindowHandle::AppKit(
                     raw_window_handle::AppKitWindowHandle { ns_view, .. },
                 ) => ns_view,


### PR DESCRIPTION
Accept raw display and window handles, instead of &dyn HasRaw*Handle.

This is consistent with other crates in the Rust ecosystem. Consequently the accepting functions are marked unsafe, as the
API can't guarantee that the handles remain valid.