### PR TITLE
C++: Fix crash when deleting a component from the click event within a sub component

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1060,8 +1060,6 @@ fn generate_item_tree(
         conditional_includes,
     );
 
-    let root_access = if parent_ctx.is_some() { "parent->root" } else { "self" };
-
     let mut item_tree_array: Vec<String> = Default::default();
     let mut item_array: Vec<String> = Default::default();
 
@@ -1411,6 +1409,7 @@ fn generate_item_tree(
         create_code.push("slint::cbindgen_private::slint_ensure_backend();".into());
     }
 
+    let root_access = if parent_ctx.is_some() { "parent->root" } else { "self" };
     create_code.extend([
         format!(
             "slint::private_api::register_component(&self_rc.into_dyn(), {root_access}->m_window);",
@@ -1442,12 +1441,10 @@ fn generate_item_tree(
         }),
     ));
 
-    let mut destructor = vec!["auto self = this;".to_owned()];
-
-    destructor.push(format!(
-        "if (auto &window = {}->m_window) window->window_handle().unregister_component(self, item_array());",
-        root_access
-    ));
+    let root_access = if parent_ctx.is_some() { "root" } else { "this" };
+    let destructor = vec![format!(
+        "if (auto &window = {root_access}->m_window) window->window_handle().unregister_component(this, item_array());"
+    )];
 
     target_struct.members.push((
         Access::Public,

--- a/tests/cases/models/delete_from_clicked.slint
+++ b/tests/cases/models/delete_from_clicked.slint
@@ -1,0 +1,81 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export global Glob {
+    in-out property <[string]> model: ["Hello", "World"];
+    in-out property <bool> condition: true;
+    callback clicked(string);
+    clicked => {
+        model = ["oops"];
+    }
+    in-out property <string> value;
+}
+
+component Button {
+    callback clicked();
+    in property <string> text;
+    Rectangle {
+        background: yellow;
+        Text { text: text; }
+        TouchArea {
+            clicked => {clicked();}
+        }
+    }
+}
+
+
+component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+    VerticalLayout {
+        for string in Glob.model: Rectangle {
+            if Glob.condition: Button {
+                text: string;
+                width: 80%;
+                height: 80%;
+                clicked => {
+                    Glob.value = string;
+                    Glob.clicked(string);
+                    //Glob.value = string; // FIXME: this still crashes (#3464)
+                }
+            }
+        }
+        Rectangle {}
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+let model = std::rc::Rc::new(slint::VecModel::<slint::SharedString>::from(
+    vec!["hello".into(), "world".into()]));
+instance.global::<Glob>().set_model(model.clone().into());
+instance.global::<Glob>().on_clicked(move |val|{
+    assert_eq!(val, "world");
+    model.remove(1);
+});
+slint_testing::send_mouse_click(&instance, 150., 150.);
+assert_eq!(instance.global::<Glob>().get_value(), "world");
+```
+
+```cpp
+auto handle = TestCase::create();
+TestCase &instance = *handle;
+
+std::vector<slint::SharedString> array;
+array.push_back("hello");
+array.push_back("world");
+auto model = std::make_shared<slint::VectorModel<slint::SharedString>>(std::move(array));
+instance.global<Glob>().set_model(model);
+instance.global<Glob>().on_clicked([=](slint::SharedString val){
+    assert_eq(val, "world");
+    model->erase(1);
+});
+slint_testing::send_mouse_click(&instance, 150., 150.);
+assert_eq(instance.global<Glob>().get_value(), "world");
+```
+
+
+
+
+*/


### PR DESCRIPTION
The parent is already deleted when we delete the component that is kept alive by the `grabber` ItemRc in `handle_mouse_grab` When the ItemRc goes out of scope, we delete the component, but the parent was already gone.

This doesn't solve a broader issue that we use the parent in many place and it is not kept alive (for example when using properties of the parent)