### PR TITLE
vscode: Make utf8 decoding of the welcome page more portable

### DIFF
--- a/editors/vscode/src/welcome/welcomepanel.ts
+++ b/editors/vscode/src/welcome/welcomepanel.ts
@@ -123,7 +123,7 @@ export class WelcomePanel {
                 "index.html",
             ),
         );
-        let result = Buffer.from(data).toString("utf-8");
+        let result = new TextDecoder().decode(data);
 
         let version = `releases/${pkg.version}`;
         if (pkg.name.endsWith("-nightly")) {


### PR DESCRIPTION
I get an error about `Buffer` being unavailable when running the extension locally in web dev mode.

This does not effect the welcome page in the github code space: That works fine without this patch.