### PR TITLE
Fix named exports in native code

### DIFF
--- a/tests/cases/exports/export_structs_and_enums_as.slint
+++ b/tests/cases/exports/export_structs_and_enums_as.slint
@@ -19,7 +19,7 @@ assert(instance.get_en() == ExportEnum::Bonjour); // FIXME: NamedEnum::Bonjour (
 
 ```rust
 let instance = TestCase::new().unwrap();
-assert_eq!(instance.get_en(), ExportEnum::Bonjour); // FIXME: NamedEnum::Bonjour (#3599)
+assert_eq!(instance.get_en(), NamedEnum::Bonjour);
 ```
 
 */

--- a/tests/cases/exports/export_structs_and_enums_as.slint
+++ b/tests/cases/exports/export_structs_and_enums_as.slint
@@ -14,12 +14,12 @@ export component TestCase inherits Rectangle {
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
-assert(instance.get_en() == ExportEnum::Bonjour);
+assert(instance.get_en() == ExportEnum::Bonjour); // FIXME: NamedEnum::Bonjour (#3599)
 ```
 
 ```rust
 let instance = TestCase::new().unwrap();
-assert_eq!(instance.get_en(), ExportEnum::Bonjour);
+assert_eq!(instance.get_en(), ExportEnum::Bonjour); // FIXME: NamedEnum::Bonjour (#3599)
 ```
 
 */

--- a/tests/cases/exports/export_structs_and_enums_as.slint
+++ b/tests/cases/exports/export_structs_and_enums_as.slint
@@ -1,0 +1,25 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+//include_path: ../../helper_components
+import { ExportedStruct, ExportEnum } from "export_structs.slint";
+export { ExportedStruct as NamedStruct, ExportEnum as NamedEnum  }
+export component TestCase inherits Rectangle {
+    in-out property<ExportedStruct> st;
+    in-out property<ExportEnum> en: ExportEnum.Bonjour;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_en() == ExportEnum::Bonjour);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_en(), ExportEnum::Bonjour);
+```
+
+*/

--- a/tests/cases/exports/named_exports.slint
+++ b/tests/cases/exports/named_exports.slint
@@ -13,9 +13,9 @@ export { TestCase as NamedTestCase }
 /*
 
 ```cpp
-auto handle = TestCase::create(); // FIXME: NamedTestCase
+auto handle = NamedTestCase::create();
 const TestCase &instance = *handle;
-assert(instance.get_en() == ExportEnum::Bonjour); // FIXME: NamedEnum::Bonjour
+assert(instance.get_en() == NamedEnum::Bonjour);
 ```
 
 ```rust

--- a/tests/cases/exports/named_exports.slint
+++ b/tests/cases/exports/named_exports.slint
@@ -4,21 +4,22 @@
 //include_path: ../../helper_components
 import { ExportedStruct, ExportEnum } from "export_structs.slint";
 export { ExportedStruct as NamedStruct, ExportEnum as NamedEnum  }
-export component TestCase inherits Rectangle {
+component TestCase inherits Rectangle {
     in-out property<ExportedStruct> st;
     in-out property<ExportEnum> en: ExportEnum.Bonjour;
 }
+export { TestCase as NamedTestCase }
 
 /*
 
 ```cpp
-auto handle = TestCase::create();
+auto handle = TestCase::create(); // FIXME: NamedTestCase
 const TestCase &instance = *handle;
-assert(instance.get_en() == ExportEnum::Bonjour); // FIXME: NamedEnum::Bonjour (#3599)
+assert(instance.get_en() == ExportEnum::Bonjour); // FIXME: NamedEnum::Bonjour
 ```
 
 ```rust
-let instance = TestCase::new().unwrap();
+let instance = NamedTestCase::new().unwrap();
 assert_eq!(instance.get_en(), NamedEnum::Bonjour);
 ```
 


### PR DESCRIPTION
When components, enums, and structs are exported with names from Slint, generate the respective aliases for Rust and C++.

Fixes: #3599