### PR TITLE
Fix support normalized ranges for Slider with Qt style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 ### General
 
  - Fixed compiler panics when some complex expressions are used for the model expression in `for` (#2977)
+ - Native style: Fixed support for floating point ranges in Slider.
 
 ### Slint Language
 


### PR DESCRIPTION
The OpenGL Texture import example uses a Slider in the range 0..1. That doesn't work with QStyleOptionSlider out of the box because it's
using integer values.