### PR TITLE
compiler: Implement resource URL remapping

### DIFF
--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -131,7 +131,9 @@ export async function showPreview(
 
 async function getDocumentSource(url: Uri): Promise<string> {
     // FIXME: is there a faster way to get the document
-    let x = vscode.workspace.textDocuments.find((d) => d.uri.toString() === url.toString());
+    let x = vscode.workspace.textDocuments.find(
+        (d) => d.uri.toString() === url.toString(),
+    );
     let source;
     if (x) {
         source = x.getText();
@@ -225,8 +227,8 @@ function getPreviewHtml(slint_wasm_preview_url: Uri): string {
 
     async function render(source, base_url, style) {
         let { component, error_string } =
-            style ? await slint.compile_from_string_with_style(source, base_url, style, async(url) => await load_file(url))
-                  : await slint.compile_from_string(source, base_url, async(url) => await load_file(url));
+            style ? await slint.compile_from_string_with_style(source, base_url, style, async(url) => Promise.resolve(undefined), async(url) => await load_file(url))
+                  : await slint.compile_from_string(source, base_url, async(url) => Promise.resolve(undefined), async(url) => await load_file(url));
         if (error_string != "") {
             var text = document.createTextNode(error_string);
             var p = document.createElement('pre');

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -66,6 +66,11 @@ pub struct CompilerConfiguration {
     pub open_import_fallback: Option<
         Rc<dyn Fn(String) -> Pin<Box<dyn Future<Output = Option<std::io::Result<String>>>>>>,
     >,
+    /// Callback to map URLs for resources
+    ///
+    /// The function takes the url and returns the mapped URL (or None if not mapped)
+    pub resource_url_mapper:
+        Option<Rc<dyn Fn(&str) -> Pin<Box<dyn Future<Output = Option<String>>>>>>,
 
     /// Run the pass that inlines all the elements.
     ///
@@ -136,7 +141,8 @@ impl CompilerConfiguration {
             embed_resources,
             include_paths: Default::default(),
             style: Default::default(),
-            open_import_fallback: Default::default(),
+            open_import_fallback: None,
+            resource_url_mapper: None,
             inline_all_elements,
             scale_factor,
             accessibility: true,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -228,8 +228,10 @@ pub async fn run_passes(
         root_component,
         compiler_config.embed_resources,
         compiler_config.scale_factor,
+        &compiler_config.resource_url_mapper,
         diag,
-    );
+    )
+    .await;
 
     match compiler_config.embed_resources {
         #[cfg(feature = "software-renderer")]

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -510,6 +510,17 @@ impl ComponentCompiler {
         Self::default()
     }
 
+    /// Allow access to the underlying `CompilerConfiguration`
+    ///
+    /// This is an internal function without and ABI or API stability guarantees.
+    #[doc(hidden)]
+    pub fn compiler_configuration(
+        &mut self,
+        _: i_slint_core::InternalToken,
+    ) -> &mut i_slint_compiler::CompilerConfiguration {
+        &mut self.config
+    }
+
     /// Sets the include paths used for looking up `.slint` imports to the specified vector of paths.
     pub fn set_include_paths(&mut self, include_paths: Vec<std::path::PathBuf>) {
         self.config.include_paths = include_paths;

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -217,7 +217,6 @@ pub fn create(
         let load_file = Function::from(load_file.clone());
         Box::pin(async move { Some(self::load_file(path, &load_file).await) })
     }));
-
     let document_cache = RefCell::new(DocumentCache::new(compiler_config));
     let send_request = Function::from(send_request.clone());
     let highlight_in_preview = Function::from(highlight_in_preview.clone());

--- a/tools/slintpad/src/preview.ts
+++ b/tools/slintpad/src/preview.ts
@@ -52,6 +52,7 @@ export Demo := Window {
                 source,
                 base_url,
                 style,
+                async (_url: string) => Promise.resolve(undefined),
                 async (url: string): Promise<string> => {
                     const file_source = loaded_documents.get(url);
                     if (file_source === undefined) {


### PR DESCRIPTION
This is used in slintpad to map relative image URLs to their real download locations.

This has the side-effect of removing the service worker.

Fixes: #2905