### PR TITLE
Implement text focus change callback

### DIFF
--- a/docs/reference/src/language/builtins/globals.md
+++ b/docs/reference/src/language/builtins/globals.md
@@ -8,7 +8,19 @@ If you're implementing your own virtual keyboard, this property is an indicator 
 
 ### Properties
 
--   **`text-input-focused`** (_bool_): True if an `TextInput` element has the focus; false otherwise.
+-   **`text-input-focused`** (_bool_): True if an `TextInput` element has the focus; false otherwise. 
+
+### Callbacks (only available in Rust)
+
+-   **`text-input-focus-changed`** (_change_): a callback that gets invoked every time a text input is focused or unfocused.
+    
+    Example:
+    ```rust
+    window.global::<TextInputInterface>.on_text_input_focus_changed(|change| match change {
+        TextInputFocusChangeEvent::Focused => system::show_popup_keyboard(),
+        TextInputFocusChangeEvent::Unfocused => system::hide_popup_keyboard(),
+    });
+    ```
 
 ### Example
 

--- a/examples/virtual_keyboard/rust/main.rs
+++ b/examples/virtual_keyboard/rust/main.rs
@@ -13,7 +13,7 @@ pub fn main() {
 
 mod virtual_keyboard {
     use super::*;
-    use slint::private_unstable_api::re_exports::TextInputInterface;
+    use slint::private_unstable_api::re_exports::{TextInputFocusChangeEvent, TextInputInterface};
     use slint::*;
 
     pub fn init(app: &MainWindow) {
@@ -31,8 +31,9 @@ mod virtual_keyboard {
 
         // An example of the text input focus callback.
         // Can be used to show or hide the virtual keyboard using system's APIs.
-        app.global::<TextInputInterface>().on_text_input_focus_changed(|change| {
-            println!("text-input-focus-changed: {:?}", change);
+        app.global::<TextInputInterface>().on_text_input_focus_changed(|change| match change {
+            TextInputFocusChangeEvent::Focused => println!("focused!"),
+            TextInputFocusChangeEvent::Unfocused => println!("unfocused!"),
         });
     }
 }

--- a/examples/virtual_keyboard/rust/main.rs
+++ b/examples/virtual_keyboard/rust/main.rs
@@ -13,8 +13,8 @@ pub fn main() {
 
 mod virtual_keyboard {
     use super::*;
-    use slint::*;
     use slint::private_unstable_api::re_exports::TextInputInterface;
+    use slint::*;
 
     pub fn init(app: &MainWindow) {
         let weak = app.as_weak();

--- a/examples/virtual_keyboard/rust/main.rs
+++ b/examples/virtual_keyboard/rust/main.rs
@@ -14,6 +14,7 @@ pub fn main() {
 mod virtual_keyboard {
     use super::*;
     use slint::*;
+    use slint::private_unstable_api::re_exports::TextInputInterface;
 
     pub fn init(app: &MainWindow) {
         let weak = app.as_weak();
@@ -26,6 +27,12 @@ mod virtual_keyboard {
                     .window()
                     .dispatch_event(slint::platform::WindowEvent::KeyReleased { text: key });
             }
+        });
+
+        // An example of the text input focus callback.
+        // Can be used to show or hide the virtual keyboard using system's APIs.
+        app.global::<TextInputInterface>().on_text_input_focus_changed(|change| {
+            println!("text-input-focus-changed: {:?}", change);
         });
     }
 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1409,16 +1409,17 @@ pub struct TextInputInterface {
 
 impl<'a, T: ComponentHandle> Global<'a, T> for TextInputInterface {
     fn get(root: &'a T) -> Self {
-        TextInputInterface {
-            w: root.window().0.window_adapter()
-        }
+        TextInputInterface { w: root.window().0.window_adapter() }
     }
 }
 
 impl TextInputInterface {
     pub fn init<T>(self: Pin<Rc<Self>>, _self_rc: &VRc<crate::item_tree::ItemTreeVTable, T>) {}
 
-    pub fn on_text_input_focus_changed(&self, mut f: impl FnMut(&TextInputFocusChangeEvent) -> () + 'static) {
+    pub fn on_text_input_focus_changed(
+        &self,
+        mut f: impl FnMut(&TextInputFocusChangeEvent) -> () + 'static,
+    ) {
         self.w.window().0.set_on_text_input_focus_changed(move |change| f(change));
     }
 }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -923,7 +923,10 @@ impl WindowInner {
     }
 
     /// Sets the close_requested callback. The callback will be run when the user tries to close a window.
-    pub fn set_on_text_input_focus_changed(&self, mut callback: impl FnMut(&TextInputFocusChangeEvent) -> () + 'static) {
+    pub fn set_on_text_input_focus_changed(
+        &self,
+        mut callback: impl FnMut(&TextInputFocusChangeEvent) -> () + 'static,
+    ) {
         self.text_input_focus_changed.set_handler(move |change| callback(change));
     }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -922,7 +922,7 @@ impl WindowInner {
         self.pinned_fields.text_input_focused.set(value)
     }
 
-    /// Sets the close_requested callback. The callback will be run when the user tries to close a window.
+    /// Sets the text_input_focus_changed callback. The callback will be run when the text input component is focused or unfocused.
     pub fn set_on_text_input_focus_changed(
         &self,
         mut callback: impl FnMut(&TextInputFocusChangeEvent) -> () + 'static,

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -910,7 +910,7 @@ impl WindowInner {
     /// Sets whether a text field is focused or not.
     pub fn set_text_input_focused(&self, value: bool) {
         if self.text_input_focused() != value {
-            let change = if self.text_input_focused() {
+            let change = if value {
                 TextInputFocusChangeEvent::Focused
             } else {
                 TextInputFocusChangeEvent::Unfocused


### PR DESCRIPTION
As discussed in https://github.com/slint-ui/slint/discussions/3767.

```rust
window.global::<TextInputInterface>.on_text_input_focus_changed(|| {
    // call my logic 
});
```