### PR TITLE
vscode: Fix error at startup

### DIFF
--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -54,7 +54,8 @@ function startClient(
                 });
             });
 
-            cl.start().then(() => (client.client = cl));
+            cl.start();
+            cl.onReady().then(() => (client.client = cl));
         }
     };
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -172,7 +172,8 @@ function startClient(
         });
     });
 
-    cl.start().then(() => (client.client = cl));
+    cl.start();
+    cl.onReady().then(() => (client.client = cl));
 }
 
 export function activate(context: vscode.ExtensionContext) {


### PR DESCRIPTION
`TypeError: cl.start(...).then is not a function`