### PR TITLE
Fix cross-compilation with a Yocto SDK

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 cmake_minimum_required(VERSION 3.21)
-project(Slint HOMEPAGE_URL "https://slint.dev/" LANGUAGES CXX VERSION 1.0.0)
+# Select C++ and C as languages, as Corrosion needs ${CMAKE_C_COMPILER}
+# for linking
+project(Slint HOMEPAGE_URL "https://slint.dev/" LANGUAGES C CXX VERSION 1.0.0)
 
 include(FeatureSummary)
 include(CMakeDependentOption)


### PR DESCRIPTION
Since commit 7947f233f1a744f5ce9dfdf44372727d4fefb50b in Corrosion, cmake will default to ${CMAKE_C_COMPILER} for linking a cdylib, which means that C must be enabled as a language in the project.

Previously, it tried C, CXX, and Fortran and picked the first one.