### PR TITLE
lsp: Use same conversion from URL to PathBuf everywhere

### DIFF
--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -680,6 +680,7 @@ fn add_components_to_import(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::language::uri_to_file;
 
     /// Given a source text containing the unicode emoji `🔺`, the emoji will be removed and then an autocompletion request will be done as if the cursor was there
     fn get_completions(file: &str) -> Option<Vec<CompletionItem>> {
@@ -688,7 +689,7 @@ mod tests {
         let source = file.replace(CURSOR_EMOJI, "");
         let (mut dc, uri, _) = crate::language::test::loaded_document_cache(source);
 
-        let doc = dc.documents.get_document(&uri.to_file_path().unwrap()).unwrap();
+        let doc = dc.documents.get_document(&uri_to_file(&uri).unwrap()).unwrap();
         let token = crate::language::token_at_offset(doc.node.as_ref().unwrap(), offset)?;
 
         completion_at(&mut dc, token, offset, None)

--- a/tools/lsp/language/semantic_tokens.rs
+++ b/tools/lsp/language/semantic_tokens.rs
@@ -32,8 +32,7 @@ pub fn get_semantic_tokens(
     document_cache: &mut DocumentCache,
     text_document: &lsp_types::TextDocumentIdentifier,
 ) -> Option<SemanticTokensResult> {
-    let uri = &text_document.uri;
-    let filepath = uri.to_file_path().ok()?;
+    let filepath = super::uri_to_file(&text_document.uri)?;
     let doc = document_cache.documents.get_document(&filepath)?;
     let doc_node = doc.node.as_ref()?;
     let mut token = doc_node.first_token()?;


### PR DESCRIPTION
This makes sure paths match up with each other. Highlighting broke for me since the paths in the DocumentCache were canonicalized while the path the LSP wanted the preview to highlight was not.