### PR TITLE
Fix bad red markup in C++ slint::Model docs

### DIFF
--- a/api/cpp/docs/conf.py
+++ b/api/cpp/docs/conf.py
@@ -115,9 +115,9 @@ myst_heading_anchors = 2
 
 rst_epilog = """
 .. |ListView| replace:: :code:`ListView`
-.. _ListView: ../slint/src/builtins/widgets.html#listview
+.. _ListView: ../../slint/src/builtins/widgets.html#listview
 .. |Repetition| replace:: :code:`for` - :code:`in`
-.. _Repetition: ../slint/src/reference/repetitions.html
+.. _Repetition: ../../slint/src/reference/repetitions.html
 """
 
 

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -678,10 +678,9 @@ auto access_array_index(const M &model, size_t index)
 } // namespace private_api
 
 /// \rst
-/// A Model is providing Data for
-/// `for - in<../../slint/src/reference/repetitions.html>`_ repetitions or
-/// `ListView<../../slint/src/builtins/widgets.html#listview>`_ elements of the :code:`.slint`
-/// language \endrst
+/// A Model is providing Data for |Repetition|_ repetitions or |ListView|_ elements of the
+/// :code:`.slint` language
+/// \endrst
 template<typename ModelData>
 class Model
 {


### PR DESCRIPTION
Revert da95051 and fix the link in the substitution instead.

Fixes #2992