### PR TITLE
Added zero width to focus scope to StandardListView

### DIFF
--- a/internal/compiler/widgets/fluent-base/listview.slint
+++ b/internal/compiler/widgets/fluent-base/listview.slint
@@ -44,6 +44,8 @@ component StandardListViewBase inherits ListView {
 
 export component StandardListView inherits StandardListViewBase {
     FocusScope {
+        x: 0;
+        width: 0;  // Do not react on clicks
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
                 root.set-current-item(root.current-item - 1);

--- a/internal/compiler/widgets/material-base/listview.slint
+++ b/internal/compiler/widgets/material-base/listview.slint
@@ -46,6 +46,8 @@ component StandardListViewBase inherits ListView {
 // Like `ListView`, but with a default delegate, and a `model` property which is a model of type `StandardListViewItem`.
 export component StandardListView inherits StandardListViewBase {
     FocusScope {
+        x: 0;
+        width: 0;  // Do not react on clicks
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
                 root.set-current-item(root.current-item - 1);


### PR DESCRIPTION
In StandardListView, it is currently needed to click an item twice to select it. This fixes the issue.