### PR TITLE
FemtoVG: fix vertical alignment of elided text

### DIFF
--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -580,7 +580,12 @@ pub(crate) fn layout_text_lines(
                 )
                 .height_length();
             if elide && text_height > max_height {
-                font_height * (max_height.get() / font_height.get()).floor()
+                // The height of the text is used for vertical alignment below.
+                // If the full text doesn't fit into max_height and eliding is
+                // enabled, calculate the height of the max number of lines that
+                // fit to ensure correct vertical alignment when elided.
+                let max_lines = (max_height.get() / font_height.get()).floor();
+                font_height * max_lines
             } else {
                 text_height
             }

--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -572,12 +572,18 @@ pub(crate) fn layout_text_lines(
             font_height
         } else {
             // Note: this is kind of doing twice the layout because text_size also does it
-            font.text_size(
-                PhysicalLength::new(paint.letter_spacing()),
-                string,
-                if wrap { Some(max_width) } else { None },
-            )
-            .height_length()
+            let text_height = font
+                .text_size(
+                    PhysicalLength::new(paint.letter_spacing()),
+                    string,
+                    if wrap { Some(max_width) } else { None },
+                )
+                .height_length();
+            if elide && text_height > max_height {
+                font_height * (max_height.get() / font_height.get()).floor()
+            } else {
+                text_height
+            }
         }
     };
 


### PR DESCRIPTION
A partial fix to #3481. Fixes vertically centered and bottom-aligned elided text for the FemtoVG renderer.

### Before

https://github.com/slint-ui/slint/assets/140617/bf7b7ed1-3528-4b1f-83a6-597a4cc4f2a8

### After

https://github.com/slint-ui/slint/assets/140617/238e171e-097a-4231-bca0-1597d00de3c8

<details><summary>testcase.slint</summary>

```
export component TestWindow inherits Window  {
    preferred-width: 640px;
    preferred-height: 320px;

    HorizontalLayout {
        x: 0;
        padding: 20px;

        for valign in [TextVerticalAlignment.top, TextVerticalAlignment.center, TextVerticalAlignment.bottom]: Rectangle {
            border-color: red;
            border-width: 2px;

            Text {
                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
                height: 100%;
                width: 100%;
                wrap: word-wrap;
                overflow: TextOverflow.elide;
                vertical-alignment: valign;
            }
        }
    }
}
```
</slint>