### PR TITLE
VSCode: add "Remove element" code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project are documented in this file.
 ### LSP
 
  - Fixed "Show Preview" command without component selected (#3412)
- - Added "Wrap in element" code action
+ - Added "Wrap in element" and "Remove element" code actions
 
 ## [1.2.0] - 2023-09-04
 

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -762,6 +762,9 @@ impl SyntaxToken {
             })?;
         Some(SyntaxToken { token, source_file: self.source_file.clone() })
     }
+    pub fn text(&self) -> &str {
+        self.token.text()
+    }
 }
 
 impl std::fmt::Display for SyntaxToken {


### PR DESCRIPTION
A counterpart of #3420 that essentially does the opposite i.e. removes an element from around its sub-element(s). The proposed algorithm substitutes the element with its sub-elements, including repeated and conditional elements, dropping properties, callbacks, and anything else associated with the element being removed.

https://github.com/slint-ui/slint/assets/140617/985b9384-422b-4b3c-b3e6-381c8108eecc
