### PR TITLE
Make `ComponentContainer` and `ComponentFactory` private for the time being

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -177,7 +177,6 @@ The follow table summarizes the entire mapping:
 | `bool` | `bool` | |
 | `brush` | [`Brush`] | |
 | `color` | [`Color`] | |
-| `component-factory` | [`ComponentFactory`] | A factory for components that can be added at runtime. |
 | `duration` | `i64` | At run-time, durations are always represented as signed 64-bit integers with millisecond precision. |
 | enumeration | `enum` of the same name | The values are converted to CamelCase |
 | `float` | `f32` | |

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -30,7 +30,6 @@ display-diagnostics = ["codemap", "codemap-diagnostic"]
 # Enabled the support to render images and font in the binary
 software-renderer = ["image", "dep:resvg", "fontdue", "i-slint-common/shared-fontdb"]
 
-
 [dependencies]
 i-slint-common = { version = "=1.1.1", path = "../common" }
 

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -20,7 +20,7 @@ use crate::typeregister::TypeRegister;
 /// Parse the contents of builtins.slint and fill the builtin type registry
 /// `register` is the register to fill with the builtin types.
 /// At this point, it really should already contain the basic Types (string, int, ...)
-pub fn load_builtins(register: &mut TypeRegister) {
+pub(crate) fn load_builtins(register: &mut TypeRegister) {
     let mut diag = crate::diagnostics::BuildDiagnostics::default();
     let node = crate::parser::parse(include_str!("builtins.slint").into(), None, &mut diag);
     if !diag.is_empty() {

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -189,6 +189,7 @@ fn process_file_source(
     let mut compiler_config = i_slint_compiler::CompilerConfiguration::new(
         i_slint_compiler::generator::OutputFormat::Interpreter,
     );
+    compiler_config.enable_component_containers = true;
     compiler_config.style = Some("fluent".into());
     let compile_diagnostics = if !parse_diagnostics.has_error() {
         let (_, build_diags) = spin_on::spin_on(i_slint_compiler::compile_syntax_node(

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -213,7 +213,7 @@ impl TypeRegister {
         self.types.insert(name, t);
     }
 
-    pub fn builtin() -> Rc<RefCell<Self>> {
+    fn builtin_internal() -> Self {
         let mut register = TypeRegister::default();
 
         register.insert_type(Type::Float32);
@@ -275,6 +275,22 @@ impl TypeRegister {
 
             _ => unreachable!(),
         };
+
+        register
+    }
+
+    #[doc(hidden)]
+    /// All builtins incl. experimental ones! Do not use in production code!
+    pub fn builtin_experimental() -> Rc<RefCell<Self>> {
+        let register = Self::builtin_internal();
+        Rc::new(RefCell::new(register))
+    }
+
+    pub fn builtin() -> Rc<RefCell<Self>> {
+        let mut register = Self::builtin_internal();
+
+        register.elements.remove("ComponentContainer");
+        register.types.remove("component-factory");
 
         Rc::new(RefCell::new(register))
     }

--- a/tests/driver/interpreter/build.rs
+++ b/tests/driver/interpreter/build.rs
@@ -30,6 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!("cargo:rustc-env=TEST_FUNCTIONS={}", tests_file_path.to_string_lossy());
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
 
     Ok(())
 }

--- a/tests/driver/nodejs/build.rs
+++ b/tests/driver/nodejs/build.rs
@@ -29,6 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "cargo:rustc-env=SLINT_NODE_NATIVE_LIB={}",
         target_dir.join(nodejs_native_lib_name).display()
     );
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1",);
 
     let tests_file_path =
         std::path::Path::new(&std::env::var_os("OUT_DIR").unwrap()).join("test_functions.rs");
@@ -38,6 +39,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for testcase in test_driver_lib::collect_test_cases("cases")? {
         println!("cargo:rerun-if-changed={}", testcase.absolute_path.display());
         let test_function_name = testcase.identifier();
+
+        if &test_function_name == "elements_component_container" {
+            // FIXME: Skip embedding test on NodeJS since ComponentFactory is not
+            // implemented there!
+            continue;
+        }
 
         write!(
             tests_file,

--- a/tests/driver/nodejs/nodejs.rs
+++ b/tests/driver/nodejs/nodejs.rs
@@ -65,6 +65,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
         .env("SLINT_NODE_NATIVE_LIB", std::env::var_os("SLINT_NODE_NATIVE_LIB").unwrap())
         .env("SLINT_INCLUDE_PATH", std::env::join_paths(include_paths).unwrap())
         .env("SLINT_SCALE_FACTOR", "1") // We don't have a testing backend, but we can try to force a SF1 as the tests expect.
+        .env("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1")
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -54,6 +54,7 @@ fn main() -> std::io::Result<()> {
 
     //Make sure to use a consistent style
     println!("cargo:rustc-env=SLINT_STYLE=fluent");
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
     Ok(())
 }
 
@@ -108,6 +109,7 @@ fn generate_source(
     let mut diag = BuildDiagnostics::default();
     let syntax_node = parser::parse(source.to_owned(), Some(&testcase.absolute_path), &mut diag);
     let mut compiler_config = CompilerConfiguration::new(generator::OutputFormat::Rust);
+    compiler_config.enable_component_containers = true;
     compiler_config.include_paths = include_paths;
     compiler_config.style = Some("fluent".to_string());
     let (root_component, diag) =

--- a/tests/screenshots/build.rs
+++ b/tests/screenshots/build.rs
@@ -119,6 +119,7 @@ fn main() -> std::io::Result<()> {
 
     //Make sure to use a consistent style
     println!("cargo:rustc-env=SLINT_STYLE=fluent");
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
 
     Ok(())
 }
@@ -139,6 +140,7 @@ fn generate_source(
     let mut compiler_config = CompilerConfiguration::new(generator::OutputFormat::Rust);
     compiler_config.include_paths = include_paths;
     compiler_config.embed_resources = EmbedResourcesKind::EmbedTextures;
+    compiler_config.enable_component_containers = true;
     compiler_config.style = Some("fluent".to_string());
     let (root_component, diag) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));


### PR DESCRIPTION
Unless the `support_component_container` flag is set to `true` in the `CompilerConfiguration`:

This was reworked quite a bit based on the feedback I got for the first round:

* component-factory and ComponentContainer are removed from the type registry now if the compiler configuration does not have the support-flag set to enable it.
  * component-factory is no longer documented (or mentioned in CHANGELOG.md ;-)
* The tests for interpreter and rust run in experimental mode, with component_factory and ComponentContainer enabled
* We have a `slint_experimental!` macro now that generates rust code in experimental mode.
* The interpreter has a `enable_experimental()` toi enable the hidden things.