### PR TITLE
Improve winit and backend selector error handling

### DIFF
--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -28,7 +28,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(feature = "i-slint-backend-winit")] {
         use i_slint_backend_winit as default_backend;
         fn create_default_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> {
-            Ok(Box::new(i_slint_backend_winit::Backend::new()))
+            Ok(Box::new(i_slint_backend_winit::Backend::new()?))
         }
     } else if #[cfg(feature = "i-slint-backend-linuxkms")] {
         use i_slint_backend_linuxkms as default_backend;
@@ -65,9 +65,9 @@ cfg_if::cfg_if! {
                 #[cfg(all(feature = "i-slint-backend-qt", not(no_qt)))]
                 "qt" => return Ok(Box::new(i_slint_backend_qt::Backend::new())),
                 #[cfg(feature = "i-slint-backend-winit")]
-                "winit" => return Ok(Box::new(i_slint_backend_winit::Backend::new_with_renderer_by_name((!_renderer.is_empty()).then_some(_renderer)))),
+                "winit" => return i_slint_backend_winit::Backend::new_with_renderer_by_name((!_renderer.is_empty()).then_some(_renderer)).map(|b| Box::new(b) as Box<dyn Platform + 'static>),
                 #[cfg(feature = "i-slint-backend-linuxkms")]
-                "linuxkms" => return Ok(Box::new(i_slint_backend_linuxkms::Backend::new_with_renderer_by_name((!_renderer.is_empty()).then(|| _renderer))?)),
+                "linuxkms" => return i_slint_backend_linuxkms::Backend::new_with_renderer_by_name((!_renderer.is_empty()).then(|| _renderer)).map(|b| Box::new(b) as Box<dyn Platform + 'static>),
                 _ => {},
             }
 

--- a/internal/backends/winit/README.md
+++ b/internal/backends/winit/README.md
@@ -33,7 +33,7 @@ To ensure that the runtime backend is selected, initialize the backend as the fi
 
 ```rust
 fn main() {
-    slint::platform::set_platform(Box::new(i_slint_backend_winit::Backend::new()));
+    slint::platform::set_platform(Box::new(i_slint_backend_winit::Backend::new().unwrap()));
     // ...
 }
 ```

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -23,7 +23,10 @@ impl GlutinFemtoVGRenderer {
     ) -> Result<(Box<dyn WinitCompatibleRenderer>, winit::window::Window), PlatformError> {
         #[cfg(not(target_arch = "wasm32"))]
         let (winit_window, opengl_context) = crate::event_loop::with_window_target(|event_loop| {
-            glcontext::OpenGLContext::new_context(window_builder, event_loop.event_loop_target())
+            Ok(glcontext::OpenGLContext::new_context(
+                window_builder,
+                event_loop.event_loop_target(),
+            )?)
         })?;
 
         #[cfg(target_arch = "wasm32")]
@@ -33,6 +36,7 @@ impl GlutinFemtoVGRenderer {
                     "FemtoVG Renderer: Could not create winit window wrapper for DOM canvas: {}",
                     winit_os_err
                 )
+                .into()
             })
         })?;
 

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -17,6 +17,7 @@ impl WinitSkiaRenderer {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_error| {
                 format!("Error creating native window for Skia rendering: {}", winit_os_error)
+                    .into()
             })
         })?;
 
@@ -32,6 +33,7 @@ impl WinitSkiaRenderer {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_error| {
                 format!("Error creating native window for Skia rendering: {}", winit_os_error)
+                    .into()
             })
         })?;
 

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -71,6 +71,7 @@ impl WinitSoftwareRenderer {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             window_builder.build(event_loop.event_loop_target()).map_err(|winit_os_error| {
                 format!("Error creating native window for software rendering: {}", winit_os_error)
+                    .into()
             })
         })?;
 


### PR DESCRIPTION
Propagate the winit error when `DISPLAY` or `WAYLAND_DISPLAY` isn't set and fall back to other available backends.