### PR TITLE
Remove the window parameter from the render() function of all the renderers

### DIFF
--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -351,11 +351,10 @@ public:
     ///
     /// The stride is the amount of pixels between two lines in the buffer.
     /// It is must be at least as large as the width of the window.
-    PhysicalRegion render(const Window &window, std::span<slint::Rgb8Pixel> buffer,
-                          std::size_t pixel_stride) const
+    PhysicalRegion render(std::span<slint::Rgb8Pixel> buffer, std::size_t pixel_stride) const
     {
-        auto r = cbindgen_private::slint_software_renderer_render_rgb8(
-                inner, &window.window_handle().inner, buffer.data(), buffer.size(), pixel_stride);
+        auto r = cbindgen_private::slint_software_renderer_render_rgb8(inner, buffer.data(),
+                                                                       buffer.size(), pixel_stride);
         return PhysicalRegion { r };
     }
 
@@ -365,12 +364,10 @@ public:
     ///
     /// The stride is the amount of pixels between two lines in the buffer.
     /// It is must be at least as large as the width of the window.
-    PhysicalRegion render(const Window &window, std::span<Rgb565Pixel> buffer,
-                          std::size_t pixel_stride) const
+    PhysicalRegion render(std::span<Rgb565Pixel> buffer, std::size_t pixel_stride) const
     {
         auto r = cbindgen_private::slint_software_renderer_render_rgb565(
-                inner, &window.window_handle().inner, reinterpret_cast<uint16_t *>(buffer.data()),
-                buffer.size(), pixel_stride);
+                inner, reinterpret_cast<uint16_t *>(buffer.data()), buffer.size(), pixel_stride);
         return PhysicalRegion { r };
     }
 };
@@ -483,10 +480,7 @@ public:
         inner = cbindgen_private::slint_skia_renderer_new(window_handle.inner, initial_size);
     }
 
-    void render(const Window &window) const
-    {
-        cbindgen_private::slint_skia_renderer_render(inner, &window.window_handle().inner);
-    }
+    void render() const { cbindgen_private::slint_skia_renderer_render(inner); }
 
     void resize(PhysicalSize size) const
     {

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -281,15 +281,12 @@ pub unsafe extern "C" fn slint_software_renderer_drop(r: SoftwareRendererOpaque)
 #[no_mangle]
 pub unsafe extern "C" fn slint_software_renderer_render_rgb8(
     r: SoftwareRendererOpaque,
-    window_adapter: *const WindowAdapterRcOpaque,
     buffer: *mut Rgb8Pixel,
     buffer_len: usize,
     pixel_stride: usize,
 ) -> IntRect {
     let buffer = core::slice::from_raw_parts_mut(buffer, buffer_len);
     let renderer = &*(r as *const SoftwareRenderer);
-    let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
-    renderer.set_window(window_adapter.window());
     let r = renderer.render(buffer, pixel_stride);
     let (orig, size) = (r.bounding_box_origin(), r.bounding_box_size());
     i_slint_core::graphics::euclid::rect(orig.x, orig.y, size.width as i32, size.height as i32)
@@ -298,15 +295,12 @@ pub unsafe extern "C" fn slint_software_renderer_render_rgb8(
 #[no_mangle]
 pub unsafe extern "C" fn slint_software_renderer_render_rgb565(
     r: SoftwareRendererOpaque,
-    window_adapter: *const WindowAdapterRcOpaque,
     buffer: *mut u16,
     buffer_len: usize,
     pixel_stride: usize,
 ) -> IntRect {
     let buffer = core::slice::from_raw_parts_mut(buffer as *mut Rgb565Pixel, buffer_len);
     let renderer = &*(r as *const SoftwareRenderer);
-    let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
-    renderer.set_window(window_adapter.window());
     let r = renderer.render(buffer, pixel_stride);
     let (orig, size) = (r.bounding_box_origin(), r.bounding_box_size());
     i_slint_core::graphics::euclid::rect(orig.x, orig.y, size.width as i32, size.height as i32)
@@ -458,13 +452,9 @@ pub mod skia {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn slint_skia_renderer_render(
-        r: SkiaRendererOpaque,
-        window: *const WindowAdapterRcOpaque,
-    ) {
-        let window_adapter = &*(window as *const Rc<dyn WindowAdapter>);
+    pub unsafe extern "C" fn slint_skia_renderer_render(r: SkiaRendererOpaque) {
         let r = &*(r as *const SkiaRenderer);
-        r.render(window_adapter.window()).unwrap();
+        r.render().unwrap();
     }
 
     #[no_mangle]

--- a/api/cpp/tests/manual/platform_native/windowadapter_win.h
+++ b/api/cpp/tests/manual/platform_native/windowadapter_win.h
@@ -82,7 +82,7 @@ struct MyWindowAdapter : public slint_platform::WindowAdapter
 
     void render()
     {
-        m_renderer->render(window());
+        m_renderer->render();
         if (has_active_animations())
             request_redraw();
     }

--- a/api/cpp/tests/manual/platform_qt/main.cpp
+++ b/api/cpp/tests/manual/platform_qt/main.cpp
@@ -83,7 +83,7 @@ public:
     {
         slint_platform::update_timers_and_animations();
 
-        m_renderer->render(window());
+        m_renderer->render();
 
         if (has_active_animations()) {
             requestUpdate();

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2016,6 +2016,10 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
         self.cache.component_destroyed(component);
         Ok(())
     }
+
+    fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>) {
+        // No-op because QtWindow is also the WindowAdapter
+    }
 }
 
 fn accessible_item(item: Option<ItemRc>) -> Option<ItemRc> {

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -158,6 +158,10 @@ impl RendererSealed for TestingWindow {
     fn default_font_size(&self) -> LogicalLength {
         LogicalLength::new(10.)
     }
+
+    fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>) {
+        // No-op since TestingWindow is also the WindowAdapter
+    }
 }
 
 /// Initialize the testing backend.

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -45,8 +45,8 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
         Ok((Self { renderer }, winit_window))
     }
 
-    fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
-        self.renderer.render(window)
+    fn render(&self, _window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
+        self.renderer.render()
     }
 
     fn as_core_renderer(&self) -> &dyn Renderer {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -63,7 +63,7 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
     }
 
     fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
-        self.renderer.render(window)
+        self.renderer.render()
     }
 
     fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer {

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -63,8 +63,6 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
             )
         })?;
 
-        self.renderer.set_window(window);
-
         let mut surface = self.surface.borrow_mut();
 
         surface

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 use alloc::boxed::Box;
+use alloc::rc::Rc;
 use core::pin::Pin;
 
 use crate::component::ComponentRef;
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
+use crate::window::WindowAdapter;
 
 /// This trait represents a Renderer that can render a slint scene.
 ///
@@ -103,4 +105,6 @@ pub trait RendererSealed {
     }
 
     fn default_font_size(&self) -> LogicalLength;
+
+    fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>);
 }

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -527,6 +527,7 @@ impl RendererSealed for SoftwareRenderer {
 
     fn set_window_adapter(&self, window_adapter: &Rc<dyn WindowAdapter>) {
         *self.maybe_window_adapter.borrow_mut() = Some(Rc::downgrade(window_adapter));
+        self.partial_cache.borrow_mut().clear();
     }
 }
 

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -203,12 +203,10 @@ impl SoftwareRenderer {
     ///
     /// returns the dirty region for this frame (not including the extra_draw_region)
     pub fn render(&self, buffer: &mut [impl TargetPixel], pixel_stride: usize) -> PhysicalRegion {
-        let window = self
-            .maybe_window_adapter
-            .borrow()
-            .as_ref()
-            .and_then(|w| w.upgrade())
-            .expect("render() called on a destroyed Window");
+        let Some(window) = self.maybe_window_adapter.borrow().as_ref().and_then(|w| w.upgrade())
+        else {
+            return Default::default();
+        };
         let window_inner = WindowInner::from_pub(window.window());
         let factor = ScaleFactor::new(window_inner.scale_factor());
         let (size, background) = if let Some(window_item) =
@@ -318,12 +316,10 @@ impl SoftwareRenderer {
     /// # }
     /// ```
     pub fn render_by_line(&self, line_buffer: impl LineBufferProvider) -> PhysicalRegion {
-        let window = self
-            .maybe_window_adapter
-            .borrow()
-            .as_ref()
-            .and_then(|w| w.upgrade())
-            .expect("render() called on a destroyed Window");
+        let Some(window) = self.maybe_window_adapter.borrow().as_ref().and_then(|w| w.upgrade())
+        else {
+            return Default::default();
+        };
         let window_inner = WindowInner::from_pub(window.window());
         let component_rc = window_inner.component();
         let component = crate::component::ComponentRc::borrow_pin(&component_rc);

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1292,10 +1292,15 @@ fn test_empty_window() {
         crate::software_renderer::RepaintBufferType::NewBuffer,
     );
     msw.window().request_redraw();
-    msw.draw_if_needed(|renderer| {
+    let mut region = None;
+    let render_called = msw.draw_if_needed(|renderer| {
         let mut buffer =
             crate::graphics::SharedPixelBuffer::<crate::graphics::Rgb8Pixel>::new(100, 100);
         let stride = buffer.width() as usize;
-        renderer.render(buffer.make_mut_slice(), stride);
+        region = Some(renderer.render(buffer.make_mut_slice(), stride));
     });
+    assert!(render_called);
+    let region = region.unwrap();
+    assert_eq!(region.bounding_box_size(), PhysicalSize::default());
+    assert_eq!(region.bounding_box_origin(), PhysicalPosition::default());
 }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -371,6 +371,7 @@ impl WindowInner {
         self.component.replace(ComponentRc::downgrade(component));
         self.pinned_fields.window_properties_tracker.set_dirty(); // component changed, layout constraints for sure must be re-calculated
         let window_adapter = self.window_adapter();
+        window_adapter.renderer().set_window_adapter(&window_adapter);
         {
             let component = ComponentRc::borrow_pin(component);
             let root_item = component.as_ref().get_item_ref(0);

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -475,6 +475,10 @@ impl RendererSealed for FemtoVGRenderer {
 
     fn set_window_adapter(&self, window_adapter: &Rc<dyn WindowAdapter>) {
         *self.maybe_window_adapter.borrow_mut() = Some(Rc::downgrade(window_adapter));
+        if self.opengl_context.ensure_current().is_ok() {
+            self.graphics_cache.clear_all();
+            self.texture_cache.borrow_mut().clear();
+        }
     }
 }
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -345,6 +345,8 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
 
     fn set_window_adapter(&self, window_adapter: &Rc<dyn WindowAdapter>) {
         *self.maybe_window_adapter.borrow_mut() = Some(Rc::downgrade(window_adapter));
+        self.image_cache.clear_all();
+        self.path_cache.clear_all();
     }
 }
 


### PR DESCRIPTION
This makes for a slimmer API and instead we can create the renderer <-> window association behind the scenes ourselves,
in set_component.