### PR TITLE
Fix Skia not rendering with some Radeon drivers on Windows

### DIFF
--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -267,7 +267,7 @@ impl OpenGLSurface {
 
                 let gles_context_attributes = ContextAttributesBuilder::new()
                     .with_context_api(ContextApi::Gles(Some(glutin::context::Version {
-                        major: 2,
+                        major: 3,
                         minor: 0,
                     })))
                     .build(Some(_window_handle.raw_window_handle()));


### PR DESCRIPTION
Sometimes Radon drivers report on Windows erroneously that it supports GL_NV_framebuffer_blit as extension but when looking up glBlitFramebufferNV via getProcAddress it returns a null pointer.

The issue goes away when bumping the GLES version. GLES 2.0 was released in 2003 and 3.0 in 2012. Practically everyone supports it nowadays (even Safari), so that's the easiest solution for the Skia renderer.