### PR TITLE
winit: re-export the winit crate

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -17,7 +17,10 @@ use i_slint_core::platform::PlatformError;
 use winitwindowadapter::*;
 pub(crate) mod event_loop;
 
-/// Internal type used by the winit backend for thread communcation and window system updates.
+/// Re-export of the winit crate
+pub use winit;
+
+/// Internal type used by the winit backend for thread communication and window system updates.
 #[non_exhaustive]
 pub enum SlintUserEvent {
     CustomEvent { event: CustomEvent },


### PR DESCRIPTION
Such that people that want to use i-slint-backend-winit don't need to also import the right version of winit from their Cargo.toml and just can re-use the re-exported version