### PR TITLE
vscode: add "wrap in element" code action

### DIFF
--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -10,6 +10,7 @@ import { LanguageClient } from "vscode-languageclient/browser";
 import { PropertiesViewProvider } from "./properties_webview";
 import * as wasm_preview from "./wasm_preview";
 import * as common from "./common";
+import * as snippets from "./snippets";
 
 let client = new common.ClientHandle();
 let statusBar: vscode.StatusBarItem;
@@ -55,6 +56,8 @@ function startClient(context: vscode.ExtensionContext) {
             );
             const disposable = cl.start();
             context.subscriptions.push(disposable);
+
+            cl.registerFeature(new snippets.SnippetTextEditFeature());
 
             cl.onReady().then(() => {
                 client.client = cl;

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 import { PropertiesViewProvider } from "./properties_webview";
 import * as wasm_preview from "./wasm_preview";
 import * as lsp_commands from "../../../tools/slintpad/src/shared/lsp_commands";
+import * as snippets from "./snippets";
 
 import {
     BaseLanguageClient,
@@ -109,6 +110,19 @@ export function languageClientOptions(
                     }
                 }
                 return next(command, args);
+            },
+            async provideCodeActions(
+                document: vscode.TextDocument,
+                range: vscode.Range,
+                context: vscode.CodeActionContext,
+                token: vscode.CancellationToken,
+                next: any,
+            ) {
+                const actions = await next(document, range, context, token);
+                if (actions) {
+                    snippets.detectSnippetCodeActions(actions);
+                }
+                return actions;
             },
         },
     };

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -12,6 +12,7 @@ import * as vscode from "vscode";
 import { PropertiesViewProvider } from "./properties_webview";
 import * as wasm_preview from "./wasm_preview";
 import * as common from "./common";
+import * as snippets from "./snippets";
 
 import {
     LanguageClient,
@@ -167,6 +168,8 @@ function startClient(context: vscode.ExtensionContext) {
         serverOptions,
         clientOptions,
     );
+
+    cl.registerFeature(new snippets.SnippetTextEditFeature());
 
     cl.onDidChangeState((event) => {
         let properly_stopped = cl.hasOwnProperty("slint_stopped");

--- a/editors/vscode/src/snippets.ts
+++ b/editors/vscode/src/snippets.ts
@@ -1,0 +1,73 @@
+// Copyright © Danny Tuppeny <danny@tuppeny.com>
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// LSP code actions and workspace edits do not yet natively support snippets,
+// or allow specifying the cursor position:
+// https://github.com/microsoft/language-server-protocol/issues/724
+//
+// This file implements an experimental SnippetTextEdit feature inspired by
+// [rust-analyzer](https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#snippet-textedit)
+// and [Dart-Code](https://github.com/Dart-Code/Dart-Code/blob/master/src/extension/analysis/analyzer_lsp_snippet_text_edits.ts).
+
+// cSpell: ignore Tuppeny
+
+import * as vscode from "vscode";
+import { ClientCapabilities, StaticFeature } from "vscode-languageclient";
+
+export class SnippetTextEditFeature implements StaticFeature {
+    private command: vscode.Disposable | undefined;
+
+    fillClientCapabilities(capabilities: ClientCapabilities) {
+        capabilities.experimental = capabilities.experimental ?? {};
+        Object.assign(capabilities.experimental, { snippetTextEdit: true });
+    }
+
+    initialize() {
+        this.command = vscode.commands.registerCommand(
+            "_slint.applySnippetTextEdit",
+            this.applySnippetTextEdit,
+        );
+    }
+
+    dispose() {
+        this.command?.dispose();
+    }
+
+    private async applySnippetTextEdit(uri: vscode.Uri, edit: vscode.TextEdit) {
+        // Compensate for VS Code's automatic indentation
+        const doc = await vscode.workspace.openTextDocument(uri);
+        const line = doc.lineAt(edit.range.start.line);
+        const indent = " ".repeat(line.firstNonWhitespaceCharacterIndex);
+        const newText = edit.newText.replaceAll(`\n${indent}`, "\n");
+
+        const editor = await vscode.window.showTextDocument(doc);
+        await editor.insertSnippet(
+            new vscode.SnippetString(newText),
+            edit.range,
+        );
+    }
+}
+
+export function detectSnippetCodeActions(
+    actions: Array<vscode.Command | vscode.CodeAction>,
+) {
+    for (const action of actions) {
+        if (action instanceof vscode.CodeAction && action.edit) {
+            const edits = action.edit.entries();
+            if (edits.length === 1 && edits[0][1].length === 1) {
+                const uri = edits[0][0];
+                const textEdit = edits[0][1][0];
+                // Check for "$0" or "${0:foo}" snippet placeholders
+                if (/\$(?:0|\{0:(?:[^}]*)\})/.test(textEdit.newText)) {
+                    action.edit = undefined;
+                    action.command = {
+                        title: "Apply snippet text edit",
+                        command: "_slint.applySnippetTextEdit",
+                        arguments: [uri, textEdit],
+                    };
+                }
+            }
+        }
+    }
+}

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -867,7 +867,7 @@ fn get_code_actions(
             ),
         )];
         result.push(CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
-            title: "Wrap in element...".into(),
+            title: "Wrap in element".into(),
             kind: Some(lsp_types::CodeActionKind::REFACTOR),
             edit: Some(WorkspaceEdit {
                 changes: Some(std::iter::once((uri, edits)).collect()),

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1408,7 +1408,7 @@ component Demo {
                     &capabilities
                 )),
                 Some(vec![CodeActionOrCommand::CodeAction(lsp_types::CodeAction {
-                    title: "Wrap in element...".into(),
+                    title: "Wrap in element".into(),
                     kind: Some(lsp_types::CodeActionKind::REFACTOR),
                     edit: Some(WorkspaceEdit {
                         changes: Some(

--- a/tools/lsp/language/properties.rs
+++ b/tools/lsp/language/properties.rs
@@ -621,7 +621,7 @@ fn set_binding_on_known_property(
 
 // Find the indentation of the element itself as well as the indentation of properties inside the
 // element. Returns the element indent followed by the block indent
-fn find_element_indent(element: &ElementRc) -> Option<String> {
+pub fn find_element_indent(element: &ElementRc) -> Option<String> {
     let mut token =
         element.borrow().node.as_ref().and_then(|n| n.first_token()).and_then(|t| t.prev_token());
     while let Some(t) = token {

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -407,6 +407,7 @@ lazy_static! {
         ("^api/cpp/docs/conf\\.py$", LicenseLocation::NoLicense),
         ("^docs/reference/Pipfile$", LicenseLocation::NoLicense),
         ("^docs/reference/conf\\.py$", LicenseLocation::NoLicense),
+        ("^editors/vscode/src/snippets\\.ts$", LicenseLocation::NoLicense), // liberal license
         ("^editors/tree-sitter-slint/binding\\.gyp$", LicenseLocation::NoLicense), // liberal license
         ("^editors/tree-sitter-slint/test-to-corpus\\.py$", LicenseLocation::Tag(LicenseTagStyle::shell_comment_style())),
         ("^Cargo\\.lock$", LicenseLocation::NoLicense),


### PR DESCRIPTION
A little productivity booster for editing .slint files in VS Code:

https://github.com/slint-ui/slint/assets/140617/5bd66495-bf1c-4f5a-9e55-326098bf3b74

Notice that LSP code actions and workspace edits do not yet natively support snippets or allow specifying the cursor position (https://github.com/microsoft/language-server-protocol/issues/724), which is necessary for pre-selecting "element" for conveniently typing in the desired type name. This limitation is worked around by registering an experimental "snippet text edit" capability for the client, guarding the snippet code action with a capability check on the server side, and finally, detecting and inserting the snippet on the client side (inspired by [rust-analyzer](https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#snippet-textedit) and [Dart-Code](https://github.com/Dart-Code/Dart-Code/blob/master/src/extension/analysis/analyzer_lsp_snippet_text_edits.ts)).