### PR TITLE
Skia: fix eliding of multiline text

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -478,6 +478,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
             max_height,
             text.horizontal_alignment(),
             text.vertical_alignment(),
+            text.wrap(),
             text.overflow(),
             None,
         );
@@ -538,6 +539,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
             max_height,
             text_input.horizontal_alignment(),
             text_input.vertical_alignment(),
+            text_input.wrap(),
             i_slint_core::items::TextOverflow::Clip,
             selection.as_ref(),
         );

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -224,6 +224,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
             Default::default(),
             Default::default(),
             Default::default(),
+            Default::default(),
             None,
         );
 
@@ -257,6 +258,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
             max_height,
             text_input.horizontal_alignment(),
             text_input.vertical_alignment(),
+            text_input.wrap(),
             i_slint_core::items::TextOverflow::Clip,
             None,
         );
@@ -304,6 +306,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
             max_height,
             text_input.horizontal_alignment(),
             text_input.vertical_alignment(),
+            text_input.wrap(),
             i_slint_core::items::TextOverflow::Clip,
             None,
         );

--- a/internal/renderers/skia/textlayout.rs
+++ b/internal/renderers/skia/textlayout.rs
@@ -59,6 +59,7 @@ pub fn create_layout(
     max_height: PhysicalLength,
     h_align: items::TextHorizontalAlignment,
     v_align: TextVerticalAlignment,
+    wrap: items::TextWrap,
     overflow: items::TextOverflow,
     selection: Option<&Selection>,
 ) -> (skia_safe::textlayout::Paragraph, PhysicalPoint) {
@@ -88,6 +89,9 @@ pub fn create_layout(
 
     if overflow == items::TextOverflow::Elide {
         style.set_ellipsis("…");
+        if wrap == items::TextWrap::WordWrap {
+            style.set_max_lines((max_height.get() / pixel_size.get()).floor() as usize);
+        }
     }
 
     style.set_text_align(match h_align {


### PR DESCRIPTION
A partial fix to #3481. Make sure to specify the maximum amount of lines when eliding text with word wrapping to avoid Skia truncating it to just one line.

### Before

https://github.com/slint-ui/slint/assets/140617/5086735d-6d0b-4736-9aab-5851793ccc4a

### After

https://github.com/slint-ui/slint/assets/140617/a86429ee-b129-41be-be88-f2e3963a9dfd

<details><summary>testcase.slint</summary>

```
export component TestWindow inherits Window  {
    preferred-width: 640px;
    preferred-height: 320px;

    HorizontalLayout {
        x: 0;
        padding: 20px;

        for valign in [TextVerticalAlignment.top, TextVerticalAlignment.center, TextVerticalAlignment.bottom]: Rectangle {
            border-color: red;
            border-width: 2px;

            Text {
                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
                height: 100%;
                width: 100%;
                wrap: word-wrap;
                overflow: TextOverflow.elide;
                vertical-alignment: valign;
            }
        }
    }
}
```
</details>