### PR TITLE
Turn `RepeatedElementInfo` into an enum

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -636,9 +636,8 @@ impl Expression {
                     .upgrade()
                     .unwrap()
                     .borrow()
-                    .repeated
-                    .as_ref()
-                    .map_or(&Expression::Invalid, |e| &e.model)
+                    .repeated_as_repeater()
+                    .map_or(&Expression::Invalid, |r| &r.model)
                 {
                     match from.ty() {
                         Type::Float32 | Type::Int32 => Type::Int32,

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -22,6 +22,7 @@ use crate::namedreference::NamedReference;
 use crate::object_tree::find_parent_element;
 use crate::object_tree::Document;
 use crate::object_tree::PropertyAnimation;
+use crate::object_tree::RepeatedElementInfo;
 use crate::object_tree::{Component, ElementRc};
 use derive_more as dm;
 
@@ -410,10 +411,16 @@ fn visit_layout_items_dependencies<'a>(
     vis: &mut impl FnMut(&PropertyPath),
 ) {
     for it in items {
-        let mut element = it.element.clone();
-        if element.borrow().repeated.is_some() {
-            element = it.element.borrow().base_type.as_component().root_element.clone();
-        }
+        let start_element = it.element.clone();
+        let element = match &start_element.borrow().repeated {
+            Some(RepeatedElementInfo::Repeater(_)) => {
+                it.element.borrow().base_type.as_component().root_element.clone()
+            }
+            Some(RepeatedElementInfo::Embedding(_)) => {
+                todo!()
+            }
+            None => it.element.clone(),
+        };
 
         if let Some(nr) = element.borrow().layout_info_prop(orientation) {
             vis(&nr.clone().into());

--- a/internal/compiler/passes/collect_init_code.rs
+++ b/internal/compiler/passes/collect_init_code.rs
@@ -6,16 +6,22 @@
 use std::rc::Rc;
 
 use crate::langtype::ElementType;
-use crate::object_tree::{recurse_elem, Component};
+use crate::object_tree::{recurse_elem, Component, RepeatedElementInfo};
 
 pub fn collect_init_code(component: &Rc<Component>) {
     recurse_elem(&component.root_element, &(), &mut |elem, _| {
-        if elem.borrow().repeated.is_some() {
-            if let ElementType::Component(base) = &elem.borrow().base_type {
-                if base.parent_element.upgrade().is_some() {
-                    collect_init_code(base);
+        match &elem.borrow().repeated {
+            Some(RepeatedElementInfo::Repeater(_)) => {
+                if let ElementType::Component(base) = &elem.borrow().base_type {
+                    if base.parent_element.upgrade().is_some() {
+                        collect_init_code(base);
+                    }
                 }
             }
+            Some(RepeatedElementInfo::Embedding(_)) => {
+                todo!()
+            }
+            None => { /* nothing to do */ }
         }
 
         if let Some(init_callback) = elem.borrow_mut().bindings.remove("init") {

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -657,24 +657,28 @@ fn create_layout_item(
     fix_explicit_percent("height", item_element);
 
     item_element.borrow_mut().child_of_layout = true;
-    let (repeater_index, actual_elem) = if let Some(r) = &item_element.borrow().repeated {
-        let rep_comp = item_element.borrow().base_type.as_component().clone();
-        fix_explicit_percent("width", &rep_comp.root_element);
-        fix_explicit_percent("height", &rep_comp.root_element);
+    let (repeater_index, actual_elem) = match &item_element.borrow().repeated {
+        Some(RepeatedElementInfo::Repeater(r)) => {
+            let rep_comp = item_element.borrow().base_type.as_component().clone();
+            fix_explicit_percent("width", &rep_comp.root_element);
+            fix_explicit_percent("height", &rep_comp.root_element);
 
-        *rep_comp.root_constraints.borrow_mut() =
-            LayoutConstraints::new(&rep_comp.root_element, diag);
-        rep_comp.root_element.borrow_mut().child_of_layout = true;
-        (
-            Some(if r.is_conditional_element {
-                Expression::NumberLiteral(0., Unit::None)
-            } else {
-                Expression::RepeaterIndexReference { element: Rc::downgrade(item_element) }
-            }),
-            rep_comp.root_element.clone(),
-        )
-    } else {
-        (None, item_element.clone())
+            *rep_comp.root_constraints.borrow_mut() =
+                LayoutConstraints::new(&rep_comp.root_element, diag);
+            rep_comp.root_element.borrow_mut().child_of_layout = true;
+            (
+                Some(if r.is_conditional_element {
+                    Expression::NumberLiteral(0., Unit::None)
+                } else {
+                    Expression::RepeaterIndexReference { element: Rc::downgrade(item_element) }
+                }),
+                rep_comp.root_element.clone(),
+            )
+        }
+        Some(RepeatedElementInfo::Embedding(_)) => {
+            todo!()
+        }
+        None => (None, item_element.clone()),
     };
 
     let constraints = LayoutConstraints::new(&actual_elem, diag);

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -58,7 +58,7 @@ pub(crate) fn lower_property_to_element(
         };
 
         for mut child in old_children {
-            if child.borrow().repeated.is_some() {
+            if child.borrow().repeated_as_repeater().is_some() {
                 let root_elem = child.borrow().base_type.as_component().root_element.clone();
                 if has_property_binding(&root_elem) {
                     object_tree::inject_element_as_repeated_element(
@@ -73,18 +73,22 @@ pub(crate) fn lower_property_to_element(
                         ),
                     )
                 }
-            } else if has_property_binding(&child) {
-                let new_child = create_property_element(
-                    &child,
-                    property_name,
-                    extra_properties.clone(),
-                    default_value_for_extra_properties,
-                    element_name,
-                    type_register,
-                );
-                crate::object_tree::adjust_geometry_for_injected_parent(&new_child, &child);
-                new_child.borrow_mut().children.push(child);
-                child = new_child;
+            } else if child.borrow().repeated_as_embedding().is_some() {
+                todo!()
+            } else {
+                if has_property_binding(&child) {
+                    let new_child = create_property_element(
+                        &child,
+                        property_name,
+                        extra_properties.clone(),
+                        default_value_for_extra_properties,
+                        element_name,
+                        type_register,
+                    );
+                    crate::object_tree::adjust_geometry_for_injected_parent(&new_child, &child);
+                    new_child.borrow_mut().children.push(child.clone());
+                    child = new_child;
+                }
             }
 
             elem.borrow_mut().children.push(child);

--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -123,7 +123,7 @@ pub fn lower_shadow_properties(
         // underneath while maintaining the hierarchy for the repeater.
         // The geometry properties are aliased using two-way bindings (which may be eliminated in a later pass).
 
-        if elem.borrow().repeated.is_some() {
+        if elem.borrow().repeated_as_repeater().is_some() {
             let component = elem.borrow().base_type.as_component().clone(); // CHECK if clone can be removed if we change borrow
 
             let drop_shadow_properties = take_shadow_property_bindings(&component.root_element);
@@ -136,6 +136,8 @@ pub fn lower_shadow_properties(
                     diag,
                 );
             }
+        } else if elem.borrow().repeated_as_embedding().is_some() {
+            todo!()
         }
 
         let old_children = {

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -68,12 +68,18 @@ fn process_tabwidget(
     let num_tabs = children.len();
     let mut tabs = Vec::new();
     for child in &mut children {
-        if child.borrow().repeated.is_some() {
-            diag.push_error(
-                "dynamic tabs ('if' or 'for') are currently not supported".into(),
-                &*child.borrow(),
-            );
-            continue;
+        match &child.borrow().repeated {
+            Some(RepeatedElementInfo::Repeater(_)) => {
+                diag.push_error(
+                    "dynamic tabs ('if' or 'for') are currently not supported".into(),
+                    &*child.borrow(),
+                );
+                continue;
+            }
+            Some(RepeatedElementInfo::Embedding(_)) => {
+                todo!()
+            }
+            None => { /* nothing to do */ }
         }
         if child.borrow().base_type.to_string() != "Tab" {
             assert!(diag.has_error());

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -83,7 +83,8 @@ pub fn resolve_expressions(
 
         recurse_elem(&component.root_element, &scope, &mut |elem, scope| {
             let mut new_scope = scope.clone();
-            let mut is_repeated = elem.borrow().repeated.is_some();
+            assert!(elem.borrow().repeated_as_embedding().is_none()); // TODO: Handle embedding!
+            let mut is_repeated = elem.borrow().repeated_as_repeater().is_some();
             new_scope.0.push(elem.clone());
             visit_element_expressions(elem, |expr, property_name, property_type| {
                 if is_repeated {

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -58,7 +58,7 @@ pub fn handle_visible(
             };
 
             for mut child in old_children {
-                if child.borrow().repeated.is_some() {
+                if child.borrow().repeated_as_repeater().is_some() {
                     let root_elem = child.borrow().base_type.as_component().root_element.clone();
                     if has_visible_binding(&root_elem) {
                         let clip_elem = create_visibility_element(&root_elem, &native_clip);
@@ -67,10 +67,14 @@ pub fn handle_visible(
                         clip_elem.borrow_mut().bindings.remove("width");
                         clip_elem.borrow_mut().bindings.remove("height");
                     }
-                } else if has_visible_binding(&child) {
-                    let new_child = create_visibility_element(&child, &native_clip);
-                    new_child.borrow_mut().children.push(child);
-                    child = new_child;
+                } else if child.borrow().repeated_as_embedding().is_some() {
+                    todo!()
+                } else {
+                    if has_visible_binding(&child) {
+                        let new_child = create_visibility_element(&child, &native_clip);
+                        new_child.borrow_mut().children.push(child.clone());
+                        child = new_child;
+                    }
                 }
 
                 elem.borrow_mut().children.push(child);

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -664,17 +664,14 @@ fn ensure_repeater_updated<'id>(
         );
         instance
     };
-    if let Some(lv) = &rep_in_comp
+    if let Some(object_tree::RepeaterInfo { is_listview: Some(lv), .. }) = &rep_in_comp
         .component_to_repeat
         .original
         .parent_element
         .upgrade()
         .unwrap()
         .borrow()
-        .repeated
-        .as_ref()
-        .unwrap()
-        .is_listview
+        .repeated_as_repeater()
     {
         let assume_property_logical_length =
             |prop| unsafe { Pin::new_unchecked(&*(prop as *const Property<LogicalLength>)) };
@@ -844,7 +841,7 @@ pub(crate) fn generate_component<'id>(
                 RepeaterWithinComponent {
                     component_to_repeat: generate_component(base_component, guard),
                     offset: self.type_builder.add_field_type::<Repeater<ErasedComponentBox>>(),
-                    model: item.repeated.as_ref().unwrap().model.clone(),
+                    model: item.repeated.as_ref().unwrap().as_repeater().unwrap().model.clone(),
                 }
                 .into(),
             );


### PR DESCRIPTION
... that can distinguish between a Repeater (`if`/`for`) and an Embedding (to be added `Embed` item).

This patch _should_ not change behavior for either "no repeater" or "repeater" cases. The "embedding" case is currently a `todo!()` as embedding is not implemented yet.

In some places we definitely and obviously do not care for embedding (e.g. when counting repeaters) and then the code is simplified with that in mind.