### PR TITLE
VSCode: Add some spacing above WASM preview canvas

### DIFF
--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -286,7 +286,7 @@ function getPreviewHtml(slint_wasm_preview_url: Uri): string {
 </head>
 <body>
   <div id="slint_error_div"></div>
-  <canvas id="slint_canvas"></canvas>
+  <canvas style="margin-top: 10px;" id="slint_canvas"></canvas>
 </body>
 </html>`;
 }


### PR DESCRIPTION
VSCode draws a frame around the canvas when it gets keyboard focus. We used to cut that off, which did not look nice.