### PR TITLE
Bump skia-safe version

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -41,7 +41,7 @@ pin-weak = "1"
 scoped-tls-hkt = "0.1"
 raw-window-handle = { version = "0.5", features = ["alloc"] }
 
-skia-safe = { version = "0.66.2", features = ["textlayout"] }
+skia-safe = { version = "0.67.0", features = ["textlayout"] }
 glow = { version = "0.12" }
 unicode-segmentation = { version = "1.8.0" }
 
@@ -55,7 +55,7 @@ bytemuck = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["impl-default", "dwrite", "d3d12", "dxgi", "dxgi1_2", "dxgi1_3", "dxgi1_4", "d3d12sdklayers", "synchapi", "winbase"] }
-skia-safe = { version = "0.66.2", features = ["d3d"] }
+skia-safe = { version = "0.67.0", features = ["d3d"] }
 wio = { version = "0.2.2" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -66,10 +66,10 @@ metal = { version = "0.24.0" }
 foreign-types = { version = "0.3.2" }
 objc = { version = "0.2.7" }
 core-graphics-types = { version = "0.1.1" }
-skia-safe = { version = "0.66.2", features = ["metal"] }
+skia-safe = { version = "0.67.0", features = ["metal"] }
 
 [target.'cfg(not(any(target_os = "macos", target_family = "windows")))'.dependencies]
-skia-safe = { version = "0.66.2", features = ["gl"] }
+skia-safe = { version = "0.67.0", features = ["gl"] }
 
 [build-dependencies]
 cfg_aliases = "0.1.0"

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -34,7 +34,7 @@ pub(crate) fn as_skia_image(
     target_size_fn: &dyn Fn() -> (LogicalLength, LogicalLength),
     image_fit: ImageFit,
     scale_factor: ScaleFactor,
-    _canvas: &mut skia_safe::Canvas,
+    _canvas: &skia_safe::Canvas,
 ) -> Option<skia_safe::Image> {
     let image_inner: &ImageInner = (&image).into();
     match image_inner {
@@ -91,10 +91,11 @@ pub(crate) fn as_skia_image(
                 texture_id.get(),
             );
             texture_info.format = glow::RGBA8;
-            let backend_texture = skia_safe::gpu::BackendTexture::new_gl(
+            let backend_texture = skia_safe::gpu::backend_textures::make_gl(
                 (size.width as _, size.height as _),
                 skia_safe::gpu::Mipmapped::No,
                 texture_info,
+                "Borrowed GL texture",
             );
             skia_safe::image::Image::from_texture(
                 _canvas.recording_context().as_mut().unwrap(),

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -443,7 +443,7 @@ impl super::Surface for D3DSurface {
     fn render(
         &self,
         _size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
+        callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         self.swap_chain
             .borrow_mut()

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -24,7 +24,7 @@ struct RenderState {
 }
 
 pub struct SkiaItemRenderer<'a> {
-    pub canvas: &'a mut skia_safe::Canvas,
+    pub canvas: &'a skia_safe::Canvas,
     pub scale_factor: ScaleFactor,
     pub window: &'a i_slint_core::api::Window,
     state_stack: Vec<RenderState>,
@@ -36,7 +36,7 @@ pub struct SkiaItemRenderer<'a> {
 
 impl<'a> SkiaItemRenderer<'a> {
     pub fn new(
-        canvas: &'a mut skia_safe::Canvas,
+        canvas: &'a skia_safe::Canvas,
         window: &'a i_slint_core::api::Window,
         image_cache: &'a ItemCache<Option<skia_safe::Image>>,
         path_cache: &'a ItemCache<Option<(Vector2D<f32, PhysicalPx>, skia_safe::Path)>>,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -523,7 +523,7 @@ pub trait Surface {
     fn render(
         &self,
         size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
+        callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), i_slint_core::platform::PlatformError>;
     /// Called when the surface should be resized.
     fn resize_event(

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -81,7 +81,7 @@ impl super::Surface for MetalSurface {
     fn render(
         &self,
         _size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
+        callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         autoreleasepool(|| {
             let drawable = match self.layer.next_drawable() {
@@ -104,7 +104,6 @@ impl super::Surface for MetalSurface {
 
                 let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_metal(
                     (size.width as i32, size.height as i32),
-                    1,
                     &texture_info,
                 );
 

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -124,7 +124,7 @@ impl super::Surface for OpenGLSurface {
     fn render(
         &self,
         size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
+        callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), PlatformError> {
         self.ensure_context_current()?;
 
@@ -341,7 +341,7 @@ impl OpenGLSurface {
     ) -> Result<skia_safe::Surface, PlatformError> {
         let config = gl_context.config();
 
-        let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_gl(
+        let backend_render_target = skia_safe::gpu::backend_render_targets::make_gl(
             (width, height),
             Some(config.num_samples() as _),
             config.stencil_size() as _,

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -43,7 +43,7 @@ impl super::Surface for SoftwareSurface {
     fn render(
         &self,
         size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
+        callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         let Some((width, height)) = size.width.try_into().ok().zip(size.height.try_into().ok())
         else {

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -239,7 +239,7 @@ impl super::Surface for VulkanSurface {
     fn render(
         &self,
         size: PhysicalWindowSize,
-        callback: &dyn Fn(&mut skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
+        callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         let gr_context = &mut self.gr_context.borrow_mut();
 
@@ -321,7 +321,7 @@ impl super::Surface for VulkanSurface {
         };
 
         let render_target =
-            &skia_safe::gpu::BackendRenderTarget::new_vulkan((width, height), 0, image_info);
+            &skia_safe::gpu::backend_render_targets::make_vk((width, height), image_info);
 
         let mut skia_surface = skia_safe::gpu::surfaces::wrap_backend_render_target(
             gr_context,


### PR DESCRIPTION
This updates to m118. See
https://github.com/rust-skia/rust-skia/releases/tag/0.67.0 for more details.