### PR TITLE
TextEdit: Discard the preedit when focus change or other text is enter

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -537,12 +537,6 @@ impl Item for TextInput {
                 KeyEventResult::EventAccepted
             }
             KeyEventType::CommitComposition => {
-                // Winit says that it will always send an event to empty the pre-edit area, but with
-                // korean IME on Windows for example that's not the case. Qt also doesn't make that guarantee,
-                // so clear it by hand here.
-                self.preedit_text.set(Default::default());
-                self.preedit_selection_start.set(0);
-                self.preedit_selection_end.set(0);
                 self.insert(&event.text, window_adapter, self_rc);
                 KeyEventResult::EventAccepted
             }
@@ -579,6 +573,9 @@ impl Item for TextInput {
                         window_adapter.input_method_request(InputMethodRequest::Disable {});
                     }
                 }
+                self.preedit_text.set(Default::default());
+                self.preedit_selection_start.set(0);
+                self.preedit_selection_end.set(0);
             }
         }
         FocusEventResult::FocusAccepted
@@ -970,6 +967,10 @@ impl TextInput {
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) {
+        self.preedit_text.set(Default::default());
+        self.preedit_selection_start.set(0);
+        self.preedit_selection_end.set(0);
+
         self.delete_selection(window_adapter, self_rc);
         let mut text: String = self.text().into();
         let cursor_pos = self.selection_anchor_and_cursor().1;

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -571,11 +571,11 @@ impl Item for TextInput {
                 if !self.read_only() {
                     if let Some(window_adapter) = window_adapter.internal(crate::InternalToken) {
                         window_adapter.input_method_request(InputMethodRequest::Disable {});
+                        self.preedit_text.set(Default::default());
+                        self.preedit_selection_start.set(0);
+                        self.preedit_selection_end.set(0);
                     }
                 }
-                self.preedit_text.set(Default::default());
-                self.preedit_selection_start.set(0);
-                self.preedit_selection_end.set(0);
             }
         }
         FocusEventResult::FocusAccepted


### PR DESCRIPTION
Otherwise we end up with outdated pre-edit data if we change focus while editing.

Note: Qt doas actually send a "commit" event when the focus change (but of course that does not happen when changing the focus within slint)
But firefox does discard the preedit when loosing the focus.

CC #1925