### PR TITLE
ffmpeg example: Change background color to black

### DIFF
--- a/examples/ffmpeg/scene.slint
+++ b/examples/ffmpeg/scene.slint
@@ -9,6 +9,7 @@ export component App inherits Window {
     min-width: 500px;
     min-height: 300px;
     title: "Slint FFmpeg Example";
+    background: #000000;
     icon: @image-url("../../logo/slint-logo-small-light-128x128.png");
 
     in property <image> video-frame <=> image.source;


### PR DESCRIPTION
In general, black background better matches the aesthetics of video playback apps, making the viewing experience more immersive.