### PR TITLE
Add support for Skia software rendering with the winit backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented in this file.
  - Changed default style to be `fluent` on Windows, and `cupertino` on macOS.
  - LinuxKMS backend: Add support for absolute motion pointer events, fixed support for touch input on
    scaled screens, and improved encoder/CRTC handling for EGL rendering.
+ - Skia renderer / winit backend: Fall back to Skia software rendering when GPU acceleration is not available.
 
 ### Slint Language
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ toml_edit = "0.20"
 css-color-parser2 = { version = "1.0.1" }
 itertools = "0.11"
 softbuffer = { version = "0.3.1" }
+bytemuck = { version = "1.13.1" }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ cbindgen = { version = "0.26", default-features = false }
 toml_edit = "0.20"
 css-color-parser2 = { version = "1.0.1" }
 itertools = "0.11"
+softbuffer = { version = "0.3.1" }
 
 [profile.release]
 lto = true

--- a/docs/reference/src/advanced/backend_winit.md
+++ b/docs/reference/src/advanced/backend_winit.md
@@ -10,11 +10,12 @@ macOS, Windows, Linux with Wayland and X11.
 The Winit backend supports different renderers. They can be explicitly selected for use through the
 `SLINT_BACKEND` environment variable.
 
-| Renderer name | Supported/Required Graphics APIs    | `SLINT_BACKEND` value to select renderer |
-|---------------|-------------------------------------|------------------------------------------|
-| FemtoVG       | OpenGL                              | `winit-femtovg`                          |
-| Skia          | OpenGL, Metal, Direct3D             | `winit-skia`                             |
-| software      | Software-rendering, no GPU required | `winit-software`                         |
+| Renderer name | Supported/Required Graphics APIs            | `SLINT_BACKEND` value to select renderer |
+|---------------|---------------------------------------------|------------------------------------------|
+| FemtoVG       | OpenGL                                      | `winit-femtovg`                          |
+| Skia          | OpenGL, Metal, Direct3D, Software-rendering | `winit-skia`                             |
+| Skia Software | Software-only rendering with Skia           | `winit-skia-software`                    |
+| software      | Software-rendering, no GPU required         | `winit-software`                         |
 
 
 ## Configuration Options

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -28,7 +28,9 @@ impl SkiaRendererAdapter {
         )?;
 
         let renderer = Box::new(Self {
-            renderer: i_slint_renderer_skia::SkiaRenderer::new_with_surface(skia_vk_surface),
+            renderer: i_slint_renderer_skia::SkiaRenderer::new_with_surface(Box::new(
+                skia_vk_surface,
+            )),
             presenter: None,
             size: display.size,
         });
@@ -55,7 +57,9 @@ impl SkiaRendererAdapter {
         let size = display.size;
 
         let renderer = Box::new(Self {
-            renderer: i_slint_renderer_skia::SkiaRenderer::new_with_surface(skia_gl_surface),
+            renderer: i_slint_renderer_skia::SkiaRenderer::new_with_surface(Box::new(
+                skia_gl_surface,
+            )),
             presenter: Some(Box::new(display)),
             size,
         });

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -57,7 +57,7 @@ i-slint-renderer-femtovg = { workspace = true, features = ["default"], optional 
 i-slint-renderer-skia = {  workspace = true, features = ["default"], optional = true }
 
 # For the software renderer
-softbuffer = { version = "0.3.1", optional = true }
+softbuffer = { workspace = true, optional = true }
 imgref = { version = "1.6.1", optional = true }
 rgb = { version = "0.8.27", optional = true }
 bytemuck = { version = "1.13.1", optional = true, features = ["derive"] }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -60,7 +60,7 @@ i-slint-renderer-skia = {  workspace = true, features = ["default"], optional = 
 softbuffer = { workspace = true, optional = true }
 imgref = { version = "1.6.1", optional = true }
 rgb = { version = "0.8.27", optional = true }
-bytemuck = { version = "1.13.1", optional = true, features = ["derive"] }
+bytemuck = { workspace = true, optional = true, features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap", "ClipboardEvent", "DataTransfer"] }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -164,13 +164,12 @@ impl Backend {
             Some("gl") | Some("femtovg") => renderer::femtovg::GlutinFemtoVGRenderer::new,
             #[cfg(enable_skia_renderer)]
             Some("skia") => renderer::skia::WinitSkiaRenderer::new,
+            #[cfg(enable_skia_renderer)]
+            Some("skia-software") => renderer::skia::WinitSkiaRenderer::new_software,
             #[cfg(feature = "renderer-software")]
             Some("sw") | Some("software") => renderer::sw::WinitSoftwareRenderer::new,
             None => default_renderer_factory,
             Some(renderer_name) => {
-                #[cfg(enable_skia_renderer)]
-                if renderer_name == "skia-software" {}
-
                 eprintln!(
                     "slint winit: unrecognized renderer {}, falling back to {}",
                     renderer_name, DEFAULT_RENDERER_NAME

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -8,6 +8,8 @@ use i_slint_renderer_femtovg::FemtoVGRenderer;
 #[cfg(target_arch = "wasm32")]
 use winit::platform::web::WindowExtWebSys;
 
+use super::WinitCompatibleRenderer;
+
 #[cfg(not(target_arch = "wasm32"))]
 mod glcontext;
 
@@ -15,10 +17,10 @@ pub struct GlutinFemtoVGRenderer {
     renderer: FemtoVGRenderer,
 }
 
-impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
-    fn new(
+impl GlutinFemtoVGRenderer {
+    pub fn new(
         window_builder: winit::window::WindowBuilder,
-    ) -> Result<(Self, winit::window::Window), PlatformError> {
+    ) -> Result<(Box<dyn WinitCompatibleRenderer>, winit::window::Window), PlatformError> {
         #[cfg(not(target_arch = "wasm32"))]
         let (winit_window, opengl_context) = crate::event_loop::with_window_target(|event_loop| {
             glcontext::OpenGLContext::new_context(window_builder, event_loop.event_loop_target())
@@ -41,9 +43,11 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
             winit_window.canvas(),
         )?;
 
-        Ok((Self { renderer }, winit_window))
+        Ok((Box::new(Self { renderer }), winit_window))
     }
+}
 
+impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn render(&self, _window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
         self.renderer.render()
     }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -9,10 +9,11 @@ pub struct WinitSkiaRenderer {
     renderer: i_slint_renderer_skia::SkiaRenderer,
 }
 
-impl super::WinitCompatibleRenderer for WinitSkiaRenderer {
-    fn new(
+impl WinitSkiaRenderer {
+    pub fn new(
         window_builder: winit::window::WindowBuilder,
-    ) -> Result<(Self, winit::window::Window), PlatformError> {
+    ) -> Result<(Box<dyn super::WinitCompatibleRenderer>, winit::window::Window), PlatformError>
+    {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_error| {
                 format!("Error creating native window for Skia rendering: {}", winit_os_error)
@@ -21,9 +22,11 @@ impl super::WinitCompatibleRenderer for WinitSkiaRenderer {
 
         let renderer = i_slint_renderer_skia::SkiaRenderer::default();
 
-        Ok((Self { renderer }, winit_window))
+        Ok((Box::new(Self { renderer }), winit_window))
     }
+}
 
+impl super::WinitCompatibleRenderer for WinitSkiaRenderer {
     fn render(&self, _window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
         self.renderer.render()
     }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -24,6 +24,21 @@ impl WinitSkiaRenderer {
 
         Ok((Box::new(Self { renderer }), winit_window))
     }
+
+    pub fn new_software(
+        window_builder: winit::window::WindowBuilder,
+    ) -> Result<(Box<dyn super::WinitCompatibleRenderer>, winit::window::Window), PlatformError>
+    {
+        let winit_window = crate::event_loop::with_window_target(|event_loop| {
+            window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_error| {
+                format!("Error creating native window for Skia rendering: {}", winit_os_error)
+            })
+        })?;
+
+        let renderer = i_slint_renderer_skia::SkiaRenderer::default_software();
+
+        Ok((Box::new(Self { renderer }), winit_window))
+    }
 }
 
 impl super::WinitCompatibleRenderer for WinitSkiaRenderer {

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -78,7 +78,7 @@ unicode-segmentation = "1.8.0"
 unicode-linebreak = { version = "0.1.2", optional = true }
 unicode-script = { version = "0.5.3", optional = true }
 integer-sqrt = { version = "0.1.5" }
-bytemuck = { version = "1.13.1", optional = true, features = ["derive"] }
+bytemuck = { workspace = true, optional = true, features = ["derive"] }
 
 image = { version = "0.24.0", optional = true, default-features = false, features = [ "png", "jpeg" ] }
 clru = { version = "0.6.0", optional = true }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -52,6 +52,8 @@ winit = { version = "0.28.6", optional = true, default-features = false }
 ash = { version = "^0.37.2", optional = true }
 vulkano = { version = "0.33.0", optional = true, default-features = false }
 
+softbuffer = { workspace = true }
+
 [target.'cfg(target_family = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["impl-default", "dwrite", "d3d12", "dxgi", "dxgi1_2", "dxgi1_3", "dxgi1_4", "d3d12sdklayers", "synchapi", "winbase"] }
 skia-safe = { version = "0.66.2", features = ["d3d"] }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -53,6 +53,7 @@ ash = { version = "^0.37.2", optional = true }
 vulkano = { version = "0.33.0", optional = true, default-features = false }
 
 softbuffer = { workspace = true }
+bytemuck = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["impl-default", "dwrite", "d3d12", "dxgi", "dxgi1_2", "dxgi1_3", "dxgi1_4", "d3d12sdklayers", "synchapi", "winbase"] }

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -443,11 +443,11 @@ impl super::Surface for D3DSurface {
     fn render(
         &self,
         _size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
+        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         self.swap_chain
             .borrow_mut()
-            .render_and_present(|surface, gr_context| callback(surface.canvas(), gr_context))
+            .render_and_present(|surface, gr_context| callback(surface.canvas(), Some(gr_context)))
     }
 
     fn bits_per_pixel(&self) -> Result<u8, i_slint_core::platform::PlatformError> {

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -81,7 +81,7 @@ impl super::Surface for MetalSurface {
     fn render(
         &self,
         _size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
+        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         autoreleasepool(|| {
             let drawable = match self.layer.next_drawable() {
@@ -119,7 +119,7 @@ impl super::Surface for MetalSurface {
                 .unwrap()
             };
 
-            callback(surface.canvas(), gr_context);
+            callback(surface.canvas(), Some(gr_context));
 
             drop(surface);
 

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -124,7 +124,7 @@ impl super::Surface for OpenGLSurface {
     fn render(
         &self,
         size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
+        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), PlatformError> {
         self.ensure_context_current()?;
 
@@ -151,7 +151,7 @@ impl super::Surface for OpenGLSurface {
 
         let skia_canvas = surface.canvas();
 
-        callback(skia_canvas, gr_context);
+        callback(skia_canvas, Some(gr_context));
 
         self.glutin_surface.swap_buffers(&current_context).map_err(|glutin_error| {
             format!("Skia OpenGL Renderer: Error swapping buffers: {glutin_error}").into()

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -68,7 +68,7 @@ impl super::Surface for SoftwareSurface {
                 skia_safe::AlphaType::Opaque,
                 None,
             ),
-            unsafe { target_buffer.as_mut().align_to_mut().1 },
+            bytemuck::cast_slice_mut(target_buffer.as_mut()),
             None,
             None,
         )

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -1,0 +1,89 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
+
+use std::cell::RefCell;
+
+/// This surface renders into the given window using Skia's software rasterize.
+pub struct SoftwareSurface {
+    _context: softbuffer::Context,
+    surface: RefCell<softbuffer::Surface>,
+}
+
+impl super::Surface for SoftwareSurface {
+    fn new(
+        window_handle: raw_window_handle::WindowHandle<'_>,
+        display_handle: raw_window_handle::DisplayHandle<'_>,
+        _size: PhysicalWindowSize,
+    ) -> Result<Self, i_slint_core::platform::PlatformError> {
+        let _context = unsafe {
+            softbuffer::Context::new(&display_handle)
+                .map_err(|e| format!("Error creating softbuffer context: {e}"))?
+        };
+
+        let surface = unsafe { softbuffer::Surface::new(&_context, &window_handle) }.map_err(
+            |softbuffer_error| format!("Error creating softbuffer surface: {}", softbuffer_error),
+        )?;
+
+        Ok(Self { _context, surface: RefCell::new(surface) })
+    }
+
+    fn name(&self) -> &'static str {
+        "software"
+    }
+
+    fn resize_event(
+        &self,
+        _size: PhysicalWindowSize,
+    ) -> Result<(), i_slint_core::platform::PlatformError> {
+        Ok(())
+    }
+
+    fn render(
+        &self,
+        size: PhysicalWindowSize,
+        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
+    ) -> Result<(), i_slint_core::platform::PlatformError> {
+        let Some((width, height)) = size.width.try_into().ok().zip(size.height.try_into().ok())
+        else {
+            // Nothing to render
+            return Ok(());
+        };
+
+        let mut surface = self.surface.borrow_mut();
+
+        surface
+            .resize(width, height)
+            .map_err(|e| format!("Error resizing softbuffer surface: {e}"))?;
+
+        let mut target_buffer = surface
+            .buffer_mut()
+            .map_err(|e| format!("Error retrieving softbuffer rendering buffer: {e}"))?;
+
+        let mut surface_borrow = skia_safe::surfaces::wrap_pixels(
+            &skia_safe::ImageInfo::new(
+                (width.get() as i32, height.get() as i32),
+                skia_safe::ColorType::BGRA8888,
+                skia_safe::AlphaType::Opaque,
+                None,
+            ),
+            unsafe { target_buffer.as_mut().align_to_mut().1 },
+            None,
+            None,
+        )
+        .ok_or_else(|| format!("Error wrapping target buffer for rendering into with Skia"))?;
+
+        callback(surface_borrow.canvas(), None);
+
+        target_buffer
+            .present()
+            .map_err(|e| format!("Error presenting softbuffer buffer after skia rendering: {e}"))?;
+
+        Ok(())
+    }
+
+    fn bits_per_pixel(&self) -> Result<u8, i_slint_core::platform::PlatformError> {
+        Ok(24)
+    }
+}

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -239,7 +239,7 @@ impl super::Surface for VulkanSurface {
     fn render(
         &self,
         size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, &mut skia_safe::gpu::DirectContext),
+        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         let gr_context = &mut self.gr_context.borrow_mut();
 
@@ -333,7 +333,7 @@ impl super::Surface for VulkanSurface {
         )
         .ok_or_else(|| format!("Error creating Skia Vulkan surface"))?;
 
-        callback(skia_surface.canvas(), gr_context);
+        callback(skia_surface.canvas(), Some(gr_context));
 
         drop(skia_surface);
 


### PR DESCRIPTION
This provides a fallback in scenarios where the GPU acceleration initialisation fails. It's sub-optimal in performance as it re-renders the entire window, but it's a starting point and better than producing an error. A warning is printed to stderr (actually, routed via our debug_log) when that fallback kicks in.

cc #1636