### PR TITLE
Replace eprintln with use of the log facade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ resvg = { version= "0.34.0", default-features = false, features = ["text"] }
 fontdb = { version = "0.14.1", default-features = false }
 send_wrapper = { version = "0.6.0" }
 log = { version = "0.4.19", default-features = false }
+env_logger = { version = "0.10.0" }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ rust-version = "1.66"
 resvg = { version= "0.34.0", default-features = false, features = ["text"] }
 fontdb = { version = "0.14.1", default-features = false }
 send_wrapper = { version = "0.6.0" }
+log = { version = "0.4.19", default-features = false }
 
 [profile.release]
 lto = true

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -41,7 +41,7 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 experimental = ["i-slint-renderer-skia", "raw-window-handle", "experimental-platform"]
 experimental-platform = []
 
-std = ["image", "i-slint-core/default", "i-slint-backend-selector"]
+std = ["image", "i-slint-core/default", "i-slint-backend-selector", "env_logger"]
 
 default = ["std", "backend-winit", "renderer-winit-femtovg", "backend-qt", "experimental"]
 
@@ -54,6 +54,7 @@ slint-interpreter = { version = "=1.1.1", path="../../internal/interpreter", def
 raw-window-handle = { version = "0.5", optional = true }
 # Enable image-rs' default features to make all image formats to C++ users
 image = { version = "0.24.0", optional = true }
+env_logger = { workspace = true, optional = true }
 
 [build-dependencies]
 anyhow = "1.0"

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -41,6 +41,12 @@ pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn slint_ensure_logger() {
+    #[cfg(feature = "std")]
+    env_logger::try_init().ok();
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn slint_ensure_backend() {
     with_platform(|_b| {
         // Nothing to do, just make sure a backend was created

--- a/api/node/native/Cargo.toml
+++ b/api/node/native/Cargo.toml
@@ -33,6 +33,7 @@ once_cell = "1.5"
 rand = "0.8"
 scoped-tls-hkt = "0.1"
 spin_on = "0.1" #FIXME: remove and delegate to async JS instead
+env_logger = { workspace = true }
 
 # Enable image-rs' default features to make all image formats available for nodejs builds
 image = { version = "0.24.0" }

--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -677,6 +677,7 @@ fn singleshot_timer(mut cx: FunctionContext) -> JsResult<JsValue> {
 }
 
 register_module!(mut m, {
+    env_logger::try_init().ok();
     m.export_function("load", load)?;
     m.export_function("mock_elapsed_time", mock_elapsed_time)?;
     m.export_function("singleshot_timer", singleshot_timer)?;

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -148,7 +148,7 @@ once_cell = { version = "1.5", default-features = false, features = ["alloc"] }
 pin-weak = { version = "1.1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 
-log = { version = "0.4.17", optional = true }
+log = { workspace = true, optional = true }
 
 [dev-dependencies]
 slint-build = { path = "../build" }

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -34,3 +34,4 @@ i-slint-backend-winit = { version = "=1.1.1", path = "../winit", optional = true
 i-slint-backend-qt = { version = "=1.1.1", path = "../qt", optional = true }
 
 cfg-if = "1"
+log = { workspace = true }

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -56,7 +56,7 @@ cfg_if::cfg_if! {
             }
 
             if !backend_config.is_empty() {
-                eprintln!("Could not load rendering backend {}, fallback to default", backend_config)
+                log::error!("Could not load rendering backend {}, fallback to default", backend_config)
             }
             Ok(create_default_backend())
         }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -50,6 +50,7 @@ instant = "0.1"
 raw-window-handle = { version = "0.5", features = ["alloc"] }
 scopeguard =  { version = "1.1.0", default-features = false }
 send_wrapper = { workspace = true }
+log = { workspace = true }
 
 # For the FemtoVG renderer
 i-slint-renderer-femtovg = { version = "=1.1.1", path = "../../renderers/femtovg", optional = true }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -166,9 +166,10 @@ impl Backend {
             }
             None => window_factory_fn::<DefaultRenderer>,
             Some(renderer_name) => {
-                eprintln!(
+                log::error!(
                     "slint winit: unrecognized renderer {}, falling back to {}",
-                    renderer_name, DEFAULT_RENDERER_NAME
+                    renderer_name,
+                    DEFAULT_RENDERER_NAME
                 );
                 window_factory_fn::<DefaultRenderer>
             }

--- a/internal/common/Cargo.toml
+++ b/internal/common/Cargo.toml
@@ -16,12 +16,13 @@ homepage = "https://slint.dev"
 path = "lib.rs"
 
 [features]
-shared-fontdb = ["dep:fontdb", "dep:libloading", "derive_more", "cfg-if"]
+shared-fontdb = ["dep:fontdb", "dep:libloading", "derive_more", "cfg-if", "log"]
 
 [dependencies]
 fontdb = { workspace = true, optional = true }
 derive_more = { version = "0.99.5", optional = true }
 cfg-if = { version = "1", optional = true }
+log = { workspace = true, optional = true }
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
 libloading = { version = "0.8.0", optional = true }

--- a/internal/common/sharedfontdb.rs
+++ b/internal/common/sharedfontdb.rs
@@ -91,7 +91,7 @@ fn init_fontdb() -> FontDatabase {
                         Some((family_ids, family_names))
                     }
                     Err(err) => {
-                        eprintln!(
+                        log::error!(
                             "Could not load the font set via `SLINT_DEFAULT_FONT`: {}: {}",
                             path.display(),
                             err,
@@ -139,7 +139,7 @@ fn init_fontdb() -> FontDatabase {
                         fontconfig_fallback_families = fallback_families;
                     }
                     Err(e) => {
-                        eprintln!("Error opening libfontconfig.so.1: {}", e);
+                        log::error!("Error opening libfontconfig.so.1: {}", e);
                     }
                 }
             }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1212,14 +1212,20 @@ fn generate_item_tree(
         init_parent_parameters = ", parent";
     }
 
-    let mut create_code = vec![
+    let mut create_code = Vec::new();
+
+    if parent_ctx.is_none() {
+        create_code.push("slint::cbindgen_private::slint_ensure_logger();".into());
+    }
+
+    create_code.extend([
         format!(
             "auto self_rc = vtable::VRc<slint::private_api::ComponentVTable, {0}>::make();",
             target_struct.name
         ),
         format!("auto self = const_cast<{0} *>(&*self_rc);", target_struct.name),
         "self->self_weak = vtable::VWeak(self_rc).into_dyn();".into(),
-    ];
+    ]);
 
     if parent_ctx.is_none() {
         create_code.push("slint::cbindgen_private::slint_ensure_backend();".into());

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -74,6 +74,7 @@ unicode-segmentation = "1.8.0"
 unicode-linebreak = { version = "0.1.2", optional = true }
 unicode-script = { version = "0.5.3", optional = true }
 integer-sqrt = { version = "0.1.5" }
+log = { workspace = true }
 
 image = { version = "0.24.0", optional = true, default-features = false, features = [ "png", "jpeg" ] }
 clru = { version = "0.6.0", optional = true }

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -362,7 +362,7 @@ impl ImageInner {
                 match svg.render(_target_size_for_scalable_source.unwrap_or_default()) {
                     Ok(b) => Some(b),
                     Err(err) => {
-                        eprintln!("Error rendering SVG: {}", err);
+                        log::error!("Error rendering SVG: {}", err);
                         None
                     }
                 }

--- a/internal/core/graphics/image/cache.rs
+++ b/internal/core/graphics/image/cache.rs
@@ -86,7 +86,7 @@ impl ImageCache {
                 return Some(ImageInner::Svg(vtable::VRc::new(
                     super::svg::load_from_path(path, cache_key).map_or_else(
                         |err| {
-                            eprintln!("Error loading SVG from {}: {}", &path, err);
+                            log::error!("Error loading SVG from {}: {}", &path, err);
                             None
                         },
                         Some,
@@ -96,7 +96,7 @@ impl ImageCache {
 
             image::open(std::path::Path::new(&path.as_str())).map_or_else(
                 |decode_err| {
-                    eprintln!("Error loading image from {}: {}", &path, decode_err);
+                    log::error!("Error loading image from {}: {}", &path, decode_err);
                     None
                 },
                 |image| {
@@ -121,7 +121,7 @@ impl ImageCache {
                 return Some(ImageInner::Svg(vtable::VRc::new(
                     super::svg::load_from_data(data.as_slice(), cache_key).map_or_else(
                         |svg_err| {
-                            eprintln!("Error loading SVG: {}", svg_err);
+                            log::error!("Error loading SVG: {}", svg_err);
                             None
                         },
                         Some,
@@ -144,7 +144,7 @@ impl ImageCache {
                     buffer: dynamic_image_to_shared_image_buffer(image),
                 }),
                 Err(decode_err) => {
-                    eprintln!("Error decoding embedded image: {}", decode_err);
+                    log::error!("Error decoding embedded image: {}", decode_err);
                     None
                 }
             }

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -304,7 +304,7 @@ impl PathData {
                     ) {
                         Ok(()) => LyonPathIteratorVariant::FromPath(builder.build()),
                         Err(e) => {
-                            eprintln!("Error while parsing path commands '{commands}': {e:?}");
+                            log::error!("Error while parsing path commands '{commands}': {e:?}");
                             LyonPathIteratorVariant::FromPath(Default::default())
                         }
                     }

--- a/internal/core/graphics/rendering_metrics_collector.rs
+++ b/internal/core/graphics/rendering_metrics_collector.rs
@@ -81,7 +81,7 @@ impl RenderingMetricsCollector {
         let refresh_mode = match RefreshMode::try_from(&options) {
             Ok(mode) => mode,
             Err(_) => {
-                eprintln!("Missing refresh mode in SLINT_DEBUG_PERFORMANCE. Please specify either refresh_full_speed or refresh_lazy");
+                log::info!("Missing refresh mode in SLINT_DEBUG_PERFORMANCE. Please specify either refresh_full_speed or refresh_lazy");
                 return None;
             }
         };
@@ -90,7 +90,7 @@ impl RenderingMetricsCollector {
         let output_overlay = options.contains(&"overlay");
 
         if !output_console && !output_overlay {
-            eprintln!("Missing output mode in SLINT_DEBUG_PERFORMANCE. Please specify either console or overlay (or both)");
+            log::info!("Missing output mode in SLINT_DEBUG_PERFORMANCE. Please specify either console or overlay (or both)");
             return None;
         }
 
@@ -107,7 +107,7 @@ impl RenderingMetricsCollector {
         #[cfg(not(debug_assertions))]
         let build_config = "release";
 
-        eprintln!("Slint: Build config: {}; Backend: {}", build_config, winsys_info);
+        log::info!("Slint: Build config: {}; Backend: {}", build_config, winsys_info);
 
         let self_weak = Rc::downgrade(&collector);
         collector.update_timer.stop();
@@ -134,7 +134,7 @@ impl RenderingMetricsCollector {
                 }
 
                 if this.output_console {
-                    eprintln!(
+                    log::info!(
                         "average frames per second: {} {}",
                         this.collected_frame_data_since_second_ago.borrow().len(),
                         last_frame_details

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -138,8 +138,7 @@ pub trait Model {
     /// If the model can update the data, it should also call [`ModelNotify::row_changed`] on its
     /// internal [`ModelNotify`].
     fn set_row_data(&self, _row: usize, _data: Self::Data) {
-        #[cfg(feature = "std")]
-        eprintln!(
+        log::error!(
             "Model::set_row_data called on a model of type {} which does not re-implement this method. \
             This happens when trying to modify a read-only model",
             core::any::type_name::<Self>(),

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -101,6 +101,7 @@ lyon_path = { version = "1.0" }
 once_cell = "1.5"
 thiserror = "1"
 document-features = { version = "0.2.0", optional = true }
+log = { workspace = true }
 
 [dependencies.spin_on]
 version = "0.1"

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -305,7 +305,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     todo!()
                 }
             }.unwrap_or_else(|_| {
-                eprintln!("Could not load image {:?}",resource_ref );
+                log::error!("Could not load image {:?}",resource_ref );
                 Default::default()
             }))
         }
@@ -1056,7 +1056,7 @@ fn eval_assignment(lhs: &Expression, op: char, rhs: Value, local_context: &mut E
                     }
                 }
                 _ => {
-                    eprintln!("Attempting to write into an array that cannot be written");
+                    log::error!("Attempting to write into an array that cannot be written");
                 }
             }
         }

--- a/internal/interpreter/value_model.rs
+++ b/internal/interpreter/value_model.rs
@@ -74,7 +74,7 @@ impl Model for ValueModel {
     fn set_row_data(&self, row: usize, data: Self::Data) {
         match &mut *self.value.borrow_mut() {
             Value::Model(model_ptr) => model_ptr.set_row_data(row, data),
-            _ => eprintln!("Trying to change the value of a read-only integer model."),
+            _ => log::error!("Trying to change the value of a read-only integer model."),
         }
     }
 

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -57,7 +57,7 @@ notify = { version = "6.0.0", default-features = false, features = ["macos_kqueu
 serde_json = "1"
 shlex = "1"
 spin_on = "0.1"
-env_logger = "0.10.0"
+env_logger = { workspace = true }
 
 # Enable image-rs' default features to make all image formats available for preview
 image = { version = "0.24.0" }


### PR DESCRIPTION
This allows rust applications to have more control over the output the run-time library generates.