### PR TITLE
winit-sw: Loop over the buffer instead of using indices

### DIFF
--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -69,9 +69,7 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
                 width.get() as usize * height.get() as usize
             ];
             self.renderer.render(buffer.as_mut_slice(), width.get() as usize);
-
-            for i in 0..target_buffer.len() {
-                let pixel = buffer[i];
+            for (i, pixel) in buffer.into_iter().enumerate() {
                 target_buffer[i] = (pixel.alpha as u32) << 24
                     | ((pixel.red as u32) << 16)
                     | ((pixel.green as u32) << 8)


### PR DESCRIPTION
It is possible that softbuf allocate a larger buffer than in needs?

Prospective fix for #3406