### PR TITLE
Fix touch in the flickable not resulting in a click

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -707,7 +707,11 @@ pub fn process_mouse_input(
     let mut result = MouseInputState::default();
     let root = ItemRc::new(component, 0);
     let r = send_mouse_event_to_item(mouse_event, root, window_adapter, &mut result, false);
-    if mouse_input_state.delayed.is_some() && !r.has_aborted() {
+    if mouse_input_state.delayed.is_some()
+        && (!r.has_aborted()
+            || Option::zip(result.item_stack.last(), mouse_input_state.item_stack.last())
+                .map_or(true, |(a, b)| a.0 != b.0))
+    {
         // Keep the delayed event
         return mouse_input_state;
     }

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -107,6 +107,31 @@ assert_eq!(instance.get_offset_y(), 0.);
 
 instance.set_clicked(-1);
 
+slint_testing::mock_elapsed_time(1000);
+
+// - Press, move a triny, then release quickly:  should click
+// Start a press
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(165.0, 175.0), button: PointerEventButton::Left });
+assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), -1);
+// make a small move
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(166.0, 174.0) });
+assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+slint_testing::mock_elapsed_time(30);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(167.0, 175.0) });
+assert!(!instance.get_inner_ta_pressed());
+// and release
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(165.0, 174.0), button: PointerEventButton::Left });
+assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), 5_00014);
+assert_eq!(instance.get_offset_x(), 0.);
+assert_eq!(instance.get_offset_y(), 0.);
+
+instance.set_clicked(-1);
+
 // Start a press
 instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(175.0, 175.0), button: PointerEventButton::Left });
 assert!(!instance.get_inner_ta_pressed());


### PR DESCRIPTION
because the pending press event might be loss if there is a move between the click and the release

This was reported on Mattermost