### PR TITLE
Fixes to wasm_preview

### DIFF
--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -131,7 +131,7 @@ export async function showPreview(
 
 async function getDocumentSource(url: Uri): Promise<string> {
     // FIXME: is there a faster way to get the document
-    let x = vscode.workspace.textDocuments.find((d) => d.uri === url);
+    let x = vscode.workspace.textDocuments.find((d) => d.uri.toString() === url.toString());
     let source;
     if (x) {
         source = x.getText();
@@ -259,7 +259,7 @@ function getPreviewHtml(slint_wasm_preview_url: Uri): string {
 
     window.addEventListener('message', async event => {
         if (event.data.command === "preview") {
-            design_mode = event.data.design_mode;
+            design_mode = !!event.data.design_mode;
             vscode.setState({base_url: event.data.base_url, component: event.data.component});
             await render(event.data.content, event.data.webview_uri, event.data.style);
         } else if (event.data.command === "file_loaded") {

--- a/tools/lsp/language/semantic_tokens.rs
+++ b/tools/lsp/language/semantic_tokens.rs
@@ -1,8 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-#[cfg(target_arch = "wasm32")]
-use crate::wasm_prelude::*;
 use i_slint_compiler::parser::SyntaxKind;
 use lsp_types::{
     SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens, SemanticTokensResult,

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -11,7 +11,7 @@ mod preview;
 pub mod util;
 
 use common::PreviewApi;
-use common::{Error, Result};
+use common::Result;
 use i_slint_compiler::CompilerConfiguration;
 use js_sys::Function;
 pub use language::{Context, DocumentCache, RequestHandler};


### PR DESCRIPTION
 - the "preview" command don't contain a "design_mode" arg, but later the generated js for the wasm checked that it is a boolean.
 - The url comparison did not work when using the binary lsp and wasm preview. Event though the URL string is the same, the object were not exactly equals.
 - Fix rust warnings in the wasm lsp build