### PR TITLE
Fix cmake producing absolute DT_NEEDED paths in applications when linking against installed libslint_cpp on Linux

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -386,6 +386,16 @@ if(SLINT_BUILD_RUNTIME)
             endif()
         endforeach()
 
+        # Corrosion sets IMPORTED_NO_SONAME and for macOS we reset that
+        # and set IMPORTED_SONAME. Make sure to propagate these locally
+        # set properties also to the installed cmake target.
+        foreach(prop IMPORTED_NO_SONAME IMPORTED_SONAME)
+            get_target_property(value ${slint_cpp_impl} ${prop})
+            if(value)
+                list(APPEND SLINT_LIB_PROPERTIES ${prop} ${value})
+            endif()
+        endforeach()
+
         get_property(_SLINT_STYLE GLOBAL PROPERTY SLINT_STYLE)
         configure_package_config_file("cmake/SlintConfig.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/Slint/SlintConfig.cmake" INSTALL_DESTINATION lib/cmake/Slint)
     endfunction()


### PR DESCRIPTION
Commit 9b62b08ed66aec83b0f5805c1d7484a968d0351f fixed https://github.com/slint-ui/slint/issues/1066 initially, but commit 1036c0d0824788d15b24214ce7b7338f75dcd7d4 erroneously regressed this again, because while Corrosion sets this property, it is only set on the locally generated CMake target. We still need to propagate that also into the installed CMake target, which this patch does.