### PR TITLE
Remove the preview from the rust docs

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -16,7 +16,7 @@ jobs:
       # for which the stable alternative is not yet available.
       # Allow suspicious-auto-trait-impls to work around https://github.com/Diggsey/scoped-tls-hkt/issues/2
       # RUSTFLAGS: -D warnings -W deprecated
-      RUSTDOCFLAGS: --html-in-header=/home/runner/work/slint/slint/docs/resources/slint-docs-preview.html --html-in-header=/home/runner/work/slint/slint/docs/resources/slint-docs-highlight.html -D warnings -W deprecated -W suspicious-auto-trait-impls
+      RUSTDOCFLAGS: --html-in-header=/home/runner/work/slint/slint/docs/resources/slint-docs-highlight.html -D warnings -W deprecated -W suspicious-auto-trait-impls
       SLINT_NO_QT: 1
       CARGO_INCREMENTAL: false
     steps:

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -174,8 +174,8 @@ serde = { version = "1.0.163", features = ["derive"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = [
-  "--html-in-header",
-  "docs/resources/slint-docs-preview.html",
+  # "--html-in-header",
+  # "docs/resources/slint-docs-preview.html",
   "--html-in-header",
   "docs/resources/slint-docs-highlight.html",
 ]


### PR DESCRIPTION
rustdoc removes the `no-preview` tag, and we anyway do not have a slint file to preview in the docs anymore