### PR TITLE
linuxkms: Prospective fix for failing crtc setup

### DIFF
--- a/internal/backends/linuxkms/display/egldisplay.rs
+++ b/internal/backends/linuxkms/display/egldisplay.rs
@@ -204,13 +204,10 @@ pub fn try_create_egl_display(
         })
         .ok_or_else(|| format!("No preferred or non-zero size display mode found"))?;
 
-    let encoder = connector.encoders().iter().find_map(|handle| {
-        if connector.current_encoder() == Some(*handle) {
-            drm_device.get_encoder(*handle).ok()
-        } else {
-            None
-        }
-    });
+    let encoder = connector
+        .current_encoder()
+        .filter(|current| connector.encoders().iter().any(|h| *h == *current))
+        .and_then(|current| drm_device.get_encoder(current).ok());
 
     let crtc = if let Some(encoder) = encoder {
         encoder.crtc().ok_or_else(|| format!("no crtc for encoder"))?


### PR DESCRIPTION
If the chosen connector doesn't have a current encoder (who's crtc we could use), fall back to the algorithm described in

    https://manpages.debian.org/testing/libdrm-dev/drm-kms.7.en.html#CRTC/Encoder_Selection

for selecting the crtc (minus the usage check, since we drive only one connector). This is also the same logic as in kmscube.