### PR TITLE
vscode extension: Use the wasm preview in codespaces

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -202,7 +202,7 @@ function startClient(context: vscode.ExtensionContext) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-    if (!!process.env.CODESPACES) {
+    if (process.env.hasOwnProperty("CODESPACES")) {
         vscode.workspace.getConfiguration("slint").update("preview.providedByEditor", true, vscode.ConfigurationTarget.Global);
     }
     [statusBar, properties_provider] = common.activate(context, client, (ctx) =>

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -202,6 +202,9 @@ function startClient(context: vscode.ExtensionContext) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
+    if (!!process.env.CODESPACES) {
+        vscode.workspace.getConfiguration("slint").update("preview.providedByEditor", true, vscode.ConfigurationTarget.Global);
+    }
     [statusBar, properties_provider] = common.activate(context, client, (ctx) =>
         startClient(ctx),
     );


### PR DESCRIPTION
Attempt to detect when we are running in a codespace and force the preview to render in wasm.
Remote view don't make sense as there is no graphical server where the extension runs