### PR TITLE
vscode: Use ESM modules

### DIFF
--- a/editors/vscode/esbuild.js
+++ b/editors/vscode/esbuild.js
@@ -50,7 +50,7 @@ esbuild
         entryPoints: ["src/browser-lsp-worker.ts"],
         bundle: true,
         outfile: "out/browserServerMain.js",
-        format: "iife",
+        format: "esm",
         platform: "browser",
         plugins: [wasmPlugin],
     })
@@ -79,6 +79,6 @@ esbuild
         bundle: true,
         outfile: "out/propertiesView.js",
         platform: "browser",
-        format: "iife",
+        format: "esm",
     })
     .catch(() => process.exit(1));

--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -47,7 +47,7 @@ function startClient(
         "out/browserServerMain.js",
     );
 
-    const worker = new Worker(serverMain.toString(true));
+    const worker = new Worker(serverMain.toString(true), { type: "module" });
     worker.onmessage = (m) => {
         // We cannot start sending messages to the client before we start listening which
         // the server only does in a future after the wasm is loaded.

--- a/editors/vscode/src/properties_webview.ts
+++ b/editors/vscode/src/properties_webview.ts
@@ -293,7 +293,7 @@ export class PropertiesViewProvider implements vscode.WebviewViewProvider {
 				<link href="${codiconsUri}" rel="stylesheet" />
 			</head>
 			<body class="properties-editor">
-                <script src="${scriptUri}"></script>
+                <script src="${scriptUri}" type="module"></script>
 			</body>
 			</html>`;
     }


### PR DESCRIPTION
A vscode extension must use CJS, but that code may use ESM modules in turn.

So update to ESM, fixing a warning when importing our WASM code.