### PR TITLE
WinitSoftwareRenderer: Present the all buffer if selecting a sub region failed

### DIFF
--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -152,17 +152,25 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
         };
 
         let size = region.bounding_box_size();
-        if let Some((w, h)) = Option::zip(NonZeroU32::new(size.width), NonZeroU32::new(size.height))
-        {
-            let pos = region.bounding_box_origin();
-            target_buffer
-                .present_with_damage(&[softbuffer::Rect {
-                    width: w,
-                    height: h,
-                    x: pos.x as u32,
-                    y: pos.y as u32,
-                }])
-                .map_err(|e| format!("Error presenting softbuffer buffer: {e}"))?;
+        match Option::zip(NonZeroU32::new(size.width), NonZeroU32::new(size.height)) {
+            Some((w, h)) => {
+                let pos = region.bounding_box_origin();
+                target_buffer
+                    .present_with_damage(&[softbuffer::Rect {
+                        width: w,
+                        height: h,
+                        x: pos.x as u32,
+                        y: pos.y as u32,
+                    }])
+                    .map_err(|e| format!("Error presenting softbuffer buffer: {e}"))?;
+            }
+            None => {
+                // If we get here the redraw was possibly not initiated by us
+                // and we should probably redraw everything.
+                target_buffer
+                    .present()
+                    .map_err(|e| format!("Error presenting softbuffer buffer: {e}"))?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Without this window passing it front or moving the window outside the screen and back would destroy the window content.