### PR TITLE
Fix rendering of QStyle animations

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -573,6 +573,22 @@ fn gen_backend_qt(
         .with_config(config)
         .with_crate(crate_dir)
         .with_include("slint_internal.h")
+        .with_after_include(
+            r"
+            namespace slint::cbindgen_private {
+                // HACK ALERT: This struct declaration is duplicated in internal/backend/qt/qt_widgets.rs - keep in sync.
+                struct SlintTypeErasedWidget
+                {
+                    virtual ~SlintTypeErasedWidget() = 0;
+                    SlintTypeErasedWidget(const SlintTypeErasedWidget&) = delete;
+                    SlintTypeErasedWidget& operator=(const SlintTypeErasedWidget&) = delete;
+
+                    virtual void *qwidget() const = 0;
+                };
+                using SlintTypeErasedWidgetPtr = std::unique_ptr<SlintTypeErasedWidget>;
+            }
+            ",
+        )
         .with_trailer(gen_item_declarations(&items))
         .generate()
         .context("Unable to generate bindings for slint_qt_internal.h")?

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -146,13 +146,6 @@ public:
         cbindgen_private::slint_windowrc_set_focus_item(&inner, &item_rc);
     }
 
-    template<typename Component, typename ItemArray>
-    void register_component(Component *c, ItemArray items) const
-    {
-        cbindgen_private::slint_register_component(
-                vtable::VRef<ComponentVTable> { &Component::static_vtable, c }, items, &inner);
-    }
-
     template<typename Component>
     void set_component(const Component &c) const
     {
@@ -269,7 +262,7 @@ public:
     }
 
     /// \private
-    const cbindgen_private::WindowAdapterRcOpaque &handle() { return inner; }
+    const cbindgen_private::WindowAdapterRcOpaque &handle() const { return inner; }
 
 private:
     friend class slint::experimental::platform::SkiaRenderer;
@@ -607,6 +600,16 @@ inline LayoutInfo LayoutInfo::merge(const LayoutInfo &other) const
 }
 
 namespace private_api {
+
+template<typename Component, typename ItemArray>
+static void register_component(const std::optional<slint::Window> &maybe_window, Component *c,
+                               ItemArray items)
+{
+    const cbindgen_private::WindowAdapterRcOpaque *window_ptr =
+            maybe_window.has_value() ? &maybe_window->window_handle().handle() : nullptr;
+    cbindgen_private::slint_register_component(
+            vtable::VRef<ComponentVTable> { &Component::static_vtable, c }, items, window_ptr);
+}
 
 inline SharedVector<float> solve_box_layout(const cbindgen_private::BoxLayoutData &data,
                                             cbindgen_private::Slice<int> repeater_indexes)

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -22,10 +22,17 @@ pub struct NativeLineEdit {
     pub has_focus: Property<bool>,
     pub enabled: Property<bool>,
     pub input_type: Property<InputType>,
+    widget_ptr: std::cell::Cell<SlintTypeErasedWidgetPtr>,
+    animation_tracker: Property<i32>,
 }
 
 impl Item for NativeLineEdit {
     fn init(self: Pin<&Self>) {
+        let animation_tracker_property_ptr = Self::FIELD_OFFSETS.animation_tracker.apply_pin(self);
+        self.widget_ptr.set(cpp! { unsafe [animation_tracker_property_ptr as "void*"] -> SlintTypeErasedWidgetPtr as "std::unique_ptr<SlintTypeErasedWidget>"  {
+            return make_unique_animated_widget<QLineEdit>(animation_tracker_property_ptr);
+        }});
+
         let paddings = Rc::pin(Property::default());
 
         paddings.as_ref().set_binding(move || {
@@ -142,6 +149,7 @@ impl Item for NativeLineEdit {
             initial_state as "int"
         ] {
             QStyleOptionFrame option;
+            option.initFrom(widget);
             option.state |= QStyle::State(initial_state);
             option.rect = QRect(QPoint(), size / dpr);
             option.lineWidth = 1;

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1370,7 +1370,7 @@ impl QtItemRenderer<'_> {
     }
 }
 
-cpp_class!(unsafe struct QWidgetPtr as "std::unique_ptr<QWidget>");
+cpp_class!(pub(crate) unsafe struct QWidgetPtr as "std::unique_ptr<QWidget>");
 
 pub struct QtWindow {
     widget_ptr: QWidgetPtr,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1227,7 +1227,7 @@ fn generate_item_tree(
 
     create_code.extend([
         format!(
-            "if (auto &window = {}->m_window) window->window_handle().register_component(self, self->item_array());",
+            "slint::private_api::register_component({}->m_window, self, self->item_array());",
             root_access
         ),
         format!("self->init({}, self->self_weak, 0, 1 {});", root_access, init_parent_parameters),

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -165,11 +165,11 @@ pub(crate) mod ffi {
         item_array: Slice<vtable::VOffset<u8, ItemVTable, vtable::AllowPin>>,
         window_handle: *const crate::window::ffi::WindowAdapterRcOpaque,
     ) {
-        let window_adapter = &*(window_handle as *const Rc<dyn WindowAdapter>);
+        let window_adapter = (window_handle as *const Rc<dyn WindowAdapter>).as_ref().cloned();
         super::register_component(
             core::pin::Pin::new_unchecked(&*(component.as_ptr() as *const u8)),
             item_array.as_slice(),
-            Some(window_adapter.clone()),
+            window_adapter,
         )
     }
 


### PR DESCRIPTION
Allocate a widget per NativeXXX. This way QStyleAnimation objects created by Qt aren't shared among style options.