### PR TITLE
cleanup widgets according to upcoming code guidelines

### DIFF
--- a/internal/compiler/widgets/common/combobox-base.slint
+++ b/internal/compiler/widgets/common/combobox-base.slint
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 export component ComboBoxBase {
-    private property <length> scroll-delta: 2px;
-
-    callback selected(string /* current-value */);
-    callback show-popup();
-
     in property <[string]> model;
     in property <bool> enabled <=> i-focus-scope.enabled;
     out property <bool> has-focus <=> i-focus-scope.has-focus;
@@ -14,6 +9,29 @@ export component ComboBoxBase {
     out property <bool> has-hover: i-touch-area.has-hover;
     in-out property <int> current-index: 0;
     in-out property <string> current-value: root.model[root.current-index];
+
+    callback selected( /* current-value */ string);
+    callback show-popup();
+
+    public function select(index: int) {
+        if (!root.enabled) {
+            return;
+        }
+
+        root.current-index = index;
+        root.current-value = root.model[root.current-index];
+        root.selected(root.current-value);
+    }
+
+    public function move-selection-up() {
+        root.select(Math.max(root.current-index - 1, 0));
+    }
+
+    public function move-selection-down() {
+        root.select(Math.min(root.current-index + 1, root.model.length - 1));
+    }
+
+    private property <length> scroll-delta: 2px;
 
     forward-focus: i-focus-scope;
 
@@ -51,23 +69,5 @@ export component ComboBoxBase {
                 reject
             }
         }
-    }
-
-    public function select(index: int) {
-        if (!root.enabled) {
-            return;
-        }
-
-        root.current-index = index;
-        root.current-value = root.model[root.current-index];
-        root.selected(root.current-value);
-    }
-
-    public function move-selection-up() {
-        root.select(Math.max(root.current-index - 1, 0));
-    }
-
-    public function move-selection-down() {
-        root.select(Math.min(root.current-index + 1, root.model.length - 1));
     }
 }

--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -4,9 +4,6 @@
 import { StyleMetrics, ScrollView } from "std-widgets-impl.slint";
 
 export component LineEditInner inherits Rectangle {
-    callback accepted(string /* text */);
-    callback edited(string /* text */);
-
     in-out property <string> placeholder-text;
     in-out property <length> font-size <=> i-text-input.font-size;
     in-out property <string> text <=> i-text-input.text;
@@ -16,6 +13,29 @@ export component LineEditInner inherits Rectangle {
     in-out property <InputType> input-type <=> i-text-input.input-type;
     in-out property <TextHorizontalAlignment> horizontal-alignment <=> i-text-input.horizontal-alignment;
     in-out property <bool> read-only <=> i-text-input.read-only;
+
+    callback accepted( /* text */ string);
+    callback edited(/* text */ string);
+
+    public function select-all() {
+        i-text-input.select-all();
+    }
+
+    public function clear-selection() {
+        i-text-input.clear-selection();
+    }
+
+    public function cut() {
+        i-text-input.cut();
+    }
+
+    public function copy() {
+        i-text-input.copy();
+    }
+
+    public function paste() {
+        i-text-input.paste();
+    }
 
     min-height: i-text-input.preferred-height;
     min-width: max(50px, i-placeholder.min-width);
@@ -55,6 +75,16 @@ export component LineEditInner inherits Rectangle {
 
         edited => { root.edited(self.text); }
     }
+}
+
+export component TextEdit inherits ScrollView {
+    in property <TextWrap> wrap <=> i-text-input.wrap;
+    in property horizontal-alignment <=> i-text-input.horizontal-alignment;
+    in property read-only <=> i-text-input.read-only;
+    in property <length> font-size <=> i-text-input.font-size;
+    in-out property <string> text <=> i-text-input.text;
+
+    callback edited(/* text */ string);
 
     public function select-all() {
         i-text-input.select-all();
@@ -75,16 +105,6 @@ export component LineEditInner inherits Rectangle {
     public function paste() {
         i-text-input.paste();
     }
-}
-
-export component TextEdit inherits ScrollView {
-    callback edited(string /* text */);
-
-    in property <TextWrap> wrap <=> i-text-input.wrap;
-    in property horizontal-alignment <=> i-text-input.horizontal-alignment;
-    in property read-only <=> i-text-input.read-only;
-    in property <length> font-size <=> i-text-input.font-size;
-    in-out property <string> text <=> i-text-input.text;
 
     forward-focus: i-text-input;
     has-focus: i-text-input.has-focus;
@@ -121,26 +141,6 @@ export component TextEdit inherits ScrollView {
                 root.viewport-y = min(0px, max(parent.visible-height - self.height,  parent.visible-height - cpos.y - StyleMetrics.layout-padding - 20px));
             }
         }
-    }
-
-    public function select-all() {
-        i-text-input.select-all();
-    }
-
-    public function clear-selection() {
-        i-text-input.clear-selection();
-    }
-
-    public function cut() {
-        i-text-input.cut();
-    }
-
-    public function copy() {
-        i-text-input.copy();
-    }
-
-    public function paste() {
-        i-text-input.paste();
     }
 }
 export component AboutSlint {

--- a/internal/compiler/widgets/common/spinbox-base.slint
+++ b/internal/compiler/widgets/common/spinbox-base.slint
@@ -3,15 +3,32 @@
 
 
 export component SpinBoxBase {
-    private property <length> scroll-delta: 2px;
-
-    callback edited(/* value */ int);
-    callback update-text(/* text */ string);
-
     in property <int> minimum;
     in property <int> maximum: 100;
     in property <bool> enabled;
     in-out property <int> value;
+
+    callback edited(/* value */ int);
+    callback update-text(/* text */ string);
+
+    public function update-value(value: int) {
+        if (value < root.minimum || value > root.maximum) {
+            return;
+        }
+
+        root.value = value;
+        root.edited(value);
+    }
+
+    public function increment() {
+        root.update-value(root.value + 1);
+    }
+
+    public function decrement() {
+        root.update-value(root.value - 1);
+    }
+
+    private property <length> scroll-delta: 2px;
 
     TouchArea {
         enabled: root.enabled;
@@ -29,22 +46,5 @@ export component SpinBoxBase {
 
             return reject;
         }
-    }
-
-    public function update-value(value: int) {
-        if (value < root.minimum || value > root.maximum) {
-            return;
-        }
-
-        root.value = value;
-        root.edited(value);
-    }
-
-    public function increment() {
-        root.update-value(root.value + 1);
-    }
-
-    public function decrement() {
-        root.update-value(root.value - 1);
     }
 }

--- a/internal/compiler/widgets/common/standardbutton.slint
+++ b/internal/compiler/widgets/common/standardbutton.slint
@@ -5,10 +5,10 @@ import { StyleMetrics, Button } from "std-widgets-impl.slint";
 
 export component StandardButton {
     in property <StandardButtonKind> kind;
+    in property <bool> enabled <=> btn.enabled;
+    out property <bool> has-focus <=> btn.has-focus;
+    out property <bool> pressed <=> btn.pressed;
 
-    out property<bool> has-focus <=> btn.has-focus;
-    out property<bool> pressed <=> btn.pressed;
-    in property<bool> enabled <=> btn.enabled;
     callback clicked <=> btn.clicked;
 
     btn := Button {

--- a/internal/compiler/widgets/cupertino-base/button.slint
+++ b/internal/compiler/widgets/cupertino-base/button.slint
@@ -5,11 +5,6 @@ import { Typography, Palette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component Button {
-    private property <brush> background: primary && root.enabled ? Palette.accent : Palette.surface;
-    private property <brush> text-color: primary && root.enabled ? Palette.on-surface : Palette.foreground;
-
-    callback clicked;
-
     in property <string> text;
     in property <image> icon;
     in property <bool> primary;
@@ -19,12 +14,32 @@ export component Button {
     out property <bool> pressed: self.enabled && i-touch-area.pressed;
     in-out property <bool> checked;
 
+    callback clicked;
+
+    private property <brush> background: primary && root.enabled ? Palette.accent : Palette.surface;
+    private property <brush> text-color: primary && root.enabled ? Palette.on-surface : Palette.foreground;
+
     min-width: max(20px, i-layout.min-width);
     min-height: max(20px, i-layout.min-height);
     horizontal-stretch: 0;
     vertical-stretch: 0;
     accessible-label: text;
     accessible-role: button;
+
+    states [
+        disabled when !i-touch-area.enabled : {
+            root.text-color: Palette.foreground-secondary;
+            root.background: Palette.surface-quaternary;
+        }
+        pressed when root.pressed : {
+            root.background: root.primary ? Palette.accent-secondary : Palette.surface-secondary;
+        }
+        checked when root.checked : {
+            root.text-color: Palette.accent-secondary;
+        }
+    ]
+
+    animate background { duration: 150ms; }
 
     FocusBorder {
         x: (parent.width - self.width) / 2;
@@ -135,19 +150,4 @@ export component Button {
             return reject;
         }
     }
-
-    states [
-        disabled when !i-touch-area.enabled : {
-            root.text-color: Palette.foreground-secondary;
-            root.background: Palette.surface-quaternary;
-        }
-        pressed when root.pressed : {
-            root.background: root.primary ? Palette.accent-secondary : Palette.surface-secondary;
-        }
-        checked when root.checked : {
-            root.text-color: Palette.accent-secondary;
-        }
-    ]
-
-    animate background { duration: 150ms; }
 }

--- a/internal/compiler/widgets/cupertino-base/checkbox.slint
+++ b/internal/compiler/widgets/cupertino-base/checkbox.slint
@@ -5,22 +5,33 @@ import { Typography, Palette, Icons } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component CheckBox {
-    private property <brush> background: checked && root.enabled ? Palette.accent : Palette.surface;
-    private property <brush> icon-color: Palette.on-surface;
-
-    callback toggled;
-
     in property <string> text;
     in property <bool> enabled <=> i-touch-area.enabled;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked;
 
-    min-height: max(16px, i-layout.min-height);
+    callback toggled;
 
+    private property <brush> background: checked && root.enabled ? Palette.accent : Palette.surface;
+    private property <brush> icon-color: Palette.on-surface;
+
+    min-height: max(16px, i-layout.min-height);
     accessible-checkable: true;
     accessible-label: root.text;
     accessible-checked <=> root.checked;
     accessible-role: checkbox;
+
+    states [
+        disabled when !root.enabled : {
+            opacity: 0.5;
+            icon-color: Palette.foreground;
+        }
+        pressed when i-touch-area.pressed : {
+            root.background: root.checked ? Palette.accent-secondary : Palette.surface-secondary;
+        }
+    ]
+
+    animate background { duration: 150ms; }
 
     FocusBorder {
         x: (parent.width - self.width) / 2;
@@ -131,16 +142,4 @@ export component CheckBox {
             return reject;
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            opacity: 0.5;
-            icon-color: Palette.foreground;
-        }
-        pressed when i-touch-area.pressed : {
-            root.background: root.checked ? Palette.accent-secondary : Palette.surface-secondary;
-        }
-    ]
-
-    animate background { duration: 150ms; }
 }

--- a/internal/compiler/widgets/cupertino-base/combobox.slint
+++ b/internal/compiler/widgets/cupertino-base/combobox.slint
@@ -6,21 +6,33 @@ import { MenuBorder, ListItem, FocusBorder } from "components.slint";
 import { ComboBoxBase } from "../common/combobox-base.slint";
 
 export component ComboBox {
-    private property <brush> background: Palette.surface;
-
-    callback selected <=> i-base.selected;
-
     in property <[string]> model <=> i-base.model;
     in property <bool> enabled <=> i-base.enabled;
     out property <bool> has-focus <=> i-base.has-focus;
     in-out property <int> current-index <=> i-base.current-index;
     in-out property <string> current-value <=> i-base.current-value;
 
+    callback selected <=> i-base.selected;
+
+    private property <brush> background: Palette.surface;
+
     min-width: max(160px, i-layout.min-width);
     min-height: max(22px, i-layout.min-height);
     horizontal-stretch: 1;
     vertical-stretch: 0;
     forward-focus: i-base;
+
+    states [
+        disabled when !root.enabled : {
+            i-text.color: Palette.foreground-secondary;
+            i-top-icon.colorize: Palette.foreground-secondary;
+            i-bottom-icon.colorize: Palette.foreground-secondary;
+            root.background: Palette.surface-tertiary;
+        }
+        pressed when i-base.pressed : {
+            root.background: Palette.surface-secondary;
+        }
+    ]
 
     i-base := ComboBoxBase {
         width: 100%;
@@ -152,16 +164,4 @@ export component ComboBox {
             }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-text.color: Palette.foreground-secondary;
-            i-top-icon.colorize: Palette.foreground-secondary;
-            i-bottom-icon.colorize: Palette.foreground-secondary;
-            root.background: Palette.surface-tertiary;
-        }
-        pressed when i-base.pressed : {
-            root.background: Palette.surface-secondary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/cupertino-base/components.slint
+++ b/internal/compiler/widgets/cupertino-base/components.slint
@@ -44,19 +44,27 @@ export component MenuBorder inherits Rectangle {
 }
 
 export component ListItem {
-    callback clicked <=> i-touch-area.clicked;
-    callback pointer-event <=> i-touch-area.pointer-event;
-
     in property <bool> selected;
     in property <string> text <=> i-text.text;
     in property <length> padding-horizontal: 12px;
     out property <length> mouse-x <=> i-touch-area.mouse-x;
     out property <length> mouse-y <=> i-touch-area.mouse-y;
 
+    callback clicked <=> i-touch-area.clicked;
+    callback pointer-event <=> i-touch-area.pointer-event;
+
     min-width: i-layout.min-width;
     min-height: max(22px, i-layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 1;
+
+    states [
+        hover when i-touch-area.has-hover : {
+            i-background.background: Palette.accent;
+            i-text.color: Palette.on-surface;
+            i-icon.colorize: Palette.on-surface;
+        }
+    ]
 
     i-layout := VerticalLayout {
         padding-left: root.padding-horizontal;
@@ -92,12 +100,4 @@ export component ListItem {
     }
 
     i-touch-area := TouchArea {}
-
-    states [
-        hover when i-touch-area.has-hover : {
-            i-background.background: Palette.accent;
-            i-text.color: Palette.on-surface;
-            i-icon.colorize: Palette.on-surface;
-        }
-    ]
 }

--- a/internal/compiler/widgets/cupertino-base/lineedit.slint
+++ b/internal/compiler/widgets/cupertino-base/lineedit.slint
@@ -5,9 +5,6 @@ import { Typography, Palette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component LineEdit {
-    callback accepted(string /* text */);
-    callback edited(string /* text */);
-
     in property <bool> enabled <=> i-text-input.enabled;
     in property <InputType> input-type <=> i-text-input.input-type;
     in property <TextHorizontalAlignment> horizontal-alignment <=> i-text-input.horizontal-alignment;
@@ -17,11 +14,45 @@ export component LineEdit {
     out property <bool> has-focus <=> i-text-input.has-focus;
     in-out property <string> text <=> i-text-input.text;
 
+    callback accepted(string /* text */);
+    callback edited(string /* text */);
+
+    public function select-all() {
+        i-text-input.select-all();
+    }
+
+    public function clear-selection() {
+        i-text-input.clear-selection();
+    }
+
+    public function cut() {
+        i-text-input.cut();
+    }
+
+    public function copy() {
+        i-text-input.copy();
+    }
+
+    public function paste() {
+        i-text-input.paste();
+    }
+
     vertical-stretch: 0;
     horizontal-stretch: 1;
     min-width: max(160px, i-layout.min-width);
     min-height: max(22px, i-layout.min-height);
     forward-focus: i-text-input;
+
+    states [
+        disabled when !root.enabled : {
+            i-text-input.color: Palette.foreground-secondary;
+            i-placeholder.color: Palette.foreground-secondary;
+            i-background.background: Palette.surface-tertiary;
+        }
+        focused when root.has-focus : {
+            i-background.background: Palette.surface;
+        }
+    ]
 
     FocusBorder {
         x: (parent.width - self.width) / 2;
@@ -87,36 +118,4 @@ export component LineEdit {
             }
         }
     }
-
-
-    public function select-all() {
-        i-text-input.select-all();
-    }
-
-    public function clear-selection() {
-        i-text-input.clear-selection();
-    }
-
-    public function cut() {
-        i-text-input.cut();
-    }
-
-    public function copy() {
-        i-text-input.copy();
-    }
-
-    public function paste() {
-        i-text-input.paste();
-    }
-
-    states [
-        disabled when !root.enabled : {
-            i-text-input.color: Palette.foreground-secondary;
-            i-placeholder.color: Palette.foreground-secondary;
-            i-background.background: Palette.surface-tertiary;
-        }
-        focused when root.has-focus : {
-            i-background.background: Palette.surface;
-        }
-    ]
 }

--- a/internal/compiler/widgets/cupertino-base/listview.slint
+++ b/internal/compiler/widgets/cupertino-base/listview.slint
@@ -9,32 +9,11 @@ export component ListView inherits ScrollView {
 }
 
 component StandardListViewBase inherits ListView {
-    private property <length> item-height: self.viewport-height / self.model.length;
-    private property <length> current-item-y: self.viewport-y + current-item * item-height;
+    in property <[StandardListViewItem]> model;
+    in-out property <int> current-item: -1;
 
     callback current-item-changed(int /* current-item */);
     callback item-pointer-event(int /* item-index */, PointerEvent /* event */, Point /* absolute mouse position */);
-
-    in property<[StandardListViewItem]> model;
-    in-out property<int> current-item: -1;
-
-
-    for item[index] in root.model : ListItem {
-        height: self.min-height;
-        text: item.text;
-        selected: index == root.current-item;
-
-        clicked => {
-            root.set-current-item(index);
-        }
-
-        pointer-event(pe) => {
-            root.item-pointer-event(index, pe, {
-                x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
-                y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
-            });
-        }
-    }
 
     public function set-current-item(index: int) {
         if(index < 0 || index >= model.length) {
@@ -50,6 +29,26 @@ component StandardListViewBase inherits ListView {
 
         if(current-item-y + item-height > self.visible-height) {
             self.viewport-y -= current-item-y + item-height - self.visible-height;
+        }
+    }
+
+    private property <length> item-height: self.viewport-height / self.model.length;
+    private property <length> current-item-y: self.viewport-y + current-item * item-height;
+
+    for item[index] in root.model : ListItem {
+        height: self.min-height;
+        text: item.text;
+        selected: index == root.current-item;
+
+        clicked => {
+            root.set-current-item(index);
+        }
+
+        pointer-event(pe) => {
+            root.item-pointer-event(index, pe, {
+                x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
+                y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
+            });
         }
     }
 }

--- a/internal/compiler/widgets/cupertino-base/progressindicator.slint
+++ b/internal/compiler/widgets/cupertino-base/progressindicator.slint
@@ -4,7 +4,7 @@
 import { Palette } from "styling.slint";
 
 export component ProgressIndicator {
-    in property<float> progress;
+    in property <float> progress;
     in property <bool> indeterminate;
 
     min-height: 6px;

--- a/internal/compiler/widgets/cupertino-base/scrollview.slint
+++ b/internal/compiler/widgets/cupertino-base/scrollview.slint
@@ -4,11 +4,6 @@
 import { Palette, Icons } from "styling.slint";
 
 export component ScrollBar inherits Rectangle {
-    private property <length> track-size: root.horizontal ? root.width - 2 * root.offset : root.height - 2 * offset;
-    private property <length> step-size: 10px;
-    private property <length> offset: 2px;
-    private property <length> pad: 2px;
-
     in property <bool> enabled;
     out property <bool> has-hover: i-touch-area.has-hover;
     in-out property <bool> horizontal;
@@ -16,7 +11,22 @@ export component ScrollBar inherits Rectangle {
     in-out property <length> page-size;
     in-out property <length> value;
 
+    private property <length> track-size: root.horizontal ? root.width - 2 * root.offset : root.height - 2 * offset;
+    private property <length> step-size: 10px;
+    private property <length> offset: 2px;
+    private property <length> pad: 2px;
+
     background: transparent;
+
+    states [
+        hover when i-touch-area.has-hover : {
+            background: Palette.foreground.with-alpha(0.2);
+            i-border.background: Palette.foreground.with-alpha(0.2);
+            pad: 4px;
+        }
+    ]
+
+    animate width, height, pad, background { duration: 150ms; easing: ease-out; }
 
     i-border := Rectangle {
         x: 0;
@@ -72,16 +82,6 @@ export component ScrollBar inherits Rectangle {
             reject
         }
     }
-
-    states [
-        hover when i-touch-area.has-hover : {
-            background: Palette.foreground.with-alpha(0.2);
-            i-border.background: Palette.foreground.with-alpha(0.2);
-            pad: 4px;
-        }
-    ]
-
-    animate width, height, pad, background { duration: 150ms; easing: ease-out; }
 }
 
 export component ScrollView {

--- a/internal/compiler/widgets/cupertino-base/slider.slint
+++ b/internal/compiler/widgets/cupertino-base/slider.slint
@@ -4,15 +4,15 @@
 import { Palette } from "styling.slint";
 
 export component Slider {
-    callback changed(float /* value */);
-
     in property <Orientation> orientation: horizontal;
-    private property<bool> vertical: orientation == Orientation.vertical;
-    in property<float> maximum: 100;
-    in property<float> minimum: 0;
-    in property<bool> enabled <=> i-touch-area.enabled;
-    out property<bool> has-focus: i-focus-scope.has-focus;
-    in-out property<float> value;
+    private property <bool> vertical: orientation == Orientation.vertical;
+    in property <float> maximum: 100;
+    in property <float> minimum: 0;
+    in property <bool> enabled <=> i-touch-area.enabled;
+    out property <bool> has-focus: i-focus-scope.has-focus;
+    in-out property <float> value;
+
+    callback changed(float /* value */);
 
     min-width: vertical ? 20px : 0px;
     min-height: vertical ? 0px : 20px;
@@ -23,6 +23,15 @@ export component Slider {
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
+
+    states [
+        disabled when !root.enabled : {
+            root.opacity: 0.5;
+        }
+        pressed when (i-touch-area.pressed &&  i-touch-area.has-hover) || i-focus-scope.has-focus : {
+            i-thumb.background: Palette.pressed;
+        }
+    ]
 
     i-rail := Rectangle {
         width: vertical ? 4px : parent.width;
@@ -108,13 +117,4 @@ export component Slider {
             }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            root.opacity: 0.5;
-        }
-        pressed when (i-touch-area.pressed &&  i-touch-area.has-hover) || i-focus-scope.has-focus : {
-            i-thumb.background: Palette.pressed;
-        }
-    ]
 }

--- a/internal/compiler/widgets/cupertino-base/spinbox.slint
+++ b/internal/compiler/widgets/cupertino-base/spinbox.slint
@@ -6,21 +6,33 @@ import { FocusBorder } from "components.slint";
 import { SpinBoxBase } from "../common/spinbox-base.slint";
 
 component SpinBoxButton {
-    private property <brush> background: Palette.accent;
-    private property <brush> icon-color: Palette.on-surface;
-
-    callback clicked <=> i-touch-area.clicked;
-
     in property <bool> enabled <=> i-touch-area.enabled;
     in property <image> icon <=> i-icon.source;
 
+    callback clicked <=> i-touch-area.clicked;
+
+    private property <brush> background: Palette.accent;
+    private property <brush> icon-color: Palette.on-surface;
+
     min-width: 16px;
     horizontal-stretch: 0;
+
+    states [
+        disabled when !i-touch-area.enabled : {
+            opacity: 0.5;
+            icon-color: Palette.foreground-secondary;
+        }
+        pressed when i-touch-area.pressed : {
+            root.background: Palette.accent-secondary;
+        }
+    ]
 
     Rectangle {
         y: (parent.height - self.height) / 2;
         width: 14px;
         height: self.width;
+
+        animate background { duration: 150ms; }
 
         if (root.enabled) : Rectangle {
             width: 100%;
@@ -62,33 +74,21 @@ component SpinBoxButton {
 
             animate colorize { duration: 150ms; }
         }
-
-        animate background { duration: 150ms; }
     }
 
     i-touch-area := TouchArea {}
-
-    states [
-        disabled when !i-touch-area.enabled : {
-            opacity: 0.5;
-            icon-color: Palette.foreground-secondary;
-        }
-        pressed when i-touch-area.pressed : {
-            root.background: Palette.accent-secondary;
-        }
-    ]
 }
 
 export component SpinBox {
-    private property <brush> background: Palette.surface;
-
-    callback edited(int /* value */);
-
     in property <int> minimum <=> i-base.minimum;
     in property <int> maximum <=> i-base.maximum;
     in property <bool> enabled <=> i-base.enabled;
     out property <bool> has-focus <=> i-text-input.has-focus;
     in-out property <int> value <=> i-base.value;
+
+    callback edited(int /* value */);
+
+    private property <brush> background: Palette.surface;
 
     min-width: 128px;
     min-height: max(22px, i-layout.min-height);
@@ -99,6 +99,13 @@ export component SpinBox {
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
+
+    states [
+        disabled when !root.enabled : {
+            i-text-input.color: Palette.foreground-secondary;
+            root.background: Palette.surface-tertiary;
+        }
+    ]
 
     i-base := SpinBoxBase {
         width: 100%;
@@ -206,11 +213,4 @@ export component SpinBox {
             }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-text-input.color: Palette.foreground-secondary;
-            root.background: Palette.surface-tertiary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/cupertino-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino-base/std-widgets-impl.slint
@@ -12,14 +12,14 @@ export { ScrollView }
 import { Palette, Typography } from "styling.slint";
 
 export global StyleMetrics  {
-    out property<length> layout-spacing: 10px;
-    out property<length> layout-padding: 12px;
-    out property<length> text-cursor-width: 1px;
-    out property<color> window-background: Palette.background;
-    out property<color> default-text-color: Palette.foreground;
-    out property<color> textedit-background: Palette.background-secondary;
-    out property<color> textedit-text-color: Palette.foreground;
-    out property<color> textedit-background-disabled: Palette.surface-tertiary;
-    out property<color> textedit-text-color-disabled: Palette.foreground-secondary;
-    out property<bool> dark-color-scheme: Palette.dark-color-scheme;
+    out property <length> layout-spacing: 10px;
+    out property <length> layout-padding: 12px;
+    out property <length> text-cursor-width: 1px;
+    out property <color> window-background: Palette.background;
+    out property <color> default-text-color: Palette.foreground;
+    out property <color> textedit-background: Palette.background-secondary;
+    out property <color> textedit-text-color: Palette.foreground;
+    out property <color> textedit-background-disabled: Palette.surface-tertiary;
+    out property <color> textedit-text-color-disabled: Palette.foreground-secondary;
+    out property <bool> dark-color-scheme: Palette.dark-color-scheme;
 }

--- a/internal/compiler/widgets/cupertino-base/styling.slint
+++ b/internal/compiler/widgets/cupertino-base/styling.slint
@@ -26,7 +26,7 @@ export global Typography {
 }
 
 export global Palette {
-    in-out property<bool> dark-color-scheme: ColorSchemeSelector.dark-color-scheme;
+    in-out property <bool> dark-color-scheme: ColorSchemeSelector.dark-color-scheme;
 
     // this are the final colors
     out property <brush> background: dark-color-scheme ? #282828 : #ffffff;

--- a/internal/compiler/widgets/cupertino-base/switch.slint
+++ b/internal/compiler/widgets/cupertino-base/switch.slint
@@ -5,15 +5,24 @@ import { Typography, Palette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component Switch {
-    private property <brush> background: checked && root.enabled ? Palette.accent : Palette.surface-alt;
-    private property <color> text-color: Palette.foreground;
-
-    callback toggled;
-
-    in property<bool> enabled: true;
+    in property <bool> enabled: true;
     in property <string> text;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked: true;
+
+    callback toggled;
+
+    private property <brush> background: checked && root.enabled ? Palette.accent : Palette.surface-alt;
+    private property <color> text-color: Palette.foreground;
+
+    function toggle-checked() {
+        if(!root.enabled) {
+            return;
+        }
+
+        root.checked = !root.checked;
+        root.toggled();
+    }
 
     min-width: 26px;
     min-height: 15px;
@@ -24,6 +33,18 @@ export component Switch {
     accessible-checked <=> root.checked;
     accessible-role: checkbox;
     forward-focus: i-focus-scope;
+
+    states [
+        disabled when !root.enabled : {
+            root.opacity: 0.5;
+        }
+        pressed when i-touch-area.pressed : {
+            root.background: root.checked ? Palette.accent-secondary : Palette.surface-secondary;
+        }
+        selected when root.checked : {
+            i-rail.background: Palette.accent;
+        }
+    ]
 
     i-layout := HorizontalLayout {
         spacing: 12px;
@@ -104,25 +125,4 @@ export component Switch {
             return reject;
         }
     }
-
-    function toggle-checked() {
-        if(!root.enabled) {
-            return;
-        }
-
-        root.checked = !root.checked;
-        root.toggled();
-    }
-
-    states [
-        disabled when !root.enabled : {
-            root.opacity: 0.5;
-        }
-        pressed when i-touch-area.pressed : {
-            root.background: root.checked ? Palette.accent-secondary : Palette.surface-secondary;
-        }
-        selected when root.checked : {
-            i-rail.background: Palette.accent;
-        }
-    ]
 }

--- a/internal/compiler/widgets/cupertino-base/tableview.slint
+++ b/internal/compiler/widgets/cupertino-base/tableview.slint
@@ -5,13 +5,19 @@ import { Palette, Typography, Icons } from "styling.slint";
 import { ListView } from "listview.slint";
 
 component TableViewColumn inherits Rectangle {
-    callback clicked <=> i-touch-area.clicked;
-    callback adjust-size(/* size **/ length);
-
     in property <SortOrder> sort-order: SortOrder.unsorted;
     in property <bool> last;
 
+    callback clicked <=> i-touch-area.clicked;
+    callback adjust-size(/* size **/ length);
+
     background: transparent;
+
+    states [
+        pressed when i-touch-area.pressed : {
+            background: Palette.surface-secondary;
+        }
+    ]
 
     i-touch-area := TouchArea {}
 
@@ -51,6 +57,8 @@ component TableViewColumn inherits Rectangle {
         background: Palette.border;
         height: parent.height - 8px;
 
+        animate background { duration: 150ms; }
+
         i-movable-touch-area := TouchArea {
             width: 10px;
             mouse-cursor: ew-resize;
@@ -61,15 +69,7 @@ component TableViewColumn inherits Rectangle {
                 }
             }
         }
-
-        animate background { duration: 150ms; }
     }
-
-    states [
-        pressed when i-touch-area.pressed : {
-            background: Palette.surface-secondary;
-        }
-    ]
 }
 
 component TableViewCell inherits Rectangle {
@@ -86,15 +86,21 @@ component TableViewCell inherits Rectangle {
 }
 
 component TableViewRow inherits Rectangle {
-    callback clicked <=> i-touch-area.clicked;
-    callback pointer-event(PointerEvent /* event */, Point /* absolute mouse position */);
-
-    in property<bool> selected;
+    in property <bool> selected;
     in property <bool> even;
+
+    callback clicked <=> i-touch-area.clicked;
+    callback pointer-event(/* event */ PointerEvent, /* absolute mouse position */ Point);
 
     min-width: i-layout.min-width;
     min-height: max(20px, i-layout.min-height);
     border-radius: 4px;
+
+    states [
+        selected when root.selected : {
+            i-background.background: Palette.accent;
+        }
+    ]
 
     i-touch-area := TouchArea {
         pointer-event(pe) => {
@@ -112,28 +118,55 @@ component TableViewRow inherits Rectangle {
     i-layout := HorizontalLayout {
        @children
     }
-
-    states [
-        selected when root.selected : {
-            i-background.background: Palette.accent;
-        }
-    ]
 }
 
 export component StandardTableView {
-    private property <length> min-header-height: 28px;
-    private property <length> item-height: i-scroll-view.viewport-height / rows.length;
-    private property <length> current-item-y: i-scroll-view.viewport-y + current-row * item-height;
+    in property <[[StandardListViewItem]]> rows;
+    out property <int> current-sort-column: -1;
+    in-out property <[TableColumn]> columns;
+    in-out property <int> current-row: -1;
 
     callback sort-ascending(int /* column-index */);
     callback sort-descending(int /* column-index */);
     callback row-pointer-event(int /* row-index */, PointerEvent /* event */, Point /* absolute mouse position */);
     callback current-row-changed(int /* current-row */);
 
-    in property <[[StandardListViewItem]]> rows;
-    out property <int> current-sort-column: -1;
-    in-out property <[TableColumn]> columns;
-    in-out property <int> current-row: -1;
+    public function set-current-row(index: int) {
+        if (index < 0 || index >= rows.length) {
+            return;
+        }
+
+        current-row = index;
+        current-row-changed(current-row);
+
+        if (current-item-y < 0) {
+            i-scroll-view.viewport-y += 0 - current-item-y;
+        }
+
+        if (current-item-y + item-height > i-scroll-view.visible-height) {
+            i-scroll-view.viewport-y -= current-item-y + item-height - i-scroll-view.visible-height;
+        }
+    }
+
+    private property <length> min-header-height: 28px;
+    private property <length> item-height: i-scroll-view.viewport-height / rows.length;
+    private property <length> current-item-y: i-scroll-view.viewport-y + current-row * item-height;
+
+    function sort(index: int) {
+        if (root.current-sort-column != index) {
+            root.columns[root.current-sort-column].sort-order = SortOrder.unsorted;
+        }
+
+        if(root.columns[index].sort-order == SortOrder.ascending) {
+            root.columns[index].sort-order = SortOrder.descending;
+            root.sort-descending(index);
+        } else {
+            root.columns[index].sort-order = SortOrder.ascending;
+            root.sort-ascending(index);
+        }
+
+        root.current-sort-column = index;
+    }
 
     min-width: 400px;
     min-height: 200px;
@@ -161,6 +194,14 @@ export component StandardTableView {
                     preferred-width: self.min-width;
                     max-width: (index < columns.length && column.width >= 1px) ? max(column.min-width, column.width) : 100000px;
 
+                    clicked => {
+                        root.sort(index);
+                    }
+
+                    adjust-size(diff) => {
+                        column.width = max(1px, self.width + diff);
+                    }
+
                     Text {
                         vertical-alignment: center;
                         text: column.title;
@@ -170,14 +211,6 @@ export component StandardTableView {
                         color: Palette.foreground;
                         overflow: elide;
                     }
-
-                    clicked => {
-                        root.sort(index);
-                    }
-
-                    adjust-size(diff) => {
-                        column.width = max(1px, self.width + diff);
-                    }
                 }
             }
         }
@@ -186,6 +219,18 @@ export component StandardTableView {
             for row[idx] in root.rows : TableViewRow {
                 selected: idx == root.current-row;
                 even: mod(idx, 2) == 0;
+
+                pointer-event(pe, pos) => {
+                    root.row-pointer-event(idx, pe, {
+                        x: pos.x - root.absolute-position.x,
+                        y: pos.y - root.absolute-position.y,
+                    });
+                }
+
+                clicked => {
+                    root.focus();
+                    root.set-current-row(idx);
+                }
 
                 for cell[index] in row : TableViewCell {
                     private property <bool> has_inner_focus;
@@ -208,18 +253,6 @@ export component StandardTableView {
                         }
                     }
                 }
-
-                pointer-event(pe, pos) => {
-                    root.row-pointer-event(idx, pe, {
-                        x: pos.x - root.absolute-position.x,
-                        y: pos.y - root.absolute-position.y,
-                    });
-                }
-
-                clicked => {
-                    root.focus();
-                    root.set-current-row(idx);
-                }
             }
         }
     }
@@ -237,39 +270,6 @@ export component StandardTableView {
                 return accept;
             }
             reject
-        }
-    }
-
-    function sort(index: int) {
-        if (root.current-sort-column != index) {
-            root.columns[root.current-sort-column].sort-order = SortOrder.unsorted;
-        }
-
-        if(root.columns[index].sort-order == SortOrder.ascending) {
-            root.columns[index].sort-order = SortOrder.descending;
-            root.sort-descending(index);
-        } else {
-            root.columns[index].sort-order = SortOrder.ascending;
-            root.sort-ascending(index);
-        }
-
-        root.current-sort-column = index;
-    }
-
-    public function set-current-row(index: int) {
-        if (index < 0 || index >= rows.length) {
-            return;
-        }
-
-        current-row = index;
-        current-row-changed(current-row);
-
-        if (current-item-y < 0) {
-            i-scroll-view.viewport-y += 0 - current-item-y;
-        }
-
-        if (current-item-y + item-height > i-scroll-view.visible-height) {
-            i-scroll-view.viewport-y -= current-item-y + item-height - i-scroll-view.visible-height;
         }
     }
 }

--- a/internal/compiler/widgets/cupertino-base/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino-base/tabwidget.slint
@@ -27,9 +27,6 @@ export component TabWidgetImpl inherits Rectangle {
 }
 
 export component TabImpl inherits Rectangle {
-    private property <bool> hide-right-border: root.tab-index == root.num-tabs - 1 || tab-index + 1 == current;
-    private property <bool> is-current: root.tab-index == root.current;
-
     in property <int> current-focused; // The currently focused tab
     in property <int> tab-index; // The index of this tab
     in property <int> num-tabs; // The total number of tabs
@@ -37,6 +34,9 @@ export component TabImpl inherits Rectangle {
     in property <bool> enabled: true;
     out property <bool> has-focus: root.current-focused == root.tab-index;
     in-out property <int> current; // The currently selected tab
+
+    private property <bool> hide-right-border: root.tab-index == root.num-tabs - 1 || tab-index + 1 == current;
+    private property <bool> is-current: root.tab-index == root.current;
 
     min-width: max(160px, i-text.min-width);
     min-height: max(30px, i-text.min-height);
@@ -93,9 +93,12 @@ export component TabImpl inherits Rectangle {
 
 export component TabBarImpl {
     // injected properties:
-    in-out property<int> current; // The currently selected tab
-    in-out property<int> current-focused: i-focus-scope.has-focus ? i-focus-scope.focused-tab : -1; // The currently focused tab
-    in-out property<int> num-tabs; // The total number of tabs
+    in-out property <int> current; // The currently selected tab
+    in-out property <int> current-focused: i-focus-scope.has-focus ? i-focus-scope.focused-tab : -1; // The currently focused tab
+    in-out property <int> num-tabs; // The total number of tabs
+
+    accessible-role: tab;
+    accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current;
 
     HorizontalLayout {
         @children
@@ -108,11 +111,8 @@ export component TabBarImpl {
         height: 1px;
     }
 
-    accessible-role: tab;
-    accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current;
-
     i-focus-scope := FocusScope {
-        property<int> focused-tab: 0;
+        property <int> focused-tab: 0;
 
         x: 0;
         width: 0px; // Do not react on clicks

--- a/internal/compiler/widgets/cupertino-base/textedit.slint
+++ b/internal/compiler/widgets/cupertino-base/textedit.slint
@@ -62,8 +62,6 @@ component ScrollView {
 }
 
 export component TextEdit {
-    callback edited(string /* text */);
-
     in property <TextWrap> wrap <=> i-text-input.wrap;
     in property <TextHorizontalAlignment> horizontal-alignment <=> i-text-input.horizontal-alignment;
     in property <bool> read-only <=> i-text-input.read-only;
@@ -78,9 +76,41 @@ export component TextEdit {
     in-out property <length> viewport-width <=> i-scroll-view.viewport-width;
     in-out property <length> viewport-height <=> i-scroll-view.viewport-height;
 
+    callback edited(/* text */ string);
+
+    public function select-all() {
+        i-text-input.select-all();
+    }
+
+    public function clear-selection() {
+        i-text-input.clear-selection();
+    }
+
+    public function cut() {
+        i-text-input.cut();
+    }
+
+    public function copy() {
+        i-text-input.copy();
+    }
+
+    public function paste() {
+        i-text-input.paste();
+    }
+
     forward-focus: i-text-input;
     horizontal-stretch: 1;
     vertical-stretch: 1;
+
+    states [
+        disabled when !root.enabled : {
+            i-text-input.color: Palette.foreground-secondary;
+            i-background.background: Palette.surface-tertiary;
+        }
+        focused when root.has-focus : {
+            i-background.background: Palette.surface;
+        }
+    ]
 
     FocusBorder {
         x: (parent.width - self.width) / 2;
@@ -133,34 +163,4 @@ export component TextEdit {
             }
         }
     }
-
-    public function select-all() {
-        i-text-input.select-all();
-    }
-
-    public function clear-selection() {
-        i-text-input.clear-selection();
-    }
-
-    public function cut() {
-        i-text-input.cut();
-    }
-
-    public function copy() {
-        i-text-input.copy();
-    }
-
-    public function paste() {
-        i-text-input.paste();
-    }
-
-    states [
-        disabled when !root.enabled : {
-            i-text-input.color: Palette.foreground-secondary;
-            i-background.background: Palette.surface-tertiary;
-        }
-        focused when root.has-focus : {
-            i-background.background: Palette.surface;
-        }
-    ]
 }

--- a/internal/compiler/widgets/cupertino-dark/color-scheme.slint
+++ b/internal/compiler/widgets/cupertino-dark/color-scheme.slint
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 export global ColorSchemeSelector  {
-    in property<bool> dark-color-scheme: true;
+    in property <bool> dark-color-scheme: true;
 }

--- a/internal/compiler/widgets/cupertino/color-scheme.slint
+++ b/internal/compiler/widgets/cupertino/color-scheme.slint
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 export global ColorSchemeSelector  {
-    in property<bool> dark-color-scheme: SlintInternal.dark-color-scheme;
+    in property <bool> dark-color-scheme: SlintInternal.dark-color-scheme;
 }

--- a/internal/compiler/widgets/fluent-base/button.slint
+++ b/internal/compiler/widgets/fluent-base/button.slint
@@ -5,10 +5,6 @@ import { Typography, Palette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component Button {
-    private property <brush> text-color: primary || checked ? Palette.text-on-accent-primary : Palette.text-primary;
-
-    callback clicked;
-
     in property <string> text;
     in property <image> icon;
     in property <bool> primary;
@@ -18,17 +14,43 @@ export component Button {
     out property <bool> pressed: self.enabled && i-touch-area.pressed;
     in-out property <bool> checked;
 
+    callback clicked;
+
+    private property <brush> text-color: primary || checked ? Palette.text-on-accent-primary : Palette.text-primary;
+
     min-width: max(32px, i-layout.min-width);
     min-height: max(32px, i-layout.min-height);
     horizontal-stretch: 0;
     vertical-stretch: 0;
-
     accessible-label: text;
     accessible-role: button;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.background: root.primary || root.checked ? Palette.accent-disabled : Palette.control-disabled;
+            i-border.border-color: root.primary || root.checked ? transparent : Palette.control-stroke;
+            root.text-color: root.primary || root.checked ? Palette.text-on-accent-disabled : Palette.text-disabled;
+        }
+        pressed when root.pressed : {
+            i-background.background: root.primary || root.checked ? Palette.accent-tertiary : Palette.control-tertiary;
+            i-border.border-color: Palette.control-stroke;
+            root.text-color: root.primary || root.checked ? Palette.text-on-accent-secondary : Palette.text-secondary;
+        }
+        hover when i-touch-area.has-hover : {
+            i-background.background: root.primary || root.checked ? Palette.accent-secondary : Palette.control-secondary;
+        }
+        checked when root.checked : {
+            i-background.background: Palette.accent-default;
+            i-border.border-color: Palette.accent-control-border;
+            root.text-color: Palette.text-on-accent-primary;
+        }
+    ]
 
     i-background := Rectangle {
         border-radius: 4px;
         background: root.primary ? Palette.accent-default : Palette.control-default;
+
+        animate background, border-color { duration: 150ms; }
 
         i-border := Rectangle {
             border-radius: parent.border-radius;
@@ -61,8 +83,6 @@ export component Button {
                 animate color { duration: 150ms; }
             }
         }
-
-        animate background, border-color { duration: 150ms; }
     }
 
     i-touch-area := TouchArea {
@@ -93,25 +113,4 @@ export component Button {
     if (root.has-focus && root.enabled) : FocusBorder {
         border-radius: i-background.border-radius;
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.background: root.primary || root.checked ? Palette.accent-disabled : Palette.control-disabled;
-            i-border.border-color: root.primary || root.checked ? transparent : Palette.control-stroke;
-            root.text-color: root.primary || root.checked ? Palette.text-on-accent-disabled : Palette.text-disabled;
-        }
-        pressed when root.pressed : {
-            i-background.background: root.primary || root.checked ? Palette.accent-tertiary : Palette.control-tertiary;
-            i-border.border-color: Palette.control-stroke;
-            root.text-color: root.primary || root.checked ? Palette.text-on-accent-secondary : Palette.text-secondary;
-        }
-        hover when i-touch-area.has-hover : {
-            i-background.background: root.primary || root.checked ? Palette.accent-secondary : Palette.control-secondary;
-        }
-        checked when root.checked : {
-            i-background.background: Palette.accent-default;
-            i-border.border-color: Palette.accent-control-border;
-            root.text-color: Palette.text-on-accent-primary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/fluent-base/checkbox.slint
+++ b/internal/compiler/widgets/fluent-base/checkbox.slint
@@ -5,21 +5,42 @@ import { Typography, Palette, Icons } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component CheckBox {
-    private property <color> text-color: Palette.text-secondary;
-
-    callback toggled;
-
     in property <string> text;
     in property <bool> enabled <=> i-touch-area.enabled;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked;
 
-    min-height: max(32px, i-layout.min-height);
+    callback toggled;
 
+    private property <color> text-color: Palette.text-secondary;
+
+    min-height: max(32px, i-layout.min-height);
     accessible-checkable: true;
     accessible-label: root.text;
     accessible-checked <=> root.checked;
     accessible-role: checkbox;
+
+    states [
+        disabled when !root.enabled : {
+            i-border.border-color: Palette.control-strong-stroke-disabled;
+            i-background.background: root.checked ? Palette.accent-disabled : Palette.control-alt-disabled;
+            i-icon.colorize: Palette.text-on-accent-disabled;
+            root.text-color: Palette.text-disabled;
+        }
+        pressed when i-touch-area.pressed : {
+            i-border.border-color: Palette.control-strong-stroke-disabled;
+            i-background.background: root.checked ? Palette.accent-tertiary : Palette.control-alt-quartiary;
+            i-icon.colorize: Palette.text-on-accent-secondary;
+        }
+        hover when i-touch-area.has-hover : {
+            i-background.background: root.checked ?  Palette.accent-secondary : Palette.control-alt-tertiary;
+        }
+        checked when root.checked && root.enabled : {
+            i-background.background: Palette.accent-default;
+        }
+    ]
+
+    animate text-color { duration: 200ms; }
 
     i-layout := HorizontalLayout {
         padding-left: 8px;
@@ -32,6 +53,8 @@ export component CheckBox {
             y: (parent.height - self.height) / 2;
             background: Palette.control-alt-secondary;
             border-radius: 2px;
+
+            animate background, border-color { duration: 150ms; }
 
             i-border := Rectangle {
                 border-color: Palette.control-strong-stroke;
@@ -48,8 +71,6 @@ export component CheckBox {
 
                 animate colorize { duration: 150ms; }
             }
-
-            animate background, border-color { duration: 150ms; }
         }
 
         if (root.text != "") : Text {
@@ -89,26 +110,4 @@ export component CheckBox {
     if (root.has-focus && root.enabled) : FocusBorder {
         border-radius: 4px;
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-border.border-color: Palette.control-strong-stroke-disabled;
-            i-background.background: root.checked ? Palette.accent-disabled : Palette.control-alt-disabled;
-            i-icon.colorize: Palette.text-on-accent-disabled;
-            root.text-color: Palette.text-disabled;
-        }
-        pressed when i-touch-area.pressed : {
-            i-border.border-color: Palette.control-strong-stroke-disabled;
-            i-background.background: root.checked ? Palette.accent-tertiary : Palette.control-alt-quartiary;
-            i-icon.colorize: Palette.text-on-accent-secondary;
-        }
-        hover when i-touch-area.has-hover : {
-            i-background.background: root.checked ?  Palette.accent-secondary : Palette.control-alt-tertiary;
-        }
-        checked when root.checked && root.enabled : {
-            i-background.background: Palette.accent-default;
-        }
-    ]
-
-    animate text-color { duration: 200ms; }
 }

--- a/internal/compiler/widgets/fluent-base/combobox.slint
+++ b/internal/compiler/widgets/fluent-base/combobox.slint
@@ -6,19 +6,37 @@ import { MenuBorder, ListItem, FocusBorder } from "components.slint";
 import { ComboBoxBase } from "../common/combobox-base.slint";
 
 export component ComboBox {
-    callback selected <=> i-base.selected;
-
     in property <[string]> model <=> i-base.model;
     in property <bool> enabled <=> i-base.enabled;
     out property <bool> has-focus <=> i-base.has-focus;
     in-out property <int> current-index <=> i-base.current-index;
     in-out property <string> current-value <=> i-base.current-value;
 
+    callback selected <=> i-base.selected;
+
     min-width: max(160px, i-layout.min-height);
     min-height: max(32px, i-layout.min-height);
     horizontal-stretch: 1;
     vertical-stretch: 0;
     forward-focus: i-base;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.background: Palette.control-disabled;
+            i-background.border-color: Palette.control-stroke;
+            i-text.color: Palette.text-disabled;
+            i-icon.colorize: Palette.text-disabled;
+        }
+        pressed when i-base.pressed : {
+            i-background.background: Palette.control-alt-tertiary;
+            i-background.border-color: Palette.control-stroke;
+            i-text.color: Palette.text-secondary;
+            i-icon.colorize: Palette.text-tertiary;
+        }
+        hover when i-base.has-hover : {
+            i-background.background: Palette.control-secondary;
+        }
+    ]
 
     i-base := ComboBoxBase {
         width: 100%;
@@ -34,6 +52,8 @@ export component ComboBox {
         background: Palette.control-default;
         border-width: 1px;
         border-color: Palette.control-border;
+
+        animate border-color { duration: 200ms; }
 
         i-layout := HorizontalLayout {
             padding-left: 11px;
@@ -58,8 +78,6 @@ export component ComboBox {
                 animate colorize { duration: 150ms; }
             }
         }
-
-        animate border-color { duration: 200ms; }
     }
 
     // focus border
@@ -87,22 +105,4 @@ export component ComboBox {
             }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.background: Palette.control-disabled;
-            i-background.border-color: Palette.control-stroke;
-            i-text.color: Palette.text-disabled;
-            i-icon.colorize: Palette.text-disabled;
-        }
-        pressed when i-base.pressed : {
-            i-background.background: Palette.control-alt-tertiary;
-            i-background.border-color: Palette.control-stroke;
-            i-text.color: Palette.text-secondary;
-            i-icon.colorize: Palette.text-tertiary;
-        }
-        hover when i-base.has-hover : {
-            i-background.background: Palette.control-secondary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/fluent-base/components.slint
+++ b/internal/compiler/widgets/fluent-base/components.slint
@@ -33,22 +33,39 @@ export component MenuBorder inherits Rectangle {
 }
 
 export component ListItem {
-    callback clicked <=> i-touch-area.clicked;
-    callback pointer-event <=> i-touch-area.pointer-event;
-
     in property <bool> selected;
     in property <string> text <=> i-text.text;
     out property <length> mouse-x <=> i-touch-area.mouse-x;
     out property <length> mouse-y <=> i-touch-area.mouse-y;
+
+    callback clicked <=> i-touch-area.clicked;
+    callback pointer-event <=> i-touch-area.pointer-event;
 
     min-width: i-layout.min-width;
     min-height: max(34px, i-layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 1;
 
+    states [
+        pressed when i-touch-area.pressed : {
+            i-background.background: selected ? Palette.subtle-secondary : Palette.subtle-tertiary;
+        }
+        hover when i-touch-area.has-hover : {
+            i-text.color: Palette.text-secondary;
+            i-background.background: selected ? Palette.subtle-tertiary : Palette.subtle-secondary;
+            i-selector.height: root.selected ? 16px : 0;
+        }
+        selected when root.selected : {
+            i-background.background: Palette.subtle-secondary;
+            i-selector.height: 16px;
+        }
+    ]
+
     i-background := Rectangle {
         background: transparent;
         border-radius: 4px;
+
+        animate background { duration: 150ms; }
 
         i-layout := HorizontalLayout {
             padding-left: 16px;
@@ -77,24 +94,7 @@ export component ListItem {
 
             animate height { duration: 150ms; easing: ease-out; }
         }
-
-        animate background { duration: 150ms; }
     }
 
     i-touch-area := TouchArea {}
-
-    states [
-        pressed when i-touch-area.pressed : {
-            i-background.background: selected ? Palette.subtle-secondary : Palette.subtle-tertiary;
-        }
-        hover when i-touch-area.has-hover : {
-            i-text.color: Palette.text-secondary;
-            i-background.background: selected ? Palette.subtle-tertiary : Palette.subtle-secondary;
-            i-selector.height: root.selected ? 16px : 0;
-        }
-        selected when root.selected : {
-            i-background.background: Palette.subtle-secondary;
-            i-selector.height: 16px;
-        }
-    ]
 }

--- a/internal/compiler/widgets/fluent-base/groupbox.slint
+++ b/internal/compiler/widgets/fluent-base/groupbox.slint
@@ -5,7 +5,7 @@ import { Typography, Palette } from "styling.slint";
 
 export component GroupBox {
     in property <string> title <=> label.text;
-    in property<bool> enabled: true;
+    in property <bool> enabled: true;
 
     VerticalLayout {
         spacing: 8px;

--- a/internal/compiler/widgets/fluent-base/lineedit.slint
+++ b/internal/compiler/widgets/fluent-base/lineedit.slint
@@ -4,9 +4,6 @@
 import { Typography, Palette } from "styling.slint";
 
 export component LineEdit {
-    callback accepted(string /* text */);
-    callback edited(string /* text */);
-
     in property <bool> enabled <=> i-text-input.enabled;
     in property <InputType> input-type <=> i-text-input.input-type;
     in property <TextHorizontalAlignment> horizontal-alignment <=> i-text-input.horizontal-alignment;
@@ -16,11 +13,50 @@ export component LineEdit {
     out property <bool> has-focus <=> i-text-input.has-focus;
     in-out property <string> text <=> i-text-input.text;
 
+    callback accepted(/* text */ string);
+    callback edited(/* text */ string);
+
+    public function select-all() {
+        i-text-input.select-all();
+    }
+
+    public function clear-selection() {
+        i-text-input.clear-selection();
+    }
+
+    public function cut() {
+        i-text-input.cut();
+    }
+
+    public function copy() {
+        i-text-input.copy();
+    }
+
+    public function paste() {
+        i-text-input.paste();
+    }
+
     vertical-stretch: 0;
     horizontal-stretch: 1;
     min-width: max(160px, i-layout.min-height);
     min-height: max(32px, i-layout.min-height);
     forward-focus: i-text-input;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.background: Palette.control-disabled;
+            i-background.border-color: Palette.control-stroke;
+            i-text-input.color: Palette.text-disabled;
+            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
+            i-placeholder.color: Palette.text-disabled;
+        }
+        focused when root.has-focus : {
+            i-background.background: Palette.control-input-active;
+            i-background.border-color: Palette.control-stroke;
+            i-focus-border.background: Palette.accent-default;
+            i-placeholder.color: Palette.text-tertiary;
+        }
+    ]
 
     i-background := Rectangle {
         border-radius: 4px;
@@ -85,40 +121,4 @@ export component LineEdit {
             height: 2px;
         }
     }
-
-    public function select-all() {
-        i-text-input.select-all();
-    }
-
-    public function clear-selection() {
-        i-text-input.clear-selection();
-    }
-
-    public function cut() {
-        i-text-input.cut();
-    }
-
-    public function copy() {
-        i-text-input.copy();
-    }
-
-    public function paste() {
-        i-text-input.paste();
-    }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.background: Palette.control-disabled;
-            i-background.border-color: Palette.control-stroke;
-            i-text-input.color: Palette.text-disabled;
-            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
-            i-placeholder.color: Palette.text-disabled;
-        }
-        focused when root.has-focus : {
-            i-background.background: Palette.control-input-active;
-            i-background.border-color: Palette.control-stroke;
-            i-focus-border.background: Palette.accent-default;
-            i-placeholder.color: Palette.text-tertiary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/fluent-base/listview.slint
+++ b/internal/compiler/widgets/fluent-base/listview.slint
@@ -9,14 +9,31 @@ export component ListView inherits ScrollView {
 }
 
 component StandardListViewBase inherits ListView {
+    in property <[StandardListViewItem]> model;
+    in-out property <int> current-item: -1;
+
+    callback current-item-changed(/* current-item */ int);
+    callback item-pointer-event( /* item-index */ int, /* event */ PointerEvent,  /* absolute mouse position */ Point);
+
+    public function set-current-item(index: int) {
+        if(index < 0 || index >= model.length) {
+            return;
+        }
+
+        current-item = index;
+        current-item-changed(current-item);
+
+        if(current-item-y < 0) {
+            self.viewport-y += 0 - current-item-y;
+        }
+
+        if(current-item-y + item-height > self.visible-height) {
+            self.viewport-y -= current-item-y + item-height - self.visible-height;
+        }
+    }
+
     private property <length> item-height: self.viewport-height / self.model.length;
     private property <length> current-item-y: self.viewport-y + current-item * item-height;
-
-    callback current-item-changed(int /* current-item */);
-    callback item-pointer-event(int /* item-index */, PointerEvent /* event */, Point /* absolute mouse position */);
-
-    in property<[StandardListViewItem]> model;
-    in-out property<int> current-item: -1;
 
     for item[index] in root.model : ListItem {
         height: self.min-height;
@@ -35,22 +52,7 @@ component StandardListViewBase inherits ListView {
         }
     }
 
-    public function set-current-item(index: int) {
-        if(index < 0 || index >= model.length) {
-            return;
-        }
 
-        current-item = index;
-        current-item-changed(current-item);
-
-        if(current-item-y < 0) {
-            self.viewport-y += 0 - current-item-y;
-        }
-
-        if(current-item-y + item-height > self.visible-height) {
-            self.viewport-y -= current-item-y + item-height - self.visible-height;
-        }
-    }
 }
 
 export component StandardListView inherits StandardListViewBase {

--- a/internal/compiler/widgets/fluent-base/progressindicator.slint
+++ b/internal/compiler/widgets/fluent-base/progressindicator.slint
@@ -4,7 +4,7 @@
 import { Palette } from "styling.slint";
 
 export component ProgressIndicator {
-    in property<float> progress;
+    in property <float> progress;
     in property <bool> indeterminate;
 
     min-height: 3px;

--- a/internal/compiler/widgets/fluent-base/scrollview.slint
+++ b/internal/compiler/widgets/fluent-base/scrollview.slint
@@ -33,19 +33,30 @@ component ScrollViewButton inherits TouchArea {
 }
 
 component ScrollBar inherits Rectangle {
+    in-out property <bool> horizontal;
+    in-out property <length> maximum;
+    in-out property <length> page-size;
+    in-out property <length> value;
+    in property <bool> enabled;
+
     private property <length> offset: 16px;
     private property <length> size: 2px;
     private property <length> track-size: root.horizontal ? root.width - 2 * root.offset : root.height - 2 * offset;
     private property <length> step-size: 10px;
 
-    in-out property <bool> horizontal;
-    in-out property<length> maximum;
-    in-out property<length> page-size;
-    in-out property<length> value;
-    in property <bool> enabled;
-
     border-width: 1px;
     border-radius: 7px;
+
+    states [
+        hover when i-touch-area.has-hover || i-down-scroll-button.has-hover || i-up-scroll-button.has-hover : {
+            root.background: Palette.acrylic-background;
+            root.size: 6px;
+            i-up-scroll-button.opacity: 1;
+            i-down-scroll-button.opacity: 1;
+        }
+    ]
+
+    animate size { duration: 150ms; easing: ease-out; }
 
     i-thumb := Rectangle {
         width: !root.horizontal ? root.size : root.maximum <= 0phx ? 0phx : max(32px, root.track-size * root.page-size / (root.maximum + root.page-size));
@@ -112,17 +123,6 @@ component ScrollBar inherits Rectangle {
             root.value = max(-root.maximum, root.value - root.step-size);
         }
     }
-
-    states [
-        hover when i-touch-area.has-hover || i-down-scroll-button.has-hover || i-up-scroll-button.has-hover : {
-            root.background: Palette.acrylic-background;
-            root.size: 6px;
-            i-up-scroll-button.opacity: 1;
-            i-down-scroll-button.opacity: 1;
-        }
-    ]
-
-    animate size { duration: 150ms; easing: ease-out; }
 }
 
 export component ScrollView {

--- a/internal/compiler/widgets/fluent-base/slider.slint
+++ b/internal/compiler/widgets/fluent-base/slider.slint
@@ -4,15 +4,16 @@
 import { Palette } from "styling.slint";
 
 export component Slider {
-    callback changed(float /* value */);
-
     in property <Orientation> orientation: horizontal;
-    private property<bool> vertical: orientation == Orientation.vertical;
-    in property<float> maximum: 100;
-    in property<float> minimum: 0;
-    in property<bool> enabled <=> i-touch-area.enabled;
-    out property<bool> has-focus: i-focus-scope.has-focus;
-    in-out property<float> value;
+    in property <float> maximum: 100;
+    in property <float> minimum: 0;
+    in property <bool> enabled <=> i-touch-area.enabled;
+    out property <bool> has-focus: i-focus-scope.has-focus;
+    in-out property <float> value;
+
+    callback changed( /* value */ float);
+
+    private property <bool> vertical: orientation == Orientation.vertical;
 
     min-width: vertical ? 20px : 0px;
     min-height: vertical ? 0px : 20px;
@@ -23,6 +24,23 @@ export component Slider {
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
+
+    states [
+        disabled when !root.enabled : {
+            i-track.background: Palette.accent-disabled;
+            i-rail.background: Palette.accent-disabled;
+            i-thumb-inner.background: Palette.accent-disabled;
+        }
+        pressed when ( i-touch-area.pressed &&  i-touch-area.has-hover) || i-focus-scope.has-focus : {
+            i-thumb-inner.width: 10px;
+            i-thumb-inner.background: Palette.accent-tertiary;
+            i-thumb.border-color: Palette.control-stroke;
+        }
+        hover when i-touch-area.has-hover : {
+            i-thumb-inner.width: 14px;
+            i-thumb-inner.background: Palette.accent-secondary;
+        }
+    ]
 
     i-rail := Rectangle {
         width: vertical ? 4px : parent.width;
@@ -118,21 +136,4 @@ export component Slider {
             }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-track.background: Palette.accent-disabled;
-            i-rail.background: Palette.accent-disabled;
-            i-thumb-inner.background: Palette.accent-disabled;
-        }
-        pressed when ( i-touch-area.pressed &&  i-touch-area.has-hover) || i-focus-scope.has-focus : {
-            i-thumb-inner.width: 10px;
-            i-thumb-inner.background: Palette.accent-tertiary;
-            i-thumb.border-color: Palette.control-stroke;
-        }
-        hover when i-touch-area.has-hover : {
-            i-thumb-inner.width: 14px;
-            i-thumb-inner.background: Palette.accent-secondary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/fluent-base/spinbox.slint
+++ b/internal/compiler/widgets/fluent-base/spinbox.slint
@@ -12,6 +12,12 @@ component SpinBoxButton {
     min-width: 28px;
     horizontal-stretch: 0;
 
+    states [
+        pressed when i-touch-area.pressed : {
+            i-background.background: Palette.subtle;
+        }
+    ]
+
     i-background := Rectangle {
         border-radius: 3px;
 
@@ -25,22 +31,16 @@ component SpinBoxButton {
     }
 
     i-touch-area := TouchArea {}
-
-    states [
-        pressed when i-touch-area.pressed : {
-            i-background.background: Palette.subtle;
-        }
-    ]
 }
 
 export component SpinBox {
-    callback edited(int /* value */);
-
     in property <int> minimum <=> i-base.minimum;
     in property <int> maximum <=> i-base.maximum;
     in property <bool> enabled <=> i-base.enabled;
     out property <bool> has-focus <=> i-text-input.has-focus;
     in-out property <int> value <=> i-base.value;
+
+    callback edited( /* value */ int);
 
     min-width: 128px;
     min-height: 30px;
@@ -51,6 +51,20 @@ export component SpinBox {
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.background: Palette.control-disabled;
+            i-background.border-color: Palette.control-stroke;
+            i-text-input.color: Palette.text-disabled;
+            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
+        }
+        focused when root.has-focus : {
+            i-background.background: Palette.control-input-active;
+            i-background.border-color: Palette.control-stroke;
+            i-focus-border.background: Palette.accent-default;
+        }
+    ]
 
     i-base := SpinBoxBase {
         width: 100%;
@@ -136,18 +150,4 @@ export component SpinBox {
             height: 2px;
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.background: Palette.control-disabled;
-            i-background.border-color: Palette.control-stroke;
-            i-text-input.color: Palette.text-disabled;
-            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
-        }
-        focused when root.has-focus : {
-            i-background.background: Palette.control-input-active;
-            i-background.border-color: Palette.control-stroke;
-            i-focus-border.background: Palette.accent-default;
-        }
-    ]
 }

--- a/internal/compiler/widgets/fluent-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent-base/std-widgets-impl.slint
@@ -12,14 +12,14 @@ export { ScrollView }
 import { Palette, Typography } from "styling.slint";
 
 export global StyleMetrics  {
-    out property<length> layout-spacing: 8px;
-    out property<length> layout-padding: 8px;
-    out property<length> text-cursor-width: 1px;
-    out property<color> window-background: Palette.background;
-    out property<color> default-text-color: Palette.text-primary;
-    out property<color> textedit-background: Palette.background;
-    out property<color> textedit-text-color: Palette.text-primary;
-    out property<color> textedit-background-disabled: Palette.control-disabled;
-    out property<color> textedit-text-color-disabled: Palette.text-disabled;
-    out property<bool> dark-color-scheme: Palette.dark-color-scheme;
+    out property <length> layout-spacing: 8px;
+    out property <length> layout-padding: 8px;
+    out property <length> text-cursor-width: 1px;
+    out property <color> window-background: Palette.background;
+    out property <color> default-text-color: Palette.text-primary;
+    out property <color> textedit-background: Palette.background;
+    out property <color> textedit-text-color: Palette.text-primary;
+    out property <color> textedit-background-disabled: Palette.control-disabled;
+    out property <color> textedit-text-color-disabled: Palette.text-disabled;
+    out property <bool> dark-color-scheme: Palette.dark-color-scheme;
 }

--- a/internal/compiler/widgets/fluent-base/styling.slint
+++ b/internal/compiler/widgets/fluent-base/styling.slint
@@ -12,12 +12,10 @@ export global Typography {
     out property <int> light-font-weight: 300;
     out property <int> regular-font-weight: 400;
     out property <int> semibold-font-weight: 600;
-
     out property <TextStyle> body: {
         font-size: 14 * 0.0769rem,
         font-weight: regular-font-weight
     };
-
     out property <TextStyle> body-strong: {
         font-size: 14 * 0.0769rem,
         font-weight: semibold-font-weight
@@ -25,7 +23,7 @@ export global Typography {
 }
 
 export global Palette {
-    in-out property<bool> dark-color-scheme: ColorSchemeSelector.dark-color-scheme;
+    in-out property <bool> dark-color-scheme: ColorSchemeSelector.dark-color-scheme;
 
     out property <brush> background: dark-color-scheme ? #1C1C1C : #FAFAFA;
     out property <brush> accent-default: dark-color-scheme ? #60CDFF : #005FB8;

--- a/internal/compiler/widgets/fluent-base/switch.slint
+++ b/internal/compiler/widgets/fluent-base/switch.slint
@@ -5,14 +5,23 @@ import { Typography, Palette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component Switch {
-    private property <color> text-color: Palette.text-secondary;
-
-    callback toggled;
-
-    in property<bool> enabled: true;
+    in property <bool> enabled: true;
     in property <string> text;
     in-out property <bool> checked: true;
     out property <bool> has-focus: i-focus-scope.has-focus;
+
+    callback toggled;
+
+    private property <color> text-color: Palette.text-secondary;
+
+    function toggle-checked() {
+        if(!root.enabled) {
+            return;
+        }
+
+        root.checked = !root.checked;
+        root.toggled();
+    }
 
     min-width: 40px;
     min-height: 20px;
@@ -23,6 +32,35 @@ export component Switch {
     accessible-checked <=> root.checked;
     accessible-role: checkbox;
     forward-focus: i-focus-scope;
+
+    states [
+        disabled when !root.enabled : {
+            i-rail.background: root.checked ? Palette.accent-disabled : transparent;
+            i-rail.border-color: Palette.control-strong-stroke-disabled;
+            i-thumb.background: Palette.text-disabled;
+            root.text-color: Palette.text-disabled;
+            i-thumb.background: root.checked ? Palette.text-on-accent-disabled : Palette.text-secondary;
+        }
+        pressed when i-touch-area.pressed : {
+            i-rail.background: root.checked ? Palette.accent-tertiary : Palette.control-alt-quartiary;
+            i-thumb.width: 17px;
+            i-thumb.height: 14px;
+            i-thumb.border-width: root.checked ? 1px : 0;
+            i-thumb.background: root.checked ? Palette.text-on-accent-primary : Palette.text-secondary;
+        }
+        hover when i-touch-area.has-hover : {
+            i-rail.background:  root.checked ? Palette.accent-secondary : Palette.control-alt-tertiary;
+            i-thumb.width: 14px;
+            i-thumb.border-width: root.checked ? 1px : 0;
+            i-thumb.background: root.checked ? Palette.text-on-accent-primary : Palette.text-secondary;
+        }
+        selected when root.checked : {
+            i-rail.background: Palette.accent-default;
+            i-thumb.border-width: 1px;
+            i-thumb.border-color: Palette.circle-border;
+            i-thumb.background: Palette.text-on-accent-primary;
+        }
+    ]
 
     i-layout := HorizontalLayout {
         spacing: 12px;
@@ -52,8 +90,6 @@ export component Switch {
 
                     animate background, width { duration: 150ms; easing: linear; }
                 }
-
-                animate background, border-color { duration: 150ms; easing: linear; }
 
                 // focus border
                 if (root.has-focus && root.enabled) : FocusBorder {
@@ -93,42 +129,4 @@ export component Switch {
             return reject;
         }
     }
-
-    function toggle-checked() {
-        if(!root.enabled) {
-            return;
-        }
-
-        root.checked = !root.checked;
-        root.toggled();
-    }
-
-    states [
-        disabled when !root.enabled : {
-            i-rail.background: root.checked ? Palette.accent-disabled : transparent;
-            i-rail.border-color: Palette.control-strong-stroke-disabled;
-            i-thumb.background: Palette.text-disabled;
-            root.text-color: Palette.text-disabled;
-            i-thumb.background: root.checked ? Palette.text-on-accent-disabled : Palette.text-secondary;
-        }
-        pressed when i-touch-area.pressed : {
-            i-rail.background: root.checked ? Palette.accent-tertiary : Palette.control-alt-quartiary;
-            i-thumb.width: 17px;
-            i-thumb.height: 14px;
-            i-thumb.border-width: root.checked ? 1px : 0;
-            i-thumb.background: root.checked ? Palette.text-on-accent-primary : Palette.text-secondary;
-        }
-        hover when i-touch-area.has-hover : {
-            i-rail.background:  root.checked ? Palette.accent-secondary : Palette.control-alt-tertiary;
-            i-thumb.width: 14px;
-            i-thumb.border-width: root.checked ? 1px : 0;
-            i-thumb.background: root.checked ? Palette.text-on-accent-primary : Palette.text-secondary;
-        }
-        selected when root.checked : {
-            i-rail.background: Palette.accent-default;
-            i-thumb.border-width: 1px;
-            i-thumb.border-color: Palette.circle-border;
-            i-thumb.background: Palette.text-on-accent-primary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/fluent-base/tableview.slint
+++ b/internal/compiler/widgets/fluent-base/tableview.slint
@@ -5,12 +5,21 @@ import { Palette, Typography, Icons } from "styling.slint";
 import { ListView } from "listview.slint";
 
 component TableViewColumn inherits Rectangle {
+    in property <SortOrder> sort-order: SortOrder.unsorted;
+
     callback clicked <=> i-touch-area.clicked;
     callback adjust_size(length);
 
-    in property <SortOrder> sort-order: SortOrder.unsorted;
-
     background: Palette.background;
+
+    states [
+        pressed when i-touch-area.pressed : {
+            background: Palette.control-secondary;
+        }
+        hover when i-touch-area.has-hover : {
+            background: Palette.sub-title-tertiary;
+        }
+    ]
 
     i-touch-area := TouchArea {
         width: parent.width - 11px;
@@ -49,6 +58,14 @@ component TableViewColumn inherits Rectangle {
         x: parent.width - 1px;
         width: 1px;
 
+        states [
+            hover when i-movable-touch-area.has-hover : {
+                background: Palette.control-secondary;
+            }
+        ]
+
+        animate background { duration: 150ms; }
+
         i-movable-touch-area := TouchArea {
             width: 10px;
             mouse-cursor: ew-resize;
@@ -59,24 +76,7 @@ component TableViewColumn inherits Rectangle {
                 }
             }
         }
-
-        animate background { duration: 150ms; }
-
-        states [
-            hover when i-movable-touch-area.has-hover : {
-                background: Palette.control-secondary;
-            }
-        ]
     }
-
-    states [
-        pressed when i-touch-area.pressed : {
-            background: Palette.control-secondary;
-        }
-        hover when i-touch-area.has-hover : {
-            background: Palette.sub-title-tertiary;
-        }
-    ]
 }
 
 component TableViewCell inherits Rectangle {
@@ -93,16 +93,30 @@ component TableViewCell inherits Rectangle {
 }
 
 component TableViewRow inherits Rectangle {
-    callback clicked <=> i-touch-area.clicked;
-    callback pointer-event(PointerEvent /* event */, Point /* absolute mouse position */);
-
-    in property<bool> selected;
+    in property <bool> selected;
     in property <bool> even;
+
+    callback clicked <=> i-touch-area.clicked;
+    callback pointer-event(/* event */ PointerEvent, /* absolute mouse position */ Point);
 
     min-width: i-layout.min-width;
     min-height: max(34px, i-layout.min-height);
     border-radius: 4px;
     background: root.even ? Palette.control-default : transparent;
+
+    states [
+        pressed when i-touch-area.pressed : {
+            root.background: selected ? Palette.subtle-secondary : Palette.subtle-tertiary;
+        }
+        hover when i-touch-area.has-hover : {
+            root.background: selected ? Palette.subtle-tertiary : Palette.subtle-secondary;
+            i-selector.height: root.selected ? 16px : 0;
+        }
+        selected when root.selected : {
+            root.background: Palette.subtle-secondary;
+            i-selector.height: 16px;
+        }
+    ]
 
     i-touch-area := TouchArea {
         pointer-event(pe) => {
@@ -127,37 +141,55 @@ component TableViewRow inherits Rectangle {
 
         animate height { duration: 150ms; easing: ease-out; }
     }
-
-    states [
-        pressed when i-touch-area.pressed : {
-            root.background: selected ? Palette.subtle-secondary : Palette.subtle-tertiary;
-        }
-        hover when i-touch-area.has-hover : {
-            root.background: selected ? Palette.subtle-tertiary : Palette.subtle-secondary;
-            i-selector.height: root.selected ? 16px : 0;
-        }
-        selected when root.selected : {
-            root.background: Palette.subtle-secondary;
-            i-selector.height: 16px;
-        }
-    ]
 }
 
 export component StandardTableView {
-    private property <length> min-header-height: 42px;
-    private property <length> item-height: i-scroll-view.viewport-height / rows.length;
-    private property <length> current-item-y: i-scroll-view.viewport-y + current-row * item-height;
-
-    callback sort-ascending(int /* column-index */);
-    callback sort-descending(int /* column-index */);
-    callback row-pointer-event(int /* row-index */, PointerEvent /* event */, Point /* absolute mouse position */);
-    callback current-row-changed(int /* current-row */);
-
     in property <[[StandardListViewItem]]> rows;
     out property <int> current-sort-column: -1;
     in-out property <[TableColumn]> columns;
     in-out property <int> current-row: -1;
 
+    callback sort-ascending(/* column-index */ int);
+    callback sort-descending(/* column-index */ int);
+    callback row-pointer-event(/* row-index */ int, /* event */ PointerEvent,  /* absolute mouse position */ Point);
+    callback current-row-changed(/* current-row */ int);
+
+    public function set-current-row(index: int) {
+        if (index < 0 || index >= rows.length) {
+            return;
+        }
+
+        current-row = index;
+        current-row-changed(current-row);
+
+        if (current-item-y < 0) {
+            i-scroll-view.viewport-y += 0 - current-item-y;
+        }
+
+        if (current-item-y + item-height > i-scroll-view.visible-height) {
+            i-scroll-view.viewport-y -= current-item-y + item-height - i-scroll-view.visible-height;
+        }
+    }
+
+    private property <length> min-header-height: 42px;
+    private property <length> item-height: i-scroll-view.viewport-height / rows.length;
+    private property <length> current-item-y: i-scroll-view.viewport-y + current-row * item-height;
+
+    function sort(index: int) {
+        if (root.current-sort-column != index) {
+            root.columns[root.current-sort-column].sort-order = SortOrder.unsorted;
+        }
+
+        if(root.columns[index].sort-order == SortOrder.ascending) {
+            root.columns[index].sort-order = SortOrder.descending;
+            root.sort-descending(index);
+        } else {
+            root.columns[index].sort-order = SortOrder.ascending;
+            root.sort-ascending(index);
+        }
+
+        root.current-sort-column = index;
+    }
 
     min-width: 400px;
     min-height: 200px;
@@ -184,6 +216,14 @@ export component StandardTableView {
                     preferred-width: self.min-width;
                     max-width: (index < columns.length && column.width >= 1px) ? max(column.min-width, column.width) : 100000px;
 
+                    clicked => {
+                        root.sort(index);
+                    }
+
+                    adjust-size(diff) => {
+                        column.width = max(1px, self.width + diff);
+                    }
+
                     Text {
                         vertical-alignment: center;
                         text: column.title;
@@ -191,14 +231,6 @@ export component StandardTableView {
                         font-size: Typography.body.font-size;
                         color: Palette.text-secondary;
                         overflow: elide;
-                    }
-
-                    clicked => {
-                        root.sort(index);
-                    }
-
-                    adjust-size(diff) => {
-                        column.width = max(1px, self.width + diff);
                     }
                 }
             }
@@ -208,6 +240,18 @@ export component StandardTableView {
             for row[idx] in root.rows : TableViewRow {
                 selected: idx == root.current-row;
                 even: mod(idx, 2) == 0;
+
+                pointer-event(pe, pos) => {
+                    root.row-pointer-event(idx, pe, {
+                        x: pos.x - root.absolute-position.x,
+                        y: pos.y - root.absolute-position.y,
+                    });
+                }
+
+                clicked => {
+                    root.focus();
+                    root.set-current-row(idx);
+                }
 
                 for cell[index] in row : TableViewCell {
                     private property <bool> has_inner_focus;
@@ -230,18 +274,6 @@ export component StandardTableView {
                         }
                     }
                 }
-
-                pointer-event(pe, pos) => {
-                    root.row-pointer-event(idx, pe, {
-                        x: pos.x - root.absolute-position.x,
-                        y: pos.y - root.absolute-position.y,
-                    });
-                }
-
-                clicked => {
-                    root.focus();
-                    root.set-current-row(idx);
-                }
             }
         }
     }
@@ -259,39 +291,6 @@ export component StandardTableView {
                 return accept;
             }
             reject
-        }
-    }
-
-    function sort(index: int) {
-        if (root.current-sort-column != index) {
-            root.columns[root.current-sort-column].sort-order = SortOrder.unsorted;
-        }
-
-        if(root.columns[index].sort-order == SortOrder.ascending) {
-            root.columns[index].sort-order = SortOrder.descending;
-            root.sort-descending(index);
-        } else {
-            root.columns[index].sort-order = SortOrder.ascending;
-            root.sort-ascending(index);
-        }
-
-        root.current-sort-column = index;
-    }
-
-    public function set-current-row(index: int) {
-        if (index < 0 || index >= rows.length) {
-            return;
-        }
-
-        current-row = index;
-        current-row-changed(current-row);
-
-        if (current-item-y < 0) {
-            i-scroll-view.viewport-y += 0 - current-item-y;
-        }
-
-        if (current-item-y + item-height > i-scroll-view.visible-height) {
-            i-scroll-view.viewport-y -= current-item-y + item-height - i-scroll-view.visible-height;
         }
     }
 }

--- a/internal/compiler/widgets/fluent-base/tabwidget.slint
+++ b/internal/compiler/widgets/fluent-base/tabwidget.slint
@@ -27,9 +27,6 @@ export component TabWidgetImpl inherits Rectangle {
 }
 
 export component TabImpl inherits Rectangle {
-    private property <bool> hide-right-border: root.tab-index == root.num-tabs - 1 || tab-index + 1 == current;
-    private property <bool> is-current: root.tab-index == root.current;
-
     in property <int> current-focused; // The currently focused tab
     in property <int> tab-index; // The index of this tab
     in property <int> num-tabs; // The total number of tabs
@@ -37,6 +34,9 @@ export component TabImpl inherits Rectangle {
     in property <bool> enabled: true;
     out property <bool> has-focus: root.current-focused == root.tab-index;
     in-out property <int> current; // The currently selected tab
+
+    private property <bool> hide-right-border: root.tab-index == root.num-tabs - 1 || tab-index + 1 == current;
+    private property <bool> is-current: root.tab-index == root.current;
 
     min-width: max(160px, i-text.min-width);
     min-height: max(32px, i-text.min-height);
@@ -105,9 +105,9 @@ export component TabImpl inherits Rectangle {
 
 export component TabBarImpl {
     // injected properties:
-    in-out property<int> current; // The currently selected tab
-    in-out property<int> current-focused: i-focus-scope.has-focus ? i-focus-scope.focused-tab : -1; // The currently focused tab
-    in-out property<int> num-tabs; // The total number of tabs
+    in-out property <int> current; // The currently selected tab
+    in-out property <int> current-focused: i-focus-scope.has-focus ? i-focus-scope.focused-tab : -1; // The currently focused tab
+    in-out property <int> num-tabs; // The total number of tabs
 
     HorizontalLayout {
         alignment: start;
@@ -119,7 +119,7 @@ export component TabBarImpl {
     accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current;
 
     i-focus-scope := FocusScope {
-        property<int> focused-tab: 0;
+        property <int> focused-tab: 0;
 
         x: 0;
         width: 0px; // Do not react on clicks

--- a/internal/compiler/widgets/fluent-base/textedit.slint
+++ b/internal/compiler/widgets/fluent-base/textedit.slint
@@ -5,8 +5,6 @@ import { Typography, Palette } from "styling.slint";
 import { ScrollView } from "scrollview.slint";
 
 export component TextEdit {
-    callback edited(string /* text */);
-
     in property <TextWrap> wrap <=> i-text-input.wrap;
     in property <TextHorizontalAlignment> horizontal-alignment <=> i-text-input.horizontal-alignment;
     in property <bool> read-only <=> i-text-input.read-only;
@@ -21,9 +19,45 @@ export component TextEdit {
     in-out property <length> viewport-width <=> i-scroll-view.viewport-width;
     in-out property <length> viewport-height <=> i-scroll-view.viewport-height;
 
+    callback edited(/* text */ string);
+
+    public function select-all() {
+        i-text-input.select-all();
+    }
+
+    public function clear-selection() {
+        i-text-input.clear-selection();
+    }
+
+    public function cut() {
+        i-text-input.cut();
+    }
+
+    public function copy() {
+        i-text-input.copy();
+    }
+
+    public function paste() {
+        i-text-input.paste();
+    }
+
     forward-focus: i-text-input;
     horizontal-stretch: 1;
     vertical-stretch: 1;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.background: Palette.control-disabled;
+            i-background.border-color: Palette.control-stroke;
+            i-text-input.color: Palette.text-disabled;
+            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
+        }
+        focused when root.has-focus : {
+            i-background.background: Palette.control-input-active;
+            i-background.border-color: Palette.control-stroke;
+            i-focus-border.background: Palette.accent-default;
+        }
+    ]
 
     i-background := Rectangle {
         width: 100%;
@@ -78,38 +112,4 @@ export component TextEdit {
             height: 2px;
         }
     }
-
-    public function select-all() {
-        i-text-input.select-all();
-    }
-
-    public function clear-selection() {
-        i-text-input.clear-selection();
-    }
-
-    public function cut() {
-        i-text-input.cut();
-    }
-
-    public function copy() {
-        i-text-input.copy();
-    }
-
-    public function paste() {
-        i-text-input.paste();
-    }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.background: Palette.control-disabled;
-            i-background.border-color: Palette.control-stroke;
-            i-text-input.color: Palette.text-disabled;
-            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
-        }
-        focused when root.has-focus : {
-            i-background.background: Palette.control-input-active;
-            i-background.border-color: Palette.control-stroke;
-            i-focus-border.background: Palette.accent-default;
-        }
-    ]
 }

--- a/internal/compiler/widgets/fluent-dark/color-scheme.slint
+++ b/internal/compiler/widgets/fluent-dark/color-scheme.slint
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 export global ColorSchemeSelector  {
-    in property<bool> dark-color-scheme: true;
+    in property <bool> dark-color-scheme: true;
 }

--- a/internal/compiler/widgets/fluent-light/color-scheme.slint
+++ b/internal/compiler/widgets/fluent-light/color-scheme.slint
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 export global ColorSchemeSelector  {
-    in property<bool> dark-color-scheme: false;
+    in property <bool> dark-color-scheme: false;
 }

--- a/internal/compiler/widgets/fluent/color-scheme.slint
+++ b/internal/compiler/widgets/fluent/color-scheme.slint
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 export global ColorSchemeSelector  {
-    in property<bool> dark-color-scheme: SlintInternal.dark-color-scheme;
+    in property <bool> dark-color-scheme: SlintInternal.dark-color-scheme;
 }

--- a/internal/compiler/widgets/material-base/button.slint
+++ b/internal/compiler/widgets/material-base/button.slint
@@ -6,25 +6,37 @@ import { Typography, Palette, Elevation } from "styling.slint";
 
 // Default button widget with Material Design Filled Button look and feel.
 export component Button {
-    private property <brush> text-color: root.primary ? Palette.on-primary : Palette.on-secondary-container;
-    private property <float> text-opacity: 1.0;
+    in property <string> text;
+    in property <bool> enabled <=> i-state-layer.enabled;
+    in property <bool> checkable;
+    in property <image> icon;
+    in property <bool> primary;
+    out property <bool> has-focus: i-state-layer.has-focus;
+    out property <bool> pressed: self.enabled &&  i-state-layer.pressed;
+    in-out property <bool> checked;
 
     callback clicked;
 
-    in property<string> text;
-    in property<bool> enabled <=> i-state-layer.enabled;
-    in property<bool> checkable;
-    in property<image> icon;
-    in property <bool> primary;
-    out property<bool> has-focus: i-state-layer.has-focus;
-    out property<bool> pressed: self.enabled &&  i-state-layer.pressed;
-    in-out property<bool> checked;
+    private property <brush> text-color: root.primary ? Palette.on-primary : Palette.on-secondary-container;
+    private property <float> text-opacity: 1.0;
 
     min-height: max(40px, i-layout.min-height);
     min-width: max(40px, i-layout.min-width);
     accessible-label: text;
     accessible-role: button;
     forward-focus: i-state-layer;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.background: Palette.on-surface;
+            i-background.opacity: 0.12;
+            root.text-opacity: 0.38;
+            root.text-color: Palette.on-surface;
+        }
+        checked when root.checked: {
+            root.text-color: Palette.on-primary;
+        }
+    ]
 
     i-background := Rectangle {
         width: 100%;
@@ -74,16 +86,4 @@ export component Button {
             animate color { duration: 250ms; easing: ease; }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.background: Palette.on-surface;
-            i-background.opacity: 0.12;
-            root.text-opacity: 0.38;
-            root.text-color: Palette.on-surface;
-        }
-        checked when root.checked: {
-            root.text-color: Palette.on-primary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/material-base/checkbox.slint
+++ b/internal/compiler/widgets/material-base/checkbox.slint
@@ -5,20 +5,67 @@ import { Palette, Typography, Icons } from "styling.slint";
 
 // Selection control that can be toggled between checked und unchecked by click.
 export component CheckBox {
-    callback toggled;
-
     in property <string> text <=> i-text.text;
     in property <bool> enabled: true;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked;
 
+    callback toggled;
+
     min-height: max(32px, i-layout.min-height);
     vertical-stretch: 0;
-
     accessible-label <=> i-text.text;
     accessible-checkable: true;
     accessible-checked <=> root.checked;
     accessible-role: checkbox;
+
+    states [
+        disabled-selected when !root.enabled && root.checked  : {
+            i-container.border-width: 0px;
+            i-container.border-color: transparent;
+            i-container.background: Palette.primary;
+            i-container.opacity: 0.38;
+            i-text.opacity: 0.38;
+            i-text.color: Palette.primary;
+        }
+        disabled when !root.enabled : {
+            i-container.opacity: 0.38;
+            i-text.opacity: 0.38;
+            i-text.color: Palette.primary;
+        }
+        pressed when i-touch-area.pressed && !root.checked : {
+            i-state-layer.opacity: 0.12;
+        }
+        pressed-selected when i-touch-area.pressed && root.checked : {
+            i-state-layer.opacity: 0.12;
+            i-state-layer.background: Palette.on-surface;
+            i-container.border-width: 0px;
+            i-container.border-color: transparent;
+            i-container.background: Palette.primary;
+        }
+        hover-selected when i-touch-area.has-hover && root.checked : {
+            i-state-layer.opacity: 0.08;
+            i-container.border-width: 0px;
+            i-container.border-color: transparent;
+            i-container.background: Palette.primary;
+        }
+        hover when i-touch-area.has-hover && !root.checked : {
+            i-state-layer.background: Palette.on-surface;
+            i-state-layer.opacity: 0.08;
+        }
+        selected when !i-touch-area.has-hover && root.checked : {
+            i-container.border-width: 0px;
+            i-container.border-color: transparent;
+            i-container.background: Palette.primary;
+        }
+        focused-selected when i-focus-scope.has-focus && root.checked : {
+            i-state-layer.opacity: 0.12;
+        }
+        focused when i-focus-scope.has-focus && !root.checked : {
+            i-state-layer.background: Palette.on-surface;
+            i-state-layer.opacity: 0.12;
+        }
+    ]
 
     i-layout := HorizontalLayout {
         spacing: 16px;
@@ -107,52 +154,4 @@ export component CheckBox {
             return reject;
         }
     }
-
-    states [
-        disabled-selected when !root.enabled && root.checked  : {
-            i-container.border-width: 0px;
-            i-container.border-color: transparent;
-            i-container.background: Palette.primary;
-            i-container.opacity: 0.38;
-            i-text.opacity: 0.38;
-            i-text.color: Palette.primary;
-        }
-        disabled when !root.enabled : {
-            i-container.opacity: 0.38;
-            i-text.opacity: 0.38;
-            i-text.color: Palette.primary;
-        }
-        pressed when i-touch-area.pressed && !root.checked : {
-            i-state-layer.opacity: 0.12;
-        }
-        pressed-selected when i-touch-area.pressed && root.checked : {
-            i-state-layer.opacity: 0.12;
-            i-state-layer.background: Palette.on-surface;
-            i-container.border-width: 0px;
-            i-container.border-color: transparent;
-            i-container.background: Palette.primary;
-        }
-        hover-selected when i-touch-area.has-hover && root.checked : {
-            i-state-layer.opacity: 0.08;
-            i-container.border-width: 0px;
-            i-container.border-color: transparent;
-            i-container.background: Palette.primary;
-        }
-        hover when i-touch-area.has-hover && !root.checked : {
-            i-state-layer.background: Palette.on-surface;
-            i-state-layer.opacity: 0.08;
-        }
-        selected when !i-touch-area.has-hover && root.checked : {
-            i-container.border-width: 0px;
-            i-container.border-color: transparent;
-            i-container.background: Palette.primary;
-        }
-        focused-selected when i-focus-scope.has-focus && root.checked : {
-            i-state-layer.opacity: 0.12;
-        }
-        focused when i-focus-scope.has-focus && !root.checked : {
-            i-state-layer.background: Palette.on-surface;
-            i-state-layer.opacity: 0.12;
-        }
-    ]
 }

--- a/internal/compiler/widgets/material-base/combobox.slint
+++ b/internal/compiler/widgets/material-base/combobox.slint
@@ -7,19 +7,34 @@ import { ListItem } from "components.slint";
 import { ComboBoxBase } from "../common/combobox-base.slint";
 
 export component ComboBox {
-    callback selected <=> i-base.selected;
-
     in property <[string]> model <=> i-base.model;
     in property <bool> enabled <=> i-base.enabled;
     out property <bool> has-focus <=> i-base.has-focus;
     in-out property <int> current-index <=> i-base.current-index;
     in-out property <string> current-value <=> i-base.current-value;
 
+    callback selected <=> i-base.selected;
+
     min-width: max(160px, i-layout.min-width);
     min-height: max(22px, i-layout.min-height);
     horizontal-stretch: 1;
     vertical-stretch: 0;
     forward-focus: i-base;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.border-color: Palette.on-surface;
+            i-background.opacity: 0.38;
+            i-label.opacity: 0.38;
+            i-icon.opacity: 0.38;
+        }
+        focused when root.has-focus : {
+            i-background.border-width: 2px;
+            i-background.border-color: Palette.primary;
+            i-label.color: Palette.primary;
+            i-icon.colorize: Palette.primary;
+        }
+    ]
 
     i-base := ComboBoxBase {
         width: 100%;
@@ -86,19 +101,4 @@ export component ComboBox {
             }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.border-color: Palette.on-surface;
-            i-background.opacity: 0.38;
-            i-label.opacity: 0.38;
-            i-icon.opacity: 0.38;
-        }
-        focused when root.has-focus : {
-            i-background.border-width: 2px;
-            i-background.border-color: Palette.primary;
-            i-label.color: Palette.primary;
-            i-icon.colorize: Palette.primary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/material-base/components.slint
+++ b/internal/compiler/widgets/material-base/components.slint
@@ -4,28 +4,28 @@
 import { Palette, Typography } from "styling.slint";
 
 export component Ripple inherits Rectangle {
-    in property<length> ripple-x;
-    in property<length> ripple-y;
-    in property<bool> active;
-    in property<bool> has-effect;
-    in property<brush> ripple-color <=> circle.background;
+    in property <length> ripple-x;
+    in property <length> ripple-y;
+    in property <bool> active;
+    in property <bool> has-effect;
+    in property <brush> ripple-color <=> i-circle.background;
 
-    circle := Rectangle {
+    states [
+        active when root.active && root.has-effect: {
+            i-circle.width: root.width * 2 * 1.4142;
+
+            in  {
+                animate i-circle.width { duration: 2s; easing: ease-out; }
+            }
+        }
+    ]
+
+    i-circle := Rectangle {
         x: root.ripple-x  - self.width / 2;
         y: root.ripple-y  - self.width / 2;
         height: self.width;
         border-radius: self.width  / 2;
     }
-
-    states [
-        active when root.active && root.has-effect: {
-            circle.width: root.width * 2 * 1.4142;
-
-            in  {
-                animate circle.width { duration: 2s; easing: ease-out; }
-            }
-        }
-    ]
 }
 
 // A touch area that also represents a visual state.
@@ -37,9 +37,25 @@ export component StateLayer inherits TouchArea {
     in property <length> border-radius;
     out property <bool> has-focus <=> i-focus-scope.has-focus;
     in-out property <brush> background;
-    in-out property< bool> checked;
+    in-out property < bool> checked;
 
     forward-focus: i-focus-scope;
+
+    states [
+        pressed when root.pressed: {
+            i-ripple.opacity: 0.12;
+        }
+        checked when root.checked: {
+            i-ripple.opacity: 1.0;
+            i-ripple.background: root.selection-background;
+        }
+        hover when root.has-hover: {
+            i-ripple.opacity: 0.08;
+        }
+        focused when root.has-focus: {
+            i-ripple.opacity: 0.12;
+        }
+    ]
 
     i-ripple := Ripple {
         width: 100%;
@@ -71,35 +87,25 @@ export component StateLayer inherits TouchArea {
             return reject;
         }
     }
-
-    states [
-        pressed when root.pressed: {
-            i-ripple.opacity: 0.12;
-        }
-        checked when root.checked: {
-            i-ripple.opacity: 1.0;
-            i-ripple.background: root.selection-background;
-        }
-        hover when root.has-hover: {
-            i-ripple.opacity: 0.08;
-        }
-        focused when root.has-focus: {
-            i-ripple.opacity: 0.12;
-        }
-    ]
 }
 
 // A selectable item that is used by `StandardListView` and  `ComboBox`.
 export component ListItem inherits Rectangle {
-    callback clicked <=> i-state-layer.clicked;
-    callback pointer-event <=> i-state-layer.pointer-event;
-
-    in property<bool> selected;
-    in property<string> text;
+    in property <bool> selected;
+    in property <string> text;
     out property <length> mouse-x <=> i-state-layer.mouse-x;
     out property <length> mouse-y <=> i-state-layer.mouse-y;
 
+    callback clicked <=> i-state-layer.clicked;
+    callback pointer-event <=> i-state-layer.pointer-event;
+
     height: max(48px, i-layout.min-height);
+
+    states [
+        selected when root.selected : {
+            i-state-layer.background: Palette.secondary-container;
+        }
+    ]
 
     i-state-layer := StateLayer {
         checked: root.selected;
@@ -123,10 +129,4 @@ export component ListItem inherits Rectangle {
             font-weight: Typography.label-large.font-weight;
         }
     }
-
-    states [
-        selected when root.selected : {
-            i-state-layer.background: Palette.secondary-container;
-        }
-    ]
 }

--- a/internal/compiler/widgets/material-base/groupbox.slint
+++ b/internal/compiler/widgets/material-base/groupbox.slint
@@ -8,6 +8,14 @@ export component GroupBox {
     in property <string> title <=> i-text.text;
     in property <bool> enabled: true;
 
+    states [
+        disabled when !root.enabled : {
+            i-background.border-color: Palette.on-surface;
+            i-background.opacity: 0.38;
+            i-text.opacity: 0.38;
+        }
+    ]
+
     VerticalLayout {
         spacing: 4px;
 
@@ -37,12 +45,4 @@ export component GroupBox {
             }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.border-color: Palette.on-surface;
-            i-background.opacity: 0.38;
-            i-text.opacity: 0.38;
-        }
-    ]
 }

--- a/internal/compiler/widgets/material-base/lineedit.slint
+++ b/internal/compiler/widgets/material-base/lineedit.slint
@@ -5,9 +5,6 @@ import { Palette, Typography } from "styling.slint";
 
 // Single line text input field with Material Design Outline TextField look and feel.
 export component LineEdit {
-    callback accepted(string /* text */);
-    callback edited(string /* text */);
-
     in property <length> font-size <=> i-text-input.font-size;
     in property <string> placeholder-text <=> i-placeholder.text;
     in property <bool> enabled <=> i-text-input.enabled;
@@ -17,9 +14,42 @@ export component LineEdit {
     out property <bool> has-focus: i-text-input.has-focus;
     in-out property <string> text <=> i-text-input.text;
 
+    callback accepted(/* text */ string);
+    callback edited(/* text */ string);
+
+    public function select-all() {
+        i-text-input.select-all();
+    }
+    public function clear-selection() {
+        i-text-input.clear-selection();
+    }
+    public function cut() {
+        i-text-input.cut();
+    }
+    public function copy() {
+        i-text-input.copy();
+    }
+    public function paste() {
+        i-text-input.paste();
+    }
+
     min-width: max(120px, i-layout.min-width);
     min-height: max(56px, i-layout.min-height);
     forward-focus: i-text-input;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.border-color: Palette.on-surface;
+            i-background.opacity: 0.38;
+            i-text-input.opacity: 0.38;
+            i-placeholder.opacity: 0.38;
+        }
+        focused when root.has-focus : {
+            i-background.border-width: 2px;
+            i-background.border-color: Palette.primary;
+            i-text-input.color: Palette.primary;
+        }
+    ]
 
     i-background := Rectangle {
         width: 100%;
@@ -63,6 +93,7 @@ export component LineEdit {
                 vertical-alignment: center;
                 font-size: Typography.body-large.font-size;
                 font-weight: Typography.body-large.font-weight;
+                selection-foreground-color: Palette.primary;
 
                 accepted => {
                     root.accepted(self.text);
@@ -82,34 +113,4 @@ export component LineEdit {
             }
         }
     }
-
-    public function select-all() {
-        i-text-input.select-all();
-    }
-    public function clear-selection() {
-        i-text-input.clear-selection();
-    }
-    public function cut() {
-        i-text-input.cut();
-    }
-    public function copy() {
-        i-text-input.copy();
-    }
-    public function paste() {
-        i-text-input.paste();
-    }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.border-color: Palette.on-surface;
-            i-background.opacity: 0.38;
-            i-text-input.opacity: 0.38;
-            i-placeholder.opacity: 0.38;
-        }
-        focused when root.has-focus : {
-            i-background.border-width: 2px;
-            i-background.border-color: Palette.primary;
-            i-text-input.color: Palette.primary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/material-base/scrollview.slint
+++ b/internal/compiler/widgets/material-base/scrollview.slint
@@ -6,11 +6,24 @@ import { Palette } from "styling.slint";
 
 component ScrollBar inherits Rectangle {
     in-out property <bool> horizontal;
-    in-out property<length> maximum;
-    in-out property<length> page-size;
+    in-out property <length> maximum;
+    in-out property <length> page-size;
     // this is always negative and bigger than  -maximum
-    in-out property<length> value;
-    in-out property<bool> enabled <=> i-touch-area.enabled;
+    in-out property <length> value;
+    in-out property <bool> enabled <=> i-touch-area.enabled;
+
+    states [
+        disabled when !i-touch-area.enabled : {
+            i-background.border-color: Palette.on-surface;
+            i-handle.opacity: 0.12;
+        }
+        hover when i-touch-area.has-hover : {
+            i-state-layer.opacity: 0.08;
+        }
+        pressed when i-touch-area.has-hover : {
+            i-state-layer.opacity: 0.12;
+        }
+    ]
 
     i-state-layer := Rectangle {
         width: 100%;
@@ -70,31 +83,18 @@ component ScrollBar inherits Rectangle {
             reject
         }
     }
-
-    states [
-        disabled when !i-touch-area.enabled : {
-            i-background.border-color: Palette.on-surface;
-            i-handle.opacity: 0.12;
-        }
-        hover when i-touch-area.has-hover : {
-            i-state-layer.opacity: 0.08;
-        }
-        pressed when i-touch-area.has-hover : {
-            i-state-layer.opacity: 0.12;
-        }
-    ]
 }
 
 // Scrollview contains a viewport that is bigger than the view and can be scrolled.
 export component ScrollView {
+    in property <bool> enabled: true;
+    out property <length> visible-width <=> i-flickable.width;
+    out property <length> visible-height <=> i-flickable.height;
+    in-out property <bool> has-focus;
     in-out property <length> viewport-width <=> i-flickable.viewport-width;
     in-out property <length> viewport-height <=> i-flickable.viewport-height;
     in-out property <length> viewport-x <=> i-flickable.viewport-x;
     in-out property <length> viewport-y <=> i-flickable.viewport-y;
-    out property <length> visible-width <=> i-flickable.width;
-    out property <length> visible-height <=> i-flickable.height;
-    in property <bool> enabled: true;
-    in-out property <bool> has-focus;
 
     min-height: 50px;
     min-width: 50px;

--- a/internal/compiler/widgets/material-base/slider.slint
+++ b/internal/compiler/widgets/material-base/slider.slint
@@ -6,24 +6,41 @@ import { Palette, Elevation } from "styling.slint";
 
 // Allows to select a value from a range of values.
 export component Slider {
-    callback changed(float /* value */);
-
     in property <Orientation> orientation: horizontal;
-    private property<bool> vertical: orientation == Orientation.vertical;
+    private property <bool> vertical: orientation == Orientation.vertical;
     in property <float> maximum: 100;
     in property <bool> enabled <=> i-touch-area.enabled;
     in property <float> minimum: 0;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <float> value;
 
+    callback changed(/* value */ float);
+
     min-width: vertical ? 20px : 0px;
     min-height: vertical ? 0px : 20px;
-
     accessible-role: slider;
     accessible-value: root.value;
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
+
+    states [
+        disabled when !root.enabled : {
+            i-handle.background: Palette.on-surface;
+            i-handle.drop-shadow-blur: Elevation.level0;
+            i-track.background: Palette.on-surface;
+            i-background.background: Palette.on-surface;
+            root.opacity: 0.38;
+        }
+        pressed when (i-touch-area.pressed && i-touch-area.i-handle-hover) || i-focus-scope.has-focus : {
+            i-state-layer.opacity: 0.12;
+            i-handle.drop-shadow-blur: Elevation.level0;
+        }
+        hover when i-touch-area.i-handle-hover : {
+            i-state-layer.background: Palette.on-surface;
+            i-state-layer.opacity: 0.08;
+        }
+    ]
 
     i-background := Rectangle {
         background: Palette.surface-variant;
@@ -119,22 +136,4 @@ export component Slider {
             }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-handle.background: Palette.on-surface;
-            i-handle.drop-shadow-blur: Elevation.level0;
-            i-track.background: Palette.on-surface;
-            i-background.background: Palette.on-surface;
-            root.opacity: 0.38;
-        }
-        pressed when (i-touch-area.pressed && i-touch-area.i-handle-hover) || i-focus-scope.has-focus : {
-            i-state-layer.opacity: 0.12;
-            i-handle.drop-shadow-blur: Elevation.level0;
-        }
-        hover when i-touch-area.i-handle-hover : {
-            i-state-layer.background: Palette.on-surface;
-            i-state-layer.opacity: 0.08;
-        }
-    ]
 }

--- a/internal/compiler/widgets/material-base/spinbox.slint
+++ b/internal/compiler/widgets/material-base/spinbox.slint
@@ -5,14 +5,29 @@ import { Palette, Typography, Icons } from "styling.slint";
 import { SpinBoxBase } from "../common/spinbox-base.slint";
 
 component SpinBoxButton inherits Rectangle {
-    callback clicked <=> i-touch-area.clicked;
-
     in-out property <bool> pressed: self.enabled && i-touch-area.pressed;
     in-out property <bool> enabled <=> i-touch-area.enabled;
     in-out property <float> icon-opacity: 1;
     in-out property <brush> icon-fill: Palette.on-primary;
 
+    callback clicked <=> i-touch-area.clicked;
+
     width: root.height;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.background: Palette.on-surface;
+            i-background.opacity: 0.12;
+            icon-opacity: 0.38;
+            icon-fill: Palette.on-surface;
+        }
+        pressed when i-touch-area.pressed : {
+            i-state-layer.opacity: 0.12;
+        }
+        hover when i-touch-area.has-hover : {
+            i-state-layer.opacity: 0.08;
+        }
+    ]
 
     i-background := Rectangle {
         width: 100%;
@@ -41,32 +56,17 @@ component SpinBoxButton inherits Rectangle {
     }
 
     i-touch-area := TouchArea { }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.background: Palette.on-surface;
-            i-background.opacity: 0.12;
-            icon-opacity: 0.38;
-            icon-fill: Palette.on-surface;
-        }
-        pressed when i-touch-area.pressed : {
-            i-state-layer.opacity: 0.12;
-        }
-        hover when i-touch-area.has-hover : {
-            i-state-layer.opacity: 0.08;
-        }
-    ]
 }
 
 // Increment and decrement a value in the given range.
 export component SpinBox {
-    callback edited(int /* value */);
-
     in property <int> minimum <=> i-base.minimum;
     in property <int> maximum <=> i-base.maximum;
     in property <bool> enabled <=> i-base.enabled;
     out property <bool> has-focus <=> i-text-input.has-focus;
     in-out property <int> value <=> i-base.value;
+
+    callback edited(/* value */ int);
 
     forward-focus: i-text-input;
     horizontal-stretch: 1;
@@ -78,6 +78,19 @@ export component SpinBox {
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
+
+    states [
+        disabled when !root.enabled : {
+            i-background.border-color: Palette.on-surface;
+            i-background.opacity: 0.38;
+            i-text-input.opacity: 0.38;
+        }
+        focused when root.has-focus : {
+            i-background.border-width: 2px;
+            i-background.border-color: Palette.primary;
+            i-text-input.color: Palette.primary;
+        }
+    ]
 
     i-base := SpinBoxBase {
         width: 100%;
@@ -182,17 +195,4 @@ export component SpinBox {
             }
         }
     }
-
-    states [
-        disabled when !root.enabled : {
-            i-background.border-color: Palette.on-surface;
-            i-background.opacity: 0.38;
-            i-text-input.opacity: 0.38;
-        }
-        focused when root.has-focus : {
-            i-background.border-width: 2px;
-            i-background.border-color: Palette.primary;
-            i-text-input.color: Palette.primary;
-        }
-    ]
 }

--- a/internal/compiler/widgets/material-base/styling.slint
+++ b/internal/compiler/widgets/material-base/styling.slint
@@ -40,8 +40,6 @@ export global Elevation {
 }
 
 export global Palette {
-    in-out property<bool> dark-color-scheme: ColorSchemeSelector.dark-color-scheme;
-
     out property <brush> background: !root.dark-color-scheme ? #f8f3f9 : #2a282d;
     out property <brush> surface: !root.dark-color-scheme ? #FFFBFE : #1C1B1F;
     out property <brush> surface-variant: !root.dark-color-scheme ? #E7E0EC.darker(0.2) : #49454F;
@@ -58,6 +56,7 @@ export global Palette {
     out property <brush> secondary-container:  !root.dark-color-scheme ? #E8DEF8 : #4A4458;
     out property <brush> on-secondary-container:  !root.dark-color-scheme ? #1E192B : #E8DEF8;
     out property <brush> secondary-ripple: !root.dark-color-scheme ? #fffc : #000000;
+    in-out property <bool> dark-color-scheme: ColorSchemeSelector.dark-color-scheme;
 }
 
 export global Icons {

--- a/internal/compiler/widgets/material-base/switch.slint
+++ b/internal/compiler/widgets/material-base/switch.slint
@@ -4,22 +4,94 @@
 import { Palette, Typography } from "styling.slint";
 
 export component Switch {
-    callback toggled;
-
     in property <string> text <=> i-label.text;
-    in property<bool> enabled: true;
+    in property <bool> enabled: true;
     out property <bool> has-focus: i-focus-scope.has-focus;
     in-out property <bool> checked;
+
+    callback toggled;
+
+    function toggle-checked() {
+        if(!root.enabled) {
+            return;
+        }
+
+        root.checked = !root.checked;
+        root.toggled();
+    }
 
     min-height: max(32px, i-layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 0;
     forward-focus: i-focus-scope;
-
     accessible-label <=> i-label.text;
     accessible-checkable: true;
     accessible-checked <=> root.checked;
     accessible-role: checkbox;
+
+    states [
+        disabled-selected when !root.enabled && root.checked  : {
+            i-label.opacity: 0.38;
+            i-label.color: Palette.primary;
+            track.opacity: 0.12;
+            i-handle.opacity: 0.38;
+            i-handle.width: 24px;
+            i-handle.x: track.width - 28px - 4px;
+        }
+        disabled when !root.enabled : {
+            i-label.opacity: 0.38;
+            i-label.color: Palette.primary;
+            track.opacity: 0.12;
+            i-handle.opacity: 0.38;
+        }
+        pressed when i-touch-area.pressed && !root.checked : {
+            state-layer.opacity: 0.12;
+            i-handle.background: Palette.on-surface-variant;
+            i-handle.width: 28px;
+            i-handle.x: track.border-width;
+        }
+        pressed-selected when i-touch-area.pressed && root.checked : {
+            state-layer.opacity: 0.12;
+            state-layer.background: Palette.on-surface;
+            track.background: Palette.primary;
+            track.border-color: Palette.primary;
+            i-handle.background: Palette.primary-container;
+            i-handle.width: 28px;
+            i-handle.x: track.width - 28px - 4px;
+        }
+        hover-selected when i-touch-area.has-hover && root.checked : {
+            state-layer.opacity: 0.08;
+            track.background: Palette.primary;
+            track.border-color: Palette.primary;
+            i-handle.background: Palette.primary-container;
+            i-handle.width: 24px;
+            i-handle.x: track.width - 24px - 4px;
+        }
+        hover when i-touch-area.has-hover && !root.checked : {
+            state-layer.background: Palette.on-surface;
+            state-layer.opacity: 0.08;
+            i-handle.background: Palette.on-surface-variant;
+        }
+        selected when !i-touch-area.has-hover && root.checked : {
+            track.background: Palette.primary;
+            track.border-color: Palette.primary;
+            i-handle.background: Palette.primary-container;
+            i-handle.width: 24px;
+            i-handle.x: track.width - 24px - 4px;
+        }
+        focused-selected when i-focus-scope.has-focus && root.checked : {
+            state-layer.opacity: 0.12;
+            track.background: Palette.primary;
+            track.border-color: Palette.primary;
+            i-handle.background: Palette.primary-container;
+            i-handle.width: 24px;
+            i-handle.x: track.width - 24px - 4px;
+        }
+        focused when i-focus-scope.has-focus && !root.checked : {
+            state-layer.background: Palette.on-surface;
+            state-layer.opacity: 0.12;
+        }
+    ]
 
     i-layout := VerticalLayout {
         alignment: center;
@@ -96,77 +168,4 @@ export component Switch {
             return reject;
         }
     }
-
-    function toggle-checked() {
-        if(!root.enabled) {
-            return;
-        }
-
-        root.checked = !root.checked;
-        root.toggled();
-    }
-
-    states [
-        disabled-selected when !root.enabled && root.checked  : {
-            i-label.opacity: 0.38;
-            i-label.color: Palette.primary;
-            track.opacity: 0.12;
-            i-handle.opacity: 0.38;
-            i-handle.width: 24px;
-            i-handle.x: track.width - 28px - 4px;
-        }
-        disabled when !root.enabled : {
-            i-label.opacity: 0.38;
-            i-label.color: Palette.primary;
-            track.opacity: 0.12;
-            i-handle.opacity: 0.38;
-        }
-        pressed when i-touch-area.pressed && !root.checked : {
-            state-layer.opacity: 0.12;
-            i-handle.background: Palette.on-surface-variant;
-            i-handle.width: 28px;
-            i-handle.x: track.border-width;
-        }
-        pressed-selected when i-touch-area.pressed && root.checked : {
-            state-layer.opacity: 0.12;
-            state-layer.background: Palette.on-surface;
-            track.background: Palette.primary;
-            track.border-color: Palette.primary;
-            i-handle.background: Palette.primary-container;
-            i-handle.width: 28px;
-            i-handle.x: track.width - 28px - 4px;
-        }
-        hover-selected when i-touch-area.has-hover && root.checked : {
-            state-layer.opacity: 0.08;
-            track.background: Palette.primary;
-            track.border-color: Palette.primary;
-            i-handle.background: Palette.primary-container;
-            i-handle.width: 24px;
-            i-handle.x: track.width - 24px - 4px;
-        }
-        hover when i-touch-area.has-hover && !root.checked : {
-            state-layer.background: Palette.on-surface;
-            state-layer.opacity: 0.08;
-            i-handle.background: Palette.on-surface-variant;
-        }
-        selected when !i-touch-area.has-hover && root.checked : {
-            track.background: Palette.primary;
-            track.border-color: Palette.primary;
-            i-handle.background: Palette.primary-container;
-            i-handle.width: 24px;
-            i-handle.x: track.width - 24px - 4px;
-        }
-        focused-selected when i-focus-scope.has-focus && root.checked : {
-            state-layer.opacity: 0.12;
-            track.background: Palette.primary;
-            track.border-color: Palette.primary;
-            i-handle.background: Palette.primary-container;
-            i-handle.width: 24px;
-            i-handle.x: track.width - 24px - 4px;
-        }
-        focused when i-focus-scope.has-focus && !root.checked : {
-            state-layer.background: Palette.on-surface;
-            state-layer.opacity: 0.12;
-        }
-    ]
 }

--- a/internal/compiler/widgets/material-base/tableview.slint
+++ b/internal/compiler/widgets/material-base/tableview.slint
@@ -7,10 +7,10 @@ import { StateLayer } from "components.slint";
 import { Palette, Icons } from "styling.slint";
 
 component TableViewColumn inherits Rectangle {
-    callback clicked <=> i-state-layer.clicked;
-    callback adjust_size(length);
-
     in property <SortOrder> sort-order: SortOrder.unsorted;
+
+    callback clicked <=> i-state-layer.clicked;
+    callback adjust-size(/* size */ length);
 
     i-state-layer := StateLayer {
         background: Palette.primary;
@@ -53,6 +53,8 @@ component TableViewColumn inherits Rectangle {
         width: 1px;
         background: i-movable-touch-area.has-hover ? Palette.outline : transparent;
 
+        animate background { duration: 250ms; }
+
         i-movable-touch-area := TouchArea {
             width: 10px;
 
@@ -63,8 +65,6 @@ component TableViewColumn inherits Rectangle {
             }
             mouse-cursor: ew-resize;
         }
-
-        animate background { duration: 250ms; }
     }
 }
 
@@ -90,14 +90,20 @@ component TableViewCell inherits Rectangle {
 }
 
 component TableViewRow inherits Rectangle {
+    in property <bool> selected;
+    out property <length> mouse-x <=> i-state-layer.mouse-x;
+    out property <length> mouse-y <=> i-state-layer.mouse-y;
+
     callback clicked <=> i-state-layer.clicked;
     callback pointer-event <=> i-state-layer.pointer-event;
 
-    in property<bool> selected;
-    out property<length> mouse-x <=> i-state-layer.mouse-x;
-    out property<length> mouse-y <=> i-state-layer.mouse-y;
-
     min-height: max(42px, i-layout.min-height);
+
+    states [
+        selected when root.selected : {
+            i-state-layer.background: Palette.secondary-container;
+        }
+    ]
 
     i-state-layer := StateLayer {
         checked: root.selected;
@@ -110,12 +116,6 @@ component TableViewRow inherits Rectangle {
     i-layout := HorizontalLayout {
        @children
     }
-
-    states [
-        selected when root.selected : {
-            i-state-layer.background: Palette.secondary-container;
-        }
-    ]
 }
 
 export component StandardTableView {
@@ -123,15 +123,48 @@ export component StandardTableView {
     private property <length> current-item-y: i-scroll-view.viewport-y + current-row * item-height;
     private property <length> min-header-height: 42px;
 
-    callback sort-ascending(int /* column-index */);
-    callback sort-descending(int /* column-index */);
-    callback row-pointer-event(int /* row-index */, PointerEvent /* event */, Point /* absolute mouse position */);
-    callback current-row-changed(int /* current-row */);
-
     in property <[[StandardListViewItem]]> rows;
     out property <int> current-sort-column: -1;
     in-out property <[TableColumn]> columns;
-    in-out property<int> current-row: -1;
+    in-out property <int> current-row: -1;
+
+    callback sort-ascending(/* column-index */ int);
+    callback sort-descending(/* column-index */ int);
+    callback row-pointer-event(/* row-index */ int, /* event */ PointerEvent,  /* absolute mouse position */ Point);
+    callback current-row-changed(/* current-row */ int);
+
+    public function set-current-row(index: int) {
+        if(index < 0 || index >= rows.length) {
+            return;
+        }
+
+        current-row = index;
+        current-row-changed(current-row);
+
+        if(current-item-y < 0) {
+            i-scroll-view.viewport-y += 0 - current-item-y;
+        }
+
+        if(current-item-y + item-height > i-scroll-view.visible-height) {
+            i-scroll-view.viewport-y -= current-item-y + item-height - i-scroll-view.visible-height;
+        }
+    }
+
+    function sort(index: int) {
+        if (root.current-sort-column != index) {
+            root.columns[root.current-sort-column].sort-order = SortOrder.unsorted;
+        }
+
+        if(root.columns[index].sort-order == SortOrder.ascending) {
+            root.columns[index].sort-order = SortOrder.descending;
+            root.sort-descending(index);
+        } else {
+            root.columns[index].sort-order = SortOrder.ascending;
+            root.sort-ascending(index);
+        }
+
+        root.current-sort-column = index;
+    }
 
     min-width: 400px;
     min-height: 200px;
@@ -184,8 +217,21 @@ export component StandardTableView {
                 for row[idx] in root.rows : TableViewRow {
                     selected: idx == root.current-row;
 
+                    clicked => {
+                        root.focus();
+                        root.set-current-row(idx);
+                    }
+
+                    pointer-event(pe) => {
+                        root.row-pointer-event(idx, pe, {
+                            x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
+                            y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
+                        });
+                    }
+
                     for cell[index] in row : TableViewCell {
                         private property <bool> has_inner_focus;
+
                         horizontal-stretch: root.columns[index].horizontal-stretch;
                         min-width: max(columns[index].min-width, columns[index].width);
                         preferred-width: self.min-width;
@@ -200,18 +246,6 @@ export component StandardTableView {
                                 text: cell.text;
                             }
                         }
-                    }
-
-                    clicked => {
-                        root.focus();
-                        root.set-current-row(idx);
-                    }
-
-                    pointer-event(pe) => {
-                        root.row-pointer-event(idx, pe, {
-                            x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
-                            y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
-                        });
                     }
                 }
             }
@@ -232,39 +266,6 @@ export component StandardTableView {
             }
 
             reject
-        }
-    }
-
-    function sort(index: int) {
-        if (root.current-sort-column != index) {
-            root.columns[root.current-sort-column].sort-order = SortOrder.unsorted;
-        }
-
-        if(root.columns[index].sort-order == SortOrder.ascending) {
-            root.columns[index].sort-order = SortOrder.descending;
-            root.sort-descending(index);
-        } else {
-            root.columns[index].sort-order = SortOrder.ascending;
-            root.sort-ascending(index);
-        }
-
-        root.current-sort-column = index;
-    }
-
-    public function set-current-row(index: int) {
-        if(index < 0 || index >= rows.length) {
-            return;
-        }
-
-        current-row = index;
-        current-row-changed(current-row);
-
-        if(current-item-y < 0) {
-            i-scroll-view.viewport-y += 0 - current-item-y;
-        }
-
-        if(current-item-y + item-height > i-scroll-view.visible-height) {
-            i-scroll-view.viewport-y -= current-item-y + item-height - i-scroll-view.visible-height;
         }
     }
 }

--- a/internal/compiler/widgets/material-base/tabwidget.slint
+++ b/internal/compiler/widgets/material-base/tabwidget.slint
@@ -27,15 +27,15 @@ export component TabWidgetImpl inherits Rectangle {
 }
 
 export component TabImpl inherits Rectangle {
-    private property<bool> has-focus: root.current-focused == root.tab-index;
-    private property<bool> active: root.tab-index == root.current;
+    in property <int> current-focused; // The currently focused tab
+    in property <int> tab-index; // The index of this tab
+    in property <int> num-tabs; // The total number of tabs
+    in property <string> title <=> i-text.text;
+    in property <bool> enabled: true;
+    in-out property <int> current; // The currently selected tab
 
-    in property<int> current-focused; // The currently focused tab
-    in property<int> tab-index; // The index of this tab
-    in property<int> num-tabs; // The total number of tabs
-    in property<string> title <=> i-text.text;
-    in property<bool> enabled: true;
-    in-out property<int> current; // The currently selected tab
+    private property <bool> has-focus: root.current-focused == root.tab-index;
+    private property <bool> active: root.tab-index == root.current;
 
     height: 48px;
     accessible-role: tab;
@@ -92,9 +92,9 @@ export component TabImpl inherits Rectangle {
 
 export component TabBarImpl {
     // injected properties:
-    in-out property<int> current; // The currently selected tab
-    in-out property<int> current-focused: i-focus-scope.has-focus ? i-focus-scope.focused-tab : -1; // The currently focused tab
-    in-out property<int> num-tabs; // The total number of tabs
+    in-out property <int> current; // The currently selected tab
+    in-out property <int> current-focused: i-focus-scope.has-focus ? i-focus-scope.focused-tab : -1; // The currently focused tab
+    in-out property <int> num-tabs; // The total number of tabs
 
     accessible-role: tab;
     accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current;
@@ -106,7 +106,7 @@ export component TabBarImpl {
     }
 
     i-focus-scope := FocusScope {
-        property<int> focused-tab: 0;
+        property <int> focused-tab: 0;
 
         x: 0;
         width: 0; // Do not react on clicks

--- a/internal/compiler/widgets/material-dark/color-scheme.slint
+++ b/internal/compiler/widgets/material-dark/color-scheme.slint
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 export global ColorSchemeSelector  {
-    in property<bool> dark-color-scheme: true;
+    in property <bool> dark-color-scheme: true;
 }

--- a/internal/compiler/widgets/material-light/color-scheme.slint
+++ b/internal/compiler/widgets/material-light/color-scheme.slint
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 export global ColorSchemeSelector  {
-    in property<bool> dark-color-scheme: false;
+    in property <bool> dark-color-scheme: false;
 }

--- a/internal/compiler/widgets/material/color-scheme.slint
+++ b/internal/compiler/widgets/material/color-scheme.slint
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 export global ColorSchemeSelector  {
-    in property<bool> dark-color-scheme: SlintInternal.dark-color-scheme;
+    in property <bool> dark-color-scheme: SlintInternal.dark-color-scheme;
 }

--- a/internal/compiler/widgets/qt/button.slint
+++ b/internal/compiler/widgets/qt/button.slint
@@ -1,0 +1,46 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component Button {
+    in property <string> text <=> native.text;
+    in property <image> icon <=> native.icon;
+    in property <bool> enabled <=> native.enabled;
+    in property <bool> checkable <=> native.checkable;
+    in property <bool> primary <=> native.primary;
+    out property <bool> has-focus <=> native.has-focus;
+    out property <bool> pressed <=> native.pressed;
+    in-out property <bool> checked <=> native.checked;
+
+    callback clicked <=> native.clicked;
+
+    accessible-checkable: root.checkable;
+    accessible-checked: root.checked;
+    accessible-label: root.text;
+    accessible-role: button;
+
+    HorizontalLayout {
+        native := NativeButton {
+            checkable: false;
+            enabled: true;
+        }
+    }
+}
+
+export component StandardButton {
+    in property <StandardButtonKind> kind <=> native.standard-button-kind;
+    in property <bool> enabled <=> native.enabled;
+    out property <bool> has-focus <=> native.has-focus;
+    out property <bool> pressed <=> native.pressed;
+
+    callback clicked <=> native.clicked;
+
+    accessible-label: native.text;
+    accessible-role: button;
+
+    HorizontalLayout {
+        native := NativeButton {
+            is-standard-button: true;
+            checkable: false;
+        }
+    }
+}

--- a/internal/compiler/widgets/qt/checkbox.slint
+++ b/internal/compiler/widgets/qt/checkbox.slint
@@ -1,0 +1,9 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component CheckBox inherits NativeCheckBox {
+    accessible-checkable: true;
+    accessible-checked <=> root.checked;
+    accessible-label <=> root.text;
+    accessible-role: checkbox;
+}

--- a/internal/compiler/widgets/qt/combobox.slint
+++ b/internal/compiler/widgets/qt/combobox.slint
@@ -1,0 +1,56 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+import { ComboBoxBase } from "../common/combobox-base.slint";
+
+export component ComboBox inherits NativeComboBox {
+    in property <[string]> model <=> i-base.model;
+    in-out property <int> current-index <=> i-base.current-index;
+    out property has-focus <=> i-base.has-focus;
+
+    callback selected <=> i-base.selected;
+
+    enabled: true;
+    accessible-role: combobox;
+    accessible-value <=> root.current-value;
+    current-value: root.model[root.current-index];
+    forward-focus: i-base;
+
+    i-base := ComboBoxBase {
+        width: 100%;
+        height: 100%;
+        current-value <=> root.current-value;
+
+        show-popup => {
+            i-popup.show();
+        }
+    }
+
+    i-popup := PopupWindow {
+        x: 0;
+        y: root.height;
+        width: root.width;
+
+        NativeComboBoxPopup {
+            width: 100%;
+            height: 100%;
+        }
+
+        VerticalLayout {
+            spacing: 0px;
+
+            for value[index] in root.model: NativeStandardListViewItem {
+                item: { text: value };
+                is-selected: root.current-index == index;
+                has-hover: ta.has-hover;
+                combobox: true;
+
+                ta := TouchArea {
+                    clicked => {
+                        i-base.select(index);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/internal/compiler/widgets/qt/groupbox.slint
+++ b/internal/compiler/widgets/qt/groupbox.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component GroupBox {
+    in property title <=> native.title;
+    in property enabled <=> native.enabled;
+
+    native := NativeGroupBox {
+        GridLayout {
+            padding-left: native.native-padding-left;
+            padding-right: native.native-padding-right;
+            padding-top: native.native-padding-top;
+            padding-bottom: native.native-padding-bottom;
+
+            @children
+        }
+    }
+}

--- a/internal/compiler/widgets/qt/layouts.slint
+++ b/internal/compiler/widgets/qt/layouts.slint
@@ -1,0 +1,17 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component VerticalBox inherits VerticalLayout {
+    spacing: NativeStyleMetrics.layout-spacing;
+    padding: NativeStyleMetrics.layout-spacing;
+}
+
+export component HorizontalBox inherits HorizontalLayout {
+    spacing: NativeStyleMetrics.layout-spacing;
+    padding: NativeStyleMetrics.layout-spacing;
+}
+
+export component GridBox inherits GridLayout {
+    spacing: NativeStyleMetrics.layout-spacing;
+    padding: NativeStyleMetrics.layout-spacing;
+}

--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -1,0 +1,64 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+import { LineEditInner } from "../common/common.slint";
+import { StyleMetrics  } from "std-widgets-impl.slint";
+
+export component LineEdit {
+    in property <length> font-size <=> inner.font-size;
+    in property <string> placeholder-text <=> inner.placeholder-text;
+    in property input-type <=> inner.input-type;
+    in property horizontal-alignment <=> inner.horizontal-alignment;
+    in property read-only <=> inner.read-only;
+    in property <bool> enabled: true;
+    out property <bool> has-focus <=> inner.has-focus;
+    in-out property <string> text <=> inner.text;
+
+    callback accepted <=> inner.accepted;
+    callback edited <=> inner.edited;
+
+    public function select-all() {
+        inner.select-all();
+    }
+
+    public function clear-selection() {
+        inner.clear-selection();
+    }
+
+    public function cut() {
+        inner.cut();
+    }
+
+    public function copy() {
+        inner.copy();
+    }
+
+    public function paste() {
+        inner.paste();
+    }
+
+    forward-focus: inner;
+    horizontal-stretch: 1;
+    vertical-stretch: 0;
+    min-width: max(160px, layout.min-height);
+    min-height: max(32px, layout.min-height);
+
+    native := NativeLineEdit {
+        has-focus <=> root.has-focus;
+        enabled: root.enabled;
+        width: 100%;
+        height: 100%;
+    }
+
+    layout := HorizontalLayout {
+        padding-left: native.native-padding-left;
+        padding-right: native.native-padding-right;
+        padding-top: native.native-padding-top;
+        padding-bottom: native.native-padding-bottom;
+
+        inner := LineEditInner {
+            placeholder-color: self.enabled ? StyleMetrics.placeholder-color : StyleMetrics.placeholder-color-disabled;
+            enabled: root.enabled;
+        }
+    }
+}

--- a/internal/compiler/widgets/qt/listview.slint
+++ b/internal/compiler/widgets/qt/listview.slint
@@ -1,11 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+import { ScrollView  } from "std-widgets-impl.slint";
 
-import { ScrollView } from "scrollview.slint";
-import { ListItem } from "components.slint";
-
-// `ListView` is like a `Scrollview` but it should have a `for` element, and the content is automatically laid out in a list.
 export component ListView inherits ScrollView {
     @children
 }
@@ -22,8 +19,8 @@ component StandardListViewBase inherits ListView {
             return;
         }
 
-        current-item = index;
-        current-item-changed(current-item);
+        root.current-item = index;
+        root.current-item-changed(current-item);
 
         if(current-item-y < 0) {
             self.viewport-y += 0 - current-item-y;
@@ -37,29 +34,29 @@ component StandardListViewBase inherits ListView {
     private property <length> item-height: self.viewport-height / self.model.length;
     private property <length> current-item-y: self.viewport-y + current-item * item-height;
 
-    for item[idx] in root.model : ListItem {
-        selected: idx == root.current-item;
-        text: item.text;
+    for item[i] in root.model : NativeStandardListViewItem {
+        item: item;
+        index: i;
+        is-selected: root.current-item == i;
+        has-hover: i-touch-area.has-hover;
 
-        clicked => {
-            set-current-item(idx);
-        }
+        i-touch-area := TouchArea {
+            clicked => {
+                set-current-item(i);
+            }
 
-        pointer-event(pe) => {
-            root.item-pointer-event(idx, pe, {
-                x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
-                y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
-            });
+            pointer-event(pe) => {
+                root.item-pointer-event(i, pe, {
+                    x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
+                    y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
+                });
+            }
         }
     }
 }
 
-// Like `ListView`, but with a default delegate, and a `model` property which is a model of type `StandardListViewItem`.
 export component StandardListView inherits StandardListViewBase {
     FocusScope {
-        x: 0;
-        width: 0;  // Do not react on clicks
-
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
                 root.set-current-item(root.current-item - 1);

--- a/internal/compiler/widgets/qt/progressindicator.slint
+++ b/internal/compiler/widgets/qt/progressindicator.slint
@@ -1,6 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-export global ColorSchemeSelector  {
-    in property <bool> dark-color-scheme: false;
-}
+export component ProgressIndicator inherits NativeProgressIndicator {}

--- a/internal/compiler/widgets/qt/scrollview.slint
+++ b/internal/compiler/widgets/qt/scrollview.slint
@@ -1,0 +1,26 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+import { InternalScrollView } from "internal-scrollview.slint";
+
+export component ScrollView {
+    in property <bool> enabled <=> internal.enabled;
+    out property <length> visible-width <=> internal.visible-width;
+    out property <length> visible-height <=> internal.visible-height;
+    in-out property <bool> has-focus <=> internal.has-focus;
+    in-out property <length> viewport-width <=> internal.viewport-width;
+    in-out property <length> viewport-height <=> internal.viewport-height;
+    in-out property <length> viewport-x <=> internal.viewport-x;
+    in-out property <length> viewport-y <=> internal.viewport-y;
+
+    min-height: internal.min-height;
+    min-width: internal.min-width;
+    horizontal-stretch: 1;
+    vertical-stretch: 1;
+    preferred-height: 100%;
+    preferred-width: 100%;
+
+    internal := InternalScrollView {
+        @children
+    }
+}

--- a/internal/compiler/widgets/qt/slider.slint
+++ b/internal/compiler/widgets/qt/slider.slint
@@ -1,0 +1,29 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component Slider inherits NativeSlider {
+    out property <bool> has-focus: i-focus-scope.has-focus;
+
+    accessible-role: slider;
+    accessible-value: root.value;
+    accessible-value-minimum: root.minimum;
+    accessible-value-maximum: root.maximum;
+    accessible-value-step: (root.maximum - root.minimum) / 100;
+
+    i-focus-scope := FocusScope {
+        x: 0;
+        width: 0;
+
+        key-pressed(event) => {
+            if (root.enabled && event.text == Key.RightArrow) {
+                root.value = Math.min(root.value + 1, root.maximum);
+                accept
+            } else if (root.enabled && event.text == Key.LeftArrow) {
+                root.value = Math.max(root.value - 1, root.minimum);
+                accept
+            } else {
+                reject
+            }
+        }
+    }
+}

--- a/internal/compiler/widgets/qt/spinbox.slint
+++ b/internal/compiler/widgets/qt/spinbox.slint
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component SpinBox inherits NativeSpinBox {
+    accessible-role: spinbox;
+    accessible-value: root.value;
+    accessible-value-minimum: root.minimum;
+    accessible-value-maximum: root.maximum;
+    accessible-value-step: (root.maximum - root.minimum) / 100;
+}

--- a/internal/compiler/widgets/qt/std-widgets-impl.slint
+++ b/internal/compiler/widgets/qt/std-widgets-impl.slint
@@ -1,28 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { InternalScrollView } from "internal-scrollview.slint";
-
 export { NativeStyleMetrics as StyleMetrics }
 
-export component ScrollView {
-    in-out property <length> viewport-width <=> internal.viewport-width;
-    in-out property <length> viewport-height <=> internal.viewport-height;
-    in-out property <length> viewport-x <=> internal.viewport-x;
-    in-out property <length> viewport-y <=> internal.viewport-y;
-    out property <length> visible-width <=> internal.visible-width;
-    out property <length> visible-height <=> internal.visible-height;
-    in-out property <bool> has-focus <=> internal.has-focus;
-    in property <bool> enabled <=> internal.enabled;
-
-    min-height: internal.min-height;
-    min-width: internal.min-width;
-    horizontal-stretch: 1;
-    vertical-stretch: 1;
-    preferred-height: 100%;
-    preferred-width: 100%;
-
-    internal := InternalScrollView {
-        @children
-    }
-}
+import { ScrollView } from "scrollview.slint";
+export { ScrollView }

--- a/internal/compiler/widgets/qt/std-widgets.slint
+++ b/internal/compiler/widgets/qt/std-widgets.slint
@@ -1,344 +1,43 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { LineEditInner, TextEdit, AboutSlint } from "../common/common.slint";
+import { TextEdit, AboutSlint } from "../common/common.slint";
 import { StyleMetrics, ScrollView  } from "std-widgets-impl.slint";
 import { StandardTableView } from "tableview.slint";
 export { StyleMetrics, ScrollView, TextEdit, AboutSlint, StandardTableView }
-import { ComboBoxBase } from "../common/combobox-base.slint";
 
-export component Button {
-    in property<string> text <=> native.text;
-    out property<bool> has-focus <=> native.has-focus;
-    out property<bool> pressed <=> native.pressed;
-    in property<bool> enabled <=> native.enabled;
-    in property<bool> checkable <=> native.checkable;
-    in-out property<bool> checked <=> native.checked;
-    in property<image> icon <=> native.icon;
-    in property <bool> primary <=> native.primary;
-    callback clicked <=> native.clicked;
+import { Button, StandardButton } from "button.slint";
+export { Button, StandardButton }
 
-    accessible-checkable: root.checkable;
-    accessible-checked: root.checked;
-    accessible-label: root.text;
-    accessible-role: button;
+import { CheckBox } from "checkbox.slint";
+export { CheckBox }
 
-    HorizontalLayout {
-        native := NativeButton {
-            checkable: false;
-            enabled: true;
-        }
-    }
-}
+import { SpinBox } from "spinbox.slint";
+export { SpinBox }
 
-export component StandardButton {
-    in property<StandardButtonKind> kind <=> native.standard-button-kind;
-    out property<bool> has-focus <=> native.has-focus;
-    out property<bool> pressed <=> native.pressed;
-    in property<bool> enabled <=> native.enabled;
-    callback clicked <=> native.clicked;
+import { Slider } from "slider.slint";
+export { Slider }
 
-    accessible-label: native.text;
-    accessible-role: button;
+import { Switch } from "switch.slint";
+export { Switch }
 
-    HorizontalLayout {
-        native := NativeButton {
-            is-standard-button: true;
-            checkable: false;
-        }
-    }
-}
+import { GroupBox } from "groupbox.slint";
+export { GroupBox }
 
-export component CheckBox inherits NativeCheckBox {
-    accessible-checkable: true;
-    accessible-checked <=> root.checked;
-    accessible-label <=> root.text;
-    accessible-role: checkbox;
-}
-export component SpinBox inherits NativeSpinBox {
-    accessible-role: spinbox;
-    accessible-value: root.value;
-    accessible-value-minimum: root.minimum;
-    accessible-value-maximum: root.maximum;
-    accessible-value-step: (root.maximum - root.minimum) / 100;
-}
+import { LineEdit } from "lineedit.slint";
+export { LineEdit }
 
-export component Slider inherits NativeSlider {
-    accessible-role: slider;
-    accessible-value: root.value;
-    accessible-value-minimum: root.minimum;
-    accessible-value-maximum: root.maximum;
-    accessible-value-step: (root.maximum - root.minimum) / 100;
+import { ListView, StandardListView } from "listview.slint";
+export { ListView, StandardListView }
 
-    out property <bool> has-focus: fs.has-focus;
+import { ComboBox } from "combobox.slint";
+export { ComboBox }
 
-    fs := FocusScope {
-        x:0;
-        width: 0px;
+import { TabWidget, TabWidgetImpl, TabImpl, TabBarImpl } from "tabwidget.slint";
+export { TabWidget, TabWidgetImpl, TabImpl, TabBarImpl }
 
-        key-pressed(event) => {
-            if (root.enabled && event.text == Key.RightArrow) {
-                root.value = Math.min(root.value + 1, root.maximum);
-                accept
-            } else if (root.enabled && event.text == Key.LeftArrow) {
-                root.value = Math.max(root.value - 1, root.minimum);
-                accept
-            } else {
-                reject
-            }
-        }
-    }
-}
+import { HorizontalBox, VerticalBox, GridBox } from "layouts.slint";
+export { HorizontalBox, VerticalBox, GridBox }
 
-export component Switch inherits NativeCheckBox {
-    accessible-checkable: true;
-    accessible-checked <=> root.checked;
-    accessible-label <=> root.text;
-    accessible-role: checkbox;
-}
-
-export component GroupBox {
-    in property title <=> native.title;
-    in property enabled <=> native.enabled;
-    native := NativeGroupBox {
-        GridLayout {
-            padding-left: native.native-padding-left;
-            padding-right: native.native-padding-right;
-            padding-top: native.native-padding-top;
-            padding-bottom: native.native-padding-bottom;
-            @children
-        }
-    }
-}
-
-export component LineEdit {
-    in property <length> font-size <=> inner.font-size;
-    in-out property <string> text <=> inner.text;
-    in property <string> placeholder-text <=> inner.placeholder-text;
-    in property input-type <=> inner.input-type;
-    in property horizontal-alignment <=> inner.horizontal-alignment;
-    in property read-only <=> inner.read-only;
-    out property<bool> has-focus <=> inner.has-focus;
-    in property<bool> enabled: true;
-    forward-focus: inner;
-    callback accepted <=> inner.accepted;
-    callback edited <=> inner.edited;
-    horizontal-stretch: 1;
-    vertical-stretch: 0;
-    min-width: max(160px, layout.min-height);
-    min-height: max(32px, layout.min-height);
-
-    public function select-all() {
-        inner.select-all();
-    }
-    public function clear-selection() {
-        inner.clear-selection();
-    }
-    public function cut() {
-        inner.cut();
-    }
-    public function copy() {
-        inner.copy();
-    }
-    public function paste() {
-        inner.paste();
-    }
-
-    native := NativeLineEdit {
-        has-focus <=> root.has-focus;
-        enabled: root.enabled;
-        width: 100%;
-        height: 100%;
-    }
-
-    layout := HorizontalLayout {
-        padding-left: native.native-padding-left;
-        padding-right: native.native-padding-right;
-        padding-top: native.native-padding-top;
-        padding-bottom: native.native-padding-bottom;
-        inner := LineEditInner {
-            placeholder-color: self.enabled ? StyleMetrics.placeholder-color : StyleMetrics.placeholder-color-disabled;
-            enabled: root.enabled;
-        }
-    }
-}
-
-export component ListView inherits ScrollView {
-    @children
-}
-
-component StandardListViewBase inherits ListView {
-    private property <length> item-height: self.viewport-height / self.model.length;
-    private property <length> current-item-y: self.viewport-y + current-item * item-height;
-
-    callback current-item-changed(int /* current-item */);
-    callback item-pointer-event(int /* item-index */, PointerEvent /* event */, Point /* absolute mouse position */);
-
-    in property<[StandardListViewItem]> model;
-    in-out property<int> current-item: -1;
-
-    for item[i] in root.model : NativeStandardListViewItem {
-        item: item;
-        index: i;
-        is-selected: root.current-item == i;
-        has-hover: ta.has-hover;
-
-        ta := TouchArea {
-            clicked => {
-                set-current-item(i);
-            }
-
-            pointer-event(pe) => {
-                root.item-pointer-event(i, pe, {
-                    x: self.absolute-position.x + self.mouse-x - root.absolute-position.x,
-                    y: self.absolute-position.y + self.mouse-y - root.absolute-position.y,
-                });
-            }
-        }
-    }
-
-    public function set-current-item(index: int) {
-        if(index < 0 || index >= model.length) {
-            return;
-        }
-
-        root.current-item = index;
-        root.current-item-changed(current-item);
-
-        if(current-item-y < 0) {
-            self.viewport-y += 0 - current-item-y;
-        }
-
-        if(current-item-y + item-height > self.visible-height) {
-            self.viewport-y -= current-item-y + item-height - self.visible-height;
-        }
-    }
-}
-
-export component StandardListView inherits StandardListViewBase {
-    FocusScope {
-        key-pressed(event) => {
-            if (event.text == Key.UpArrow) {
-                root.set-current-item(root.current-item - 1);
-                return accept;
-            } else if (event.text == Key.DownArrow) {
-                root.set-current-item(root.current-item + 1);
-                return accept;
-            }
-            reject
-        }
-    }
-}
-
-export component ComboBox inherits NativeComboBox {
-    callback selected <=> i-base.selected;
-
-    in property <[string]> model <=> i-base.model;
-    in-out property <int> current-index <=> i-base.current-index;
-    out property has-focus <=> i-base.has-focus;
-
-    enabled: true;
-    accessible-role: combobox;
-    accessible-value <=> root.current-value;
-    current-value: root.model[root.current-index];
-    forward-focus: i-base;
-
-    i-base := ComboBoxBase {
-        width: 100%;
-        height: 100%;
-        current-value <=> root.current-value;
-
-        show-popup => {
-            i-popup.show();
-        }
-    }
-
-    i-popup := PopupWindow {
-        x: 0;
-        y: root.height;
-        width: root.width;
-
-        NativeComboBoxPopup {
-            width: 100%;
-            height: 100%;
-        }
-
-        VerticalLayout {
-            spacing: 0px;
-
-            for value[index] in root.model: NativeStandardListViewItem {
-                item: { text: value };
-                is-selected: root.current-index == index;
-                has-hover: ta.has-hover;
-                combobox: true;
-
-                ta := TouchArea {
-                    clicked => {
-                        i-base.select(index);
-                    }
-                }
-            }
-        }
-    }
-}
-
-export component TabWidgetImpl inherits NativeTabWidget { }
-
-export component TabImpl inherits NativeTab {
-    accessible-role: tab;
-    accessible-label <=> root.title;
-}
-
-export component TabBarImpl {
-    // injected properties:
-    in-out property<int> current; // The currently selected tab
-    in-out property<int> current-focused: fs.has-focus ? root.current : -1; // The currently focused tab
-    in-out property<int> num-tabs; // The total number of tabs
-
-    accessible-role: tab;
-    accessible-delegate-focus: root.current;
-
-    Rectangle {
-        clip: true; // The breeze style draws outside of the tab bar, which is clip by default with Qt
-        HorizontalLayout {
-            spacing: 0px; // Qt renders Tabs next to each other and renders "spacing" as part of the tab itself
-            alignment: NativeStyleMetrics.tab-bar-alignment;
-            @children
-        }
-    }
-
-    fs := FocusScope {
-        x:0;
-        width: 0px; // Do not react on clicks
-        key-pressed(event) => {
-            if (event.text == Key.LeftArrow) {
-                 root.current = Math.max(root.current - 1,  0);
-                 return accept;
-            }
-            if (event.text == Key.RightArrow) {
-                 root.current = Math.min(root.current + 1, root.num-tabs - 1);
-                 return accept;
-            }
-            return reject;
-        }
-    }
-}
-
-export component TabWidget inherits TabWidget {}
-
-export component VerticalBox inherits VerticalLayout {
-    spacing: NativeStyleMetrics.layout-spacing;
-    padding: NativeStyleMetrics.layout-spacing;
-}
-
-export component HorizontalBox inherits HorizontalLayout {
-    spacing: NativeStyleMetrics.layout-spacing;
-    padding: NativeStyleMetrics.layout-spacing;
-}
-
-export component GridBox inherits GridLayout {
-    spacing: NativeStyleMetrics.layout-spacing;
-    padding: NativeStyleMetrics.layout-spacing;
-}
-
-export component ProgressIndicator inherits NativeProgressIndicator {}
+import { ProgressIndicator } from "progressindicator.slint";
+export { ProgressIndicator }

--- a/internal/compiler/widgets/qt/switch.slint
+++ b/internal/compiler/widgets/qt/switch.slint
@@ -1,0 +1,9 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component Switch inherits NativeCheckBox {
+    accessible-checkable: true;
+    accessible-checked <=> root.checked;
+    accessible-label <=> root.text;
+    accessible-role: checkbox;
+}

--- a/internal/compiler/widgets/qt/tableview.slint
+++ b/internal/compiler/widgets/qt/tableview.slint
@@ -15,7 +15,7 @@ export component StandardTableView {
     out property <int> current-sort-column: -1;
     in-out property <[TableColumn]> columns;
     in property <[[StandardListViewItem]]> rows;
-    in-out property<int> current-row: -1;
+    in-out property <int> current-row: -1;
 
     horizontal-stretch: 1;
     vertical-stretch: 1;

--- a/internal/compiler/widgets/qt/tabwidget.slint
+++ b/internal/compiler/widgets/qt/tabwidget.slint
@@ -1,0 +1,48 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component TabWidgetImpl inherits NativeTabWidget { }
+
+export component TabImpl inherits NativeTab {
+    accessible-role: tab;
+    accessible-label <=> root.title;
+}
+
+export component TabBarImpl {
+    // injected properties:
+    in-out property <int> current; // The currently selected tab
+    in-out property <int> current-focused: i-focus-scope.has-focus ? root.current : -1; // The currently focused tab
+    in-out property <int> num-tabs; // The total number of tabs
+
+    accessible-role: tab;
+    accessible-delegate-focus: root.current;
+
+    Rectangle {
+        clip: true; // The breeze style draws outside of the tab bar, which is clip by default with Qt
+
+        HorizontalLayout {
+            spacing: 0px; // Qt renders Tabs next to each other and renders "spacing" as part of the tab itself
+            alignment: NativeStyleMetrics.tab-bar-alignment;
+            @children
+        }
+    }
+
+    i-focus-scope := FocusScope {
+        x:0;
+        width: 0px; // Do not react on clicks
+
+        key-pressed(event) => {
+            if (event.text == Key.LeftArrow) {
+                 root.current = Math.max(root.current - 1,  0);
+                 return accept;
+            }
+            if (event.text == Key.RightArrow) {
+                 root.current = Math.min(root.current + 1, root.num-tabs - 1);
+                 return accept;
+            }
+            return reject;
+        }
+    }
+}
+
+export component TabWidget inherits TabWidget {}


### PR DESCRIPTION
It's marked as draft because it touches now only a few files to check how the suggestion for the Slint code style from @ogoffart would looks like (check #3768).

1. Public interface  (public properties / callbacks / public functions)
3. private interface (private properties / private functions)
4. property setters
5. states (as they are kind of property setters / animations)
6. children

I've added an order for the public properties 

1. in
2. out
3. in-out

I personally not happy with the result of that code style. Yes the profit is you can see the whole public api in the start of the component, but for my taste I think the code in common looks much more unclear. But that's my personal feeling. What the majority says counts, because I will not the only person writing Slint code and others will use the guidelines also for their projects.