### PR TITLE
Update license symlinks

### DIFF
--- a/api/cpp/esp-idf/slint/LICENSES/MIT.txt
+++ b/api/cpp/esp-idf/slint/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../../LICENSES/MIT.txt

--- a/api/rs/build/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/api/rs/build/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/api/rs/macros/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/api/rs/macros/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/api/rs/macros/LICENSES/MIT.txt
+++ b/api/rs/macros/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/MIT.txt

--- a/api/rs/slint/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/api/rs/slint/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/api/rs/slint/LICENSES/MIT.txt
+++ b/api/rs/slint/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/MIT.txt

--- a/examples/mcu-board-support/LICENSES/Apache-2.0.txt
+++ b/examples/mcu-board-support/LICENSES/Apache-2.0.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/Apache-2.0.txt

--- a/examples/mcu-board-support/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/examples/mcu-board-support/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/examples/mcu-board-support/LICENSES/MIT.txt
+++ b/examples/mcu-board-support/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/MIT.txt

--- a/helper_crates/vtable/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/helper_crates/vtable/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/helper_crates/vtable/macro/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/helper_crates/vtable/macro/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/backends/linuxkms/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/backends/linuxkms/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/backends/linuxkms/LICENSES/MIT.txt
+++ b/internal/backends/linuxkms/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/MIT.txt

--- a/internal/backends/qt/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/backends/qt/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/backends/qt/LICENSES/MIT.txt
+++ b/internal/backends/qt/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/MIT.txt

--- a/internal/backends/selector/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/backends/selector/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/backends/selector/LICENSES/MIT.txt
+++ b/internal/backends/selector/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/MIT.txt

--- a/internal/backends/winit/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/backends/winit/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/backends/winit/LICENSES/MIT.txt
+++ b/internal/backends/winit/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/MIT.txt

--- a/internal/common/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/common/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/common/LICENSES/MIT.txt
+++ b/internal/common/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/MIT.txt

--- a/internal/compiler/LICENSES/Apache-2.0.txt
+++ b/internal/compiler/LICENSES/Apache-2.0.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/Apache-2.0.txt

--- a/internal/compiler/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/compiler/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/compiler/LICENSES/MIT.txt
+++ b/internal/compiler/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/MIT.txt

--- a/internal/core-macros/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/core-macros/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/core-macros/LICENSES/MIT.txt
+++ b/internal/core-macros/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/MIT.txt

--- a/internal/core/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/core/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/core/LICENSES/MIT.txt
+++ b/internal/core/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/MIT.txt

--- a/internal/interpreter/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/interpreter/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/renderers/femtovg/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/renderers/femtovg/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/renderers/femtovg/LICENSES/MIT.txt
+++ b/internal/renderers/femtovg/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/MIT.txt

--- a/internal/renderers/skia/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/renderers/skia/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/renderers/skia/LICENSES/MIT.txt
+++ b/internal/renderers/skia/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/MIT.txt

--- a/tools/lsp/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/tools/lsp/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/tools/lsp/LICENSES/MIT.txt
+++ b/tools/lsp/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/MIT.txt

--- a/tools/viewer/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/tools/viewer/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/tools/viewer/LICENSES/MIT.txt
+++ b/tools/viewer/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/MIT.txt


### PR DESCRIPTION
run `cargo xtask check_reuse_compliance --fix-symlinks`