### PR TITLE
Make it easier to use the software renderer with PremultipliedRgbaColor in "foreign" environments

### DIFF
--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -32,7 +32,7 @@ unsafe-single-threaded = []
 unicode = ["unicode-script", "unicode-linebreak"]
 
 software-renderer-systemfonts = ["shared-fontdb", "rustybuzz", "fontdue", "software-renderer"]
-software-renderer = []
+software-renderer = ["bytemuck"]
 
 image-decoders = ["image", "clru"]
 svg = ["dep:resvg", "shared-fontdb"]
@@ -75,6 +75,7 @@ unicode-segmentation = "1.8.0"
 unicode-linebreak = { version = "0.1.2", optional = true }
 unicode-script = { version = "0.5.3", optional = true }
 integer-sqrt = { version = "0.1.5" }
+bytemuck = { version = "1.13.1", optional = true, features = ["derive"] }
 
 image = { version = "0.24.0", optional = true, default-features = false, features = [ "png", "jpeg" ] }
 clru = { version = "0.6.0", optional = true }

--- a/internal/core/software_renderer/draw_functions.rs
+++ b/internal/core/software_renderer/draw_functions.rs
@@ -408,7 +408,8 @@ pub(super) fn draw_gradient_line(
 /// the [`From`] trait. This conversion will pre-multiply the color
 /// components
 #[allow(missing_docs)]
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
 pub struct PremultipliedRgbaColor {
     pub red: u8,
     pub green: u8,
@@ -484,7 +485,7 @@ impl TargetPixel for PremultipliedRgbaColor {
 
 /// A 16bit pixel that has 5 red bits, 6 green bits and  5 blue bits
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Rgb565Pixel(pub u16);
 
 impl Rgb565Pixel {


### PR DESCRIPTION
Implement rgb::Pod/rgb::Zeroable for PremultipliedRgbaColor. This allows for bytemuck::cast_slice(), making it easier to copy software renderer output
into another buffer that's the same format but
Vec<u8> for example.