### PR TITLE
use `#repr(uX)` instead of `repr(C)` for fieldless enums

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -94,7 +94,7 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
     writeln!(structs_priv, "#include \"slint_builtin_structs.h\"")?;
     writeln!(structs_priv, "#include \"slint_enums_internal.h\"")?;
     writeln!(structs_priv, "namespace slint::cbindgen_private {{")?;
-    writeln!(structs_priv, "enum class KeyEventType;")?;
+    writeln!(structs_priv, "enum class KeyEventType : uint8_t;")?;
     macro_rules! struct_file {
         (StandardListViewItem) => {{
             writeln!(structs_priv, "using slint::StandardListViewItem;")?;

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 use crate::items::ItemRc;
 
 // The property names of the accessible-properties
-#[repr(C)]
+#[repr(u32)]
 #[derive(PartialEq, Eq, Copy, Clone, strum::Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum AccessibleStringProperty {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -275,7 +275,7 @@ impl<'a> core::fmt::Debug for GraphicsAPI<'a> {
 /// This enum describes the different rendering states, that will be provided
 /// to the parameter of the callback for `set_rendering_notifier` on the `slint::Window`.
 #[derive(Debug, Clone)]
-#[repr(C)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum RenderingState {
     /// The window has been created and the graphics adapter/context initialized. When OpenGL
@@ -309,7 +309,7 @@ impl<F: FnMut(RenderingState, &GraphicsAPI)> RenderingNotifier for F {
 /// This enum describes the different error scenarios that may occur when the application
 /// registers a rendering notifier on a `slint::Window`.
 #[derive(Debug, Clone)]
-#[repr(C)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum SetRenderingNotifierError {
     /// The rendering backend does not support rendering notifiers.
@@ -327,7 +327,7 @@ pub struct Window(pub(crate) WindowInner);
 /// This enum describes whether a Window is allowed to be hidden when the user tries to close the window.
 /// It is the return type of the callback provided to [Window::on_close_requested].
 #[derive(Copy, Clone, Debug, PartialEq, Default)]
-#[repr(C)]
+#[repr(u8)]
 pub enum CloseRequestResponse {
     /// The Window will be hidden (default action)
     #[default]

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -690,7 +690,7 @@ impl Image {
 /// This enum describes the origin to use when rendering a borrowed OpenGL texture.
 /// Use this with [`BorrowedOpenGLTextureBuilder::origin`].
 #[derive(Copy, Clone, Debug, PartialEq, Default)]
-#[repr(C)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum BorrowedOpenGLTextureOrigin {
     /// The top-left of the texture is the top-left of the texture drawn on the screen.

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -80,7 +80,7 @@ impl MouseEvent {
 /// to notify the run-time about how the event was handled and
 /// what the next steps are.
 /// See [`crate::items::ItemVTable::input_event`].
-#[repr(C)]
+#[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum InputEventResult {
     /// The event was accepted. This may result in additional events, for example
@@ -133,7 +133,6 @@ pub mod key_codes {
             #[allow(missing_docs)]
             #[derive(Debug, Copy, Clone, PartialEq)]
             #[non_exhaustive]
-            #[repr(C)]
             /// The `Key` enum is used to map a specific key by name e.g. `Key::Control` to an
             /// internal used unicode representation. The enum is convertible to [`std::char`] and [`slint::SharedString`](`crate::SharedString`).
             /// Use this with [`slint::platform::WindowEvent`](`crate::platform::WindowEvent`) to supply key events to Slint's platform abstraction.
@@ -255,7 +254,7 @@ impl From<InternalKeyboardModifierState> for KeyboardModifiers {
 
 /// This enum defines the different kinds of key events that can happen.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
-#[repr(C)]
+#[repr(u8)]
 pub enum KeyEventType {
     /// A key on a keyboard was pressed.
     #[default]
@@ -444,7 +443,7 @@ pub enum TextShortcut {
 
 /// Represents how an item's key_event handler dealt with a key event.
 /// An accepted event results in no further event propagation.
-#[repr(C)]
+#[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum KeyEventResult {
     /// The event was handled.
@@ -455,7 +454,7 @@ pub enum KeyEventResult {
 
 /// Represents how an item's focus_event handler dealt with a focus event.
 /// An accepted event results in no further event propagation.
-#[repr(C)]
+#[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FocusEventResult {
     /// The event was handled.
@@ -467,7 +466,7 @@ pub enum FocusEventResult {
 /// This event is sent to a component and items when they receive or loose
 /// the keyboard focus.
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[repr(C)]
+#[repr(u8)]
 pub enum FocusEvent {
     /// This event is sent when an item receives the focus.
     FocusIn,

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1426,7 +1426,7 @@ macro_rules! declare_enums {
     ($( $(#[$enum_doc:meta])* enum $Name:ident { $( $(#[$value_doc:meta])* $Value:ident,)* })*) => {
         $(
             #[derive(Copy, Clone, Debug, PartialEq, Eq, strum::EnumString, strum::Display, Hash)]
-            #[repr(C)]
+            #[repr(u32)]
             #[strum(serialize_all = "kebab-case")]
             $(#[$enum_doc])*
             pub enum $Name {

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -21,7 +21,7 @@ type SingleShotTimerCallback = Box<dyn FnOnce()>;
 ///
 /// Used by the [`Timer::start()`] function.
 #[derive(Copy, Clone)]
-#[repr(C)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum TimerMode {
     /// A SingleShot timer is fired only once.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -982,7 +982,7 @@ pub mod ffi {
 
     /// This enum describes a low-level access to specific graphics APIs used
     /// by the renderer.
-    #[repr(C)]
+    #[repr(u8)]
     pub enum GraphicsAPI {
         /// The rendering is done using OpenGL.
         NativeOpenGL,

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -701,7 +701,7 @@ pub unsafe extern "C" fn slint_interpreter_model_notify_row_removed(
 // FIXME: Figure out how to re-export the one from compilerlib
 /// DiagnosticLevel describes the severity of a diagnostic.
 #[derive(Clone)]
-#[repr(C)]
+#[repr(u8)]
 pub enum DiagnosticLevel {
     /// The diagnostic belongs to an error.
     Error,


### PR DESCRIPTION
Otherwise the ABI may differ between the C++ and the Rust