### PR TITLE
Allow specifying paths for `@library` imports

### DIFF
--- a/api/napi/Cargo.toml
+++ b/api/napi/Cargo.toml
@@ -26,6 +26,7 @@ i-slint-core = { workspace = true, features = ["default"] }
 slint-interpreter = { workspace = true, features = ["default", "display-diagnostics"] }
 spin_on = "0.1"
 css-color-parser2 = { workspace = true }
+itertools = { workspace = true }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/api/node/native/Cargo.toml
+++ b/api/node/native/Cargo.toml
@@ -28,6 +28,7 @@ vtable = { version = "0.1.6", path="../../../helper_crates/vtable" }
 
 css-color-parser2 = { workspace = true }
 generativity = "1"
+itertools = { workspace = true }
 neon = "0.8.0"
 once_cell = "1.5"
 rand = "0.8"

--- a/api/node/native/lib.rs
+++ b/api/node/native/lib.rs
@@ -6,6 +6,7 @@ use i_slint_compiler::langtype::Type;
 use i_slint_core::model::{Model, ModelRc};
 use i_slint_core::window::WindowInner;
 use i_slint_core::{ImageInner, SharedVector};
+use itertools::Itertools;
 use neon::prelude::*;
 use rand::RngCore;
 use slint_interpreter::ComponentHandle;
@@ -59,8 +60,22 @@ fn load(mut cx: FunctionContext) -> JsResult<JsValue> {
         }
         None => vec![],
     };
+    let library_paths = match std::env::var_os("SLINT_LIBRARY_PATH") {
+        Some(paths) => std::env::split_paths(&paths)
+            .filter_map(|entry| {
+                entry
+                    .to_str()
+                    .unwrap_or_default()
+                    .split('=')
+                    .collect_tuple()
+                    .map(|(k, v)| (k.into(), v.into()))
+            })
+            .collect(),
+        None => std::collections::HashMap::new(),
+    };
     let mut compiler = slint_interpreter::ComponentCompiler::default();
     compiler.set_include_paths(include_paths);
+    compiler.set_library_paths(library_paths);
     let c = spin_on::spin_on(compiler.build_from_path(path));
 
     slint_interpreter::print_diagnostics(compiler.diagnostics());

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -113,6 +113,15 @@
                         "type": "string"
                     },
                     "description": "List of paths in which the `import` statement and `@image-url` are looked up"
+                },
+                "slint.libraryPaths": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z][a-zA-Z0-9-_]*$": {
+                            "type": "string"
+                        }
+                    },
+                    "description": "Map of paths in which the `import` statement for `@library` imports are looked up"
                 }
             }
         },

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -12,6 +12,7 @@ extern crate proc_macro;
 use core::future::Future;
 use core::pin::Pin;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 pub mod builtin_macros;
@@ -56,6 +57,8 @@ pub struct CompilerConfiguration {
     pub embed_resources: EmbedResourcesKind,
     /// The compiler will look in these paths for components used in the file to compile.
     pub include_paths: Vec<std::path::PathBuf>,
+    /// The compiler will look in these paths for library imports.
+    pub library_paths: HashMap<String, std::path::PathBuf>,
     /// the name of the style. (eg: "native")
     pub style: Option<String>,
 
@@ -140,6 +143,7 @@ impl CompilerConfiguration {
         Self {
             embed_resources,
             include_paths: Default::default(),
+            library_paths: Default::default(),
             style: Default::default(),
             open_import_fallback: None,
             resource_url_mapper: None,

--- a/internal/compiler/tests/typeloader/dependency_test_main.slint
+++ b/internal/compiler/tests/typeloader/dependency_test_main.slint
@@ -3,8 +3,10 @@
 
 import { SubType } from "./dependency_local.slint";
 import { AnotherType } from "dependency_from_incpath.slint";
+import { LibraryType } from "@library";
 
 export Main := Rectangle {
     SubType {}
     AnotherType {}
+    LibraryType {}
 }

--- a/internal/compiler/tests/typeloader/library/dependency_from_library.slint
+++ b/internal/compiler/tests/typeloader/library/dependency_from_library.slint
@@ -1,0 +1,4 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component LibraryType inherits Rectangle {}

--- a/internal/compiler/tests/typeloader/library/lib.slint
+++ b/internal/compiler/tests/typeloader/library/lib.slint
@@ -1,0 +1,5 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+import { LibraryType } from "./dependency_from_library.slint";
+export { LibraryType }

--- a/internal/compiler/tests/typeloader/library/library_helper_type.slint
+++ b/internal/compiler/tests/typeloader/library/library_helper_type.slint
@@ -1,0 +1,4 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component LibraryHelperType inherits Rectangle {}

--- a/internal/compiler/tests/typeloader/some_rust_file.rs
+++ b/internal/compiler/tests/typeloader/some_rust_file.rs
@@ -4,9 +4,11 @@
 slint!(
     import { SubType } from "./tests/typeloader/dependency_local.slint";
     import { AnotherType } from "dependency_from_incpath.slint";
+    import { LibraryType } from "@library";
 
     export component Main {
         SubType {}
         AnotherType {}
+        LibraryType {}
     }
 );

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -531,6 +531,16 @@ impl ComponentCompiler {
         &self.config.include_paths
     }
 
+    /// Sets the library paths used for looking up `@library` imports to the specified map of library names to paths.
+    pub fn set_library_paths(&mut self, library_paths: HashMap<String, PathBuf>) {
+        self.config.library_paths = library_paths;
+    }
+
+    /// Returns the library paths the component compiler is currently configured with.
+    pub fn library_paths(&self) -> &HashMap<String, PathBuf> {
+        &self.config.library_paths
+    }
+
     /// Sets the style to be used for widgets.
     ///
     /// Use the "material" style as widget style when compiling:

--- a/tests/cases/imports/library.slint
+++ b/tests/cases/imports/library.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+//library_path(helper_components): ../../helper_components/
+//library_path(helper_buttons): ../../helper_components/test_button.slint
+import { TestButton } from "@helper_components/test_button.slint";
+import { ColorButton } from "@helper_buttons";
+
+export component TestCase {
+    TestButton {}
+    ColorButton {}
+}

--- a/tests/driver/cpp/cppdriver.rs
+++ b/tests/driver/cpp/cppdriver.rs
@@ -12,11 +12,15 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
     let include_paths = test_driver_lib::extract_include_paths(&source)
         .map(std::path::PathBuf::from)
         .collect::<Vec<_>>();
+    let library_paths = test_driver_lib::extract_library_paths(&source)
+        .map(|(k, v)| (k.to_string(), std::path::PathBuf::from(v)))
+        .collect::<std::collections::HashMap<_, _>>();
 
     let mut diag = BuildDiagnostics::default();
     let syntax_node = parser::parse(source.clone(), Some(&testcase.absolute_path), &mut diag);
     let mut compiler_config = CompilerConfiguration::new(generator::OutputFormat::Cpp);
     compiler_config.include_paths = include_paths;
+    compiler_config.library_paths = library_paths;
     let (root_component, diag) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
 

--- a/tests/driver/interpreter/interpreter.rs
+++ b/tests/driver/interpreter/interpreter.rs
@@ -3,7 +3,7 @@
 
 use itertools::Itertools;
 use slint_interpreter::{DiagnosticLevel, Value, ValueType};
-use std::error::Error;
+use std::{collections::HashMap, error::Error};
 
 pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> {
     i_slint_backend_testing::init();
@@ -12,8 +12,12 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
     let include_paths = test_driver_lib::extract_include_paths(&source)
         .map(std::path::PathBuf::from)
         .collect::<Vec<_>>();
+    let library_paths = test_driver_lib::extract_library_paths(&source)
+        .map(|(k, v)| (k.to_string(), std::path::PathBuf::from(v)))
+        .collect::<HashMap<_, _>>();
     let mut compiler = slint_interpreter::ComponentCompiler::default();
     compiler.set_include_paths(include_paths);
+    compiler.set_library_paths(library_paths);
     compiler.set_style(String::from("fluent")); // force to fluent style as Qt does not like multi-threaded test execution
 
     let component =

--- a/tests/driver/napi/nodejs.rs
+++ b/tests/driver/napi/nodejs.rs
@@ -44,6 +44,14 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
     )?;
     let source = std::fs::read_to_string(&testcase.absolute_path)?;
     let include_paths = test_driver_lib::extract_include_paths(&source);
+    let library_paths = test_driver_lib::extract_library_paths(&source)
+        .map(|(k, v)| {
+            let mut abs_path = testcase.absolute_path.clone();
+            abs_path.pop();
+            abs_path.push(v);
+            format!("{}={}", k, abs_path.to_string_lossy())
+        })
+        .collect::<Vec<_>>();
     for x in test_driver_lib::extract_test_functions(&source).filter(|x| x.language_id == "js") {
         write!(main_js, "{{\n    {}\n}}\n", x.source.replace("\n", "\n    "))?;
     }
@@ -52,6 +60,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
         .arg(dir.path().join("main.js"))
         .current_dir(dir.path())
         .env("SLINT_INCLUDE_PATH", std::env::join_paths(include_paths).unwrap())
+        .env("SLINT_LIBRARY_PATH", std::env::join_paths(library_paths).unwrap())
         .env("SLINT_SCALE_FACTOR", "1") // We don't have a testing backend, but we can try to force a SF1 as the tests expect.
         .env("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1")
         .stdout(std::process::Stdio::piped())

--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -28,3 +28,4 @@ i-slint-compiler = { workspace = true, features = ["default", "display-diagnosti
 clap = { version = "4.0", features = ["derive", "wrap_help"] }
 proc-macro2 = "1.0.11"
 spin_on = "0.1"
+itertools = { workspace = true }

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -4,6 +4,7 @@
 use clap::{Parser, ValueEnum};
 use i_slint_compiler::diagnostics::BuildDiagnostics;
 use i_slint_compiler::*;
+use itertools::Itertools;
 use std::io::Write;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -31,6 +32,12 @@ struct Cli {
     /// Include path for other .slint files
     #[arg(short = 'I', name = "include path", number_of_values = 1, action)]
     include_paths: Vec<std::path::PathBuf>,
+
+    /// The argument should be in the format `<library>=<path>` specifying the
+    /// name of the library and the path to the library directory or a .slint
+    /// entry-point file.
+    #[arg(short = 'L', name = "library path", number_of_values = 1, action)]
+    library_paths: Vec<String>,
 
     /// Path to .slint file ('-' for stdin)
     #[arg(name = "file", action)]
@@ -81,6 +88,11 @@ fn main() -> std::io::Result<()> {
     }
 
     compiler_config.include_paths = args.include_paths;
+    compiler_config.library_paths = args
+        .library_paths
+        .iter()
+        .filter_map(|entry| entry.split('=').collect_tuple().map(|(k, v)| (k.into(), v.into())))
+        .collect();
     if let Some(style) = args.style {
         compiler_config.style = Some(style);
     }

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -3,7 +3,10 @@
 
 //! Data structures common between LSP and previewer
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
@@ -15,7 +18,12 @@ pub trait PreviewApi {
     fn design_mode(&self) -> bool;
     fn set_contents(&self, path: &Path, contents: &str);
     fn load_preview(&self, component: PreviewComponent, behavior: PostLoadBehavior);
-    fn config_changed(&self, style: &str, include_paths: &[PathBuf]);
+    fn config_changed(
+        &self,
+        style: &str,
+        include_paths: &[PathBuf],
+        library_paths: &HashMap<String, PathBuf>,
+    );
     fn highlight(&self, path: Option<PathBuf>, offset: u32) -> Result<()>;
 }
 
@@ -31,6 +39,9 @@ pub struct PreviewComponent {
 
     /// The list of include paths
     pub include_paths: Vec<PathBuf>,
+
+    /// The map of library paths
+    pub library_paths: HashMap<String, PathBuf>,
 
     /// The style name for the preview
     pub style: String,

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -62,9 +62,14 @@ impl PreviewApi for Previewer {
         preview::load_preview(self.server_notifier.clone(), _component, _behavior);
     }
 
-    fn config_changed(&self, _style: &str, _include_paths: &[PathBuf]) {
+    fn config_changed(
+        &self,
+        _style: &str,
+        _include_paths: &[PathBuf],
+        _library_paths: &HashMap<String, PathBuf>,
+    ) {
         #[cfg(feature = "preview")]
-        preview::config_changed(_style, _include_paths);
+        preview::config_changed(_style, _include_paths, _library_paths);
     }
 
     fn highlight(&self, _path: Option<std::path::PathBuf>, _offset: u32) -> Result<()> {

--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -147,13 +147,21 @@ pub fn set_contents(path: &Path, content: String) {
     }
 }
 
-pub fn config_changed(style: &str, include_paths: &[PathBuf]) {
+pub fn config_changed(
+    style: &str,
+    include_paths: &[PathBuf],
+    library_paths: &HashMap<String, PathBuf>,
+) {
     if let Some(cache) = CONTENT_CACHE.get() {
         let mut cache = cache.lock().unwrap();
         let style = style.to_string();
-        if cache.current.style != style || cache.current.include_paths != include_paths {
+        if cache.current.style != style
+            || cache.current.include_paths != include_paths
+            || cache.current.library_paths != *library_paths
+        {
             cache.current.style = style;
             cache.current.include_paths = include_paths.to_vec();
+            cache.current.library_paths = library_paths.clone();
             let current = cache.current.clone();
             let sender = cache.sender.clone();
             drop(cache);
@@ -276,6 +284,7 @@ async fn reload_preview(
         builder.set_style(preview_component.style);
     }
     builder.set_include_paths(preview_component.include_paths);
+    builder.set_library_paths(preview_component.library_paths);
 
     builder.set_file_loader(|path| {
         let path = path.to_owned();

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -17,6 +17,7 @@ use js_sys::Function;
 pub use language::{Context, DocumentCache, RequestHandler};
 use serde::Serialize;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::future::Future;
 use std::io::ErrorKind;
 use std::path::PathBuf;
@@ -69,7 +70,12 @@ impl PreviewApi for Previewer {
         // do nothing!
     }
 
-    fn config_changed(&self, _style: &str, _include_paths: &[PathBuf]) {
+    fn config_changed(
+        &self,
+        _style: &str,
+        _include_paths: &[PathBuf],
+        _library_paths: &HashMap<String, PathBuf>,
+    ) {
         // do nothing!
     }
 

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -67,6 +67,7 @@ serde_json = "1"
 shlex = "1"
 spin_on = "0.1"
 env_logger = "0.10.0"
+itertools = { workspace = true }
 
 # Enable image-rs' default features to make all image formats available for preview
 image = { version = "0.24.0" }

--- a/tools/viewer/README.md
+++ b/tools/viewer/README.md
@@ -35,6 +35,7 @@ slint-viewer path/to/myfile.slint
    This option is incompatible with `--auto-reload`
  - `--load-data <file>`: Load the values of public properties from a json file.
  - `-I <path>`: Add an include path to look for imported .slint files or images.
+ - `-L <library:path>`: Add a library path to look for `@library` imports.
  - `--style <style>`: Set the style. Defaults to `native` if the Qt backend is compiled, otherwise `fluent`
  - `--backend <backend>`: Override the Slint rendering backend
  - `--on <callback> <handler>`: Set a callback handler, see [callback handler](#callback-handlers)

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
 use clap::Parser;
+use itertools::Itertools;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -21,6 +22,10 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 struct Cli {
     #[arg(short = 'I', name = "include path for other .slint files", number_of_values = 1, action)]
     include_paths: Vec<std::path::PathBuf>,
+
+    /// The first argument is the library name, and the second argument is the path to the library.
+    #[arg(short = 'L', name = "library path for @library imports", number_of_values = 1, action)]
+    library_paths: Vec<String>,
 
     /// The .slint file to load ('-' for stdin)
     #[arg(name = "path to .slint file", action)]
@@ -165,6 +170,12 @@ fn init_compiler(
         compiler.set_translation_domain(domain);
     }
     compiler.set_include_paths(args.include_paths.clone());
+    compiler.set_library_paths(
+        args.library_paths
+            .iter()
+            .filter_map(|entry| entry.split('=').collect_tuple().map(|(k, v)| (k.into(), v.into())))
+            .collect(),
+    );
     if let Some(style) = &args.style {
         compiler.set_style(style.clone());
     }


### PR DESCRIPTION
This PR is a revised version of #3523 that drops everything related to Cargo and NPM, and instead allows manually specifying library paths in the compiler config:

```rust
// build.rs
use std::{collections::HashMap, env, path::PathBuf};

fn main() {
    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
    let library_paths = HashMap::from([
        (
            "libfile.slint".to_string(),
            manifest_dir.join("third_party/libfoo/ui/lib.slint"),
        ),
        (
            "libdir".to_string(),
            manifest_dir.join("third_party/libbar/ui/"),
        ),
    ]);
    slint_build::compile_with_config(
        "ui/main.slint",
        slint_build::CompilerConfiguration::new().with_library_paths(library_paths),
    )
    .unwrap();
}
```

Import types from the libraries:
```js
import { Foo } from "@libfile.slint";
import { Bar } from "@libdir/components.slint";

export component MyApp inherits Window {
    Foo {}
    Bar {}
}
```