### PR TITLE
C++: Improve type-safety of NativeWindowHandle API on macOS

### DIFF
--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -15,6 +15,16 @@ struct xcb_connection_t;
 struct wl_surface;
 struct wl_display;
 
+#    if defined(__APPLE__) && !defined(_WIN32) && !defined(_WIN64)
+#        ifdef __OBJC__
+@class NSView;
+@class NSWindow;
+#        else
+typedef struct objc_object NSView;
+typedef struct objc_object NSWindow;
+#        endif
+#    endif
+
 namespace slint {
 
 /// This namespace contains experimental API.
@@ -378,7 +388,7 @@ public:
 
 #    elif defined(__APPLE__) && !defined(_WIN32) && !defined(_WIN64)
 
-    static NativeWindowHandle from_appkit(void *nsview, void *nswindow)
+    static NativeWindowHandle from_appkit(NSView *nsview, NSWindow *nswindow)
     {
 
         return { cbindgen_private::slint_new_raw_window_handle_appkit(nsview, nswindow) };

--- a/api/cpp/tests/manual/platform_qt/main.cpp
+++ b/api/cpp/tests/manual/platform_qt/main.cpp
@@ -31,8 +31,10 @@ static slint_platform::NativeWindowHandle window_handle_for_qt_window(QWindow *w
     window->create();
 #ifdef __APPLE__
     QPlatformNativeInterface *native = qApp->platformNativeInterface();
-    void *nsview = native->nativeResourceForWindow(QByteArray("nsview"), window);
-    void *nswindow = native->nativeResourceForWindow(QByteArray("nswindow"), window);
+    NSView *nsview = reinterpret_cast<NSView *>(
+            native->nativeResourceForWindow(QByteArray("nsview"), window));
+    NSWindow *nswindow = reinterpret_cast<NSWindow *>(
+            native->nativeResourceForWindow(QByteArray("nswindow"), window));
     return slint_platform::NativeWindowHandle::from_appkit(nsview, nswindow);
 #elif defined Q_OS_WIN
     auto wid = Qt::HANDLE(window->winId());


### PR DESCRIPTION
Replace void* with forward-declared NSView/NSWindow in NativeWindowHandle::from_appkit