### PR TITLE
Fix has-hover in Flickable with scroll wheel 

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -671,7 +671,7 @@ pub fn process_mouse_input(
     };
 
     let mut result = MouseInputState::default();
-    let root = ItemRc::new(component, 0);
+    let root = ItemRc::new(component.clone(), 0);
     let r = send_mouse_event_to_item(mouse_event, root, window_adapter, &mut result, false);
     if mouse_input_state.delayed.is_some()
         && (!r.has_aborted()
@@ -682,6 +682,18 @@ pub fn process_mouse_input(
         return mouse_input_state;
     }
     send_exit_events(&mouse_input_state, &mut result, mouse_event.position(), window_adapter);
+
+    if let MouseEvent::Wheel { position, .. } = mouse_event {
+        if r.has_aborted() {
+            // An accepted wheel event might have moved things. Send a move event at the position to reset the has-hover
+            return process_mouse_input(
+                component,
+                MouseEvent::Moved { position },
+                window_adapter,
+                result,
+            );
+        }
+    }
 
     result
 }

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -112,8 +112,6 @@ pub enum InputEventFilterResult {
     /// The event will not be forwarded to children, if a children already had the grab, the
     /// grab will be cancelled with a [`MouseEvent::Exit`] event
     Intercept,
-    /// Similar to `Intercept` but the contained [`MouseEvent`] will be forwarded to children
-    InterceptAndDispatch(MouseEvent),
     /// The event will be forwarding to the children with a delay (in milliseconds), unless it is
     /// being intercepted.
     /// This is what happens when the flickable wants to delay the event.
@@ -752,10 +750,6 @@ fn send_mouse_event_to_item(
         InputEventFilterResult::ForwardAndIgnore => (true, true),
         InputEventFilterResult::ForwardAndInterceptGrab => (true, false),
         InputEventFilterResult::Intercept => (false, false),
-        InputEventFilterResult::InterceptAndDispatch(new_event) => {
-            event_for_children = new_event;
-            (true, false)
-        }
         InputEventFilterResult::DelayForwarding(_) if ignore_delays => (true, false),
         InputEventFilterResult::DelayForwarding(duration) => {
             let timer = Timer::default();
@@ -796,12 +790,6 @@ fn send_mouse_event_to_item(
             actual_visitor,
         );
         if r.has_aborted() {
-            // the event was intercepted by a children
-            if matches!(filter_result, InputEventFilterResult::InterceptAndDispatch(_)) {
-                let mut event = mouse_event;
-                event.translate(-geom.origin.to_vector());
-                item.as_ref().input_event(event, window_adapter, &item_rc);
-            }
             return r;
         }
     };

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -548,7 +548,13 @@ impl Item for TouchArea {
                     InputEventResult::GrabMouse
                 } else {
                     match r {
-                        EventResult::Reject => InputEventResult::EventIgnored,
+                        EventResult::Reject => {
+                            // We are ignoring the event, so we will be removed from the item_stack,
+                            // therefore we must remove the has_hover flag as there might be a scroll under us.
+                            // It will be put back later.
+                            Self::FIELD_OFFSETS.has_hover.apply_pin(self).set(false);
+                            InputEventResult::EventIgnored
+                        }
                         EventResult::Accept => InputEventResult::EventAccepted,
                     }
                 };

--- a/tests/cases/elements/flickable3.slint
+++ b/tests/cases/elements/flickable3.slint
@@ -13,6 +13,13 @@ TestCase := Window {
 
     t1 := TouchArea {
       height: 50phx;
+      y: 0px;
+      Rectangle { background: parent.has-hover ? red: blue; }
+    }
+    t1sec := TouchArea {
+      height: 10phx;
+      y: 50px;
+      Rectangle { background: parent.has-hover ? red: blue; }
     }
   }
 
@@ -23,13 +30,15 @@ TestCase := Window {
 
     t2 := TouchArea {
       width: 50phx;
+      Rectangle { background: parent.has-hover ? green: yellow; }
     }
   }
 
-  property<bool> t1-has-hover: t1.has-hover;
-  property<bool> t2-has-hover: t2.has-hover;
+  out property<bool> t1-has-hover: t1.has-hover;
+  out property<bool> t1sec-has-hover: t1sec.has-hover;
+  out property<bool> t2-has-hover: t2.has-hover;
 
-  property f1_pos <=> f1.viewport_y;
+  in-out property f1_pos <=> f1.viewport_y;
 }
 
 /*
@@ -39,30 +48,47 @@ use slint::{platform::WindowEvent, LogicalPosition, platform::PointerEventButton
 let instance = TestCase::new().unwrap();
 // Vertical
 assert_eq!(instance.get_t1_has_hover(), false);
+assert_eq!(instance.get_t1sec_has_hover(), false);
+assert_eq!(instance.get_t2_has_hover(), false);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(25.0, 25.0) });
 assert_eq!(instance.get_t1_has_hover(), true);
+assert_eq!(instance.get_t1sec_has_hover(), false);
+assert_eq!(instance.get_t2_has_hover(), false);
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(25.0, 25.0), delta_x: 0.0, delta_y: -30.0 });
 assert_eq!(instance.get_t1_has_hover(), false);
+assert_eq!(instance.get_t1sec_has_hover(), true);
+assert_eq!(instance.get_t2_has_hover(), false);
 assert_eq!(instance.get_f1_pos(), -30.0);
+
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(25.0, 25.0), delta_x: 0.0, delta_y: -30.0 });
+assert_eq!(instance.get_t1_has_hover(), false);
+assert_eq!(instance.get_t1sec_has_hover(), false);
+assert_eq!(instance.get_t2_has_hover(), false);
+assert_eq!(instance.get_f1_pos(), -60.0);
+
+
 // Horizontal
 assert_eq!(instance.get_t2_has_hover(), false);
+assert_eq!(instance.get_t1_has_hover(), false);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(275.0, 25.0) });
 assert_eq!(instance.get_t2_has_hover(), true);
+assert_eq!(instance.get_t1_has_hover(), false);
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(275.0, 25.0), delta_x: -30.0, delta_y: 0.0 });
 assert_eq!(instance.get_t2_has_hover(), false);
+assert_eq!(instance.get_t1_has_hover(), false);
 
 
 
 
 // Test that it's not flicking when the mouse is released
-assert_eq!(instance.get_f1_pos(), -30.0);
+assert_eq!(instance.get_f1_pos(), -60.0);
 instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(25.0, 125.0), button: PointerEventButton::Left });
 slint_testing::mock_elapsed_time(100);
 instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(25.0, 125.0), button: PointerEventButton::Left });
 slint_testing::mock_elapsed_time(100);
-assert_eq!(instance.get_f1_pos(), -30.0);
+assert_eq!(instance.get_f1_pos(), -60.0);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(30.0, 25.0) });
-assert_eq!(instance.get_f1_pos(), -30.0);
+assert_eq!(instance.get_f1_pos(), -60.0);
 ```
 
 


### PR DESCRIPTION
The code that was making sure has-hover is kept in sync was no longer working
because of the introduction of the scroll-event.
Sadly, the flickable3.slint test didn't catch that because of another
bug.

Fixes https://github.com/slint-ui/slint/issues/3666