### PR TITLE
Tests: add support for `//ignore: <driver(s)>`

### DIFF
--- a/tests/cases/elements/component_container.slint
+++ b/tests/cases/elements/component_container.slint
@@ -1,6 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+// FIXME: Skip embedding test on C++ and NodeJS since ComponentFactory is not
+// implemented there!
+//ignore: cpp,js
+
 import { Button } from "std-widgets.slint";
 
 export component TestCase inherits Rectangle {
@@ -18,8 +22,6 @@ export component TestCase inherits Rectangle {
 /*
 ```cpp
 // ComponentFactory not supported yet!
-
-// THIS TEST IS HARD DISABLED IN build.rs of the C++ test driver
 ```
 
 ```rust

--- a/tests/driver/cpp/build.rs
+++ b/tests/driver/cpp/build.rs
@@ -44,17 +44,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for testcase in test_driver_lib::collect_test_cases("cases")? {
         let test_function_name = testcase.identifier();
-
-        if &test_function_name == "elements_component_container" {
-            // FIXME: Skip embedding test on C++ since ComponentFactory is not
-            // implemented there!
-            continue;
-        }
+        let ignored = testcase.is_ignored("cpp");
 
         write!(
             tests_file,
             r##"
             #[test]
+            {ignore}
             fn test_cpp_{function_name}() {{
                 cppdriver::test(&test_driver_lib::TestCase{{
                     absolute_path: std::path::PathBuf::from(r#"{absolute_path}"#),
@@ -63,6 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }}
 
         "##,
+            ignore = if ignored { "#[ignore]" } else { "" },
             function_name = test_function_name,
             absolute_path = testcase.absolute_path.to_string_lossy(),
             relative_path = testcase.relative_path.to_string_lossy(),

--- a/tests/driver/interpreter/build.rs
+++ b/tests/driver/interpreter/build.rs
@@ -11,11 +11,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for testcase in test_driver_lib::collect_test_cases("cases")? {
         let test_function_name = testcase.identifier();
+        let ignored = testcase.is_ignored("interpreter");
 
         write!(
             tests_file,
             r##"
             #[test]
+            {ignore}
             fn test_interpreter_{function_name}() {{
                 interpreter::test(&test_driver_lib::TestCase{{
                     absolute_path: std::path::PathBuf::from(r#"{absolute_path}"#),
@@ -23,6 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }}).unwrap();
             }}
         "##,
+            ignore = if ignored { "#[ignore]" } else { "" },
             function_name = test_function_name,
             absolute_path = testcase.absolute_path.to_string_lossy(),
             relative_path = testcase.relative_path.to_string_lossy(),

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -17,6 +17,7 @@ fn main() -> std::io::Result<()> {
         }
         writeln!(generated_file, "#[path=\"{0}.rs\"] mod r#{0};", module_name)?;
         let source = std::fs::read_to_string(&testcase.absolute_path)?;
+        let ignored = testcase.is_ignored("rust");
 
         let mut output = std::fs::File::create(
             Path::new(&std::env::var_os("OUT_DIR").unwrap()).join(format!("{}.rs", module_name)),
@@ -36,12 +37,13 @@ fn main() -> std::io::Result<()> {
             write!(
                 output,
                 r"
-#[test] fn t_{}() -> Result<(), Box<dyn std::error::Error>> {{
+#[test] {} fn t_{}() -> Result<(), Box<dyn std::error::Error>> {{
     use i_slint_backend_testing as slint_testing;
     slint_testing::init();
     {}
     Ok(())
 }}",
+                if ignored { "#[ignore]" } else { "" },
                 i,
                 x.source.replace('\n', "\n    ")
             )?;


### PR DESCRIPTION
Makes it easy to ignore unsupported test cases for specific drivers (cpp, interpreter, js, rust) at the cost of having to read test case sources at build time.

For example, `tests/cases/elements/component_container.slint` does not support C++ or JS:
```
//ignore: cpp,js
```

See also https://github.com/slint-ui/slint/pull/3523#discussion_r1337664179