### PR TITLE
SW: stop breaking lines after reaching the max (elided) lines

### DIFF
--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1584,13 +1584,7 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
                             };
                         }
                     }
-                    if paragraph.overflow == TextOverflow::Elide
-                        && line_y + paragraph.layout.font.height() * 2 > paragraph.max_height
-                    {
-                        core::ops::ControlFlow::Break(())
-                    } else {
-                        core::ops::ControlFlow::Continue(())
-                    }
+                    core::ops::ControlFlow::Continue(())
                 },
                 selection.as_ref().map(|s| s.selection.clone()),
             )

--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -69,7 +69,7 @@ impl<'a, Font: AbstractFont> TextLayout<'a, Font> {
         let mut line_count: i16 = 0;
         let shape_buffer = ShapeBuffer::new(self, text);
 
-        for line in TextLineBreaker::<Font>::new(text, &shape_buffer, max_width) {
+        for line in TextLineBreaker::<Font>::new(text, &shape_buffer, max_width, None) {
             max_line_width = euclid::approxord::max(max_line_width, line.text_width);
             line_count += 1;
         }
@@ -130,6 +130,7 @@ impl<'a, Font: AbstractFont> TextParagraphLayout<'a, Font> {
                 self.string,
                 &shape_buffer,
                 if wrap { Some(self.max_width) } else { None },
+                if elide { Some(self.layout.font.max_lines(self.max_height)) } else { None },
             )
         };
         let mut text_lines = None;
@@ -139,18 +140,7 @@ impl<'a, Font: AbstractFont> TextParagraphLayout<'a, Font> {
                 self.layout.font.height()
             } else {
                 text_lines = Some(new_line_break_iter().collect::<Vec<_>>());
-                let text_height =
-                    self.layout.font.height() * (text_lines.as_ref().unwrap().len() as i16).into();
-                if elide && text_height > self.max_height {
-                    // The height of the text is used for vertical alignment below.
-                    // If the full text doesn't fit into max_height and eliding is
-                    // enabled, calculate the height of the max number of lines that
-                    // fit to ensure correct vertical alignment when elided.
-                    let max_lines = self.layout.font.max_lines(self.max_height) as i16;
-                    self.layout.font.height() * max_lines.into()
-                } else {
-                    text_height
-                }
+                self.layout.font.height() * (text_lines.as_ref().unwrap().len() as i16).into()
             }
         };
 

--- a/internal/core/textlayout/linebreaker.rs
+++ b/internal/core/textlayout/linebreaker.rs
@@ -69,6 +69,7 @@ pub struct TextLineBreaker<'a, Font: TextShaper> {
     current_line: TextLine<Font::Length>,
     num_emitted_lines: usize,
     mandatory_line_break_on_next_iteration: bool,
+    max_lines: Option<usize>,
 }
 
 impl<'a, Font: TextShaper> TextLineBreaker<'a, Font> {
@@ -76,6 +77,7 @@ impl<'a, Font: TextShaper> TextLineBreaker<'a, Font> {
         text: &'a str,
         shape_buffer: &'a ShapeBuffer<Font::Length>,
         available_width: Option<Font::Length>,
+        max_lines: Option<usize>,
     ) -> Self {
         Self {
             fragments: TextFragmentIterator::new(text, shape_buffer),
@@ -83,6 +85,7 @@ impl<'a, Font: TextShaper> TextLineBreaker<'a, Font> {
             current_line: Default::default(),
             num_emitted_lines: 0,
             mandatory_line_break_on_next_iteration: false,
+            max_lines,
         }
     }
 }
@@ -91,6 +94,12 @@ impl<'a, Font: TextShaper> Iterator for TextLineBreaker<'a, Font> {
     type Item = TextLine<Font::Length>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if let Some(max_lines) = self.max_lines {
+            if self.num_emitted_lines >= max_lines {
+                return None;
+            }
+        }
+
         if core::mem::take(&mut self.mandatory_line_break_on_next_iteration) {
             self.num_emitted_lines += 1;
             return Some(core::mem::take(&mut self.current_line));
@@ -172,8 +181,8 @@ fn test_empty_line_break() {
     let font = FixedTestFont;
     let text = "";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 1);
     assert_eq!(lines[0].line_text(text), "");
 }
@@ -183,11 +192,22 @@ fn test_basic_line_break() {
     let font = FixedTestFont;
     let text = "Hello World";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].line_text(text), "Hello");
     assert_eq!(lines[1].line_text(text), "World");
+}
+
+#[test]
+fn test_basic_line_break_max_lines() {
+    let font = FixedTestFont;
+    let text = "Hello World";
+    let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.), Some(1))
+        .collect::<Vec<_>>();
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].line_text(text), "Hello");
 }
 
 #[test]
@@ -195,8 +215,8 @@ fn test_linebreak_trailing_space() {
     let font = FixedTestFont;
     let text = "Hello              ";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 1);
     assert_eq!(lines[0].line_text(text), "Hello");
 }
@@ -207,7 +227,7 @@ fn test_forced_break() {
     let text = "Hello\nWorld";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
     let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None).collect::<Vec<_>>();
+        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None, None).collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].line_text(text), "Hello");
     assert_eq!(lines[1].line_text(text), "World");
@@ -219,7 +239,7 @@ fn test_forced_break_multi() {
     let text = "Hello\n\n\nWorld";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
     let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None).collect::<Vec<_>>();
+        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None, None).collect::<Vec<_>>();
     assert_eq!(lines.len(), 4);
     assert_eq!(lines[0].line_text(text), "Hello");
     assert_eq!(lines[1].line_text(text), "");
@@ -228,12 +248,24 @@ fn test_forced_break_multi() {
 }
 
 #[test]
+fn test_forced_break_max_lines() {
+    let font = FixedTestFont;
+    let text = "Hello\n\n\nWorld";
+    let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None, Some(2))
+        .collect::<Vec<_>>();
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "");
+}
+
+#[test]
 fn test_nbsp_break() {
     let font = FixedTestFont;
     let text = "Ok Hello\u{00a0}World";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(110.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(110.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].line_text(text), "Ok");
     assert_eq!(lines[1].line_text(text), "Hello\u{00a0}World");
@@ -245,7 +277,7 @@ fn test_single_line_multi_break_opportunity() {
     let text = "a b c";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
     let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None).collect::<Vec<_>>();
+        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None, None).collect::<Vec<_>>();
     assert_eq!(lines.len(), 1);
     assert_eq!(lines[0].line_text(text), "a b c");
 }
@@ -255,8 +287,8 @@ fn test_basic_line_break_anywhere_fallback() {
     let font = FixedTestFont;
     let text = "HelloWorld";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].line_text(text), "Hello");
     assert_eq!(lines[1].line_text(text), "World");
@@ -267,8 +299,8 @@ fn test_basic_line_break_anywhere_fallback_multi_line() {
     let font = FixedTestFont;
     let text = "HelloWorld\nHelloWorld";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 4);
     assert_eq!(lines[0].line_text(text), "Hello");
     assert_eq!(lines[1].line_text(text), "World");
@@ -281,8 +313,8 @@ fn test_basic_line_break_anywhere_fallback_multi_line_v2() {
     let font = FixedTestFont;
     let text = "HelloW orldHellow";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 4);
     assert_eq!(lines[0].line_text(text), "Hello");
     assert_eq!(lines[1].line_text(text), "W");
@@ -291,13 +323,26 @@ fn test_basic_line_break_anywhere_fallback_multi_line_v2() {
 }
 
 #[test]
+fn test_basic_line_break_anywhere_fallback_max_lines() {
+    let font = FixedTestFont;
+    let text = "HelloW orldHellow";
+    let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(50.), Some(3))
+        .collect::<Vec<_>>();
+    assert_eq!(lines.len(), 3);
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "W");
+    assert_eq!(lines[2].line_text(text), "orldH");
+}
+
+#[test]
 fn test_basic_line_break_space() {
     // The available width is half-way into the trailing "W"
     let font = FixedTestFont;
     let text = "H W";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(25.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(25.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].line_text(text), "H");
     assert_eq!(lines[1].line_text(text), "W");
@@ -309,8 +354,8 @@ fn test_basic_line_break_space_v2() {
     let font = FixedTestFont;
     let text = "B B W";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(45.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(45.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].line_text(text), "B B");
     assert_eq!(lines[1].line_text(text), "W");
@@ -322,8 +367,8 @@ fn test_basic_line_break_space_v3() {
     let font = FixedTestFont;
     let text = "H   W";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(15.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(15.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].line_text(text), "H");
     assert_eq!(lines[1].line_text(text), "W");
@@ -335,8 +380,8 @@ fn test_basic_line_break_space_v4() {
     let font = FixedTestFont;
     let text = "H W  H  ";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(65.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(65.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 1);
     assert_eq!(lines[0].line_text(text), "H W  H");
 }
@@ -346,8 +391,8 @@ fn test_line_width_with_whitespace() {
     let font = FixedTestFont;
     let text = "Hello World";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines =
-        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(200.)).collect::<Vec<_>>();
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(200.), None)
+        .collect::<Vec<_>>();
     assert_eq!(lines.len(), 1);
     assert_eq!(lines[0].text_width, text.len() as f32 * 10.);
 }
@@ -357,7 +402,7 @@ fn zero_width() {
     let font = FixedTestFont;
     let text = "He\nHe o";
     let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
-    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(0.0001))
+    let lines = TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, Some(0.0001), None)
         .map(|t| t.line_text(text))
         .collect::<Vec<_>>();
     assert_eq!(lines, ["H", "e", "", "H", "e", "o"]);


### PR DESCRIPTION
#3615 made sure to stop rendering after reaching the last elided line. We can do better and stop breaking lines at all when reaching the max, to avoid unnecessary work and to simplify the subsequent layout and rendering process.