### PR TITLE
C++: Make the platform support work without the "std" feature

### DIFF
--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -38,7 +38,8 @@ renderer-winit-software = ["i-slint-backend-selector/renderer-winit-software"]
 gettext = ["i-slint-core/gettext-rs"]
 accessibility = ["i-slint-backend-selector/accessibility"]
 
-experimental = ["i-slint-renderer-skia", "raw-window-handle", "std"]
+experimental = ["i-slint-renderer-skia", "raw-window-handle", "experimental-platform"]
+experimental-platform = []
 
 std = ["image", "i-slint-core/default", "i-slint-backend-selector"]
 

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -10,7 +10,7 @@ use alloc::rc::Rc;
 use core::ffi::c_void;
 use i_slint_core::window::{ffi::WindowAdapterRcOpaque, WindowAdapter};
 
-#[cfg(feature = "experimental")]
+#[cfg(feature = "experimental-platform")]
 pub mod platform;
 
 #[cfg(feature = "i-slint-backend-selector")]


### PR DESCRIPTION
Add a experimental-platform feature that doesn't include skia