### PR TITLE
Fix Node.js version of memory game not working properly

### DIFF
--- a/api/node/__test__/js_value_conversion.spec.ts
+++ b/api/node/__test__/js_value_conversion.spec.ts
@@ -193,7 +193,7 @@ test('get/set image properties', async (t) => {
   if (t.true((slintImage instanceof private_api.ImageData))) {
     t.deepEqual((slintImage as private_api.ImageData).width, 64);
     t.deepEqual((slintImage as private_api.ImageData).height, 64);
-    t.true((slintImage as ImageData).path.endsWith("resources/rgb.png"));
+    t.true((slintImage as ImageData).path.endsWith("rgb.png"));
 
     let image = await Jimp.read(path.join(__dirname, "resources/rgb.png"));
 

--- a/api/node/__test__/js_value_conversion.spec.ts
+++ b/api/node/__test__/js_value_conversion.spec.ts
@@ -193,6 +193,7 @@ test('get/set image properties', async (t) => {
   if (t.true((slintImage instanceof private_api.ImageData))) {
     t.deepEqual((slintImage as private_api.ImageData).width, 64);
     t.deepEqual((slintImage as private_api.ImageData).height, 64);
+    t.true((slintImage as ImageData).path.endsWith("resources/rgb.png"));
 
     let image = await Jimp.read(path.join(__dirname, "resources/rgb.png"));
 
@@ -227,6 +228,8 @@ test('get/set image properties', async (t) => {
 
     t.is(image.bitmap.data.length, (slintImage as ImageData).data.length);
     t.deepEqual(image.bitmap.data, (slintImage as ImageData).data);
+
+    t.deepEqual((instance!.getProperty("external-image") as ImageData).path, undefined);
   }
 })
 

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -76,6 +76,12 @@ export interface ImageData {
      *  Returns the height of the image in pixels.
      */
     get height(): number;
+
+    /**
+     * Returns the path of the image, if it was loaded from disk. Otherwise
+     * the property is undefined.
+     */
+    readonly path: string | undefined;
 }
 
 /**

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -81,7 +81,7 @@ export interface ImageData {
      * Returns the path of the image, if it was loaded from disk. Otherwise
      * the property is undefined.
      */
-    readonly path: string | undefined;
+    readonly path?: string;
 }
 
 /**

--- a/api/node/src/types/image_data.rs
+++ b/api/node/src/types/image_data.rs
@@ -7,7 +7,10 @@ use i_slint_core::{
     graphics::{Image, SharedImageBuffer, SharedPixelBuffer},
     ImageInner,
 };
-use napi::bindgen_prelude::{Buffer, External};
+use napi::{
+    bindgen_prelude::{Buffer, External},
+    Env, JsUnknown,
+};
 
 // This is needed for typedoc check JsImageData::image
 pub type ImageData = Image;
@@ -69,6 +72,14 @@ impl JsImageData {
         }
 
         Buffer::from(vec![0; (self.width() * self.height() * 4) as usize])
+    }
+
+    #[napi(getter)]
+    pub fn path(&self, env: Env) -> napi::Result<JsUnknown> {
+        self.inner.path().map_or_else(
+            || env.get_undefined().map(|v| v.into_unknown()),
+            |p| env.create_string(p.to_string_lossy().as_ref()).map(|v| v.into_unknown()),
+        )
     }
 
     /// @hidden

--- a/docs/tutorial/node/src/main_game_logic.js
+++ b/docs/tutorial/node/src/main_game_logic.js
@@ -42,7 +42,7 @@ mainWindow.check_if_pair_solved = function () {
             index: tile2_index
         } = flipped_tiles[1];
 
-        let is_pair_solved = tile1.image.path.path === tile2.image.path.path;
+        let is_pair_solved = tile1.image.path === tile2.image.path;
         if (is_pair_solved) {
             tile1.solved = true;
             model.setRowData(tile1_index, tile1);

--- a/docs/tutorial/node/src/main_game_logic.js
+++ b/docs/tutorial/node/src/main_game_logic.js
@@ -42,7 +42,7 @@ mainWindow.check_if_pair_solved = function () {
             index: tile2_index
         } = flipped_tiles[1];
 
-        let is_pair_solved = tile1.image === tile2.image;
+        let is_pair_solved = tile1.image.path.path === tile2.image.path.path;
         if (is_pair_solved) {
             tile1.solved = true;
             model.setRowData(tile1_index, tile1);

--- a/examples/memory/main.js
+++ b/examples/memory/main.js
@@ -40,7 +40,7 @@ window.check_if_pair_solved = function () {
             index: tile2_index
         } = flipped_tiles[1];
 
-        let is_pair_solved = tile1.image === tile2.image;
+        let is_pair_solved = tile1.image.path === tile2.image.path;
         if (is_pair_solved) {
             tile1.solved = true;
             model.setRowData(tile1_index, tile1);


### PR DESCRIPTION
The rules require comparing if tiles are equal, which used to be a string comparison as we just converted the image to a path. With ImageData this doesn't work anymore, so this patch proposes an optional path property that makes the code also a tad bit more readable.