### PR TITLE
napi: Catch typescript errors in the CI and in debug builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,6 +178,9 @@ jobs:
     - name: Run npm install
       working-directory: ./api/napi
       run: npm install
+    - name: Typescript check
+      working-directory: ./api/napi
+      run: npm syntax_check
     - name: Run napi tests
       working-directory: ./api/napi
       run: npm test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,7 @@ jobs:
       run: npm install
     - name: Typescript check
       working-directory: ./api/napi
-      run: npm syntax_check
+      run: npm run syntax_check
     - name: Run napi tests
       working-directory: ./api/napi
       run: npm test

--- a/api/napi/package.json
+++ b/api/napi/package.json
@@ -24,11 +24,12 @@
     "artifacts": "napi artifacts",
     "compile": "esbuild index.ts --bundle --external:*.node --format=cjs --platform=node --outfile=index.js",
     "build": "napi build --platform --release --js rust-module.js --dts rust-module.d.ts && npm run compile",
-    "build:debug": "napi build --platform --js rust-module.js --dts rust-module.d.ts && npm run compile",
+    "build:debug": "napi build --platform --js rust-module.js --dts rust-module.d.ts && npm run compile && npm run syntax_check",
     "install": "npm run build",
     "docs": "npm run build && typedoc --hideGenerator --treatWarningsAsErrors --readme cover.md index.ts",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "ava",
+    "syntax_check": "tsc -noEmit index.ts",
     "universal": "napi universal",
     "version": "1.3.0"
   },


### PR DESCRIPTION
We use esbuild to transform index.ts into index.js, but we also need to perform a type check. esbuild doesn't do that, this is left to the typescript compiler. So let's run it with -noEmit as recommended by the esbuild folks, in debug builds as well as in the CI (which doesn't do debug builds).