### PR TITLE
Don't panic when an unresolved alias has a binding

### DIFF
--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -181,8 +181,10 @@ pub async fn compile_syntax_node(
     }
 
     if !diagnostics.has_error() {
-        // FIXME: ideally we would be able to run more passes, but currently we panic because invariant are not met.
         passes::run_passes(&doc, &mut diagnostics, &mut loader, &compiler_config).await;
+    } else {
+        // Don't run all the passes in case of errors because because some invariants are not met.
+        passes::run_import_passes(&doc, &mut loader, &mut diagnostics);
     }
 
     diagnostics.all_loaded_files = loader.all_files().cloned().collect();

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1349,12 +1349,13 @@ impl Element {
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
     ) -> ElementRc {
-        let id = parser::identifier_text(&node).unwrap_or_default();
+        let mut id = parser::identifier_text(&node).unwrap_or_default();
         if matches!(id.as_ref(), "parent" | "self" | "root") {
             diag.push_error(
                 format!("'{}' is a reserved id", id),
                 &node.child_token(SyntaxKind::Identifier).unwrap(),
-            )
+            );
+            id = String::new();
         }
         Element::from_node(
             node.Element(),

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -924,17 +924,16 @@ impl Element {
             );
 
             if let Some(csn) = prop_decl.BindingExpression() {
-                if r.bindings
-                    .insert(
-                        prop_name.to_string(),
-                        BindingExpression::new_uncompiled(csn.into()).into(),
-                    )
-                    .is_some()
-                {
-                    diag.push_error(
-                        "Duplicated property binding".into(),
-                        &prop_decl.DeclaredIdentifier(),
-                    );
+                match r.bindings.entry(prop_name.to_string()) {
+                    Entry::Vacant(e) => {
+                        e.insert(BindingExpression::new_uncompiled(csn.into()).into());
+                    }
+                    Entry::Occupied(_) => {
+                        diag.push_error(
+                            "Duplicated property binding".into(),
+                            &prop_decl.DeclaredIdentifier(),
+                        );
+                    }
                 }
             }
             if let Some(csn) = prop_decl.TwoWayBinding() {
@@ -1140,17 +1139,14 @@ impl Element {
                 );
                 continue;
             }
-            if r.bindings
-                .insert(
-                    resolved_name.into_owned(),
-                    BindingExpression::new_uncompiled(con_node.clone().into()).into(),
-                )
-                .is_some()
-            {
-                diag.push_error(
+            match r.bindings.entry(resolved_name.into_owned()) {
+                Entry::Vacant(e) => {
+                    e.insert(BindingExpression::new_uncompiled(con_node.clone().into()).into());
+                }
+                Entry::Occupied(_) => diag.push_error(
                     "Duplicated callback".into(),
                     &con_node.child_token(SyntaxKind::Identifier).unwrap(),
-                );
+                ),
             }
         }
 
@@ -1525,16 +1521,14 @@ impl Element {
                 );
             }
 
-            if self
-                .bindings
-                .insert(
-                    lookup_result.resolved_name.to_string(),
-                    BindingExpression::new_uncompiled(b).into(),
-                )
-                .is_some()
-            {
-                diag.push_error("Duplicated property binding".into(), &name_token);
-            }
+            match self.bindings.entry(lookup_result.resolved_name.to_string()) {
+                Entry::Occupied(_) => {
+                    diag.push_error("Duplicated property binding".into(), &name_token);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(BindingExpression::new_uncompiled(b).into());
+                }
+            };
         }
     }
 

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -155,7 +155,13 @@ impl Expression {
                 return Expression::Invalid;
             }
         };
-        e.maybe_convert_to(ctx.property_type.clone(), &node, ctx.diag)
+        if !matches!(ctx.property_type, Type::Callback { .. } | Type::Function { .. }) {
+            e.maybe_convert_to(ctx.property_type.clone(), &node, ctx.diag)
+        } else {
+            // Binding to a callback or function shouldn't happen
+            assert!(ctx.diag.has_error());
+            e
+        }
     }
 
     fn from_codeblock_node(node: syntax_nodes::CodeBlock, ctx: &mut LookupCtx) -> Expression {

--- a/internal/compiler/tests/syntax/basic/inline_component.slint
+++ b/internal/compiler/tests/syntax/basic/inline_component.slint
@@ -12,5 +12,6 @@ export SubElements := Rectangle {
         background: yellow;
         invalid: yellow;
 //      ^error{Unknown property invalid in Inline1}
+//               ^^error{Unknown unqualified identifier 'yellow'}
     }
 }

--- a/internal/compiler/tests/syntax/basic/item_as_property.slint
+++ b/internal/compiler/tests/syntax/basic/item_as_property.slint
@@ -24,5 +24,6 @@ export Foo := Rectangle {
     Comp {
         r: xx;
 //      ^error{Unknown property}
+//         ^^error{Cannot take reference of an element}
     }
 }

--- a/internal/compiler/tests/syntax/basic/states_transitions.slint
+++ b/internal/compiler/tests/syntax/basic/states_transitions.slint
@@ -17,10 +17,12 @@ export TestCase := Rectangle {
 ///         ^error{'text.foo.bar' is not a valid property}
             colour: yellow;
 ///         ^error{'colour' is not a valid property}
+///                 ^^error{Unknown unqualified identifier 'yellow'}
             fox.color: yellow;
 ///         ^error{'fox' is not a valid element id}
             text.fox: yellow;
 ///         ^error{'fox' not found in 'text'}
+///                   ^^error{Unknown unqualified identifier 'yellow'}
         }
     ]
 
@@ -63,10 +65,12 @@ export component NewSyntax {
 ///         ^error{'text.foo.bar' is not a valid property}
             colour: yellow;
 ///         ^error{'colour' is not a valid property}
+///                 ^^error{Unknown unqualified identifier 'yellow'}
             fox.color: yellow;
 ///         ^error{'fox' is not a valid element id}
             text.fox: yellow;
 ///         ^error{'fox' not found in 'text'}
+///                   ^^error{Unknown unqualified identifier 'yellow'}
 
             in  {
                 animate * { duration: 88ms; }
@@ -104,10 +108,12 @@ export component OldInNewSyntax {
 ///         ^error{'text.foo.bar' is not a valid property}
             colour: yellow;
 ///         ^error{'colour' is not a valid property}
+///                 ^^error{Unknown unqualified identifier 'yellow'}
             fox.color: yellow;
 ///         ^error{'fox' is not a valid element id}
             text.fox: yellow;
 ///         ^error{'fox' not found in 'text'}
+///                   ^^error{Unknown unqualified identifier 'yellow'}
         }
     ]
 

--- a/internal/compiler/tests/syntax/basic/type_declaration.slint
+++ b/internal/compiler/tests/syntax/basic/type_declaration.slint
@@ -21,6 +21,7 @@ global MyType := {
 //  ^error{A global component cannot have sub elements}
     for x in mod : Text { }
 //  ^error{A global component cannot have sub elements}
+//           ^^error{Builtin function must be called}
     aaa <=> bbb;
 
     property <int> eee <=> aaa;

--- a/internal/compiler/tests/syntax/basic/unknown_item.slint
+++ b/internal/compiler/tests/syntax/basic/unknown_item.slint
@@ -17,6 +17,7 @@ export SuperSimple := Rectangle {
             background: blue;
             foo_bar: blue;
 //          ^error{Unknown property foo-bar in Rectangle}
+//                   ^^error{Unknown unqualified identifier 'blue'}
         }
     }
 
@@ -39,6 +40,7 @@ export SuperSimple := Rectangle {
     Rectangle {
         foo_bar: blue;
 //      ^error{Unknown property foo-bar in Rectangle}
+//               ^^error{Unknown unqualified identifier 'blue'}
     }
 
     NativeLineEdit { }

--- a/internal/compiler/tests/syntax/functions/functions.slint
+++ b/internal/compiler/tests/syntax/functions/functions.slint
@@ -12,6 +12,7 @@ export Xxx := Rectangle {
 //                        ^error{Duplicated argument name 'a'}
 
     function plop2() -> int {
+//  ^error{Cannot convert string to int}
         return 45;
         "xxx"
     }
@@ -19,8 +20,10 @@ export Xxx := Rectangle {
     function plop3() { return 45; "xxx" }
 
     function plop4(string: int) -> int {  return "45"; }
+//                                        ^error{Cannot convert string to int}
 
     function plop5() {  plop4("456") }
+//                            ^error{Cannot convert string to int}
 
 
     function background() {}
@@ -45,6 +48,8 @@ export Xxx := Rectangle {
 //              ^error{Cannot assign to par in Abc because it does not have a valid property type}
     Abc { par <=> aa.par; }
 //        ^error{Cannot assign to par in Abc because it does not have a valid property type}
+//        ^^error{Cannot bind to a function}
+//                   ^^^error{The function 'par' is private. Annotate it with 'public' to make it accessible from other components}
     fooo => {}
 //  ^error{'fooo' is not a callback in Rectangle}
 

--- a/internal/compiler/tests/syntax/imports/error_in_import.slint
+++ b/internal/compiler/tests/syntax/imports/error_in_import.slint
@@ -10,4 +10,5 @@ export Foo := Rectangle {
 //      ^error{Unknown property meh in X}
     }
     background: x.blah;
+    //            ^error{Element 'X' does not have a property 'blah'}
 }

--- a/internal/compiler/tests/syntax/lookup/callback_alias2.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias2.slint
@@ -10,4 +10,12 @@ export Xxx := Rectangle {
     callback bar(int) -> int;
     bar <=> foo.hello;
 //  ^error{Unknown property bar in Rectangle}
+
+
+    // #3085
+    callback row-pointer-event <=> dontexist;
+//                                 ^error{Unknown unqualified identifier 'dontexist'}
+//  ^^error{Binding to callback 'row-pointer-event' must bind to another callback}
+    row-pointer-event => {}
+//  ^error{Duplicated callback}
 }

--- a/internal/compiler/tests/syntax/lookup/two_way_binding_infer.slint
+++ b/internal/compiler/tests/syntax/lookup/two_way_binding_infer.slint
@@ -23,4 +23,10 @@ export X := Rectangle {
     property <string> alias_to_background <=> auto_background;
 //                                        ^error{The property does not have the same type as the bound property}
 
+
+    property abc <=> self.opacity;
+    abc: "eee";
+//  ^error{Duplicated property binding}
+
+
 }

--- a/internal/compiler/tests/syntax/new_syntax/input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output.slint
@@ -14,6 +14,7 @@ component Compo inherits Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
+//          ^error{Assignment on a input property}
             inout1 = 75;
         }
 
@@ -47,9 +48,11 @@ OldCompo := Rectangle {
     TouchArea {
         clicked => {
             pub1 = 32;
+//          ^error{Unknown unqualified identifier 'pub1'}
             priv2 = 78;
             output1 = input1;
             input1 = 75;
+//          ^error{Assignment on a input property}
             inout1 = 75;
         }
     }


### PR DESCRIPTION
The first commit increase the test coverage by running the import pass even in case of error building the object_tree (the LSP does that)

The second commit fixes #3085