### PR TITLE
Provide a more idiomatic API for accessible_descendents

### DIFF
--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -275,10 +275,9 @@ cpp! {{
         Descendents(void *root_item) {
             rustDescendents = rust!(Descendents_ctor [root_item: *mut c_void as "void*"] ->
                     SharedVector<ItemRc> as "void*" {
-                let mut descendents = SharedVector::default();
                 i_slint_core::accessibility::accessible_descendents(
-                        &*(root_item as *mut ItemRc), &mut descendents);
-                descendents
+                        &*(root_item as *mut ItemRc))
+                .collect()
             });
         }
 


### PR DESCRIPTION
With just the Qt accessibility support, this is not impactful. But with accesskit it'll be useful to avoid the intermediate vector of ItemRcs and map directly to a different data structure.

Otherwise, this is a trade-off between the stack allocation of the recursion and instead allocating the stack of pending itemrs
on the heap.