### PR TITLE
Internal FemtoVG renderer API cleanup

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -43,9 +43,6 @@ mod renderer {
         fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer;
 
         fn resize_event(&self, size: PhysicalSize) -> Result<(), PlatformError>;
-
-        #[cfg(target_arch = "wasm32")]
-        fn html_canvas_element(&self) -> web_sys::HtmlCanvasElement;
     }
 
     #[cfg(feature = "renderer-winit-femtovg")]

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -30,7 +30,6 @@ mod renderer {
     pub(crate) trait WinitCompatibleRenderer {
         fn new(
             window_builder: winit::window::WindowBuilder,
-            #[cfg(target_arch = "wasm32")] canvas_id: &str,
         ) -> Result<(Self, winit::window::Window), PlatformError>
         where
             Self: Sized;

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -9,6 +9,7 @@ use i_slint_renderer_femtovg::FemtoVGRenderer;
 #[cfg(target_arch = "wasm32")]
 use winit::platform::web::WindowExtWebSys;
 
+#[cfg(not(target_arch = "wasm32"))]
 mod glcontext;
 
 pub struct GlutinFemtoVGRenderer {
@@ -19,11 +20,23 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn new(
         window_builder: winit::window::WindowBuilder,
     ) -> Result<(Self, winit::window::Window), PlatformError> {
+        #[cfg(not(target_arch = "wasm32"))]
         let (winit_window, opengl_context) = crate::event_loop::with_window_target(|event_loop| {
             glcontext::OpenGLContext::new_context(window_builder, event_loop.event_loop_target())
         })?;
 
+        #[cfg(target_arch = "wasm32")]
+        let winit_window = crate::event_loop::with_window_target(|event_loop| {
+            window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_err| {
+                format!(
+                    "FemtoVG Renderer: Could not create winit window wrapper for DOM canvas: {}",
+                    winit_os_err
+                )
+            })
+        })?;
+
         let renderer = FemtoVGRenderer::new(
+            #[cfg(not(target_arch = "wasm32"))]
             opengl_context,
             #[cfg(target_arch = "wasm32")]
             winit_window.canvas(),

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -50,9 +50,4 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
         self.renderer.resize(size)
     }
-
-    #[cfg(target_arch = "wasm32")]
-    fn html_canvas_element(&self) -> web_sys::HtmlCanvasElement {
-        self.renderer.html_canvas_element()
-    }
 }

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -6,6 +6,9 @@ use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::Renderer;
 use i_slint_renderer_femtovg::FemtoVGRenderer;
 
+#[cfg(target_arch = "wasm32")]
+use winit::platform::web::WindowExtWebSys;
+
 mod glcontext;
 
 pub struct GlutinFemtoVGRenderer {
@@ -15,18 +18,16 @@ pub struct GlutinFemtoVGRenderer {
 impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn new(
         window_builder: winit::window::WindowBuilder,
-        #[cfg(target_arch = "wasm32")] canvas_id: &str,
     ) -> Result<(Self, winit::window::Window), PlatformError> {
         let (winit_window, opengl_context) = crate::event_loop::with_window_target(|event_loop| {
-            glcontext::OpenGLContext::new_context(
-                window_builder,
-                event_loop.event_loop_target(),
-                #[cfg(target_arch = "wasm32")]
-                canvas_id,
-            )
+            glcontext::OpenGLContext::new_context(window_builder, event_loop.event_loop_target())
         })?;
 
-        let renderer = FemtoVGRenderer::new(opengl_context)?;
+        let renderer = FemtoVGRenderer::new(
+            opengl_context,
+            #[cfg(target_arch = "wasm32")]
+            winit_window.canvas(),
+        )?;
 
         Ok((Self { renderer }, winit_window))
     }

--- a/internal/backends/winit/renderer/femtovg/glcontext.rs
+++ b/internal/backends/winit/renderer/femtovg/glcontext.rs
@@ -17,15 +17,9 @@ pub struct OpenGLContext {
     context: glutin::context::PossiblyCurrentContext,
     #[cfg(not(target_arch = "wasm32"))]
     surface: glutin::surface::Surface<glutin::surface::WindowSurface>,
-    #[cfg(target_arch = "wasm32")]
-    canvas: web_sys::HtmlCanvasElement,
 }
 
 unsafe impl i_slint_renderer_femtovg::OpenGLContextWrapper for OpenGLContext {
-    #[cfg(target_arch = "wasm32")]
-    fn html_canvas_element(&self) -> web_sys::HtmlCanvasElement {
-        self.canvas.clone()
-    }
     fn ensure_current(&self) -> Result<(), PlatformError> {
         #[cfg(not(target_arch = "wasm32"))]
         if !self.context.is_current() {
@@ -192,7 +186,6 @@ impl OpenGLContext {
     pub fn new_context<T>(
         window_builder: winit::window::WindowBuilder,
         window_target: &winit::event_loop::EventLoopWindowTarget<T>,
-        canvas_id: &str,
     ) -> Result<(winit::window::Window, Self), PlatformError> {
         let window = window_builder.build(window_target).map_err(|winit_os_err| {
             format!(
@@ -200,22 +193,6 @@ impl OpenGLContext {
                 winit_os_err
             )
         })?;
-
-        use wasm_bindgen::JsCast;
-
-        let canvas = web_sys::window()
-            .ok_or_else(|| "FemtoVG Renderer: Could not retrieve DOM window".to_string())?
-            .document()
-            .ok_or_else(|| "FemtoVG Renderer: Could not retrieve DOM document".to_string())?
-            .get_element_by_id(canvas_id)
-            .ok_or_else(|| {
-                format!("FemtoVG Renderer: Could not retrieve existing HTML Canvas element '{canvas_id}'")
-            })?
-            .dyn_into::<web_sys::HtmlCanvasElement>()
-            .map_err(|_| {
-                format!("FemtoVG Renderer: Specified DOM element '{canvas_id}' is not a HTML Canvas")
-            })?;
-
-        Ok((window, Self { canvas }))
+        Ok((window, Self {}))
     }
 }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -129,13 +129,7 @@ impl WinitWindowAdapter {
             #[cfg(target_arch = "wasm32")]
             canvas_id,
         )
-        .and_then(|builder| {
-            R::new(
-                builder,
-                #[cfg(target_arch = "wasm32")]
-                canvas_id,
-            )
-        })?;
+        .and_then(|builder| R::new(builder))?;
 
         let self_rc = Rc::new_cyclic(|self_weak| Self {
             window: OnceCell::with_value(corelib::api::Window::new(self_weak.clone() as _)),

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -13,6 +13,9 @@ use std::rc::Rc;
 #[cfg(target_arch = "wasm32")]
 use std::rc::Weak;
 
+#[cfg(target_arch = "wasm32")]
+use winit::platform::web::WindowExtWebSys;
+
 use crate::renderer::WinitCompatibleRenderer;
 use const_field_offset::FieldOffsets;
 
@@ -415,7 +418,7 @@ impl WindowAdapterSealed for WinitWindowAdapter {
             // Auto-resize to the preferred size if users (SlintPad) requests it
             #[cfg(target_arch = "wasm32")]
             {
-                let canvas = self.renderer().html_canvas_element();
+                let canvas = winit_window.canvas();
 
                 if canvas
                     .dataset()
@@ -461,7 +464,7 @@ impl WindowAdapterSealed for WinitWindowAdapter {
 
         #[cfg(target_arch = "wasm32")]
         {
-            let html_canvas = self.renderer().html_canvas_element();
+            let html_canvas = winit_window.canvas();
             let existing_canvas_size = winit::dpi::LogicalSize::new(
                 html_canvas.client_width() as f32,
                 html_canvas.client_height() as f32,
@@ -587,7 +590,7 @@ impl WindowAdapterSealed for WinitWindowAdapter {
             corelib::window::InputMethodRequest::Enable { .. } => {
                 let mut vkh = self.virtual_keyboard_helper.borrow_mut();
                 let h = vkh.get_or_insert_with(|| {
-                    let canvas = self.renderer().html_canvas_element();
+                    let canvas = self.winit_window().canvas();
                     super::wasm_input_helper::WasmInputHelper::new(self.self_weak.clone(), canvas)
                 });
                 h.show();


### PR DESCRIPTION
Separate the wasm vs. non-wasm code path on the renderer level, not on the OpenGL context handling. The latter doesn't exist in WebGL.