### PR TITLE
Get rid of the "use_modules" workaround

### DIFF
--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -10,14 +10,10 @@ use std::rc::Rc;
 #[cfg(feature = "experimental")]
 pub mod platform;
 
-#[doc(hidden)]
-#[cold]
-pub fn use_modules() -> usize {
-    #[cfg(feature = "slint-interpreter")]
-    slint_interpreter::use_modules();
-    i_slint_backend_selector::use_modules();
-    i_slint_core::use_modules()
-}
+/// One need to make sure something from the crate is exported,
+/// otherwise its symbols are not going to be in the final binary
+#[cfg(feature = "slint-interpreter")]
+pub use slint_interpreter;
 
 #[no_mangle]
 pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) {

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -22,21 +22,6 @@ mod qt_window;
 mod accessible_generated;
 mod key_generated;
 
-#[doc(hidden)]
-#[cold]
-#[cfg(not(target_arch = "wasm32"))]
-pub fn use_modules() -> usize {
-    #[cfg(no_qt)]
-    {
-        ffi::slint_qt_get_widget as usize
-    }
-    #[cfg(not(no_qt))]
-    {
-        qt_window::ffi::slint_qt_get_widget as usize
-            + (&qt_widgets::NativeButtonVTable) as *const _ as usize
-    }
-}
-
 #[cfg(no_qt)]
 mod ffi {
     #[no_mangle]

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -81,14 +81,3 @@ pub fn with_platform<R>(
 ) -> Result<R, PlatformError> {
     i_slint_core::with_platform(create_backend, f)
 }
-
-#[doc(hidden)]
-#[cold]
-#[cfg(not(target_arch = "wasm32"))]
-pub fn use_modules() {
-    i_slint_core::use_modules();
-    #[cfg(feature = "i-slint-backend-qt")]
-    i_slint_backend_qt::use_modules();
-    #[cfg(feature = "i-slint-backend-winit")]
-    i_slint_backend_winit::use_modules();
-}

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -117,11 +117,6 @@ fn try_create_window_with_fallback_renderer() -> Option<Rc<dyn WindowAdapter>> {
 }
 
 #[doc(hidden)]
-#[cold]
-#[cfg(not(target_arch = "wasm32"))]
-pub fn use_modules() {}
-
-#[doc(hidden)]
 pub type NativeWidgets = ();
 #[doc(hidden)]
 pub type NativeGlobals = ();

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -102,32 +102,3 @@ pub fn with_platform<R>(
         }
     })
 }
-
-/// One need to use at least one function in each module in order to get them
-/// exported in the final binary.
-/// This only use functions from modules which are not otherwise used.
-#[doc(hidden)]
-#[cold]
-#[cfg(not(target_arch = "wasm32"))]
-pub fn use_modules() -> usize {
-    #[cfg(feature = "ffi")]
-    {
-        tests::slint_mock_elapsed_time as usize
-            + callbacks::ffi::slint_callback_init as usize
-            + sharedvector::ffi::slint_shared_vector_empty as usize
-            + layout::ffi::slint_solve_grid_layout as usize
-            + item_tree::ffi::slint_visit_item_tree as usize
-            + graphics::ffi::slint_new_path_elements as usize
-            + properties::ffi::slint_property_init as usize
-            + string::ffi::slint_shared_string_bytes as usize
-            + window::ffi::slint_windowrc_drop as usize
-            + component::ffi::slint_register_component as usize
-            + timers::ffi::slint_timer_start as usize
-            + graphics::color::ffi::slint_color_brighter as usize
-            + graphics::image::ffi::slint_image_size as usize
-    }
-    #[cfg(not(feature = "ffi"))]
-    {
-        0
-    }
-}

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -90,15 +90,5 @@ pub use api::*;
 #[doc(inline)]
 pub use i_slint_core::{Brush, Color, SharedString, SharedVector};
 
-/// One need to use at least one function in each module in order to get them
-/// exported in the final binary.
-/// This only use functions from modules which are not otherwise used.
-#[doc(hidden)]
-#[cold]
-#[cfg(feature = "ffi")]
-pub fn use_modules() -> usize {
-    crate::api::ffi::slint_interpreter_value_new as usize
-}
-
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
This doesn't seem to be needed anymore with newer rust version. As long as one symbol from the crate is used, all exported function from the crate are available.

The reason why some symbols in some module were gone was a bug in rust that has been fixed, it seems