### PR TITLE
Expand InputType to support number type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project are documented in this file.
 
 ### Slint Language
 
+ - Added `Number`, `Decimal` variant to enum `InputType`
+
 ### Rust API
 
 ### C++

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -234,15 +234,17 @@ macro_rules! for_each_enums {
                 Pixelated,
             }
 
-            /// This enum is used to define the type of the input field. Currently this only differentiates between
-            /// text and password inputs but in the future it could be expanded to also define what type of virtual keyboard
-            /// should be shown, for example.
+            /// This enum is used to define the type of the input field.
             #[non_exhaustive]
             enum InputType {
                 /// The default value. This will render all characters normally
                 Text,
                 /// This will render all characters with a character that defaults to "*"
                 Password,
+                /// This will only accept and render number characters (0-9)
+                Number,
+                /// This will accept and render characters if it's valid part of a decimal
+                Decimal,
             }
 
             /// Enum representing the [alignment](../concepts/layouting.md#alignment) property of a

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -479,6 +479,7 @@ impl Item for TextInput {
                 {
                     return KeyEventResult::EventIgnored;
                 }
+
                 if let Some(shortcut) = event.shortcut() {
                     match shortcut {
                         StandardShortcut::SelectAll => {
@@ -503,6 +504,21 @@ impl Item for TextInput {
                         _ => (),
                     }
                 }
+
+                let input_type = self.input_type();
+                if input_type == InputType::Number
+                    && !event.text.as_str().chars().all(|ch| ch.is_ascii_digit())
+                {
+                    return KeyEventResult::EventIgnored;
+                }
+                if input_type == InputType::Decimal {
+                    let text = self.text().clone() + event.text.as_str();
+                    if text.as_str() != "." && text.as_str() != "-" && text.parse::<f64>().is_err()
+                    {
+                        return KeyEventResult::EventIgnored;
+                    }
+                }
+
                 if self.read_only() || event.modifiers.control {
                     return KeyEventResult::EventIgnored;
                 }

--- a/tests/cases/text/input_type_decimal.slint
+++ b/tests/cases/text/input_type_decimal.slint
@@ -1,0 +1,38 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+TestCase := Window {
+    width: 100phx;
+    height: 100phx;
+    ti := TextInput {
+        input-type: decimal;
+    }
+
+    property <bool> input_focused: ti.has_focus;
+    property <string> text <=> ti.text;
+}
+
+/*
+```rust
+use slint::platform::Key;
+
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_input_focused());
+assert!(instance.get_text().is_empty());
+
+// accept characters as valid decimal only
+slint_testing::send_keyboard_char(&instance, 'a', true);
+assert!(instance.get_text().is_empty());
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+assert!(instance.get_text().is_empty());
+slint_testing::send_keyboard_char(&instance, '-', true);
+assert_eq!(instance.get_text(), "-");
+slint_testing::send_keyboard_char(&instance, '1', true);
+assert_eq!(instance.get_text(), "-1");
+slint_testing::send_keyboard_char(&instance, '.', true);
+assert_eq!(instance.get_text(), "-1.");
+slint_testing::send_keyboard_char(&instance, '0', true);
+assert_eq!(instance.get_text(), "-1.0");
+```
+*/

--- a/tests/cases/text/input_type_number.slint
+++ b/tests/cases/text/input_type_number.slint
@@ -1,0 +1,32 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+TestCase := Window {
+    width: 100phx;
+    height: 100phx;
+    ti := TextInput {
+        input-type: number;
+    }
+
+    property <bool> input_focused: ti.has_focus;
+    property <string> text <=> ti.text;
+}
+
+/*
+```rust
+use slint::platform::Key;
+
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_input_focused());
+assert!(instance.get_text().is_empty());
+
+// accept number characters only
+slint_testing::send_keyboard_char(&instance, 'a', true);
+assert!(instance.get_text().is_empty());
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+assert!(instance.get_text().is_empty());
+slint_testing::send_keyboard_char(&instance, '1', true);
+assert_eq!(instance.get_text(), "1");
+```
+*/


### PR DESCRIPTION
This PR is for issue https://github.com/slint-ui/slint/issues/3356

Changes include:

- Update enum `InputType`, add `Number` and `Decimal` field
- Update `key_event` logic
- Add two more test cases
