### PR TITLE
Fix drop shadow

### DIFF
--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -163,9 +163,8 @@ pub fn lower_shadow_properties(
                     }
                 };
 
-                shadow_elem.geometry_props = elem.borrow().geometry_props.clone();
-
-                elem.borrow_mut().children.push(Element::make_rc(shadow_elem));
+                shadow_elem.geometry_props = child.borrow().geometry_props.clone();
+                elem.borrow_mut().children.push(ElementRc::new(shadow_elem.into()));
             }
             elem.borrow_mut().children.push(child);
         }


### PR DESCRIPTION
commit 975abf3c42d8c91b36c9a0347f82d6138b52fb47 introduced a regression. Two problem:
 - we were taking the geometry from the parent instead of the element that need the shadow
 - Element::make_rc override the geometry with its own properties

Unfortunately annot be tested as this only visual, and the software renderer don't support shadow yet

Fixes #3743