### PR TITLE
Fix alias to externaly modified property not being marked as such

### DIFF
--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -89,6 +89,9 @@ impl WindowAdapter for TestingWindow {
     }
 
     fn set_size(&self, size: i_slint_core::api::WindowSize) {
+        self.window.dispatch_event(i_slint_core::platform::WindowEvent::Resized {
+            size: size.to_logical(1.),
+        });
         self.size.set(size.to_physical(1.))
     }
 

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -90,11 +90,10 @@ pub fn generate(
             )); // Perhaps byte code in the future?
         }
         OutputFormat::Llr => {
-            writeln!(
-                destination,
-                "{:#?}",
-                crate::llr::lower_to_item_tree::lower_to_item_tree(&doc.root_component)
-            )?;
+            let root = crate::llr::lower_to_item_tree::lower_to_item_tree(&doc.root_component);
+            let mut output = String::new();
+            crate::llr::pretty_print::pretty_print(&root, &mut output).unwrap();
+            write!(destination, "{output}")?;
         }
     }
     Ok(())

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -64,9 +64,10 @@ impl<'a> PrettyPrinter<'a> {
             self.indent()?;
             writeln!(
                 self.writer,
-                "{}: {};",
+                "{}: {};{}",
                 DisplayPropertyRef(p, &ctx),
-                DisplayExpression(&init.expression.borrow(), &ctx)
+                DisplayExpression(&init.expression.borrow(), &ctx),
+                if init.is_constant { " /*const*/" } else { "" }
             )?
         }
         for ssc in &sc.sub_components {

--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -190,8 +190,14 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
                 }
             } else {
                 // This is not a declaration, we must re-create the binding
-                elem.bindings
-                    .insert(remove.name().to_owned(), BindingExpression::new_two_way(to).into());
+                elem.bindings.insert(
+                    remove.name().to_owned(),
+                    BindingExpression::new_two_way(to.clone()).into(),
+                );
+                drop(elem);
+                if remove.is_externally_modified() {
+                    to.mark_as_set();
+                }
             }
         }
     }

--- a/tests/cases/issues/issue_3318_window_size.slint
+++ b/tests/cases/issues/issue_3318_window_size.slint
@@ -1,0 +1,20 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component TestCase  {
+    VerticalLayout {
+        t := Text {
+            text: "Hello World";
+        }
+    }
+    out property <int> t-width: t.width / 1px;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+instance.window().set_size(slint::PhysicalSize::new(300, 500));
+assert_eq!(instance.get_t_width(), 300);
+
+```
+*/


### PR DESCRIPTION
In the case of bug #3318, the implicit alias to the window's height or width was removed but the propery was not marked as externaly modified, causing later pass to optimize and inline things that shouldn't

Fixes #3318