### PR TITLE
Some attempts at reducing the generated code size

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -191,16 +191,21 @@ impl LayoutConstraints {
         constraints
     }
 
-    pub fn has_explicit_restrictions(&self) -> bool {
-        self.min_width.is_some()
-            || self.max_width.is_some()
-            || self.min_height.is_some()
-            || self.max_width.is_some()
-            || self.max_height.is_some()
-            || self.preferred_height.is_some()
-            || self.preferred_width.is_some()
-            || self.horizontal_stretch.is_some()
-            || self.vertical_stretch.is_some()
+    pub fn has_explicit_restrictions(&self, orientation: Orientation) -> bool {
+        match orientation {
+            Orientation::Horizontal => {
+                self.min_width.is_some()
+                    || self.max_width.is_some()
+                    || self.preferred_width.is_some()
+                    || self.horizontal_stretch.is_some()
+            }
+            Orientation::Vertical => {
+                self.min_height.is_some()
+                    || self.max_height.is_some()
+                    || self.preferred_height.is_some()
+                    || self.vertical_stretch.is_some()
+            }
+        }
     }
 
     // Iterate over the constraint with a reference to a property, and the corresponding member in the i_slint_core::layout::LayoutInfo struct

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -519,7 +519,17 @@ pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> 
                 }
             }
             ElementType::Builtin(base_type)
-                if matches!(base_type.name.as_str(), "Rectangle" | "Empty") =>
+                if matches!(
+                    base_type.name.as_str(),
+                    "Rectangle"
+                        | "Empty"
+                        | "TouchArea"
+                        | "FocusScope"
+                        | "Opacity"
+                        | "Layer"
+                        | "BoxShadow"
+                        | "Clip"
+                ) =>
             {
                 // hard-code the value for rectangle because many rectangle end up optimized away and we
                 // don't want to depend on the element.

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -819,7 +819,7 @@ pub fn get_layout_info(
         lower_expression(&crate::layout::implicit_layout_info_call(elem, orientation), ctx)
     };
 
-    if constraints.has_explicit_restrictions() {
+    if constraints.has_explicit_restrictions(orientation) {
         let store = llr_Expression::StoreLocalVariable {
             name: "layout_info".into(),
             value: layout_info.into(),

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1584,7 +1584,7 @@ extern "C" fn layout_info(component: ItemTreeRefPin, orientation: Orientation) -
     );
 
     let constraints = instance_ref.description.original.root_constraints.borrow();
-    if constraints.has_explicit_restrictions() {
+    if constraints.has_explicit_restrictions(orientation) {
         crate::eval_layout::fill_layout_info_constraints(
             &mut result,
             &constraints,


### PR DESCRIPTION
 Before:

    cargo run -p slint-compiler -- examples/printerdemo_mcu/ui/printerdemo.slint -f rust | rustfmt | wc
      40014   86643 2010535
    cargo run -p slint-compiler -- examples/gallery/gallery.slint -f rust | rustfmt | wc
      105715  229009 5434115


After:

    cargo run -p slint-compiler -- examples/printerdemo_mcu/ui/printerdemo.slint -f rust | rustfmt | wc
      38643   84506 1925846
    cargo run -p slint-compiler -- examples/gallery/gallery.slint -f rust | rustfmt | wc
     103210  224427 5291034


No measurable changes in compilation time.
