### PR TITLE
FemtoVG: fix empty text input cursor alignment

### DIFF
--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -14,6 +14,7 @@ use i_slint_core::graphics::{Image, IntRect, Point, Size};
 use i_slint_core::item_rendering::{ItemCache, ItemRenderer};
 use i_slint_core::items::{
     self, Clip, FillRule, ImageFit, ImageRendering, ItemRc, Layer, Opacity, RenderingResult,
+    TextHorizontalAlignment,
 };
 use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector, PointLengths,
@@ -520,7 +521,14 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
         );
 
         if let Some(cursor_point) = cursor_point.or_else(|| {
-            cursor_visible.then(|| PhysicalPoint::from_lengths(PhysicalLength::default(), next_y))
+            cursor_visible.then(|| {
+                let x = match text_input.horizontal_alignment() {
+                    TextHorizontalAlignment::Left => PhysicalLength::default(),
+                    TextHorizontalAlignment::Center => width / 2.,
+                    TextHorizontalAlignment::Right => width,
+                };
+                PhysicalPoint::from_lengths(x, next_y)
+            })
         }) {
             let mut cursor_rect = femtovg::Path::new();
             cursor_rect.rect(


### PR DESCRIPTION
A partial fix to #3580.

Calculate the appropriate cursor position according to the horizontal alignment instead of falling back to `PhysicalLength::default()` when there's nothing to layout i.e. the text input is empty.

## Before

https://github.com/slint-ui/slint/assets/140617/0787fc01-9db0-4d67-987e-0d0c7c560908

## After

https://github.com/slint-ui/slint/assets/140617/291c6c7e-2b7e-401a-b6fe-f9d02f826fc1
