### PR TITLE
janitor: Fix clippy errors about wrong clone implementations

### DIFF
--- a/helper_crates/vtable/src/lib.rs
+++ b/helper_crates/vtable/src/lib.rs
@@ -231,7 +231,7 @@ impl<'a, T: ?Sized + VTableMeta> Copy for VRef<'a, T> {}
 
 impl<'a, T: ?Sized + VTableMeta> Clone for VRef<'a, T> {
     fn clone(&self) -> Self {
-        Self { inner: self.inner, phantom: PhantomData }
+        *self
     }
 }
 
@@ -542,7 +542,7 @@ impl<Base, T: ?Sized + VTableMeta, Flag> Copy for VOffset<Base, T, Flag> {}
 
 impl<Base, T: ?Sized + VTableMeta, Flag> Clone for VOffset<Base, T, Flag> {
     fn clone(&self) -> Self {
-        Self { vtable: self.vtable, offset: self.offset, phantom: PhantomData }
+        *self
     }
 }
 

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -420,7 +420,7 @@ pub struct ParentCtx<'a, T = ()> {
 
 impl<'a, T> Clone for ParentCtx<'a, T> {
     fn clone(&self) -> Self {
-        Self { ctx: self.ctx, repeater_index: self.repeater_index }
+        *self
     }
 }
 impl<'a, T> Copy for ParentCtx<'a, T> {}

--- a/internal/core/slice.rs
+++ b/internal/core/slice.rs
@@ -53,7 +53,7 @@ impl<'a, T> Copy for Slice<'a, T> {}
 
 impl<'a, T> Clone for Slice<'a, T> {
     fn clone(&self) -> Self {
-        Self { ptr: self.ptr, len: self.len, phantom: PhantomData }
+        *self
     }
 }
 


### PR DESCRIPTION
... for Copy types.

This breaks running clippy for me, so I'd appreciate to see this fixed.