### PR TITLE
vscode: Fix web extension

### DIFF
--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -8,7 +8,7 @@ import * as vscode from "vscode";
 import { PropertiesViewProvider } from "./properties_webview";
 import * as wasm_preview from "./wasm_preview";
 import * as lsp_commands from "../../../tools/slintpad/src/shared/lsp_commands";
-import * as welcome from "./welcome/welcomepanel";
+import * as welcome from "./welcome/welcome_panel";
 
 import {
     BaseLanguageClient,
@@ -104,7 +104,7 @@ export function languageClientOptions(
                     if (showPreview(args)) {
                         return;
                     }
-                } else if (command == "slint/toggleDesignMode") {
+                } else if (command === "slint/toggleDesignMode") {
                     if (toggleDesignMode(args)) {
                         return;
                     }
@@ -150,7 +150,7 @@ export function activate(
     );
     context.subscriptions.push(
         vscode.commands.registerCommand("slint.showWelcome", function () {
-            welcome.WelcomePanel.createOrShow(context.extensionPath);
+            welcome.WelcomePanel.createOrShow(context.extensionUri);
         }),
     );
     context.subscriptions.push(
@@ -209,7 +209,7 @@ export function activate(
         }, 1);
     });
 
-    setTimeout(() => welcome.WelcomePanel.maybeShow(context.extensionPath), 1);
+    setTimeout(() => welcome.WelcomePanel.maybeShow(context.extensionUri), 1);
 
     return [statusBar, properties_provider];
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -171,11 +171,19 @@ function startClient(context: vscode.ExtensionContext) {
 
     cl.onDidChangeState((event) => {
         let properly_stopped = cl.hasOwnProperty("slint_stopped");
-        if (!properly_stopped && event.newState === State.Stopped && event.oldState == State.Running) {
-            cl.outputChannel.appendLine("The Slint Language Server crashed. This is a bug.\nPlease open an issue on https://github.com/slint-ui/slint/issues");
+        if (
+            !properly_stopped &&
+            event.newState === State.Stopped &&
+            event.oldState === State.Running
+        ) {
+            cl.outputChannel.appendLine(
+                "The Slint Language Server crashed. This is a bug.\nPlease open an issue on https://github.com/slint-ui/slint/issues",
+            );
             cl.outputChannel.show();
-            vscode.commands.executeCommand('workbench.action.output.focus');
-            vscode.window.showErrorMessage("The Slint Language Server crashed! Please open a bug on the Slint bug tracker with the panic message.");
+            vscode.commands.executeCommand("workbench.action.output.focus");
+            vscode.window.showErrorMessage(
+                "The Slint Language Server crashed! Please open a bug on the Slint bug tracker with the panic message.",
+            );
         }
     });
 

--- a/editors/vscode/src/welcome/welcome_panel.ts
+++ b/editors/vscode/src/welcome/welcome_panel.ts
@@ -11,8 +11,7 @@ export class WelcomePanel {
     #webview: vscode.WebviewPanel;
     #disposables: vscode.Disposable[] = [];
 
-    constructor(extensionPath: string, column: vscode.ViewColumn) {
-        const url = vscode.Uri.file(extensionPath);
+    constructor(extensionPath: vscode.Uri, column: vscode.ViewColumn) {
         this.#webview = vscode.window.createWebviewPanel(
             "slint.WelcomePage",
             "Slint Welcome Page",
@@ -20,10 +19,9 @@ export class WelcomePanel {
             {
                 enableScripts: true,
                 retainContextWhenHidden: true,
-                localResourceRoots: [vscode.Uri.joinPath(url, "static")],
             },
         );
-        this.getHtml(url).then(
+        this.getHtml(extensionPath).then(
             (contents) => (this.#webview.webview.html = contents),
         );
         this.#webview.webview.onDidReceiveMessage(async (message: any) => {
@@ -50,7 +48,7 @@ export class WelcomePanel {
         this.#webview.dispose();
     }
 
-    public static createOrShow(extensionPath: string) {
+    public static createOrShow(extensionPath: vscode.Uri) {
         const column = vscode.window.activeTextEditor?.viewColumn;
         if (WelcomePanel.#currentPanel) {
             WelcomePanel.#currentPanel.#webview.reveal(column);
@@ -63,7 +61,7 @@ export class WelcomePanel {
         WelcomePanel.updateShowConfig();
     }
 
-    public static maybeShow(extensionPath: string) {
+    public static maybeShow(extensionPath: vscode.Uri) {
         if (WelcomePanel.openPanelOnActivation()) {
             WelcomePanel.createOrShow(extensionPath);
         }

--- a/tools/slintpad/src/tsconfig.json
+++ b/tools/slintpad/src/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": ["dom", "es2021"],
         "types": ["json-schema", "vscode"]
     },
-    "include": ["./*.ts", "./shared/*.ts", "../package.json"],
+    "include": ["./*.ts", "./shared/*.ts", "../package.json", "./welcome/*.ts"],
     "references": [
         {
             "path": "worker"


### PR DESCRIPTION
Make sure to pass around the extensionUrl, not the extensioPath. The web extension seems to need the full URL when actually deploying this. It works fine in web extension test mode either way.

Sorry, some linter fixes sneaked in as well, which unfortunately lead to some reformatting :-/