### PR TITLE
Bump some winit dependencies

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -75,7 +75,7 @@ accesskit_winit = { version = "0.14.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # For GL rendering
-cocoa = { version = "0.24.0" }
+cocoa = { version = "0.25.0" }
 
 [build-dependencies]
 cfg_aliases = "0.1.0"

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -59,7 +59,7 @@ i-slint-renderer-femtovg = { version = "=1.1.0", path = "../../renderers/femtovg
 i-slint-renderer-skia = { version = "=1.1.0", path = "../../renderers/skia", optional = true }
 
 # For the software renderer
-softbuffer = { version = "0.2.0", optional = true }
+softbuffer = { version = "0.3.0", optional = true }
 imgref = { version = "1.6.1", optional = true }
 rgb = { version = "0.8.27", optional = true }
 

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -47,7 +47,7 @@ dwrote = { version = "0.11.0" }
 [target.'cfg(target_os = "macos")'.dependencies]
 # For GL rendering
 core-foundation = { version = "0.9.1" }
-core-text = { version = "19.1.0" }
+core-text = { version = "20.0.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["console", "WebGlContextAttributes", "CanvasRenderingContext2d", "HtmlInputElement", "HtmlCanvasElement", "Window", "Document"] }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -58,9 +58,8 @@ skia-safe = { version = "0.63", features = ["d3d"] }
 wio = { version = "0.2.2" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = { version = "0.24.0" }
+cocoa = { version = "0.25.0" }
 core-foundation = { version = "0.9.1" }
-core-text = { version = "19.1.0" }
 metal = { version = "0.24.0" }
 # Use the same version of foreign-types as the metal crate uses.
 foreign-types = { version = "0.3.2" }


### PR DESCRIPTION
This bumps softbuffer, cocoa, and core-text. I left out rustybuzz/ttf-parser, as that would introduce rustybuzz as a duplicate. The missing link here is usvg-text-layout that depends on old rustybuzz/ttf-parser and needs a new version.