### PR TITLE
component_container: Add background rectangle

### DIFF
--- a/internal/compiler/passes/lower_component_container.rs
+++ b/internal/compiler/passes/lower_component_container.rs
@@ -34,7 +34,7 @@ fn diagnose_component_container(element: &ElementRc, diag: &mut BuildDiagnostics
 fn process_component_container(element: &ElementRc, empty_type: &ElementType) {
     let mut elem = element.borrow_mut();
 
-    let new = Rc::new(RefCell::new(Element {
+    let embedded_element = Rc::new(RefCell::new(Element {
         base_type: empty_type.clone(),
         id: elem.id.clone(),
         node: elem.node.clone(),
@@ -45,5 +45,6 @@ fn process_component_container(element: &ElementRc, empty_type: &ElementType) {
         is_component_placeholder: true,
         ..Default::default()
     }));
-    elem.children.push(new);
+
+    elem.children.push(embedded_element);
 }


### PR DESCRIPTION
Render the background rectangle of an embedded component.

This is needed for the `lsp_preview_ui` branch, but has no dependencies on that branch and is behind a feature gate anyway. So let's get it into master, the lsp_preview_ui branch is getting unwieldy :-)