### PR TITLE
ComboBox reset current value if current-index < 0

### DIFF
--- a/internal/compiler/widgets/cupertino-base/combobox.slint
+++ b/internal/compiler/widgets/cupertino-base/combobox.slint
@@ -13,7 +13,7 @@ export component ComboBox {
     in property <bool> enabled <=> i-focus-scope.enabled;
     out property <bool> has-focus <=> i-focus-scope.has-focus;
     in-out property <int> current-index: 0;
-    in-out property <string> current-value: root.model[root.current-index];
+    in-out property <string> current-value: root.get-current-value();
 
     min-width: max(160px, i-layout.min-width);
     min-height: max(22px, i-layout.min-height);
@@ -168,8 +168,11 @@ export component ComboBox {
 
     function select(index: int) {
         root.current-index = index;
-        root.current-value = root.model[root.current-index];
         root.selected(root.current-value);
+    }
+
+    function get-current-value() -> string {
+        root.current-index >= 0 && root.current-index <= root.model.length ? root.model[root.current-index] : ""
     }
 
     function move-selection-up() {

--- a/internal/compiler/widgets/fluent-base/combobox.slint
+++ b/internal/compiler/widgets/fluent-base/combobox.slint
@@ -11,7 +11,7 @@ export component ComboBox {
     in property <bool> enabled <=> i-focus-scope.enabled;
     out property <bool> has-focus <=> i-focus-scope.has-focus;
     in-out property <int> current-index: 0;
-    in-out property <string> current-value: root.model[root.current-index];
+    in-out property <string> current-value: root.get-current-value();
 
     min-width: max(160px, i-layout.min-height);
     min-height: max(32px, i-layout.min-height);
@@ -105,8 +105,11 @@ export component ComboBox {
 
     function select(index: int) {
         root.current-index = index;
-        root.current-value = root.model[root.current-index];
         root.selected(root.current-value);
+    }
+
+    function get-current-value() -> string {
+        root.current-index >= 0 && root.current-index <= root.model.length ? root.model[root.current-index] : ""
     }
 
     function move-selection-up() {

--- a/internal/compiler/widgets/material-base/combobox.slint
+++ b/internal/compiler/widgets/material-base/combobox.slint
@@ -12,7 +12,8 @@ export component ComboBox {
     in property <[string]> model;
     out property <bool> has-focus <=> i-focus-scope.has-focus;
     in-out property <int> current-index : 0;
-    in-out property <string> current-value: root.model[root.current-index];
+    in-out property <string> current-value: root.current-index >= 0 && root.current-index <= root.model.length  ?
+        root.model[root.current-index] : "";
 
     horizontal-stretch: 1;
     vertical-stretch: 0;
@@ -25,13 +26,14 @@ export component ComboBox {
     i-focus-scope := FocusScope {
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
-                root.current-index = Math.max(root.current-index - 1, 0);
-                root.current-value = root.model[root.current-index];
+                root.move-selection-up();
                 return accept;
             } else if (event.text == Key.DownArrow) {
-                root.current-index = Math.min(root.current-index + 1, root.model.length - 1);
-                root.current-value = root.model[root.current-index];
+
+                root.move-selection-down();
                 return accept;
+            } else if (event.text == Key.Return) {
+                i-popup.show();
             }
             return reject;
         }
@@ -92,19 +94,32 @@ export component ComboBox {
         }
 
         VerticalLayout {
-            for value[idx] in root.model: ListItem {
+            for value[index] in root.model: ListItem {
                 text: value;
-                selected: idx == root.current-index;
+                selected: index == root.current-index;
 
                 clicked => {
-                    if (root.enabled) {
-                        root.current-index = idx;
-                        root.current-value = value;
-                        root.selected(root.current-value);
-                    }
+                    root.select(index);
                 }
             }
         }
+    }
+
+    function select(index: int) {
+        root.current-index = index;
+        root.selected(root.current-value);
+    }
+
+    function move-selection-up() {
+        root.select(Math.max(root.current-index - 1, 0));
+    }
+
+    function move-selection-down() {
+        root.select(Math.min(root.current-index + 1, root.model.length - 1));
+    }
+
+    function get-current-value() -> string {
+        root.current-index >= 0 && root.current-index <= root.model.length ? root.model[root.current-index] : ""
     }
 
     states [

--- a/internal/compiler/widgets/qt/std-widgets.slint
+++ b/internal/compiler/widgets/qt/std-widgets.slint
@@ -234,7 +234,7 @@ export component StandardListView inherits StandardListViewBase {
 export component ComboBox inherits NativeComboBox {
     in property <[string]> model;
     in-out property <int> current-index : 0;
-    current-value: root.model[root.current-index];
+    current-value: root.get-current-value();
     out property has-focus <=> fs.has-focus;
     enabled: true;
     callback selected(string);
@@ -253,18 +253,14 @@ export component ComboBox inherits NativeComboBox {
         width: root.width;
         VerticalLayout {
             spacing: 0px;
-            for value[i] in root.model: NativeStandardListViewItem {
+            for value[index] in root.model: NativeStandardListViewItem {
                 item: { text: value };
-                is-selected: root.current-index == i;
+                is-selected: root.current-index == index;
                 has-hover: ta.has-hover;
                 combobox: true;
                 ta := TouchArea {
                     clicked => {
-                        if (root.enabled) {
-                            root.current-index = i;
-                            root.current-value = value;
-                            root.selected(root.current-value);
-                        }
+                        root.select(index);
                         //is-open = false;
                     }
                 }
@@ -275,12 +271,10 @@ export component ComboBox inherits NativeComboBox {
     fs := FocusScope {
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
-                root.current-index = Math.max(root.current-index - 1, 0);
-                root.current-value = root.model[root.current-index];
+                root.move-selection-up();
                 return accept;
             } else if (event.text == Key.DownArrow) {
-                root.current-index = Math.min(root.current-index + 1, root.model.length - 1);
-                root.current-value = root.model[root.current-index];
+                root.move-selection-down();
                 return accept;
             // PopupWindow can not get hidden again at this time, so do not allow to pop that up.
             // } else if (event.text == Key.Return) {
@@ -297,6 +291,23 @@ export component ComboBox inherits NativeComboBox {
                 popup.show();
             }
         }
+    }
+
+    function select(index: int) {
+        root.current-index = index;
+        root.selected(root.current-value);
+    }
+
+    function move-selection-up() {
+        root.select(Math.max(root.current-index - 1, 0));
+    }
+
+    function move-selection-down() {
+        root.select(Math.min(root.current-index + 1, root.model.length - 1));
+    }
+
+    function get-current-value() -> string {
+        root.current-index >= 0 && root.current-index <= root.model.length ? root.model[root.current-index] : ""
     }
 }
 


### PR DESCRIPTION
* This resets the `current-value` of `Combobox` if the `current-index` is `< 0` or `>= model.length`
* Fixes #3628
* At the moment `current-value` is `in-out`, that could cases trouble because from outside you can set any string and  also if it's not part of the list. I would suggest to change it to a `out` property in the future but it will be a breaking change.