### PR TITLE
Winit: allow theme selection at runtime via SLINT_THEME env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented in this file.
  - Changed default style to be `fluent` on Windows, and `cupertino` on macOS.
  - LinuxKMS backend: Add support for absolute motion pointer events, fixed support for touch input on
    scaled screens, and improved encoder/CRTC handling for EGL rendering.
+ - Winit backend: Allow theme selection at runtime via the `SLINT_THEME` environment variable.
 
 ### Slint Language
 

--- a/docs/reference/src/advanced/backend_winit.md
+++ b/docs/reference/src/advanced/backend_winit.md
@@ -21,6 +21,9 @@ The Winit backend supports different renderers. They can be explicitly selected 
 
 The Winit backend reads and interprets the following environment variables:
 
-| Name               | Accepted Values | Description                                                        |
-|--------------------|-----------------|--------------------------------------------------------------------|
-| `SLINT_FULLSCREEN` | any value       | If this variable is set, every window is shown in fullscreen mode. |
+| Name               | Accepted Values | Description                                                           |
+|--------------------|-----------------|-----------------------------------------------------------------------|
+| `SLINT_FULLSCREEN` | any value       | If this variable is set, every window is shown in fullscreen mode.    |
+| `SLINT_THEME`      | `light`, `dark` | If this variable is set, every window is shown in light or dark mode. |
+
+Note: the `SLINT_THEME` environment variable can be used to override the system theme for the following [styles](style.md#selecting-a-widget-style) that follow the system theme: `cupertino`, `fluent`, and `material`.


### PR DESCRIPTION
The `-light` and `-dark` style variants are great for selecting a specific theme at build time, but then it won't be possible to run the app in either mode. The adaptive style variants, on the other hand, follow the system theme leaving no control to apps or users.

The purpose of the `SLINT_THEME` environment variable is to fill that gap and let apps and users choose between light and dark themes without rebuilding the app or changing the system theme. On Linux, specifying the system theme would require the XDG desktop portal which often doesn't exist on Embedded Linux platforms not running full-blown desktop environments.

```sh
$ SLINT_STYLE=fluent cargo build -p gallery
```

| `SLINT_THEME=light ./target/debug/gallery` | `SLINT_THEME=dark ./target/debug/gallery` |
|---|---|
| <img width="812" alt="Screenshot 2023-10-18 at 14 42 01" src="https://github.com/slint-ui/slint/assets/140617/775b48de-4760-4afd-b545-341505081037"> | <img width="812" alt="Screenshot 2023-10-18 at 14 42 35" src="https://github.com/slint-ui/slint/assets/140617/b6d5bd09-626c-49fc-877e-0a370157275f"> |