### PR TITLE
add row-pointer-event callback to tableview

### DIFF
--- a/docs/language/src/builtins/widgets.md
+++ b/docs/language/src/builtins/widgets.md
@@ -447,6 +447,7 @@ Same as [`ListView`](#listview), and in addition:
 
 -   **`sort-ascending(`_`int`_`)`**: Emitted if the model should be sorted by the given column in ascending order.
 -   **`sort-descending(`_`int`_`)`**: Emitted if the model should be sorted by the given column in descending order.
+-   **`row-pointer-event(`_`index: int`_`, `_`event: PointerEvent`_`, `_`pos: Point`_`)`**: Emitted on any mouse pointer event similar to `TouchArea`. Arguments are row index associated with the event, the `PointerEvent` itself and the mouse position within the tableview.
 
 ### Functions
 

--- a/internal/compiler/widgets/fluent-base/tableview.slint
+++ b/internal/compiler/widgets/fluent-base/tableview.slint
@@ -141,12 +141,13 @@ export component StandardTableView {
 
     callback sort-ascending(int /* column-index */);
     callback sort-descending(int /* column-index */);
-    callback row-pointer-event(int /* row-index */, PointerEvent);
+    callback row-pointer-event(int /* row-index */, PointerEvent /* event */);
 
     in property <[[StandardListViewItem]]> rows;
     out property <int> current-sort-column: -1;
     in-out property <[TableColumn]> columns;
     in-out property <int> current-row: -1;
+
 
     min-width: 400px;
     min-height: 200px;

--- a/internal/compiler/widgets/fluent-base/tableview.slint
+++ b/internal/compiler/widgets/fluent-base/tableview.slint
@@ -233,7 +233,10 @@ export component StandardTableView {
                     }
 
                     pointer-event(pe, pos) => {
-                        root.row-pointer-event(idx, pe, pos);
+                        root.row-pointer-event(idx, pe, {
+                            x: pos.x - root.absolute-position.x,
+                            y: pos.y - root.absolute-position.y,
+                        });
                     }
 
                     clicked => {

--- a/internal/compiler/widgets/fluent-base/tableview.slint
+++ b/internal/compiler/widgets/fluent-base/tableview.slint
@@ -92,6 +92,7 @@ component TableViewCell inherits Rectangle {
 
 component TableViewRow inherits Rectangle {
     callback clicked <=> i-touch-area.clicked;
+    callback pointer-event <=> i-touch-area.pointer-event;
 
     in property<bool> selected;
     in property <bool> even;
@@ -140,6 +141,7 @@ export component StandardTableView {
 
     callback sort-ascending(int /* column-index */);
     callback sort-descending(int /* column-index */);
+    callback row-pointer-event(int /* row-index */, PointerEvent);
 
     in property <[[StandardListViewItem]]> rows;
     out property <int> current-sort-column: -1;
@@ -220,6 +222,10 @@ export component StandardTableView {
                                 color: mod(idx, 2) == 0 ? Palette.text-primary : Palette.text-secondary;
                             }
                         }
+                    }
+
+                    pointer-event(pe) => {
+                        root.row-pointer-event(idx, pe);
                     }
 
                     clicked => {

--- a/internal/compiler/widgets/fluent-base/tableview.slint
+++ b/internal/compiler/widgets/fluent-base/tableview.slint
@@ -92,7 +92,7 @@ component TableViewCell inherits Rectangle {
 
 component TableViewRow inherits Rectangle {
     callback clicked <=> i-touch-area.clicked;
-    callback pointer-event <=> i-touch-area.pointer-event;
+    callback pointer-event(PointerEvent /* event */, Point /* absolute mouse position */);
 
     in property<bool> selected;
     in property <bool> even;
@@ -102,7 +102,14 @@ component TableViewRow inherits Rectangle {
     border-radius: 4px;
     background: root.even ? Palette.control-default : transparent;
 
-    i-touch-area := TouchArea {}
+    i-touch-area := TouchArea {
+        pointer-event(pe) => {
+            root.pointer-event(pe, {
+                x: self.absolute-position.x + self.mouse-x,
+                y: self.absolute-position.y + self.mouse-y,
+            });
+        }
+    }
 
     i-layout := HorizontalLayout {
        @children
@@ -141,7 +148,7 @@ export component StandardTableView {
 
     callback sort-ascending(int /* column-index */);
     callback sort-descending(int /* column-index */);
-    callback row-pointer-event(int /* row-index */, PointerEvent /* event */);
+    callback row-pointer-event(int /* row-index */, PointerEvent /* event */, Point /* absolute mouse position */);
 
     in property <[[StandardListViewItem]]> rows;
     out property <int> current-sort-column: -1;
@@ -225,8 +232,8 @@ export component StandardTableView {
                         }
                     }
 
-                    pointer-event(pe) => {
-                        root.row-pointer-event(idx, pe);
+                    pointer-event(pe, pos) => {
+                        root.row-pointer-event(idx, pe, pos);
                     }
 
                     clicked => {

--- a/internal/compiler/widgets/material-base/tableview.slint
+++ b/internal/compiler/widgets/material-base/tableview.slint
@@ -204,8 +204,8 @@ export component StandardTableView {
 
                     pointer-event(pe) => {
                         root.row-pointer-event(idx, pe, {
-                            x: self.absolute-position.x + self.mouse-x,
-                            y: self.absolute-position.y + self.mouse-y,
+                            x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
+                            y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
                         });
                     }
                 }

--- a/internal/compiler/widgets/material-base/tableview.slint
+++ b/internal/compiler/widgets/material-base/tableview.slint
@@ -89,8 +89,11 @@ component TableViewCell inherits Rectangle {
 
 component TableViewRow inherits Rectangle {
     callback clicked <=> i-state-layer.clicked;
+    callback pointer-event <=> i-state-layer.pointer-event;
 
     in property<bool> selected;
+    out property<length> mouse-x <=> i-state-layer.mouse-x;
+    out property<length> mouse-y <=> i-state-layer.mouse-y;
 
     min-height: max(42px, i-layout.min-height);
 
@@ -120,6 +123,7 @@ export component StandardTableView {
 
     callback sort-ascending(int /* column-index */);
     callback sort-descending(int /* column-index */);
+    callback row-pointer-event(int /* row-index */, PointerEvent /* event */, Point /* absolute mouse position */);
 
     in property <[[StandardListViewItem]]> rows;
     out property <int> current-sort-column: -1;
@@ -196,6 +200,13 @@ export component StandardTableView {
 
                     clicked => {
                         root.set-current-row(idx);
+                    }
+
+                    pointer-event(pe) => {
+                        root.row-pointer-event(idx, pe, {
+                            x: self.absolute-position.x + self.mouse-x,
+                            y: self.absolute-position.y + self.mouse-y,
+                        });
                     }
                 }
             }

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -423,8 +423,8 @@ export component StandardTableView {
 
                         pointer-event(pe) => {
                             root.row-pointer-event(i, pe, {
-                                x: self.absolute-position.x + self.mouse-x,
-                                y: self.absolute-position.y + self.mouse-y,
+                                x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
+                                y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
                             });
                         }
                     }

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -353,6 +353,7 @@ export component StandardTableView {
 
     callback sort-ascending(int);
     callback sort-descending(int);
+    callback row-pointer-event(int /* row-index */, PointerEvent /* event */, Point /* absolute mouse position */);
 
     out property <int> current-sort-column: -1;
     in-out property <[TableColumn]> columns;
@@ -418,6 +419,13 @@ export component StandardTableView {
                     row-ta := TouchArea {
                         clicked => {
                             root.set-current-row(i);
+                        }
+
+                        pointer-event(pe) => {
+                            root.row-pointer-event(i, pe, {
+                                x: self.absolute-position.x + self.mouse-x,
+                                y: self.absolute-position.y + self.mouse-y,
+                            });
                         }
                     }
                     row-layout := HorizontalLayout {


### PR DESCRIPTION
Adds a `row-pointer-event` callback that bubbles up from `StandardTableView` rows so users can assign events such as menu popups etc.

NOTE: this has only been implemented and tested with fluent