### PR TITLE
Qt Widgets: set the preferred-size to the minimum-size

### DIFF
--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -225,13 +225,11 @@ impl Item for NativeButton {
             }
             return qApp->style()->sizeFromContents(QStyle::CT_PushButton, &option, option.rect.size(), widget_ptr);
         });
-        LayoutInfo {
-            min: match orientation {
-                Orientation::Horizontal => size.width as f32,
-                Orientation::Vertical => size.height as f32,
-            },
-            ..LayoutInfo::default()
-        }
+        let min = match orientation {
+            Orientation::Horizontal => size.width as f32,
+            Orientation::Vertical => size.height as f32,
+        };
+        LayoutInfo { min, preferred: min, ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -45,11 +45,15 @@ impl Item for NativeCheckBox {
             return qApp->style()->sizeFromContents(QStyle::CT_CheckBox, &option, option.rect.size(), widget);
         });
         match orientation {
-            Orientation::Horizontal => {
-                LayoutInfo { min: size.width as f32, stretch: 1., ..LayoutInfo::default() }
-            }
+            Orientation::Horizontal => LayoutInfo {
+                min: size.width as f32,
+                preferred: size.width as f32,
+                stretch: 1.,
+                ..LayoutInfo::default()
+            },
             Orientation::Vertical => LayoutInfo {
                 min: size.height as f32,
+                preferred: size.height as f32,
                 max: size.height as f32,
                 ..LayoutInfo::default()
             },

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -40,13 +40,11 @@ impl Item for NativeComboBox {
             option.subControls = QStyle::SC_All;
             return qApp->style()->sizeFromContents(QStyle::CT_ComboBox, &option, option.rect.size(), widget);
         });
-        LayoutInfo {
-            min: match orientation {
-                Orientation::Horizontal => size.width,
-                Orientation::Vertical => size.height,
-            } as f32,
-            ..LayoutInfo::default()
-        }
+        let min = match orientation {
+            Orientation::Horizontal => size.width,
+            Orientation::Vertical => size.height,
+        } as f32;
+        LayoutInfo { min, preferred: min, ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -151,14 +151,11 @@ impl Item for NativeGroupBox {
 
         let size = minimum_group_box_size(text);
 
-        LayoutInfo {
-            min: match orientation {
-                Orientation::Horizontal => size.width as f32,
-                Orientation::Vertical => size.height as f32,
-            },
-            stretch: 1.,
-            ..LayoutInfo::default()
-        }
+        let min = match orientation {
+            Orientation::Horizontal => size.width as f32,
+            Orientation::Vertical => size.height as f32,
+        };
+        LayoutInfo { min, preferred: min, stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -77,12 +77,14 @@ impl Item for NativeLineEdit {
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
+        let min = match orientation {
+            Orientation::Horizontal => self.native_padding_left() + self.native_padding_right(),
+            Orientation::Vertical => self.native_padding_top() + self.native_padding_bottom(),
+        }
+        .get();
         LayoutInfo {
-            min: match orientation {
-                Orientation::Horizontal => self.native_padding_left() + self.native_padding_right(),
-                Orientation::Vertical => self.native_padding_top() + self.native_padding_bottom(),
-            }
-            .get(),
+            min,
+            preferred: min,
             stretch: if orientation == Orientation::Horizontal { 1. } else { 0. },
             ..LayoutInfo::default()
         }

--- a/internal/backends/qt/qt_widgets/progress_indicator.rs
+++ b/internal/backends/qt/qt_widgets/progress_indicator.rs
@@ -54,11 +54,15 @@ impl Item for NativeProgressIndicator {
         });
 
         match orientation {
-            Orientation::Horizontal => {
-                LayoutInfo { min: size.width as f32, stretch: 1., ..LayoutInfo::default() }
-            }
+            Orientation::Horizontal => LayoutInfo {
+                min: size.width as f32,
+                preferred: size.width as f32,
+                stretch: 1.,
+                ..LayoutInfo::default()
+            },
             Orientation::Vertical => LayoutInfo {
                 min: size.height as f32,
+                preferred: size.height as f32,
                 max: size.height as f32,
                 ..LayoutInfo::default()
             },

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -91,15 +91,12 @@ impl Item for NativeScrollView {
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
-        LayoutInfo {
-            min: match orientation {
-                Orientation::Horizontal => self.native_padding_left() + self.native_padding_right(),
-                Orientation::Vertical => self.native_padding_top() + self.native_padding_bottom(),
-            }
-            .get(),
-            stretch: 1.,
-            ..LayoutInfo::default()
+        let min = match orientation {
+            Orientation::Horizontal => self.native_padding_left() + self.native_padding_right(),
+            Orientation::Vertical => self.native_padding_top() + self.native_padding_bottom(),
         }
+        .get();
+        LayoutInfo { min, preferred: min, stretch: 1., ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -101,14 +101,21 @@ impl Item for NativeSlider {
             auto thick = style->pixelMetric(QStyle::PM_SliderThickness, &option, widget);
             return style->sizeFromContents(QStyle::CT_Slider, &option, QSize(0, thick), widget);
         });
+        let (width, height) = (size.width as f32, size.height as f32);
         match orientation {
             Orientation::Horizontal => {
                 if !vertical {
-                    LayoutInfo { min: size.width as f32, stretch: 1., ..LayoutInfo::default() }
+                    LayoutInfo {
+                        min: width,
+                        preferred: width,
+                        stretch: 1.,
+                        ..LayoutInfo::default()
+                    }
                 } else {
                     LayoutInfo {
-                        min: size.height as f32,
-                        max: size.height as f32,
+                        min: height,
+                        preferred: height,
+                        max: height,
                         ..LayoutInfo::default()
                     }
                 }
@@ -116,12 +123,18 @@ impl Item for NativeSlider {
             Orientation::Vertical => {
                 if !vertical {
                     LayoutInfo {
-                        min: size.height as f32,
-                        max: size.height as f32,
+                        min: height,
+                        preferred: height,
+                        max: height,
                         ..LayoutInfo::default()
                     }
                 } else {
-                    LayoutInfo { min: size.width as f32, stretch: 1., ..LayoutInfo::default() }
+                    LayoutInfo {
+                        min: width,
+                        preferred: width,
+                        stretch: 1.,
+                        ..LayoutInfo::default()
+                    }
                 }
             }
         }

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -98,11 +98,15 @@ impl Item for NativeSpinBox {
             return style->sizeFromContents(QStyle::CT_SpinBox, &option, line_edit_size, widget);
         });
         match orientation {
-            Orientation::Horizontal => {
-                LayoutInfo { min: size.width as f32, stretch: 1., ..LayoutInfo::default() }
-            }
+            Orientation::Horizontal => LayoutInfo {
+                min: size.width as f32,
+                preferred: size.width as f32,
+                stretch: 1.,
+                ..LayoutInfo::default()
+            },
             Orientation::Vertical => LayoutInfo {
                 min: size.height as f32,
+                preferred: size.height as f32,
                 max: size.height as f32,
                 ..LayoutInfo::default()
             },


### PR DESCRIPTION
Instead of setting it to 0 which cause `widget.preferred-width` ti be 0

Fixes #3527