### PR TITLE
material style todo demo polish

### DIFF
--- a/examples/todo/ui/todo.slint
+++ b/examples/todo/ui/todo.slint
@@ -59,6 +59,7 @@ component MainWindow inherits Window {
 
     VerticalBox {
         HorizontalBox {
+            padding: 0px;
             text-edit := LineEdit {
                 placeholder-text: "What needs to be done?";
                 accepted(text) => {
@@ -77,6 +78,7 @@ component MainWindow inherits Window {
         }
 
         if (root.show-header) : HorizontalBox {
+            padding: 0px;
             alignment: start;
 
             CheckBox {
@@ -110,6 +112,7 @@ component MainWindow inherits Window {
             }
         }
         HorizontalBox {
+            padding: 0px;
             alignment: end;
             Button {
                 text: "Remove Done Items";

--- a/internal/compiler/widgets/material-base/checkbox.slint
+++ b/internal/compiler/widgets/material-base/checkbox.slint
@@ -12,7 +12,8 @@ export component CheckBox {
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked;
 
-    min-height: max(18px, i-layout.min-height);
+    min-height: max(32px, i-layout.min-height);
+    vertical-stretch: 0;
 
     accessible-label <=> i-text.text;
     accessible-checkable: true;
@@ -34,7 +35,7 @@ export component CheckBox {
                     height: 100%;
                     border-radius: 2px;
                     border-width: 2px;
-                    border-color: Palette.on-surface;
+                    border-color: Palette.on-surface-variant;
                 }
 
                 i-state-layer := Rectangle {


### PR DESCRIPTION
 - Remove extra padding from the todo demo. Box in Box causes the padding to be added twice otherwise. And the Box have extra big padding with the material style.

 - Fixup the combobox size to be consistant with fluent wrt sizing

 - Use the proper color for the checkbox border, following the style specification