### PR TITLE
window: Allow access to named parts of the item tree

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -59,6 +59,7 @@ export { ClippedImage as Image }
 
 export component ComponentContainer inherits Empty {
     in property <component-factory> component-factory;
+    in property <string> component_root_item_id;
 
     //-default_size_binding:expands_to_parent_geometry
 }


### PR DESCRIPTION
This allows the previewer to access the item tree of the previewed component, which enables it to do e.g. implement item selection.

I think that is nicer mid-term than having all that code in the interpreter.