### PR TITLE
Simplify FemtoVG and Skia renderer APIs: remove resize()

### DIFF
--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -485,11 +485,6 @@ public:
     }
 
     void render() const { cbindgen_private::slint_skia_renderer_render(inner); }
-
-    void resize(PhysicalSize size) const
-    {
-        cbindgen_private::slint_skia_renderer_resize(inner, size);
-    }
 };
 
 /// Call this function at each iteration of the event loop to call the timer handler and advance

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -446,12 +446,6 @@ pub mod skia {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn slint_skia_renderer_resize(r: SkiaRendererOpaque, size: IntSize) {
-        let r = &*(r as *const SkiaRenderer);
-        r.resize_event(PhysicalSize { width: size.width, height: size.height }).unwrap();
-    }
-
-    #[no_mangle]
     pub unsafe extern "C" fn slint_skia_renderer_render(r: SkiaRendererOpaque) {
         let r = &*(r as *const SkiaRenderer);
         r.render().unwrap();

--- a/api/cpp/tests/manual/platform_native/windowadapter_win.h
+++ b/api/cpp/tests/manual/platform_native/windowadapter_win.h
@@ -89,8 +89,6 @@ struct MyWindowAdapter : public slint_platform::WindowAdapter
 
     void resize(uint32_t width, uint32_t height)
     {
-        slint::PhysicalSize windowSize({ width, height });
-        m_renderer->resize(windowSize);
         dispatch_resize_event(slint::LogicalSize({ (float)width, (float)height }));
     }
 

--- a/api/cpp/tests/manual/platform_qt/main.cpp
+++ b/api/cpp/tests/manual/platform_qt/main.cpp
@@ -121,9 +121,6 @@ public:
     void resizeEvent(QResizeEvent *ev) override
     {
         auto logicalSize = ev->size();
-        float scale_factor = devicePixelRatio();
-        m_renderer->resize(slint::PhysicalSize({ uint32_t(logicalSize.width() * scale_factor),
-                                                 uint32_t(logicalSize.height() * scale_factor) }));
         WindowAdapter::dispatch_resize_event(
                 slint::LogicalSize({ float(logicalSize.width()), float(logicalSize.height()) }));
     }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -24,7 +24,6 @@ pub enum SlintUserEvent {
 }
 
 mod renderer {
-    use i_slint_core::api::PhysicalSize;
     use i_slint_core::platform::PlatformError;
 
     pub(crate) trait WinitCompatibleRenderer {
@@ -37,8 +36,6 @@ mod renderer {
         fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError>;
 
         fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer;
-
-        fn resize_event(&self, size: PhysicalSize) -> Result<(), PlatformError>;
     }
 
     #[cfg(feature = "renderer-winit-femtovg")]

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -1,7 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::Renderer;
 use i_slint_renderer_femtovg::FemtoVGRenderer;
@@ -51,9 +50,5 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
 
     fn as_core_renderer(&self) -> &dyn Renderer {
         &self.renderer
-    }
-
-    fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
-        self.renderer.resize(size)
     }
 }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -69,8 +69,4 @@ impl super::WinitCompatibleRenderer for SkiaRenderer {
     fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer {
         &self.renderer
     }
-
-    fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
-        self.renderer.resize_event(size)
-    }
 }

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -3,7 +3,6 @@
 
 //! Delegate the rendering to the [`i_slint_core::software_renderer::SoftwareRenderer`]
 
-use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::graphics::Rgb8Pixel;
 use i_slint_core::platform::PlatformError;
 use i_slint_core::software_renderer::PremultipliedRgbaColor;
@@ -119,26 +118,6 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
         target_buffer.present().map_err(|e| format!("Error presenting softbuffer buffer: {e}"))?;
 
         Ok(())
-    }
-
-    fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
-        let width = size.width.try_into().map_err(|_| {
-            format!(
-                "Attempting to resize softbuffer window surface with an invalid width: {}",
-                size.width
-            )
-        })?;
-        let height = size.height.try_into().map_err(|_| {
-            format!(
-                "Attempting to resize softbuffer window surface with an invalid height: {}",
-                size.height
-            )
-        })?;
-
-        self.surface
-            .borrow_mut()
-            .resize(width, height)
-            .map_err(|e| format!("Error resizing softbuffer surface: {e}").into())
     }
 
     fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -287,10 +287,8 @@ impl WinitWindowAdapter {
             self.window().dispatch_event(WindowEvent::Resized {
                 size: physical_size.to_logical(scale_factor),
             });
-            self.renderer().resize_event(physical_size)
-        } else {
-            Ok(())
         }
+        Ok(())
     }
 
     pub fn set_dark_color_scheme(&self, dark_mode: bool) {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -437,6 +437,7 @@ impl Window {
     ///
     /// Any position fields in the event must be in the logical pixel coordinate system relative to
     /// the top left corner of the window.
+    // TODO: Return a Result<(), PlatformError>
     pub fn dispatch_event(&self, event: crate::platform::WindowEvent) {
         match event {
             crate::platform::WindowEvent::PointerPressed { position, button } => {
@@ -488,6 +489,11 @@ impl Window {
             }
             crate::platform::WindowEvent::Resized { size } => {
                 self.0.set_window_item_geometry(size.to_euclid());
+                self.0
+                    .window_adapter()
+                    .renderer()
+                    .resize(size.to_physical(self.scale_factor()))
+                    .unwrap()
             }
         }
     }

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -5,6 +5,7 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::pin::Pin;
 
+use crate::api::PlatformError;
 use crate::component::ComponentRef;
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
 use crate::window::WindowAdapter;
@@ -107,4 +108,8 @@ pub trait RendererSealed {
     fn default_font_size(&self) -> LogicalLength;
 
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>);
+
+    fn resize(&self, _size: crate::api::PhysicalSize) -> Result<(), PlatformError> {
+        Ok(())
+    }
 }

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -264,11 +264,6 @@ impl FemtoVGRenderer {
         self.opengl_context.swap_buffers()
     }
 
-    /// Inform the renderer about the new size of the underlying window.
-    pub fn resize(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
-        self.opengl_context.resize(size)
-    }
-
     #[cfg(not(target_arch = "wasm32"))]
     fn with_graphics_api(
         &self,
@@ -479,6 +474,10 @@ impl RendererSealed for FemtoVGRenderer {
             self.graphics_cache.clear_all();
             self.texture_cache.borrow_mut().clear();
         }
+    }
+
+    fn resize(&self, size: i_slint_core::api::PhysicalSize) -> Result<(), PlatformError> {
+        self.opengl_context.resize(size)
     }
 }
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -171,14 +171,6 @@ impl SkiaRenderer {
         })
     }
 
-    /// Call this when you receive a notification from the windowing system that the size of the window has changed.
-    pub fn resize_event(
-        &self,
-        size: PhysicalWindowSize,
-    ) -> Result<(), i_slint_core::platform::PlatformError> {
-        self.surface.resize_event(size)
-    }
-
     fn window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
         self.maybe_window_adapter
             .borrow()
@@ -347,6 +339,10 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         *self.maybe_window_adapter.borrow_mut() = Some(Rc::downgrade(window_adapter));
         self.image_cache.clear_all();
         self.path_cache.clear_all();
+    }
+
+    fn resize(&self, size: i_slint_core::api::PhysicalSize) -> Result<(), PlatformError> {
+        self.surface.resize_event(size)
     }
 }
 


### PR DESCRIPTION
We can convey the new physical window size from the run-time through the private renderer API
when a window resize event is dispatched.