### PR TITLE
Improve the slint! macro with rust-analyzer with `-`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ All notable changes to this project are documented in this file.
  - `SpinBox` value can now be incremented and decremented by scroll event
  - Added `focus-changed-event` callback to `FocusScope`
 
-### Rust API
+### Rust
 
+- Improved support of the `slint!` macro for rust-analyzer.
 - Added `source_model()` to `MapModel`, `FilterModel`, `SortModel`, `ReverseModel` to access inner model.
 
 ### C++


### PR DESCRIPTION
We currently use the debug representation of Span to know if they are next touching eachother as there are no stable way currently. But that doesn't work with rust analyzer as it doesn't have a representation we can test.
Also Span::source_text is not implemented with rust analyzer.

So just default to identifier with `-` touching instead of not touching as this happens more often.

One can still use `(foo)-(bar)` when one really need minus

CC #685