### PR TITLE
API fixes to the OpenGL texture borrowing API

### DIFF
--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -129,6 +129,9 @@ impl Texture {
                     i_slint_core::graphics::BorrowedOpenGLTextureOrigin::BottomLeft => {
                         image_flags | femtovg::ImageFlags::FLIP_Y
                     }
+                    _ => unimplemented!(
+                        "internal error: missing implementation for BorrowedOpenGLTextureOrigin"
+                    ),
                 };
                 canvas
                     .borrow_mut()

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -106,6 +106,9 @@ pub(crate) fn as_skia_image(
                     i_slint_core::graphics::BorrowedOpenGLTextureOrigin::BottomLeft => {
                         skia_safe::gpu::SurfaceOrigin::BottomLeft
                     }
+                    _ => unimplemented!(
+                        "internal error: missing implementation for BorrowedOpenGLTextureOrigin"
+                    ),
                 },
                 skia_safe::ColorType::RGBA8888,
                 skia_safe::AlphaType::Unpremul,


### PR DESCRIPTION
- Make BorrowedOpenGLTextureOrigin non_exhaustive
- Mark BorrowedOpenGLTextureBuilder::new_gl_2d_rgba_texture as unsafe instead of build(). The former takes the arguments that may be garbage, not the latter.