### PR TITLE
Reduce clippy warnings

### DIFF
--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -144,6 +144,12 @@ impl Backend {
     }
 }
 
+impl Default for Backend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl i_slint_core::platform::Platform for Backend {
     fn create_window_adapter(
         &self,

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -237,14 +237,14 @@ impl AccessKitAdapter {
         builder.set_children(children.clone());
 
         let component = item.component();
-        let component_ptr = ComponentRef::as_ptr(ComponentRc::borrow(&component));
+        let component_ptr = ComponentRef::as_ptr(ComponentRc::borrow(component));
         if !self.component_ids.borrow().contains_key(&component_ptr) {
             let component_id = self.next_component_id.get();
             self.next_component_id.set(component_id + 1);
             self.component_ids.borrow_mut().insert(component_ptr, component_id);
             self.components_by_id
                 .borrow_mut()
-                .insert(component_id, ComponentRc::downgrade(&component));
+                .insert(component_id, ComponentRc::downgrade(component));
         }
 
         let id = self.encode_item_node_id(&item).unwrap();

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -141,6 +141,12 @@ pub struct Backend {
     window_factory_fn: fn() -> Result<Rc<dyn WindowAdapter>, PlatformError>,
 }
 
+impl Default for Backend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Backend {
     #[doc = concat!("Creates a new winit backend with the default renderer that's compiled in. See the [backend documentation](https://slint.dev/releases/", env!("CARGO_PKG_VERSION"), "/docs/rust/slint/index.html#backends) for")]
     /// details on how to select the default renderer.

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -133,6 +133,7 @@ pub struct WinitWindowAdapter {
 
 impl WinitWindowAdapter {
     /// Creates a new reference-counted instance.
+    #[allow(clippy::new_ret_no_self)]
     pub(crate) fn new<R: WinitCompatibleRenderer + 'static>(
         #[cfg(target_arch = "wasm32")] canvas_id: &str,
     ) -> Result<Rc<dyn WindowAdapter>, PlatformError> {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1309,7 +1309,7 @@ impl Expression {
 
 fn model_inner_type(model: &Expression) -> Type {
     match model {
-        Expression::Cast { from, to: Type::Model } => model_inner_type(&from),
+        Expression::Cast { from, to: Type::Model } => model_inner_type(from),
         Expression::CodeBlock(cb) => cb.last().map_or(Type::Invalid, model_inner_type),
         _ => match model.ty() {
             Type::Float32 | Type::Int32 => Type::Int32,

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -44,7 +44,7 @@ impl LogicalPosition {
         PhysicalPosition::from_logical(*self, scale_factor)
     }
 
-    pub(crate) fn to_euclid(&self) -> crate::lengths::LogicalPoint {
+    pub(crate) fn to_euclid(self) -> crate::lengths::LogicalPoint {
         [self.x as _, self.y as _].into()
     }
     pub(crate) fn from_euclid(p: crate::lengths::LogicalPoint) -> Self {
@@ -139,7 +139,7 @@ impl LogicalSize {
         PhysicalSize::from_logical(*self, scale_factor)
     }
 
-    pub(crate) fn to_euclid(&self) -> crate::lengths::LogicalSize {
+    pub(crate) fn to_euclid(self) -> crate::lengths::LogicalSize {
         [self.width as _, self.height as _].into()
     }
 }

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -742,7 +742,7 @@ pub(crate) fn process_delayed_event(
             )
         };
     vtable::new_vref!(let mut actual_visitor : VRefMut<crate::item_tree::ItemVisitorVTable> for crate::item_tree::ItemVisitor = &mut actual_visitor);
-    vtable::VRc::borrow_pin(&top_item.component()).as_ref().visit_children_item(
+    vtable::VRc::borrow_pin(top_item.component()).as_ref().visit_children_item(
         top_item.index() as isize,
         crate::item_tree::TraversalOrder::FrontToBack,
         actual_visitor,
@@ -818,7 +818,7 @@ fn send_mouse_event_to_item(
                 )
             };
         vtable::new_vref!(let mut actual_visitor : VRefMut<crate::item_tree::ItemVisitorVTable> for crate::item_tree::ItemVisitor = &mut actual_visitor);
-        let r = vtable::VRc::borrow_pin(&item_rc.component()).as_ref().visit_children_item(
+        let r = vtable::VRc::borrow_pin(item_rc.component()).as_ref().visit_children_item(
             item_rc.index() as isize,
             crate::item_tree::TraversalOrder::FrontToBack,
             actual_visitor,

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -216,7 +216,7 @@ impl ItemRc {
         let mut current_child_index = child_access(&item_tree, self.index())?;
         loop {
             if let Some(item) = step_into_node(
-                &self.component(),
+                self.component(),
                 &comp_ref_pin,
                 current_child_index,
                 &item_tree,
@@ -260,7 +260,7 @@ impl ItemRc {
             let current_component_subtree_index = comp_ref_pin.as_ref().subtree_index();
             if let Some(parent_item) = parent_item.upgrade() {
                 let parent = parent_item.component();
-                let parent_ref_pin = vtable::VRc::borrow_pin(&parent);
+                let parent_ref_pin = vtable::VRc::borrow_pin(parent);
                 let parent_item_index = parent_item.index();
                 let parent_item_tree = crate::item_tree::ComponentItemTree::new(&parent_ref_pin);
 
@@ -1025,17 +1025,17 @@ mod tests {
 
         let fc = item.first_child().unwrap();
         assert_eq!(fc.index(), 1);
-        assert!(VRc::ptr_eq(&fc.component(), &item.component()));
+        assert!(VRc::ptr_eq(fc.component(), item.component()));
 
         let fcn = fc.next_sibling().unwrap();
         assert_eq!(fcn.index(), 2);
 
         let lc = item.last_child().unwrap();
         assert_eq!(lc.index(), 3);
-        assert!(VRc::ptr_eq(&lc.component(), &item.component()));
+        assert!(VRc::ptr_eq(lc.component(), item.component()));
 
         let lcp = lc.previous_sibling().unwrap();
-        assert!(VRc::ptr_eq(&lcp.component(), &item.component()));
+        assert!(VRc::ptr_eq(lcp.component(), item.component()));
         assert_eq!(lcp.index(), 2);
 
         // Examine first child:
@@ -1217,18 +1217,18 @@ mod tests {
         assert!(item.next_sibling().is_none());
 
         let fc = item.first_child().unwrap();
-        assert!(VRc::ptr_eq(&fc.component(), &item.component()));
+        assert!(VRc::ptr_eq(fc.component(), item.component()));
         assert_eq!(fc.index(), 1);
 
         let lc = item.last_child().unwrap();
-        assert!(VRc::ptr_eq(&lc.component(), &item.component()));
+        assert!(VRc::ptr_eq(lc.component(), item.component()));
         assert_eq!(lc.index(), 3);
 
         let fcn = fc.next_sibling().unwrap();
         let lcp = lc.previous_sibling().unwrap();
 
         assert_eq!(fcn, lcp);
-        assert!(!VRc::ptr_eq(&fcn.component(), &item.component()));
+        assert!(!VRc::ptr_eq(fcn.component(), item.component()));
 
         let last = fcn.next_sibling().unwrap();
         assert_eq!(last, lc);
@@ -1369,18 +1369,18 @@ mod tests {
         assert!(item.next_sibling().is_none());
 
         let fc = item.first_child().unwrap();
-        assert!(VRc::ptr_eq(&fc.component(), &item.component()));
+        assert!(VRc::ptr_eq(fc.component(), item.component()));
         assert_eq!(fc.index(), 1);
 
         let lc = item.last_child().unwrap();
-        assert!(VRc::ptr_eq(&lc.component(), &item.component()));
+        assert!(VRc::ptr_eq(lc.component(), item.component()));
         assert_eq!(lc.index(), 3);
 
         let fcn = fc.next_sibling().unwrap();
         let lcp = lc.previous_sibling().unwrap();
 
         assert_eq!(fcn, lcp);
-        assert!(!VRc::ptr_eq(&fcn.component(), &item.component()));
+        assert!(!VRc::ptr_eq(fcn.component(), item.component()));
 
         let last = fcn.next_sibling().unwrap();
         assert_eq!(last, lc);
@@ -1393,12 +1393,12 @@ mod tests {
         assert_eq!(nested_root, fcn.last_child().unwrap());
         assert!(nested_root.next_sibling().is_none());
         assert!(nested_root.previous_sibling().is_none());
-        assert!(!VRc::ptr_eq(&nested_root.component(), &item.component()));
-        assert!(!VRc::ptr_eq(&nested_root.component(), &fcn.component()));
+        assert!(!VRc::ptr_eq(nested_root.component(), item.component()));
+        assert!(!VRc::ptr_eq(nested_root.component(), fcn.component()));
 
         let nested_child = nested_root.first_child().unwrap();
         assert_eq!(nested_child, nested_root.last_child().unwrap());
-        assert!(VRc::ptr_eq(&nested_root.component(), &nested_child.component()));
+        assert!(VRc::ptr_eq(nested_root.component(), nested_child.component()));
     }
 
     #[test]
@@ -1546,22 +1546,22 @@ mod tests {
 
         let sub1 = item.first_child().unwrap();
         assert_eq!(sub1.index(), 0);
-        assert!(!VRc::ptr_eq(&sub1.component(), &item.component()));
+        assert!(!VRc::ptr_eq(sub1.component(), item.component()));
 
         // assert!(sub1.previous_sibling().is_none());
 
         let sub2 = sub1.next_sibling().unwrap();
         assert_eq!(sub2.index(), 0);
-        assert!(!VRc::ptr_eq(&sub1.component(), &sub2.component()));
-        assert!(!VRc::ptr_eq(&item.component(), &sub2.component()));
+        assert!(!VRc::ptr_eq(sub1.component(), sub2.component()));
+        assert!(!VRc::ptr_eq(item.component(), sub2.component()));
 
         assert!(sub2.previous_sibling() == Some(sub1.clone()));
 
         let sub3 = sub2.next_sibling().unwrap();
         assert_eq!(sub3.index(), 0);
-        assert!(!VRc::ptr_eq(&sub1.component(), &sub2.component()));
-        assert!(!VRc::ptr_eq(&sub2.component(), &sub3.component()));
-        assert!(!VRc::ptr_eq(&item.component(), &sub3.component()));
+        assert!(!VRc::ptr_eq(sub1.component(), sub2.component()));
+        assert!(!VRc::ptr_eq(sub2.component(), sub3.component()));
+        assert!(!VRc::ptr_eq(item.component(), sub3.component()));
 
         assert_eq!(sub3.previous_sibling().unwrap(), sub2.clone());
     }

--- a/internal/core/textlayout/linebreaker.rs
+++ b/internal/core/textlayout/linebreaker.rs
@@ -175,7 +175,7 @@ fn test_empty_line_break() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 1);
-    assert_eq!(lines[0].line_text(&text), "");
+    assert_eq!(lines[0].line_text(text), "");
 }
 
 #[test]
@@ -186,8 +186,8 @@ fn test_basic_line_break() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
-    assert_eq!(lines[0].line_text(&text), "Hello");
-    assert_eq!(lines[1].line_text(&text), "World");
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "World");
 }
 
 #[test]
@@ -198,7 +198,7 @@ fn test_linebreak_trailing_space() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 1);
-    assert_eq!(lines[0].line_text(&text), "Hello");
+    assert_eq!(lines[0].line_text(text), "Hello");
 }
 
 #[test]
@@ -209,8 +209,8 @@ fn test_forced_break() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None).collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
-    assert_eq!(lines[0].line_text(&text), "Hello");
-    assert_eq!(lines[1].line_text(&text), "World");
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "World");
 }
 
 #[test]
@@ -221,10 +221,10 @@ fn test_forced_break_multi() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None).collect::<Vec<_>>();
     assert_eq!(lines.len(), 4);
-    assert_eq!(lines[0].line_text(&text), "Hello");
-    assert_eq!(lines[1].line_text(&text), "");
-    assert_eq!(lines[2].line_text(&text), "");
-    assert_eq!(lines[3].line_text(&text), "World");
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "");
+    assert_eq!(lines[2].line_text(text), "");
+    assert_eq!(lines[3].line_text(text), "World");
 }
 
 #[test]
@@ -235,8 +235,8 @@ fn test_nbsp_break() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(110.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
-    assert_eq!(lines[0].line_text(&text), "Ok");
-    assert_eq!(lines[1].line_text(&text), "Hello\u{00a0}World");
+    assert_eq!(lines[0].line_text(text), "Ok");
+    assert_eq!(lines[1].line_text(text), "Hello\u{00a0}World");
 }
 
 #[test]
@@ -247,7 +247,7 @@ fn test_single_line_multi_break_opportunity() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None).collect::<Vec<_>>();
     assert_eq!(lines.len(), 1);
-    assert_eq!(lines[0].line_text(&text), "a b c");
+    assert_eq!(lines[0].line_text(text), "a b c");
 }
 
 #[test]
@@ -258,8 +258,8 @@ fn test_basic_line_break_anywhere_fallback() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
-    assert_eq!(lines[0].line_text(&text), "Hello");
-    assert_eq!(lines[1].line_text(&text), "World");
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "World");
 }
 
 #[test]
@@ -270,10 +270,10 @@ fn test_basic_line_break_anywhere_fallback_multi_line() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 4);
-    assert_eq!(lines[0].line_text(&text), "Hello");
-    assert_eq!(lines[1].line_text(&text), "World");
-    assert_eq!(lines[2].line_text(&text), "Hello");
-    assert_eq!(lines[3].line_text(&text), "World");
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "World");
+    assert_eq!(lines[2].line_text(text), "Hello");
+    assert_eq!(lines[3].line_text(text), "World");
 }
 
 #[test]
@@ -284,10 +284,10 @@ fn test_basic_line_break_anywhere_fallback_multi_line_v2() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 4);
-    assert_eq!(lines[0].line_text(&text), "Hello");
-    assert_eq!(lines[1].line_text(&text), "W");
-    assert_eq!(lines[2].line_text(&text), "orldH");
-    assert_eq!(lines[3].line_text(&text), "ellow");
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "W");
+    assert_eq!(lines[2].line_text(text), "orldH");
+    assert_eq!(lines[3].line_text(text), "ellow");
 }
 
 #[test]
@@ -299,8 +299,8 @@ fn test_basic_line_break_space() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(25.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
-    assert_eq!(lines[0].line_text(&text), "H");
-    assert_eq!(lines[1].line_text(&text), "W");
+    assert_eq!(lines[0].line_text(text), "H");
+    assert_eq!(lines[1].line_text(text), "W");
 }
 
 #[test]
@@ -312,8 +312,8 @@ fn test_basic_line_break_space_v2() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(45.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
-    assert_eq!(lines[0].line_text(&text), "B B");
-    assert_eq!(lines[1].line_text(&text), "W");
+    assert_eq!(lines[0].line_text(text), "B B");
+    assert_eq!(lines[1].line_text(text), "W");
 }
 
 #[test]
@@ -325,8 +325,8 @@ fn test_basic_line_break_space_v3() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(15.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
-    assert_eq!(lines[0].line_text(&text), "H");
-    assert_eq!(lines[1].line_text(&text), "W");
+    assert_eq!(lines[0].line_text(text), "H");
+    assert_eq!(lines[1].line_text(text), "W");
 }
 
 #[test]
@@ -338,7 +338,7 @@ fn test_basic_line_break_space_v4() {
     let lines =
         TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(65.)).collect::<Vec<_>>();
     assert_eq!(lines.len(), 1);
-    assert_eq!(lines[0].line_text(&text), "H W  H");
+    assert_eq!(lines[0].line_text(text), "H W  H");
 }
 
 #[test]
@@ -358,7 +358,7 @@ fn zero_width() {
     let text = "He\nHe o";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
     let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(0.0001))
-        .map(|t| t.line_text(&text))
+        .map(|t| t.line_text(text))
         .collect::<Vec<_>>();
     assert_eq!(lines, ["H", "e", "", "H", "e", "o"]);
 }

--- a/internal/core/textlayout/shaping.rs
+++ b/internal/core/textlayout/shaping.rs
@@ -259,7 +259,7 @@ impl<'a> TextShaper for &rustybuzz::Face<'a> {
     ) {
         let mut buffer = rustybuzz::UnicodeBuffer::new();
         buffer.push_str(text);
-        let glyph_buffer = rustybuzz::shape(&self, &[], buffer);
+        let glyph_buffer = rustybuzz::shape(self, &[], buffer);
 
         let output_glyph_generator =
             glyph_buffer.glyph_infos().iter().zip(glyph_buffer.glyph_positions().iter()).map(

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -206,17 +206,15 @@ fn translate_gettext(string: &str, ctx: &str, domain: &str, n: i32, plural: &str
         } else {
             gettextrs::dgettext(domain, string)
         }
+    } else if !ctx.is_empty() {
+        demangle_context(gettextrs::dngettext(
+            domain,
+            &mangle_context(ctx, string),
+            &mangle_context(ctx, plural),
+            n as u32,
+        ))
     } else {
-        if !ctx.is_empty() {
-            demangle_context(gettextrs::dngettext(
-                domain,
-                &mangle_context(ctx, string),
-                &mangle_context(ctx, plural),
-                n as u32,
-            ))
-        } else {
-            gettextrs::dngettext(domain, string, plural, n as u32)
-        }
+        gettextrs::dngettext(domain, string, plural, n as u32)
     }
 }
 

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -202,15 +202,15 @@ fn translate_gettext(string: &str, ctx: &str, domain: &str, n: i32, plural: &str
 
     if plural.is_empty() {
         if !ctx.is_empty() {
-            demangle_context(gettextrs::dgettext(domain, &mangle_context(ctx, string)))
+            demangle_context(gettextrs::dgettext(domain, mangle_context(ctx, string)))
         } else {
             gettextrs::dgettext(domain, string)
         }
     } else if !ctx.is_empty() {
         demangle_context(gettextrs::dngettext(
             domain,
-            &mangle_context(ctx, string),
-            &mangle_context(ctx, plural),
+            mangle_context(ctx, string),
+            mangle_context(ctx, plural),
             n as u32,
         ))
     } else {

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -12,7 +12,9 @@ mod formatter {
         type Output<'a>: Display
         where
             Self: 'a;
+        #[allow(clippy::wrong_self_convention)]
         fn from_index(&self, index: usize) -> Option<Self::Output<'_>>;
+        #[allow(clippy::wrong_self_convention)]
         fn from_name(&self, _name: &str) -> Option<Self::Output<'_>> {
             None
         }

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -155,7 +155,7 @@ pub fn on_element_selected(
                 state.borrow_mut().current_item = Some(i.downgrade());
 
                 let component = i.component();
-                let component_ref = VRc::borrow(&component);
+                let component_ref = VRc::borrow(component);
                 let Some(component_box) = component_ref.downcast::<ErasedComponentBox>() else {
                     continue; // Skip components of unexpected type!
                 };

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -345,7 +345,7 @@ fn load_data(
 
         match types.get(name) {
             Some(t) => {
-                match instance.set_property(name, from_json(&t, v)) {
+                match instance.set_property(name, from_json(t, v)) {
                     Ok(()) => (),
                     Err(e) => {
                         eprintln!("Warning: cannot set property '{}' from data file: {:?}", name, e)


### PR DESCRIPTION
Contributing to #1874

I made one commit by lint rule, so we can easily drop any of them if you do not care for it.

I did not handle:
- `clippy::match_single_binding`: kind of false-positive due to temporary life prolongation hack (did not add a `allow`)
- `clippy::await_holding_refcell_ref`
    - in `compiler/passes.rs`: it could be fixed with some cloning but I hope the panic issue can not be triggered so we do not need to.
    - in `lsp` there is two occurrences on `document_cache` (in `main` and `server_loop`), I do not know the code enough to rule out a danger here
