### PR TITLE
Fix slint-lsp process zombies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ All notable changes to this project are documented in this file.
  - Extended `slint::Image::create_from_borrowed_gl_2d_rgba_texture` with an option to configure more aspects
    of texture rendering.
 
+### LSP
+
+ - Fixed termination of the lsp process.
+
 ## [1.1.1] - 2023-07-10
 
 ### General

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -200,12 +200,12 @@ pub fn run_lsp_server() -> Result<(), Error> {
         serde_json::to_value(server_loop::server_initialize_result(&init_param.capabilities))?;
     connection.initialize_finish(id, initialize_result)?;
 
-    main_loop(&connection, init_param)?;
+    main_loop(connection, init_param)?;
     io_threads.join()?;
     Ok(())
 }
 
-fn main_loop(connection: &Connection, init_param: InitializeParams) -> Result<(), Error> {
+fn main_loop(connection: Connection, init_param: InitializeParams) -> Result<(), Error> {
     let mut compiler_config =
         CompilerConfiguration::new(i_slint_compiler::generator::OutputFormat::Interpreter);
 


### PR DESCRIPTION
Drop the connection before waiting for the io_threads to join, because those require the Connection's
sender to be destroyed so that the stdio writer
thread can terminate cleanly.