### PR TITLE
StandardTableView: prevent internal FocusScope from eating the first press

### DIFF
--- a/internal/compiler/widgets/cupertino-base/tableview.slint
+++ b/internal/compiler/widgets/cupertino-base/tableview.slint
@@ -139,6 +139,7 @@ export component StandardTableView {
     min-height: 200px;
     horizontal-stretch: 1;
     vertical-stretch: 1;
+    forward-focus: i-focus-scope;
 
     VerticalLayout {
         Rectangle {
@@ -216,13 +217,14 @@ export component StandardTableView {
                 }
 
                 clicked => {
+                    root.focus();
                     root.set-current-row(idx);
                 }
             }
         }
     }
 
-    FocusScope {
+    i-focus-scope := FocusScope {
         x: 0;
         width: 0; // Do not react on clicks
 

--- a/internal/compiler/widgets/cupertino-base/tableview.slint
+++ b/internal/compiler/widgets/cupertino-base/tableview.slint
@@ -223,6 +223,9 @@ export component StandardTableView {
     }
 
     FocusScope {
+        x: 0;
+        width: 0; // Do not react on clicks
+
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
                 root.set-current-row(root.current-row - 1);

--- a/internal/compiler/widgets/fluent-base/tableview.slint
+++ b/internal/compiler/widgets/fluent-base/tableview.slint
@@ -163,6 +163,7 @@ export component StandardTableView {
     min-height: 200px;
     horizontal-stretch: 1;
     vertical-stretch: 1;
+    forward-focus: i-focus-scope;
 
     VerticalLayout {
         Rectangle {
@@ -238,13 +239,14 @@ export component StandardTableView {
                 }
 
                 clicked => {
+                    root.focus();
                     root.set-current-row(idx);
                 }
             }
         }
     }
 
-    FocusScope {
+    i-focus-scope := FocusScope {
         x: 0;
         width: 0; // Do not react on clicks
 

--- a/internal/compiler/widgets/fluent-base/tableview.slint
+++ b/internal/compiler/widgets/fluent-base/tableview.slint
@@ -245,6 +245,9 @@ export component StandardTableView {
     }
 
     FocusScope {
+        x: 0;
+        width: 0; // Do not react on clicks
+
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
                 root.set-current-row(root.current-row - 1);

--- a/internal/compiler/widgets/material-base/tableview.slint
+++ b/internal/compiler/widgets/material-base/tableview.slint
@@ -137,6 +137,7 @@ export component StandardTableView {
     min-height: 200px;
     horizontal-stretch: 1;
     vertical-stretch: 1;
+    forward-focus: i-focus-scope;
 
     VerticalLayout {
         Rectangle {
@@ -202,6 +203,7 @@ export component StandardTableView {
                     }
 
                     clicked => {
+                        root.focus();
                         root.set-current-row(idx);
                     }
 
@@ -216,7 +218,7 @@ export component StandardTableView {
         }
     }
 
-    FocusScope {
+    i-focus-scope := FocusScope {
         x: 0;
         width: 0; // Do not react on clicks
 

--- a/internal/compiler/widgets/material-base/tableview.slint
+++ b/internal/compiler/widgets/material-base/tableview.slint
@@ -217,6 +217,9 @@ export component StandardTableView {
     }
 
     FocusScope {
+        x: 0;
+        width: 0; // Do not react on clicks
+
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
                 root.set-current-row(root.current-row - 1);

--- a/internal/compiler/widgets/native/tableview.slint
+++ b/internal/compiler/widgets/native/tableview.slint
@@ -19,6 +19,7 @@ export component StandardTableView {
 
     horizontal-stretch: 1;
     vertical-stretch: 1;
+    forward-focus: i-focus-scope;
 
     public function set-current-row(index: int) {
         if(index < 0 || index >= rows.length) {
@@ -60,6 +61,7 @@ export component StandardTableView {
             width: max(row-layout.preferred-width, scroll-view.visible-width);
             row-ta := TouchArea {
                 clicked => {
+                    root.focus();
                     root.set-current-row(i);
                 }
 
@@ -126,7 +128,7 @@ export component StandardTableView {
         }
     }
 
-    FocusScope {
+    i-focus-scope := FocusScope {
         x: 0;
         width: 0; // Do not react on clicks
 

--- a/internal/compiler/widgets/native/tableview.slint
+++ b/internal/compiler/widgets/native/tableview.slint
@@ -127,6 +127,9 @@ export component StandardTableView {
     }
 
     FocusScope {
+        x: 0;
+        width: 0; // Do not react on clicks
+
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
                 root.set-current-row(root.current-row - 1);


### PR DESCRIPTION
This PR fixes the issue that it was not possible to drag `StandardTableView` scroll bars or resize its headers when initiated from the first mouse press because the internal `FocusScope` ate the first mouse press.

Fixes: #3436