### PR TITLE
LSP: fix typo in "slint.includePaths" config

### DIFF
--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1200,7 +1200,7 @@ pub async fn load_configuration(ctx: &Context) -> Result<()> {
     let document_cache = &mut ctx.document_cache.borrow_mut();
     for v in r {
         if let Some(o) = v.as_object() {
-            if let Some(ip) = o.get("includePath").and_then(|v| v.as_array()) {
+            if let Some(ip) = o.get("includePaths").and_then(|v| v.as_array()) {
                 if !ip.is_empty() {
                     document_cache.documents.compiler_config.include_paths =
                         ip.iter().filter_map(|x| x.as_str()).map(PathBuf::from).collect();


### PR DESCRIPTION
In [package.json](https://github.com/slint-ui/slint/blob/7d7b73107504f267d4f8752c4d8ab7c354c8bae9/editors/vscode/package.json#L110-L116), the config item is spelled `includePaths` not `includePath`.

![Screenshot 2023-10-11 at 18 44 22](https://github.com/slint-ui/slint/assets/140617/74932936-1064-4a20-9569-5655779bee79)