### PR TITLE
core: Make debug print of `PropertyHandle` more useful

### DIFF
--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -461,7 +461,7 @@ impl core::fmt::Debug for PropertyHandle {
         let handle = self.handle.get();
         write!(
             f,
-            "PropertyHandle {{ handle: {}, is_locked: {}, is_list: {} }}",
+            "PropertyHandle {{ handle: 0x{:x}, locked: {}, binding: {} }}",
             handle & !0b11,
             (handle & 0b01) == 0b01,
             (handle & 0b10) == 0b10


### PR DESCRIPTION
Just a quick hack I found helpful while debugging properties...