### PR TITLE
Backends: don't resize the WindowItem in set_visible

### DIFF
--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -86,8 +86,6 @@ private:
 ///     slint::platform::AbstractRenderer &renderer() override { return m_renderer; }
 ///     void set_visible(bool v) override {
 ///         if (v) {
-///             window().dispatch_resize_event(slint::LogicalSize(
-///                 { float(m_native_window.width), float(m_native_window.height) }));
 ///             m_native_window.show();
 ///         } else {
 ///             m_native_window.hide();
@@ -148,8 +146,8 @@ public:
     ///
     /// Re-implement this function to forward the call to show/hide the native window
     ///
-    /// When the window becomes visible, this is a good place to send
-    /// slint::Window::dispatch_resize_event and slint::Window::dispatch_scale_factor_change_event
+    /// When the window becomes visible, this is a good place to send the first
+    /// slint::Window::dispatch_scale_factor_change_event
     virtual void set_visible(bool) { }
 
     /// This function is called when Slint detects that the window need to be repainted.

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -146,8 +146,8 @@ public:
     ///
     /// Re-implement this function to forward the call to show/hide the native window
     ///
-    /// When the window becomes visible, this is a good place to send the first
-    /// slint::Window::dispatch_scale_factor_change_event
+    /// When the window becomes visible, this is a good time to call
+    /// slint::Window::dispatch_scale_factor_change_event to initialise the scale factor.
     virtual void set_visible(bool) { }
 
     /// This function is called when Slint detects that the window need to be repainted.

--- a/internal/backends/linuxkms/fullscreenwindowadapter.rs
+++ b/internal/backends/linuxkms/fullscreenwindowadapter.rs
@@ -50,16 +50,11 @@ impl WindowAdapter for FullscreenWindowAdapter {
 
     fn set_visible(&self, visible: bool) -> Result<(), PlatformError> {
         if visible {
-            let scale_factor = if let Some(scale_factor) =
+            if let Some(scale_factor) =
                 std::env::var("SLINT_SCALE_FACTOR").ok().and_then(|sf| sf.parse().ok())
             {
                 self.window.dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor });
-                scale_factor
-            } else {
-                1.0
-            };
-            let size = self.size().to_logical(scale_factor);
-            self.window.dispatch_event(WindowEvent::Resized { size });
+            }
         }
         Ok(())
     }

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -15,7 +15,7 @@ use i_slint_core::input::{KeyEventType, KeyInputEvent, MouseEvent};
 use i_slint_core::item_rendering::{ItemCache, ItemRenderer};
 use i_slint_core::items::{
     self, FillRule, ImageRendering, Item, ItemRc, ItemRef, Layer, MouseCursor, Opacity,
-    PointerEventButton, RenderingResult, TextOverflow, TextWrap, WindowItem,
+    PointerEventButton, RenderingResult, TextOverflow, TextWrap,
 };
 use i_slint_core::layout::Orientation;
 use i_slint_core::lengths::{
@@ -1515,22 +1515,6 @@ impl WindowAdapter for QtWindow {
 
     fn set_visible(&self, visible: bool) -> Result<(), PlatformError> {
         if visible {
-            let component_rc = WindowInner::from_pub(&self.window).component();
-            let component = ComponentRc::borrow_pin(&component_rc);
-            let root_item = component.as_ref().get_item_ref(0);
-            if let Some(window_item) = ItemRef::downcast_pin::<WindowItem>(root_item) {
-                if window_item.width() <= LogicalLength::zero() {
-                    window_item.width.set(LogicalLength::new(
-                        component.as_ref().layout_info(Orientation::Horizontal).preferred_bounded(),
-                    ))
-                }
-                if window_item.height() <= LogicalLength::zero() {
-                    window_item.height.set(LogicalLength::new(
-                        component.as_ref().layout_info(Orientation::Vertical).preferred_bounded(),
-                    ))
-                }
-            }
-
             let widget_ptr = self.widget_ptr();
             let fullscreen = std::env::var("SLINT_FULLSCREEN").is_ok();
             cpp! {unsafe [widget_ptr as "QWidget*", fullscreen as "bool"] {


### PR DESCRIPTION
We already query the size right after the call to set_visible in the WindowInner::show()