### PR TITLE
Invalidate more item caches in the renderers when the window scale factor changes

### DIFF
--- a/internal/core/graphics/boxshadowcache.rs
+++ b/internal/core/graphics/boxshadowcache.rs
@@ -95,11 +95,12 @@ impl<ImageType: Clone> BoxShadowCache<ImageType> {
         item_rc: &ItemRc,
         item_cache: &crate::item_rendering::ItemCache<Option<ImageType>>,
         box_shadow: std::pin::Pin<&crate::items::BoxShadow>,
-        scale_factor: ScaleFactor,
+        window: &crate::api::Window,
         shadow_render_fn: impl FnOnce(&BoxShadowOptions) -> ImageType,
     ) -> Option<ImageType> {
         item_cache.get_or_update_cache_entry(item_rc, || {
-            let shadow_options = BoxShadowOptions::new(box_shadow, scale_factor)?;
+            let shadow_options =
+                BoxShadowOptions::new(box_shadow, ScaleFactor::new(window.scale_factor()))?;
             self.0
                 .borrow_mut()
                 .entry(shadow_options.clone())

--- a/internal/core/graphics/boxshadowcache.rs
+++ b/internal/core/graphics/boxshadowcache.rs
@@ -95,12 +95,11 @@ impl<ImageType: Clone> BoxShadowCache<ImageType> {
         item_rc: &ItemRc,
         item_cache: &crate::item_rendering::ItemCache<Option<ImageType>>,
         box_shadow: std::pin::Pin<&crate::items::BoxShadow>,
-        window: &crate::api::Window,
+        scale_factor: ScaleFactor,
         shadow_render_fn: impl FnOnce(&BoxShadowOptions) -> ImageType,
     ) -> Option<ImageType> {
         item_cache.get_or_update_cache_entry(item_rc, || {
-            let shadow_options =
-                BoxShadowOptions::new(box_shadow, ScaleFactor::new(window.scale_factor()))?;
+            let shadow_options = BoxShadowOptions::new(box_shadow, scale_factor)?;
             self.0
                 .borrow_mut()
                 .entry(shadow_options.clone())

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -14,6 +14,7 @@ use crate::item_tree::{
 use crate::lengths::{
     LogicalLength, LogicalPoint, LogicalPx, LogicalRect, LogicalSize, LogicalVector,
 };
+use crate::properties::PropertyTracker;
 use crate::Coord;
 use alloc::boxed::Box;
 use core::cell::{Cell, RefCell};
@@ -72,11 +73,20 @@ impl CachedRenderingData {
 /// [`ItemCache::component_destroyed`] must be called to clear the cache for that
 /// component.
 #[cfg(feature = "std")]
-#[derive(Default)]
 pub struct ItemCache<T> {
     /// The pointer is a pointer to a component
     map: RefCell<HashMap<*const vtable::Dyn, HashMap<usize, CachedGraphicsData<T>>>>,
+    /// Track if the window scale factor changes; used to clear the cache if necessary.
+    window_scale_factor_tracker: Pin<Box<PropertyTracker>>,
 }
+
+#[cfg(feature = "std")]
+impl<T> Default for ItemCache<T> {
+    fn default() -> Self {
+        Self { map: Default::default(), window_scale_factor_tracker: Box::pin(Default::default()) }
+    }
+}
+
 #[cfg(feature = "std")]
 impl<T: Clone> ItemCache<T> {
     /// Returns the cached value associated to the `item_rc` if it is still valid.
@@ -130,6 +140,16 @@ impl<T: Clone> ItemCache<T> {
             .get(&component)
             .and_then(|per_component_entries| per_component_entries.get(&item_rc.index()))
             .and_then(|entry| callback(&entry.data))
+    }
+
+    /// Clears the cache if the window's scale factor has changed since the last call.
+    pub fn clear_cache_if_scale_factor_changed(&self, window: &crate::api::Window) {
+        if self.window_scale_factor_tracker.is_dirty() {
+            self.window_scale_factor_tracker
+                .as_ref()
+                .evaluate_as_dependency_root(|| window.scale_factor());
+            self.clear_all();
+        }
     }
 
     /// free the whole cache

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -667,7 +667,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
             item_rc,
             self.graphics_cache,
             box_shadow,
-            self.scale_factor,
+            self.window,
             |shadow_options| {
                 let blur = shadow_options.blur;
                 let width = shadow_options.width;

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1101,7 +1101,9 @@ impl<'a> GLItemRenderer<'a> {
 
         let cache_entry = self.graphics_cache.get_or_update_cache_entry(item_rc, || {
             ItemGraphicsCacheEntry::Texture({
-                let size = (layer_logical_size_fn() * self.scale_factor).ceil().try_cast()?;
+                let size = (layer_logical_size_fn() * ScaleFactor::new(self.window.scale_factor()))
+                    .ceil()
+                    .try_cast()?;
 
                 let layer_image = existing_layer_texture
                     .and_then(|layer_texture| {

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -667,7 +667,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
             item_rc,
             self.graphics_cache,
             box_shadow,
-            self.window,
+            self.scale_factor,
             |shadow_options| {
                 let blur = shadow_options.blur;
                 let width = shadow_options.width;
@@ -1101,9 +1101,7 @@ impl<'a> GLItemRenderer<'a> {
 
         let cache_entry = self.graphics_cache.get_or_update_cache_entry(item_rc, || {
             ItemGraphicsCacheEntry::Texture({
-                let size = (layer_logical_size_fn() * ScaleFactor::new(self.window.scale_factor()))
-                    .ceil()
-                    .try_cast()?;
+                let size = (layer_logical_size_fn() * self.scale_factor).ceil().try_cast()?;
 
                 let layer_image = existing_layer_texture
                     .and_then(|layer_texture| {
@@ -1310,9 +1308,8 @@ impl<'a> GLItemRenderer<'a> {
                     if image_size.is_empty() {
                         return None;
                     }
-                    let scale_factor = ScaleFactor::new(self.window.scale_factor());
                     let t = LogicalSize::from_lengths(target_width.get(), target_height.get())
-                        * scale_factor;
+                        * self.scale_factor;
 
                     Some(i_slint_core::graphics::fit_size(image_fit, t, image_size).cast())
                 } else {

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -214,6 +214,8 @@ impl FemtoVGRenderer {
                     })?;
                 }
 
+                self.graphics_cache.clear_cache_if_scale_factor_changed(window);
+
                 let mut item_renderer = self::itemrenderer::GLItemRenderer::new(
                     &self.canvas,
                     &self.graphics_cache,

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -33,7 +33,7 @@ pub(crate) fn as_skia_image(
     image: Image,
     target_size_fn: &dyn Fn() -> (LogicalLength, LogicalLength),
     image_fit: ImageFit,
-    window: &i_slint_core::api::Window,
+    scale_factor: ScaleFactor,
     _canvas: &mut skia_safe::Canvas,
 ) -> Option<skia_safe::Image> {
     let image_inner: &ImageInner = (&image).into();
@@ -54,8 +54,7 @@ pub(crate) fn as_skia_image(
         ImageInner::Svg(svg) => {
             // Query target_width/height here again to ensure that changes will invalidate the item rendering cache.
             let (target_width, target_height) = target_size_fn();
-            let target_size = LogicalSize::from_lengths(target_width, target_height)
-                * ScaleFactor::new(window.scale_factor());
+            let target_size = LogicalSize::from_lengths(target_width, target_height) * scale_factor;
             let target_size = i_slint_core::graphics::fit_size(image_fit, target_size, svg.size());
             let pixels = match svg.render(target_size.cast()).ok()? {
                 SharedImageBuffer::RGB8(_) => unreachable!(),

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -239,7 +239,7 @@ impl<'a> SkiaItemRenderer<'a> {
         layer_logical_size_fn: &dyn Fn() -> LogicalSize,
     ) -> Option<skia_safe::Image> {
         self.image_cache.get_or_update_cache_entry(item_rc, || {
-            let layer_size = layer_logical_size_fn() * self.scale_factor;
+            let layer_size = layer_logical_size_fn() * ScaleFactor::new(self.window.scale_factor());
 
             let image_info = skia_safe::ImageInfo::new(
                 to_skia_size(&layer_size).to_ceil(),

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -576,6 +576,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
 
         let (physical_offset, skpath): (crate::euclid::Vector2D<f32, PhysicalPx>, _) =
             match self.path_cache.get_or_update_cache_entry(item_rc, || {
+                let scale_factor = ScaleFactor::new(self.window.scale_factor());
                 let (logical_offset, path_events): (crate::euclid::Vector2D<f32, LogicalPx>, _) =
                     path.fitted_path_events()?;
 
@@ -585,30 +586,26 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
                     match x {
                         lyon_path::Event::Begin { at } => {
                             skpath.move_to(to_skia_point(
-                                LogicalPoint::from_untyped(at) * self.scale_factor,
+                                LogicalPoint::from_untyped(at) * scale_factor,
                             ));
                         }
                         lyon_path::Event::Line { from: _, to } => {
                             skpath.line_to(to_skia_point(
-                                LogicalPoint::from_untyped(to) * self.scale_factor,
+                                LogicalPoint::from_untyped(to) * scale_factor,
                             ));
                         }
                         lyon_path::Event::Quadratic { from: _, ctrl, to } => {
                             skpath.quad_to(
-                                to_skia_point(LogicalPoint::from_untyped(ctrl) * self.scale_factor),
-                                to_skia_point(LogicalPoint::from_untyped(to) * self.scale_factor),
+                                to_skia_point(LogicalPoint::from_untyped(ctrl) * scale_factor),
+                                to_skia_point(LogicalPoint::from_untyped(to) * scale_factor),
                             );
                         }
 
                         lyon_path::Event::Cubic { from: _, ctrl1, ctrl2, to } => {
                             skpath.cubic_to(
-                                to_skia_point(
-                                    LogicalPoint::from_untyped(ctrl1) * self.scale_factor,
-                                ),
-                                to_skia_point(
-                                    LogicalPoint::from_untyped(ctrl2) * self.scale_factor,
-                                ),
-                                to_skia_point(LogicalPoint::from_untyped(to) * self.scale_factor),
+                                to_skia_point(LogicalPoint::from_untyped(ctrl1) * scale_factor),
+                                to_skia_point(LogicalPoint::from_untyped(ctrl2) * scale_factor),
+                                to_skia_point(LogicalPoint::from_untyped(to) * scale_factor),
                             );
                         }
                         lyon_path::Event::End { last: _, first: _, close } => {
@@ -619,7 +616,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
                     }
                 }
 
-                (logical_offset * self.scale_factor, skpath).into()
+                (logical_offset * scale_factor, skpath).into()
             }) {
                 Some(offset_and_path) => offset_and_path,
                 None => return,

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -660,7 +660,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
             self_rc,
             self.image_cache,
             box_shadow,
-            self.scale_factor,
+            self.window,
             |shadow_options| {
                 let shadow_size: skia_safe::Size = (
                     shadow_options.width.get() + shadow_options.blur.get() * 2.,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -144,6 +144,9 @@ impl SkiaRenderer {
 
                 let mut box_shadow_cache = Default::default();
 
+                self.image_cache.clear_cache_if_scale_factor_changed(window);
+                self.path_cache.clear_cache_if_scale_factor_changed(window);
+
                 let mut item_renderer = itemrenderer::SkiaItemRenderer::new(
                     skia_canvas,
                     window,


### PR DESCRIPTION
The path and layer caches were missing. The first three patches try to fix the individual cases, the last patch tries to clean it all up and make it more robust.