### PR TITLE
Skia: fix empty text input cursor alignment

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -552,6 +552,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
                 cursor_position,
                 layout,
                 text_input.text_cursor_width() * self.scale_factor,
+                text_input.horizontal_alignment(),
             )
             .translate(layout_top_left.to_vector());
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -338,6 +338,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
             byte_offset,
             layout,
             text_input.text_cursor_width() * scale_factor,
+            text_input.horizontal_alignment(),
         );
 
         physical_cursor_rect.translate(layout_top_left.to_vector()) / scale_factor

--- a/internal/renderers/skia/textlayout.rs
+++ b/internal/renderers/skia/textlayout.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use i_slint_core::graphics::euclid::num::Zero;
 use i_slint_core::graphics::FontRequest;
-use i_slint_core::items::TextVerticalAlignment;
+use i_slint_core::items::{TextHorizontalAlignment, TextVerticalAlignment};
 use i_slint_core::lengths::{LogicalLength, ScaleFactor};
 use i_slint_core::{items, Color};
 
@@ -204,10 +204,16 @@ pub fn cursor_rect(
     cursor_pos: usize,
     layout: skia_safe::textlayout::Paragraph,
     cursor_width: PhysicalLength,
+    h_align: TextHorizontalAlignment,
 ) -> PhysicalRect {
     if string.is_empty() {
+        let x = match h_align {
+            TextHorizontalAlignment::Left => PhysicalLength::default(),
+            TextHorizontalAlignment::Center => PhysicalLength::new(layout.max_width() / 2.),
+            TextHorizontalAlignment::Right => PhysicalLength::new(layout.max_width()),
+        };
         return PhysicalRect::new(
-            PhysicalPoint::default(),
+            PhysicalPoint::from_lengths(x, PhysicalLength::default()),
             PhysicalSize::from_lengths(cursor_width, PhysicalLength::new(layout.height())),
         );
     }


### PR DESCRIPTION
Same as #3585 but for Skia. Calculate the appropriate cursor position according to the horizontal alignment instead of falling back to `PhysicalLength::default()` when there's nothing to layout i.e. the text input is empty.

## Before

https://github.com/slint-ui/slint/assets/140617/bfd94d9b-3c3a-40ae-a566-b076939e8da9

## After

https://github.com/slint-ui/slint/assets/140617/ce858e1e-2da8-46bf-bd0e-e7c2982ba9e1

Close: #3580