### PR TITLE
Compiler: Visit the model and other "side" named reference in binding_analysis

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -172,6 +172,23 @@ fn analyze_element(
             }
         }
     }
+
+    if let Some(repeated) = &elem.borrow().repeated {
+        recurse_expression(&repeated.model, &mut |prop| {
+            process_property(prop, context, reverse_aliases, diag);
+        });
+        if let Some(lv) = &repeated.is_listview {
+            process_property(&lv.viewport_y.clone().into(), context, reverse_aliases, diag);
+            process_property(&lv.viewport_height.clone().into(), context, reverse_aliases, diag);
+            process_property(&lv.viewport_width.clone().into(), context, reverse_aliases, diag);
+            process_property(&lv.listview_height.clone().into(), context, reverse_aliases, diag);
+            process_property(&lv.listview_width.clone().into(), context, reverse_aliases, diag);
+        }
+    }
+    if let Some((h, v)) = &elem.borrow().layout_info_prop {
+        process_property(&h.clone().into(), context, reverse_aliases, diag);
+        process_property(&v.clone().into(), context, reverse_aliases, diag);
+    }
 }
 
 #[derive(Copy, Clone, dm::BitAnd, dm::BitOr, dm::BitAndAssign, dm::BitOrAssign)]

--- a/tests/cases/issues/issue_3107_if_optimized_rect.slint
+++ b/tests/cases/issues/issue_3107_if_optimized_rect.slint
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.0 OR LicenseRef-Slint-commercial
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 component TestComponent {
     in-out property <bool> check;

--- a/tests/cases/issues/issue_3107_if_optimized_rect.slint
+++ b/tests/cases/issues/issue_3107_if_optimized_rect.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.0 OR LicenseRef-Slint-commercial
+
+component TestComponent {
+    in-out property <bool> check;
+}
+
+export component App inherits Window {
+    min-width: 800px;
+    min-height: 600px;
+    title: "Test";
+
+    Rectangle {
+        i-test := TestComponent {}
+
+        if (i-test.check) : Rectangle {  }
+    }
+}


### PR DESCRIPTION
This is necessary for the `is_used` to be set properly

Fixes #3107