### PR TITLE
ci: Use reviewdog to post diffs comments for approval

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -58,25 +58,41 @@ jobs:
     - name: Remove docs from cache  # Avoid stale docs
       run: |
           rm -rf target/doc target/cppdocs api/node/docs
-    - name: Check Rust formatting
-      run: cargo fmt -- --check
-    - name: Check C++ formatting
-      run: |
-        find  -iname \*.h -o -iname \*.cpp | xargs clang-format -i
-        git diff --exit-code
-    - name: Check license headers
-      run: cargo xtask check_license_headers --show-all
+
+    - name: Rust format
+      run: cargo fmt --
+    - name: C++ format
+      run: find -iname \*.h -o -iname \*.cpp | xargs clang-format -i
+    - name: Suggest format changes
+      uses: reviewdog/action-suggester@v1
+      with:
+        tool_name: formatters
+        level: error
+        fail_on_error: true
     - name: Check Enum docs
-      run: |
-        cargo xtask enumdocs
-        echo "Check that the docs were actual. If there is a diff you need to run 'cargo xtask enumdocs'"
-        git diff --exit-code
+      run: cargo xtask enumdocs
+    - name: Suggest enum doc changes
+      uses: reviewdog/action-suggester@v1
+      with:
+        tool_name: xtask enumdocs
+        level: error
+        fail_on_error: true
+
+    - name: Check license headers
+      run: cargo xtask check_license_headers --fix-it || echo "License information needs an update"
+    - name: Suggest license header changes
+      uses: reviewdog/action-suggester@v1
+      with:
+        tool_name: xtask license_header
+        level: error
+        fail_on_error: true
     - name: Check reuse compliance
       run: cargo xtask check_reuse_compliance
+
     - name: Build Cpp docs
       run: cargo xtask cppdocs --show-warnings
     - name: "Rust docs"
-      run: cargo +nightly doc  -p slint -p slint-build -p slint-interpreter --no-deps --all-features
+      run: cargo +nightly doc -p slint -p slint-build -p slint-interpreter --no-deps --all-features
     - name: "Rust Tutorial Docs"
       run: mdbook build
       working-directory: docs/tutorial/rust


### PR DESCRIPTION
Reviewdog is a tool to feed suggestions back into a PR for review. This patch enables this for
 
 * Formating changes
 * the license xtask
 * enum doc changes

The idea was to have those changes ready for review straight away without having to check he action to see what actually is wrong, fix that locally and reupload.

This all changes to check the comments on the PR and apply whatever is sensical.

Check out https://github.com/hunger/slint/pull/4 to see how this feels. It is a bit more fine grained than I want it for the formatting, but it is IMHO great for the license change.

Note that the logic is unchanged: If one step fails, the job fails and the later steps are not executed anymore. So is you are unlucky you need to apply all suggestions and rerun the job a couple of times before you have them all.