### PR TITLE
C++, remove the experimental flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,7 +214,7 @@ jobs:
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
         cmakeListsTxtPath: CMakeLists.txt
-        cmakeAppendedArgs: '-DSLINT_BUILD_TESTING=ON -DSLINT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Debug -DSLINT_FEATURE_EXPERIMENTAL=ON'
+        cmakeAppendedArgs: '-DSLINT_BUILD_TESTING=ON -DSLINT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Debug -DSLINT_FEATURE_RENDERER_SKIA=ON'
         buildDirectory: ${{ runner.workspace }}/cppbuild
         buildWithCMakeArgs: '--config Debug'
     - name: ctest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project are documented in this file.
 
 ### C++
 
+ - Added Platform API to write your own platform that drives its own event loop.
  - Added `SLINT_TARGET_CARGO_FLAGS` cmake variable
  - Added `ReverseModel`
  - Added functions in Window to dispatch pointer events

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -143,7 +143,6 @@ define_cargo_feature(renderer-software "Enable support for the software renderer
 
 define_cargo_dependent_feature(backend-qt "Enable Qt based rendering backend" ON SLINT_FEATURE_STD)
 
-define_cargo_feature(experimental "Enable experimental features (no compatibility guarantees)" OFF)
 define_cargo_dependent_feature(gettext "Enable support of translations using gettext" OFF SLINT_FEATURE_STD)
 define_cargo_dependent_feature(accessibility "Enable integration with operating system provided accessibility APIs" ON SLINT_FEATURE_STD)
 
@@ -153,10 +152,6 @@ if (NOT SLINT_FEATURE_STD)
     if (ESP_PLATFORM)
         list(APPEND features "esp-backtrace/${IDF_TARGET}")
     endif()
-endif()
-
-if (SLINT_FEATURE_STD AND SLINT_FEATURE_EXPERIMENTAL)
-    list(APPEND features experimental-skia)
 endif()
 
 set_property(

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -31,19 +31,16 @@ backend-winit = ["i-slint-backend-selector/backend-winit", "std"]
 backend-winit-x11 = ["i-slint-backend-selector/backend-winit-x11", "std"]
 backend-winit-wayland = ["i-slint-backend-selector/backend-winit-wayland", "std"]
 renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg"]
-renderer-skia = ["i-slint-backend-selector/renderer-skia"]
-renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl"]
-renderer-skia-vulkan = ["i-slint-backend-selector/renderer-skia-vulkan"]
+renderer-skia = ["i-slint-backend-selector/renderer-skia", "i-slint-renderer-skia", "raw-window-handle"]
+renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "renderer-skia"]
+renderer-skia-vulkan = ["i-slint-backend-selector/renderer-skia-vulkan", "renderer-skia"]
 renderer-software = ["i-slint-backend-selector/renderer-software"]
 gettext = ["i-slint-core/gettext-rs"]
 accessibility = ["i-slint-backend-selector/accessibility"]
 
-experimental = []
-experimental-skia = ["i-slint-renderer-skia", "raw-window-handle", "experimental"]
-
 std = ["image", "i-slint-core/default", "i-slint-backend-selector"]
 
-default = ["std", "backend-winit", "renderer-femtovg", "backend-qt", "experimental"]
+default = ["std", "backend-winit", "renderer-femtovg", "backend-qt"]
 
 [dependencies]
 i-slint-backend-selector = { version = "=1.2.0", path="../../internal/backends/selector", optional = true }

--- a/api/cpp/build.rs
+++ b/api/cpp/build.rs
@@ -23,10 +23,10 @@ fn main() -> Result<(), anyhow::Error> {
 
     let enabled_features = EnabledFeatures {
         interpreter: std::env::var("CARGO_FEATURE_SLINT_INTERPRETER").is_ok(),
-        experimental: std::env::var("CARGO_FEATURE_EXPERIMENTAL").is_ok(),
         backend_qt: std::env::var("CARGO_FEATURE_BACKEND_QT").is_ok(),
         std: std::env::var("CARGO_FEATURE_STD").is_ok(),
         renderer_software: std::env::var("CARGO_FEATURE_RENDERER_SOFTWARE").is_ok(),
+        renderer_skia: std::env::var("CARGO_FEATURE_RENDERER_SKIA").is_ok(),
     };
 
     let dependencies = cbindgen::gen_all(&root_dir, &output_dir, enabled_features)?;

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -722,10 +722,10 @@ fn gen_interpreter(
 #[derive(Clone, Copy)]
 pub struct EnabledFeatures {
     pub interpreter: bool,
-    pub experimental: bool,
     pub backend_qt: bool,
     pub std: bool,
     pub renderer_software: bool,
+    pub renderer_skia: bool,
 }
 
 impl EnabledFeatures {
@@ -735,9 +735,6 @@ impl EnabledFeatures {
         if self.interpreter {
             defines += "#define SLINT_FEATURE_INTERPRETER\n";
         }
-        if self.experimental {
-            defines += "#define SLINT_FEATURE_EXPERIMENTAL\n";
-        }
         if self.backend_qt {
             defines += "#define SLINT_FEATURE_BACKEND_QT\n";
         }
@@ -746,6 +743,9 @@ impl EnabledFeatures {
         }
         if self.renderer_software {
             defines += "#define SLINT_FEATURE_RENDERER_SOFTWARE\n";
+        }
+        if self.renderer_skia {
+            defines += "#define SLINT_FEATURE_RENDERER_SKIA\n";
         }
         defines
     }

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -605,7 +605,6 @@ public:
         inner.dispatch_pointer_event(event);
     }
 
-#ifdef SLINT_FEATURE_EXPERIMENTAL
     /// Set the logical size of this window after a resize event
     ///
     /// The backend must send this event to ensure that the `width` and `height` property of the
@@ -634,18 +633,11 @@ public:
         private_api::assert_main_thread();
         return cbindgen_private::slint_windowrc_has_active_animations(&inner.handle());
     }
-#endif
 
     /// \private
-    private_api::WindowAdapterRc &window_handle()
-    {
-        return inner;
-    }
+    private_api::WindowAdapterRc &window_handle() { return inner; }
     /// \private
-    const private_api::WindowAdapterRc &window_handle() const
-    {
-        return inner;
-    }
+    const private_api::WindowAdapterRc &window_handle() const { return inner; }
 
 private:
     private_api::WindowAdapterRc inner;

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -10,7 +10,6 @@ use alloc::rc::Rc;
 use core::ffi::c_void;
 use i_slint_core::window::{ffi::WindowAdapterRcOpaque, WindowAdapter};
 
-#[cfg(feature = "experimental")]
 pub mod platform;
 
 #[cfg(feature = "i-slint-backend-selector")]

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -249,6 +249,7 @@ pub unsafe extern "C" fn slint_platform_task_run(event: PlatformTaskOpaque) {
 mod software_renderer {
     use super::*;
     type SoftwareRendererOpaque = *const c_void;
+    use i_slint_core::graphics::{IntRect, Rgb8Pixel};
     use i_slint_core::software_renderer::{RepaintBufferType, Rgb565Pixel, SoftwareRenderer};
 
     #[no_mangle]
@@ -310,7 +311,6 @@ mod software_renderer {
 #[cfg(all(feature = "i-slint-renderer-skia", feature = "raw-window-handle"))]
 pub mod skia {
     use super::*;
-    use i_slint_core::graphics::{IntRect, IntSize, Rgb8Pixel};
     use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 
     struct CppRawHandle(RawWindowHandle, RawDisplayHandle);

--- a/api/cpp/tests/CMakeLists.txt
+++ b/api/cpp/tests/CMakeLists.txt
@@ -47,11 +47,12 @@ slint_test(models)
 
 add_subdirectory(multiple-includes)
 
-if(SLINT_FEATURE_EXPERIMENTAL)
-    slint_test(platform_eventloop)
-    target_link_libraries(test_platform_eventloop PRIVATE Threads::Threads)
+slint_test(platform_eventloop)
+target_link_libraries(test_platform_eventloop PRIVATE Threads::Threads)
+
+if(SLINT_FEATURE_RENDER_SKIA OR SLINT_FEATURE_RENDER_SKIA_OPENGL OR SLINT_FEATURE_RENDER_SKIA_VULKAN)
     if(Qt6_FOUND)
         add_subdirectory(manual/platform_qt)
     endif(Qt6_FOUND)
     add_subdirectory(manual/platform_native)
-endif(SLINT_FEATURE_EXPERIMENTAL)
+endif()

--- a/xtask/src/cppdocs.rs
+++ b/xtask/src/cppdocs.rs
@@ -89,10 +89,10 @@ pub fn generate(show_warnings: bool) -> Result<(), Box<dyn std::error::Error>> {
     let generated_headers_dir = docs_build_dir.join("generated_include");
     let enabled_features = cbindgen::EnabledFeatures {
         interpreter: true,
-        experimental: false,
         backend_qt: false,
         std: true,
         renderer_software: true,
+        renderer_skia: true,
     };
     cbindgen::gen_all(&root, &generated_headers_dir, enabled_features)?;
 


### PR DESCRIPTION
The platform namespace is now always enabled.