### PR TITLE
Fix race in Slintpad causing preview to panic (esp. in FF)

### DIFF
--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -237,7 +237,7 @@ function getPreviewHtml(slint_wasm_interpreter_url: Uri): string {
         if (component !== undefined) {
             document.getElementById("slint_error_div").innerHTML = "";
             if (current_instance !== null) {
-                current_instance = component.create_with_existing_window(current_instance);
+                current_instance = await component.create_with_existing_window(current_instance);
             } else {
                 try {
                     slint.run_event_loop();


### PR DESCRIPTION
With the following snippet there was a race:

```
if (instance === null) {
    instance = await create();
    await instance.show();
} else {
    instance.create_with_existing_window(...);
}
```

When awaiting for the promise that show() returns to settle, we would re-enter this function (due to a broken recursion guard, that's now removed). When re-entering, create_with_existing_window() is called, which - in order to access the slint::Window to re-use - must create the window adapter. Since that didn't happen from within an event loop invocation, winit would panic.

Consequently, this patch set also makes create_with_existing_window() return a promise, as well as hide() (for the sake of it).

The broken recursion guard is easy to fix (with a .finally() handler setting the boolean back), but that would mean we end up not always rendering the very latest sources. Plus, the same issue exists in wasm_preview.ts.

Now, in case of subsequent re-entrancy in this code, we end up creating a bunch of create_with_exiting_window() promises, which will eventually settle and then we go back to the original show() call that will show the canvas.