### PR TITLE
Derive serde for Color

### DIFF
--- a/internal/core/graphics/color.rs
+++ b/internal/core/graphics/color.rs
@@ -44,6 +44,7 @@ pub struct RgbaColor<T> {
 /// let new_col = Color::from(RgbaColor{ red: 0.5, green: 0.65, blue: 0.32, alpha: 1.});
 /// ```
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct Color {
     red: u8,


### PR DESCRIPTION
The `serde` feature enables serde implementations for various structures. I'd like to see them for Color.