### PR TITLE
qt: Silence warning during Slint build

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1533,7 +1533,7 @@ impl WindowAdapter for QtWindow {
                 widget_ptr->hide();
                 // Since we don't call close(), this will force Qt to recompute wether there are any
                 // visible windows, and ends the application if needed
-                QEventLoopLocker();
+                auto _locker = QEventLoopLocker();
             }};
             Ok(())
         }


### PR DESCRIPTION
Silence this warning:

```
warning: i-slint-backend-qt@1.3.0: qt_window.rs:1536:17: warning: ignoring temporary created by a constructor declared with 'nodiscard' attribute [-Wunused-value]
```