### PR TITLE
Layout: when using a fixed window size, dissociate the WindowItem's …

### DIFF
--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -28,7 +28,7 @@ impl i_slint_core::platform::Platform for TestingBackend {
     ) -> Result<Rc<dyn WindowAdapter>, i_slint_core::platform::PlatformError> {
         Ok(Rc::new_cyclic(|self_weak| TestingWindow {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),
-            size: PhysicalSize::new(600, 800).into(),
+            size: Default::default(),
             ime_requests: Default::default(),
         }))
     }
@@ -97,7 +97,11 @@ impl WindowAdapter for TestingWindow {
     }
 
     fn size(&self) -> PhysicalSize {
-        self.size.get()
+        if self.size.get().width == 0 {
+            PhysicalSize::new(800, 600)
+        } else {
+            self.size.get()
+        }
     }
 
     fn set_size(&self, size: i_slint_core::api::WindowSize) {
@@ -109,6 +113,13 @@ impl WindowAdapter for TestingWindow {
 
     fn renderer(&self) -> &dyn Renderer {
         self
+    }
+
+    fn update_window_properties(&self, properties: i_slint_core::window::WindowProperties<'_>) {
+        if self.size.get().width == 0 {
+            let c = properties.layout_constraints();
+            self.size.set(c.preferred.to_physical(self.window.scale_factor()));
+        }
     }
 
     fn internal(&self, _: i_slint_core::InternalToken) -> Option<&dyn WindowAdapterInternal> {

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -180,6 +180,7 @@ pub async fn run_passes(
         collect_init_code::collect_init_code(component);
         materialize_fake_properties::materialize_fake_properties(component);
     }
+    lower_layout::check_window_layout(root_component);
     collect_globals::collect_globals(doc, diag);
 
     if compiler_config.inline_all_elements {

--- a/tests/cases/issues/issue_3318_window_size.slint
+++ b/tests/cases/issues/issue_3318_window_size.slint
@@ -17,4 +17,11 @@ instance.window().set_size(slint::PhysicalSize::new(300, 500));
 assert_eq!(instance.get_t_width(), 300);
 
 ```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+instance.window().set_size(slint::PhysicalSize({300, 500}));
+assert_eq(instance.get_t_width(), 300);
+```
 */

--- a/tests/cases/layout/window_fixed.slint
+++ b/tests/cases/layout/window_fixed.slint
@@ -1,0 +1,67 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component TestCase inherits Window {
+    width: 200px;
+    min-height: 300px;
+    VerticalLayout {
+        HorizontalLayout {
+            green := Rectangle {
+                background: Colors.green;
+                width: 100px;
+            }
+            red := Rectangle { background: Colors.red; }
+        }
+        Rectangle { background: orange; }
+    }
+
+    out property <length> win_w: root.width;
+    out property <length> win_h: root.height;
+    out property <length> green_w: green.width;
+    out property <length> red_w: red.width;
+
+
+    out property <bool> test: root.min-height == 300px && root.width == 200px && green.width == 100px && red.width == 100px;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+TestCase &instance = *handle;
+instance.show();
+assert(instance.get_test());
+auto size = instance.window().size();
+assert(size == slint::PhysicalSize({200, 300}));
+assert_eq(instance.get_win_h(), 300.);
+assert_eq(instance.get_win_w(), 200.);
+assert_eq(instance.get_green_w(), 100.);
+assert_eq(instance.get_red_w(), 100.);
+instance.window().set_size(slint::PhysicalSize({150, 150}));
+assert_eq(instance.get_win_h(), 150.); // this didn't have a fixed sized, so the size follow (FIXME: it probably shouldn't)
+assert_eq(instance.get_win_w(), 200.); // but because we have a fixed sized, the geometry don't change
+assert_eq(instance.get_green_w(), 100.);
+assert_eq(instance.get_red_w(), 100.);
+
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+instance.show().unwrap();
+assert!(instance.get_test());
+let size = instance.window().size();
+assert_eq!(size, slint::PhysicalSize::new(200, 300));
+assert_eq!(instance.get_win_h(), 300.);
+assert_eq!(instance.get_win_w(), 200.);
+assert_eq!(instance.get_green_w(), 100.);
+assert_eq!(instance.get_red_w(), 100.);
+instance.window().set_size(slint::PhysicalSize::new(150, 150));
+assert_eq!(instance.get_win_h(), 150.); // this didn't have a fixed sized, so the size follow (FIXME: it probably shouldn't)
+assert_eq!(instance.get_win_w(), 200.); // but because we have a fixed sized, the geometry don't change
+assert_eq!(instance.get_green_w(), 100.);
+assert_eq!(instance.get_red_w(), 100.);
+```
+
+
+*/


### PR DESCRIPTION
…size with the slint size

If you have a window like so:
```
component W inherits Window {
   width: 200px; // or some other bindings
}
```

Before this patch, it will be converted by the compiler to something like

```
component W inherits Window {
   width: 200px; // or some other bindings
   min-width: width; // (not actual property, but part of the layout_info)
   max-width: width;
}
```

When the window is on the screen, the platform backend will set the max with and min width on the window manager window to the value from the layout info.
But slint will also set the width and the height of the WindowItem to the actual value.  This will break the binding for width if any, and will also cause the min and max with do be updated, which is wrong.

We haven't had much problem with that before, but with the ComponentContainer, this becomes a problem as we want to set the width and height of the inner from the outer by adding a two way binding, which cause a binding loop at runtime.

The behavior change is that if you have a fixed window size and use that on a MCU or platform that has a different size, the window will be cropped or padded but will no longer be resized