### PR TITLE
Remove the Slint language docs from the C++ API docs index

### DIFF
--- a/xtask/src/cppdocs.rs
+++ b/xtask/src/cppdocs.rs
@@ -76,8 +76,6 @@ pub fn generate(show_warnings: bool) -> Result<(), Box<dyn std::error::Error>> {
     )
     .context("Error creating symlinks from docs source to docs build dir")?;
 
-    symlink_dir(["..", "..", "docs"].iter().collect::<PathBuf>(), docs_build_dir.join("markdown"))?;
-
     symlink_file(
         ["..", "..", "api", "cpp", "README.md"].iter().collect::<PathBuf>(),
         docs_build_dir.join("README.md"),


### PR DESCRIPTION
The symlink from docs/ is not needed anymore. Its presence meant that sphinx recursively compiled all .md and .rst files and ended up adding them to the searchable index.

Fixes #3033