### PR TITLE
Fix setting rotation-angle and opacity from a callback

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -192,7 +192,7 @@ pub fn generate(doc: &Document) -> TokenStream {
          // These make code generation easier
         #[allow(clippy::style)]
         #[allow(clippy::complexity)]
-        #[allow(unused_braces)]
+        #[allow(unused_braces, unused_parens)]
         #[allow(clippy::erasing_op)]
         #[allow(clippy::approx_constant)] // We may get those from .slint inputs!
         #[allow(clippy::eq_op)] // The generated code will compare/subtract/etc. equal values
@@ -928,7 +928,6 @@ fn generate_sub_component(
             pub fn init(self_rc: sp::VRcMapped<sp::ComponentVTable, Self>,
                     root : &sp::VRc<sp::ComponentVTable, #root_component_id>,
                     tree_index: u32, tree_index_of_first_child: u32) {
-                #![allow(unused)]
                 #![allow(unused)]
                 let _self = self_rc.as_pin_ref();
                 _self.self_weak.set(VRcMapped::downgrade(&self_rc));

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -102,21 +102,15 @@ fn create_property_element(
 ) -> ElementRc {
     let bindings = core::iter::once(property_name)
         .chain(extra_properties)
-        .filter_map(|property_name| {
-            if child.borrow().bindings.contains_key(property_name) {
-                Some((
-                    property_name.to_string(),
-                    BindingExpression::new_two_way(NamedReference::new(child, property_name))
-                        .into(),
-                ))
-            } else {
-                default_value_for_extra_properties.map(|f| {
-                    (
-                        property_name.to_string(),
-                        BindingExpression::from(f(child, property_name)).into(),
-                    )
-                })
+        .map(|property_name| {
+            let mut bind =
+                BindingExpression::new_two_way(NamedReference::new(child, property_name));
+            if let Some(default_value_for_extra_properties) = default_value_for_extra_properties {
+                if !child.borrow().bindings.contains_key(property_name) {
+                    bind.expression = default_value_for_extra_properties(child, property_name)
+                }
             }
+            (property_name.to_string(), bind.into())
         })
         .collect();
 

--- a/tests/screenshots/cases/software/basic/linear-gradients.slint
+++ b/tests/screenshots/cases/software/basic/linear-gradients.slint
@@ -13,9 +13,8 @@ export TestCase := Window {
         Row {
             Rectangle {
                 background: @linear-gradient(90deg, red, blue);
-                Rectangle {
+                with_opacity := Rectangle {
                     background: @linear-gradient(0deg, limegreen 10%, transparent 50%);
-                    opacity: 0.5;
                 }
             }
             Rectangle { background: @linear-gradient(0deg, green, yellow 20%, cyan); }
@@ -30,6 +29,13 @@ export TestCase := Window {
             }
             Rectangle { background: @linear-gradient(128deg, red, white 0%, transparent); }
             Rectangle { background: @linear-gradient(242deg, white 10%, #239 35%, red 85%); }
+        }
+    }
+
+    init => {
+        // This is a test for the binding part of #3068
+        if (with_opacity.opacity == 1) {
+            with_opacity.opacity = 0.5;
         }
     }
 }


### PR DESCRIPTION
... if they are not set as actual binding before

As reported in #3068

The problem is that the pass will properly create the Rotation or Opacity item, but will not create the two way binding if there is no existing binding. This causes code like `img.rotation-angle = ...` to change the rotation angle of the image, but not its parent Rotation item.
Fix it by making sure there is always a binding.

Since the change only affect visual representation, I abused one of the screenshot test to test this feature. And I also patched another bug that some #[allow(unused_parens)] was not set in the 'init' callback and would cause a warning in the test