### PR TITLE
Don't show a preview for the sample component in the Rust docs

### DIFF
--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -24,7 +24,7 @@ pub mod generated_code {
     /// This an example of the API that is generated for a component in `.slint` design markup. This may help you understand
     /// what functions you can call and how you can pass data in and out.
     /// This is the source code:
-    /// ```slint
+    /// ```slint,no-preview
     /// export component SampleComponent inherits Window {
     ///     in-out property<int> counter;
     ///     // note that dashes will be replaced by underscores in the generated code


### PR DESCRIPTION
It's not a visual example.

Currently it looks like this:

<img width="1020" alt="Screenshot 2023-09-19 at 10 49 21" src="https://github.com/slint-ui/slint/assets/1486/69d41a05-5cec-4e0c-8ffb-806740c6ddab">
