### PR TITLE
Rework the translation documentation

### DIFF
--- a/docs/language/src/concepts/translations.md
+++ b/docs/language/src/concepts/translations.md
@@ -62,12 +62,13 @@ to the `@tr(...)` macro using the `"..." =>` syntax.
 
 Use the context to provide additional context information to translators, ensuring accurate and contextually appropriate translations.
 
-The context must be a plain string literal.
+The context must be a plain string literal and it appears as `msgctx` in the `.pot` files. If not specified, the context defaults
+to the name of the surrounding component.
 
 ```slint,no-preview
 export component MenuItem {
-    property <string> name : @tr("Name" => "Default Name");
-    property <string> tooltip : @tr("ToolTip" => "ToolTip for {}", name);
+    property <string> name : @tr("Name" => "Default Name"); // Default: `MenuItem` will be the context.
+    property <string> tooltip : @tr("ToolTip" => "ToolTip for {}", name); // Specified: The context will be `ToolTip`.
 }
 ```
 

--- a/docs/language/src/concepts/translations.md
+++ b/docs/language/src/concepts/translations.md
@@ -1,9 +1,22 @@
 # Translations
 
-Translations of text in Slint can be done with the `@tr` macro.
-That macro will take care both of the translation, and formatting (replacements of `{}` placeholders).
-The first argument must be a plain string  literal, and the arguments to be formatted follows
+Use Slint's translation infrastructure to make your application available in different languages.
 
+Complete the following steps to translate your application:
+
+1. Identify all user visible strings that need to be translated and annotate them with the `@tr()` macro.
+2. Extract translatable strings using the `slint-tr-extractor` tool and generate `.pot` files.
+3. Use a third-party tool to translate the strings into a target language, as `.po` files.
+4. Use gettext's `msgfmt` tool to convert `.po` files into run-time loadable `.mo` files.
+5. Use Slint's API select and load `.mo` files at run-time based on the user's locale settings.
+   At this point, all strings marked for translation will automatically be rendered in the target language.
+
+## Annotating Translatable Strings
+
+Use the `@tr` macro in `.slint` files to mark that a string is meant to be translated. This macro
+will take care both of the translation and the formatting by replacing `{}` placeholders.
+
+The first argument must be a plain string literal, followed by the arguments:
 
 ```slint,no-preview
 export component Example {
@@ -14,21 +27,24 @@ export component Example {
 }
 ```
 
-## Formatting
+### Formatting
 
-The `@tr` macro will by replacing placeholders in the translated string with corresponding values.
-Each `{}` is replaced by the corresponding argument.
-It is also possible to re-order the arguments using `{0}`, `{1}` and so on.
-The translator can use ordered placeholder even if the original string did not.
+The `@tr` macro replaces each `{}` placeholder in the translate string with the corresponding argument.
+It's also possible to re-order the arguments using `{0}`, `{1}` and so on. Translators can use ordered
+placeholders even if the original string did not.
 
-The literal characters `{` and `}` may be included in a string by preceding them with the same character. For example, the `{` character is escaped with `{{` and the `}` character is escaped with `}}`.
+The literal characters `{` and `}` may be included in a string by preceding them with the same character.
+For example, the `{` character is escaped with `{{` and the `}` character is escaped with `}}`.
 
-## Plurals
+### Plurals
 
-A special kind of formatting is the plural formatting, because the string may change depending on if there is a single element or several.
+Use plural formatting when the translation of text involving a variable number of elements should change
+depending on whether there is a single element or multiple.
 
-Given `count` and an expression that represents the count of something, we can form the plural with the `|` and `%` symbols like so:
+Given `count` and an expression that represents the count of something, form the plural with the `|` and `%` symbols like so:
+
 `@tr("I have {n} item" | "I have {n} items" % count)`.
+
 Use `{n}` in the format string to access the expression after the `%`.
 
 ```slint,no-preview
@@ -39,15 +55,14 @@ export component Example inherits Text {
 }
 ```
 
-## Context
+### Context
 
-It is possible to add a context in the `@tr(...)` macro using the `"..." =>`.
+Disambiguate translations for strings with the same source text but different contextual meanings by adding a context
+to the `@tr(...)` macro using the `"..." =>` syntax.
 
-The context provides a mechanism to disambiguate translations for strings with the same source text but different contextual meanings.
 Use the context to provide additional context information to translators, ensuring accurate and contextually appropriate translations.
 
 The context must be a plain string literal.
-
 
 ```slint,no-preview
 export component MenuItem {
@@ -56,60 +71,86 @@ export component MenuItem {
 }
 ```
 
-## Extracting the String from the files
+## Extract Translatable Strings
 
-Use the `slint-tr-extractor` tool to generate a .po file from .slint files.
+Use the `slint-tr-extractor` tool to generate a `.pot` file from `.slint` files.
 You can run it like so:
 
 ```sh
 find -name \*.slint | xargs slint-tr-extractor -o MY_PROJECT.pot
 ```
 
-This will create a file called `MY_PROJECT.pot`. Replace MY_PROJECT with your actual project name. To learn how the project name affects the lookup of translations, see the sections below.
+This will create a file called `MY_PROJECT.pot`. Replace MY_PROJECT with your actual project name.
+To learn how the project name affects the lookup of translations, see the sections below.
 
-## Translating Your Application
+## Translate the Strings
 
-`.pot` file are [Gettext](https://www.gnu.org/software/gettext/) template files. It is the same as a `.po` file, but doesn't contain actual
-translations. They can be edited by hand with a text editor, or there are a few tools you can use to translate them, option include:
+`.pot` file are [Gettext](https://www.gnu.org/software/gettext/) template files. It's the same as a `.po` file, but doesn't contain actual
+translations. They can be created and edited by hand with a text editor, or there are a few tools you can use to translate them, such as the
+following:
  - [poedit](https://poedit.net/)
  - [OmegaT](https://omegat.org/)
  - [Lokalize](https://userbase.kde.org/Lokalize)
  - [Transifex](https://www.transifex.com/) (web interface)
 
-## Loading the Translations at Run-Time
+## Convert `.po` Files to `.mo` Files
 
-[Gettext](https://www.gnu.org/software/gettext/) is used at runtime to get the translations.
+The human readable `.po` files need to be converted into machine-friendly `.mo` files, a binary representation
+that is very efficient to read.
 
-So the first thing to do is to convert the `.po` files in `.mo` files that the gettext runtime can open.
-This can be done with the `msgfmt` command line tool from the gettext package.
+Use [Gettext](https://www.gnu.org/software/gettext/)'s `msgfmt` command line tool to convert `.po` files to `.mo`
+files:
 
-Then, gettext will locate the translation file in the following location:
+```
+msgfmt translation.po -o translation.mo
+```
+
+## Select and Load `.mo` Files at Run-Time
+
+Slint uses the [Gettext](https://www.gnu.org/software/gettext/) library to load translations at run-time.
+Gettext locates the translation file in the following location:
+Gettext expects translation files - called message catalogs - to be placed in following directory hierarchy:
 
 ```
 dir_name/locale/LC_MESSAGES/domain_name.mo
 ```
 
-See the [Gettext documentation](https://www.gnu.org/software/gettext/manual/gettext.html#Locating-Catalogs) for more info.
+* `dir_name`: the base directory that you can choose freely.
+* `locale`: The name of the user's locale for a given target language, such as `fr` for French, or `de` for German.
+  The locale is typically determined using environment variables that your operating system sets.
+* `domain_name`: Selected based on the programming language you're using Slint with.
 
-The locale is determined with environment variables.
+For more info, see the [Gettext documentation](https://www.gnu.org/software/gettext/manual/gettext.html#Locating-Catalogs).
 
-The dir_name and domain_name are optained depending on with which programming language slint is used:
+### Select and Load Translations with Rust
 
-### Rust
+First, enable the `gettext` feature of the `slint` create to gain access to the translations API
+and activate run-time translation support.
 
-You must enable the `gettext` feature of the `slint` create.
+Next, use the `slint::init_translations!` to specify the base location of your `.mo` files. This is
+the `dir_name` in the scheme of the previous section. The `.mo` files are expected to be in the
+corresponding sub-directories and their file name - `domain_name` - must match the package name
+in your `Cargo.toml`. This is often the same as the crate name.
 
-When used from Rust, either via a build.rs script or using a `slint!` macro, the `domain_name`
-is the same as the package name from the Cargo.toml (This is often the same as the crate name)
 
-You must specify `dir_name` with the init_translation macro.
-For example, it may look like this:
+For example:
 
 ```rust
 slint::init_translations!(concat!(env!("CARGO_MANIFEST_DIR"), "/lang/"));
 ```
 
-### C++
+Suppose your `Cargo.toml` contains the following lines and the user's locale is `fr`:
+
+```toml
+[package]
+name = "gallery"
+```
+
+With these sttings, Slint will look for `gallery.mo` in the `lang/fr/LC_MESSAGES/gallery.mo`.
+
+### Select and Load Translations with C++
+
+TODO: Adjust this to whatever we determine as the final mechanism of accessing gettext.
 
 In C++ application using cmake, the `domain_name` is the CMake target name.
 
@@ -143,7 +184,7 @@ int main()
 }
 ```
 
-### `slint-viewer`
+## Previewing Translations with `slint-viewer`
 
-When previewing files with the `slint-viewer` binary, you can pass the `--translation-domain` and `--translation-dir`.
-option to the viewer
+When previewing `.slint` files with `slint-viewer`, use the `--translation-domain` and `--translation-dir`.
+command line option to automatically load translations and display them based on the current locale.


### PR DESCRIPTION
Provide an intro that outlines the overall steps, and then go into details in each of them.

The C++ bit is marked with TODO, as I think we still have to sort out some details there.