### PR TITLE
Improve robustness of Skia OpenGL renderer in case of GL context loss

### DIFF
--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -97,13 +97,13 @@ impl SkiaRenderer {
 
     /// Notifiers the renderer that the underlying window will be hidden soon.
     pub fn hide(&self) -> Result<(), i_slint_core::platform::PlatformError> {
-        self.surface.with_active_surface(|| {
-            if let Some(callback) = self.rendering_notifier.borrow_mut().as_mut() {
+        if let Some(callback) = self.rendering_notifier.borrow_mut().as_mut() {
+            self.surface.with_active_surface(|| {
                 self.surface.with_graphics_api(|api| {
                     callback.notify(RenderingState::RenderingTeardown, &api)
                 })
-            }
-        })?;
+            })?;
+        }
         Ok(())
     }
 

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -384,6 +384,10 @@ impl OpenGLSurface {
 impl Drop for OpenGLSurface {
     fn drop(&mut self) {
         // Make sure that the context is current before Skia calls glDelete***
-        self.ensure_context_current().expect("Skia OpenGL Renderer: Failed to make OpenGL context current before deleting graphics resources");
+        // In the event that this fails for some reason (lost GL context), convey that to Skia so that it doesn't try to call
+        // glDelete***
+        if self.ensure_context_current().is_err() {
+            self.gr_context.borrow_mut().abandon();
+        }
     }
 }


### PR DESCRIPTION
Gracefully handle a loss before destruction time and reduce the chance of hide() failing to those applications that use a rendering notifier (only those might actually be interested in this error anyway).