### PR TITLE
Upgrade MSRV to 1.70

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-11] # windows-2022 disabled due to https://github.com/actions/runner-images/issues/8125
-        rust_version: [stable, "1.66"]
+        rust_version: [stable, "1.70"]
         include:
 #          - os: windows-2022
 #            extra_args: "--exclude ffmpeg"
@@ -30,7 +30,7 @@ jobs:
             extra_args: "--exclude ffmpeg"
         exclude:
           - os: macos-11
-            rust_version: "1.66"
+            rust_version: "1.70"
 
     runs-on: ${{ matrix.os }}
 
@@ -62,17 +62,17 @@ jobs:
       with:
         toolchain: ${{ matrix.rust_version }}
         key: x-v2
-    - name: Pin dependencies to make it build with our MSRV
-      if: matrix.rust_version == '1.66'
-      shell: bash
-      run: |
-        if [ ! -f ./Cargo.lock ]; then
-          cargo update -p half --precise 2.2.1
-          cargo update -p codemap-diagnostic --precise 0.1.1
-          cargo update -p clap --precise 4.3.24
-          cargo update -p clap_builder --precise 4.3.24
-          cargo update -p clap_lex --precise 0.5.0
-        fi
+    # - name: Pin dependencies to make it build with our MSRV
+    #   if: matrix.rust_version == '1.66'
+    #   shell: bash
+    #   run: |
+    #     if [ ! -f ./Cargo.lock ]; then
+    #       cargo update -p half --precise 2.2.1
+    #       cargo update -p codemap-diagnostic --precise 0.1.1
+    #       cargo update -p clap --precise 4.3.24
+    #       cargo update -p clap_builder --precise 4.3.24
+    #       cargo update -p clap_lex --precise 0.5.0
+    #     fi
     - name: Run tests
       run: DYLD_FRAMEWORK_PATH=$Qt5_DIR/lib cargo test --verbose --all-features --workspace ${{ matrix.extra_args }} --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude mcu-board-support --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### General
+
+ - Minimum Rust version is now 1.70.
+
+### Slint Language
+
+### Rust API
+
+### C++
+
 ## [1.2.0] - 2023-09-04
 
 ### General

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ default-members = [
 resolver="2"
 
 [workspace.package]
-rust-version = "1.66"
+rust-version = "1.70"
 
 [workspace.dependencies]
 resvg = { version= "0.34.0", default-features = false, features = ["text"] }

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Corrosion)
 
 list(PREPEND CMAKE_MODULE_PATH ${Corrosion_SOURCE_DIR}/cmake)
-find_package(Rust 1.66 REQUIRED MODULE)
+find_package(Rust 1.70 REQUIRED MODULE)
 
 option(BUILD_SHARED_LIBS "Build Slint as shared library" ON)
 option(SLINT_FEATURE_COMPILER "Enable support for compiling .slint files to C++ ahead of time" ON)

--- a/api/node/README.md
+++ b/api/node/README.md
@@ -28,7 +28,7 @@ You need to install the following components:
 
   * **[Node.js](https://nodejs.org/download/release/v16.19.1/)** (v16. Newer versions currently not supported: [#961](https://github.com/slint-ui/slint/issues/961))
   * **[npm](https://www.npmjs.com/)**
-  * **[Rust compiler](https://www.rust-lang.org/tools/install)** (1.66 or newer)
+  * **[Rust compiler](https://www.rust-lang.org/tools/install)** (1.70 or newer)
 
 You will also need a few more dependencies, see <https://github.com/slint-ui/slint/blob/master/docs/building.md#prerequisites>
 

--- a/api/node/cover.md
+++ b/api/node/cover.md
@@ -32,7 +32,7 @@ You need to install the following components:
 
   * **[Node.js](https://nodejs.org/download/release/v16.19.1/)** (v16. Newer versions currently not supported: [#961](https://github.com/slint-ui/slint/issues/961))
   * **[npm](https://www.npmjs.com/)**
-  * **[Rust compiler](https://www.rust-lang.org/tools/install)** (1.66 or newer)
+  * **[Rust compiler](https://www.rust-lang.org/tools/install)** (1.70 or newer)
 
 You will also need a few more dependencies, see <https://github.com/slint-ui/slint/blob/master/docs/building.md#prerequisites>
 

--- a/api/rs/slint/README.md
+++ b/api/rs/slint/README.md
@@ -61,7 +61,3 @@ You can quickly try out the [examples](/examples) by cloning this repo and runni
 # Runs the "printerdemo" example
 cargo run --release --bin printerdemo
 ```
-
-### Minimum Supported Rust Version
-
- This crate's minimum supported `rustc` version is 1.66.

--- a/docs/building.md
+++ b/docs/building.md
@@ -8,7 +8,7 @@ This page explains how to build and test Slint.
 ### Installing Rust
 
 Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). If you already
-have Rust installed, make sure that it's at least version 1.66 or newer. You can check which version you have installed
+have Rust installed, make sure that it's at least version 1.70 or newer. You can check which version you have installed
 by running `rustc --version`.
 
 Once this is done, you should have the `rustc` compiler and the `cargo` build system installed in your path.

--- a/docs/tutorial/cpp/src/getting_started.md
+++ b/docs/tutorial/cpp/src/getting_started.md
@@ -8,7 +8,7 @@ You will need a development environment that can compile C++20, [CMake 3.21](htt
 and we recommend [Ninja](https://ninja-build.org) for `-GNinja`.
 We don't provide binaries of Slint yet, so we will use the CMake integration that will automatically build
 the tools and library from source. Since it's implemented in the Rust programming language, this means that
-you also need to install a Rust compiler (1.66 or newer). You can easily install a Rust compiler
+you also need to install a Rust compiler (1.70 or newer). You can easily install a Rust compiler
 following the instruction from [the Rust website](https://www.rust-lang.org/learn/get-started).
 We're going to use `cmake`'s builtin FetchContent module to fetch the source code of Slint.
 

--- a/docs/tutorial/node/src/getting_started.md
+++ b/docs/tutorial/node/src/getting_started.md
@@ -6,7 +6,7 @@ In this tutorial, we use JavaScript as the host programming language. We also su
 
 You'll need a development environment with [Node.js 16](https://nodejs.org/download/release/v16.19.1/) and [npm](https://www.npmjs.com/) installed. More recent
 versions of NodeJS are currently not supported, for details check [Issue #961](https://github.com/slint-ui/slint/issues/961).
-Since Slint is implemented in the Rust programming language, you also need to install a Rust compiler (1.66 or newer). You can easily install a Rust compiler
+Since Slint is implemented in the Rust programming language, you also need to install a Rust compiler (1.70 or newer). You can easily install a Rust compiler
 following the instruction from [the Rust website](https://www.rust-lang.org/learn/get-started).
 You will also need some additional platform-specific dependencies, see <https://github.com/slint-ui/slint/blob/master/docs/building.md#prerequisites>
 


### PR DESCRIPTION
Many of our dependencies already made the jump and require a cargo update hack, so make it official

Removed the MSRV from the README since it applies to master branch and people read the readme also for the released version. There is enough documentation of the MSRV in other locations.