### PR TITLE
C++: Fix ninja always rebuilding the .slint file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project are documented in this file.
  - The features `SLINT_FEATURE_RENDERER_WINIT_*` were renamed to `SLINT_FEATURE_RENDERER_*`.
  - Extended `slint::Image::create_from_borrowed_gl_2d_rgba_texture` with an option to configure more aspects
    of texture rendering.
+ - Fixed cmake dependencies of the generated header so it is generated if and only if the .slint files have changed
 
 ### LSP
 

--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -21,15 +21,11 @@ function(SLINT_TARGET_SOURCES target)
         set(embed "$<IF:$<STREQUAL:${t_prop},>,${global_fallback},${t_prop}>")
 
         if(CMAKE_GENERATOR STREQUAL "Ninja")
-            # this code is inspired from the llvm source
-            # https://github.com/llvm/llvm-project/blob/a00290ed10a6b4e9f6e9be44ceec367562f270c6/llvm/cmake/modules/TableGen.cmake#L13
-
-            file(RELATIVE_PATH _SLINT_BASE_NAME_REL ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME})
-
             add_custom_command(
                 OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
                 COMMAND Slint::slint-compiler ${_SLINT_ABSOLUTE}
-                    -o ${_SLINT_BASE_NAME_REL}.h  --depfile ${_SLINT_BASE_NAME_REL}.d
+                    -o ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
+                    --depfile ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d
                     --style ${_SLINT_STYLE}
                     --embed-resources=${embed}
                     --translation-domain="${target}"

--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -20,34 +20,19 @@ function(SLINT_TARGET_SOURCES target)
         set(global_fallback "${DEFAULT_SLINT_EMBED_RESOURCES}")
         set(embed "$<IF:$<STREQUAL:${t_prop},>,${global_fallback},${t_prop}>")
 
-        if(CMAKE_GENERATOR STREQUAL "Ninja")
-            add_custom_command(
-                OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
-                COMMAND Slint::slint-compiler ${_SLINT_ABSOLUTE}
-                    -o ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
-                    --depfile ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d
-                    --style ${_SLINT_STYLE}
-                    --embed-resources=${embed}
-                    --translation-domain="${target}"
-                DEPENDS Slint::slint-compiler ${_SLINT_ABSOLUTE}
-                COMMENT "Generating ${_SLINT_BASE_NAME}.h"
-                DEPFILE ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            )
-        else(CMAKE_GENERATOR STREQUAL "Ninja")
-            get_filename_component(_SLINT_DIR ${_SLINT_ABSOLUTE} DIRECTORY )
-            file(GLOB ALL_SLINTS "${_SLINT_DIR}/*.slint")
-            add_custom_command(
-                OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
-                COMMAND Slint::slint-compiler ${_SLINT_ABSOLUTE}
-                    -o ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
-                    --style ${_SLINT_STYLE}
-                    --embed-resources=${embed}
-                    --translation-domain="${target}"
-                DEPENDS Slint::slint-compiler ${_SLINT_ABSOLUTE} ${ALL_SLINTS}
-                COMMENT "Generating ${_SLINT_BASE_NAME}.h"
-            )
-        endif(CMAKE_GENERATOR STREQUAL "Ninja")
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
+            COMMAND Slint::slint-compiler ${_SLINT_ABSOLUTE}
+                -o ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
+                --depfile ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d
+                --style ${_SLINT_STYLE}
+                --embed-resources=${embed}
+                --translation-domain="${target}"
+            DEPENDS Slint::slint-compiler ${_SLINT_ABSOLUTE}
+            COMMENT "Generating ${_SLINT_BASE_NAME}.h"
+            DEPFILE ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
 
         target_sources(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h)
     endforeach()

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -97,7 +97,7 @@ fn main() -> std::io::Result<()> {
 
     if let Some(depfile) = args.depfile {
         let mut f = std::fs::File::create(depfile)?;
-        write!(f, "{}:", args.output.display())?;
+        write!(f, "{}: {}", args.output.display(), args.path.display())?;
         for x in &diag.all_loaded_files {
             if x.is_absolute() {
                 write!(f, " {}", x.display())?;


### PR DESCRIPTION
two bugs:
 - If the .slint file did not contain any import, the depfile would have
   no dependencies, and as a result, ninja would consider that it is
   always dirty.
 - In case the binary dir is a sub directory, the dependencies were
   relative to the wrong directory. Thgis is because the behavior
   changed in some version of cmake (see https://cmake.org/cmake/help/latest/policy/CMP0116.html)
   to avoid any problem, use the absolute paths

Fixes https://github.com/slint-ui/slint/issues/3261

Also make the DEPFILE active with other generators than Ninja since it is supported there.