### PR TITLE
Attempt to fix a panic in accesskit

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -285,7 +285,10 @@ impl AccessKitAdapter {
                 .take()
                 .upgrade()
                 .map(|adapter| adapter.accesskit_adapter.build_new_tree())
-                .unwrap_or_default();
+                .unwrap_or(TreeUpdate {
+                    tree: Some(Tree::new(NodeId(std::num::NonZeroU128::new(1).unwrap()))),
+                    ..Default::default()
+                });
         }
 
         let update_from_main_thread = Arc::new((Mutex::new(None), Condvar::new()));


### PR DESCRIPTION
On unix, the panic happens since the upgrade from zbus 3.10 to zbus 3.14

```
thread 'test_window_accessor' panicked at 'called `Option::unwrap()` on a `None` value', /home/olivier/.cargo/registry/src/index.crates.io-6f17d22bba15001f/accesskit_consumer-0.15.0/src/tree.rs:274:45
stack backtrace: [...]
   3: core::option::Option<T>::unwrap
   4: accesskit_consumer::tree::Tree::new
             at /home/olivier/.cargo/registry/src/index.crates.io-6f17d22bba15001f/accesskit_consumer-0.15.0/src/tree.rs:274:19
   5: accesskit_unix::adapter::Adapter::new
             at /home/olivier/.cargo/registry/src/index.crates.io-6f17d22bba15001f/accesskit_unix-0.5.0/src/adapter.rs:53:20
   6: accesskit_winit::platform_impl::platform::Adapter::new
             at /home/olivier/.cargo/registry/src/index.crates.io-6f17d22bba15001f/accesskit_winit-0.14.1/src/platform_impl/unix.rs:21:23
   7: accesskit_winit::Adapter::with_action_handler
             at /home/olivier/.cargo/registry/src/index.crates.io-6f17d22bba15001f/accesskit_winit-0.14.1/src/lib.rs:170:23
   8: i_slint_backend_winit::accesskit::AccessKitAdapter::new
             at ./accesskit.rs:62:20
   9: i_slint_backend_winit::winitwindowadapter::WinitWindowAdapter::new::{{closure}}
             at ./winitwindowadapter.rs:163:32
  10: alloc::rc::Rc<T>::new_cyclic
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/alloc/src/rc.rs:461:20
  11: i_slint_backend_winit::winitwindowadapter::WinitWindowAdapter::new
             at ./winitwindowadapter.rs:148:23
  12: i_slint_backend_winit::window_factory_fn
             at ./lib.rs:71:5
  13: <i_slint_backend_winit::Backend as i_slint_core::platform::Platform>::create_window_adapter
             at ./lib.rs:220:9
```

The problem is that we get called to create the tree directly from WinitWindowAdapter::new before the WinitWindowAdaptor is initialized, So of course, the upgrade from weak is still the pseudo-weak from Rc::new_cyclic, so the upgrade fails, resulting in a default constructed `TreeUpdate` which is invalid for the first call as it doesn't have a tree.

Just give it a tree with a dummy id