### PR TITLE
Don't show live-preview in fullscreen when running VS code with WSL

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -41,7 +41,6 @@ function lspPlatform(): Platform | null {
         if (typeof vscode.env.remoteName !== "undefined") {
             remote_env_options = {
                 DISPLAY: ":0",
-                SLINT_FULLSCREEN: "1",
             };
         }
         if (process.arch === "x64") {


### PR DESCRIPTION
Generally, disable the fullscreen rendering. This selection mechanism
needs reworking, as one might want to use the live-preview in a setup
where weston, etc. are running side-by-side.

This could be made configurable in the future, i.e. choosing a backend
like linuxkms, or having the window state as property in Slint.