### PR TITLE
Simplify the SkiaRenderer C++ constructor

### DIFF
--- a/api/cpp/include/slint_platform.h
+++ b/api/cpp/include/slint_platform.h
@@ -478,10 +478,10 @@ public:
     SkiaRenderer(const SkiaRenderer &) = delete;
     SkiaRenderer &operator=(const SkiaRenderer &) = delete;
     /// Constructs a new Skia renderer for the given window - referenced by the provided
-    /// WindowHandle - and the specified initial size.
-    explicit SkiaRenderer(const NativeWindowHandle &window_handle, PhysicalSize initial_size)
+    /// WindowHandle.
+    explicit SkiaRenderer(const NativeWindowHandle &window_handle)
     {
-        inner = cbindgen_private::slint_skia_renderer_new(window_handle.inner, initial_size);
+        inner = cbindgen_private::slint_skia_renderer_new(window_handle.inner);
     }
 
     void render() const { cbindgen_private::slint_skia_renderer_render(inner); }

--- a/api/cpp/tests/manual/platform_native/windowadapter_win.h
+++ b/api/cpp/tests/manual/platform_native/windowadapter_win.h
@@ -56,8 +56,7 @@ struct MyWindowAdapter : public slint_platform::WindowAdapter
                               NULL // Additional application data
         );
 
-        m_renderer.emplace(slint_platform::NativeWindowHandle::from_win32(hwnd, hInstance),
-                           slint::PhysicalSize({ 600, 300 }));
+        m_renderer.emplace(slint_platform::NativeWindowHandle::from_win32(hwnd, hInstance));
 
         SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)this);
     }

--- a/api/cpp/tests/manual/platform_qt/main.cpp
+++ b/api/cpp/tests/manual/platform_qt/main.cpp
@@ -68,8 +68,7 @@ class MyWindow : public QWindow, public slint_platform::WindowAdapter
 public:
     MyWindow(QWindow *parentWindow = nullptr) : QWindow(parentWindow)
     {
-        resize(640, 480);
-        m_renderer.emplace(window_handle_for_qt_window(this), physical_size());
+        m_renderer.emplace(window_handle_for_qt_window(this));
     }
 
     slint_platform::AbstractRenderer &renderer() override { return m_renderer.value(); }

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -8,6 +8,8 @@ use i_slint_renderer_femtovg::FemtoVGRenderer;
 #[cfg(target_arch = "wasm32")]
 use winit::platform::web::WindowExtWebSys;
 
+use crate::WinitWindowRc;
+
 #[cfg(not(target_arch = "wasm32"))]
 mod glcontext;
 
@@ -18,7 +20,7 @@ pub struct GlutinFemtoVGRenderer {
 impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn new(
         window_builder: winit::window::WindowBuilder,
-    ) -> Result<(Self, winit::window::Window), PlatformError> {
+    ) -> Result<(Self, WinitWindowRc), PlatformError> {
         #[cfg(not(target_arch = "wasm32"))]
         let (winit_window, opengl_context) = crate::event_loop::with_window_target(|event_loop| {
             glcontext::OpenGLContext::new_context(window_builder, event_loop.event_loop_target())
@@ -41,7 +43,7 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
             winit_window.canvas(),
         )?;
 
-        Ok((Self { renderer }, winit_window))
+        Ok((Self { renderer }, winit_window.into()))
     }
 
     fn render(&self, _window: &i_slint_core::api::Window) -> Result<(), PlatformError> {

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+use std::rc::Rc;
+
 use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::Renderer;
 use i_slint_renderer_femtovg::FemtoVGRenderer;
@@ -8,7 +10,7 @@ use i_slint_renderer_femtovg::FemtoVGRenderer;
 #[cfg(target_arch = "wasm32")]
 use winit::platform::web::WindowExtWebSys;
 
-use crate::WinitWindowRc;
+use crate::WinitWindow;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod glcontext;
@@ -20,7 +22,7 @@ pub struct GlutinFemtoVGRenderer {
 impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn new(
         window_builder: winit::window::WindowBuilder,
-    ) -> Result<(Self, WinitWindowRc), PlatformError> {
+    ) -> Result<(Self, Rc<WinitWindow>), PlatformError> {
         #[cfg(not(target_arch = "wasm32"))]
         let (winit_window, opengl_context) = crate::event_loop::with_window_target(|event_loop| {
             glcontext::OpenGLContext::new_context(window_builder, event_loop.event_loop_target())
@@ -43,7 +45,7 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
             winit_window.canvas(),
         )?;
 
-        Ok((Self { renderer }, winit_window.into()))
+        Ok((Self { renderer }, Rc::new(winit_window.into())))
     }
 
     fn render(&self, _window: &i_slint_core::api::Window) -> Result<(), PlatformError> {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -1,9 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+use std::rc::Rc;
+
 use i_slint_core::platform::PlatformError;
 
-use crate::WinitWindowRc;
+use crate::WinitWindow;
 
 pub struct SkiaRenderer {
     renderer: i_slint_renderer_skia::SkiaRenderer,
@@ -12,14 +14,14 @@ pub struct SkiaRenderer {
 impl super::WinitCompatibleRenderer for SkiaRenderer {
     fn new(
         window_builder: winit::window::WindowBuilder,
-    ) -> Result<(Self, WinitWindowRc), PlatformError> {
+    ) -> Result<(Self, Rc<WinitWindow>), PlatformError> {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_error| {
                 format!("Error creating native window for Skia rendering: {}", winit_os_error)
             })
         })?;
 
-        let winit_window: WinitWindowRc = winit_window.into();
+        let winit_window: Rc<WinitWindow> = Rc::new(winit_window.into());
 
         let renderer =
             i_slint_renderer_skia::SkiaRenderer::new(winit_window.clone(), winit_window.clone())?;

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -1,11 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::platform::PlatformError;
 
-use raw_window_handle::HasRawDisplayHandle;
-use raw_window_handle::HasRawWindowHandle;
+use crate::WinitWindowRc;
 
 pub struct SkiaRenderer {
     renderer: i_slint_renderer_skia::SkiaRenderer,
@@ -14,50 +12,17 @@ pub struct SkiaRenderer {
 impl super::WinitCompatibleRenderer for SkiaRenderer {
     fn new(
         window_builder: winit::window::WindowBuilder,
-    ) -> Result<(Self, winit::window::Window), PlatformError> {
+    ) -> Result<(Self, WinitWindowRc), PlatformError> {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_error| {
                 format!("Error creating native window for Skia rendering: {}", winit_os_error)
             })
         })?;
 
-        let size: winit::dpi::PhysicalSize<u32> = winit_window.inner_size();
+        let winit_window: WinitWindowRc = winit_window.into();
 
-        let width: u32 = size.width.try_into().map_err(|_| {
-            format!(
-                "Attempting to create a Skia window surface with an invalid width: {}",
-                size.width
-            )
-        })?;
-        let height: u32 = size.height.try_into().map_err(|_| {
-            format!(
-                "Attempting to create a Skia window surface with an invalid height: {}",
-                size.height
-            )
-        })?;
-
-        // Safety: This is safe because the handle remains valid; the next rwh release provides `new()` without unsafe.
-        let active_handle = unsafe { raw_window_handle::ActiveHandle::new_unchecked() };
-
-        // Safety: API wise we can't guarantee that the window/display handles remain valid, so we
-        // use unsafe here. However the winit window adapter keeps the winit window alive as long as
-        // the renderer.
-        // TODO: remove once winit implements HasWindowHandle/HasDisplayHandle
-        let (window_handle, display_handle) = unsafe {
-            (
-                raw_window_handle::WindowHandle::borrow_raw(
-                    winit_window.raw_window_handle(),
-                    active_handle,
-                ),
-                raw_window_handle::DisplayHandle::borrow_raw(winit_window.raw_display_handle()),
-            )
-        };
-
-        let renderer = i_slint_renderer_skia::SkiaRenderer::new(
-            window_handle,
-            display_handle,
-            PhysicalWindowSize::new(width, height),
-        )?;
+        let renderer =
+            i_slint_renderer_skia::SkiaRenderer::new(winit_window.clone(), winit_window.clone())?;
 
         Ok((Self { renderer }, winit_window))
     }

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -9,6 +9,8 @@ use i_slint_core::software_renderer::PremultipliedRgbaColor;
 pub use i_slint_core::software_renderer::SoftwareRenderer;
 use std::cell::RefCell;
 
+use crate::WinitWindowRc;
+
 pub struct WinitSoftwareRenderer {
     renderer: SoftwareRenderer,
     _context: softbuffer::Context,
@@ -18,7 +20,7 @@ pub struct WinitSoftwareRenderer {
 impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
     fn new(
         window_builder: winit::window::WindowBuilder,
-    ) -> Result<(Self, winit::window::Window), PlatformError> {
+    ) -> Result<(Self, WinitWindowRc), PlatformError> {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_error| {
                 format!("Error creating native window for software rendering: {}", winit_os_error)
@@ -42,7 +44,7 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
                 _context: context,
                 surface: RefCell::new(surface),
             },
-            winit_window,
+            winit_window.into(),
         ))
     }
 

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -8,8 +8,9 @@ use i_slint_core::platform::PlatformError;
 use i_slint_core::software_renderer::PremultipliedRgbaColor;
 pub use i_slint_core::software_renderer::SoftwareRenderer;
 use std::cell::RefCell;
+use std::rc::Rc;
 
-use crate::WinitWindowRc;
+use crate::WinitWindow;
 
 pub struct WinitSoftwareRenderer {
     renderer: SoftwareRenderer,
@@ -20,7 +21,7 @@ pub struct WinitSoftwareRenderer {
 impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
     fn new(
         window_builder: winit::window::WindowBuilder,
-    ) -> Result<(Self, WinitWindowRc), PlatformError> {
+    ) -> Result<(Self, Rc<WinitWindow>), PlatformError> {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_error| {
                 format!("Error creating native window for software rendering: {}", winit_os_error)
@@ -44,7 +45,7 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
                 _context: context,
                 surface: RefCell::new(surface),
             },
-            winit_window.into(),
+            Rc::new(winit_window.into()),
         ))
     }
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -17,7 +17,7 @@ use std::rc::Weak;
 use winit::platform::web::WindowExtWebSys;
 
 use crate::renderer::WinitCompatibleRenderer;
-use crate::WinitWindowRc;
+use crate::WinitWindow;
 use const_field_offset::FieldOffsets;
 
 use corelib::component::ComponentRc;
@@ -130,7 +130,7 @@ pub struct WinitWindowAdapter {
     #[cfg(enable_accesskit)]
     pub accesskit_adapter: crate::accesskit::AccessKitAdapter,
 
-    winit_window: WinitWindowRc, // Last field so that any previously provided window handles are still valid in the drop impl of the renderers, etc.
+    winit_window: Rc<WinitWindow>,
 }
 
 impl WinitWindowAdapter {
@@ -252,8 +252,8 @@ impl WinitWindowAdapter {
         callback(&self.winit_window());
     }
 
-    pub fn winit_window(&self) -> Rc<winit::window::Window> {
-        self.winit_window.0.clone()
+    pub(crate) fn winit_window(&self) -> Rc<WinitWindow> {
+        self.winit_window.clone()
     }
 
     pub fn is_shown(&self) -> bool {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -17,6 +17,7 @@ use std::rc::Weak;
 use winit::platform::web::WindowExtWebSys;
 
 use crate::renderer::WinitCompatibleRenderer;
+use crate::WinitWindowRc;
 use const_field_offset::FieldOffsets;
 
 use corelib::component::ComponentRc;
@@ -129,7 +130,7 @@ pub struct WinitWindowAdapter {
     #[cfg(enable_accesskit)]
     pub accesskit_adapter: crate::accesskit::AccessKitAdapter,
 
-    winit_window: Rc<winit::window::Window>, // Last field so that any previously provided window handles are still valid in the drop impl of the renderers, etc.
+    winit_window: WinitWindowRc, // Last field so that any previously provided window handles are still valid in the drop impl of the renderers, etc.
 }
 
 impl WinitWindowAdapter {
@@ -143,8 +144,6 @@ impl WinitWindowAdapter {
             canvas_id,
         )
         .and_then(|builder| R::new(builder))?;
-
-        let winit_window = Rc::new(winit_window);
 
         let self_rc = Rc::new_cyclic(|self_weak| Self {
             window: OnceCell::with_value(corelib::api::Window::new(self_weak.clone() as _)),
@@ -254,7 +253,7 @@ impl WinitWindowAdapter {
     }
 
     pub fn winit_window(&self) -> Rc<winit::window::Window> {
-        self.winit_window.clone()
+        self.winit_window.0.clone()
     }
 
     pub fn is_shown(&self) -> bool {

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -288,8 +288,6 @@ pub struct D3DSurface {
 }
 
 impl super::Surface for D3DSurface {
-    const SUPPORTS_GRAPHICS_API: bool = false;
-
     fn new(
         window_handle: raw_window_handle::WindowHandle<'_>,
         _display_handle: raw_window_handle::DisplayHandle<'_>,
@@ -430,10 +428,6 @@ impl super::Surface for D3DSurface {
         "d3d"
     }
 
-    fn with_graphics_api(&self, _cb: impl FnOnce(i_slint_core::api::GraphicsAPI<'_>)) {
-        unimplemented!()
-    }
-
     fn resize_event(
         &self,
         size: PhysicalWindowSize,
@@ -444,7 +438,7 @@ impl super::Surface for D3DSurface {
     fn render(
         &self,
         _size: PhysicalWindowSize,
-        callback: impl FnOnce(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
+        callback: &dyn Fn(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         self.swap_chain
             .borrow_mut()

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -65,15 +65,15 @@ pub struct SkiaRenderer {
     rendering_metrics_collector: RefCell<Option<Rc<RenderingMetricsCollector>>>,
     rendering_first_time: Cell<bool>,
     surface: once_cell::unsync::OnceCell<Box<dyn Surface>>,
-    window_handle_provider: Box<dyn raw_window_handle::HasWindowHandle>,
-    display_handle_provider: Box<dyn raw_window_handle::HasDisplayHandle>,
+    window_handle_provider: Rc<dyn raw_window_handle::HasWindowHandle>,
+    display_handle_provider: Rc<dyn raw_window_handle::HasDisplayHandle>,
 }
 
 impl SkiaRenderer {
     /// Creates a new renderer is associated with the provided window adapter.
     pub fn new(
-        window_handle_provider: impl raw_window_handle::HasWindowHandle + 'static,
-        display_handle_provider: impl raw_window_handle::HasDisplayHandle + 'static,
+        window_handle_provider: Rc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle_provider: Rc<dyn raw_window_handle::HasDisplayHandle>,
     ) -> Result<Self, PlatformError> {
         Ok(Self {
             maybe_window_adapter: Default::default(),
@@ -83,8 +83,8 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Cell::new(true),
             surface: Default::default(),
-            window_handle_provider: Box::new(window_handle_provider),
-            display_handle_provider: Box::new(display_handle_provider),
+            window_handle_provider,
+            display_handle_provider,
         })
     }
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -91,7 +91,7 @@ impl SkiaRenderer {
     /// Render the scene in the previously associated window. The size parameter must match the size of the window.
     pub fn render(&self) -> Result<(), i_slint_core::platform::PlatformError> {
         let Some(surface) = self.surface.get() else {
-            return Err(format!("Skia Renderer: render() called before a resize event was dispatched to the slint::Window").into())
+            return Err(format!("Skia Renderer: render() called before a resize event was dispatched to the slint::Window").into());
         };
 
         if self.rendering_first_time.take() {

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -20,8 +20,6 @@ pub struct MetalSurface {
 }
 
 impl super::Surface for MetalSurface {
-    const SUPPORTS_GRAPHICS_API: bool = false;
-
     fn new(
         window_handle: raw_window_handle::WindowHandle<'_>,
         _display_handle: raw_window_handle::DisplayHandle<'_>,
@@ -70,10 +68,6 @@ impl super::Surface for MetalSurface {
         "metal"
     }
 
-    fn with_graphics_api(&self, _cb: impl FnOnce(i_slint_core::api::GraphicsAPI<'_>)) {
-        unimplemented!()
-    }
-
     fn resize_event(
         &self,
         size: PhysicalWindowSize,
@@ -85,7 +79,7 @@ impl super::Surface for MetalSurface {
     fn render(
         &self,
         _size: PhysicalWindowSize,
-        callback: impl FnOnce(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
+        callback: &dyn Fn(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         autoreleasepool(|| {
             let drawable = match self.layer.next_drawable() {

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -23,8 +23,6 @@ pub struct OpenGLSurface {
 }
 
 impl super::Surface for OpenGLSurface {
-    const SUPPORTS_GRAPHICS_API: bool = true;
-
     fn new(
         window_handle: raw_window_handle::WindowHandle<'_>,
         display_handle: raw_window_handle::DisplayHandle<'_>,
@@ -98,7 +96,11 @@ impl super::Surface for OpenGLSurface {
         "opengl"
     }
 
-    fn with_graphics_api(&self, callback: impl FnOnce(GraphicsAPI<'_>)) {
+    fn supports_graphics_api(&self) -> bool {
+        true
+    }
+
+    fn with_graphics_api(&self, callback: &mut dyn FnMut(GraphicsAPI<'_>)) {
         let api = GraphicsAPI::NativeOpenGL {
             get_proc_address: &|name| {
                 self.glutin_context.display().get_proc_address(name) as *const _
@@ -107,7 +109,7 @@ impl super::Surface for OpenGLSurface {
         callback(api)
     }
 
-    fn with_active_surface(&self, callback: impl FnOnce()) -> Result<(), PlatformError> {
+    fn with_active_surface(&self, callback: &mut dyn FnMut()) -> Result<(), PlatformError> {
         self.ensure_context_current()?;
         callback();
         Ok(())
@@ -116,7 +118,7 @@ impl super::Surface for OpenGLSurface {
     fn render(
         &self,
         size: PhysicalWindowSize,
-        callback: impl FnOnce(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
+        callback: &dyn Fn(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
     ) -> Result<(), PlatformError> {
         self.ensure_context_current()?;
 

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -34,8 +34,6 @@ pub struct VulkanSurface {
 }
 
 impl super::Surface for VulkanSurface {
-    const SUPPORTS_GRAPHICS_API: bool = false;
-
     fn new(
         window_handle: raw_window_handle::WindowHandle<'_>,
         display_handle: raw_window_handle::DisplayHandle<'_>,
@@ -205,10 +203,6 @@ impl super::Surface for VulkanSurface {
         "vulkan"
     }
 
-    fn with_graphics_api(&self, _cb: impl FnOnce(i_slint_core::api::GraphicsAPI<'_>)) {
-        unimplemented!()
-    }
-
     fn resize_event(
         &self,
         _size: PhysicalWindowSize,
@@ -220,7 +214,7 @@ impl super::Surface for VulkanSurface {
     fn render(
         &self,
         size: PhysicalWindowSize,
-        callback: impl FnOnce(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
+        callback: &dyn Fn(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         let gr_context = &mut self.gr_context.borrow_mut();
 


### PR DESCRIPTION
Remove the size parameter, and instead allocate the
renderer's surface on demand.