### PR TITLE
Don't panic when the windowing system tries to assign a zero size to a GL surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
  - Minimum Rust version is now 1.70.
  - Fixed generated C++ and Rust code in conversion from unnamed to named struct in complex expressions (#2765)
  - Improved wasm preview in the documentation (especially on mobile)
+ - Fixed panic when using Skia OpenGL renderer with fullscreen windows.
 
 ### Slint Language
 

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -157,20 +157,10 @@ impl super::Surface for OpenGLSurface {
     fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
         self.ensure_context_current()?;
 
-        let width = size.width.try_into().map_err(|_| {
-            format!(
-                "Attempting to resize OpenGL window surface with an invalid width: {}",
-                size.width
-            )
-        })?;
-        let height = size.height.try_into().map_err(|_| {
-            format!(
-                "Attempting to resize OpenGL window surface with an invalid height: {}",
-                size.height
-            )
-        })?;
+        if let Some((width, height)) = size.width.try_into().ok().zip(size.height.try_into().ok()) {
+            self.glutin_surface.resize(&self.glutin_context, width, height);
+        }
 
-        self.glutin_surface.resize(&self.glutin_context, width, height);
         Ok(())
     }
 


### PR DESCRIPTION
Apply https://github.com/slint-ui/slint/pull/3179 also to the Skia OpenGL surface.

A zero size is permitted with Metal for example, but we panic'ed.

Fixes #3472