### PR TITLE
C++: Api changes in the WindowAdapter/Platform

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -749,8 +749,7 @@ fn gen_platform(
         .with_include("slint_internal.h")
         .with_after_include(
             r"
-namespace slint::platform { struct WindowProperties; }
-namespace slint::cbindgen_private { using platform::WindowProperties; }
+namespace slint::cbindgen_private { struct WindowProperties; }
 ",
         )
         .generate()

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -49,26 +49,18 @@ class EspWindowAdapter : public slint::platform::WindowAdapter
 public:
     slint::platform::SoftwareRenderer m_renderer;
     bool needs_redraw = true;
-    const slint::PhysicalSize size;
+    const slint::PhysicalSize m_size;
 
     explicit EspWindowAdapter(RepaintBufferType buffer_type, slint::PhysicalSize size)
-        : m_renderer(buffer_type), size(size)
+        : m_renderer(buffer_type), m_size(size)
     {
     }
 
     slint::platform::AbstractRenderer &renderer() override { return m_renderer; }
 
-    slint::PhysicalSize physical_size() const override { return size; }
+    slint::PhysicalSize size() override { return m_size; }
 
     void request_redraw() override { needs_redraw = true; }
-
-    void set_visible(bool v) override
-    {
-        if (v) {
-            window().dispatch_resize_event(
-                    slint::LogicalSize({ float(size.width), float(size.height) }));
-        }
-    }
 };
 
 std::unique_ptr<slint::platform::WindowAdapter> EspPlatform::create_window_adapter()

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -24,7 +24,7 @@ struct EspPlatform : public slint::platform::Platform
 
     std::unique_ptr<slint::platform::WindowAdapter> create_window_adapter() override;
 
-    std::chrono::milliseconds duration_since_start() const override;
+    std::chrono::milliseconds duration_since_start() override;
     void run_event_loop() override;
     void quit_event_loop() override;
     void run_in_event_loop(Task) override;
@@ -77,7 +77,7 @@ std::unique_ptr<slint::platform::WindowAdapter> EspPlatform::create_window_adapt
     return window;
 }
 
-std::chrono::milliseconds EspPlatform::duration_since_start() const
+std::chrono::milliseconds EspPlatform::duration_since_start()
 {
     auto ticks = xTaskGetTickCount();
     return std::chrono::milliseconds(pdTICKS_TO_MS(ticks));

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -470,24 +470,6 @@ inline void set_platform(std::unique_ptr<Platform> platform)
 }
 
 #ifdef SLINT_FEATURE_RENDERER_SOFTWARE
-/// Represents a region on the screen, used for partial rendering.
-///
-/// The region may be composed of multiple sub-regions.
-struct PhysicalRegion
-{
-    /// Returns the size of the bounding box of this region.
-    PhysicalSize bounding_box_size() const
-    {
-        return PhysicalSize({ uint32_t(inner.width), uint32_t(inner.height) });
-    }
-    /// Returns the origin of the bounding box of this region.
-    PhysicalPosition bounding_box_origin() const { return PhysicalPosition({ inner.x, inner.y }); }
-
-private:
-    cbindgen_private::types::IntRect inner;
-    friend class SoftwareRenderer;
-    PhysicalRegion(cbindgen_private::types::IntRect inner) : inner(inner) { }
-};
 
 /// A 16bit pixel that has 5 red bits, 6 green bits and 5 blue bits
 struct Rgb565Pixel
@@ -549,6 +531,28 @@ class SoftwareRenderer : public AbstractRenderer
     }
 
 public:
+    /// Represents a region on the screen, used for partial rendering.
+    ///
+    /// The region may be composed of multiple sub-regions.
+    struct PhysicalRegion
+    {
+        /// Returns the size of the bounding box of this region.
+        PhysicalSize bounding_box_size() const
+        {
+            return PhysicalSize({ uint32_t(inner.width), uint32_t(inner.height) });
+        }
+        /// Returns the origin of the bounding box of this region.
+        PhysicalPosition bounding_box_origin() const
+        {
+            return PhysicalPosition({ inner.x, inner.y });
+        }
+
+    private:
+        cbindgen_private::types::IntRect inner;
+        friend class SoftwareRenderer;
+        PhysicalRegion(cbindgen_private::types::IntRect inner) : inner(inner) { }
+    };
+
     /// This enum describes which parts of the buffer passed to the SoftwareRenderer may be
     /// re-used to speed up painting.
     enum class RepaintBufferType : uint32_t {

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -343,10 +343,7 @@ public:
     ///
     /// This function should only be implemented  if the runtime is compiled with
     /// SLINT_FEATURE_FREESTANDING
-    virtual std::chrono::milliseconds duration_since_start() const
-    {
-        return {};
-    }
+    virtual std::chrono::milliseconds duration_since_start() = 0;
 #endif
 
     /// The type of clipboard used in Platform::clipboard_text and PLatform::set_clipboard_text.
@@ -449,7 +446,7 @@ inline void set_platform(std::unique_ptr<Platform> platform)
 #ifndef SLINT_FEATURE_FREESTANDING
                 return 0;
 #else
-                return reinterpret_cast<const Platform *>(p)->duration_since_start().count();
+                return reinterpret_cast<Platform *>(p)->duration_since_start().count();
 #endif
             },
             [](void *p, const SharedString *text, cbindgen_private::Clipboard clipboard) {

--- a/api/cpp/tests/platform_eventloop.cpp
+++ b/api/cpp/tests/platform_eventloop.cpp
@@ -73,7 +73,7 @@ struct TestPlatform : slint::platform::Platform
     }
 
 #ifdef SLINT_FEATURE_FREESTANDING
-    virtual std::chrono::milliseconds duration_since_start() const override
+    virtual std::chrono::milliseconds duration_since_start() override
     {
         return std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - start);

--- a/examples/cpp/platform_native/windowadapter_win.h
+++ b/examples/cpp/platform_native/windowadapter_win.h
@@ -62,7 +62,7 @@ struct MyWindowAdapter : public slint::platform::WindowAdapter
 
     slint::platform::AbstractRenderer &renderer() override { return m_renderer.value(); }
 
-    slint::PhysicalSize physical_size() const override
+    slint::PhysicalSize size() override
     {
         RECT r;
         GetWindowRect(hwnd, &r);

--- a/examples/cpp/platform_qt/main.cpp
+++ b/examples/cpp/platform_qt/main.cpp
@@ -198,7 +198,7 @@ public:
     MyWindow(QWindow *parentWindow = nullptr) : QWindow(parentWindow)
     {
         resize(640, 480);
-        m_renderer.emplace(window_handle_for_qt_window(this), physical_size());
+        m_renderer.emplace(window_handle_for_qt_window(this), size());
     }
 
     slint::platform::AbstractRenderer &renderer() override { return m_renderer.value(); }
@@ -256,13 +256,13 @@ public:
         }
     }
 
-    void set_physical_size(slint::PhysicalSize size) override
+    void set_size(slint::PhysicalSize size) override
     {
         float scale_factor = devicePixelRatio();
         resize(size.width / scale_factor, size.height / scale_factor);
     }
 
-    slint::PhysicalSize physical_size() const override
+    slint::PhysicalSize size() override
     {
         auto windowSize = slint::LogicalSize({ float(width()), float(height()) });
         float scale_factor = devicePixelRatio();
@@ -276,7 +276,7 @@ public:
         setFramePosition(QPointF(position.x / scale_factor, position.y / scale_factor).toPoint());
     }
 
-    std::optional<slint::PhysicalPosition> position() const override
+    std::optional<slint::PhysicalPosition> position() override
     {
         auto pos = framePosition();
         float scale_factor = devicePixelRatio();
@@ -286,7 +286,7 @@ public:
 
     void request_redraw() override { requestUpdate(); }
 
-    void update_window_properties(const slint::platform::WindowProperties &props) override
+    void update_window_properties(const WindowProperties &props) override
     {
         QWindow::setTitle(QString::fromUtf8(props.title().data()));
         auto c = props.layout_constraints();


### PR DESCRIPTION
 - s/physical_size/size/ (consistant with the slint::Window API)
 - remove const of virtual function  (they don't need to be const and make implementation potentially easier)
 - Move the WindowProperties in it
 - [make Platform::duration_since_start non-const and pure](https://github.com/slint-ui/slint/pull/3381/commits/c1e25959acd0ad4832902e9c0ef9a398560f6609)
 - [Move the PhysicalRegion in the SofwtareRenderer](https://github.com/slint-ui/slint/pull/3381/commits/5b0e40f9a1dcc7a5f17246f6578b0675003e8279)