### PR TITLE
Build the node package only once in debug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,13 +128,13 @@ jobs:
         key: x-napi-v2-${{ steps.node-install.outputs.node-version }} # the cache key consists of a manually bumpable version and the node version, as the cached rustc artifacts contain linking information where to find node.lib, which is in a versioned directory.
     - name: Run npm install
       working-directory: ./api/node
-      run: npm install
-    - name: Typescript check
-      working-directory: ./api/node
-      run: npm run syntax_check
+      run: npm install --ignore-scripts
     - name: Build node plugin in debug
       run: npm run build:debug
       working-directory: ./api/node
+    - name: Typescript check
+      working-directory: ./api/node
+      run: npm run syntax_check
     - name: Run node tests
       working-directory: ./api/node
       run: npm test

--- a/tests/driver/nodejs/nodejs.rs
+++ b/tests/driver/nodejs/nodejs.rs
@@ -12,15 +12,27 @@ lazy_static::lazy_static! {
         // it tries to emulate CreateProcess.
         let npm = which::which("npm").unwrap();
 
-        // builds and installs the slint node package
+        // installs the slint node package dependencies
         std::process::Command::new(npm.clone())
                 .arg("install")
                 .arg("--no-audit")
+                .arg("--ignore-scripts")
                 .current_dir(node_dir.clone())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output()
                 .map_err(|err| format!("Could not launch npm install: {}", err)).unwrap();
+
+        // builds the slint node package in debug
+        std::process::Command::new(npm.clone())
+                .arg("run")
+                .arg("build:debug")
+                .current_dir(node_dir.clone())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .output()
+                .map_err(|err| format!("Could not launch npm install: {}", err)).unwrap();
+
 
         node_dir.join("index.js")
     };


### PR DESCRIPTION
In the ci and on workstations the steps are the same:

1. Install (without building, which would build release)
2. Build debug
3. Run tests

Previously only on Windows the tests were run in debug, because the "npm install" step in the nodejs test driver would overwrite a previously created debug build. On windows they are separate DLLs, and thus co-exist. With this patch we always build debug.