### PR TITLE
Wasm: use the winit spawn() api to run the event loop for the interpreter

### DIFF
--- a/api/wasm-interpreter/src/lib.rs
+++ b/api/wasm-interpreter/src/lib.rs
@@ -155,7 +155,8 @@ impl WrappedCompiledComp {
     #[wasm_bindgen]
     pub fn run(&self, canvas_id: String) {
         let component = self.0.create_with_canvas_id(&canvas_id).unwrap();
-        component.run().unwrap();
+        component.show().unwrap();
+        slint_interpreter::spawn_event_loop().unwrap();
     }
     /// Creates this compiled component in a canvas, wrapped in a promise.
     /// The HTML must contains a <canvas> element with the given `canvas_id`
@@ -309,6 +310,6 @@ impl WrappedInstance {
 /// to ignore.
 #[wasm_bindgen]
 pub fn run_event_loop() -> Result<(), JsValue> {
-    slint_interpreter::run_event_loop().map_err(|e| -> JsValue { format!("{e}").into() })?;
+    slint_interpreter::spawn_event_loop().map_err(|e| -> JsValue { format!("{e}").into() })?;
     Ok(())
 }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -277,6 +277,12 @@ impl i_slint_core::platform::Platform for Backend {
     }
 }
 
+/// Spawn the event loop, using [`winit::platform::web::EventLoopExtWebSys::spawn()`]
+#[cfg(target_arch = "wasm32")]
+pub fn spawn_event_loop() -> Result<(), PlatformError> {
+    crate::event_loop::spawn()
+}
+
 /// Invokes the specified callback with a reference to the [`winit::event_loop::EventLoopWindowTarget`].
 /// Use this to get access to the display connection or create new windows with [`winit::window::WindowBuilder`].
 ///

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1271,6 +1271,15 @@ pub fn run_event_loop() -> Result<(), PlatformError> {
     i_slint_backend_selector::with_platform(|b| b.run_event_loop())
 }
 
+#[cfg(all(feature = "internal", target_arch = "wasm32"))]
+/// Spawn the event loop.
+///
+/// Like [`run_event_loop()`], but returns immediately as the loop is running within
+/// the browser's runtime
+pub fn spawn_event_loop() -> Result<(), PlatformError> {
+    i_slint_backend_selector::with_platform(|_| i_slint_backend_winit::spawn_event_loop())
+}
+
 /// This module contains a few functions used by the tests
 #[doc(hidden)]
 pub mod testing {

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -188,7 +188,8 @@ impl WrappedCompiledComp {
     #[wasm_bindgen]
     pub fn run(&self, canvas_id: String) {
         let component = self.0.create_with_canvas_id(&canvas_id).unwrap();
-        component.run().unwrap();
+        component.show().unwrap();
+        slint_interpreter::spawn_event_loop().unwrap();
     }
     /// Creates this compiled component in a canvas, wrapped in a promise.
     /// The HTML must contains a <canvas> element with the given `canvas_id`


### PR DESCRIPTION
This seems to solve the bug that the wasm interpreter (or slintpad) is
not working when compiled in release since the winit0.29 update


This PR also contains two cleanups commits from https://github.com/slint-ui/slint/pull/3718