### PR TITLE
Hide the ComponentFactory from the docs

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -202,6 +202,8 @@ compile_error!(
 pub use slint_macros::slint;
 
 pub use i_slint_core::api::*;
+#[doc(hidden)]
+#[deprecated(note = "Experimental type was made public by mistake")]
 pub use i_slint_core::component_factory::ComponentFactory;
 #[cfg(not(target_arch = "wasm32"))]
 pub use i_slint_core::graphics::{BorrowedOpenGLTextureBuilder, BorrowedOpenGLTextureOrigin};


### PR DESCRIPTION
It was not meant to be public.

Added a deprecated note even if deprecared on `pub use` don't show warnings