### PR TITLE
Improve file type for SLINT_COMPILER cmake cache variable

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -26,7 +26,7 @@ add_feature_info(SLINT_FEATURE_COMPILER SLINT_FEATURE_COMPILER "Enable support f
 option(SLINT_BUILD_RUNTIME "Actually build the Slint runtime libraries (Disable that to only build the compiler)" ON)
 add_feature_info(SLINT_BUILD_RUNTIME SLINT_BUILD_RUNTIME "Actually build the Slint runtime libraries (Disable that to only build the compiler)")
 
-set(SLINT_COMPILER "" CACHE STRING "Path to the slint-compiler executable. When unset, it the compiler will be build as part of the build process")
+set(SLINT_COMPILER "" CACHE FILEPATH "Path to the slint-compiler executable. When unset, it the compiler will be build as part of the build process")
 set(SLINT_LIBRARY_CARGO_FLAGS "" CACHE STRING
     "Flags to pass to cargo when building the Slint runtime library")
 

--- a/api/cpp/cmake/SlintConfig.cmake.in
+++ b/api/cpp/cmake/SlintConfig.cmake.in
@@ -14,7 +14,7 @@ endif()
 add_library(@slint_cpp_impl@ @cmake_lib_type@ IMPORTED)
 set_target_properties(@slint_cpp_impl@ PROPERTIES @SLINT_LIB_PROPERTIES@)
 
-set(SLINT_COMPILER @SLINT_COMPILER@ CACHE STRING "Path to the slint-compiler executable")
+set(SLINT_COMPILER @SLINT_COMPILER@ CACHE FILEPATH "Path to the slint-compiler executable")
 if (SLINT_COMPILER)
   set(SLINT_STYLE @_SLINT_STYLE@ CACHE STRING "The Slint widget style")
     add_executable(Slint::slint-compiler IMPORTED GLOBAL)


### PR DESCRIPTION
Use a FILEPATH to reflect that this is a path to a file and then the cmake configurator will show a file dialog.