### PR TITLE
Fix build of linuxkms backend on Yocto

### DIFF
--- a/internal/backends/linuxkms/Cargo.toml
+++ b/internal/backends/linuxkms/Cargo.toml
@@ -34,7 +34,7 @@ i-slint-renderer-femtovg = { workspace = true, features = ["default"], optional 
 input = { version = "0.8.2" }
 xkbcommon = { version = "0.6.0" }
 calloop = { version = "0.11.0" }
-libseat = { version = "0.2.1" }
+libseat = { version = "0.2.1", default-features = false }
 nix = { version = "0.27.0", features=["fs"] }
 vulkano = { version = "0.33.0", optional = true, default-features = false }
 drm = { version = "0.9.0", optional = true }


### PR DESCRIPTION
We enable libseat's custom_logger feature by default, which redirects log output from libseat into the Rust log facade. That's nice, but as part of the implementation of this feature unfortunately libseat's build.rs unconditionally adds /usr/local/include to the list of the search include paths when compiling the log_handler.c file. That breaks the Yocto build, rightly so:

warning: cc1: error: include location "/usr/local/include" is unsafe for cross-compilation [-Werror=poison-system-directories]

We can do without this feature, so let's not enable it.