### PR TITLE
reuse: remove glob for markdown files

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -11,7 +11,7 @@ Files: .gitattributes .gitignore */.gitignore .dockerignore .prettierignore .pre
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-Files: *.md api/cpp/docs/*/*.html api/cpp/docs/*/*.css docs/*/*.css docs/*/*.html docs/*/book.toml docs/*/package.json
+Files: api/cpp/docs/*/*.html api/cpp/docs/*/*.css docs/*/*.css docs/*/*.html docs/*/book.toml docs/*/package.json
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: MIT
 
@@ -19,13 +19,10 @@ Files: examples/*/LC_MESSAGES/*.mo examples/*/sdkconfig*
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: MIT
 
-Files: helper_crates/vtable/*.md
+Files: .github/issue_template.md
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
-License: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+License: MIT
 
-Files: helper_crates/const-field-offset/*.md
-Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
-License: MIT or Apache-2.0
 
 Files: api/*/*.json
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
@@ -51,15 +48,11 @@ Files: editors/sublime/LSP.sublime-settings
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-Files: editors/tree-sitter-slint/binding.gyp editors/tree-sitter-slint/CONTRIBUTING.md
-Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
-License: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
-
 Files: tools/slintpad/*.html tools/slintpad/styles/*.css tools/slintpad/*.json
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-Files: editors/vscode/*.json editors/vscode/README.md editors/vscode/css/*.css editors/tree-sitter-slint/corpus/*.txt editors/vscode/static/**/*.html editors/vscode/static/assets/img/bg-dark.svg editors/vscode/static/assets/img/slint-*.svg
+Files: editors/vscode/*.json editors/vscode/css/*.css editors/tree-sitter-slint/corpus/*.txt editors/vscode/static/**/*.html editors/vscode/static/assets/img/bg-dark.svg editors/vscode/static/assets/img/slint-*.svg
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+
 # Changelog
 All notable changes to this project are documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Changelog
 All notable changes to this project are documented in this file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+
 # Contributing
 
 We warmly welcome contributions to the project. Let's discuss ideas or questions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Contributing
 
 We warmly welcome contributions to the project. Let's discuss ideas or questions

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 
 # Frequently Asked Questions: <!-- omit in toc -->
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Slint License
 
 You can use Slint under ***any*** of the following licenses, at your choice:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+
 # Slint License
 
 You can use Slint under ***any*** of the following licenses, at your choice:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # ![Slint](./logo/slint-logo-full-light.svg#gh-light-mode-only)![Slint](./logo/slint-logo-full-white.svg#gh-dark-mode-only)
 
 <!-- cSpell: ignore ChipTrack Moiré Trolltech valign Woboq -->

--- a/api/cpp/README.md
+++ b/api/cpp/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint-cpp
 
 ## A C++ UI toolkit

--- a/api/cpp/docs/cmake.md
+++ b/api/cpp/docs/cmake.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 <!-- cSpell: ignore ccmake dslint femtovg skia winit -->
 
 # Installing Or Building With CMake

--- a/api/cpp/docs/generated_code.md
+++ b/api/cpp/docs/generated_code.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Generated code
 
 The Slint compiler called by the build system will generate a header file for the root `.slint`

--- a/api/cpp/docs/getting_started.md
+++ b/api/cpp/docs/getting_started.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Getting Started
 
 Once Slint is built, you can use it in your CMake application or library

--- a/api/cpp/docs/overview.md
+++ b/api/cpp/docs/overview.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Overview
 
 The following sections explain how to integrate your `.slint` designs into your

--- a/api/cpp/docs/types.md
+++ b/api/cpp/docs/types.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Type Mappings
 
 The types used for properties in `.slint` design markup each translate to specific types in C++.

--- a/api/cpp/esp-idf/slint/LICENSES/MIT.txt
+++ b/api/cpp/esp-idf/slint/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../../../LICENSES/MIT.txt

--- a/api/cpp/esp-idf/slint/README.md
+++ b/api/cpp/esp-idf/slint/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint
 
 [![Component Registry](https://components.espressif.com/components/slint/slint/badge.svg)](https://components.espressif.com/components/slint/slint)

--- a/api/cpp/tests/multiple-includes/README.md
+++ b/api/cpp/tests/multiple-includes/README.md
@@ -1,1 +1,2 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 This is a test making sure that the header can be included in several file without causing multiple definitions

--- a/api/napi/README.md
+++ b/api/napi/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint-napi (pre-Alpha)
 
 This is a restart of `Slint-node` based on [napi-rs](https://github.com/napi-rs/napi-rs). The current state is `pre-Alpha` what means it is not yet ready for testing and use.

--- a/api/node/README.md
+++ b/api/node/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint-node (Beta)
 
 [![npm](https://img.shields.io/npm/v/slint-ui)](https://www.npmjs.com/package/slint-ui)

--- a/api/node/cover.md
+++ b/api/node/cover.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Slint-node (Beta)
 
 [![npm](https://img.shields.io/npm/v/slint-ui)](https://www.npmjs.com/package/slint-ui)

--- a/api/rs/macros/LICENSES/MIT.txt
+++ b/api/rs/macros/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../../LICENSES/MIT.txt

--- a/api/rs/macros/README.md
+++ b/api/rs/macros/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 **NOTE**: This library is an **internal** crate for the [Slint project](https://slint.rs).
 This crate should **not be used directly** by applications using Slint.
 You should use the `slint` crate instead.

--- a/api/rs/slint/README.md
+++ b/api/rs/slint/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint
 
 [![Crates.io](https://img.shields.io/crates/v/slint)](https://crates.io/crates/slint)

--- a/api/rs/slint/mcu.md
+++ b/api/rs/slint/mcu.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Slint on Microcontrollers
 
 ![](https://slint.dev/blog/porting-slint-to-microcontrollers/rp-pico_and_screen.jpg)

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Slint Build Guide
 
 This page explains how to build and test Slint.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Slint development guide
 
 The build instructions are in the [building.md](./building.md) file.

--- a/docs/install_qt.md
+++ b/docs/install_qt.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Install Qt
 
 TLDR; If you are redirected to this document because of a link in the warning that Qt wasn't found and

--- a/docs/reference/src/advanced/debugging_techniques.md
+++ b/docs/reference/src/advanced/debugging_techniques.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Debugging Techniques
 
 On this page we're presenting different techniques and tools we've built into Slint that may help you track down different issues you may be running into, during the design and development.

--- a/docs/reference/src/advanced/style.md
+++ b/docs/reference/src/advanced/style.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Selecting a Widget Style
 
 The widget style is selected at compile time of your project. The details depend on which programming

--- a/docs/reference/src/introduction/supported_platforms.md
+++ b/docs/reference/src/introduction/supported_platforms.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Supported Platforms
 
 Slint runs on many desktop and embedded platforms and micro-controllers.

--- a/docs/reference/src/language/builtins/callbacks.md
+++ b/docs/reference/src/language/builtins/callbacks.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Builtin Callbacks
 
 ## `init()`

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Builtin Elements
 
 ## Common properties

--- a/docs/reference/src/language/builtins/functions.md
+++ b/docs/reference/src/language/builtins/functions.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Builtin Functions
 
 ## `animation-tick() -> duration`

--- a/docs/reference/src/language/builtins/globals.md
+++ b/docs/reference/src/language/builtins/globals.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Builtin Global Singletons
 
 ## `TextInputInterface`

--- a/docs/reference/src/language/builtins/namespaces.md
+++ b/docs/reference/src/language/builtins/namespaces.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Builtin Namespaces
 
 The following namespaces provide access to common constants such as special keys or named colors.

--- a/docs/reference/src/language/concepts/container.md
+++ b/docs/reference/src/language/concepts/container.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Container Components
 
 When creating components, it's sometimes useful to influence where child

--- a/docs/reference/src/language/concepts/file.md
+++ b/docs/reference/src/language/concepts/file.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # The `.slint` File
 
 User interfaces are written in the Slint language and saved in files with the `.slint` extension.

--- a/docs/reference/src/language/concepts/focus.md
+++ b/docs/reference/src/language/concepts/focus.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Focus Handling
 
 Certain elements such as `TextInput` accept not only input from the mouse/finger but

--- a/docs/reference/src/language/concepts/fonts.md
+++ b/docs/reference/src/language/concepts/fonts.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Font Handling
 
 Elements such as `Text` and `TextInput` can render text and allow customizing the appearance of the text through

--- a/docs/reference/src/language/concepts/layouting.md
+++ b/docs/reference/src/language/concepts/layouting.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Positioning and Layout of Elements
 
 All visual elements are shown in a window. The `x` and `y` properties store

--- a/docs/reference/src/language/concepts/purity.md
+++ b/docs/reference/src/language/concepts/purity.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Purity
 
 Slint's property evaluation is lazy and "reactive". Property

--- a/docs/reference/src/language/concepts/translations.md
+++ b/docs/reference/src/language/concepts/translations.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Translations
 
 Use Slint's translation infrastructure to make your application available in different languages.

--- a/docs/reference/src/language/syntax/animations.md
+++ b/docs/reference/src/language/syntax/animations.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Animations
 
 Declare animations for properties with the `animate` keyword like this:

--- a/docs/reference/src/language/syntax/callbacks.md
+++ b/docs/reference/src/language/syntax/callbacks.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Callbacks
 
 Components may declare callbacks, that communicate changes of state

--- a/docs/reference/src/language/syntax/comments.md
+++ b/docs/reference/src/language/syntax/comments.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Comments
 
 C-style comments are supported:

--- a/docs/reference/src/language/syntax/conditions.md
+++ b/docs/reference/src/language/syntax/conditions.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Conditional Element
 
 The `if` construct instantiates an element only if a given condition is true.

--- a/docs/reference/src/language/syntax/expressions.md
+++ b/docs/reference/src/language/syntax/expressions.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Expressions
 
 Expressions are a powerful way to declare relationships and connections in your

--- a/docs/reference/src/language/syntax/functions.md
+++ b/docs/reference/src/language/syntax/functions.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Functions
 
 Declare helper functions with the `function` keyword.

--- a/docs/reference/src/language/syntax/globals.md
+++ b/docs/reference/src/language/syntax/globals.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Global Singletons
 
 Declare a global singleton with `global Name { /* .. properties or callbacks .. */ }` to

--- a/docs/reference/src/language/syntax/identifiers.md
+++ b/docs/reference/src/language/syntax/identifiers.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Identifiers
 
 Identifiers can be composed of letter (`a-zA-Z`), of numbers (`0-9`), or of the underscore (`_`) or the dash (`-`).

--- a/docs/reference/src/language/syntax/legacy_syntax.md
+++ b/docs/reference/src/language/syntax/legacy_syntax.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Legacy Syntax
 
 To maintain compatibility with earlier version of Slint, the pre-1.0 syntax that declared

--- a/docs/reference/src/language/syntax/modules.md
+++ b/docs/reference/src/language/syntax/modules.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Modules
 
 Components declared in a `.slint` file can be used as elements in other

--- a/docs/reference/src/language/syntax/properties.md
+++ b/docs/reference/src/language/syntax/properties.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Properties
 
 All elements have properties. Built-in elements come with common properties such

--- a/docs/reference/src/language/syntax/repetitions.md
+++ b/docs/reference/src/language/syntax/repetitions.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Repetition
 
 Use the `for`-`in` syntax to create an element multiple times.

--- a/docs/reference/src/language/syntax/statements.md
+++ b/docs/reference/src/language/syntax/statements.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Statements
 
 Callback handlers may contain complex statements:

--- a/docs/reference/src/language/syntax/states.md
+++ b/docs/reference/src/language/syntax/states.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # States
 
 The `states` statement allows to declare states and set properties of multiple elements in one go:

--- a/docs/reference/src/language/syntax/types.md
+++ b/docs/reference/src/language/syntax/types.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Types
 
 All properties in Slint have a type. Slint knows these basic types:

--- a/docs/reference/src/language/widgets/aboutslint.md
+++ b/docs/reference/src/language/widgets/aboutslint.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `AboutSlint`
 
 This element displays a "Made with Slint" badge.

--- a/docs/reference/src/language/widgets/button.md
+++ b/docs/reference/src/language/widgets/button.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `Button`
 
 A simple button. Common types of buttons can also be created with [`StandardButton`](#standardbutton).

--- a/docs/reference/src/language/widgets/checkbox.md
+++ b/docs/reference/src/language/widgets/checkbox.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `CheckBox`
 
 Use a `CheckBox` to let the user select or deselect values, for example in a list with multiple options. Consider using a `Switch` element instead if the action resembles more something that's turned on or off.

--- a/docs/reference/src/language/widgets/combobox.md
+++ b/docs/reference/src/language/widgets/combobox.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `ComboBox`
 
 A button that, when clicked, opens a popup to select a value.

--- a/docs/reference/src/language/widgets/gridbox.md
+++ b/docs/reference/src/language/widgets/gridbox.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `GridBox`
 
 A `GridBox` is a [`GridLayout`](../builtins/elements.md#gridlayout) where the spacing and padding values

--- a/docs/reference/src/language/widgets/horizontalbox.md
+++ b/docs/reference/src/language/widgets/horizontalbox.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `HorizontalBox`
 
 A `HorizontalBox` is a [`HorizontalLayout`](../builtins/elements.md#verticallayout-and-horizontallayout) where the spacing and padding values

--- a/docs/reference/src/language/widgets/lineedit.md
+++ b/docs/reference/src/language/widgets/lineedit.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `LineEdit`
 
 A widget used to enter a single line of text. See [`TextEdit`](#textedit) for

--- a/docs/reference/src/language/widgets/listview.md
+++ b/docs/reference/src/language/widgets/listview.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `ListView`
 
 A ListView is like a Scrollview but it should have a `for` element, and the content are

--- a/docs/reference/src/language/widgets/progressindicator.md
+++ b/docs/reference/src/language/widgets/progressindicator.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `ProgressIndicator`
 
 The `ProgressIndicator` informs the user about the status of an on-going operation, such as loading data from the network.

--- a/docs/reference/src/language/widgets/scrollview.md
+++ b/docs/reference/src/language/widgets/scrollview.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `ScrollView`
 
 A Scrollview contains a viewport that is bigger than the view and can be

--- a/docs/reference/src/language/widgets/slider.md
+++ b/docs/reference/src/language/widgets/slider.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `Slider`
 
 ### Properties

--- a/docs/reference/src/language/widgets/spinbox.md
+++ b/docs/reference/src/language/widgets/spinbox.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `SpinBox`
 
 ### Properties

--- a/docs/reference/src/language/widgets/standardbutton.md
+++ b/docs/reference/src/language/widgets/standardbutton.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `StandardButton`
 
 The StandardButton looks like a button, but instead of customizing with `text` and `icon`,

--- a/docs/reference/src/language/widgets/standardlistview.md
+++ b/docs/reference/src/language/widgets/standardlistview.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `StandardListView`
 
 Like ListView, but with a default delegate, and a `model` property which is a model of type

--- a/docs/reference/src/language/widgets/standardtableview.md
+++ b/docs/reference/src/language/widgets/standardtableview.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `StandardTableView`
 
 The `StandardTableView` represents a table of data with columns and rows. Cells

--- a/docs/reference/src/language/widgets/switch.md
+++ b/docs/reference/src/language/widgets/switch.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `Switch`
 
 A `Switch` is a representation of a physical switch that allows users to turn things on or off. Consider using a `CheckBox` instead if you want the user to select or deselect values, for example in a list with multiple options.

--- a/docs/reference/src/language/widgets/tabwidget.md
+++ b/docs/reference/src/language/widgets/tabwidget.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `TabWidget`
 
 `TabWidget` is a container for a set of tabs. It can only have `Tab` elements as children and only one tab will be visible at

--- a/docs/reference/src/language/widgets/textedit.md
+++ b/docs/reference/src/language/widgets/textedit.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `TextEdit`
 
 Similar to [`LineEdit`](#lineedit)`, but can be used to enter several lines of text

--- a/docs/reference/src/language/widgets/verticalbox.md
+++ b/docs/reference/src/language/widgets/verticalbox.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## `VerticalBox`
 
 A `VerticalBox` is a [`VerticalLayout`](../builtins/elements.md#verticallayout-and-horizontallayout) where the spacing and padding values

--- a/docs/reference/src/language/widgets/widgets.md
+++ b/docs/reference/src/language/widgets/widgets.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 
 Slint provides a series of built-in widgets that can be imported from `"std-widgets.slint"`.
 

--- a/docs/reference/src/recipes/recipes.md
+++ b/docs/reference/src/recipes/recipes.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 <!-- cSpell: ignore dgettext ngettext xgettext -->
 
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Slint tests
 
 This documents describe the testing infrastructure of Slint

--- a/docs/torizon.md
+++ b/docs/torizon.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Running Slint Demos on Torizon
 
 Toradex provides [TorizonCore](https://developer.toradex.com/torizon/) a Linux based platform for its embedded devices that packages applications in docker containers.

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 ## Introduction
 
 This document will outline the process of triaging GitHub issues and provide an explanation of GitHub labels.

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Tutorials
 
 The source code for the Rust and C++ versions of the Memory Game tutorial are located in

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # Tutorials
 
 The source code for the Rust and C++ versions of the Memory Game tutorial are located in

--- a/docs/tutorial/cpp/src/SUMMARY.md
+++ b/docs/tutorial/cpp/src/SUMMARY.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Summary
 
 - [Introduction](./introduction.md)

--- a/docs/tutorial/cpp/src/conclusion.md
+++ b/docs/tutorial/cpp/src/conclusion.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Conclusion
 
 In this tutorial, we have demonstrated how to combine some built-in Slint elements with C++ code to build a little

--- a/docs/tutorial/cpp/src/creating_the_tiles_from_cpp.md
+++ b/docs/tutorial/cpp/src/creating_the_tiles_from_cpp.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Creating The Tiles From C++
 
 What we'll do is take the list of tiles declared in the .slint language, duplicate it, and shuffle it.

--- a/docs/tutorial/cpp/src/from_one_to_multiple_tiles.md
+++ b/docs/tutorial/cpp/src/from_one_to_multiple_tiles.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # From One To Multiple Tiles
 
 After modeling a single tile, let's create a grid of them. For the grid to be our game board, we need two features:

--- a/docs/tutorial/cpp/src/game_logic_in_cpp.md
+++ b/docs/tutorial/cpp/src/game_logic_in_cpp.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Game Logic In C++
 
 We'll implement the rules of the game in C++ as well. The general philosophy of Slint is that merely the user

--- a/docs/tutorial/cpp/src/getting_started.md
+++ b/docs/tutorial/cpp/src/getting_started.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Getting Started
 
 In this tutorial, we use C++ as the host programming language. We also support other programming languages like

--- a/docs/tutorial/cpp/src/ideas_for_the_reader.md
+++ b/docs/tutorial/cpp/src/ideas_for_the_reader.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Ideas For The Reader
 
 The game is visually a little bare. Here are some ideas how you could make further changes to enhance it:

--- a/docs/tutorial/cpp/src/introduction.md
+++ b/docs/tutorial/cpp/src/introduction.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Introduction
 
 This tutorial will introduce you to the Slint UI framework in a playful way by implementing a little memory game. We're going to combine the `.slint` language for the graphics with the game rules implemented in C++.

--- a/docs/tutorial/cpp/src/memory_tile.md
+++ b/docs/tutorial/cpp/src/memory_tile.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Memory Tile
 
 With the skeleton in place, let's look at the first element of the game, the memory tile. It will be the

--- a/docs/tutorial/cpp/src/polishing_the_tile.md
+++ b/docs/tutorial/cpp/src/polishing_the_tile.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Polishing the Tile
 
 Next, let's add a curtain like cover that opens up when clicking. We achieve this by declaring two rectangles

--- a/docs/tutorial/node/src/SUMMARY.md
+++ b/docs/tutorial/node/src/SUMMARY.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Summary
 
 - [Introduction](./introduction.md)

--- a/docs/tutorial/node/src/conclusion.md
+++ b/docs/tutorial/node/src/conclusion.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Conclusion
 
 In this tutorial, we have demonstrated how to combine some built-in Slint elements with JavaScript code to build a little

--- a/docs/tutorial/node/src/creating_the_tiles_from_js.md
+++ b/docs/tutorial/node/src/creating_the_tiles_from_js.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Creating The Tiles From JavaScript
 
 What we'll do is take the list of tiles declared in the .slint language, duplicate it, and shuffle it.

--- a/docs/tutorial/node/src/from_one_to_multiple_tiles.md
+++ b/docs/tutorial/node/src/from_one_to_multiple_tiles.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # From One To Multiple Tiles
 
 After modeling a single tile, let's create a grid of them. For the grid to be our game board, we need two features:

--- a/docs/tutorial/node/src/game_logic_in_js.md
+++ b/docs/tutorial/node/src/game_logic_in_js.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Game Logic In JavaScript
 
 We'll implement the rules of the game in JavaScript as well. The general philosophy of Slint is that merely the user

--- a/docs/tutorial/node/src/getting_started.md
+++ b/docs/tutorial/node/src/getting_started.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Getting Started
 
 In this tutorial, we use JavaScript as the host programming language. We also support other programming languages like

--- a/docs/tutorial/node/src/ideas_for_the_reader.md
+++ b/docs/tutorial/node/src/ideas_for_the_reader.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Ideas For The Reader
 
 The game is visually a little bare. Here are some ideas how you could make further changes to enhance it:

--- a/docs/tutorial/node/src/introduction.md
+++ b/docs/tutorial/node/src/introduction.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Introduction
 
 This tutorial will introduce you to the Slint UI framework in a playful way by implementing a little memory game. We're going to combine the `.slint` language for the graphics with the game rules implemented in JavaScript.

--- a/docs/tutorial/node/src/memory_tile.md
+++ b/docs/tutorial/node/src/memory_tile.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Memory Tile
 
 With the skeleton in place, let's look at the first element of the game, the memory tile. It will be the

--- a/docs/tutorial/node/src/polishing_the_tile.md
+++ b/docs/tutorial/node/src/polishing_the_tile.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Polishing the Tile
 
 Next, let's add a curtain like cover that opens up when clicking. We achieve this by declaring two rectangles

--- a/docs/tutorial/rust/src/SUMMARY.md
+++ b/docs/tutorial/rust/src/SUMMARY.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Summary
 
 - [Introduction](./introduction.md)

--- a/docs/tutorial/rust/src/conclusion.md
+++ b/docs/tutorial/rust/src/conclusion.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Conclusion
 
 In this tutorial, we have demonstrated how to combine some built-in Slint elements with Rust code to build a little

--- a/docs/tutorial/rust/src/creating_the_tiles_from_rust.md
+++ b/docs/tutorial/rust/src/creating_the_tiles_from_rust.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Creating The Tiles From Rust
 
 The tiles in the game should have a random placement. We'll need to add the `rand` dependency to

--- a/docs/tutorial/rust/src/from_one_to_multiple_tiles.md
+++ b/docs/tutorial/rust/src/from_one_to_multiple_tiles.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # From One To Multiple Tiles
 
 After modeling a single tile, let's create a grid of them. For the grid to be our game board, we need two features:

--- a/docs/tutorial/rust/src/game_logic_in_rust.md
+++ b/docs/tutorial/rust/src/game_logic_in_rust.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Game Logic In Rust
 
 We'll implement the rules of the game in Rust as well. The general philosophy of Slint is that merely the user

--- a/docs/tutorial/rust/src/getting_started.md
+++ b/docs/tutorial/rust/src/getting_started.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Getting Started
 
 We assume that you are a somewhat familiar with Rust, and that you know how to create a Rust application with

--- a/docs/tutorial/rust/src/ideas_for_the_reader.md
+++ b/docs/tutorial/rust/src/ideas_for_the_reader.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Ideas For The Reader
 
 The game is visually a little bare. Here are some ideas how you could make further changes to enhance it:

--- a/docs/tutorial/rust/src/introduction.md
+++ b/docs/tutorial/rust/src/introduction.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Introduction
 
 This tutorial will introduce you to the Slint UI framework in a playful way by implementing a little memory game. We're going to combine the `.slint` language for the graphics with the game rules implemented in Rust.

--- a/docs/tutorial/rust/src/memory_tile.md
+++ b/docs/tutorial/rust/src/memory_tile.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Memory Tile
 
 With the skeleton in place, let's look at the first element of the game, the memory tile. It will be the

--- a/docs/tutorial/rust/src/polishing_the_tile.md
+++ b/docs/tutorial/rust/src/polishing_the_tile.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Polishing the Tile
 
 Next, let's add a curtain like cover that opens up when clicking. We achieve this by declaring two rectangles

--- a/docs/tutorial/rust/src/running_in_a_browser.md
+++ b/docs/tutorial/rust/src/running_in_a_browser.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Running In A Browser Using WebAssembly
 
 Right now, we used `cargo run` to build and run our program as a native application.

--- a/editors/README.md
+++ b/editors/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Editor Configuration for Slint
 
 This folder contains extensions or configuration files for different editor to better support .slint files.

--- a/editors/tree-sitter-slint/CONTRIBUTING.md
+++ b/editors/tree-sitter-slint/CONTRIBUTING.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+
 # Contributing
 
 Contributions to the tree-sitter parser are wanted to fix currently failing tests and to test any other regressions.

--- a/editors/tree-sitter-slint/CONTRIBUTING.md
+++ b/editors/tree-sitter-slint/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Contributing
 
 Contributions to the tree-sitter parser are wanted to fix currently failing tests and to test any other regressions.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint for Visual Studio Code
 
 This extension for VS Code adds support for the [Slint](https://slint.dev) design markup language.

--- a/examples/7guis/README.md
+++ b/examples/7guis/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # Slint's 7GUIs implementation
 
 [7GUIs](https://7guis.github.io/7guis/) is a "GUI Programming Benchmark".

--- a/examples/7guis/README.md
+++ b/examples/7guis/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint's 7GUIs implementation
 
 [7GUIs](https://7guis.github.io/7guis/) is a "GUI Programming Benchmark".

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Examples
 
 These examples demonstrate the main features of Slint and how to use them in different language environments.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # Examples
 
 These examples demonstrate the main features of Slint and how to use them in different language environments.

--- a/examples/bash/README.md
+++ b/examples/bash/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint Bash example
 
 This shows how to use [`slint-viewer`](../../tools/viewer) to display dialog from a bash script.

--- a/examples/bash/README.md
+++ b/examples/bash/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # Slint Bash example
 
 This shows how to use [`slint-viewer`](../../tools/viewer) to display dialog from a bash script.

--- a/examples/carousel/README.md
+++ b/examples/carousel/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 See the [MCU backend Readme](../mcu-board-support) to see how to run the example on a smaller device like the Raspberry Pi Pico.
 
 The example can run with the mcu simulator with the following command

--- a/examples/carousel/README.md
+++ b/examples/carousel/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 See the [MCU backend Readme](../mcu-board-support) to see how to run the example on a smaller device like the Raspberry Pi Pico.
 
 The example can run with the mcu simulator with the following command

--- a/examples/carousel/esp-idf/README.md
+++ b/examples/carousel/esp-idf/README.md
@@ -1,4 +1,4 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 
 # Carousel Demo with ESP-IDF
 

--- a/examples/carousel/esp-idf/README.md
+++ b/examples/carousel/esp-idf/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 
 # Carousel Demo with ESP-IDF
 

--- a/examples/cpp/platform_native/README.md
+++ b/examples/cpp/platform_native/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 This shows how one can use the Slint C++ platform API to integrate into any Windows application
 
  - main.cpp is basically a shell of an application written using the native WIN32 api.

--- a/examples/cpp/platform_native/README.md
+++ b/examples/cpp/platform_native/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 This shows how one can use the Slint C++ platform API to integrate into any Windows application
 
  - main.cpp is basically a shell of an application written using the native WIN32 api.

--- a/examples/cpp/platform_qt/README.md
+++ b/examples/cpp/platform_qt/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # C++ Platform Qt example
 
 This example shows how to use the Slint platform API to render a Slint scene in a Qt window

--- a/examples/cpp/platform_qt/README.md
+++ b/examples/cpp/platform_qt/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # C++ Platform Qt example
 
 This example shows how to use the Slint platform API to render a Slint scene in a Qt window

--- a/examples/cpp/qt_viewer/README.md
+++ b/examples/cpp/qt_viewer/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # qt_viewer
 
 This is an example that shows how to embed a dynamically loaded .slint into a Qt (QWidgets) application

--- a/examples/cpp/qt_viewer/README.md
+++ b/examples/cpp/qt_viewer/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # qt_viewer
 
 This is an example that shows how to embed a dynamically loaded .slint into a Qt (QWidgets) application

--- a/examples/energy-monitor/README.md
+++ b/examples/energy-monitor/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 See the [MCU backend Readme](../mcu-board-support) to see how to run the example on a smaller device like the Raspberry Pi Pico.
 
 The example can run with the mcu simulator with the following command

--- a/examples/energy-monitor/README.md
+++ b/examples/energy-monitor/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 See the [MCU backend Readme](../mcu-board-support) to see how to run the example on a smaller device like the Raspberry Pi Pico.
 
 The example can run with the mcu simulator with the following command

--- a/examples/ffmpeg/README.md
+++ b/examples/ffmpeg/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # FFmpeg Example
 
 This example application demonstrates the use of ffmpeg with Rust to play back video.

--- a/examples/ffmpeg/README.md
+++ b/examples/ffmpeg/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # FFmpeg Example
 
 This example application demonstrates the use of ffmpeg with Rust to play back video.

--- a/examples/iot-dashboard/README.md
+++ b/examples/iot-dashboard/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # iot-dashboard
 
 This example is a clone of https://github.com/uwerat/qskinny/tree/master/examples/iotdashboard from

--- a/examples/iot-dashboard/README.md
+++ b/examples/iot-dashboard/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # iot-dashboard
 
 This example is a clone of https://github.com/uwerat/qskinny/tree/master/examples/iotdashboard from

--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # Slint MCU backend
 
 See also the [MCU docs](../../api/rs/slint/mcu.md)

--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint MCU backend
 
 See also the [MCU docs](../../api/rs/slint/mcu.md)

--- a/examples/memory/icons/README.md
+++ b/examples/memory/icons/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 The icons originate from Font-Awesome font ( http://fontawesome.io ) and licensed under the CC BY 4.0 (SVG download)
 
     https://fontawesome.com/license/free

--- a/examples/memory/icons/README.md
+++ b/examples/memory/icons/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 The icons originate from Font-Awesome font ( http://fontawesome.io ) and licensed under the CC BY 4.0 (SVG download)
 
     https://fontawesome.com/license/free

--- a/examples/opengl_texture/README.md
+++ b/examples/opengl_texture/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # OpenGL Texture Import Example
 
 This example application demonstrates how import an OpenGL texture into a Sline scene:

--- a/examples/opengl_texture/README.md
+++ b/examples/opengl_texture/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # OpenGL Texture Import Example
 
 This example application demonstrates how import an OpenGL texture into a Sline scene:

--- a/examples/opengl_underlay/README.md
+++ b/examples/opengl_underlay/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # OpenGL Underlay Example
 
 This example application demonstrates how layer two scenes together in a window:

--- a/examples/opengl_underlay/README.md
+++ b/examples/opengl_underlay/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # OpenGL Underlay Example
 
 This example application demonstrates how layer two scenes together in a window:

--- a/examples/printerdemo_mcu/README.md
+++ b/examples/printerdemo_mcu/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 This is a "fork" of the [printer demo](../printerdemo/) modified to run on a smaller screen.
 
 See the [MCU backend Readme](../mcu-board-support) for more info.

--- a/examples/printerdemo_mcu/README.md
+++ b/examples/printerdemo_mcu/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 This is a "fork" of the [printer demo](../printerdemo/) modified to run on a smaller screen.
 
 See the [MCU backend Readme](../mcu-board-support) for more info.

--- a/examples/printerdemo_mcu/esp-idf/README.md
+++ b/examples/printerdemo_mcu/esp-idf/README.md
@@ -1,4 +1,4 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 
 # ESP32-S3-Box Printer Demo with ESP-IDF
 

--- a/examples/printerdemo_mcu/esp-idf/README.md
+++ b/examples/printerdemo_mcu/esp-idf/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 
 # ESP32-S3-Box Printer Demo with ESP-IDF
 

--- a/examples/slide_puzzle/README.md
+++ b/examples/slide_puzzle/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # Slide Puzzle
 
 Example based on the flutter slide_puzzle example:

--- a/examples/slide_puzzle/README.md
+++ b/examples/slide_puzzle/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slide Puzzle
 
 Example based on the flutter slide_puzzle example:

--- a/examples/uefi-demo/README.md
+++ b/examples/uefi-demo/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # Slint UEFI demo
 
 This example demonstrates Slint in a UEFI environment.

--- a/examples/uefi-demo/README.md
+++ b/examples/uefi-demo/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint UEFI demo
 
 This example demonstrates Slint in a UEFI environment.

--- a/examples/virtual_keyboard/README.md
+++ b/examples/virtual_keyboard/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
 # Virtual Keyboard Example
 
 This example application demonstrates how to implement and display a custom virtual keyboard in Slint.

--- a/examples/virtual_keyboard/README.md
+++ b/examples/virtual_keyboard/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Virtual Keyboard Example
 
 This example application demonstrates how to implement and display a custom virtual keyboard in Slint.

--- a/helper_crates/const-field-offset/CHANGELOG.md
+++ b/helper_crates/const-field-offset/CHANGELOG.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
 # Changelog
 
 ## [0.1.3] - 2023-04-03

--- a/helper_crates/const-field-offset/CHANGELOG.md
+++ b/helper_crates/const-field-offset/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Changelog
 
 ## [0.1.3] - 2023-04-03

--- a/helper_crates/const-field-offset/README.md
+++ b/helper_crates/const-field-offset/README.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
 # const-field-offset crate
 
 [![Crates.io](https://img.shields.io/crates/v/const-field-offset)](https://crates.io/crates/const-field-offset)

--- a/helper_crates/const-field-offset/README.md
+++ b/helper_crates/const-field-offset/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # const-field-offset crate
 
 [![Crates.io](https://img.shields.io/crates/v/const-field-offset)](https://crates.io/crates/const-field-offset)

--- a/helper_crates/vtable/CHANGELOG.md
+++ b/helper_crates/vtable/CHANGELOG.md
@@ -1,4 +1,5 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
 # Changelog
 All notable changes to this crate will be documented in this file.
 

--- a/helper_crates/vtable/CHANGELOG.md
+++ b/helper_crates/vtable/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 # Changelog
 All notable changes to this crate will be documented in this file.
 

--- a/helper_crates/vtable/Cargo.toml
+++ b/helper_crates/vtable/Cargo.toml
@@ -1,12 +1,12 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
-# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
 [package]
 name = "vtable"
 version = "0.1.10"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2021"
-license = "GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial"
+license = "MIT OR Apache-2.0"
 description = "Helper crate to generate ffi-friendly virtual tables"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint.dev"

--- a/helper_crates/vtable/LICENSES/Apache-2.0.txt
+++ b/helper_crates/vtable/LICENSES/Apache-2.0.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/Apache-2.0.txt

--- a/helper_crates/vtable/LICENSES/GPL-3.0-only.txt
+++ b/helper_crates/vtable/LICENSES/GPL-3.0-only.txt
@@ -1,1 +1,0 @@
-../../../LICENSES/GPL-3.0-only.txt

--- a/helper_crates/vtable/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/helper_crates/vtable/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,1 +1,0 @@
-../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/helper_crates/vtable/LICENSES/LicenseRef-Slint-commercial.md
+++ b/helper_crates/vtable/LICENSES/LicenseRef-Slint-commercial.md
@@ -1,1 +1,0 @@
-../../../LICENSES/LicenseRef-Slint-commercial.md

--- a/helper_crates/vtable/LICENSES/MIT.txt
+++ b/helper_crates/vtable/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../LICENSES/MIT.txt

--- a/helper_crates/vtable/README.md
+++ b/helper_crates/vtable/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 
 # `vtable` crate
 

--- a/helper_crates/vtable/README.md
+++ b/helper_crates/vtable/README.md
@@ -1,4 +1,4 @@
-<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT OR Apache-2.0 -->
 
 # `vtable` crate
 

--- a/helper_crates/vtable/macro/Cargo.toml
+++ b/helper_crates/vtable/macro/Cargo.toml
@@ -1,12 +1,12 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
-# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
 [package]
 name = "vtable-macro"
 version = "0.1.10"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2021"
-license = "GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial"
+license = "MIT OR Apache-2.0"
 description = "Helper crate to generate ffi-friendly virtual tables"
 repository = "https://github.com/slint-ui/slint"
 homepage = "https://slint.dev"

--- a/helper_crates/vtable/macro/LICENSES/Apache-2.0.txt
+++ b/helper_crates/vtable/macro/LICENSES/Apache-2.0.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/Apache-2.0.txt

--- a/helper_crates/vtable/macro/LICENSES/GPL-3.0-only.txt
+++ b/helper_crates/vtable/macro/LICENSES/GPL-3.0-only.txt
@@ -1,1 +1,0 @@
-../../../../LICENSES/GPL-3.0-only.txt

--- a/helper_crates/vtable/macro/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/helper_crates/vtable/macro/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,1 +1,0 @@
-../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/helper_crates/vtable/macro/LICENSES/LicenseRef-Slint-commercial.md
+++ b/helper_crates/vtable/macro/LICENSES/LicenseRef-Slint-commercial.md
@@ -1,1 +1,0 @@
-../../../../LICENSES/LicenseRef-Slint-commercial.md

--- a/helper_crates/vtable/macro/LICENSES/MIT.txt
+++ b/helper_crates/vtable/macro/LICENSES/MIT.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/MIT.txt

--- a/helper_crates/vtable/macro/macro.rs
+++ b/helper_crates/vtable/macro/macro.rs
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+// SPDX-License-Identifier: MIT OR Apache-2.0
 
 // cSpell: ignore asyncness constness containee defaultness impls qself supertraits vref
 

--- a/helper_crates/vtable/src/compile_fail_tests.rs
+++ b/helper_crates/vtable/src/compile_fail_tests.rs
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+// SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod m1 {
 

--- a/helper_crates/vtable/src/lib.rs
+++ b/helper_crates/vtable/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+// SPDX-License-Identifier: MIT OR Apache-2.0
 
 /*!
 This crate allows you to create ffi-friendly virtual tables.

--- a/helper_crates/vtable/src/vrc.rs
+++ b/helper_crates/vtable/src/vrc.rs
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+// SPDX-License-Identifier: MIT OR Apache-2.0
 
 // cSpell: ignore pointee repr
 

--- a/helper_crates/vtable/tests/test_vrc.rs
+++ b/helper_crates/vtable/tests/test_vrc.rs
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+// SPDX-License-Identifier: MIT OR Apache-2.0
 
 #![allow(improper_ctypes_definitions)]
 

--- a/helper_crates/vtable/tests/test_vtable.rs
+++ b/helper_crates/vtable/tests/test_vtable.rs
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+// SPDX-License-Identifier: MIT OR Apache-2.0
 
 #![no_std]
 extern crate alloc;

--- a/internal/backends/linuxkms/README.md
+++ b/internal/backends/linuxkms/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint-ui.com).
 This crate should **not be used directly** by applications using Slint.
 You should use the `slint` crate instead.

--- a/internal/backends/qt/LICENSES/MIT.txt
+++ b/internal/backends/qt/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../../LICENSES/MIT.txt

--- a/internal/backends/qt/README.md
+++ b/internal/backends/qt/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).
 This crate should **not be used directly** by applications using Slint.
 You should use the `slint` crate instead.

--- a/internal/backends/selector/LICENSES/MIT.txt
+++ b/internal/backends/selector/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../../LICENSES/MIT.txt

--- a/internal/backends/selector/README.md
+++ b/internal/backends/selector/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).
 This crate should **not be used directly** by applications using Slint.
 You should use the `slint` crate instead.

--- a/internal/backends/testing/README.md
+++ b/internal/backends/testing/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).
 This crate should **not be used directly** by applications using Slint.
 You should use the `slint` crate instead.

--- a/internal/backends/winit/LICENSES/MIT.txt
+++ b/internal/backends/winit/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../../LICENSES/MIT.txt

--- a/internal/backends/winit/README.md
+++ b/internal/backends/winit/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).
 This crate should **not be used directly** by applications using Slint.
 You should use the `slint` crate instead.

--- a/internal/common/LICENSES/MIT.txt
+++ b/internal/common/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../LICENSES/MIT.txt

--- a/internal/common/README.md
+++ b/internal/common/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 This crate contains internal data structures and code that is shared between
 the i-slint-core and the i-slint-compiler crates.
 

--- a/internal/compiler/README.md
+++ b/internal/compiler/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # The Slint Compiler Library
 
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).

--- a/internal/compiler/parser-test-macro/README.md
+++ b/internal/compiler/parser-test-macro/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 parser_test: a proc macro attribute that generate tests for the parser functions
 
 The parser_test macro will look at the documentation of a function for a

--- a/internal/core-macros/LICENSES/MIT.txt
+++ b/internal/core-macros/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../LICENSES/MIT.txt

--- a/internal/core-macros/README.md
+++ b/internal/core-macros/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 This crate contains the internal procedural macros used by the i-slint-core crate
 
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).

--- a/internal/core/LICENSES/MIT.txt
+++ b/internal/core/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../LICENSES/MIT.txt

--- a/internal/core/README.md
+++ b/internal/core/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint Runtime Library
 
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).

--- a/internal/renderers/femtovg/LICENSES/MIT.txt
+++ b/internal/renderers/femtovg/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../../LICENSES/MIT.txt

--- a/internal/renderers/femtovg/README.md
+++ b/internal/renderers/femtovg/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).
 This crate should **not be used directly** by applications using Slint.
 You should use the `slint` crate instead.

--- a/internal/renderers/skia/LICENSES/MIT.txt
+++ b/internal/renderers/skia/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../../LICENSES/MIT.txt

--- a/internal/renderers/skia/README.md
+++ b/internal/renderers/skia/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 **NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).
 This crate should **not be used directly** by applications using Slint.
 You should use the `slint` crate instead.

--- a/logo/README.md
+++ b/logo/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 
 This directory contains the different versions of the Slint logo.
 It is (manually) copied into the website under https://slint.dev/logo/

--- a/tools/figma_import/README.md
+++ b/tools/figma_import/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # figma_import: Figma to Slint import tool
 
 This tool imports a design from Figma into a .slint file.

--- a/tools/fmt/README.md
+++ b/tools/fmt/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint-fmt
 
 This tool for formatting .slint syntax is in a very early stage.

--- a/tools/lsp/LICENSES/MIT.txt
+++ b/tools/lsp/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../LICENSES/MIT.txt

--- a/tools/lsp/README.md
+++ b/tools/lsp/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # LSP (Language Server Protocol) Server for Slint
 
 This directory contains the implementation of the LSP server for [Slint](https://slint.dev)

--- a/tools/slintpad/README.md
+++ b/tools/slintpad/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # SlintPad
 
 This directory contains the frontend code for SlintPad, the online code editor

--- a/tools/tr-extractor/README.md
+++ b/tools/tr-extractor/README.md
@@ -1,1 +1,2 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 This utility extract `@tr` strings in a Slint file and generate a `.po` file

--- a/tools/updater/README.md
+++ b/tools/updater/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Slint Updater
 
 This program is a tool to upgrade `.slint` files from the [Slint Project](https://slint.dev) to the latest syntax.

--- a/tools/viewer/LICENSES/MIT.txt
+++ b/tools/viewer/LICENSES/MIT.txt
@@ -1,1 +1,0 @@
-../../../LICENSES/MIT.txt

--- a/tools/viewer/README.md
+++ b/tools/viewer/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
 # Viewer for Slint
 
 This program is a viewer for `.slint` files from the [Slint Project](https://slint.dev).


### PR DESCRIPTION
Instead, place the copyright and license right into the source.

This changes the license of helper_crates/const-field-offset/README.md to be MIT only, no more Apache-2.0. It also makes helper_crates/vtable/README.md MIT licensed, as previously triple-licensed.