### PR TITLE
VSCode: Fix refactoring code

### DIFF
--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -59,6 +59,8 @@ function startClient(
                 worker,
             );
 
+            common.prepare_client(cl);
+
             client.add_updater((cl) => {
                 cl?.onRequest("slint/load_file", async (param: string) => {
                     let contents = await vscode.workspace.fs.readFile(

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -130,6 +130,13 @@ export function languageClientOptions(
     };
 }
 
+// Setup code to be run *before* the client is started.
+// Use the ClientHandle for code that runs after the client is started.
+
+export function prepare_client(client: BaseLanguageClient) {
+    client.registerFeature(new snippets.SnippetTextEditFeature());
+}
+
 // VSCode Plugin lifecycle related:
 
 export function activate(
@@ -149,7 +156,6 @@ export function activate(
 
     client.add_updater((cl) => {
         if (cl !== null) {
-            cl.registerFeature(new snippets.SnippetTextEditFeature());
             cl.onNotification(serverStatus, (params: ServerStatusParams) =>
                 setServerStatus(params, statusBar),
             );

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -197,6 +197,8 @@ function startClient(
         clientOptions,
     );
 
+    common.prepare_client(cl);
+
     cl.start().then(() => (client.client = cl));
 }
 


### PR DESCRIPTION
The refatoring code (wrap in eleemnt/remove element) needs some setup to happen before the client is started. Add a little helper function and call it.