### PR TITLE
ci: Do not commit "empty" translation updates

### DIFF
--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -48,14 +48,22 @@ jobs:
       - name: "Fix license headers"
         run: cargo xtask check_license_headers --fix-it
 
+      - name: Check for interesting changes
+        id: git_diff
+        run: git diff --ignore-matching-lines="POT-Creation-Date:.*" --exit-code --quiet HEAD
+        continue-on-error: true
+
       - name: commit
+        # Only run this if there was a diff!
+        if: steps.git_diff.outcome == 'failure'
         run: |
           git config --global user.email "noreply@slint.dev"
           git config --global user.name "Update Translations Bot"
           git add examples
           git commit -a -m 'Update Translations: extract strings'
       - name: Result
-        run: git show
+        # Only run this if there was a diff!
+        run: if [ '${{ steps.git_diff.outcome }}' = 'failure' ]; then echo "I commited this change to git:"; git show ; else echo "This change was ignored:" ; git diff HEAD ; fi
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
Ignore translation updates if they only change the creation date in the generated files.