### PR TITLE
Add edited callback for SpinBox

### DIFF
--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -12,6 +12,8 @@ struct NativeSpinBoxData {
     pressed: bool,
 }
 
+type IntArg = (i32,);
+
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
@@ -26,6 +28,7 @@ pub struct NativeSpinBox {
     pub minimum: Property<i32>,
     pub maximum: Property<i32>,
     pub cached_rendering_data: CachedRenderingData,
+    pub edited: Callback<IntArg>,
     data: Property<NativeSpinBoxData>,
     widget_ptr: std::cell::Cell<SlintTypeErasedWidgetPtr>,
     animation_tracker: Property<i32>,
@@ -179,6 +182,7 @@ impl Item for NativeSpinBox {
                         let v = self.value();
                         if v < self.maximum() {
                             self.value.set(v + 1);
+                            Self::FIELD_OFFSETS.edited.apply_pin(self).call(&(v + 1,));
                         }
                     }
                     if new_control
@@ -188,6 +192,7 @@ impl Item for NativeSpinBox {
                         let v = self.value();
                         if v > self.minimum() {
                             self.value.set(v - 1);
+                            Self::FIELD_OFFSETS.edited.apply_pin(self).call(&(v - 1,));
                         }
                     }
                     true
@@ -220,12 +225,16 @@ impl Item for NativeSpinBox {
         if event.text.starts_with(i_slint_core::input::key_codes::UpArrow)
             && self.value() < self.maximum()
         {
-            self.value.set(self.value() + 1);
+            let new_val = self.value() + 1;
+            self.value.set(new_val);
+            Self::FIELD_OFFSETS.edited.apply_pin(self).call(&(new_val,));
             KeyEventResult::EventAccepted
         } else if event.text.starts_with(i_slint_core::input::key_codes::DownArrow)
             && self.value() > self.minimum()
         {
-            self.value.set(self.value() - 1);
+            let new_val = self.value() - 1;
+            self.value.set(new_val);
+            Self::FIELD_OFFSETS.edited.apply_pin(self).call(&(new_val,));
             KeyEventResult::EventAccepted
         } else {
             KeyEventResult::EventIgnored

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -463,7 +463,7 @@ export component NativeSpinBox {
     in-out property <int> value;
     in property <int> minimum;
     in property <int> maximum: 100;
-    callback edited(int);
+    callback edited(int /* value */);
     //-is_internal
 }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -463,6 +463,7 @@ export component NativeSpinBox {
     in-out property <int> value;
     in property <int> minimum;
     in property <int> maximum: 100;
+    callback edited(int);
     //-is_internal
 }
 

--- a/internal/compiler/widgets/fluent-base/spinbox.slint
+++ b/internal/compiler/widgets/fluent-base/spinbox.slint
@@ -33,6 +33,8 @@ component SpinBoxButton {
 }
 
 export component SpinBox {
+    callback edited(int);
+
     in property <int> minimum;
     in property <int> maximum: 100;
     in property <bool> enabled <=> i-text-input.enabled;
@@ -137,6 +139,7 @@ export component SpinBox {
         }
 
         root.value = value;
+        root.edited(value);
     }
 
     function increment() {

--- a/internal/compiler/widgets/fluent-base/spinbox.slint
+++ b/internal/compiler/widgets/fluent-base/spinbox.slint
@@ -33,7 +33,7 @@ component SpinBoxButton {
 }
 
 export component SpinBox {
-    callback edited(int);
+    callback edited(int /* value */);
 
     in property <int> minimum;
     in property <int> maximum: 100;

--- a/internal/compiler/widgets/material-base/spinbox.slint
+++ b/internal/compiler/widgets/material-base/spinbox.slint
@@ -59,7 +59,7 @@ component SpinBoxButton inherits Rectangle {
 
 // Increment and decrement a value in the given range.
 export component SpinBox {
-    callback edited(int);
+    callback edited(int /* value */);
 
     in property <int> minimum;
     in property <int> maximum: 100;

--- a/internal/compiler/widgets/material-base/spinbox.slint
+++ b/internal/compiler/widgets/material-base/spinbox.slint
@@ -59,6 +59,8 @@ component SpinBoxButton inherits Rectangle {
 
 // Increment and decrement a value in the given range.
 export component SpinBox {
+    callback edited(int);
+
     in property <int> minimum;
     in property <int> maximum: 100;
     in property <bool> enabled <=> i-focus-scope.enabled;
@@ -80,9 +82,11 @@ export component SpinBox {
         key-pressed(event) => {
             if (root.enabled && event.text == Key.UpArrow && root.value < root.maximum) {
                 root.value += 1;
+                root.edited(value);
                 accept
             } else if (root.enabled && event.text == Key.DownArrow && root.value > root.minimum) {
                 root.value -= 1;
+                root.edited(value);
                 accept
             } else {
                 reject
@@ -131,9 +135,7 @@ export component SpinBox {
                 }
 
                 clicked => {
-                    if (root.value < root.maximum) {
-                        root.value += 1;
-                    }
+                    root.update-value(root.value + 1);
 
                     root.focus();
                 }
@@ -151,14 +153,21 @@ export component SpinBox {
                 }
 
                 clicked => {
-                    if (root.value > root.minimum) {
-                        root.value -= 1;
-                    }
+                    root.update-value(root.value - 1);
 
                     root.focus();
                 }
             }
         }
+    }
+
+    function update-value(value: int) {
+        if (value < root.minimum || value > root.maximum) {
+            return;
+        }
+
+        root.value = value;
+        root.edited(value);
     }
 
     states [


### PR DESCRIPTION
This PR is for https://github.com/slint-ui/slint/issues/3054

Add `edited` callback similar to `LineEdit` component, for different three styles: `native`, `fluent` & `material`.