### PR TITLE
Optimize StandardTableView in Fluent, Material and Native styles

### DIFF
--- a/internal/compiler/widgets/fluent-base/tableview.slint
+++ b/internal/compiler/widgets/fluent-base/tableview.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 import { Palette, Typography, Icons } from "styling.slint";
-import { ScrollView } from "scrollview.slint";
+import { ListView } from "listview.slint";
 
 component TableViewColumn inherits Rectangle {
     callback clicked <=> i-touch-area.clicked;
@@ -85,6 +85,8 @@ component TableViewCell inherits Rectangle {
     HorizontalLayout {
         padding-left: 12px;
         padding-right: 12px;
+        padding-top: 9px;
+        padding-bottom: 9px;
 
         @children
     }
@@ -201,48 +203,42 @@ export component StandardTableView {
             }
         }
 
-        i-scroll-view := ScrollView {
-            vertical-stretch: 1;
+        i-scroll-view := ListView {
+            for row[idx] in root.rows : TableViewRow {
+                selected: idx == root.current-row;
+                even: mod(idx, 2) == 0;
 
-            VerticalLayout {
-                alignment: start;
+                for cell[index] in row : TableViewCell {
+                    private property <bool> has_inner_focus;
 
-                for row[idx] in root.rows : TableViewRow {
-                    selected: idx == root.current-row;
-                    even: mod(idx, 2) == 0;
+                    horizontal-stretch: root.columns[index].horizontal-stretch;
+                    min-width: max(columns[index].min-width, columns[index].width);
+                    preferred-width: self.min-width;
+                    max-width: (index < columns.length && columns[index].width >= 1px) ? max(columns[index].min-width, columns[index].width) : 100000px;
 
-                    for cell[index] in row : TableViewCell {
-                        private property <bool> has_inner_focus;
-
-                        horizontal-stretch: root.columns[index].horizontal-stretch;
-                        min-width: max(columns[index].min-width, columns[index].width);
-                        preferred-width: self.min-width;
-                        max-width: (index < columns.length && columns[index].width >= 1px) ? max(columns[index].min-width, columns[index].width) : 100000px;
-
-                        Rectangle {
-                            Text {
-                                width: 100%;
-                                height: 100%;
-                                overflow: elide;
-                                vertical-alignment: center;
-                                text: cell.text;
-                                font-weight: Typography.body.font-weight;
-                                font-size: Typography.body.font-size;
-                                color: mod(idx, 2) == 0 ? Palette.text-primary : Palette.text-secondary;
-                            }
+                    Rectangle {
+                        Text {
+                            width: 100%;
+                            height: 100%;
+                            overflow: elide;
+                            vertical-alignment: center;
+                            text: cell.text;
+                            font-weight: Typography.body.font-weight;
+                            font-size: Typography.body.font-size;
+                            color: mod(idx, 2) == 0 ? Palette.text-primary : Palette.text-secondary;
                         }
                     }
+                }
 
-                    pointer-event(pe, pos) => {
-                        root.row-pointer-event(idx, pe, {
-                            x: pos.x - root.absolute-position.x,
-                            y: pos.y - root.absolute-position.y,
-                        });
-                    }
+                pointer-event(pe, pos) => {
+                    root.row-pointer-event(idx, pe, {
+                        x: pos.x - root.absolute-position.x,
+                        y: pos.y - root.absolute-position.y,
+                    });
+                }
 
-                    clicked => {
-                        root.set-current-row(idx);
-                    }
+                clicked => {
+                    root.set-current-row(idx);
                 }
             }
         }

--- a/internal/compiler/widgets/material-base/tableview.slint
+++ b/internal/compiler/widgets/material-base/tableview.slint
@@ -74,6 +74,8 @@ component TableViewCell inherits Rectangle {
     HorizontalLayout {
         padding-left: 16px;
         padding-right: 16px;
+        padding-top: 12px;
+        padding-bottom: 12px;
 
         @children
     }

--- a/internal/compiler/widgets/native/internal-scrollview.slint
+++ b/internal/compiler/widgets/native/internal-scrollview.slint
@@ -49,6 +49,8 @@ export component InternalScrollView {
     }
 }
 
+// This is an internal ListView, used by the StandardTableView. It needs to be
+// called "ListView", for the compiler to recognize it.
 export component ListView inherits InternalScrollView {
     @children
 }

--- a/internal/compiler/widgets/native/internal-scrollview.slint
+++ b/internal/compiler/widgets/native/internal-scrollview.slint
@@ -1,0 +1,54 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export { NativeStyleMetrics as StyleMetrics }
+
+// This internal ScrollView has some additional properties, used by the
+// StandardTableView, which are not currently exposed by the public ScrollView
+// (since then it would need to be done for all styles).
+export component InternalScrollView {
+    in-out property <length> viewport-width <=> fli.viewport-width;
+    in-out property <length> viewport-height <=> fli.viewport-height;
+    in-out property <length> viewport-x <=> fli.viewport-x;
+    in-out property <length> viewport-y <=> fli.viewport-y;
+    out property <length> visible-width <=> fli.width;
+    out property <length> visible-height <=> fli.height;
+    in-out property <bool> has-focus <=> native.has-focus;
+    in property <bool> enabled <=> native.enabled;
+
+    // Used by the StandardTableView
+    out property <length> native-padding-left: native.native-padding-left;
+    out property <length> native-padding-right: native.native-padding-right;
+    out property <length> native-padding-top: native.native-padding-top;
+    out property <length> native-padding-bottom: native.native-padding-bottom;
+    in property <length> header-height: 0;
+
+    preferred-height: 100%;
+    preferred-width: 100%;
+    min-height: native.min-height;
+    min-width: native.min-width;
+
+    native := NativeScrollView {
+        vertical-max: fli.viewport-height > fli.height ? fli.viewport-height - fli.height : 0phx;
+        vertical-page-size: fli.height;
+
+        horizontal-max: fli.viewport-width > fli.width ? fli.viewport-width - fli.width : 0phx;
+        horizontal-page-size: fli.width;
+    }
+
+    fli := Flickable {
+        x: native.native-padding-left;
+        width: root.width - native.native-padding-left - native.native-padding-right;
+        y: native.native-padding-top + header-height;
+        height: root.height - self.y - native.native-padding-bottom;
+
+        @children
+        interactive: false;
+        viewport-y <=> native.vertical-value;
+        viewport-x <=> native.horizontal-value;
+    }
+}
+
+export component ListView inherits InternalScrollView {
+    @children
+}

--- a/internal/compiler/widgets/native/std-widgets-impl.slint
+++ b/internal/compiler/widgets/native/std-widgets-impl.slint
@@ -1,47 +1,21 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+import { InternalScrollView } from "internal-scrollview.slint";
+
 export { NativeStyleMetrics as StyleMetrics }
 
 export component ScrollView {
-    in-out property <length> viewport-width <=> fli.viewport-width;
-    in-out property <length> viewport-height <=> fli.viewport-height;
-    in-out property <length> viewport-x <=> fli.viewport-x;
-    in-out property <length> viewport-y <=> fli.viewport-y;
-    out property <length> visible-width <=> fli.width;
-    out property <length> visible-height <=> fli.height;
-    in-out property <bool> has-focus <=> native.has-focus;
-    in property <bool> enabled <=> native.enabled;
+    in-out property <length> viewport-width <=> internal.viewport-width;
+    in-out property <length> viewport-height <=> internal.viewport-height;
+    in-out property <length> viewport-x <=> internal.viewport-x;
+    in-out property <length> viewport-y <=> internal.viewport-y;
+    out property <length> visible-width <=> internal.visible-width;
+    out property <length> visible-height <=> internal.visible-height;
+    in-out property <bool> has-focus <=> internal.has-focus;
+    in property <bool> enabled <=> internal.enabled;
 
-    // Used by the StandardTableView
-    out property <length> native-padding-left: native.native-padding-left;
-    out property <length> native-padding-right: native.native-padding-right;
-    out property <length> native-padding-top: native.native-padding-top;
-    out property <length> native-padding-bottom: native.native-padding-bottom;
-    in property <length> header-height: 0;
-
-    preferred-height: 100%;
-    preferred-width: 100%;
-    min-height: native.min-height;
-    min-width: native.min-width;
-
-    native := NativeScrollView {
-        vertical-max: fli.viewport-height > fli.height ? fli.viewport-height - fli.height : 0phx;
-        vertical-page-size: fli.height;
-
-        horizontal-max: fli.viewport-width > fli.width ? fli.viewport-width - fli.width : 0phx;
-        horizontal-page-size: fli.width;
-    }
-
-    fli := Flickable {
-        x: native.native-padding-left;
-        width: root.width - native.native-padding-left - native.native-padding-right;
-        y: native.native-padding-top + header-height;
-        height: root.height - self.y - native.native-padding-bottom;
-
+    internal := InternalScrollView {
         @children
-        interactive: false;
-        viewport-y <=> native.vertical-value;
-        viewport-x <=> native.horizontal-value;
     }
 }

--- a/internal/compiler/widgets/native/std-widgets-impl.slint
+++ b/internal/compiler/widgets/native/std-widgets-impl.slint
@@ -12,6 +12,14 @@ export component ScrollView {
     out property <length> visible-height <=> fli.height;
     in-out property <bool> has-focus <=> native.has-focus;
     in property <bool> enabled <=> native.enabled;
+
+    // Used by the StandardTableView
+    out property <length> native-padding-left: native.native-padding-left;
+    out property <length> native-padding-right: native.native-padding-right;
+    out property <length> native-padding-top: native.native-padding-top;
+    out property <length> native-padding-bottom: native.native-padding-bottom;
+    in property <length> header-height: 0;
+
     preferred-height: 100%;
     preferred-width: 100%;
     min-height: native.min-height;
@@ -28,8 +36,8 @@ export component ScrollView {
     fli := Flickable {
         x: native.native-padding-left;
         width: root.width - native.native-padding-left - native.native-padding-right;
-        y: native.native-padding-top;
-        height: root.height - native.native-padding-top - native.native-padding-bottom;
+        y: native.native-padding-top + header-height;
+        height: root.height - self.y - native.native-padding-bottom;
 
         @children
         interactive: false;

--- a/internal/compiler/widgets/native/std-widgets-impl.slint
+++ b/internal/compiler/widgets/native/std-widgets-impl.slint
@@ -15,6 +15,13 @@ export component ScrollView {
     in-out property <bool> has-focus <=> internal.has-focus;
     in property <bool> enabled <=> internal.enabled;
 
+    min-height: internal.min-height;
+    min-width: internal.min-width;
+    horizontal-stretch: 1;
+    vertical-stretch: 1;
+    preferred-height: 100%;
+    preferred-width: 100%;
+
     internal := InternalScrollView {
         @children
     }

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -359,8 +359,8 @@ export component GridBox inherits GridLayout {
 }
 
 export component StandardTableView {
-    private property <length> item-height: fli.viewport-height / rows.length;
-    private property <length> current-item-y: fli.viewport-y + current-row * item-height;
+    private property <length> item-height: scroll-view.viewport-height / rows.length;
+    private property <length> current-item-y: scroll-view.viewport-y + current-row * item-height;
 
     callback sort-ascending(int);
     callback sort-descending(int);
@@ -384,11 +384,11 @@ export component StandardTableView {
         current-row-changed(current-row);
 
         if(current-item-y < 0) {
-            fli.viewport-y += 0 - current-item-y;
+            scroll-view.viewport-y += 0 - current-item-y;
         }
 
-        if(current-item-y + item-height > fli.height) {
-            fli.viewport-y -= current-item-y + item-height - fli.height;
+        if(current-item-y + item-height > scroll-view.visible-height) {
+            scroll-view.viewport-y -= current-item-y + item-height - scroll-view.visible-height;
         }
     }
 
@@ -408,53 +408,35 @@ export component StandardTableView {
         current-sort-column = index;
     }
 
-    scroll-view := NativeScrollView {
-        vertical-max: fli.viewport-height > fli.height ? fli.viewport-height - fli.height : 0phx;
-        vertical-page-size: fli.height;
+    scroll-view := ListView {
+        header-height: header-layout.preferred-height;
 
-        horizontal-max: fli.viewport-width > fli.width ? fli.viewport-width - fli.width : 0phx;
-        horizontal-page-size: fli.width;
+        for row[i] in rows : Rectangle {
+            width: max(row-layout.preferred-width, scroll-view.visible-width);
+            row-ta := TouchArea {
+                clicked => {
+                    root.set-current-row(i);
+                }
 
-        fli := Flickable {
-            x: scroll-view.native-padding-left;
-            width: scroll-view.width - scroll-view.native-padding-left - scroll-view.native-padding-right;
-            y: scroll-view.native-padding-top + header.height;
-            height: scroll-view.height - self.y - scroll-view.native-padding-bottom;
-            interactive: false;
-            viewport-y <=> scroll-view.vertical-value;
-            viewport-x <=> scroll-view.horizontal-value;
-
-            VerticalLayout {
-                alignment: start;
-
-                for row[i] in rows : Rectangle {
-                    width: max(row-layout.preferred-width, fli.width);
-                    row-ta := TouchArea {
-                        clicked => {
-                            root.set-current-row(i);
-                        }
-
-                        pointer-event(pe) => {
-                            root.row-pointer-event(i, pe, {
-                                x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
-                                y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
-                            });
-                        }
-                    }
-                    row-layout := HorizontalLayout {
-                        for cell[index] in row : Rectangle {
-                            horizontal-stretch: columns[index].horizontal-stretch;
-                            min-width: max(columns[index].min-width, columns[index].width);
-                            preferred-width: self.min-width;
-                            max-width: (index < columns.length && columns[index].width >= 1px) ? max(columns[index].min-width, columns[index].width) : 100000px;
-                            HorizontalLayout {
-                                NativeStandardListViewItem {
-                                    is_selected: i == root.current-row;
-                                    item: cell;
-                                    index: i;
-                                    has-hover: row-ta.has-hover;
-                                }
-                            }
+                pointer-event(pe) => {
+                    root.row-pointer-event(i, pe, {
+                        x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
+                        y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
+                    });
+                }
+            }
+            row-layout := HorizontalLayout {
+                for cell[index] in row : Rectangle {
+                    horizontal-stretch: columns[index].horizontal-stretch;
+                    min-width: max(columns[index].min-width, columns[index].width);
+                    preferred-width: self.min-width;
+                    max-width: (index < columns.length && columns[index].width >= 1px) ? max(columns[index].min-width, columns[index].width) : 100000px;
+                    HorizontalLayout {
+                        NativeStandardListViewItem {
+                            is_selected: i == root.current-row;
+                            item: cell;
+                            index: i;
+                            has-hover: row-ta.has-hover;
                         }
                     }
                 }
@@ -467,11 +449,11 @@ export component StandardTableView {
         height: header-layout.preferred-height;
         x: scroll-view.native-padding-left;
         y: scroll-view.native-padding-top;
-        width: fli.width;
+        width: scroll-view.visible-width;
 
         header-layout := HorizontalLayout {
             width: max(self.preferred-width, parent.width);
-            x: fli.viewport-x;
+            x: scroll-view.viewport-x;
             for column[index] in columns : NativeTableHeaderSection {
                 item: column;
                 horizontal-stretch: column.horizontal-stretch;

--- a/internal/compiler/widgets/native/std-widgets.slint
+++ b/internal/compiler/widgets/native/std-widgets.slint
@@ -5,7 +5,8 @@
 
 import { LineEditInner, TextEdit, AboutSlint } from "../common/common.slint";
 import { StyleMetrics, ScrollView  } from "std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, TextEdit, AboutSlint }
+import { StandardTableView } from "tableview.slint";
+export { StyleMetrics, ScrollView, TextEdit, AboutSlint, StandardTableView }
 
 export component Button {
     in property<string> text <=> native.text;
@@ -356,143 +357,6 @@ export component HorizontalBox inherits HorizontalLayout {
 export component GridBox inherits GridLayout {
     spacing: NativeStyleMetrics.layout-spacing;
     padding: NativeStyleMetrics.layout-spacing;
-}
-
-export component StandardTableView {
-    private property <length> item-height: scroll-view.viewport-height / rows.length;
-    private property <length> current-item-y: scroll-view.viewport-y + current-row * item-height;
-
-    callback sort-ascending(int);
-    callback sort-descending(int);
-    callback row-pointer-event(int /* row-index */, PointerEvent /* event */, Point /* absolute mouse position */);
-    callback current-row-changed(int /* current-row */);
-
-    out property <int> current-sort-column: -1;
-    in-out property <[TableColumn]> columns;
-    in property <[[StandardListViewItem]]> rows;
-    in-out property<int> current-row: -1;
-
-    horizontal-stretch: 1;
-    vertical-stretch: 1;
-
-    public function set-current-row(index: int) {
-        if(index < 0 || index >= rows.length) {
-            return;
-        }
-
-        current-row = index;
-        current-row-changed(current-row);
-
-        if(current-item-y < 0) {
-            scroll-view.viewport-y += 0 - current-item-y;
-        }
-
-        if(current-item-y + item-height > scroll-view.visible-height) {
-            scroll-view.viewport-y -= current-item-y + item-height - scroll-view.visible-height;
-        }
-    }
-
-    function sort(index: int) {
-        if (current-sort-column != index) {
-            columns[current-sort-column].sort-order = SortOrder.unsorted;
-        }
-
-        if(columns[index].sort-order == SortOrder.ascending) {
-            columns[index].sort-order = SortOrder.descending;
-            sort-descending(index);
-        } else {
-            columns[index].sort-order = SortOrder.ascending;
-            sort-ascending(index);
-        }
-
-        current-sort-column = index;
-    }
-
-    scroll-view := ListView {
-        header-height: header-layout.preferred-height;
-
-        for row[i] in rows : Rectangle {
-            width: max(row-layout.preferred-width, scroll-view.visible-width);
-            row-ta := TouchArea {
-                clicked => {
-                    root.set-current-row(i);
-                }
-
-                pointer-event(pe) => {
-                    root.row-pointer-event(i, pe, {
-                        x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
-                        y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
-                    });
-                }
-            }
-            row-layout := HorizontalLayout {
-                for cell[index] in row : Rectangle {
-                    horizontal-stretch: columns[index].horizontal-stretch;
-                    min-width: max(columns[index].min-width, columns[index].width);
-                    preferred-width: self.min-width;
-                    max-width: (index < columns.length && columns[index].width >= 1px) ? max(columns[index].min-width, columns[index].width) : 100000px;
-                    HorizontalLayout {
-                        NativeStandardListViewItem {
-                            is_selected: i == root.current-row;
-                            item: cell;
-                            index: i;
-                            has-hover: row-ta.has-hover;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    header := Rectangle {
-        clip: true;
-        height: header-layout.preferred-height;
-        x: scroll-view.native-padding-left;
-        y: scroll-view.native-padding-top;
-        width: scroll-view.visible-width;
-
-        header-layout := HorizontalLayout {
-            width: max(self.preferred-width, parent.width);
-            x: scroll-view.viewport-x;
-            for column[index] in columns : NativeTableHeaderSection {
-                item: column;
-                horizontal-stretch: column.horizontal-stretch;
-                min-width: max(column.min-width, column.width);
-                preferred-width: self.min-width;
-                max-width: (index < columns.length && column.width >= 1px) ? max(column.min-width, column.width) : 100000px;
-
-                TouchArea {
-                    clicked => {
-                        sort(index);
-                    }
-                }
-
-                TouchArea {
-                    width: 10px;
-                    x: parent.width - self.width / 2;
-                    moved => {
-                        if (self.pressed) {
-                            column.width = max(1px, parent.width + (self.mouse-x - self.pressed-x));
-                        }
-                    }
-                    mouse-cursor: ew-resize;
-                }
-            }
-        }
-    }
-
-    FocusScope {
-        key-pressed(event) => {
-            if (event.text == Key.UpArrow) {
-                root.set-current-row(root.current-row - 1);
-                return accept;
-            } else if (event.text == Key.DownArrow) {
-                root.set-current-row(root.current-row + 1);
-                return accept;
-            }
-            reject
-        }
-    }
 }
 
 export component ProgressIndicator inherits NativeProgressIndicator {}

--- a/internal/compiler/widgets/native/tableview.slint
+++ b/internal/compiler/widgets/native/tableview.slint
@@ -1,0 +1,141 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+import { ListView } from "internal-scrollview.slint";
+
+export component StandardTableView {
+    private property <length> item-height: scroll-view.viewport-height / rows.length;
+    private property <length> current-item-y: scroll-view.viewport-y + current-row * item-height;
+
+    callback sort-ascending(int);
+    callback sort-descending(int);
+    callback row-pointer-event(int /* row-index */, PointerEvent /* event */, Point /* absolute mouse position */);
+    callback current-row-changed(int /* current-row */);
+
+    out property <int> current-sort-column: -1;
+    in-out property <[TableColumn]> columns;
+    in property <[[StandardListViewItem]]> rows;
+    in-out property<int> current-row: -1;
+
+    horizontal-stretch: 1;
+    vertical-stretch: 1;
+
+    public function set-current-row(index: int) {
+        if(index < 0 || index >= rows.length) {
+            return;
+        }
+
+        current-row = index;
+        current-row-changed(current-row);
+
+        if(current-item-y < 0) {
+            scroll-view.viewport-y += 0 - current-item-y;
+        }
+
+        if(current-item-y + item-height > scroll-view.visible-height) {
+            scroll-view.viewport-y -= current-item-y + item-height - scroll-view.visible-height;
+        }
+    }
+
+    function sort(index: int) {
+        if (current-sort-column != index) {
+            columns[current-sort-column].sort-order = SortOrder.unsorted;
+        }
+
+        if(columns[index].sort-order == SortOrder.ascending) {
+            columns[index].sort-order = SortOrder.descending;
+            sort-descending(index);
+        } else {
+            columns[index].sort-order = SortOrder.ascending;
+            sort-ascending(index);
+        }
+
+        current-sort-column = index;
+    }
+
+    scroll-view := ListView {
+        header-height: header-layout.preferred-height;
+
+        for row[i] in rows : Rectangle {
+            width: max(row-layout.preferred-width, scroll-view.visible-width);
+            row-ta := TouchArea {
+                clicked => {
+                    root.set-current-row(i);
+                }
+
+                pointer-event(pe) => {
+                    root.row-pointer-event(i, pe, {
+                        x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
+                        y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
+                    });
+                }
+            }
+            row-layout := HorizontalLayout {
+                for cell[index] in row : Rectangle {
+                    horizontal-stretch: columns[index].horizontal-stretch;
+                    min-width: max(columns[index].min-width, columns[index].width);
+                    preferred-width: self.min-width;
+                    max-width: (index < columns.length && columns[index].width >= 1px) ? max(columns[index].min-width, columns[index].width) : 100000px;
+                    HorizontalLayout {
+                        NativeStandardListViewItem {
+                            is_selected: i == root.current-row;
+                            item: cell;
+                            index: i;
+                            has-hover: row-ta.has-hover;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    header := Rectangle {
+        clip: true;
+        height: header-layout.preferred-height;
+        x: scroll-view.native-padding-left;
+        y: scroll-view.native-padding-top;
+        width: scroll-view.visible-width;
+
+        header-layout := HorizontalLayout {
+            width: max(self.preferred-width, parent.width);
+            x: scroll-view.viewport-x;
+            for column[index] in columns : NativeTableHeaderSection {
+                item: column;
+                horizontal-stretch: column.horizontal-stretch;
+                min-width: max(column.min-width, column.width);
+                preferred-width: self.min-width;
+                max-width: (index < columns.length && column.width >= 1px) ? max(column.min-width, column.width) : 100000px;
+
+                TouchArea {
+                    clicked => {
+                        sort(index);
+                    }
+                }
+
+                TouchArea {
+                    width: 10px;
+                    x: parent.width - self.width / 2;
+                    moved => {
+                        if (self.pressed) {
+                            column.width = max(1px, parent.width + (self.mouse-x - self.pressed-x));
+                        }
+                    }
+                    mouse-cursor: ew-resize;
+                }
+            }
+        }
+    }
+
+    FocusScope {
+        key-pressed(event) => {
+            if (event.text == Key.UpArrow) {
+                root.set-current-row(root.current-row - 1);
+                return accept;
+            } else if (event.text == Key.DownArrow) {
+                root.set-current-row(root.current-row + 1);
+                return accept;
+            }
+            reject
+        }
+    }
+}


### PR DESCRIPTION
By using a `ListView` instead of a `ScrollView` + `VerticalLayout`, we trigger the optimization where only visible children are being instantiated. In my application it makes a very noticeable difference.

For some reason, changing to `ListView` made the existing vertical padding disappear. I don't know where this padding came from before, but I've restored it by adding padding to the `TableViewCell`.

If this optimization is correct I can look into doing the same for other styles.