### PR TITLE
doc: Remove the need to use nightly for pico and stm32 builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -265,7 +265,7 @@ jobs:
         buildDirectory: ${{ runner.workspace }}/examples/build
         buildWithCMakeArgs: '--config Release'
 
-  # test to compile the mcu backend with nightly and for the armv6 target (no_std)
+  # test to compile the mcu backend for the armv6 target (no_std)
   mcu:
     env:
       SLINT_EMBED_GLYPHS: 1
@@ -278,7 +278,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/setup-rust
       with:
-        toolchain: nightly
         target: thumbv6m-none-eabi
     - name: Check
       run: cargo check --target=thumbv6m-none-eabi -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789

--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -48,12 +48,10 @@ cargo run -p printerdemo_mcu --features=simulator --release
 
 ### On the Raspberry Pi Pico
 
-You need nightly rust because that's the only way to get an allocator.
-
 Build the demo with:
 
 ```sh
-cargo +nightly build -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
+cargo build -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
 ```
 
 The resulting file can be flashed conveniently with [elf2uf2-rs](https://github.com/jonil/elf2uf2-rs). Install it using `cargo install`:
@@ -82,7 +80,7 @@ and to connect the pico via a probe (for example another pico running the probe)
 Then you can simply run with `cargo run`
 
 ```sh
-CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER="flip-link" CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-run --chip RP2040" cargo +nightly run -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
+CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER="flip-link" CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-run --chip RP2040" cargo run -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
 ```
 
 #### Flashing and Debugging the Pico with `probe-rs`'s VSCode Plugin
@@ -97,9 +95,6 @@ Add this build task to your `.vscode/tasks.json`:
 		{
 			"type": "cargo",
 			"command": "build",
-			"env": {
-				"RUSTUP_TOOLCHAIN": "nightly"
-			},
 			"args": [
 				"--package=printerdemo_mcu",
 				"--features=mcu-pico-st7789",
@@ -164,7 +159,7 @@ This was tested using a second Raspberry Pi Pico programmed as a probe with [Dap
 Using [probe-run](https://github.com/knurling-rs/probe-run) (`cargo install probe-run`)
 
 ```sh
-CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-run --chip STM32H735IGKx" cargo +nightly run -p printerdemo_mcu --no-default-features  --features=mcu-board-support/stm32h735g --target=thumbv7em-none-eabihf --release
+CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-run --chip STM32H735IGKx" cargo run -p printerdemo_mcu --no-default-features  --features=mcu-board-support/stm32h735g --target=thumbv7em-none-eabihf --release
 ```
 
 ### ESP32


### PR DESCRIPTION
Amends bea263a447e354370dcff01f79ed4312e3abb37c