### PR TITLE
Keep the component alive when the window is visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project are documented in this file.
  - Fixed setting rotation-angle and opacity from a callback
  - Fixed touch in the Flickable not resulting in a click
  - Added support for a new experimental backend that renders fullscreen on Linux using KMS (`backend-linuxkms`).
+ - Calling `show()` on a component (or its window) now keeps the component alive for as long as the window
+   is visible.
 
 ### Slint language
 

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -124,11 +124,25 @@ private:
 /// Base class for the layer between a slint::Window and the windowing system specific window type,
 /// such as a Win32 `HWND` handle or a `wayland_surface_t`.
 ///
-/// Re-implement this class to establish the link between the two.
+/// Re-implement this class to establish the link between the two, and pass messages in both
+/// directions:
+///
+/// - When receiving messages from the windowing system about state changes, such as the window
+///   being resized, the user requested the window to be closed, input being received, etc. you
+///   need to call the corresponding event functions on the Window, such as
+///   Window::dispatch_resize_event(), Window::dispatch_mouse_press_event(), or
+///   Window::dispatch_close_requested_event().
+///
+/// - Slint sends requests to change visibility, position, size, etc. via virtual functions such as
+///   set_visible(), set_size(), set_position(), or update_window_properties().
+///   Re-implement these functions and delegate the requests to the windowing system.
+///
+/// If the implementation of this bi-directional message passing protocol is incomplete, the user
+/// may experience unexpected behavior, or the intention of the developer calling functions on the
+/// Window API may not be fullfilled.
 ///
 /// Your WindowAdapter subclass must hold a renderer (either a SoftwareRenderer or a SkiaRenderer).
-/// In the renderer() method, you must return a
-/// reference to it.
+/// In the renderer() method, you must return a reference to it.
 ///
 /// # Example
 /// ```cpp

--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -254,9 +254,15 @@ public:
     /// system, then it will also become hidden and destroyed.
     ~Window() = default;
 
-    /// Registers the window with the windowing system in order to make it visible on the screen.
+    /// Shows the window on the screen. An additional strong reference on the
+    /// associated component is maintained while the window is visible.
+    ///
+    /// Call hide() to make the window invisible again, and drop the additional
+    /// strong reference.
     void show() { inner.show(); }
-    /// De-registers the window from the windowing system, therefore hiding it.
+    /// Hides the window, so that it is not visible anymore. The additional strong
+    /// reference on the associated component, that was created when show() was called, is
+    /// dropped.
     void hide() { inner.hide(); }
 
     /// Returns the visibility state of the window. This function can return false even if you

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -167,7 +167,6 @@ log = { version = "0.4.17", optional = true }
 [dev-dependencies]
 slint-build = { path = "../build" }
 i-slint-backend-testing = { path = "../../../internal/backends/testing" }
-i-slint-backend-winit = { path = "../../../internal/backends/winit", features = ["wayland", "x11", "renderer-software"] }
 serde_json = "1.0.96"
 serde = { version = "1.0.163", features = ["derive"] }
 

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -167,6 +167,7 @@ log = { version = "0.4.17", optional = true }
 [dev-dependencies]
 slint-build = { path = "../build" }
 i-slint-backend-testing = { path = "../../../internal/backends/testing" }
+i-slint-backend-winit = { path = "../../../internal/backends/winit", features = ["wayland", "x11", "renderer-software"] }
 serde_json = "1.0.96"
 serde = { version = "1.0.163", features = ["derive"] }
 

--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -100,16 +100,17 @@ pub mod generated_code {
             unimplemented!();
         }
 
-        /// Marks the window of this component to be shown on the screen. This registers
-        /// the window with the windowing system. In order to react to events from the windowing system,
-        /// such as draw requests or mouse/touch input, it is still necessary to spin the event loop,
-        /// using [`crate::run_event_loop`].
+        /// Convenience function for [`crate::Window::show()`]. This shows the window on the screen
+        /// and maintains an extra strong reference while the window is visible. To react
+        /// to events from the windowing system, such as draw requests or mouse/touch input, it is
+        /// still necessary to spin the event loop, using [`crate::run_event_loop`].
         fn show(&self) -> Result<(), crate::PlatformError> {
             unimplemented!();
         }
 
-        /// Marks the window of this component to be hidden on the screen. This de-registers
-        /// the window from the windowing system and it will not receive any further events.
+        /// Convenience function for [`crate::Window::hide()`]. Hides the window, so that it is not
+        /// visible anymore. The additional strong reference on the associated component, that was
+        /// created when show() was called, is dropped.
         fn hide(&self) -> Result<(), crate::PlatformError> {
             unimplemented!();
         }

--- a/api/rs/slint/tests/show_strongref.rs
+++ b/api/rs/slint/tests/show_strongref.rs
@@ -1,0 +1,34 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+use ::slint::slint;
+
+// Sorry, can't test with rust test harness and multiple threads.
+#[cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios")))]
+#[test]
+fn show_maintains_strong_reference() {
+    slint::platform::set_platform(Box::new(i_slint_backend_winit::Backend::new())).unwrap();
+
+    slint!(export component TestWindow inherits Window {
+        callback root-clicked();
+        TouchArea {
+            clicked => { root.root-clicked(); }
+        }
+    });
+
+    let window = TestWindow::new().unwrap();
+
+    let window_weak = window.as_weak();
+    let window_weak_2 = window_weak.clone();
+
+    slint::Timer::single_shot(std::time::Duration::from_millis(20), move || {
+        window_weak_2.upgrade().unwrap().hide().unwrap();
+        slint::quit_event_loop().unwrap();
+    });
+
+    window.show().unwrap();
+    drop(window);
+    slint::run_event_loop().unwrap();
+
+    assert!(window_weak.upgrade().is_none());
+}

--- a/api/rs/slint/tests/show_strongref.rs
+++ b/api/rs/slint/tests/show_strongref.rs
@@ -3,11 +3,9 @@
 
 use ::slint::slint;
 
-// Sorry, can't test with rust test harness and multiple threads.
-#[cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios")))]
 #[test]
 fn show_maintains_strong_reference() {
-    slint::platform::set_platform(Box::new(i_slint_backend_winit::Backend::new())).unwrap();
+    i_slint_backend_testing::init_with_event_loop();
 
     slint!(export component TestWindow inherits Window {
         callback root-clicked();
@@ -21,10 +19,11 @@ fn show_maintains_strong_reference() {
     let window_weak = window.as_weak();
     let window_weak_2 = window_weak.clone();
 
-    slint::Timer::single_shot(std::time::Duration::from_millis(20), move || {
+    slint::invoke_from_event_loop(move || {
         window_weak_2.upgrade().unwrap().hide().unwrap();
         slint::quit_event_loop().unwrap();
-    });
+    })
+    .unwrap();
 
     window.show().unwrap();
     drop(window);

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -368,12 +368,18 @@ impl Window {
         Self(WindowInner::new(window_adapter_weak))
     }
 
-    /// Registers the window with the windowing system in order to make it visible on the screen.
+    /// Shows the window on the screen. An additional strong reference on the
+    /// associated component is maintained while the window is visible.
+    ///
+    /// Call [`self::hide()`] to make the window invisible again, and drop the additional
+    /// strong reference.
     pub fn show(&self) -> Result<(), PlatformError> {
         self.0.show()
     }
 
-    /// De-registers the window from the windowing system, therefore hiding it.
+    /// Hides the window, so that it is not visible anymore. The additional strong
+    /// reference on the associated component, that was created when [`Self::show()`] was called, is
+    /// dropped.
     pub fn hide(&self) -> Result<(), PlatformError> {
         self.0.hide()
     }
@@ -586,14 +592,16 @@ pub trait ComponentHandle {
     #[doc(hidden)]
     fn from_inner(_: vtable::VRc<ComponentVTable, Self::Inner>) -> Self;
 
-    /// Marks the window of this component to be shown on the screen. This registers
-    /// the window with the windowing system. In order to react to events from the windowing system,
-    /// such as draw requests or mouse/touch input, it is still necessary to spin the event loop,
+    /// Convenience function for [`crate::Window::show()`](struct.Window.html#method.show).
+    /// This shows the window on the screen and maintains an extra strong reference while
+    /// the window is visible. To react to events from the windowing system, such as draw
+    /// requests or mouse/touch input, it is still necessary to spin the event loop,
     /// using [`crate::run_event_loop`](fn.run_event_loop.html).
     fn show(&self) -> Result<(), PlatformError>;
 
-    /// Marks the window of this component to be hidden on the screen. This de-registers
-    /// the window from the windowing system and it will not receive any further events.
+    /// Convenience function for [`crate::Window::hide()`](struct.Window.html#method.hide).
+    /// Hides the window, so that it is not visible anymore. The additional strong reference
+    /// on the associated component, that was created when show() was called, is dropped.
     fn hide(&self) -> Result<(), PlatformError>;
 
     /// Returns the Window associated with this component. The window API can be used

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -48,9 +48,29 @@ fn input_as_key_event(input: KeyInputEvent, modifiers: KeyboardModifiers) -> Key
     }
 }
 
-/// This trait represents the adaptation layer between the [`Window`] API, and the
-/// internal type from the backend that provides functionality such as device-independent pixels,
-/// window resizing, and other typically windowing system related tasks.
+/// This trait represents the adaptation layer between the [`Window`] API and then
+/// windowing specific window representation, such as a Win32 `HWND` handle or a `wayland_surface_t`.
+///
+/// Implement this trait to establish the link between the two, and pass messages in both
+/// directions:
+///
+/// - When receiving messages from the windowing system about state changes, such as the window being resized,
+///   the user requested the window to be closed, input being received, etc. you need to create a
+///   [`crate::platform::WindowEvent`](enum.WindowEvent.html) and send it to Slint via [`create::Window::dispatch_event()`](../struct.Window.html#method.dispatch_event).
+///
+/// - Slint sends requests to change visibility, position, size, etc. via functions such as [`Self::set_visible`],
+///   [`Self::set_size`], [`Self::set_position`], or [`Self::update_window_properties()`]. Re-implement these functions
+///   and delegate the requests to the windowing system.
+///
+/// If the implementation of this bi-directional message passing protocol is incomplete, the user may
+/// experience unexpected behavior, or the intention of the developer calling functions on the [`crate::Window`](struct.Window.html)
+/// API may not be fullfilled.
+///
+/// Your implementation must hold a renderer, such as [`crate::software_renderer::SoftwareRenderer`].
+/// In the [`Self::renderer()`] function, you must return a reference to it.
+///
+/// It is also required to hold a [`crate::Window`](struct.Window.html) and return a reference to it in your
+/// implementation of [`Self::window()`].
 ///
 /// See also [`MinimalSoftwareWindow`](crate::software_renderer::MinimalSoftwareWindow)
 /// for a minimal implementation of this trait using the software renderer


### PR DESCRIPTION
show() now let's Slint maintain a strong reference to the component, so that it's easy to create new windows without having to do an awkward dance around keeping the component alive.

Closes #3328