### PR TITLE
Fix rendering of links in data structures where docs are shared between C++ and Rust

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -299,7 +299,7 @@ impl<F: FnMut(RenderingState, &GraphicsAPI)> RenderingNotifier for F {
 }
 
 /// This enum describes the different error scenarios that may occur when the application
-/// registers a rendering notifier on a [`crate::Window`](struct.Window.html).
+/// registers a rendering notifier on a `slint::Window`.
 #[derive(Debug, Clone)]
 #[repr(C)]
 #[non_exhaustive]

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -19,7 +19,7 @@ type SingleShotTimerCallback = Box<dyn FnOnce()>;
 
 /// The TimerMode specifies what should happen after the timer fired.
 ///
-/// Used by the [`Timer::start`] function.
+/// Used by the [`Timer::start()`] function.
 #[derive(Copy, Clone)]
 #[repr(C)]
 #[non_exhaustive]


### PR DESCRIPTION

- in SetRenderingNotifierError using a rustdoc link breaks the C++ docs. Using a qualified backtick'ed slint::Window works perfect with both.
- In TimerMode, the same track unfortunately doesn't work with a function, but we can use [`Foo::bar()`] to make the link work with rustdoc and myst-parser. The look isn't perfect in C++, the square brackets are visible.