### PR TITLE
Don't emit clicked when the pointer did not press the area

### DIFF
--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -259,11 +259,13 @@ impl Item for NativeButton {
             return InputEventResult::EventIgnored;
         }
 
+        let was_pressed = self.pressed();
+
         Self::FIELD_OFFSETS.pressed.apply_pin(self).set(match event {
             MouseEvent::Pressed { .. } => true,
             MouseEvent::Exit | MouseEvent::Released { .. } => false,
             MouseEvent::Moved { .. } => {
-                return if self.pressed() {
+                return if was_pressed {
                     InputEventResult::GrabMouse
                 } else {
                     InputEventResult::EventAccepted
@@ -277,6 +279,7 @@ impl Item for NativeButton {
                 LogicalSize::from_lengths(self.width(), self.height()),
             )
             .contains(position)
+                && was_pressed
             {
                 self.activate();
             }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -532,6 +532,7 @@ impl Item for TouchArea {
                     LogicalSize::from_lengths(self.width(), self.height()),
                 )
                 .contains(position)
+                && self.pressed()
             {
                 Self::FIELD_OFFSETS.clicked.apply_pin(self).call(&());
             }

--- a/tests/cases/elements/toucharea.slint
+++ b/tests/cases/elements/toucharea.slint
@@ -1,12 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.0 OR LicenseRef-Slint-commercial
 
-TestCase := Rectangle {
-    property <int> touch1;
-    property <int> touch2;
-    property <int> touch3;
+export component TestCase  {
+    in-out property <int> touch1;
+    in-out property <int> touch2;
+    in-out property <int> touch3;
 
-    property <string> pointer-event-test;
+    in-out property <string> pointer-event-test;
 
     TouchArea {
         x: 100phx;
@@ -94,6 +94,9 @@ assert_eq(instance.get_pointer_event_test(), "downleftclickupleft");
 
 
 ```rust
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
+
+
 let instance = TestCase::new().unwrap();
 // does not click on anything
 slint_testing::send_mouse_click(&instance, 5., 5.);
@@ -120,6 +123,16 @@ assert_eq!(instance.get_touch2(), 1);
 assert_eq!(instance.get_touch3(), 1);
 
 assert_eq!(instance.get_pointer_event_test().as_str(), "downleftclickupleft");
+
+instance.set_pointer_event_test("".into());
+// issue #2918:  press anywhere, release on a toucharea
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(70.0, 6.0), button: PointerEventButton::Left });
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(102.0, 103.0) });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(101.0, 104.0), button: PointerEventButton::Left });
+assert_eq!(instance.get_pointer_event_test().as_str(), "upleft"); // no "clicked"
+assert_eq!(instance.get_touch1(), 1);
+assert_eq!(instance.get_touch2(), 1);
+assert_eq!(instance.get_touch3(), 1);
 
 ```
 


### PR DESCRIPTION
eg: releasing the pointer over a button that wasn't pressed shouldn't click it

Fixes #2918