### PR TITLE
Fluent: fix selection foreground color

### DIFF
--- a/internal/compiler/widgets/fluent-base/lineedit.slint
+++ b/internal/compiler/widgets/fluent-base/lineedit.slint
@@ -57,7 +57,7 @@ export component LineEdit {
                     font-size: Typography.body.font-size;
                     font-weight: Typography.body.font-weight;
                     selection-background-color: Palette.accent-selected-text;
-                    selection-foreground-color: self.color;
+                    selection-foreground-color: Palette.text-on-accent-primary;
 
                     accepted => {
                         root.accepted(self.text);
@@ -111,6 +111,7 @@ export component LineEdit {
             i-background.background: Palette.control-disabled;
             i-background.border-color: Palette.control-stroke;
             i-text-input.color: Palette.text-disabled;
+            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
             i-placeholder.color: Palette.text-disabled;
         }
         focused when root.has-focus : {

--- a/internal/compiler/widgets/fluent-base/spinbox.slint
+++ b/internal/compiler/widgets/fluent-base/spinbox.slint
@@ -74,7 +74,7 @@ export component SpinBox {
                     font-size: Typography.body.font-size;
                     font-weight: Typography.body.font-weight;
                     selection-background-color: Palette.accent-selected-text;
-                    selection-foreground-color: self.color;
+                    selection-foreground-color: Palette.text-on-accent-primary;
                     horizontal-stretch: 1;
                     text: root.value;
 
@@ -147,6 +147,7 @@ export component SpinBox {
             i-background.background: Palette.control-disabled;
             i-background.border-color: Palette.control-stroke;
             i-text-input.color: Palette.text-disabled;
+            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
         }
         focused when root.has-focus : {
             i-background.background: Palette.control-input-active;

--- a/internal/compiler/widgets/fluent-base/textedit.slint
+++ b/internal/compiler/widgets/fluent-base/textedit.slint
@@ -47,7 +47,7 @@ export component TextEdit {
                 font-size: Typography.body.font-size;
                 font-weight: Typography.body.font-weight;
                 selection-background-color: Palette.accent-selected-text;
-                selection-foreground-color: self.color;
+                selection-foreground-color: Palette.text-on-accent-primary;
                 single-line: false;
                 wrap: word-wrap;
 
@@ -104,6 +104,7 @@ export component TextEdit {
             i-background.background: Palette.control-disabled;
             i-background.border-color: Palette.control-stroke;
             i-text-input.color: Palette.text-disabled;
+            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
         }
         focused when root.has-focus : {
             i-background.background: Palette.control-input-active;


### PR DESCRIPTION
When selecting text, the foreground color is inverted