### PR TITLE
remove clippy warning in rust code gen

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1243,7 +1243,7 @@ fn generate_item_tree(
             quote!(
                 #[allow(unused)]
                 fn window_adapter(&self) -> Rc<dyn sp::WindowAdapter> {
-                    self.window_adapter_ref().unwrap().clone()
+                    Rc::clone(self.window_adapter_ref().unwrap())
                 }
 
                 fn window_adapter_ref(


### PR DESCRIPTION
This generated a `clippy::clone-on-ref-ptr` warning