### PR TITLE
Add native support for min/max

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -309,7 +309,7 @@ mod cpp_ast {
     }
 }
 
-use crate::expression_tree::{BuiltinFunction, EasingCurve};
+use crate::expression_tree::{BuiltinFunction, EasingCurve, MinMaxOp};
 use crate::langtype::{ElementType, Enumeration, EnumerationValue, NativeClass, Type};
 use crate::layout::Orientation;
 use crate::llr::{
@@ -2775,6 +2775,21 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                     c = cells.join(", "),
                 )
 
+        }
+        Expression::MinMax { ty, op, lhs, rhs } => {
+            let ident = match op {
+                MinMaxOp::Min => "min",
+                MinMaxOp::Max => "max",
+            };
+            let lhs_code = compile_expression(lhs, ctx);
+            let rhs_code = compile_expression(rhs, ctx);
+            format!(
+                r#"std::{ident}<{ty}>({lhs_code}, {rhs_code})"#,
+                ty = ty.cpp_type().unwrap_or_default(),
+                ident = ident,
+                lhs_code = lhs_code,
+                rhs_code = rhs_code
+            )
         }
     }
 }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 use super::PropertyReference;
-use crate::expression_tree::{BuiltinFunction, OperatorClass};
+use crate::expression_tree::{BuiltinFunction, MinMaxOp, OperatorClass};
 use crate::langtype::Type;
 use crate::layout::Orientation;
 use itertools::Either;
@@ -180,6 +180,13 @@ pub enum Expression {
         /// This is an Expression::Array
         unsorted_cells: Box<Expression>,
     },
+
+    MinMax {
+        ty: Type,
+        op: MinMaxOp,
+        lhs: Box<Expression>,
+        rhs: Box<Expression>,
+    },
 }
 
 impl Expression {
@@ -292,6 +299,7 @@ impl Expression {
             Self::ComputeDialogLayoutCells { .. } => {
                 Type::Array(super::lower_expression::grid_layout_cell_data_ty().into())
             }
+            Self::MinMax { ty, .. } => ty.clone(),
         }
     }
 }
@@ -373,6 +381,10 @@ macro_rules! visit_impl {
             Expression::ComputeDialogLayoutCells { roles, unsorted_cells, .. } => {
                 $visitor(roles);
                 $visitor(unsorted_cells);
+            }
+            Expression::MinMax { ty: _, op: _, lhs, rhs } => {
+                $visitor(lhs);
+                $visitor(rhs);
             }
         }
     };

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -197,6 +197,12 @@ pub fn lower_expression(
         }
         tree_Expression::ComputeLayoutInfo(l, o) => compute_layout_info(l, *o, ctx),
         tree_Expression::SolveLayout(l, o) => solve_layout(l, *o, ctx),
+        tree_Expression::MinMax { ty, op, lhs, rhs } => llr_Expression::MinMax {
+            ty: ty.clone(),
+            op: *op,
+            lhs: Box::new(lower_expression(lhs, ctx)),
+            rhs: Box::new(lower_expression(rhs, ctx)),
+        },
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -54,6 +54,7 @@ fn expression_cost(exp: &Expression, ctx: &EvaluationContext) -> isize {
         Expression::LayoutCacheAccess { .. } => PROPERTY_ACCESS_COST,
         Expression::BoxLayoutFunction { .. } => return isize::MAX,
         Expression::ComputeDialogLayoutCells { .. } => return isize::MAX,
+        Expression::MinMax { .. } => 10,
     };
 
     exp.visit(|e| cost = cost.saturating_add(expression_cost(e, ctx)));

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -5,6 +5,8 @@ use std::fmt::{Display, Result, Write};
 
 use itertools::Itertools;
 
+use crate::expression_tree::MinMaxOp;
+
 use super::{
     EvaluationContext, Expression, ParentCtx, PropertyReference, PublicComponent, SubComponent,
 };
@@ -250,6 +252,10 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
             Expression::ComputeDialogLayoutCells { .. } => {
                 write!(f, "ComputeDialogLayoutCells(TODO)",)
             }
+            Expression::MinMax { ty: _, op, lhs, rhs } => match op {
+                MinMaxOp::Min => write!(f, "min({}, {})", e(lhs), e(rhs)),
+                MinMaxOp::Max => write!(f, "max({}, {})", e(lhs), e(rhs)),
+            },
         }
     }
 }

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{
-    BindingExpression, BuiltinFunction, Expression, NamedReference, Unit,
+    BindingExpression, BuiltinFunction, Expression, MinMaxOp, NamedReference, Unit,
 };
 use crate::langtype::{BuiltinElement, DefaultSizeBinding, PropertyLookupResult, Type};
 use crate::layout::{implicit_layout_info_call, LayoutConstraints, Orientation};
@@ -297,7 +297,7 @@ fn make_default_implicit(elem: &ElementRc, property: &str) {
             &format!("preferred-{}", property),
         )),
         Expression::PropertyReference(NamedReference::new(elem, &format!("min-{}", property))),
-        '>',
+        MinMaxOp::Max,
     );
     elem.borrow_mut().set_binding_if_not_set(property.into(), || e);
 }

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -13,7 +13,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::expression_tree::{BindingExpression, Expression, NamedReference};
+use crate::expression_tree::{BindingExpression, Expression, MinMaxOp, NamedReference};
 use crate::langtype::{ElementType, NativeClass};
 use crate::object_tree::{Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
@@ -85,7 +85,7 @@ fn create_viewport_element(flickable: &ElementRc, native_empty: &Rc<NativeClass>
 }
 
 fn fixup_geometry(flickable_elem: &ElementRc) {
-    let forward_minmax_of = |prop: &str, op: char| {
+    let forward_minmax_of = |prop: &str, op: MinMaxOp| {
         set_binding_if_not_explicit(flickable_elem, prop, || {
             flickable_elem
                 .borrow()
@@ -100,12 +100,12 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
     };
 
     if !flickable_elem.borrow().bindings.contains_key("height") {
-        forward_minmax_of("max-height", '<');
-        forward_minmax_of("preferred-height", '<');
+        forward_minmax_of("max-height", MinMaxOp::Min);
+        forward_minmax_of("preferred-height", MinMaxOp::Min);
     }
     if !flickable_elem.borrow().bindings.contains_key("width") {
-        forward_minmax_of("max-width", '<');
-        forward_minmax_of("preferred-width", '<');
+        forward_minmax_of("max-width", MinMaxOp::Min);
+        forward_minmax_of("preferred-width", MinMaxOp::Min);
     }
     set_binding_if_not_explicit(flickable_elem, "viewport-width", || {
         Some(
@@ -119,7 +119,7 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
                 .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-width")))
                 .fold(
                     Expression::PropertyReference(NamedReference::new(flickable_elem, "width")),
-                    |lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, '>'),
+                    |lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, MinMaxOp::Max),
                 ),
         )
     });
@@ -135,7 +135,7 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
                 .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-height")))
                 .fold(
                     Expression::PropertyReference(NamedReference::new(flickable_elem, "height")),
-                    |lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, '>'),
+                    |lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, MinMaxOp::Max),
                 ),
         )
     });

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -9,7 +9,7 @@
 //! be further inlined as it may expends to native widget that needs inlining
 
 use crate::diagnostics::BuildDiagnostics;
-use crate::expression_tree::{BindingExpression, Expression, NamedReference, Unit};
+use crate::expression_tree::{BindingExpression, Expression, MinMaxOp, NamedReference, Unit};
 use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use std::cell::RefCell;
@@ -167,14 +167,14 @@ fn process_tabwidget(
     if let Some(expr) = children
         .iter()
         .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-width")))
-        .reduce(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, '>'))
+        .reduce(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, MinMaxOp::Max))
     {
         elem.borrow_mut().bindings.insert("content-min-width".into(), RefCell::new(expr.into()));
     };
     if let Some(expr) = children
         .iter()
         .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-height")))
-        .reduce(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, '>'))
+        .reduce(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, MinMaxOp::Max))
     {
         elem.borrow_mut().bindings.insert("content-min-height".into(), RefCell::new(expr.into()));
     };

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -11,7 +11,8 @@ use corelib::model::{Model, ModelRc};
 use corelib::rtti::AnimatedBindingKind;
 use corelib::{Brush, Color, PathData, SharedString, SharedVector};
 use i_slint_compiler::expression_tree::{
-    BuiltinFunction, EasingCurve, Expression, Path as ExprPath, PathElement as ExprPathElement,
+    BuiltinFunction, EasingCurve, Expression, MinMaxOp, Path as ExprPath,
+    PathElement as ExprPathElement,
 };
 use i_slint_compiler::langtype::Type;
 use i_slint_compiler::object_tree::ElementRc;
@@ -386,6 +387,18 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         }
         Expression::ComputeLayoutInfo(lay, o) => crate::eval_layout::compute_layout_info(lay, *o, local_context),
         Expression::SolveLayout(lay, o) => crate::eval_layout::solve_layout(lay, *o, local_context),
+        Expression::MinMax { ty: _, op, lhs, rhs } => {
+            let Value::Number(lhs) = eval_expression(lhs, local_context) else {
+                return local_context.return_value.clone().expect("minmax lhs expression did not evaluate to number");
+            };
+            let Value::Number(rhs) =  eval_expression(rhs, local_context) else {
+                return local_context.return_value.clone().expect("minmax rhs expression did not evaluate to number");
+            };
+            match op {
+                MinMaxOp::Min => Value::Number(lhs.min(rhs)),
+                MinMaxOp::Max => Value::Number(lhs.max(rhs)),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The generated code was itching me, so I'm suggesting this. I won't take it badly if you do not like it :stuck_out_tongue: .

Adds `Expression::MinMax`

- Avoid usage of `Expression::Condition` => cleaner code
- Open optimization possibility => `Expression::MinMax` can be seen as `const` if sub expressions are (see example below)
- Use new enum instead of `char` in compiler code for operation selection

After this we could try to optimize min/max during constant optimization.

<details>
  <summary>Slint source file</summary>
  <pre><code>
export component App inherits Window {
    in property<float> f1;
    in property<float> f2;
    out property<float> f_max: max(f1, f2);
    out property<float> f_min: min(f1, f2);

    in property<int> i1;
    in property<int> i2;
    out property<int> i_max: max(i1, i2);
    out property<int> i_min: min(i1, i2);

    in property<physical-length> pl1;
    in property<physical-length> pl2;
    out property<physical-length> pl_max: max(pl1, pl2);
    out property<physical-length> pl_min: min(pl1, pl2);

    in property<length> l1;
    in property<length> l2;
    out property<length> l_max: max(l1, l2);
    out property<length> l_min: min(l1, l2);

    in property<duration> d1;
    in property<duration> d2;
    out property<duration> d_max: max(d1, d2);
    out property<duration> d_min: min(d1, d2);

    in property<angle> a1;
    in property<angle> a2;
    out property<angle> a_max: max(a1, a2);
    out property<angle> a_min: min(a1, a2);

    in property<percent> p1;
    in property<percent> p2;
    out property<percent> p_max: max(p1, p2);
    out property<percent> p_min: min(p1, p2);

    out property<int> f_max_opt: max(2, 3);
    out property<int> f_min_opt: min(2, 3);
}
  </code></pre>
</details>


<details>
  <summary>Generated LLR on master</summary>
  <pre><code>
     a-max: { minmax_lhs62 = root-1.a1; minmax_rhs62 = root-1.a2; if ((minmax_lhs62 > minmax_rhs62)) { minmax_lhs62 } else { minmax_rhs62 }; };
   a-min: { minmax_lhs63 = root-1.a1; minmax_rhs63 = root-1.a2; if ((minmax_lhs63 < minmax_rhs63)) { minmax_lhs63 } else { minmax_rhs63 }; };
   d-max: { minmax_lhs64 = root-1.d1; minmax_rhs64 = root-1.d2; if ((minmax_lhs64 > minmax_rhs64)) { minmax_lhs64 } else { minmax_rhs64 }; };
   d-min: { minmax_lhs65 = root-1.d1; minmax_rhs65 = root-1.d2; if ((minmax_lhs65 < minmax_rhs65)) { minmax_lhs65 } else { minmax_rhs65 }; };
   f-max: { minmax_lhs66 = root-1.f1; minmax_rhs66 = root-1.f2; if ((minmax_lhs66 > minmax_rhs66)) { minmax_lhs66 } else { minmax_rhs66 }; };
   f-max-opt: ({ minmax_lhs67 = 2; minmax_rhs67 = 3; if ((minmax_lhs67 > minmax_rhs67)) { minmax_lhs67 } else { minmax_rhs67 }; }/* as int */);
   f-min: { minmax_lhs68 = root-1.f1; minmax_rhs68 = root-1.f2; if ((minmax_lhs68 < minmax_rhs68)) { minmax_lhs68 } else { minmax_rhs68 }; };
   f-min-opt: ({ minmax_lhs69 = 2; minmax_rhs69 = 3; if ((minmax_lhs69 < minmax_rhs69)) { minmax_lhs69 } else { minmax_rhs69 }; }/* as int */);
   i-max: { minmax_lhs70 = root-1.i1; minmax_rhs70 = (root-1.i2/* as float */); if ((minmax_lhs70 > minmax_rhs70)) { minmax_lhs70 } else { minmax_rhs70 }; };
   i-min: { minmax_lhs71 = root-1.i1; minmax_rhs71 = (root-1.i2/* as float */); if ((minmax_lhs71 < minmax_rhs71)) { minmax_lhs71 } else { minmax_rhs71 }; };
   l-max: { minmax_lhs72 = root-1.l1; minmax_rhs72 = root-1.l2; if ((minmax_lhs72 > minmax_rhs72)) { minmax_lhs72 } else { minmax_rhs72 }; };
   l-min: { minmax_lhs73 = root-1.l1; minmax_rhs73 = root-1.l2; if ((minmax_lhs73 < minmax_rhs73)) { minmax_lhs73 } else { minmax_rhs73 }; };
   p-max: { minmax_lhs74 = root-1.p1; minmax_rhs74 = (root-1.p2 * 0.01); if ((minmax_lhs74 > minmax_rhs74)) { minmax_lhs74 } else { minmax_rhs74 }; };
   p-min: { minmax_lhs75 = root-1.p1; minmax_rhs75 = (root-1.p2 * 0.01); if ((minmax_lhs75 < minmax_rhs75)) { minmax_lhs75 } else { minmax_rhs75 }; };
   pl-max: { minmax_lhs76 = root-1.pl1; minmax_rhs76 = root-1.pl2; if ((minmax_lhs76 > minmax_rhs76)) { minmax_lhs76 } else { minmax_rhs76 }; };
   pl-min: { minmax_lhs77 = root-1.pl1; minmax_rhs77 = root-1.pl2; if ((minmax_lhs77 < minmax_rhs77)) { minmax_lhs77 } else { minmax_rhs77 }; };
  </code></pre>
</details>

<details>
  <summary>Generated LLR on this branch</summary>
  <pre><code>
   a-max: max(root-1.a1, root-1.a2);
   a-min: min(root-1.a1, root-1.a2);
   d-max: max(root-1.d1, root-1.d2);
   d-min: min(root-1.d1, root-1.d2);
   f-max: max(root-1.f1, root-1.f2);
   f-max-opt: (max(2, 3)/* as int */)/*const*/;
   f-min: min(root-1.f1, root-1.f2);
   f-min-opt: (min(2, 3)/* as int */)/*const*/;
   i-max: max(root-1.i1, (root-1.i2/* as float */));
   i-min: min(root-1.i1, (root-1.i2/* as float */));
   l-max: max(root-1.l1, root-1.l2);
   l-min: min(root-1.l1, root-1.l2);
   p-max: max(root-1.p1, (root-1.p2 * 0.01));
   p-min: min(root-1.p1, (root-1.p2 * 0.01));
   pl-max: max(root-1.pl1, root-1.pl2);
   pl-min: min(root-1.pl1, root-1.pl2);
  </code></pre>
</details>

For the given example:
- before: crate build time 639.42 millis, generated file is 50_629 octets for 1_105 formatted lines
- after: crate build time 632.26 millis, generated file is  43_193 octets for 1_009 formatted lines

Disclaimer: I did not try the C++ generated code, hopefully the CI will.