### PR TITLE
Skia renderer: Fixed the `source` property of `Image` elements sometimes not changing when setting dynamically loaded images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 ### General
 
  - Minimum Rust version is now 1.70.
+ - Skia renderer: Fixed the `source` property of `Image` elements sometimes not changing when setting dynamically loaded images. (#3510)
 
 ### Slint Language
 

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -457,7 +457,7 @@ impl PartialEq for ImageInner {
             (Self::BackendStorage(l0), Self::BackendStorage(r0)) => vtable::VRc::ptr_eq(l0, r0),
             #[cfg(not(target_arch = "wasm32"))]
             (Self::BorrowedOpenGLTexture(l0), Self::BorrowedOpenGLTexture(r0)) => l0 == r0,
-            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+            _ => false,
         }
     }
 }

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -454,6 +454,7 @@ impl PartialEq for ImageInner {
             (Self::StaticTextures(l0), Self::StaticTextures(r0)) => l0 == r0,
             #[cfg(target_arch = "wasm32")]
             (Self::HTMLImage(l0), Self::HTMLImage(r0)) => vtable::VRc::ptr_eq(l0, r0),
+            (Self::BackendStorage(l0), Self::BackendStorage(r0)) => vtable::VRc::ptr_eq(l0, r0),
             #[cfg(not(target_arch = "wasm32"))]
             (Self::BorrowedOpenGLTexture(l0), Self::BorrowedOpenGLTexture(r0)) => l0 == r0,
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),


### PR DESCRIPTION
After loading an image with `Image::load_from_path` and setting to a source property, upon rendering with Skia, it would get replaced with a Skia renderer specific image representation. When later setting another image that was also using `ImageInner::BackedStorage`, the property would not get set because PartialEq::eq would return true because the image inner types are the same, instead of comparing the vtable pointers.

Fixes #3510