### PR TITLE
LSP: add "Repeat element" and "Make conditional" code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ All notable changes to this project are documented in this file.
 
 ### LSP
 
- - Added "Wrap in element" and "Remove element" code actions
+ - Added "Wrap in element", "Remove element", "Repeat element", and "Make conditional" code actions
 
 ## [1.2.2] - 2023-10-02
 


### PR DESCRIPTION
With named snippet placeholders copied from the docs:

- Repeat element: "`for <name>[index] in <model> : `Element {}"
- Make conditional: "`if <condition> : `Element {}"

https://github.com/slint-ui/slint/assets/140617/250c4b92-a47c-45ba-9bac-76d74597190f
