### PR TITLE
Simplify implementation of absolute-position

### DIFF
--- a/internal/compiler/tests/syntax/analysis/binding_loop_mappointtowindow.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_mappointtowindow.slint
@@ -7,8 +7,7 @@ export App := Rectangle {
         x: inner.absolute-position.x > 10px ? 10px : 0px;
 //         ^error{The binding for the property 'x' is part of a binding loop}
         inner := Rectangle {
-//               ^error{The binding for the property 'absolute-parent-position' is part of a binding loop}
-//               ^^error{The binding for the property 'absolute-position' is part of a binding loop}
+//               ^error{The binding for the property 'absolute-position' is part of a binding loop}
         }
     }
 


### PR DESCRIPTION
Since we materialize only one point property, we don't need to cache the parent position in a separate property, but we can just store that in the binding.