### PR TITLE
Fix preview in SlintPad and VS code web extension

### DIFF
--- a/docs/resources/slint-docs-preview.html
+++ b/docs/resources/slint-docs-preview.html
@@ -26,7 +26,7 @@
         }
         if (component !== undefined) {
             let instance = await component.create(canvas_id);
-            instance.show();
+            await instance.show();
             all_instances.push(instance);
         }
     }

--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -245,7 +245,7 @@ function getPreviewHtml(slint_wasm_interpreter_url: Uri): string {
                     // ignore winit event loop exception
                 }
                 current_instance = await component.create("slint_canvas");
-                current_instance.show();
+                await current_instance.show();
             }
             current_instance?.set_design_mode(design_mode);
             current_instance?.on_element_selected(element_selected);

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -288,7 +288,7 @@ class PreviewerBackend {
                     is_event_loop_running = true; // Assume the winit caused the exception and that the event loop is up now
                 }
                 this.#instance = await component.create(this.canvas_id!); // eslint-disable-line
-                this.#instance.show();
+                await this.#instance.show();
             } else {
                 this.#instance = component.create_with_existing_window(
                     this.#instance,


### PR DESCRIPTION
The interpreter now creates the window typically in show(), so similar to commit a8fcb5acd6d3d1631c2cbaa634086811b249eed5 make show() return a promise and invoke show() from within the event loop.

Amends d98c6773e15664127409a9d2d748cf2ce1caac3b