### PR TITLE
Make Qt installation more robust in the CI

### DIFF
--- a/.github/actions/install-qt/action.yaml
+++ b/.github/actions/install-qt/action.yaml
@@ -1,0 +1,29 @@
+# Copyright © SixtyFPS GmbH <info@slint-ui.com>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+---
+name: Install Qt
+description: Install Qt from either an action or distro repos
+
+inputs:
+  version-wish:
+    description: 'Version desired ot install - may not be fullfilled when using distro packages'
+    required: false
+    default: "5.15.2"
+
+runs:
+  using: composite
+  steps:
+    # TODO: upgrade to qt6-base-dev once GH runners have ubunut 22.10
+    - name: Install Qt from distro repos
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get install qtbase5-dev
+      shell: bash
+    - name: Install Qt (via separate repo)
+      uses: jurplel/install-qt-action@v3
+      if: runner.os == 'macOS'
+      with:
+        version: 5.15.2
+        setup-python: false
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,12 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/install-linux-dependencies
-    - name: Install Qt
-      if: runner.os != 'Windows'
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '5.15.2'
-        setup-python: false
+    - uses: ./.github/actions/install-qt
     - name: Install ffmpeg and alsa (Linux)
       if: runner.os == 'Linux'
       run: sudo apt-get install clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev libasound2-dev pkg-config
@@ -95,12 +90,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - name: Install Qt
-      if: runner.os != 'Windows'
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '5.15.2'
-        setup-python: false
+    - uses: ./.github/actions/install-qt
     - name: Setup headless display
       uses: pyvista/setup-headless-display-action@v1
     - name: Set default style
@@ -140,11 +130,7 @@ jobs:
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
-    - name: Install Qt
-      if: runner.os != 'Windows'
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '5.15.2'
+    - uses: ./.github/actions/install-qt
     - name: Set default style
       if: runner.os != 'Windows'
       run: echo "SLINT_STYLE=native" >> $GITHUB_ENV
@@ -175,16 +161,9 @@ jobs:
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
-    - name: Install Qt (Ubuntu)
-      uses: jurplel/install-qt-action@v3
-      if: matrix.os == 'ubuntu-20.04'
+    - uses: ./.github/actions/install-qt
       with:
-        version: 5.15.2
-    - name: Install Qt (cached)
-      if: matrix.os != 'ubuntu-20.04'
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: 6.5.1
+        version-wish: 6.5.1
     - uses: ./.github/actions/setup-rust
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Select MSVC (windows)
@@ -229,10 +208,7 @@ jobs:
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
-    - name: Install Qt (Ubuntu)
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: 5.15.2
+    - uses: ./.github/actions/install-qt
     - uses: actions/download-artifact@v2
       with:
         name: cpp_bin-ubuntu-20.04

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -20,16 +20,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/install-linux-dependencies
-    - name: Install Qt (Ubuntu)
-      uses: jurplel/install-qt-action@v3
-      if: matrix.os == 'ubuntu-20.04'
+    - uses: ./.github/actions/install-qt
       with:
-        version: 5.15.2
-    - name: Install Qt (cached)
-      if: matrix.os != 'ubuntu-20.04'
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: 6.5.1
+        version-wish: 6.5.1
     - uses: ./.github/actions/setup-rust
     - uses: baptiste0928/cargo-install@v2
       with:


### PR DESCRIPTION
On Linux, use the (older) distro Qt 5 packages,
to avoid frequent errors with install-qt-action on Linux.