### PR TITLE
Skia: Fix re-rendering quality of SVGs when the scale factor changes

### DIFF
--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -33,7 +33,7 @@ pub(crate) fn as_skia_image(
     image: Image,
     target_size_fn: &dyn Fn() -> (LogicalLength, LogicalLength),
     image_fit: ImageFit,
-    scale_factor: ScaleFactor,
+    window: &i_slint_core::api::Window,
     _canvas: &mut skia_safe::Canvas,
 ) -> Option<skia_safe::Image> {
     let image_inner: &ImageInner = (&image).into();
@@ -54,7 +54,8 @@ pub(crate) fn as_skia_image(
         ImageInner::Svg(svg) => {
             // Query target_width/height here again to ensure that changes will invalidate the item rendering cache.
             let (target_width, target_height) = target_size_fn();
-            let target_size = LogicalSize::from_lengths(target_width, target_height) * scale_factor;
+            let target_size = LogicalSize::from_lengths(target_width, target_height)
+                * ScaleFactor::new(window.scale_factor());
             let target_size = i_slint_core::graphics::fit_size(image_fit, target_size, svg.size());
             let pixels = match svg.render(target_size.cast()).ok()? {
                 SharedImageBuffer::RGB8(_) => unreachable!(),

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -163,7 +163,7 @@ impl<'a> SkiaItemRenderer<'a> {
                 image,
                 &|| (target_width.get(), target_height.get()),
                 image_fit,
-                self.scale_factor,
+                self.window,
                 self.canvas,
             )
             .and_then(|skia_image| {
@@ -816,7 +816,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
                 (LogicalLength::new(size.width as _), LogicalLength::new(size.height as _))
             },
             ImageFit::Fill,
-            self.scale_factor,
+            self.window,
             self.canvas,
         );
 


### PR DESCRIPTION
Make sure that the scale factor to compute the target size for an SVG is a property dependency.