### PR TITLE
Fix panic with very large ListView

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -1208,8 +1208,11 @@ public:
         return { &C::static_vtable, const_cast<C *>(&(**x.ptr)) };
     }
 
-    vtable::VWeak<private_api::ItemTreeVTable> instance_at(int i) const
+    vtable::VWeak<private_api::ItemTreeVTable> instance_at(std::size_t i) const
     {
+        if (i >= inner->data.size()) {
+            return {};
+        }
         const auto &x = inner->data.at(i);
         return vtable::VWeak<private_api::ItemTreeVTable> { x.ptr->into_dyn() };
     }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -730,7 +730,9 @@ fn generate_sub_component(
         repeated_subtree_components.push(quote!(
             #idx => {
                 #ensure_updated
-                *result = vtable::VRc::downgrade(&vtable::VRc::into_dyn(_self.#repeater_id.instance_at(subtree_index).unwrap()))
+                if let Some(instance) = _self.#repeater_id.instance_at(subtree_index) {
+                    *result = vtable::VRc::downgrade(&vtable::VRc::into_dyn(instance));
+                }
             }
         ));
         repeated_element_names.push(repeater_id);
@@ -771,7 +773,9 @@ fn generate_sub_component(
         repeated_subtree_components.push(quote!(
             #repeater_index => {
                 #ensure_updated
-                *result = #embed_item.subtree_component()
+                if subtree_index == 0 {
+                    *result = #embed_item.subtree_component()
+                }
             }
         ));
     }

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -130,8 +130,10 @@ impl ComponentContainer {
     }
 
     pub fn subtree_component(self: Pin<&Self>) -> ItemTreeWeak {
-        let rc = self.item_tree.borrow().clone();
-        vtable::VRc::downgrade(rc.as_ref().unwrap())
+        self.item_tree
+            .borrow()
+            .as_ref()
+            .map_or(ItemTreeWeak::default(), |rc| vtable::VRc::downgrade(rc))
     }
 
     pub fn visit_children_item(

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1652,16 +1652,18 @@ extern "C" fn get_subtree(
         >(container)
         .unwrap();
         container.ensure_updated();
-        *result = container.subtree_component();
+        if subtree_index == 0 {
+            *result = container.subtree_component();
+        }
     } else {
         let rep_in_comp =
             unsafe { instance_ref.description.repeater[index as usize].get_untagged() };
         ensure_repeater_updated(instance_ref, rep_in_comp);
 
         let repeater = rep_in_comp.offset.apply(&instance_ref.instance);
-        *result = vtable::VRc::downgrade(&vtable::VRc::into_dyn(
-            repeater.instance_at(subtree_index).unwrap(),
-        ))
+        if let Some(instance_at) = repeater.instance_at(subtree_index) {
+            *result = vtable::VRc::downgrade(&vtable::VRc::into_dyn(instance_at))
+        }
     }
 }
 


### PR DESCRIPTION
In `ItemRc::find_sibling` we currently do:
 1. get the range
 2. check that the next index is within the range
 3. call `get_subtree`

The problem is that get_subtree itselg will call 'ensure_updated' which will do the relayout of the ListView and may get a different range of element.

So don't query the range before and just have get_subtree to return an empty ItemWeak if we are out of the actual range.

Couldn't really find a way to make a test since this is called from the accessibility code which is hard to test as is

For #3700