### PR TITLE
Interpreter: Add support for save/load of enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5277,6 +5277,7 @@ dependencies = [
  "codemap-diagnostic",
  "env_logger",
  "i-slint-backend-selector",
+ "i-slint-compiler",
  "i-slint-core",
  "image",
  "notify",

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -43,6 +43,7 @@ backend-gl-x11 = ["backend-winit-x11", "renderer-winit-femtovg"]
 default = ["backend-qt", "backend-winit", "renderer-winit-femtovg"]
 
 [dependencies]
+i-slint-compiler = { version = "=1.1.1", path = "../../internal/compiler" }
 i-slint-core = { version = "=1.1.1", path="../../internal/core" }
 slint-interpreter = { version = "=1.1.1", path = "../../internal/interpreter", default-features = false, features = ["display-diagnostics", "compat-1-0"] }
 i-slint-backend-selector = { version = "=1.1.1", path="../../internal/backends/selector" }

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -135,7 +135,7 @@ fn main() -> Result<()> {
                         }
                         Some(obj.into())
                     }
-                    slint_interpreter::Value::EnumerationValue(class, value) => {
+                    slint_interpreter::Value::EnumerationValue(_class, value) => {
                         Some(value.as_str().into())
                     }
                     _ => None,


### PR DESCRIPTION
Fixes for #3011

This uses a hack to serialize enum values in string format, maybe this can be made in a better way.