### PR TITLE
Make the SkiaRenderer public in the Rust API

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -134,13 +134,13 @@ renderer-winit-software = ["renderer-software"]
 renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "std"]
 
 ## Render using [Skia](https://skia.org/).
-renderer-skia = ["i-slint-backend-selector/renderer-skia", "std"]
+renderer-skia = ["i-slint-backend-selector/renderer-skia", "dep:i-slint-renderer-skia", "std"]
 
 ## Same as `renderer-skia`, but Skia will always use OpenGL.
-renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "std"]
+renderer-skia-opengl = ["i-slint-backend-selector/renderer-skia-opengl", "dep:i-slint-renderer-skia", "std"]
 
 ## Same as `renderer-skia`, but Skia will always use Vulkan.
-renderer-skia-vulkan = ["i-slint-backend-selector/renderer-skia-vulkan", "std"]
+renderer-skia-vulkan = ["i-slint-backend-selector/renderer-skia-vulkan", "dep:i-slint-renderer-skia", "std"]
 
 ## Render using the software renderer.
 renderer-software = ["i-slint-backend-selector/renderer-software", "i-slint-core/software-renderer"]
@@ -153,6 +153,7 @@ backend-linuxkms = ["i-slint-backend-selector/backend-linuxkms", "std"]
 i-slint-core = { version = "=1.2.0", path = "../../../internal/core", default-features = false }
 slint-macros = { version = "=1.2.0", path = "../macros" }
 i-slint-backend-selector = { version = "=1.2.0", path = "../../../internal/backends/selector" }
+i-slint-renderer-skia = { version = "=1.2.0", path = "../../../internal/renderers/skia", optional = true, default-features = false }
 
 const-field-offset = { version = "0.1.2", path = "../../../helper_crates/const-field-offset" }
 document-features = { version = "0.2.0", optional = true }
@@ -177,4 +178,4 @@ rustdoc-args = [
   "--html-in-header",
   "docs/resources/slint-docs-highlight.html",
 ]
-features = ["document-features", "log", "gettext", "renderer-software", "renderer-femtovg"]
+features = ["document-features", "log", "gettext", "renderer-software", "renderer-femtovg", "renderer-skia"]

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -349,6 +349,14 @@ macro_rules! init_translations {
 /// The [Slint on Microcontrollers](crate::docs::mcu) documentation has additional examples.
 pub mod platform {
     pub use i_slint_core::platform::*;
+
+    /// This module contains the [`skia_renderer::SkiaRenderer`] and related types.
+    ///
+    /// It is only enabled when the `renderer-skia` Slint feature is enabled.
+    #[cfg(any(feature = "renderer-skia", feature = "renderer-skia-opengl", feature = "renderer-skia-vulkan"))]
+    pub mod skia_renderer {
+        pub use i_slint_renderer_skia::SkiaRenderer;
+    }
 }
 
 /// Helper type that helps checking that the generated code is generated for the right version

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -353,7 +353,11 @@ pub mod platform {
     /// This module contains the [`skia_renderer::SkiaRenderer`] and related types.
     ///
     /// It is only enabled when the `renderer-skia` Slint feature is enabled.
-    #[cfg(any(feature = "renderer-skia", feature = "renderer-skia-opengl", feature = "renderer-skia-vulkan"))]
+    #[cfg(any(
+        feature = "renderer-skia",
+        feature = "renderer-skia-opengl",
+        feature = "renderer-skia-vulkan"
+    ))]
     pub mod skia_renderer {
         pub use i_slint_renderer_skia::SkiaRenderer;
     }

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -72,7 +72,7 @@ impl SkiaRenderer {
     /// must match the size of the underlying native window.
     ///
     /// Subsequent calls to [`Self::render()`] will render into the window.
-    /// 
+    ///
     /// Safety: It is the caller's responsibility to ensure that the underlying native
     /// window exists and remains valid for the life-time of the SkiaRenderer.
     pub fn new(

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -70,7 +70,7 @@ pub struct SkiaRenderer {
 impl SkiaRenderer {
     /// Creates a new renderer for the given window/display handle. The provided size
     /// must match the size of the underlying native window.
-    /// 
+    ///
     /// Subsequent calls to [`Self::render()`] will render into the window.
     /// 
     /// Safety: It is the caller's responsibility to ensure that the underlying native


### PR DESCRIPTION
It's also public in the C++ API and this is the equivalent change on the Rust API side.