### PR TITLE
Interpreter: fix crash when clicking on a item causes it to be destroyed

### DIFF
--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -377,7 +377,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
             if let Value::LayoutCache(cache) = cache {
                 if let Some(ri) = repeater_index {
                     let offset : usize = eval_expression(ri, local_context).try_into().unwrap();
-                    Value::Number(cache[(cache[*index] as usize) + offset * 2].into())
+                    Value::Number(cache.get((cache[*index] as usize) + offset * 2).copied().unwrap_or(0.).into())
                 } else {
                     Value::Number(cache[*index].into())
                 }

--- a/tests/cases/crashes/issue3589_layout_click_deletes_item.slint
+++ b/tests/cases/crashes/issue3589_layout_click_deletes_item.slint
@@ -1,0 +1,59 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+
+export component TestCase inherits Rectangle {
+
+    width: 300px;
+    height: 300px;
+
+    property <bool> screen-state;
+    out property <bool> activated;
+
+    if !screen-state:
+        vl := VerticalLayout {
+        if !screen-state:
+            ta1 := TouchArea {
+                clicked => {
+                    screen-state = true;
+                }
+
+        }
+
+        // comment the line below and this page will work
+        re := Rectangle { height: 5px; }
+    }
+
+    if screen-state : ta2 := TouchArea {
+        clicked => { activated = true; }
+    }
+}
+
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 95., 5.);
+assert(!instance.get_activated());
+slint_testing::send_mouse_click(&instance, 95., 5.);
+assert(instance.get_activated());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 95., 5.);
+assert!(!instance.get_activated());
+slint_testing::send_mouse_click(&instance, 95., 5.);
+assert!(instance.get_activated());
+```
+
+```js
+var instance = new slint.TestCase();
+instance.send_mouse_click(95., 5.);
+assert(!instance.activated);
+instance.send_mouse_click(95., 5.);
+assert(instance.activated);
+```
+*/


### PR DESCRIPTION
What happens is that the item is destroyed and removed from the layout
when clicking. But the send exit event still query the geometry if the
ItemRc which points to position in the layout cache that is not valid.

The Rust and C++ generator already check for the vailidity of the index
and return 0 if it's too large.

Fixes https://github.com/slint-ui/slint/issues/3589