### PR TITLE
Skia: fix line height calculation for eliding the last line of text

### DIFF
--- a/internal/renderers/skia/textlayout.rs
+++ b/internal/renderers/skia/textlayout.rs
@@ -90,7 +90,9 @@ pub fn create_layout(
     if overflow == items::TextOverflow::Elide {
         style.set_ellipsis("…");
         if wrap == items::TextWrap::WordWrap {
-            style.set_max_lines((max_height.get() / pixel_size.get()).floor() as usize);
+            let metrics = text_style.font_metrics();
+            let line_height = metrics.descent - metrics.ascent + metrics.leading;
+            style.set_max_lines((max_height.get() / line_height).floor() as usize);
         }
     }
 


### PR DESCRIPTION
Second attempt to fix multi-line eliding (#3481) for Skia.

| | Before | After |
|---|---|---|
| Linux | ![image](https://github.com/slint-ui/slint/assets/140617/0d316229-2599-4600-8d9f-e78cfac1e6f3) | ![image](https://github.com/slint-ui/slint/assets/140617/67089ecd-d4c9-4e55-b4a6-f2c1afc0dc41) |
| macOS | <img width="212" alt="Screenshot 2023-10-02 at 19 07 03" src="https://github.com/slint-ui/slint/assets/140617/b6cee6a3-83d7-43ee-a52d-9dc285341e4b"> | <img width="212" alt="Screenshot 2023-10-02 at 19 07 31" src="https://github.com/slint-ui/slint/assets/140617/da66560a-b2dc-432b-bee2-97c740010a17"> |