### PR TITLE
wasm: Don't include all image codecs on the lsp

### DIFF
--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -37,7 +37,7 @@ software-renderer = ["bytemuck"]
 # This is under a feature flag because it is experimental feature.
 software-renderer-rotation = []
 
-image-decoders = ["image", "clru"]
+image-decoders = ["dep:image", "dep:clru"]
 svg = ["dep:resvg", "shared-fontdb"]
 
 box-shadow-cache = []

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -13,14 +13,14 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
-categories = ["gui", "rendering::engine", "development-tools", "no-std"]
+categories = ["gui", "rendering::engine", "development-tools"]
 
 [lib]
 path = "lib.rs"
 
 [features]
 
-default = ["std", "backend-winit", "renderer-femtovg", "backend-qt", "accessibility", "compat-1-2"]
+default = ["backend-winit", "renderer-femtovg", "backend-qt", "accessibility", "compat-1-2"]
 
 ## Mandatory feature:
 ## This feature is required to keep the compatibility with Slint 1.2
@@ -39,8 +39,8 @@ ffi = ["spin_on", "i-slint-core/ffi"]
 # NOTE: this is not a semver compatible feature
 highlight = []
 
-## Enable use of the Rust standard library.
-std = ["i-slint-core/std"]
+# unused (std is mandatory for the interpreter)
+std = []
 
 #! ### Backends
 
@@ -103,10 +103,10 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 internal = []
 
 [dependencies]
-i-slint-compiler = { workspace = true, features = ["default"] }
-i-slint-common = { workspace = true, features = ["default"] }
+i-slint-compiler = { workspace = true  }
+i-slint-common = { workspace = true }
 i-slint-core = { workspace = true, features = ["default", "rtti"] }
-i-slint-backend-selector = { workspace = true, features = ["default", "rtti"] }
+i-slint-backend-selector = { workspace = true, features = ["rtti"] }
 
 vtable = { version = "0.1.6", path="../../helper_crates/vtable" }
 
@@ -116,17 +116,13 @@ lyon_path = { version = "1.0" }
 once_cell = "1.5"
 thiserror = "1"
 document-features = { version = "0.2.0", optional = true }
-
-[dependencies.spin_on]
-version = "0.1"
-optional = true
+spin_on = { version = "0.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-i-slint-backend-winit = { workspace = true, features = ["default"] }
+i-slint-backend-winit = { workspace = true }
 
 [dev-dependencies]
-i-slint-backend-testing = { workspace = true, features = ["default"] }
-
+i-slint-backend-testing = { workspace = true }
 spin_on = "0.1"
 
 [package.metadata.docs.rs]

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -80,10 +80,11 @@ rowan = "0.15.5"
 i-slint-core = { workspace = true, features = ["default"], optional = true }
 slint-interpreter = { workspace = true, features = ["compat-1-2", "highlight", "internal"], optional = true  }
 i-slint-backend-selector = { workspace = true, features = ["default"], optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Enable image-rs' default features to make all image formats available for the preview
 image = { version = "0.24.0", optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.0", features = ["derive", "wrap_help"] }
 crossbeam-channel = "0.5"  # must match the version used by lsp-server
 lsp-server = "0.7"


### PR DESCRIPTION
Saves 1M in the binary

We use the browser to render the images anyway

Note: i-slint-core still bring image with png and jpeg codecs, as well
as svg deps. We just need the image-decoders feature to load the builtin
images, of these there are only svg.

(also has a cleanup stuff for the interpreter Cargo.toml)