### PR TITLE
FemtoVG: fix eliding empty lines

### DIFF
--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -654,7 +654,7 @@ pub(crate) fn layout_text_lines(
                     }
                 }
                 if elide_last_line {
-                    let elided = format!("{}…", line);
+                    let elided = format!("{}…", line.strip_suffix('\n').unwrap_or(line));
                     process_line(&elided, y, start, &text_metrics);
                     y += font_height;
                     start = index;


### PR DESCRIPTION
Eliding a single line or long wrapping lines works fine because the ellipsis character is inserted after the last glyph that fits, before the newline character. But when eliding the last visible text line, the FemtoVG renderer would format the elided line like this:

https://github.com/slint-ui/slint/blob/14f7fe4ba295cc93d450a162e13699df657badff/internal/renderers/femtovg/fonts.rs#L657

If the line ended with a trailing newline, it would append the ellipsis after the newline character. For example, an empty line would become `"\n…"`.

### Before

https://github.com/slint-ui/slint/assets/140617/1d0d6639-f1c5-44d1-abb1-3a8f90c07cf9

### After

https://github.com/slint-ui/slint/assets/140617/d1a5a807-66fc-4c61-8c1e-df009c5a14ec

### Testcase

```
export component StatusBox inherits Window  {
    preferred-width: 400px;
    preferred-height: 400px;

    Rectangle {
        x: 20px;
        y: 20px;
        width: parent.width - 40px;
        height: parent.height - 40px;

        border-width: 2px;
        border-color: red;

        Text {
            width: 100%;
            height: 100%;

            text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.\n\nOne newline:\nTwo newlines:\n\nThree newlines:\n\n\nThe end.";
            font-size: 28px;
            overflow: elide;
            wrap: word-wrap;
        }
    }
}
```