### PR TITLE
Fix getting type of more complex expressions in model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 
 ### General
 
+ - Fixed compiler panics when some complex expressions are used for the model expression in `for` (#2977)
+
 ### Slint Language
 
 ### Rust

--- a/editors/tree-sitter-slint/corpus/lookup.txt
+++ b/editors/tree-sitter-slint/corpus/lookup.txt
@@ -59,7 +59,9 @@ TestCase := Rectangle {
           (post_identifier)))
       (for_loop
         (var_identifier)
-        (for_range)
+        (for_range
+          (value
+            (int_value)))
         (component
           (user_type_identifier)
           (block

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -355,7 +355,7 @@ module.exports = grammar({
         type: ($) =>
             choice($._type_identifier, $.type_list, $.type_anon_struct),
 
-        for_range: ($) => choice($._int_number, $.value_list, $.var_identifier),
+        for_range: ($) => $._expression,
 
         _assignment_setup: ($) =>
             seq(

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -47,6 +47,7 @@ pub enum Type {
     Percent,
     Image,
     Bool,
+    /// Fake type that can represent anything that can be converted into a model.
     Model,
     PathData, // Either a vector of path elements or a two vectors of events and coordinates
     Easing,
@@ -217,7 +218,6 @@ impl Type {
                 | Self::Percent
                 | Self::Image
                 | Self::Bool
-                | Self::Model
                 | Self::Easing
                 | Self::Enumeration(_)
                 | Self::ElementReference

--- a/tests/cases/models/for.slint
+++ b/tests/cases/models/for.slint
@@ -82,6 +82,9 @@ export TestCase := Rectangle {
             root.value = x.a;
         }
     }
+
+    // issue #2977
+    for v in value + value : Text { text: v; }
 }
 
 


### PR DESCRIPTION
Fixes #2977

The problem is that expressions such as "foo * foo" can be optimized by optimization pass to only query the property once, and this is transformed in a Expression::CodeBlock and is no longer a Expression::Cast(Model)
So we need to introspect the expression more.