### PR TITLE
Make the extraction of `slint!` macro as part of the compiler core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project are documented in this file.
  - In the Slint language, struct can be annotated with `@rust-attr(...)` that is forwarded as a Rust attribute (`#[...]`) for the generated struct
  - Added a `serde` feature to enable serialization of some Slint structure
  - Added convenience `From` conversions for `ModelRc` from slices and arrays.
+ - `slint-viewer` gained the ability to preview .rs files with a `slint!` macro.
 
 ### C++
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -521,6 +521,7 @@ impl ComponentCompiler {
     /// Diagnostics from previous calls are cleared when calling this function.
     ///
     /// If the path is `"-"`, the file will be read from stdin.
+    /// If the extension of the file .rs, the first `slint!` macro from a rust file will be extracted
     ///
     /// This function is `async` but in practice, this is only asynchronous if
     /// [`Self::set_file_loader`] was called and its future is actually asynchronous.


### PR DESCRIPTION
This includes slint-viewer, slint-interpreter (when loading path, not string), slint-compiler.

(This would also include internal things such as
`import { Xxx } from "foo.rs"`, if we didn't check for .slint or .60 extension before)

But that doesn't include anything that's not opening the source by path (so not the lsp which use its own representation coming from the editor, or varius tools like the updater and fmt which also open the files themselves)