### PR TITLE
Change "Slint design markup language" to "Slint language" to make it clearer and catchier.

### DIFF
--- a/docs/language/index.rst
+++ b/docs/language/index.rst
@@ -27,7 +27,7 @@ cooperation between design-focused team members and those concentrating on the p
 side of the project.
 
 
-The Slint design markup language describes extensible graphical user interfaces using the
+The Slint language describes extensible graphical user interfaces using the
 `Slint framework <https://slint.dev>`_
 
 - Place and compose a tree of visual elements in a window using a textual representation.
@@ -52,7 +52,7 @@ in a supported programming language, like C++, Rust, or JavaScript.
 
 There are three different pathways to get started with Slint:
 
-1. `SlintPad <https://slint.dev/editor>`_ - Use this to get a feel of the Slint design markup language.
+1. `SlintPad <https://slint.dev/editor>`_ - Use this to get a feel of the Slint language.
    This is a web browser-based tool where you can try Slint out.
 
 2. As a UI Designer, working with Slint files locally, we recommend the following combination of software tools:


### PR DESCRIPTION
I'd like to propose simplifying the name of the "Slint design markup language" to the "Slint language". This makes it clearer and people who are interested can learn more what it is. But, for the average user, the name of it can be shorter.