### PR TITLE
Add source_model() in adapter models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project are documented in this file.
 
 ### Rust API
 
+- Added `source_model()` to `MapModel`, `FilterModel`, `SortModel`, `ReverseModel` to access inner model.
+
 ### C++
 
  - Removed the need for C++ exceptions in generated code.

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -439,6 +439,10 @@ where
     fn model_tracker(&self) -> &dyn ModelTracker {
         &self.0.notify
     }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
 }
 
 #[test]
@@ -524,7 +528,7 @@ where
 struct SortModelInner<M, S>
 where
     M: Model + 'static,
-    S: SortHelper<M::Data>,
+    S: SortHelper<M::Data> + 'static,
 {
     wrapped_model: M,
     sort_helper: RefCell<S>,
@@ -562,7 +566,7 @@ where
 impl<M, S> ModelChangeListener for SortModelInner<M, S>
 where
     M: Model + 'static,
-    S: SortHelper<M::Data>,
+    S: SortHelper<M::Data> + 'static,
 {
     fn row_changed(&self, row: usize) {
         if self.sorted_rows_dirty.get() {
@@ -766,7 +770,7 @@ where
 pub struct SortModel<M, F>(Pin<Box<ModelChangeListenerContainer<SortModelInner<M, F>>>>)
 where
     M: Model + 'static,
-    F: SortHelper<M::Data>;
+    F: SortHelper<M::Data> + 'static;
 
 impl<M, F> SortModel<M, F>
 where
@@ -867,6 +871,10 @@ where
 
     fn model_tracker(&self) -> &dyn ModelTracker {
         &self.0.notify
+    }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
     }
 }
 
@@ -1144,6 +1152,10 @@ where
 
     fn model_tracker(&self) -> &dyn ModelTracker {
         &self.0.notify
+    }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
     }
 }
 


### PR DESCRIPTION
As a mean of getting the inner model, useful to be able to push into the underlying model. (This already exists in the CPP API.)

Also implement `as_any()` on adapters model otherwise the `source_model()` is a bit useless.