### PR TITLE
wasm-interpreter: remove the highlight feature

### DIFF
--- a/api/wasm-interpreter/Cargo.toml
+++ b/api/wasm-interpreter/Cargo.toml
@@ -15,9 +15,6 @@ homepage = "https://slint.dev"
 [lib]
 crate-type = ["cdylib"]
 
-[features]
-highlight = ["slint-interpreter/highlight"]
-
 [dependencies]
 slint-interpreter = { path = "../../internal/interpreter", default-features = false, features = ["std", "backend-winit", "renderer-femtovg", "compat-1-2"] }
 send_wrapper = { workspace = true }

--- a/api/wasm-interpreter/src/lib.rs
+++ b/api/wasm-interpreter/src/lib.rs
@@ -302,44 +302,6 @@ impl WrappedInstance {
             }
         }))
     }
-
-    /// THIS FUNCTION IS NOT PART THE PUBLIC API!
-    /// Highlights instances of the requested component
-    #[cfg(feature = "highlight")]
-    #[wasm_bindgen]
-    pub fn highlight(&self, _path: &str, _offset: u32) {
-        self.0.highlight(_path.into(), _offset);
-        let _ = slint_interpreter::invoke_from_event_loop(|| {}); // wake event loop
-    }
-
-    /// THIS FUNCTION IS NOT PART THE PUBLIC API!
-    /// Request information on what to highlight in the editor based on clicks in the UI
-    #[cfg(feature = "highlight")]
-    #[wasm_bindgen]
-    pub fn set_design_mode(&self, active: bool) {
-        self.0.set_design_mode(active);
-        let _ = slint_interpreter::invoke_from_event_loop(|| {}); // wake event loop
-    }
-
-    /// THIS FUNCTION IS NOT PART THE PUBLIC API!
-    /// Request information on what to highlight in the editor based on clicks in the UI
-    #[cfg(feature = "highlight")]
-    #[wasm_bindgen]
-    pub fn on_element_selected(&self, callback: CurrentElementInformationCallbackFunction) {
-        self.0.on_element_selected(Box::new(
-            move |url: &str, start_line: u32, start_column: u32, end_line: u32, end_column: u32| {
-                let args = js_sys::Array::of5(
-                    &url.into(),
-                    &start_line.into(),
-                    &start_column.into(),
-                    &end_line.into(),
-                    &end_column.into(),
-                );
-                let callback = js_sys::Function::from(callback.clone());
-                let _ = callback.apply(&JsValue::UNDEFINED, &args);
-            },
-        ));
-    }
 }
 
 /// Register DOM event handlers on all instance and set up the event loop for that.


### PR DESCRIPTION
We do the highlighting only from the LSP, even in wasm