### PR TITLE
Remove embedded_graphics dependency from i-slint-core

### DIFF
--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -73,7 +73,6 @@ strum = { version = "0.25.0", default-features = false, features = ["derive"] }
 unicode-segmentation = "1.8.0"
 unicode-linebreak = { version = "0.1.2", optional = true }
 unicode-script = { version = "0.5.3", optional = true }
-embedded-graphics = { version = "0.7.1", optional = true }
 integer-sqrt = { version = "0.1.5" }
 
 image = { version = "0.24.0", optional = true, default-features = false, features = [ "png", "jpeg" ] }

--- a/internal/core/software_renderer/draw_functions.rs
+++ b/internal/core/software_renderer/draw_functions.rs
@@ -9,8 +9,6 @@ use crate::graphics::{PixelFormat, Rgb8Pixel};
 use crate::lengths::{PointLengths, RectLengths, SizeLengths};
 use crate::Color;
 use derive_more::{Add, Mul, Sub};
-#[cfg(feature = "embedded-graphics")]
-use embedded_graphics::prelude::RgbColor as _;
 use integer_sqrt::IntegerSquareRoot;
 
 /// Draw one line of the texture in the line buffer
@@ -455,38 +453,6 @@ pub trait TargetPixel: Sized + Copy {
     }
     /// Create a pixel from the red, gree, blue component in the range 0..=255
     fn from_rgb(red: u8, green: u8, blue: u8) -> Self;
-}
-
-#[cfg(feature = "embedded-graphics")]
-impl TargetPixel for embedded_graphics::pixelcolor::Rgb888 {
-    fn blend(&mut self, color: PremultipliedRgbaColor) {
-        let a = (u8::MAX - color.alpha) as u16;
-        *self = Self::new(
-            (self.r() as u16 * a / 255) as u8 + color.red,
-            (self.g() as u16 * a / 255) as u8 + color.green,
-            (self.b() as u16 * a / 255) as u8 + color.blue,
-        );
-    }
-
-    fn from_rgb(r: u8, g: u8, b: u8) -> Self {
-        Self::new(r, g, b)
-    }
-}
-
-#[cfg(feature = "embedded-graphics")]
-impl TargetPixel for embedded_graphics::pixelcolor::Rgb565 {
-    fn blend(&mut self, color: PremultipliedRgbaColor) {
-        let a = (u8::MAX - color.alpha) as u16;
-        *self = Self::new(
-            (((self.r() as u16) * a) / 255) as u8 + (color.red >> 3),
-            (((self.g() as u16) * a) / 255) as u8 + (color.green >> 2),
-            (((self.b() as u16) * a) / 255) as u8 + (color.blue >> 3),
-        )
-    }
-
-    fn from_rgb(r: u8, g: u8, b: u8) -> Self {
-        Self::new(r >> 3, g >> 2, b >> 3)
-    }
 }
 
 impl TargetPixel for crate::graphics::image::Rgb8Pixel {


### PR DESCRIPTION
This feature was never used.