### PR TITLE
Decouple the Skia renderer from winit

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -20,7 +20,7 @@ path = "lib.rs"
 # the C++ crate's CMakeLists.txt
 [features]
 wayland = ["glutin/wayland", "softbuffer/wayland", "softbuffer/wayland-dlopen"]
-x11 = ["glutin/x11", "glutin/glx", "winit/x11", "softbuffer/x11", "softbuffer/x11-dlopen"]
+x11 = ["glutin/x11", "glutin/glx", "softbuffer/x11", "softbuffer/x11-dlopen"]
 opengl = ["skia-safe/gl"]
 vulkan = ["skia-safe/vulkan", "ash", "vulkano"]
 default = []
@@ -70,9 +70,6 @@ skia-safe = { version = "0.66.2", features = ["metal"] }
 
 [target.'cfg(not(any(target_os = "macos", target_family = "windows")))'.dependencies]
 skia-safe = { version = "0.66.2", features = ["gl"] }
-
-[target.'cfg(not(any(target_os = "macos", target_family = "windows", target_os = "android")))'.dependencies]
-winit = { version = "0.29.2", optional = true, default-features = false }
 
 [build-dependencies]
 cfg_aliases = "0.1.0"

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -201,12 +201,6 @@ impl OpenGLSurface {
         cfg_if::cfg_if! {
             if #[cfg(target_os = "macos")] {
                 let prefs = [glutin::display::DisplayApiPreference::Cgl];
-            } else if #[cfg(all(feature = "x11", not(target_family = "windows"), not(target_os = "android")))] {
-                let mut prefs = vec![glutin::display::DisplayApiPreference::Egl];
-                // GLX can only be supported with xlib, not xcb.
-                if matches!(_window_handle.raw_window_handle(), raw_window_handle::RawWindowHandle::Xlib(..)) {
-                    prefs.push(glutin::display::DisplayApiPreference::Glx(Box::new(winit::platform::x11::register_xlib_error_hook)));
-                }
             } else if #[cfg(not(target_family = "windows"))] {
                 let prefs = [glutin::display::DisplayApiPreference::Egl];
             } else {


### PR DESCRIPTION
 Remove support for GLX. The primary use-case is indirect GPU accelerated
 rendering over remote X (say via ssh and X forwarding). That comes at
 the expense of an otherwise ugly API (see earlier revisions of this PR)
 and issues like #3757, because the GLX error handling requires hooking
 into the process-global X error handler. This was already supported only
 when using Skia with winit (and thus Rust), not when using the C++ Skia
 renderer.

 Instead, if GLX is not available, we will fall back to software
 rendering as per #3716.