### PR TITLE
Improve error handling in C++ Skia Renderer API 

### DIFF
--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -255,13 +255,22 @@ public:
     }
 
 #    if !defined(__APPLE__) && !defined(_WIN32) && !defined(_WIN64)
-    static NativeWindowHandle from_x11(uint32_t /*xcb_window_t*/ window,
-                                       uint32_t /*xcb_visualid_t*/ visual_id,
-                                       xcb_connection_t *connection, int screen)
+    static NativeWindowHandle from_x11_xcb(uint32_t /*xcb_window_t*/ window,
+                                           uint32_t /*xcb_visualid_t*/ visual_id,
+                                           xcb_connection_t *connection, int screen)
     {
 
-        return { cbindgen_private::slint_new_raw_window_handle_x11(window, visual_id, connection,
-                                                                   screen) };
+        return { cbindgen_private::slint_new_raw_window_handle_x11_xcb(window, visual_id,
+                                                                       connection, screen) };
+    }
+
+    static NativeWindowHandle from_x11_xlib(uint32_t /*Window*/ window,
+                                            unsigned long /*VisualID*/ visual_id,
+                                            void /*Display*/ *display, int screen)
+    {
+
+        return { cbindgen_private::slint_new_raw_window_handle_x11_xlib(window, visual_id, display,
+                                                                        screen) };
     }
 
     static NativeWindowHandle from_wayland(wl_surface *surface, wl_display *display)

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -249,7 +249,7 @@ pub mod skia {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn slint_new_raw_window_handle_x11(
+    pub unsafe extern "C" fn slint_new_raw_window_handle_x11_xcb(
         window: u32,
         visual_id: u32,
         connection: *mut c_void,
@@ -259,6 +259,21 @@ pub mod skia {
         let handle = CppRawHandle(
             RawWindowHandle::Xcb(init_raw!(XcbWindowHandle { window, visual_id })),
             RawDisplayHandle::Xcb(init_raw!(XcbDisplayHandle { connection, screen })),
+        );
+        Box::into_raw(Box::new(handle)) as CppRawHandleOpaque
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn slint_new_raw_window_handle_x11_xlib(
+        window: core::ffi::c_ulong,
+        visual_id: core::ffi::c_ulong,
+        display: *mut c_void,
+        screen: core::ffi::c_int,
+    ) -> CppRawHandleOpaque {
+        use raw_window_handle::{XlibDisplayHandle, XlibWindowHandle};
+        let handle = CppRawHandle(
+            RawWindowHandle::Xlib(init_raw!(XlibWindowHandle { window, visual_id })),
+            RawDisplayHandle::Xlib(init_raw!(XlibDisplayHandle { display, screen })),
         );
         Box::into_raw(Box::new(handle)) as CppRawHandleOpaque
     }

--- a/api/cpp/tests/manual/platform_qt/main.cpp
+++ b/api/cpp/tests/manual/platform_qt/main.cpp
@@ -43,7 +43,7 @@ static slint_platform::NativeWindowHandle window_handle_for_qt_window(QWindow *w
     QPlatformNativeInterface *native = qApp->platformNativeInterface();
     auto *connection = reinterpret_cast<xcb_connection_t *>(
             native->nativeResourceForWindow(QByteArray("connection"), window));
-    auto screen = quintptr(native->nativeResourceForWindow(QByteArray("screen"), window));
+    auto screen = quintptr(native->nativeResourceForWindow(QByteArray("x11screen"), window));
 
     return slint_platform::NativeWindowHandle::from_x11_xcb(wid, wid, connection, screen);
 #endif

--- a/api/cpp/tests/manual/platform_qt/main.cpp
+++ b/api/cpp/tests/manual/platform_qt/main.cpp
@@ -45,7 +45,7 @@ static slint_platform::NativeWindowHandle window_handle_for_qt_window(QWindow *w
             native->nativeResourceForWindow(QByteArray("connection"), window));
     auto screen = quintptr(native->nativeResourceForWindow(QByteArray("screen"), window));
 
-    return slint_platform::NativeWindowHandle::from_x11(wid, wid, connection, screen);
+    return slint_platform::NativeWindowHandle::from_x11_xcb(wid, wid, connection, screen);
 #endif
 }
 
@@ -56,6 +56,7 @@ class MyWindow : public QWindow, public slint_platform::WindowAdapter
 public:
     MyWindow(QWindow *parentWindow = nullptr) : QWindow(parentWindow)
     {
+        resize(640, 480);
         m_renderer.emplace(window_handle_for_qt_window(this), physical_size());
     }
 

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -204,7 +204,11 @@ impl OpenGLSurface {
             if #[cfg(target_os = "macos")] {
                 let prefs = [glutin::display::DisplayApiPreference::Cgl];
             } else if #[cfg(all(feature = "x11", not(target_family = "windows")))] {
-                let prefs = [glutin::display::DisplayApiPreference::Egl, glutin::display::DisplayApiPreference::Glx(Box::new(winit::platform::x11::register_xlib_error_hook))];
+                let mut prefs = vec![glutin::display::DisplayApiPreference::Egl];
+                // GLX can only be supported with xlib, not xcb.
+                if matches!(_window_handle.raw_window_handle(), raw_window_handle::RawWindowHandle::Xlib(..)) {
+                    prefs.push(glutin::display::DisplayApiPreference::Glx(Box::new(winit::platform::x11::register_xlib_error_hook)));
+                }
             } else if #[cfg(not(target_family = "windows"))] {
                 let prefs = [glutin::display::DisplayApiPreference::Egl];
             } else {


### PR DESCRIPTION
- Don't try to create a GLX context when we only have an XCB window handle,
  XLib is required for that.
- Make it possible to create a NativeWindowHandle from Xlib data types.

Fixes #2978