### PR TITLE
Default backend selection depending on platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     'internal/backends/selector',
     'internal/backends/testing',
     'internal/backends/linuxkms',
+    'internal/backends/default',
     'internal/renderers/skia',
     'internal/renderers/femtovg',
     'internal/common',
@@ -105,6 +106,7 @@ rust-version = "1.70"
 version = "1.3.0"
 
 [workspace.dependencies]
+i-slint-backend-default = { version = "=1.3.0", path = "internal/backends/default", default-features = false }
 i-slint-backend-linuxkms = { version = "=1.3.0", path = "internal/backends/linuxkms", default-features = false }
 i-slint-backend-qt = { version = "=1.3.0", path="internal/backends/qt", default-features = false }
 i-slint-backend-selector = { version = "=1.3.0", path = "internal/backends/selector", default-features = false }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -25,7 +25,7 @@ default = [
   "backend-winit",
   "renderer-femtovg",
   "renderer-software",
-  "backend-qt",
+  "backend-default",
   "accessibility",
   "compat-1-2",
 ]
@@ -124,6 +124,10 @@ backend-winit-x11 = ["i-slint-backend-selector/backend-winit-x11", "std"]
 ## with support for the Wayland window system on Unix.
 backend-winit-wayland = ["i-slint-backend-selector/backend-winit-wayland", "std"]
 
+## Alias to a backend and renderer that depends on the platform.
+## Will select the Qt backend on linux, and the skia backend on everything but wasm.
+backend-default = ["dep:i-slint-backend-default"]
+
 # deprecated aliases
 renderer-winit-femtovg = ["renderer-femtovg"]
 renderer-winit-skia = ["renderer-skia"]
@@ -155,6 +159,7 @@ i-slint-core = { workspace = true }
 slint-macros = { workspace = true, features = ["default"] }
 i-slint-backend-selector = { workspace = true, features = ["default"] }
 i-slint-renderer-femtovg = { workspace = true, optional = true }
+i-slint-backend-default = { workspace = true, optional = true }
 
 const-field-offset = { version = "0.1.2", path = "../../../helper_crates/const-field-offset" }
 document-features = { version = "0.2.0", optional = true }

--- a/internal/backends/default/Cargo.toml
+++ b/internal/backends/default/Cargo.toml
@@ -1,0 +1,25 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+[package]
+name = "i-slint-backend-default"
+description = "Helper crate to pick the default rendering backend for Slint"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lib]
+path = "lib.rs"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+i-slint-backend-selector = { workspace = true, features = [ "i-slint-backend-qt" ] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+i-slint-backend-selector = { workspace = true, features = ["renderer-femtovg"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+i-slint-backend-selector = { workspace = true, features = ["renderer-skia"] }

--- a/internal/backends/default/README.md
+++ b/internal/backends/default/README.md
@@ -1,0 +1,10 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+
+This crate exist just as an indirection to pick a default backend or renderer depending on the platform
+
+**NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).
+This crate should **not be used directly** by applications using Slint.
+You should use the `slint` crate instead.
+
+**WARNING**: This crate does not follow the semver convention for versioning and can
+only be used with `version = "=x.y.z"` in Cargo.toml.

--- a/internal/backends/default/lib.rs
+++ b/internal/backends/default/lib.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+#![doc = include_str!("README.md")]
+#![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
+#![no_std]

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -20,7 +20,7 @@ path = "lib.rs"
 
 [features]
 
-default = ["std", "backend-winit", "renderer-femtovg", "backend-qt", "accessibility", "compat-1-2"]
+default = ["std", "backend-winit", "renderer-femtovg", "backend-default", "accessibility", "compat-1-2"]
 
 ## Mandatory feature:
 ## This feature is required to keep the compatibility with Slint 1.2
@@ -69,6 +69,10 @@ backend-winit-wayland = ["i-slint-backend-selector/backend-winit-wayland", "std"
 ## windowing system.
 backend-linuxkms = ["i-slint-backend-selector/backend-linuxkms", "std"]
 
+## Alias to a backend and renderer that depends on the platform.
+## Will select the Qt backend on linux, and the skia backend on everything but wasm.
+backend-default = ["dep:i-slint-backend-default"]
+
 ## Make the winit backend capable of rendering using the [femtovg](https://crates.io/crates/femtovg) crate.
 renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "std"]
 
@@ -103,6 +107,7 @@ i-slint-compiler = { workspace = true, features = ["default"] }
 i-slint-common = { workspace = true, features = ["default"] }
 i-slint-core = { workspace = true, features = ["default", "rtti"] }
 i-slint-backend-selector = { workspace = true, features = ["default", "rtti"] }
+i-slint-backend-default = { workspace = true, optional = true }
 
 vtable = { version = "0.1.6", path="../../helper_crates/vtable" }
 

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -38,6 +38,7 @@ backend-winit = ["slint-interpreter/backend-winit", "preview"]
 backend-winit-x11 = ["slint-interpreter/backend-winit-x11", "preview"]
 backend-winit-wayland = ["slint-interpreter/backend-winit-wayland", "preview"]
 backend-linuxkms = ["slint-interpreter/backend-linuxkms", "preview"]
+backend-default = ["slint-interpreter/backend-default", "preview"]
 
 renderer-femtovg = ["slint-interpreter/renderer-femtovg", "preview"]
 renderer-skia = ["slint-interpreter/renderer-skia", "preview"]
@@ -66,7 +67,7 @@ preview-lense = []
 ## Open a notification channel so that the LSP can communicate with the preview (when the preview is handled by the client)
 preview-api = []
 
-default = ["backend-qt", "backend-winit", "renderer-femtovg", "preview"]
+default = ["backend-default", "backend-winit", "renderer-femtovg", "preview"]
 
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default"] }
@@ -80,6 +81,7 @@ rowan = "0.15.5"
 i-slint-core = { workspace = true, features = ["default"], optional = true }
 slint-interpreter = { workspace = true, features = ["compat-1-2", "highlight"], optional = true  }
 i-slint-backend-selector = { workspace = true, features = ["default"], optional = true }
+i-slint-backend-default = { workspace = true, optional = true }
 # Enable image-rs' default features to make all image formats available for the preview
 image = { version = "0.24.0", optional = true }
 

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -20,6 +20,8 @@ backend-qt = ["slint-interpreter/backend-qt"]
 backend-winit = ["slint-interpreter/backend-winit"]
 backend-winit-x11 = ["slint-interpreter/backend-winit-x11"]
 backend-winit-wayland = ["slint-interpreter/backend-winit-wayland"]
+backend-linuxkms = ["slint-interpreter/backend-linuxkms"]
+backend-default = ["slint-interpreter/backend-default"]
 
 renderer-femtovg = ["slint-interpreter/renderer-femtovg"]
 renderer-skia = ["slint-interpreter/renderer-skia"]
@@ -39,9 +41,6 @@ renderer-winit-skia-opengl= ["renderer-skia-opengl"]
 renderer-winit-skia-vulkan= ["renderer-skia-vulkan"]
 renderer-winit-software = ["renderer-software"]
 
-
-backend-linuxkms = ["slint-interpreter/backend-linuxkms"]
-
 ## Enable the translations using [gettext](https://www.gnu.org/software/gettext/gettext)
 ##
 ## the `@tr(...)` code from .slint files will be transformed into call to `dgettext`.
@@ -49,7 +48,7 @@ backend-linuxkms = ["slint-interpreter/backend-linuxkms"]
 ## so that the viewer can find the translation
 gettext = ["i-slint-core/gettext-rs"]
 
-default = ["backend-qt", "backend-winit", "renderer-femtovg"]
+default = ["backend-default", "backend-winit", "renderer-femtovg"]
 
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default"] }


### PR DESCRIPTION
Don't have Qt by default on non-linux

Make skia the default on non-wasm  (but unfortunately still builds femtovg by default)

In order to have default feature dependent on the platform, one must use an intermediate crate