### PR TITLE
Simplify component container index handling

### DIFF
--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -108,7 +108,6 @@ pub trait ItemTreeBuilder {
     fn push_repeated_item(
         &mut self,
         item: &crate::object_tree::ElementRc,
-        repeater_count: u32,
         parent_index: u32,
         component_state: &Self::SubComponentState,
     );
@@ -138,7 +137,6 @@ pub trait ItemTreeBuilder {
     fn enter_component_children(
         &mut self,
         item: &ElementRc,
-        repeater_count: u32,
         component_state: &Self::SubComponentState,
         sub_component_state: &Self::SubComponentState,
     );
@@ -156,7 +154,6 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
             builder.enter_component(&root_component.root_element, sub_component, 1, initial_state);
         builder.enter_component_children(
             &root_component.root_element,
-            0,
             initial_state,
             &sub_compo_state,
         );
@@ -278,7 +275,7 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
         for e in children.iter() {
             if let Some(sub_component) = e.borrow().sub_component() {
                 let sub_tree_state = sub_component_states.pop_front().unwrap();
-                builder.enter_component_children(e, *repeater_count, state, &sub_tree_state);
+                builder.enter_component_children(e, state, &sub_tree_state);
                 visit_children(
                     &sub_tree_state,
                     &sub_component.root_element.borrow().children,
@@ -325,7 +322,7 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
         if item.borrow().is_component_placeholder {
             builder.push_component_placeholder_item(item, parent_index, component_state);
         } else if item.borrow().repeated.is_some() {
-            builder.push_repeated_item(item, *repeater_count, parent_index, component_state);
+            builder.push_repeated_item(item, parent_index, component_state);
             *repeater_count += 1;
         } else {
             let mut item = item.clone();

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -159,8 +159,7 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
         );
         build_item_tree::<T>(sub_component, &sub_compo_state, builder);
     } else {
-        let mut repeater_count = 0;
-        visit_item(initial_state, &root_component.root_element, 1, &mut repeater_count, 0, builder);
+        visit_item(initial_state, &root_component.root_element, 1, 0, builder);
 
         visit_children(
             initial_state,
@@ -171,7 +170,6 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
             0,
             1,
             1,
-            &mut repeater_count,
             builder,
         );
     }
@@ -199,7 +197,6 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
         relative_parent_index: u32,
         children_offset: u32,
         relative_children_offset: u32,
-        repeater_count: &mut u32,
         builder: &mut T,
     ) {
         debug_assert_eq!(
@@ -237,7 +234,6 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
                     relative_parent_index,
                     children_offset,
                     relative_children_offset,
-                    repeater_count,
                     builder,
                 );
                 return;
@@ -256,13 +252,12 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
                     &sub_component_state,
                     &sub_component.root_element,
                     offset,
-                    repeater_count,
                     parent_index,
                     builder,
                 );
                 sub_component_states.push_back(sub_component_state);
             } else {
-                visit_item(state, child, offset, repeater_count, parent_index, builder);
+                visit_item(state, child, offset, parent_index, builder);
             }
             offset += item_sub_tree_size(child) as u32;
         }
@@ -285,7 +280,6 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
                     0,
                     offset,
                     1,
-                    repeater_count,
                     builder,
                 );
             } else {
@@ -298,7 +292,6 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
                     relative_index,
                     offset,
                     relative_offset,
-                    repeater_count,
                     builder,
                 );
             }
@@ -315,7 +308,6 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
         component_state: &T::SubComponentState,
         item: &ElementRc,
         children_offset: u32,
-        repeater_count: &mut u32,
         parent_index: u32,
         builder: &mut T,
     ) {
@@ -323,7 +315,6 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
             builder.push_component_placeholder_item(item, parent_index, component_state);
         } else if item.borrow().repeated.is_some() {
             builder.push_repeated_item(item, parent_index, component_state);
-            *repeater_count += 1;
         } else {
             let mut item = item.clone();
             let mut component_state = component_state.clone();

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -741,7 +741,7 @@ fn generate_sub_component(
 
     for container in component.component_containers.iter() {
         let items_index = container.component_container_items_index;
-        let repeater_index = container.component_container_item_tree_index.as_repeater_index();
+        let repeater_index = container.component_container_item_tree_index;
 
         let embed_item = access_member(
             &llr::PropertyReference::InNativeItem {

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -142,47 +142,10 @@ pub struct RepeatedElement {
     pub listview: Option<ListViewInfo>,
 }
 
-#[derive(Clone, Debug)]
-pub struct ComponentContainerIndex(u32);
-
-impl From<u32> for ComponentContainerIndex {
-    fn from(value: u32) -> Self {
-        assert!(value < ComponentContainerIndex::MAGIC);
-        ComponentContainerIndex(value + ComponentContainerIndex::MAGIC)
-    }
-}
-
-impl ComponentContainerIndex {
-    // Choose a MAGIC value that is big enough so we can have lots of repeaters
-    // (repeater_index must be < MAGIC), but small enough to leave room for
-    // lots of embeddings (which will use item_index + MAGIC as its
-    // repeater_index).
-    // Also pick a MAGIC that works on 32bit as well as 64bit systems.
-    const MAGIC: u32 = (u32::MAX / 2) + 1;
-
-    pub fn as_item_tree_index(&self) -> u32 {
-        assert!(self.0 >= ComponentContainerIndex::MAGIC);
-        self.0 - ComponentContainerIndex::MAGIC
-    }
-
-    pub fn as_repeater_index(&self) -> u32 {
-        assert!(self.0 >= ComponentContainerIndex::MAGIC);
-        self.0
-    }
-
-    pub fn try_from_repeater_index(index: u32) -> Option<Self> {
-        if index >= ComponentContainerIndex::MAGIC {
-            Some(ComponentContainerIndex(index))
-        } else {
-            None
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct ComponentContainerElement {
     /// The item tree index of the `ComponentContainer` item node, controlling this Placeholder
-    pub component_container_item_tree_index: ComponentContainerIndex,
+    pub component_container_item_tree_index: u32,
     /// The index of the `ComponentContainer` item in the enclosing components `items` array
     pub component_container_items_index: u32,
     /// The index to a dynamic tree node where the component is supposed to be embedded at

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -63,7 +63,7 @@ pub enum LoweredElement {
     SubComponent { sub_component_index: usize },
     NativeItem { item_index: u32 },
     Repeated { repeated_index: u32 },
-    ComponentPlaceholder { component_container_index: ComponentContainerIndex },
+    ComponentPlaceholder { component_container_index: u32 },
 }
 
 #[derive(Default, Debug, Clone)]
@@ -536,13 +536,15 @@ fn lower_component_container(
 ) -> ComponentContainerElement {
     let c = container.borrow();
 
-    let component_container_index: ComponentContainerIndex = (*c.item_index.get().unwrap()).into();
-    let ti = component_container_index.as_item_tree_index();
-    let component_container_items_index =
-        sub_component.items.iter().position(|i| i.index_in_tree == ti).unwrap() as u32;
+    let component_container_item_tree_index = *c.item_index.get().unwrap();
+    let component_container_items_index = sub_component
+        .items
+        .iter()
+        .position(|i| i.index_in_tree == component_container_item_tree_index)
+        .unwrap() as u32;
 
     ComponentContainerElement {
-        component_container_item_tree_index: component_container_index,
+        component_container_item_tree_index,
         component_container_items_index,
         component_placeholder_item_tree_index: *c.item_index_of_first_children.get().unwrap(),
     }
@@ -746,7 +748,7 @@ fn make_tree(
         LoweredElement::ComponentPlaceholder { component_container_index } => TreeNode {
             is_accessible: false,
             sub_component_path: sub_component_path.into(),
-            item_index: component_container_index.as_repeater_index(),
+            item_index: *component_container_index,
             children: vec![],
             repeated: true,
         },

--- a/internal/compiler/passes/generate_item_indices.rs
+++ b/internal/compiler/passes/generate_item_indices.rs
@@ -53,7 +53,6 @@ impl crate::generator::ItemTreeBuilder for Helper {
     fn push_repeated_item(
         &mut self,
         item: &ElementRc,
-        _repeater_count: u32,
         _parent_index: u32,
         component_state: &Self::SubComponentState,
     ) {
@@ -109,7 +108,6 @@ impl crate::generator::ItemTreeBuilder for Helper {
     fn enter_component_children(
         &mut self,
         _item: &ElementRc,
-        _repeater_count: u32,
         _component_state: &Self::SubComponentState,
         _sub_component_state: &Self::SubComponentState,
     ) {

--- a/internal/interpreter/dynamic_component.rs
+++ b/internal/interpreter/dynamic_component.rs
@@ -854,7 +854,6 @@ pub(crate) fn generate_component<'id>(
         fn push_repeated_item(
             &mut self,
             item_rc: &ElementRc,
-            _repeater_count: u32,
             parent_index: u32,
             _component_state: &Self::SubComponentState,
         ) {
@@ -939,7 +938,6 @@ pub(crate) fn generate_component<'id>(
         fn enter_component_children(
             &mut self,
             _item: &ElementRc,
-            _repeater_count: u32,
             _component_state: &Self::SubComponentState,
             _sub_component_state: &Self::SubComponentState,
         ) {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1030,9 +1030,9 @@ fn eval_assignment(lhs: &Expression, op: char, rhs: Value, local_context: &mut E
             // Safety: This is the only 'static Id in scope.
             let static_guard =
                 unsafe { generativity::Guard::new(generativity::Id::<'static>::new()) };
-            let repeater = crate::dynamic_component::get_repeater_by_name(
+            let repeater = crate::dynamic_component::get_repeater_by_item_index(
                 enclosing_component,
-                element.borrow().id.as_str(),
+                *element.borrow().item_index.get().unwrap(),
                 static_guard,
             );
             repeater.0.model_set_row_data(

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -193,9 +193,9 @@ fn box_layout_data(
     for cell in &box_layout.elems {
         if cell.element.borrow().repeated.is_some() {
             generativity::make_guard!(guard);
-            let rep = crate::dynamic_component::get_repeater_by_name(
+            let rep = crate::dynamic_component::get_repeater_by_item_index(
                 component,
-                cell.element.borrow().id.as_str(),
+                *cell.element.borrow().item_index.get().unwrap(),
                 guard,
             );
             rep.0.as_ref().ensure_updated(|| {

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -252,16 +252,16 @@ pub fn highlight(component_instance: &DynamicComponentVRc, path: PathBuf, offset
 }
 
 fn fill_model(
-    repeater_path: &[String],
+    repeater_path: &[u32],
     element: &ElementRc,
     component_instance: &ComponentBox,
     values: &mut Vec<Value>,
 ) {
     if let [first, rest @ ..] = repeater_path {
         generativity::make_guard!(guard);
-        let rep = crate::dynamic_component::get_repeater_by_name(
+        let rep = crate::dynamic_component::get_repeater_by_item_index(
             component_instance.borrow_instance(),
-            first.as_str(),
+            *first,
             guard,
         );
         for idx in rep.0.range() {
@@ -313,14 +313,14 @@ fn find_element_at_offset(component: &Rc<Component>, path: PathBuf, offset: u32)
     result
 }
 
-fn repeater_path(elem: &ElementRc) -> Option<Vec<String>> {
+fn repeater_path(elem: &ElementRc) -> Option<Vec<u32>> {
     let enclosing = elem.borrow().enclosing_component.upgrade().unwrap();
     if let Some(parent) = enclosing.parent_element.upgrade() {
         // This is not a repeater, it might be a popup menu which is not supported ATM
         parent.borrow().repeated.as_ref()?;
 
         let mut r = repeater_path(&parent)?;
-        r.push(parent.borrow().id.clone());
+        r.push(*parent.borrow().item_index.get().unwrap());
         Some(r)
     } else {
         Some(vec![])


### PR DESCRIPTION
Remove the ComponentContainerIndex that maps
component container indices into the upper u32 half to separate them from repeater indices.
This was done to be able to identify if an item
index in the dynamic visitor in the interpreter
belongs to a repeater or not. Instead, this patch
stores the repeaters in a hashmap that maps from
item index.