### PR TITLE
Skia: align gradient rendering with software renderer and Qt

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -87,7 +87,7 @@ impl<'a> SkiaRenderer<'a> {
                     skia_safe::gradient_shader::GradientShaderColors::Colors(&colors),
                     Some(&*pos),
                     skia_safe::TileMode::Clamp,
-                    None,
+                    skia_safe::gradient_shader::Flags::INTERPOLATE_COLORS_IN_PREMUL,
                     &skia_safe::Matrix::scale((width.get(), height.get())),
                 )
             }
@@ -101,7 +101,7 @@ impl<'a> SkiaRenderer<'a> {
                     skia_safe::gradient_shader::GradientShaderColors::Colors(&colors),
                     Some(&*pos),
                     skia_safe::TileMode::Clamp,
-                    None,
+                    skia_safe::gradient_shader::Flags::INTERPOLATE_COLORS_IN_PREMUL,
                     skia_safe::Matrix::scale((circle_scale.get(), circle_scale.get()))
                         .post_translate((width.get() / 2., height.get() / 2.))
                         as &skia_safe::Matrix,


### PR DESCRIPTION
Interpolate colors as pre-multiplied.

cc #313

Qt reference:

<img width="752" alt="Qt" src="https://github.com/slint-ui/slint/assets/1486/d1d9551e-e668-417e-96e6-d598efc72ee6">

Skia before this patch:

<img width="640" alt="Skia Before" src="https://github.com/slint-ui/slint/assets/1486/fc16c1af-40b4-4583-895e-c9fec4e9d80e">


Skia with this patch applied:

<img width="640" alt="Skia After" src="https://github.com/slint-ui/slint/assets/1486/f0ca85f2-71a3-4ffb-b142-5bcbfa4c8b97">
