### PR TITLE
node: Fix typescript setup for tests

### DIFF
--- a/api/node/__test__/api.spec.ts
+++ b/api/node/__test__/api.spec.ts
@@ -7,16 +7,16 @@ const path = require('node:path');
 import { loadFile, CompileError } from '../index'
 
 test('loadFile', (t) => {
-    let demo = loadFile(path.join(__dirname, "resources/test.slint"));
+    let demo = loadFile(path.join(__dirname, "resources/test.slint")) as any;
     let test = new demo.Test();
     t.is(test.check, "Test");
 
     let errorPath = path.join(__dirname, "resources/error.slint");
 
     const error = t.throws(() => {
-            loadFile(errorPath)
-        },
-        {instanceOf: CompileError}
+        loadFile(errorPath)
+    },
+        { instanceOf: CompileError }
     );
 
     t.is(error?.message, "Could not compile " + errorPath);
@@ -46,9 +46,9 @@ test('loadFile', (t) => {
 })
 
 test('constructor parameters', (t) => {
-    let demo = loadFile(path.join(__dirname, "resources/test-constructor.slint"));
+    let demo = loadFile(path.join(__dirname, "resources/test-constructor.slint")) as any;
     let hello = "";
-    let test = new demo.Test({ say_hello: function() { hello = "hello"; }, check: "test"});
+    let test = new demo.Test({ say_hello: function () { hello = "hello"; }, check: "test" });
 
     test.say_hello();
 

--- a/api/node/__test__/compiler.spec.ts
+++ b/api/node/__test__/compiler.spec.ts
@@ -19,13 +19,13 @@ test('get/set library paths', (t) => {
   let compiler = new private_api.ComponentCompiler;
 
   compiler.libraryPaths = {
-    "libfile.slint" : "third_party/libfoo/ui/lib.slint",
-    "libdir" : "third_party/libbar/ui/",
+    "libfile.slint": "third_party/libfoo/ui/lib.slint",
+    "libdir": "third_party/libbar/ui/",
   };
 
   t.deepEqual(compiler.libraryPaths, {
-    "libfile.slint" : "third_party/libfoo/ui/lib.slint",
-    "libdir" : "third_party/libbar/ui/",
+    "libfile.slint": "third_party/libfoo/ui/lib.slint",
+    "libdir": "third_party/libbar/ui/",
   });
 })
 
@@ -241,13 +241,13 @@ test('non-existent properties and callbacks', (t) => {
 
   const prop_err = t.throws(() => {
     instance!.setProperty("non-existent", 42);
-  });
+  }) as any;
   t.is(prop_err!.code, 'GenericFailure');
   t.is(prop_err!.message, 'Property non-existent not found in the component');
 
   const callback_err = t.throws(() => {
     instance!.setCallback("non-existent-callback", () => { });
-  });
+  }) as any;
   t.is(callback_err!.code, 'GenericFailure');
   t.is(callback_err!.message, 'Callback non-existent-callback not found in the component');
 })

--- a/api/node/__test__/js_value_conversion.spec.ts
+++ b/api/node/__test__/js_value_conversion.spec.ts
@@ -157,7 +157,7 @@ test('set struct properties', (t) => {
   }, {
     instanceOf: Error
   }
-  );
+  ) as any;
   t.is(incomplete_struct_err!.code, 'InvalidArg');
   t.is(incomplete_struct_err!.message, 'expect Number, got: Undefined');
 

--- a/api/node/package.json
+++ b/api/node/package.json
@@ -30,7 +30,7 @@
     "install": "npm run build",
     "docs": "npm run build && typedoc --hideGenerator --treatWarningsAsErrors --readme cover.md index.ts",
     "test": "ava",
-    "syntax_check": "tsc -noEmit index.ts"
+    "syntax_check": "tsc -noEmit"
   },
   "ava": {
     "require": [

--- a/api/node/tsconfig.json
+++ b/api/node/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "esnext"
+    }
+}


### PR DESCRIPTION
Share tsconfig.json so that ava runs the typescript compiler also on the tests.

Sadly, the exception that the Slint compiler throws is not type declared, so we have to use any.
Similarly, the object share returned by loadFile() is unknown in terms of properties, callbacks, etc.