### PR TITLE
C++: fix string conversion from float not being round

### DIFF
--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -375,7 +375,7 @@ pub(crate) mod ffi {
     /// The resulting structure must be passed to slint_shared_string_drop
     #[no_mangle]
     pub unsafe extern "C" fn slint_shared_string_from_number(out: *mut SharedString, n: f64) {
-        let str = crate::format!("{}", n);
+        let str = crate::format!("{}", n as f32);
         core::ptr::write(out, str);
     }
 
@@ -397,6 +397,13 @@ pub(crate) mod ffi {
             let mut s = core::mem::MaybeUninit::uninit();
             slint_shared_string_from_number(s.as_mut_ptr(), 0.);
             assert_eq!(s.assume_init(), "0");
+
+            let mut s = core::mem::MaybeUninit::uninit();
+            slint_shared_string_from_number(
+                s.as_mut_ptr(),
+                ((1235.82756f32 * 1000f32).round() / 1000f32) as _,
+            );
+            assert_eq!(s.assume_init(), "1235.828");
         }
     }
 

--- a/tests/cases/types/string.slint
+++ b/tests/cases/types/string.slint
@@ -1,12 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-TestCase := Rectangle {
-    property<string> p1: "hello";
-    property<string> p2: "fox:🦊";
-    property<string> p3: "with\"quote\\\"\u{8}";
-    property<bool> e1: p2 == "fox:🦊";
-    property<bool> e2: p2 == "fox:🦍";
+export component TestCase  {
+    in-out property<string> p1: "hello";
+    in-out property<string> p2: "fox:🦊";
+    in-out property<string> p3: "with\"quote\\\"\u{8}";
+    in-out property<bool> e1: p2 == "fox:🦊";
+    in-out property<bool> e2: p2 == "fox:🦍";
+
+    // conversion from float
+    in property<float> value: 98.7654321;
+    out property <string> converted_value: round(value * 100)/100;
+    out property <bool> test: e1 && !e2 && converted_value == "98.77";
 }
 
 
@@ -20,6 +25,7 @@ assert_eq(instance.get_p2(), "fox:🦊");
 assert_eq(instance.get_p3(), "with\"quote\\\"\x08");
 assert(instance.get_e1());
 assert(!instance.get_e2());
+assert(instance.get_test());
 ```
 
 ```rust
@@ -29,6 +35,7 @@ assert_eq!(instance.get_p2(), "fox:🦊");
 assert_eq!(instance.get_p3(), "with\"quote\\\"\u{8}");
 assert!(instance.get_e1());
 assert!(!instance.get_e2());
+assert!(instance.get_test());
 ```
 
 ```js
@@ -38,6 +45,7 @@ assert.equal(instance.p2, "fox:🦊");
 assert.equal(instance.p3, "with\"quote\\\"\u0008");
 assert(instance.e1);
 assert(!instance.e2);
+assert(instance.test);
 ```
 
 */

--- a/tests/cases/types/string_to_float.slint
+++ b/tests/cases/types/string_to_float.slint
@@ -25,6 +25,7 @@ const TestCase &instance = *handle;
 assert(instance.get_test_is_float());
 assert(fuzzy_compare(instance.get_number_as_float(), 42.56));
 assert(fuzzy_compare(instance.get_negative_as_float(), -1200000.1));
+assert(instance.get_test());
 ```
 
 ```rust
@@ -32,6 +33,7 @@ let instance = TestCase::new().unwrap();
 assert!(instance.get_test_is_float());
 assert_eq!(instance.get_number_as_float(), 42.56);
 assert_eq!(instance.get_negative_as_float(), -1200000.1);
+assert!(instance.get_test());
 ```
 
 ```js
@@ -40,6 +42,7 @@ var instance = new slint.TestCase({});
 assert(instance.test_is_float);
 assert.equal(n(instance.number_as_float), n(42.56));
 assert.equal(n(instance.negative_as_float/1000), n(-1200000.1/1000));
+assert(instance.test);
 ```
 
 */


### PR DESCRIPTION
Converting 12.3 to a string would be "12.30000001907" which is not what one would want