### PR TITLE
Software renderer: Prevent the drawing of a window in a too small buffer

### DIFF
--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -75,6 +75,13 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
 
         let mut surface = self.surface.borrow_mut();
 
+        // It is possible that we get the render event before the resize event, yet, the window.size() is already the new size.
+        // To prevent drawing the window with the wrong size, always send a resize event.
+        // It should be ignored in most case if the window did not change size
+        window.dispatch_event(i_slint_core::platform::WindowEvent::Resized {
+            size: size.to_logical(window.scale_factor()),
+        });
+
         surface
             .resize(width, height)
             .map_err(|e| format!("Error resizing softbuffer surface: {e}"))?;

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -231,6 +231,11 @@ impl SoftwareRenderer {
         } else {
             (euclid::size2(pixel_stride as _, (buffer.len() / pixel_stride) as _), Brush::default())
         };
+        assert!(
+            pixel_stride >= size.width as usize
+                && buffer.len() >= size.height as usize * pixel_stride + size.width as usize - pixel_stride,
+            "buffer of size {} with stride {pixel_stride} is too small to handle a window of size {size:?}", buffer.len()
+        );
         let buffer_renderer = SceneBuilder::new(
             size,
             factor,


### PR DESCRIPTION
Fixes: #2027
Fixes: #2957