### PR TITLE
napi: Remove unnecessary cargo build

### DIFF
--- a/api/napi/Cargo.toml
+++ b/api/napi/Cargo.toml
@@ -20,6 +20,3 @@ spin_on = "0.1"
 
 [build-dependencies]
 napi-build = "2.0.1"
-
-[profile.release]
-lto = true


### PR DESCRIPTION
Since this file is part of the repository workspace, we should use the common profile in the top-level Cargo.toml.