### PR TITLE
compiler: add a software-renderer feature

### DIFF
--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -16,6 +16,11 @@ publish = false
 name = "slint-compiler"
 path = "main.rs"
 
+[features]
+software-renderer = ["i-slint-compiler/software-renderer"]
+
+default = ["software-renderer"]
+
 [dependencies]
 i-slint-compiler = { version = "=1.1.1", path = "../../internal/compiler", features = ["display-diagnostics", "cpp", "rust"]}
 

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -17,6 +17,7 @@ enum Embedding {
     /// Embed in a format optimized for the software renderer. This
     /// option falls back to `embed-files` if the software-renderer is not
     /// used
+    #[cfg(feature = "software-renderer")]
     EmbedForSoftwareRenderer,
 }
 
@@ -76,8 +77,6 @@ fn main() -> std::io::Result<()> {
             Embedding::EmbedFiles => EmbedResourcesKind::EmbedAllResources,
             #[cfg(feature = "software-renderer")]
             Embedding::EmbedForSoftwareRenderer => EmbedResourcesKind::EmbedTextures,
-            #[cfg(not(feature = "software-renderer"))]
-            Embedding::EmbedForSoftwareRenderer => EmbedResourcesKind::EmbedAllResources,
         };
     }
 


### PR DESCRIPTION
We aldready document in cmake.md that a valid value for `SLINT_EMBED_RESOURCES` is `embed-for-software-renderer`, but this doesn't work since it expect a `software-renderer` feature that don't exist. So create this feature.

This feature brings on all the image and font loading machinery in the compiler. But I still enable it by default since it is a documented cmake option.