### PR TITLE
Winit initial size adjustments and wasm size fixes

### DIFF
--- a/examples/gallery/index.html
+++ b/examples/gallery/index.html
@@ -37,7 +37,7 @@
       <option value="cupertino">Cupertino</option>
     </select>
   </p>
-  <div id="canvas-parent" width="640" height="480"></div>
+  <div id="canvas-parent"></div>
   <p class="links">
     <a href="https://github.com/slint-ui/slint/blob/master/examples/gallery/gallery.slint">
       View Source Code on GitHub</a> -
@@ -59,6 +59,7 @@
       import(gallery).then(module => {
         let canvas = document.createElement("canvas");
         canvas.id = "canvas";
+        canvas.dataset.slintAutoResizeToPreferred = "true";
 
         document.getElementById("canvas-parent").appendChild(canvas);
         module.default().finally(() => {

--- a/examples/imagefilter/index.html
+++ b/examples/imagefilter/index.html
@@ -23,7 +23,7 @@
     <div id="spinner" style="position: relative;">
         <div class="spinner">Loading...</div>
     </div>
-    <canvas id="canvas"></canvas>
+    <canvas id="canvas" data-slint-auto-resize-to-preferred="true"></canvas>
     <p class="links">
         <a href="https://github.com/slint-ui/slint/blob/master/examples/imagefilter/main.rs">
             View Source Code on GitHub</a>

--- a/examples/memory/index.html
+++ b/examples/memory/index.html
@@ -21,7 +21,7 @@
     <div id="spinner" style="position: relative;">
         <div class="spinner">Loading...</div>
     </div>
-    <canvas id="canvas"></canvas>
+    <canvas id="canvas" data-slint-auto-resize-to-preferred="true"></canvas>
     <p class="links">
         <a href="https://github.com/slint-ui/slint/blob/master/examples/memory/main.rs">
             View Source Code on GitHub</a>

--- a/examples/plotter/index.html
+++ b/examples/plotter/index.html
@@ -21,7 +21,7 @@
     <div id="spinner" style="position: relative;">
         <div class="spinner">Loading...</div>
     </div>
-    <canvas id="canvas"></canvas>
+    <canvas id="canvas" data-slint-auto-resize-to-preferred="true"></canvas>
     <p class="links">
         <a href="https://github.com/slint-ui/slint/blob/master/examples/plotter/main.rs">
             View Source Code on GitHub</a>

--- a/examples/printerdemo/rust/index.html
+++ b/examples/printerdemo/rust/index.html
@@ -45,7 +45,7 @@
   <div id="spinner" style="position: relative;">
     <div class="spinner">Loading...</div>
   </div>
-  <canvas id="canvas" width="640" height="480" unselectable="on"></canvas>
+  <canvas id="canvas" unselectable="on"></canvas>
   <p class="hide-in-mobile-landscape links">
     <a href="https://github.com/slint-ui/slint/blob/master/examples/printerdemo/ui/printerdemo.slint">
       View Source Code on GitHub</a> -

--- a/examples/slide_puzzle/main.rs
+++ b/examples/slide_puzzle/main.rs
@@ -173,9 +173,6 @@ pub fn main() {
 
     let main_window = MainWindow::new().unwrap();
 
-    #[cfg(target_arch = "wasm32")]
-    handle_resize(main_window.as_weak());
-
     let state = Rc::new(RefCell::new(AppState {
         pieces: Rc::new(slint::VecModel::<Piece>::from(vec![Piece::default(); 15])),
         main_window: main_window.as_weak(),
@@ -234,44 +231,4 @@ pub fn main() {
         }
     });
     main_window.run().unwrap();
-}
-
-#[cfg(target_arch = "wasm32")]
-/// winit doesn't handle the resizing of the canvas from CSS well
-/// https://github.com/rust-windowing/winit/issues/1661
-/// in the mean time, adjust the size manually
-fn handle_resize(slint_window: slint::Weak<MainWindow>) -> Option<()> {
-    let window = web_sys::window()?;
-    let resize_handler = move || {
-        let window = web_sys::window()?;
-        let doc = window.document()?;
-
-        let container = doc.get_element_by_id("container")?;
-        let children = container.children();
-        let mut height_sum = 0.;
-        for i in 0..children.length() {
-            let child = children.item(i).unwrap();
-            if child.tag_name().to_lowercase() == "canvas" {
-                continue;
-            }
-            let style = window.get_computed_style(&child).ok()?;
-            let get_margin = |m| {
-                style.as_ref()?.get_property_value(m).ok()?.strip_suffix("px")?.parse::<f32>().ok()
-            };
-            height_sum += child.scroll_height() as f32
-                + get_margin("margin-top").unwrap_or(0.)
-                + get_margin("margin-bottom").unwrap_or(0.)
-                + 1.;
-        }
-
-        let width = doc.body()?.client_width() as f32;
-        let height = doc.body()?.client_height() as f32 - height_sum;
-        slint_window.upgrade()?.window().set_size(slint::LogicalSize { width, height });
-        Some(())
-    };
-    resize_handler();
-    let closure = Closure::wrap(Box::new(move || drop(resize_handler())) as Box<dyn FnMut()>);
-    window.set_onresize(Some(closure.as_ref().unchecked_ref()));
-    closure.forget();
-    Some(())
 }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -59,7 +59,7 @@ mod accesskit;
 #[cfg(target_arch = "wasm32")]
 pub(crate) mod wasm_input_helper;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "renderer-femtovg"))]
 pub fn create_gl_window_with_canvas_id(
     canvas_id: &str,
 ) -> Result<Rc<dyn WindowAdapter>, PlatformError> {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -122,9 +122,12 @@ pub struct WinitWindowAdapter {
     window_level: Cell<winit::window::WindowLevel>,
 
     pub(crate) renderer: Box<dyn WinitCompatibleRenderer>,
-    // We cache the size because winit_window.inner_size() can return different value between calls (eg, on X11)
-    // And we wan see the newer value before the Resized event was received, leading to inconsistencies
+    /// We cache the size because winit_window.inner_size() can return different value between calls (eg, on X11)
+    /// And we wan see the newer value before the Resized event was received, leading to inconsistencies
     size: Cell<PhysicalSize>,
+
+    /// Whether the size has been set explicitly
+    has_explicit_size: Cell<bool>,
 
     #[cfg(target_arch = "wasm32")]
     virtual_keyboard_helper: RefCell<Option<super::wasm_input_helper::WasmInputHelper>>,
@@ -166,6 +169,7 @@ impl WinitWindowAdapter {
             window_level: Default::default(),
             winit_window: winit_window.clone(),
             size: Default::default(),
+            has_explicit_size: Default::default(),
             renderer,
             #[cfg(target_arch = "wasm32")]
             virtual_keyboard_helper: Default::default(),
@@ -292,6 +296,15 @@ impl WinitWindowAdapter {
             self.window().dispatch_event(WindowEvent::Resized {
                 size: physical_size.to_logical(scale_factor),
             });
+
+            // Workaround fox winit not sync'ing CSS size of the canvas (the size shown on the browser)
+            // with the width/height attribute (the size of the viewport/GL surface)
+            // If they're not in sync, the UI would be shown as scaled
+            #[cfg(target_arch = "wasm32")]
+            if let Some(html_canvas) = self.winit_window.canvas() {
+                html_canvas.set_width(physical_size.width);
+                html_canvas.set_height(physical_size.height);
+            }
         }
         Ok(())
     }
@@ -344,18 +357,17 @@ impl WindowAdapter for WinitWindowAdapter {
                     html_canvas.client_width() as f32,
                     html_canvas.client_height() as f32,
                 );
-
-                // Try to maintain the existing size of the canvas element. A window created with winit
-                // on the web will always have 1024x768 as size otherwise.
-                if preferred_size.width <= 0. {
+                // Try to maintain the existing size of the canvas element, if any
+                if existing_canvas_size.width > 0. {
                     preferred_size.width = existing_canvas_size.width;
                 }
-                if preferred_size.height <= 0. {
+                if existing_canvas_size.height > 0. {
                     preferred_size.height = existing_canvas_size.height;
                 }
             }
 
             if winit_window.fullscreen().is_none()
+                && !self.has_explicit_size.get()
                 && preferred_size.width > 0 as Coord
                 && preferred_size.height > 0 as Coord
             {
@@ -415,6 +427,7 @@ impl WindowAdapter for WinitWindowAdapter {
     }
 
     fn set_size(&self, size: corelib::api::WindowSize) {
+        self.has_explicit_size.set(true);
         if let Some(size) = self.winit_window().request_inner_size(window_size_to_winit(&size)) {
             self.size.set(physical_size_to_slint(&size));
         }
@@ -524,36 +537,6 @@ impl WindowAdapter for WinitWindowAdapter {
             let winit_max_inner = new_constraints.max.map(into_size);
             winit_window.set_max_inner_size(winit_max_inner);
             winit_window.set_resizable(resizable);
-
-            if let Some(s) = adjust_window_size_to_satisfy_constraints(
-                winit_window,
-                winit_min_inner,
-                winit_max_inner,
-            ) {
-                self.size.set(physical_size_to_slint(&s));
-            }
-
-            #[cfg(target_arch = "wasm32")]
-            if let Some((
-                corelib::api::LogicalSize { width: min_width, height: min_height, .. },
-                corelib::api::LogicalSize { width: max_width, height: max_height, .. },
-            )) = new_constraints.min.zip(new_constraints.max)
-            {
-                // set_max_inner_size / set_min_inner_size don't work on wasm, so apply the size manually
-                let existing_size: winit::dpi::LogicalSize<f32> =
-                    winit_window.inner_size().to_logical(sf as f64);
-                if !(min_width..=max_width).contains(&(existing_size.width))
-                    || !(min_height..=max_height).contains(&(existing_size.height))
-                {
-                    let new_size = winit::dpi::LogicalSize::new(
-                        existing_size.width.min(max_width).max(min_width),
-                        existing_size.height.min(max_height).max(min_height),
-                    );
-                    if let Some(size) = winit_window.request_inner_size(new_size) {
-                        self.size.set(physical_size_to_slint(&size));
-                    }
-                }
-            }
 
             // Auto-resize to the preferred size if users (SlintPad) requests it
             #[cfg(target_arch = "wasm32")]
@@ -712,32 +695,5 @@ struct WindowProperties {
 impl Default for WindowProperties {
     fn default() -> Self {
         Self { scale_factor: Property::new(1.0) }
-    }
-}
-
-// Winit doesn't automatically resize the window to satisfy constraints. Qt does it though, and so do we here.
-fn adjust_window_size_to_satisfy_constraints(
-    winit_window: &winit::window::Window,
-    min_size: Option<winit::dpi::PhysicalSize<f32>>,
-    max_size: Option<winit::dpi::PhysicalSize<f32>>,
-) -> Option<winit::dpi::PhysicalSize<u32>> {
-    let mut window_size = winit_window.inner_size();
-
-    if let Some(min_size) = min_size {
-        let min_size = min_size.cast();
-        window_size.width = window_size.width.max(min_size.width);
-        window_size.height = window_size.height.max(min_size.height);
-    }
-
-    if let Some(max_size) = max_size {
-        let max_size = max_size.cast();
-        window_size.width = window_size.width.min(max_size.width);
-        window_size.height = window_size.height.min(max_size.height);
-    }
-
-    if window_size != winit_window.inner_size() {
-        winit_window.request_inner_size(window_size)
-    } else {
-        None
     }
 }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -126,7 +126,7 @@ pub struct WinitWindowAdapter {
     /// And we wan see the newer value before the Resized event was received, leading to inconsistencies
     size: Cell<PhysicalSize>,
 
-    /// Whether the size has been set explicitly
+    /// Whether the size has been set explicitly via `set_size`
     has_explicit_size: Cell<bool>,
 
     #[cfg(target_arch = "wasm32")]

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -82,14 +82,19 @@ pub fn min_max_size_for_layout_constraints(
     let max_width = constraints_horizontal.max.max(constraints_horizontal.min) as f32;
     let max_height = constraints_vertical.max.max(constraints_vertical.min) as f32;
 
-    let min_size = if min_width > 0. || min_height > 0. {
+    //cfg!(target_arch = "wasm32") is there because wasm32 winit don't like when max size is None:
+    // panicked at 'Property is read only: JsValue(NoModificationAllowedError: CSSStyleDeclaration.removeProperty: Can't remove property 'max-width' from computed style
+
+    let min_size = if min_width > 0. || min_height > 0. || cfg!(target_arch = "wasm32") {
         Some(crate::api::LogicalSize::new(min_width, min_height))
     } else {
         None
     };
-    let max_size = if max_width > 0.
+
+    let max_size = if (max_width > 0.
         && max_height > 0.
-        && (max_width < i32::MAX as f32 || max_height < i32::MAX as f32)
+        && (max_width < i32::MAX as f32 || max_height < i32::MAX as f32))
+        || cfg!(target_arch = "wasm32")
     {
         // maximum widget size for Qt and a workaround for the winit api not allowing partial constraints
         let window_size_max = 16_777_215.;


### PR DESCRIPTION
Following the winit 0.29 merge, a few adjustments are in order:

 - Make slint::Window.set_size() before show keep the size
 - on wasm, attempt to keep the size of the canvas from CSS
 - on wasm, one must set the width and height explicitly on the canvas otherwise there is wierd scaling
 - on wasm, we can't set None as maximum or minimum size otherwise winit panics
 - It seems that the hack we had to keep the size in range is no longer necessary
 - The hack in the slide puzzle can be removed. (but unfortunately it doesn't follow resizes

Unfortunatelly we always call set_inner_size to avoid infinite loop when the css properties are not specificed, so this will override layouts

Also we don't default anymore to the preferred size