### PR TITLE
Un-seal the WindowAdaptor trait

### DIFF
--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -43,13 +43,18 @@ impl WindowAdapter for CppWindowAdapter {
     fn window(&self) -> &Window {
         &self.window
     }
-}
 
-impl WindowAdapterSealed for CppWindowAdapter {
+    fn size(&self) -> PhysicalSize {
+        let s = unsafe { (self.size)(self.user_data) };
+        PhysicalSize::new(s.width, s.height)
+    }
+
     fn renderer(&self) -> &dyn Renderer {
         unsafe { core::mem::transmute((self.get_renderer_ref)(self.user_data)) }
     }
+}
 
+impl WindowAdapterSealed for CppWindowAdapter {
     fn show(&self) -> Result<(), PlatformError> {
         unsafe { (self.show)(self.user_data) };
         Ok(())
@@ -61,11 +66,6 @@ impl WindowAdapterSealed for CppWindowAdapter {
 
     fn request_redraw(&self) {
         unsafe { (self.request_redraw)(self.user_data) }
-    }
-
-    fn size(&self) -> PhysicalSize {
-        let s = unsafe { (self.size)(self.user_data) };
-        PhysicalSize::new(s.width, s.height)
     }
 }
 

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -8,7 +8,7 @@ use i_slint_core::platform::{Platform, PlatformError};
 use i_slint_core::renderer::Renderer;
 use i_slint_core::software_renderer::{RepaintBufferType, SoftwareRenderer};
 use i_slint_core::window::ffi::WindowAdapterRcOpaque;
-use i_slint_core::window::{WindowAdapter, WindowAdapterSealed};
+use i_slint_core::window::{WindowAdapter, WindowAdapterInternal};
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use std::rc::Rc;
 
@@ -54,7 +54,7 @@ impl WindowAdapter for CppWindowAdapter {
     }
 }
 
-impl WindowAdapterSealed for CppWindowAdapter {
+impl WindowAdapterInternal for CppWindowAdapter {
     fn show(&self) -> Result<(), PlatformError> {
         unsafe { (self.show)(self.user_data) };
         Ok(())

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -52,6 +52,10 @@ impl WindowAdapter for CppWindowAdapter {
     fn renderer(&self) -> &dyn Renderer {
         unsafe { core::mem::transmute((self.get_renderer_ref)(self.user_data)) }
     }
+
+    fn internal(&self, _: i_slint_core::InternalToken) -> Option<&dyn WindowAdapterInternal> {
+        Some(self)
+    }
 }
 
 impl WindowAdapterInternal for CppWindowAdapter {

--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -491,7 +491,9 @@ declare_types! {
             let this = cx.this();
             let window = cx.borrow(&this, |x| x.0.as_ref().cloned());
             let window_adapter = window.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
-            window_adapter.show().unwrap();
+            if let Some(window_adapter) = window_adapter.internal(i_slint_core::InternalToken) {
+                window_adapter.show().unwrap();
+            }
             Ok(JsUndefined::new().as_value(&mut cx))
         }
 
@@ -499,7 +501,9 @@ declare_types! {
             let this = cx.this();
             let window = cx.borrow(&this, |x| x.0.as_ref().cloned());
             let window_adapter = window.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
-            window_adapter.hide().unwrap();
+            if let Some(window_adapter) = window_adapter.internal(i_slint_core::InternalToken) {
+                window_adapter.hide().unwrap();
+            }
             Ok(JsUndefined::new().as_value(&mut cx))
         }
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -22,7 +22,7 @@ use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector, PhysicalPx, ScaleFactor,
 };
 use i_slint_core::platform::{PlatformError, WindowEvent};
-use i_slint_core::window::{WindowAdapter, WindowAdapterSealed, WindowInner};
+use i_slint_core::window::{WindowAdapter, WindowAdapterInternal, WindowInner};
 use i_slint_core::{ImageInner, Property, SharedString};
 use items::{ImageFit, TextHorizontalAlignment, TextVerticalAlignment};
 
@@ -1563,7 +1563,7 @@ impl WindowAdapter for QtWindow {
     }
 }
 
-impl WindowAdapterSealed for QtWindow {
+impl WindowAdapterInternal for QtWindow {
     fn show(&self) -> Result<(), PlatformError> {
         let component_rc = WindowInner::from_pub(&self.window).component();
         let component = ComponentRc::borrow_pin(&component_rc);

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1561,6 +1561,10 @@ impl WindowAdapter for QtWindow {
         }};
         i_slint_core::api::PhysicalSize::new(s.width as _, s.height as _)
     }
+
+    fn internal(&self, _: i_slint_core::InternalToken) -> Option<&dyn WindowAdapterInternal> {
+        Some(self)
+    }
 }
 
 impl WindowAdapterInternal for QtWindow {
@@ -2221,7 +2225,9 @@ pub(crate) mod ffi {
     pub extern "C" fn slint_qt_get_widget(
         window_adapter: &i_slint_core::window::WindowAdapterRc,
     ) -> *mut c_void {
-        <dyn std::any::Any>::downcast_ref(window_adapter.as_any())
+        window_adapter
+            .internal(i_slint_core::InternalToken)
+            .and_then(|wa| <dyn std::any::Any>::downcast_ref(wa.as_any()))
             .map_or(std::ptr::null_mut(), |win: &QtWindow| {
                 win.widget_ptr().cast::<c_void>().as_ptr()
             })

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1840,7 +1840,7 @@ impl WindowAdapterSealed for QtWindow {
     }
 }
 
-impl Renderer for QtWindow {
+impl i_slint_core::renderer::RendererSealed for QtWindow {
     fn text_size(
         &self,
         font_request: FontRequest,

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -71,20 +71,8 @@ impl WindowAdapterSealed for TestingWindow {
         Ok(())
     }
 
-    fn renderer(&self) -> &dyn Renderer {
-        self
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
-    }
-
-    fn size(&self) -> PhysicalSize {
-        self.size.get()
-    }
-
-    fn set_size(&self, size: i_slint_core::api::WindowSize) {
-        self.size.set(size.to_physical(1.))
     }
 
     fn is_visible(&self) -> bool {
@@ -99,6 +87,18 @@ impl WindowAdapterSealed for TestingWindow {
 impl WindowAdapter for TestingWindow {
     fn window(&self) -> &i_slint_core::api::Window {
         &self.window
+    }
+
+    fn size(&self) -> PhysicalSize {
+        self.size.get()
+    }
+
+    fn set_size(&self, size: i_slint_core::api::WindowSize) {
+        self.size.set(size.to_physical(1.))
+    }
+
+    fn renderer(&self) -> &dyn Renderer {
+        self
     }
 }
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -8,7 +8,7 @@ use i_slint_core::graphics::euclid::{Point2D, Size2D};
 use i_slint_core::graphics::FontRequest;
 use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
 use i_slint_core::renderer::{Renderer, RendererSealed};
-use i_slint_core::window::WindowAdapterSealed;
+use i_slint_core::window::WindowAdapterInternal;
 use i_slint_core::window::{InputMethodRequest, WindowAdapter};
 
 use std::cell::RefCell;
@@ -60,7 +60,7 @@ pub struct TestingWindow {
     pub ime_requests: RefCell<Vec<InputMethodRequest>>,
 }
 
-impl WindowAdapterSealed for TestingWindow {
+impl WindowAdapterInternal for TestingWindow {
     fn show(&self) -> Result<(), PlatformError> {
         self.shown.set(true);
         Ok(())

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -7,7 +7,7 @@
 use i_slint_core::graphics::euclid::{Point2D, Size2D};
 use i_slint_core::graphics::FontRequest;
 use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
-use i_slint_core::renderer::Renderer;
+use i_slint_core::renderer::{Renderer, RendererSealed};
 use i_slint_core::window::WindowAdapterSealed;
 use i_slint_core::window::{InputMethodRequest, WindowAdapter};
 
@@ -102,7 +102,7 @@ impl WindowAdapter for TestingWindow {
     }
 }
 
-impl Renderer for TestingWindow {
+impl RendererSealed for TestingWindow {
     fn text_size(
         &self,
         _font_request: i_slint_core::graphics::FontRequest,

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -100,6 +100,10 @@ impl WindowAdapter for TestingWindow {
     fn renderer(&self) -> &dyn Renderer {
         self
     }
+
+    fn internal(&self, _: i_slint_core::InternalToken) -> Option<&dyn WindowAdapterInternal> {
+        Some(self)
+    }
 }
 
 impl RendererSealed for TestingWindow {
@@ -240,8 +244,8 @@ pub fn access_testing_window<R>(
 ) -> R {
     i_slint_core::window::WindowInner::from_pub(&window)
         .window_adapter()
-        .as_any()
-        .downcast_ref::<TestingWindow>()
+        .internal(i_slint_core::InternalToken)
+        .and_then(|wa| wa.as_any().downcast_ref::<TestingWindow>())
         .map(|adapter| callback(adapter))
         .expect("access_testing_window called without testing backend/adapter")
 }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -277,8 +277,8 @@ fn winit_window_rc_for_window(
 ) -> Option<Rc<winit::window::Window>> {
     i_slint_core::window::WindowInner::from_pub(&window)
         .window_adapter()
-        .as_any()
-        .downcast_ref::<WinitWindowAdapter>()
+        .internal(i_slint_core::InternalToken)
+        .and_then(|wa| wa.as_any().downcast_ref::<WinitWindowAdapter>())
         .map(|adapter| adapter.winit_window())
 }
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -308,6 +308,10 @@ impl WindowAdapter for WinitWindowAdapter {
     fn size(&self) -> corelib::api::PhysicalSize {
         physical_size_to_slint(&self.winit_window().inner_size())
     }
+
+    fn internal(&self, _: corelib::InternalToken) -> Option<&dyn WindowAdapterInternal> {
+        Some(self)
+    }
 }
 
 impl WindowAdapterInternal for WinitWindowAdapter {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -283,6 +283,31 @@ impl WindowAdapter for WinitWindowAdapter {
     fn window(&self) -> &corelib::api::Window {
         self.window.get().unwrap()
     }
+
+    fn renderer(&self) -> &dyn i_slint_core::renderer::Renderer {
+        self.renderer().as_core_renderer()
+    }
+
+    fn position(&self) -> Option<corelib::api::PhysicalPosition> {
+        match self.winit_window().outer_position() {
+            Ok(outer_position) => {
+                Some(corelib::api::PhysicalPosition::new(outer_position.x, outer_position.y))
+            }
+            Err(_) => None,
+        }
+    }
+
+    fn set_position(&self, position: corelib::api::WindowPosition) {
+        self.winit_window().set_outer_position(position_to_winit(&position))
+    }
+
+    fn set_size(&self, size: corelib::api::WindowSize) {
+        self.winit_window().set_inner_size(window_size_to_slint(&size))
+    }
+
+    fn size(&self) -> corelib::api::PhysicalSize {
+        physical_size_to_slint(&self.winit_window().inner_size())
+    }
 }
 
 impl WindowAdapterSealed for WinitWindowAdapter {
@@ -559,10 +584,6 @@ impl WindowAdapterSealed for WinitWindowAdapter {
         });
     }
 
-    fn renderer(&self) -> &dyn i_slint_core::renderer::Renderer {
-        self.renderer().as_core_renderer()
-    }
-
     fn input_method_request(&self, request: corelib::window::InputMethodRequest) {
         #[cfg(not(target_arch = "wasm32"))]
         self.with_window_handle(&mut |winit_window| {
@@ -600,27 +621,6 @@ impl WindowAdapterSealed for WinitWindowAdapter {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
-    }
-
-    fn position(&self) -> Option<corelib::api::PhysicalPosition> {
-        match self.winit_window().outer_position() {
-            Ok(outer_position) => {
-                Some(corelib::api::PhysicalPosition::new(outer_position.x, outer_position.y))
-            }
-            Err(_) => None,
-        }
-    }
-
-    fn set_position(&self, position: corelib::api::WindowPosition) {
-        self.winit_window().set_outer_position(position_to_winit(&position))
-    }
-
-    fn set_size(&self, size: corelib::api::WindowSize) {
-        self.winit_window().set_inner_size(window_size_to_slint(&size))
-    }
-
-    fn size(&self) -> corelib::api::PhysicalSize {
-        physical_size_to_slint(&self.winit_window().inner_size())
     }
 
     fn dark_color_scheme(&self) -> bool {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -25,7 +25,7 @@ use corelib::items::MouseCursor;
 use corelib::layout::Orientation;
 use corelib::lengths::{LogicalLength, LogicalSize};
 use corelib::platform::{PlatformError, WindowEvent};
-use corelib::window::{WindowAdapter, WindowAdapterSealed, WindowInner};
+use corelib::window::{WindowAdapter, WindowAdapterInternal, WindowInner};
 use corelib::Property;
 use corelib::{graphics::*, Coord};
 use i_slint_core as corelib;
@@ -310,7 +310,7 @@ impl WindowAdapter for WinitWindowAdapter {
     }
 }
 
-impl WindowAdapterSealed for WinitWindowAdapter {
+impl WindowAdapterInternal for WinitWindowAdapter {
     fn request_redraw(&self) {
         self.pending_redraw.set(true);
         self.with_window_handle(&mut |window| window.request_redraw())

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2510,7 +2510,7 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::DarkColorScheme => {
             let window_adapter_tokens = access_window_adapter_field(ctx);
-            quote!(#window_adapter_tokens.dark_color_scheme())
+            quote!(slint::private_unstable_api::re_exports::WindowInner::from_pub(#window_adapter_tokens.window()).dark_color_scheme())
         }
         BuiltinFunction::TextInputFocused => {
             let window_adapter_tokens = access_window_adapter_field(ctx);

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -352,7 +352,7 @@ impl Window {
     ///    fn size(&self) -> PhysicalSize { unimplemented!() }
     ///    fn renderer(&self) -> &dyn Renderer { unimplemented!() }
     /// }
-    /// # impl i_slint_core::window::WindowAdapterSealed for MyWindowAdapter {
+    /// # impl i_slint_core::window::WindowAdapterInternal for MyWindowAdapter {
     /// # }
     ///
     /// fn create_window_adapter() -> Rc<dyn WindowAdapter> {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -352,8 +352,6 @@ impl Window {
     ///    fn size(&self) -> PhysicalSize { unimplemented!() }
     ///    fn renderer(&self) -> &dyn Renderer { unimplemented!() }
     /// }
-    /// # impl i_slint_core::window::WindowAdapterInternal for MyWindowAdapter {
-    /// # }
     ///
     /// fn create_window_adapter() -> Rc<dyn WindowAdapter> {
     ///    Rc::<MyWindowAdapter>::new_cyclic(|weak| {
@@ -396,7 +394,9 @@ impl Window {
 
     /// This function issues a request to the windowing system to redraw the contents of the window.
     pub fn request_redraw(&self) {
-        self.0.window_adapter().request_redraw();
+        if let Some(x) = self.0.window_adapter().internal(crate::InternalToken) {
+            x.request_redraw()
+        }
     }
 
     /// This function returns the scale factor that allows converting between logical and
@@ -502,7 +502,11 @@ impl Window {
     /// Returns the visibility state of the window. This function can return false even if you previously called show()
     /// on it, for example if the user minimized the window.
     pub fn is_visible(&self) -> bool {
-        self.0.window_adapter().is_visible()
+        self.0
+            .window_adapter()
+            .internal(crate::InternalToken)
+            .map(|w| w.is_visible())
+            .unwrap_or(false)
     }
 }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -349,11 +349,10 @@ impl Window {
     /// }
     /// impl WindowAdapter for MyWindowAdapter {
     ///    fn window(&self) -> &Window { &self.window }
-    ///    //...
+    ///    fn size(&self) -> i_slint_core::api::PhysicalSize { unimplemented!() }
+    ///    fn renderer(&self) -> &dyn i_slint_core::renderer::Renderer { unimplemented!() }
     /// }
     /// # impl i_slint_core::window::WindowAdapterSealed for MyWindowAdapter {
-    /// #   fn size(&self) -> i_slint_core::api::PhysicalSize { unimplemented!() }
-    /// #   fn renderer(&self) -> &dyn i_slint_core::renderer::Renderer { unimplemented!() }
     /// # }
     ///
     /// fn create_window_adapter() -> Rc<dyn WindowAdapter> {
@@ -430,7 +429,7 @@ impl Window {
     /// a window frame (if present).
     pub fn set_size(&self, size: impl Into<WindowSize>) {
         let size = size.into();
-        self.0.window_adapter().set_size(size);
+        crate::window::WindowAdapter::set_size(&*self.0.window_adapter(), size);
     }
 
     /// Dispatch a window event to the scene.

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -341,16 +341,16 @@ impl Window {
     /// # Example
     /// ```rust
     /// use std::rc::Rc;
-    /// use slint::platform::WindowAdapter;
-    /// use slint::Window;
+    /// use slint::platform::{WindowAdapter, Renderer};
+    /// use slint::{Window, PhysicalSize};
     /// struct MyWindowAdapter {
     ///     window: Window,
     ///     //...
     /// }
     /// impl WindowAdapter for MyWindowAdapter {
     ///    fn window(&self) -> &Window { &self.window }
-    ///    fn size(&self) -> i_slint_core::api::PhysicalSize { unimplemented!() }
-    ///    fn renderer(&self) -> &dyn i_slint_core::renderer::Renderer { unimplemented!() }
+    ///    fn size(&self) -> PhysicalSize { unimplemented!() }
+    ///    fn renderer(&self) -> &dyn Renderer { unimplemented!() }
     /// }
     /// # impl i_slint_core::window::WindowAdapterSealed for MyWindowAdapter {
     /// # }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -341,7 +341,7 @@ impl Window {
     /// # Example
     /// ```rust
     /// use std::rc::Rc;
-    /// use slint::platform::{WindowAdapter, Renderer};
+    /// use slint::platform::WindowAdapter;
     /// use slint::{Window, PhysicalSize};
     /// struct MyWindowAdapter {
     ///     window: Window,
@@ -350,7 +350,7 @@ impl Window {
     /// impl WindowAdapter for MyWindowAdapter {
     ///    fn window(&self) -> &Window { &self.window }
     ///    fn size(&self) -> PhysicalSize { unimplemented!() }
-    ///    fn renderer(&self) -> &dyn Renderer { unimplemented!() }
+    /// #   fn renderer(&self) -> &dyn i_slint_core::renderer::Renderer { unimplemented!() }
     /// }
     ///
     /// fn create_window_adapter() -> Rc<dyn WindowAdapter> {

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -129,7 +129,7 @@ pub fn register_component<Base>(
     window_adapter: Option<Rc<dyn WindowAdapter>>,
 ) {
     item_array.iter().for_each(|item| item.apply_pin(base).as_ref().init());
-    if let Some(adapter) = window_adapter {
+    if let Some(adapter) = window_adapter.as_ref().and_then(|a| a.internal(crate::InternalToken)) {
         adapter.register_component();
     }
 }
@@ -145,8 +145,9 @@ pub fn unregister_component<Base>(
         component,
         &mut item_array.iter().map(|item| item.apply_pin(base)),
     ).expect("Fatal error encountered when freeing graphics resources while destroying Slint component");
-    window_adapter
-        .unregister_component(component, &mut item_array.iter().map(|item| item.apply_pin(base)));
+    if let Some(w) = window_adapter.internal(crate::InternalToken) {
+        w.unregister_component(component, &mut item_array.iter().map(|item| item.apply_pin(base)));
+    }
 }
 
 #[cfg(feature = "ffi")]

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -139,7 +139,7 @@ impl<T: Clone> ItemCache<T> {
 
     /// Function that must be called when a component is destroyed.
     ///
-    /// Usually can be called from [`crate::window::WindowAdapterSealed::unregister_component`]
+    /// Usually can be called from [`crate::window::WindowAdapterInternal::unregister_component`]
     pub fn component_destroyed(&self, component: crate::component::ComponentRef) {
         let component_ptr: *const _ =
             crate::component::ComponentRef::as_ptr(component).cast().as_ptr();

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -503,7 +503,9 @@ impl Item for TouchArea {
         let hovering = !matches!(event, MouseEvent::Exit);
         Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(hovering);
         if hovering {
-            window_adapter.set_mouse_cursor(self.mouse_cursor());
+            if let Some(x) = window_adapter.internal(crate::InternalToken) {
+                x.set_mouse_cursor(self.mouse_cursor());
+            }
         }
         InputEventFilterResult::ForwardAndInterceptGrab
     }
@@ -516,7 +518,9 @@ impl Item for TouchArea {
     ) -> InputEventResult {
         if matches!(event, MouseEvent::Exit) {
             Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(false);
-            window_adapter.set_mouse_cursor(MouseCursor::Default);
+            if let Some(x) = window_adapter.internal(crate::InternalToken) {
+                x.set_mouse_cursor(MouseCursor::Default);
+            }
         }
         if !self.enabled() {
             return InputEventResult::EventIgnored;

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -82,6 +82,10 @@ pub type Coord = f32;
 #[cfg(slint_int_coord)]
 pub type Coord = i32;
 
+/// This type is not exported from the public API crate, so function having this
+/// parameter cannot be called from the public API without naming it
+pub struct InternalToken;
+
 /// Internal function to access the platform abstraction.
 /// The factory function is called if the platform abstraction is not yet
 /// initialized, and should be given by the platform_selector

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -9,7 +9,6 @@ The backend is the abstraction for crates that need to do the actual drawing and
 
 pub use crate::api::PlatformError;
 use crate::api::{LogicalPosition, LogicalSize};
-pub use crate::renderer::Renderer;
 pub use crate::software_renderer;
 #[cfg(all(not(feature = "std"), feature = "unsafe-single-threaded"))]
 use crate::unsafe_single_threaded::{thread_local, OnceCell};

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -9,6 +9,7 @@ The backend is the abstraction for crates that need to do the actual drawing and
 
 pub use crate::api::PlatformError;
 use crate::api::{LogicalPosition, LogicalSize};
+pub use crate::renderer::Renderer;
 pub use crate::software_renderer;
 #[cfg(all(not(feature = "std"), feature = "unsafe-single-threaded"))]
 use crate::unsafe_single_threaded::{thread_local, OnceCell};

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -7,7 +7,19 @@ use core::pin::Pin;
 use crate::component::ComponentRef;
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
 
-pub trait Renderer {
+/// This trait represents a Renderer that can render a slint scene.
+///
+/// This trait is [sealed](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed),
+/// meaning that you are not expected to implement this trait
+/// yourself, but you should use the provided one from Slint such as
+/// [`SoftwareRenderer`](crate::software_renderer::SoftwareRenderer)
+pub trait Renderer: RendererSealed {}
+impl<T: RendererSealed> Renderer for T {}
+
+/// Implementation details behind [`Renderer`], but since this
+/// trait is not exported in the public API, it is not possible for the
+/// users to re-implement these functions.
+pub trait RendererSealed {
     /// Returns the size of the given text in logical pixels.
     /// When set, `max_width` means that one need to wrap the text so it does not go further than that
     fn text_size(

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -18,7 +18,7 @@ use crate::lengths::{
 };
 use crate::renderer::{Renderer, RendererSealed};
 use crate::textlayout::{AbstractFont, FontMetrics, TextParagraphLayout};
-use crate::window::{WindowAdapter, WindowInner};
+use crate::window::{WindowAdapter, WindowAdapterInternal, WindowInner};
 use crate::{Brush, Color, Coord, ImageInner, StaticTextures};
 use alloc::rc::{Rc, Weak};
 use alloc::{vec, vec::Vec};
@@ -2012,7 +2012,7 @@ impl MinimalSoftwareWindow {
     }
 }
 
-impl crate::window::WindowAdapterInternal for MinimalSoftwareWindow {
+impl WindowAdapterInternal for MinimalSoftwareWindow {
     fn request_redraw(&self) {
         self.needs_redraw.set(true);
     }
@@ -2041,6 +2041,10 @@ impl WindowAdapter for MinimalSoftwareWindow {
         self.size.set(size.to_physical(1.));
         self.window
             .dispatch_event(crate::platform::WindowEvent::Resized { size: size.to_logical(1.) })
+    }
+
+    fn internal(&self, _: crate::InternalToken) -> Option<&dyn WindowAdapterInternal> {
+        Some(self)
     }
 }
 

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -2002,14 +2002,19 @@ impl MinimalSoftwareWindow {
             false
         }
     }
+
+    #[doc(hidden)]
+    /// Forward to the window through Deref
+    /// (Before 1.1, WindowAdapter didn't have set_size, so the one from Deref was used.
+    /// But in Slint 1.1, if one had imported the WindowAdapter trait, the other one would be found)
+    pub fn set_size(&self, size: impl Into<crate::api::WindowSize>) {
+        self.window.set_size(size);
+    }
 }
 
 impl crate::window::WindowAdapterSealed for MinimalSoftwareWindow {
     fn request_redraw(&self) {
         self.needs_redraw.set(true);
-    }
-    fn renderer(&self) -> &dyn Renderer {
-        &self.renderer
     }
 
     fn unregister_component<'a>(
@@ -2017,6 +2022,16 @@ impl crate::window::WindowAdapterSealed for MinimalSoftwareWindow {
         _component: crate::component::ComponentRef,
         _items: &mut dyn Iterator<Item = Pin<crate::items::ItemRef<'a>>>,
     ) {
+    }
+}
+
+impl WindowAdapter for MinimalSoftwareWindow {
+    fn window(&self) -> &Window {
+        &self.window
+    }
+
+    fn renderer(&self) -> &dyn Renderer {
+        &self.renderer
     }
 
     fn size(&self) -> crate::api::PhysicalSize {
@@ -2026,12 +2041,6 @@ impl crate::window::WindowAdapterSealed for MinimalSoftwareWindow {
         self.size.set(size.to_physical(1.));
         self.window
             .dispatch_event(crate::platform::WindowEvent::Resized { size: size.to_logical(1.) })
-    }
-}
-
-impl WindowAdapter for MinimalSoftwareWindow {
-    fn window(&self) -> &Window {
-        &self.window
     }
 }
 

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -2012,7 +2012,7 @@ impl MinimalSoftwareWindow {
     }
 }
 
-impl crate::window::WindowAdapterSealed for MinimalSoftwareWindow {
+impl crate::window::WindowAdapterInternal for MinimalSoftwareWindow {
     fn request_redraw(&self) {
         self.needs_redraw.set(true);
     }

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -16,7 +16,7 @@ use crate::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector, PhysicalPx, PointLengths,
     RectLengths, ScaleFactor, SizeLengths,
 };
-use crate::renderer::Renderer;
+use crate::renderer::{Renderer, RendererSealed};
 use crate::textlayout::{AbstractFont, FontMetrics, TextParagraphLayout};
 use crate::window::{WindowAdapter, WindowInner};
 use crate::{Brush, Color, Coord, ImageInner, StaticTextures};
@@ -344,7 +344,7 @@ impl SoftwareRenderer {
 }
 
 #[doc(hidden)]
-impl Renderer for SoftwareRenderer {
+impl RendererSealed for SoftwareRenderer {
     fn text_size(
         &self,
         font_request: crate::graphics::FontRequest,

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -98,6 +98,7 @@ pub trait WindowAdapter {
     /// In your implementation you should return a reference to an instance of one of the renderers provided by Slint.
     ///
     /// Currently, the only public struct that implement renderer is [`SoftwareRenderer`](crate::software_renderer::SoftwareRenderer).
+    #[doc(hidden)]
     fn renderer(&self) -> &dyn Renderer;
 
     #[doc(hidden)]

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -57,7 +57,7 @@ fn input_as_key_event(input: KeyInputEvent, modifiers: KeyboardModifiers) -> Key
 /// yourself, but you should use the provided window adapter. Use
 /// [`MinimalSoftwareWindow`](crate::software_renderer::MinimalSoftwareWindow) when
 /// implementing your own [`platform`](crate::platform).
-pub trait WindowAdapter: WindowAdapterSealed {
+pub trait WindowAdapter: WindowAdapterInternal {
     /// Returns the window API.
     fn window(&self) -> &Window;
 
@@ -109,7 +109,7 @@ pub trait WindowAdapter: WindowAdapterSealed {
 // `#[doc(hidden)] fn internal(&self, InternalToken) -> Option<&WindowAdapterInternal> {None}`
 // TODO: add events for window receiving and loosing focus
 #[doc(hidden)]
-pub trait WindowAdapterSealed {
+pub trait WindowAdapterInternal {
     /// Registers the window with the windowing system.
     // TODO: make public, consider renaming to set_visible with a bool
     fn show(&self) -> Result<(), PlatformError> {
@@ -193,7 +193,7 @@ pub trait WindowAdapterSealed {
     }
 }
 
-/// This is the parameter from [`WindowAdapterSealed::input_method_request()`] which lets the editable text input field
+/// This is the parameter from [`WindowAdapterInternal::input_method_request()`] which lets the editable text input field
 /// communicate with the platform about input methods.
 #[derive(Debug, Clone)]
 #[non_exhaustive]

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -60,6 +60,46 @@ fn input_as_key_event(input: KeyInputEvent, modifiers: KeyboardModifiers) -> Key
 pub trait WindowAdapter: WindowAdapterSealed {
     /// Returns the window API.
     fn window(&self) -> &Window;
+
+    /// Returns the position of the window on the screen, in physical screen coordinates and including
+    /// a window frame (if present).
+    ///
+    /// The default implementation returns `None`
+    ///
+    /// Called from [`Window::position()`]
+    fn position(&self) -> Option<PhysicalPosition> {
+        None
+    }
+    /// Sets the position of the window on the screen, in physical screen coordinates and including
+    /// a window frame (if present).
+    ///
+    /// The default implementation does nothing
+    ///
+    /// Called from [`Window::set_position()`]
+    fn set_position(&self, _position: WindowPosition) {}
+
+    /// Request a new size for the window to the specified size on the screen, in physical or logical pixels
+    /// and excluding a window frame (if present).
+    ///
+    /// This is called from [`Window::set_size()`]
+    ///
+    /// The default implementation does nothing
+    ///
+    /// This function should sent the size to the Windowing system. If the window size actually changes, you
+    /// should dispatch a [`WindowEvent::Resized`](crate::platform::WindowEvent::Resized) using
+    /// [`Window::dispatch_event()`] to propagate the new size to the slint view
+    fn set_size(&self, _size: WindowSize) {}
+
+    /// Return the size of the Window on the screen
+    fn size(&self) -> PhysicalSize;
+
+    /// Return the renderer.
+    ///
+    /// The `Renderer` trait is an internal trait that you are not expected to implement.
+    /// In your implementation you should return a reference to an instance of one of the renderers provided by Slint.
+    ///
+    /// Currently, the only public struct that implement renderer is [`SoftwareRenderer`](crate::software_renderer::SoftwareRenderer).
+    fn renderer(&self) -> &dyn Renderer;
 }
 
 /// Implementation details behind [`WindowAdapter`], but since this
@@ -141,46 +181,10 @@ pub trait WindowAdapterSealed {
     // used for accessibility
     fn handle_focus_change(&self, _old: Option<ItemRc>, _new: Option<ItemRc>) {}
 
-    /// Returns the position of the window on the screen, in physical screen coordinates and including
-    /// a window frame (if present).
-    ///
-    /// The default implementation returns `None`
-    ///
-    /// Called from [`Window::position()`]
-    // TODO: Make public
-    fn position(&self) -> Option<PhysicalPosition> {
-        None
-    }
-    /// Sets the position of the window on the screen, in physical screen coordinates and including
-    /// a window frame (if present).
-    ///
-    /// The default implementation does nothing
-    ///
-    /// Called from [`Window::set_position()`]
-    fn set_position(&self, _position: WindowPosition) {}
-
-    /// Resizes the window to the specified size on the screen, in physical or logical pixels
-    /// and excluding a window frame (if present).
-    ///
-    /// The default implementation does nothing
-    ///
-    /// Called from [`Window::set_size`]
-    ///
-    /// This function should sent the size to the Windowing system. If the window size actually changes, you
-    /// should dispatch a [`WindowEvent::Resized`](crate::platform::WindowEvent::Resized) using
-    /// [`Window::dispatch_event()`] to propagate the new size to the slint view
-    fn set_size(&self, _size: WindowSize) {}
-    /// Return the size of the Window on the screen
-    fn size(&self) -> PhysicalSize;
-
     /// returns wether a dark theme is used
     fn dark_color_scheme(&self) -> bool {
         false
     }
-
-    /// Return the renderer
-    // TODO: make the Renderer trait public, but sealed
-    fn renderer(&self) -> &dyn Renderer;
 
     /// Get the visibility of the window
     // todo: replace with WindowEvent::VisibilityChanged and require backend to dispatch event

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -785,9 +785,12 @@ fn call_builtin_function(
             Value::Brush(Brush::SolidColor(Color::from_argb_u8(a, r, g, b)))
         }
         BuiltinFunction::DarkColorScheme => match local_context.component_instance {
-            ComponentInstance::InstanceRef(component) => {
-                Value::Bool(component.window_adapter().dark_color_scheme())
-            }
+            ComponentInstance::InstanceRef(component) => Value::Bool(
+                component
+                    .window_adapter()
+                    .internal(corelib::InternalToken)
+                    .map_or(false, |x| x.dark_color_scheme()),
+            ),
             ComponentInstance::GlobalComponent(_) => {
                 panic!("Cannot get the window from a global component")
             }

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -561,10 +561,12 @@ pub extern "C" fn slint_interpreter_component_instance_show(
 ) {
     generativity::make_guard!(guard);
     let comp = inst.unerase(guard);
-    if is_visible {
-        comp.borrow_instance().window_adapter().show().unwrap();
-    } else {
-        comp.borrow_instance().window_adapter().hide().unwrap();
+    if let Some(w) = comp.borrow_instance().window_adapter().internal(i_slint_core::InternalToken) {
+        if is_visible {
+            w.show().unwrap();
+        } else {
+            w.hide().unwrap();
+        }
     }
 }
 

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -19,7 +19,7 @@ use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PhysicalPx, ScaleFactor,
 };
 use i_slint_core::platform::PlatformError;
-use i_slint_core::renderer::Renderer;
+use i_slint_core::renderer::RendererSealed;
 use i_slint_core::window::WindowInner;
 use i_slint_core::Brush;
 
@@ -309,7 +309,7 @@ impl FemtoVGRenderer {
     }
 }
 
-impl Renderer for FemtoVGRenderer {
+impl RendererSealed for FemtoVGRenderer {
     fn text_size(
         &self,
         font_request: i_slint_core::graphics::FontRequest,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -191,7 +191,7 @@ impl SkiaRenderer {
     }
 }
 
-impl i_slint_core::renderer::Renderer for SkiaRenderer {
+impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
     fn text_size(
         &self,
         font_request: i_slint_core::graphics::FontRequest,

--- a/tests/screenshots/testing.rs
+++ b/tests/screenshots/testing.rs
@@ -14,7 +14,7 @@ use i_slint_core::{
     },
     item_rendering::DirtyRegion,
     platform::PlatformError,
-    renderer::Renderer,
+    renderer::RendererSealed,
     software_renderer::{LineBufferProvider, MinimalSoftwareWindow},
     window::WindowAdapterSealed,
 };

--- a/tests/screenshots/testing.rs
+++ b/tests/screenshots/testing.rs
@@ -16,7 +16,7 @@ use i_slint_core::{
     platform::PlatformError,
     renderer::RendererSealed,
     software_renderer::{LineBufferProvider, MinimalSoftwareWindow},
-    window::WindowAdapterSealed,
+    window::WindowAdapterInternal,
 };
 
 pub struct SwrTestingBackend {


### PR DESCRIPTION
Note: the addition of MinimalSoftwareWindow::set_size is there because it would be a breaking change for user who called set_size on the MinimalSoftwareWindow while also using the WindowAdapter trait. This was the case of a test.
The same problem theorically exist with set_position and position, but is unlikely to be a problem because i don't think people would use the position with a MinimalSoftwareWindow

The renderer() is now public as well. That's because I want to make sure that the scealed trait don't have non-provided method