### PR TITLE
Unpin winit version

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -44,8 +44,7 @@ lyon_path = "1.0"
 once_cell = "1.5"
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
-# Pinned due to https://github.com/slint-ui/slint/issues/2424
-winit = { version = "=0.28.6", default-features = false }
+winit = { version = "0.28.7", default-features = false }
 instant = "0.1"
 raw-window-handle = { version = "0.5", features = ["alloc"] }
 scopeguard =  { version = "1.1.0", default-features = false }


### PR DESCRIPTION
The new version of winit fixes an important bug for macOS Sonoma, and the bugvix for the workaround won't happen before winit 0.29. The branch that port to winit 0.29 already removed the workaround

Fixes #3559