### PR TITLE
Change item indices from usize to u32

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -70,7 +70,7 @@ constexpr inline ItemTreeNode make_item_node(uint32_t child_count, uint32_t chil
                                                     item_array_index } };
 }
 
-constexpr inline ItemTreeNode make_dyn_node(std::uintptr_t offset, std::uint32_t parent_index)
+constexpr inline ItemTreeNode make_dyn_node(std::uint32_t offset, std::uint32_t parent_index)
 {
     return ItemTreeNode { ItemTreeNode::DynamicTree_Body { ItemTreeNode::Tag::DynamicTree, offset,
                                                            parent_index } };

--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -90,7 +90,7 @@ public:
                 items, &inner);
     }
 
-    void set_focus_item(const ComponentRc &component_rc, uintptr_t item_index)
+    void set_focus_item(const ComponentRc &component_rc, uint32_t item_index)
     {
         cbindgen_private::ItemRc item_rc { component_rc, item_index };
         cbindgen_private::slint_windowrc_set_focus_item(&inner, &item_rc);

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -152,7 +152,7 @@ impl AccessKitAdapter {
 
     fn item_rc_for_node_id(&self, id: NodeId) -> Option<ItemRc> {
         let component_id: usize = (id.0.get() >> usize::BITS) as _;
-        let index: usize = (id.0.get() & usize::MAX as u128) as _;
+        let index: u32 = (id.0.get() & u32::MAX as u128) as _;
         let component = self.components_by_id.borrow().get(&component_id)?.upgrade()?;
         Some(ItemRc::new(component, index))
     }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -166,7 +166,7 @@ pub enum Expression {
         /// The name for the local variable that contains the repeater indices
         repeater_indices: Option<String>,
         /// Either an expression of type BoxLayoutCellData, or an index to the repeater
-        elements: Vec<Either<Expression, usize>>,
+        elements: Vec<Either<Expression, u32>>,
         orientation: Orientation,
         sub_expression: Box<Expression>,
     },
@@ -415,7 +415,7 @@ pub trait TypeResolutionContext {
 pub struct ParentCtx<'a, T = ()> {
     pub ctx: &'a EvaluationContext<'a, T>,
     // Index of the repeater within the ctx.current_sub_component
-    pub repeater_index: Option<usize>,
+    pub repeater_index: Option<u32>,
 }
 
 impl<'a, T> Clone for ParentCtx<'a, T> {
@@ -426,7 +426,7 @@ impl<'a, T> Clone for ParentCtx<'a, T> {
 impl<'a, T> Copy for ParentCtx<'a, T> {}
 
 impl<'a, T> ParentCtx<'a, T> {
-    pub fn new(ctx: &'a EvaluationContext<'a, T>, repeater_index: Option<usize>) -> Self {
+    pub fn new(ctx: &'a EvaluationContext<'a, T>, repeater_index: Option<u32>) -> Self {
         Self { ctx, repeater_index }
     }
 }
@@ -504,7 +504,7 @@ impl<'a, T> TypeResolutionContext for EvaluationContext<'a, T> {
                 for i in sub_component_path {
                     sub_component = &sub_component.sub_components[*i].ty;
                 }
-                sub_component.items[*item_index].ty.lookup_property(prop_name).unwrap()
+                sub_component.items[*item_index as usize].ty.lookup_property(prop_name).unwrap()
             }
             PropertyReference::InParent { level, parent_reference } => {
                 let mut ctx = self;

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -646,7 +646,7 @@ struct BoxLayoutDataResult {
     cells: llr_Expression,
     /// When there are repeater involved, we need to do a BoxLayoutFunction with the
     /// given cell variable and elements
-    compute_cells: Option<(String, Vec<Either<llr_Expression, usize>>)>,
+    compute_cells: Option<(String, Vec<Either<llr_Expression, u32>>)>,
 }
 
 fn box_layout_data(

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -61,8 +61,8 @@ pub struct LoweringState {
 #[derive(Debug, Clone)]
 pub enum LoweredElement {
     SubComponent { sub_component_index: usize },
-    NativeItem { item_index: usize },
-    Repeated { repeated_index: usize },
+    NativeItem { item_index: u32 },
+    Repeated { repeated_index: u32 },
     ComponentPlaceholder { component_container_index: ComponentContainerIndex },
 }
 
@@ -270,7 +270,7 @@ fn lower_sub_component(
         if elem.repeated.is_some() {
             mapping.element_mapping.insert(
                 element.clone().into(),
-                LoweredElement::Repeated { repeated_index: repeated.len() },
+                LoweredElement::Repeated { repeated_index: repeated.len() as u32 },
             );
             repeated.push(element.clone());
             return None;
@@ -295,7 +295,7 @@ fn lower_sub_component(
             }
 
             ElementType::Native(n) => {
-                let item_index = sub_component.items.len();
+                let item_index = sub_component.items.len() as u32;
                 mapping
                     .element_mapping
                     .insert(element.clone().into(), LoweredElement::NativeItem { item_index });
@@ -397,7 +397,7 @@ fn lower_sub_component(
     sub_component.repeated =
         repeated.into_iter().map(|elem| lower_repeated_component(&elem, &ctx)).collect();
     for s in &mut sub_component.sub_components {
-        s.repeater_offset += sub_component.repeated.len();
+        s.repeater_offset += sub_component.repeated.len() as u32;
     }
     sub_component.component_containers = component_container_data
         .into_iter()
@@ -539,7 +539,7 @@ fn lower_component_container(
     let component_container_index: ComponentContainerIndex = (*c.item_index.get().unwrap()).into();
     let ti = component_container_index.as_item_tree_index();
     let component_container_items_index =
-        sub_component.items.iter().position(|i| i.index_in_tree == ti).unwrap();
+        sub_component.items.iter().position(|i| i.index_in_tree == ti).unwrap() as u32;
 
     ComponentContainerElement {
         component_container_item_tree_index: component_container_index,

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -72,7 +72,7 @@ pub fn count_property_use(root: &PublicComponent) {
                     root,
                     &r.sub_tree.root,
                     (),
-                    Some(ParentCtx::new(ctx, Some(idx))),
+                    Some(ParentCtx::new(ctx, Some(idx as u32))),
                 );
                 visit_property(&lv.prop_y, &rep_ctx);
                 visit_property(&lv.prop_width, &rep_ctx);

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -81,7 +81,11 @@ impl<'a> PrettyPrinter<'a> {
         for (idx, r) in sc.repeated.iter().enumerate() {
             self.indent()?;
             write!(self.writer, "for in {} : ", DisplayExpression(&r.model.borrow(), &ctx))?;
-            self.print_component(root, &r.sub_tree.root, Some(ParentCtx::new(&ctx, Some(idx))))?
+            self.print_component(
+                root,
+                &r.sub_tree.root,
+                Some(ParentCtx::new(&ctx, Some(idx as u32))),
+            )?
         }
         for w in &sc.popup_windows {
             self.indent()?;
@@ -123,7 +127,7 @@ impl<T> Display for DisplayPropertyRef<'_, T> {
                     write!(f, "{}.", sc.sub_components[*i].name)?;
                     sc = &sc.sub_components[*i].ty;
                 }
-                let i = &sc.items[*item_index];
+                let i = &sc.items[*item_index as usize];
                 write!(f, "{}.{}", i.name, prop_name)
             }
             PropertyReference::InParent { level, parent_reference } => {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -603,9 +603,9 @@ pub struct Element {
 
     /// This is the component-local index of this item in the item tree array.
     /// It is generated after the last pass and before the generators run.
-    pub item_index: once_cell::unsync::OnceCell<usize>,
+    pub item_index: once_cell::unsync::OnceCell<u32>,
     /// the index of the first children in the tree, set with item_index
-    pub item_index_of_first_children: once_cell::unsync::OnceCell<usize>,
+    pub item_index_of_first_children: once_cell::unsync::OnceCell<u32>,
 
     /// True when this element is in a component was declared with the `:=` symbol instead of the `component` keyword
     pub is_legacy_syntax: bool,

--- a/internal/compiler/passes/generate_item_indices.rs
+++ b/internal/compiler/passes/generate_item_indices.rs
@@ -44,7 +44,7 @@ pub fn generate_item_indices(component: &Rc<Component>) {
 }
 
 struct Helper {
-    current_item_index: usize,
+    current_item_index: u32,
 }
 impl crate::generator::ItemTreeBuilder for Helper {
     // true when not at the root

--- a/internal/core/component.rs
+++ b/internal/core/component.rs
@@ -53,17 +53,17 @@ pub struct ComponentVTable {
     /// Return a reference to an item using the given index
     pub get_item_ref: extern "C" fn(
         core::pin::Pin<VRef<ComponentVTable>>,
-        index: usize,
+        index: u32,
     ) -> core::pin::Pin<VRef<ItemVTable>>,
 
     /// Return the range of indices below the dynamic `ItemTreeNode` at `index`
     pub get_subtree_range:
-        extern "C" fn(core::pin::Pin<VRef<ComponentVTable>>, index: usize) -> IndexRange,
+        extern "C" fn(core::pin::Pin<VRef<ComponentVTable>>, index: u32) -> IndexRange,
 
     /// Return the `ComponentRc` at `subindex` below the dynamic `ItemTreeNode` at `index`
     pub get_subtree_component: extern "C" fn(
         core::pin::Pin<VRef<ComponentVTable>>,
-        index: usize,
+        index: u32,
         subindex: usize,
         result: &mut vtable::VWeak<ComponentVTable, Dyn>,
     ),
@@ -88,7 +88,7 @@ pub struct ComponentVTable {
     pub embed_component: extern "C" fn(
         core::pin::Pin<VRef<ComponentVTable>>,
         parent_component: &VWeak<ComponentVTable>,
-        parent_item_tree_index: usize,
+        parent_item_tree_index: u32,
     ) -> bool,
 
     /// Return the index of the current subtree or usize::MAX if this is not a subtree
@@ -100,12 +100,12 @@ pub struct ComponentVTable {
 
     /// Returns the accessible role for a given item
     pub accessible_role:
-        extern "C" fn(core::pin::Pin<VRef<ComponentVTable>>, item_index: usize) -> AccessibleRole,
+        extern "C" fn(core::pin::Pin<VRef<ComponentVTable>>, item_index: u32) -> AccessibleRole,
 
     /// Returns the accessible property
     pub accessible_string_property: extern "C" fn(
         core::pin::Pin<VRef<ComponentVTable>>,
-        item_index: usize,
+        item_index: u32,
         what: AccessibleStringProperty,
         result: &mut SharedString,
     ),
@@ -143,6 +143,7 @@ pub fn register_component(component_rc: &ComponentRc, window_adapter: Option<Win
     let c = vtable::VRc::borrow_pin(component_rc);
     let item_tree = c.as_ref().get_item_tree();
     item_tree.iter().enumerate().for_each(|(tree_index, node)| {
+        let tree_index = tree_index as u32;
         if let ItemTreeNode::Item { .. } = &node {
             let item = ItemRc::new(component_rc.clone(), tree_index);
             c.as_ref().get_item_ref(tree_index).as_ref().init(&item);

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -704,7 +704,7 @@ pub(crate) fn process_delayed_event(
     };
 
     let mut actual_visitor =
-        |component: &ComponentRc, index: usize, _: Pin<ItemRef>| -> VisitChildrenResult {
+        |component: &ComponentRc, index: u32, _: Pin<ItemRef>| -> VisitChildrenResult {
             send_mouse_event_to_item(
                 event,
                 ItemRc::new(component.clone(), index),
@@ -780,7 +780,7 @@ fn send_mouse_event_to_item(
     result.item_stack.push((item_rc.downgrade(), filter_result));
     if forward_to_children {
         let mut actual_visitor =
-            |component: &ComponentRc, index: usize, _: Pin<ItemRef>| -> VisitChildrenResult {
+            |component: &ComponentRc, index: u32, _: Pin<ItemRef>| -> VisitChildrenResult {
                 send_mouse_event_to_item(
                     event_for_children,
                     ItemRc::new(component.clone(), index),

--- a/internal/core/item_focus.rs
+++ b/internal/core/item_focus.rs
@@ -10,9 +10,9 @@ This module contains the code moving the keyboard focus between items
 use crate::item_tree::ComponentItemTree;
 
 pub fn step_out_of_node(
-    index: usize,
+    index: u32,
     item_tree: &crate::item_tree::ComponentItemTree,
-) -> Option<usize> {
+) -> Option<u32> {
     let mut self_or_ancestor = index;
     loop {
         if let Some(sibling) = item_tree.next_sibling(self_or_ancestor) {
@@ -27,9 +27,9 @@ pub fn step_out_of_node(
 }
 
 pub fn default_next_in_local_focus_chain(
-    index: usize,
+    index: u32,
     item_tree: &crate::item_tree::ComponentItemTree,
-) -> Option<usize> {
+) -> Option<u32> {
     if let Some(child) = item_tree.first_child(index) {
         return Some(child);
     }
@@ -37,7 +37,7 @@ pub fn default_next_in_local_focus_chain(
     step_out_of_node(index, item_tree)
 }
 
-fn step_into_node(item_tree: &ComponentItemTree, index: usize) -> usize {
+fn step_into_node(item_tree: &ComponentItemTree, index: u32) -> u32 {
     let mut node = index;
     loop {
         if let Some(last_child) = item_tree.last_child(node) {
@@ -49,9 +49,9 @@ fn step_into_node(item_tree: &ComponentItemTree, index: usize) -> usize {
 }
 
 pub fn default_previous_in_local_focus_chain(
-    index: usize,
+    index: u32,
     item_tree: &crate::item_tree::ComponentItemTree,
-) -> Option<usize> {
+) -> Option<u32> {
     if let Some(previous) = item_tree.previous_sibling(index) {
         Some(step_into_node(item_tree, previous))
     } else {

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -75,7 +75,7 @@ impl CachedRenderingData {
 #[cfg(feature = "std")]
 pub struct ItemCache<T> {
     /// The pointer is a pointer to a component
-    map: RefCell<HashMap<*const vtable::Dyn, HashMap<usize, CachedGraphicsData<T>>>>,
+    map: RefCell<HashMap<*const vtable::Dyn, HashMap<u32, CachedGraphicsData<T>>>>,
     /// Track if the window scale factor changes; used to clear the cache if necessary.
     window_scale_factor_tracker: Pin<Box<PropertyTracker>>,
 }
@@ -189,7 +189,7 @@ pub fn render_item_children(
     index: isize,
 ) {
     let mut actual_visitor =
-        |component: &ComponentRc, index: usize, item: Pin<ItemRef>| -> VisitChildrenResult {
+        |component: &ComponentRc, index: u32, item: Pin<ItemRef>| -> VisitChildrenResult {
             renderer.save_state();
 
             let (do_draw, item_geometry) = renderer.filter_item(item);
@@ -252,7 +252,7 @@ pub fn item_children_bounding_rect(
     let mut bounding_rect = LogicalRect::zero();
 
     let mut actual_visitor =
-        |component: &ComponentRc, index: usize, item: Pin<ItemRef>| -> VisitChildrenResult {
+        |component: &ComponentRc, index: u32, item: Pin<ItemRef>| -> VisitChildrenResult {
             let item_geometry = item.as_ref().geometry();
 
             let local_clip_rect = clip_rect.translate(-item_geometry.origin.to_vector());

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1482,7 +1482,7 @@ i_slint_common::for_each_builtin_structs!(declare_builtin_structs);
 #[no_mangle]
 pub unsafe extern "C" fn slint_item_absolute_position(
     self_component: &vtable::VRc<crate::component::ComponentVTable>,
-    self_index: usize,
+    self_index: u32,
 ) -> LogicalPoint {
     let self_rc = ItemRc::new(self_component.clone(), self_index);
     self_rc.map_to_window(Default::default())

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -60,7 +60,7 @@ pub struct ComponentContainer {
     component: RefCell<Option<ComponentRc>>,
 
     my_component: OnceCell<ComponentWeak>,
-    embedding_item_tree_index: OnceCell<usize>,
+    embedding_item_tree_index: OnceCell<u32>,
 }
 
 impl ComponentContainer {
@@ -158,12 +158,12 @@ impl Item for ComponentContainer {
         let pin_rc = vtable::VRc::borrow_pin(rc);
         let item_tree = pin_rc.as_ref().get_item_tree();
         let ItemTreeNode::Item { children_index: child_item_tree_index, .. } =
-            item_tree[self_rc.index()]
+            item_tree[self_rc.index() as usize]
         else {
             panic!("Internal compiler error: ComponentContainer had no child.");
         };
 
-        self.embedding_item_tree_index.set(child_item_tree_index as usize).ok().unwrap();
+        self.embedding_item_tree_index.set(child_item_tree_index).ok().unwrap();
 
         self.component_tracker.set(Box::pin(PropertyTracker::default())).ok().unwrap();
     }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1248,7 +1248,7 @@ pub unsafe extern "C" fn slint_textinput_select_all(
     text_input: *const TextInput,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
     self_component: &vtable::VRc<crate::component::ComponentVTable>,
-    self_index: usize,
+    self_index: u32,
 ) {
     let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
     let self_rc = ItemRc::new(self_component.clone(), self_index);
@@ -1261,7 +1261,7 @@ pub unsafe extern "C" fn slint_textinput_clear_selection(
     text_input: *const TextInput,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
     self_component: &vtable::VRc<crate::component::ComponentVTable>,
-    self_index: usize,
+    self_index: u32,
 ) {
     let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
     let self_rc = ItemRc::new(self_component.clone(), self_index);
@@ -1274,7 +1274,7 @@ pub unsafe extern "C" fn slint_textinput_cut(
     text_input: *const TextInput,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
     self_component: &vtable::VRc<crate::component::ComponentVTable>,
-    self_index: usize,
+    self_index: u32,
 ) {
     let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
     let self_rc = ItemRc::new(self_component.clone(), self_index);
@@ -1287,7 +1287,7 @@ pub unsafe extern "C" fn slint_textinput_copy(
     text_input: *const TextInput,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
     self_component: &vtable::VRc<crate::component::ComponentVTable>,
-    self_index: usize,
+    self_index: u32,
 ) {
     let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
     let self_rc = ItemRc::new(self_component.clone(), self_index);
@@ -1300,7 +1300,7 @@ pub unsafe extern "C" fn slint_textinput_paste(
     text_input: *const TextInput,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
     self_component: &vtable::VRc<crate::component::ComponentVTable>,
-    self_index: usize,
+    self_index: u32,
 ) {
     let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
     let self_rc = ItemRc::new(self_component.clone(), self_index);

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1163,10 +1163,10 @@ impl<C: RepeatedComponent + 'static> Repeater<C> {
         mut visitor: crate::item_tree::ItemVisitorRefMut,
     ) -> crate::item_tree::VisitChildrenResult {
         // We can't keep self.inner borrowed because the event might modify the model
-        let count = self.0.inner.borrow().components.len();
+        let count = self.0.inner.borrow().components.len() as u32;
         for i in 0..count {
             let i = if order == TraversalOrder::BackToFront { i } else { count - i - 1 };
-            let c = self.0.inner.borrow().components.get(i).and_then(|c| c.1.clone());
+            let c = self.0.inner.borrow().components.get(i as usize).and_then(|c| c.1.clone());
             if let Some(c) = c {
                 if c.as_pin_ref().visit_children_item(-1, order, visitor.borrow_mut()).has_aborted()
                 {

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -52,11 +52,11 @@ fn next_item_down(item: &ItemRc) -> ItemRc {
     }
 }
 
-fn element_providing_item(component: &ErasedComponentBox, index: usize) -> Option<ElementRc> {
+fn element_providing_item(component: &ErasedComponentBox, index: u32) -> Option<ElementRc> {
     generativity::make_guard!(guard);
     let c = component.unerase(guard);
 
-    c.description().original_elements.get(index).cloned()
+    c.description().original_elements.get(index as usize).cloned()
 }
 
 fn find_element_range(element: &ElementRc) -> Option<(Option<SourceFile>, TextRange)> {


### PR DESCRIPTION
So that the compiler and run-time can never disagree on the number of bytes the item index can use.