### PR TITLE
Add spacing-horizontal and spacing-vertical to layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project are documented in this file.
 ### Slint Language
 
  - Added `Number`, `Decimal` variant to enum `InputType`
+ - Added `spacing-horizontal` and `spacing-vertical` in `GridLayout`
 
 ### Rust API
 

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -223,6 +223,8 @@ Alternatively, the item can be put in a `Row` element.
 ### Properties
 
 -   **`spacing`** (_in_ _length_): The distance between the elements in the layout.
+-   **`spacing-horizontal`**, **`spacing-vertical`** (_in_ _length_): 
+    Set these properties to override the spacing on specific directions.
 -   **`padding`** (_in_ _length_): The padding within the layout.
 -   **`padding-left`**, **`padding-right`**, **`padding-top`** and **`padding-bottom`** (_in_ _length_):
     Set these properties to override the padding on specific sides.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -212,6 +212,8 @@ component Row {
 
 // Note: layouts are not NativeClass, but this is lowered in lower_layout
 export component GridLayout {
+    in property <length> spacing-horizontal;
+    in property <length> spacing-vertical;
     in property <length> spacing;
 
     // Additional accepted child

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -785,7 +785,7 @@ fn generate_layout_padding_and_spacing(
             llr_Expression::NumberLiteral(0.)
         }
     };
-    let spacing = padding_prop(layout_geometry.spacing.as_ref());
+    let spacing = padding_prop(layout_geometry.spacing.orientation(orientation));
     let (begin, end) = layout_geometry.padding.begin_end(orientation);
 
     let padding = make_struct(

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -437,7 +437,14 @@ fn lower_dialog_layout(
         grid.geometry.padding.top.get_or_insert(NamedReference::new(metrics, "layout-padding"));
         grid.geometry.padding.left.get_or_insert(NamedReference::new(metrics, "layout-padding"));
         grid.geometry.padding.right.get_or_insert(NamedReference::new(metrics, "layout-padding"));
-        grid.geometry.spacing.get_or_insert(NamedReference::new(metrics, "layout-spacing"));
+        grid.geometry
+            .spacing
+            .horizontal
+            .get_or_insert(NamedReference::new(metrics, "layout-spacing"));
+        grid.geometry
+            .spacing
+            .vertical
+            .get_or_insert(NamedReference::new(metrics, "layout-spacing"));
     }
 
     let layout_cache_prop_h = create_new_prop(dialog_element, "layout-cache-h", Type::LayoutCache);

--- a/internal/compiler/tests/syntax/layout/spacing.slint
+++ b/internal/compiler/tests/syntax/layout/spacing.slint
@@ -1,0 +1,22 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export Test := Rectangle {
+
+    HorizontalLayout {
+        spacing-horizontal: 8px;
+//      ^error{Unknown property spacing-horizontal in HorizontalLayout}
+        spacing-vertical: 8px;
+//      ^error{Unknown property spacing-vertical in HorizontalLayout}
+    }
+
+    VerticalLayout {
+        spacing-horizontal: 8px;
+//      ^error{Unknown property spacing-horizontal in VerticalLayout}
+        spacing-vertical: 8px;
+//      ^error{Unknown property spacing-vertical in VerticalLayout}
+    }
+
+
+}
+

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -144,7 +144,7 @@ fn padding_and_spacing(
     orientation: Orientation,
     expr_eval: &impl Fn(&NamedReference) -> f32,
 ) -> (core_layout::Padding, f32) {
-    let spacing = layout_geometry.spacing.as_ref().map_or(0., expr_eval);
+    let spacing = layout_geometry.spacing.orientation(orientation).map_or(0., expr_eval);
     let (begin, end) = layout_geometry.padding.begin_end(orientation);
     let padding =
         core_layout::Padding { begin: begin.map_or(0., expr_eval), end: end.map_or(0., expr_eval) };

--- a/tests/cases/layout/grid_spacing.slint
+++ b/tests/cases/layout/grid_spacing.slint
@@ -82,6 +82,8 @@ TestCase := Rectangle {
 
     property <bool> rect3_pos_ok: rect3.x == 25phx && rect3.y == 0phx; 
     property <bool> rect4_pos_ok: rect4.x == 25phx && rect4.y == 35phx; 
+    
+    out property <bool> test: rect1_pos_ok && rect2_pos_ok &&rect3_pos_ok && rect4_pos_ok;
 }
 
 /*

--- a/tests/cases/layout/grid_spacing.slint
+++ b/tests/cases/layout/grid_spacing.slint
@@ -1,0 +1,107 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+TestCase := Rectangle {
+    width: 600phx;
+    height: 300phx;
+
+    Rectangle {
+        width: 300phx;
+        height: 300phx;
+        GridLayout {
+            spacing: 10phx;
+            Row {
+                Rectangle {
+                    width: 5phx;
+                    height: 5phx;
+                    background: red;
+                }
+
+                rect1 := Rectangle {
+                    width: 5phx;
+                    height: 5phx;
+                    background: red;
+                }
+            }
+
+            Row {
+                Rectangle {
+                    width: 5phx;
+                    height: 5phx;
+                    background: red;
+                }
+
+                rect2 := Rectangle {
+                    width: 5phx;
+                    height: 5phx;
+                    background: red;
+                }
+            }
+        }
+    }
+
+    property <bool> rect1_pos_ok: rect1.x == 15phx && rect1.y == 0phx; 
+    property <bool> rect2_pos_ok: rect2.x == 15phx && rect2.y == 15phx; 
+
+    Rectangle {
+        width: 300phx;
+        height: 300phx;
+        GridLayout {
+            spacing-horizontal: 20phx;
+            spacing-vertical: 30phx;
+            spacing: 10phx;
+            Row {
+                Rectangle {
+                    width: 5phx;
+                    height: 5phx;
+                    background: red;
+                }
+
+                rect3 := Rectangle {
+                    width: 5phx;
+                    height: 5phx;
+                    background: red;
+                }
+            }
+
+            Row {
+                Rectangle {
+                    width: 5phx;
+                    height: 5phx;
+                    background: red;
+                }
+
+                rect4 := Rectangle {
+                    width: 5phx;
+                    height: 5phx;
+                    background: red;
+                }
+            }
+        }
+    }
+
+    property <bool> rect3_pos_ok: rect3.x == 25phx && rect3.y == 0phx; 
+    property <bool> rect4_pos_ok: rect4.x == 25phx && rect4.y == 35phx; 
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_rect1_pos_ok());
+assert(instance.get_rect2_pos_ok());
+assert(instance.get_rect3_pos_ok());
+assert(instance.get_rect4_pos_ok());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_rect1_pos_ok());
+assert!(instance.get_rect2_pos_ok());
+assert!(instance.get_rect3_pos_ok());
+assert!(instance.get_rect4_pos_ok());
+```
+
+*/


### PR DESCRIPTION
Close #3492 

Add `spacing-horizontal` and `spacing-vertical` as specialization of `spacing` in `GridLayout`.

As mention in the issue, this currently also add them to `HorizontalLayput` and `VerticalLayout`. How should I handle this ? forbid it through a compiler step ?