### PR TITLE
Prospective fix for pipenv errors about invalid specifiers

### DIFF
--- a/api/cpp/docs/Pipfile
+++ b/api/cpp/docs/Pipfile
@@ -9,13 +9,13 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-breathe = "4.33.1"
-sphinx = "4.5.0"
-exhale = "0.2.4"
-myst_parser = "0.17.2"
-sphinx-markdown-tables = "0.0.15"
-furo = "2022.12.7"
-sphinxcontrib-jquery = "4.1"
+breathe = ">=4.33.1"
+sphinx = ">=4.5.0"
+exhale = ">=0.2.4"
+myst_parser = ">=0.17.2"
+sphinx-markdown-tables = ">=0.0.15"
+furo = ">=2022.12.7"
+sphinxcontrib-jquery = ">=4.1"
 
 [requires]
 python_version = "3"

--- a/docs/language/Pipfile
+++ b/docs/language/Pipfile
@@ -9,11 +9,11 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-sphinx = "4.5.0"
-myst_parser = "0.17.2"
-sphinx-markdown-tables = "0.0.15"
-furo = "2022.12.7"
-sphinxcontrib-jquery = "4.1"
+sphinx = ">=4.5.0"
+myst_parser = ">=0.17.2"
+sphinx-markdown-tables = ">=0.0.15"
+furo = ">=2022.12.7"
+sphinxcontrib-jquery = ">=4.1"
 
 [requires]
 python_version = "3"


### PR DESCRIPTION
PEP 508 requires a comparator for version_one, so specify some.