### PR TITLE
test-driver-screenshots: don't generate rotated screenshots

### DIFF
--- a/tests/screenshots/testing.rs
+++ b/tests/screenshots/testing.rs
@@ -223,7 +223,9 @@ fn compare_images(
 
     let result = compare();
 
-    if result.is_err() && std::env::var("SLINT_CREATE_SCREENSHOTS").map_or(false, |var| var == "1")
+    if result.is_err()
+        && rotated == WindowRotation::NoRotation
+        && std::env::var("SLINT_CREATE_SCREENSHOTS").map_or(false, |var| var == "1")
     {
         eprintln!("saving rendered image as comparison to reference failed");
         image::save_buffer(


### PR DESCRIPTION
For example, with the rotation threshold removed from `linear-gradients.slint` 

```diff
diff --git a/tests/screenshots/cases/software/basic/linear-gradients.slint b/tests/screenshots/cases/software/basic/linear-gradients.slint
index 24c6d0467..eba1fa872 100644
--- a/tests/screenshots/cases/software/basic/linear-gradients.slint
+++ b/tests/screenshots/cases/software/basic/linear-gradients.slint
@@ -1,8 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-// ROTATION_THRESHOLD=150  - because gradiants are very impresise in rotation
-
 export component TestCase inherits Window {
     width:  64px;
     height: 64px;
```

```sh
$ SLINT_TEST_FILTER=linear-gradients SLINT_CREATE_SCREENSHOTS=1 cargo test -p test-driver-screenshots
```

The comparison fails when running 180° rotated as expected, but it also generates the reference image 180° rotated.

| Before | After |
|---|---|
| ![linear-gradients](https://github.com/slint-ui/slint/assets/140617/a83abc8b-89cb-49d6-9400-d31693499012) | ![linear-gradients](https://github.com/slint-ui/slint/assets/140617/6f7785e1-f7c3-4e35-8304-f0473d6a8144) |