### PR TITLE
LSP: fix errors or panic when exiting  (Option 2)

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -233,11 +233,8 @@ impl i_slint_core::platform::Platform for Backend {
         struct Proxy;
         impl EventLoopProxy for Proxy {
             fn quit_event_loop(&self) -> Result<(), i_slint_core::api::EventLoopError> {
-                crate::event_loop::with_window_target(|event_loop| {
-                    event_loop
-                        .event_loop_proxy()
-                        .send_event(SlintUserEvent::CustomEvent { event: CustomEvent::Exit })
-                        .map_err(|_| i_slint_core::api::EventLoopError::EventLoopTerminated)
+                send_event_via_global_event_loop_proxy(SlintUserEvent::CustomEvent {
+                    event: CustomEvent::Exit,
                 })
             }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -755,6 +755,8 @@ pub fn invoke_from_event_loop(func: impl FnOnce() + Send + 'static) -> Result<()
 /// to be called from callbacks triggered by the UI. After calling the function,
 /// it will return immediately and once control is passed back to the event loop,
 /// the initial call to `slint::run_event_loop()` will return.
+///
+/// This function can be called from any thread
 pub fn quit_event_loop() -> Result<(), EventLoopError> {
     crate::platform::event_loop_proxy()
         .ok_or(EventLoopError::NoEventLoopProvider)?

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -259,7 +259,8 @@ fn main_loop(connection: &Connection, init_param: InitializeParams) -> Result<()
     for msg in &connection.receiver {
         match msg {
             Message::Request(req) => {
-                if connection.handle_shutdown(&req)? {
+                // ignore errors when shutdown
+                if connection.handle_shutdown(&req).unwrap_or(false) {
                     return Ok(());
                 }
                 futures.push(Box::pin(rh.handle_request(req, &ctx)));


### PR DESCRIPTION
Two problem:
 1. we were calling quit_event_loop from another thread, which didn't work with winit
 2. we need to ignore error from the lsp-server when shutdown as it may result in https://github.com/slint-ui/slint-cpp-template/issues/15

Closes https://github.com/slint-ui/slint-cpp-template/issues/15