### PR TITLE
C++: Use a static_assert to detect Slint version mismatch

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -435,20 +435,23 @@ fn gen_corelib(
         .with_src(crate_dir.join("graphics/image.rs"))
         .with_include("slint_string.h")
         .with_after_include(format!(
-            r"
+            r#"
 /// This macro expands to the to the numeric value of the major version of Slint you're
 /// developing against. For example if you're using version 1.5.2, this macro will expand to 1.
-#define SLINT_VERSION_MAJOR {}
+#define SLINT_VERSION_MAJOR {x}
 /// This macro expands to the to the numeric value of the minor version of Slint you're
 /// developing against. For example if you're using version 1.5.2, this macro will expand to 5.
-#define SLINT_VERSION_MINOR {}
+#define SLINT_VERSION_MINOR {y}
 /// This macro expands to the to the numeric value of the patch version of Slint you're
 /// developing against. For example if you're using version 1.5.2, this macro will expand to 2.
-#define SLINT_VERSION_PATCH {}
-",
-            env!("CARGO_PKG_VERSION_MAJOR"),
-            env!("CARGO_PKG_VERSION_MINOR"),
-            env!("CARGO_PKG_VERSION_PATCH"),
+#define SLINT_VERSION_PATCH {z}
+/// This macro expands to the string representation of the version of Slint you're developing against.
+/// For example if you're using version 1.5.2, this macro will expand to "1.5.2".
+#define SLINT_VERSION_STRING "{x}.{y}.{z}"
+"#,
+            x = env!("CARGO_PKG_VERSION_MAJOR"),
+            y = env!("CARGO_PKG_VERSION_MINOR"),
+            z = env!("CARGO_PKG_VERSION_PATCH"),
         ))
         .generate()
         .context("Unable to generate bindings for slint_generated_public.h")?

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -1505,8 +1505,9 @@ cbindgen_private::NativeStyleMetrics::~NativeStyleMetrics()
 #endif // !defined(DOXYGEN)
 
 namespace private_api {
+// Was used in Slint <= 1.1.0 to have an error message in case of mismatch
 template<int Major, int Minor, int Patch>
-struct VersionCheckHelper
+struct [[deprecated]] VersionCheckHelper
 {
 };
 }


### PR DESCRIPTION
cc #2909 , #223

New message:
```
/home/olivier/slint/build2/examples/gallery/gallery.h:6:73: error: static assertion failed: This file was generated with Slint compiler version 1.1.1, but the Slint library used is 1.1.0. The version numbers must match exactly.
    6 | static_assert(1 == SLINT_VERSION_MAJOR && 1 == SLINT_VERSION_MINOR && 1 == SLINT_VERSION_PATCH, "This file was generated with Slint compiler version 1.1.1, but the Slint library used is " SLINT_VERSION_STRING ". The version numbers must match exactly.");
/home/olivier/slint/build2/examples/gallery/gallery.h:6:73: note: the comparison reduces to ‘(1 == 0)’
```

Previous message:
```
/home/olivier/slint/build2/examples/printerdemo/cpp/printerdemo.h:12218:161: error: conversion from ‘VersionCheckHelper<[...],[...],0>’ to non-scalar type ‘VersionCheckHelper<[...],[...],1>’ requested
12218 | [[maybe_unused]] constexpr slint::private_api::VersionCheckHelper<1, 1, 1> THE_SAME_VERSION_MUST_BE_USED_FOR_THE_COMPILER_AND_THE_RUNTIME = slint::private_api::VersionCheckHelper<SLINT_VERSION_MAJOR, SLINT_VERSION_MINOR, SLINT_VERSION_PATCH>();
      |                                                                                                                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/olivier/slint/build2/examples/printerdemo/cpp/printerdemo.h:12218:161: error: could not convert ‘slint::private_api::VersionCheckHelper<1, 1, 0>()’ from ‘VersionCheckHelper<[...],[...],0>’ to ‘VersionCheckHelper<[...],[...],1>’
12218 | [[maybe_unused]] constexpr slint::private_api::VersionCheckHelper<1, 1, 1> THE_SAME_VERSION_MUST_BE_USED_FOR_THE_COMPILER_AND_THE_RUNTIME = slint::private_api::VersionCheckHelper<SLINT_VERSION_MAJOR, SLINT_VERSION_MINOR, SLINT_VERSION_PATCH>();
      |                                                                                                                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                                                                                 |
      |                                                                                                                                                                 VersionCheckHelper<[...],[...],0>
```