### PR TITLE
Fix disapearing debugging techniques docs from C++ docs

### DIFF
--- a/api/cpp/docs/index.rst
+++ b/api/cpp/docs/index.rst
@@ -35,7 +35,7 @@ Welcome to Slint C++'s documentation!
 
    genindex
 
-   markdown/debugging_techniques.md
+   debugging_techniques.md
 
 .. image:: https://github.com/slint-ui/slint/workflows/CI/badge.svg
    :target: https://github.com/slint-ui/slint/actions

--- a/xtask/src/cppdocs.rs
+++ b/xtask/src/cppdocs.rs
@@ -77,6 +77,11 @@ pub fn generate(show_warnings: bool) -> Result<(), Box<dyn std::error::Error>> {
     .context("Error creating symlinks from docs source to docs build dir")?;
 
     symlink_file(
+        ["..", "..", "docs", "debugging_techniques.md"].iter().collect::<PathBuf>(),
+        docs_build_dir.join("debugging_techniques.md"),
+    )?;
+
+    symlink_file(
         ["..", "..", "api", "cpp", "README.md"].iter().collect::<PathBuf>(),
         docs_build_dir.join("README.md"),
     )?;


### PR DESCRIPTION
Amends a11c4c42b091c5b7e7815000818890811ae1eda0