### PR TITLE
Fix crash when evaluating two_lay_link too early

### DIFF
--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -987,7 +987,7 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
         #[cfg(slint_debug_property)]
         let debug_name = format!("<{}<=>{}>", prop1.debug_name.borrow(), prop2.debug_name.borrow());
 
-        let value = prop2.get_untracked();
+        let value = prop2.get_internal();
 
         let prop1_handle_val = prop1.handle.handle.get();
         if prop1_handle_val & 0b10 == 0b10 {

--- a/tests/cases/crashes/link_two_way_geometry_if.slint
+++ b/tests/cases/crashes/link_two_way_geometry_if.slint
@@ -1,0 +1,20 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.0 OR LicenseRef-Slint-commercial
+
+export component TestCase {
+    tl_layout := HorizontalLayout {
+        if true: Rectangle {
+            l := Rectangle {
+                preferred-width: 320px;
+                preferred-height: 240px;
+                background: red;
+            }
+            Rectangle {
+                background: blue;
+                width <=> l.width;
+            }
+        }
+    }
+
+    out property<bool> test: tl_layout.preferred-width == 320px;
+}


### PR DESCRIPTION
two_way_link shouldn't force the evaluation of the property