### PR TITLE
Introduce android-activity backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     'helper_crates/vtable',
     'helper_crates/vtable/macro',
     'internal/backends/winit',
+    'internal/backends/android-activity',
     'internal/backends/qt',
     'internal/backends/selector',
     'internal/backends/testing',
@@ -108,6 +109,7 @@ i-slint-backend-qt = { version = "=1.3.0", path="internal/backends/qt", default-
 i-slint-backend-selector = { version = "=1.3.0", path = "internal/backends/selector", default-features = false }
 i-slint-backend-testing = { version = "=1.3.0", path = "internal/backends/testing", default-features = false }
 i-slint-backend-winit = { version = "=1.3.0", path = "internal/backends/winit", default-features = false }
+i-slint-backend-android-activity = { version = "=1.3.0", path = "internal/backends/android-activity", default-features = false }
 i-slint-common = { version = "=1.3.0", path = "internal/common", default-features = false }
 i-slint-compiler = { version = "=1.3.0", path = "internal/compiler", default-features = false }
 i-slint-core = { version = "=1.3.0", path = "internal/core", default-features = false }

--- a/examples/todo/rust/Cargo.toml
+++ b/examples/todo/rust/Cargo.toml
@@ -17,18 +17,21 @@ name = "todo"
 [dependencies]
 slint = { path = "../../../api/rs/slint" }
 
+[target.'cfg(target_os = "android")'.dependencies]
+i-slint-backend-android-activity = { workspace = true, features = ["native-activity"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { version = "0.2" }
+console_error_panic_hook = "0.1.5"
+
 [build-dependencies]
 slint-build = { path = "../../../api/rs/build" }
 
-# Remove the `#wasm#` to uncomment the wasm build.
+# Remove the `#wasm#` to uncomment the wasm and android build.
 # This is commented out by default because we don't want to build it as a library by default
 # The CI has a script that does sed "s/#wasm# //" to generate the wasm build.
 
 #wasm# [lib]
 #wasm# crate-type = ["cdylib"]
 #wasm# path = "main.rs"
-#wasm#
-#wasm# [target.'cfg(target_arch = "wasm32")'.dependencies]
-#wasm# wasm-bindgen = { version = "0.2" }
-#wasm# web-sys = { version = "0.3", features=["console"] }
-#wasm# console_error_panic_hook = "0.1.5"
+

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -96,3 +96,15 @@ pub fn main() {
 
     main_window.run().unwrap();
 }
+
+#[cfg(target_os = "android")]
+#[no_mangle]
+fn android_main(app: i_slint_backend_android_activity::AndroidApp) {
+    slint::platform::set_platform(Box::new(
+        i_slint_backend_android_activity::AndroidPlatform::new_with_event_listener(app, |event| {
+            eprintln!("Got event: {event:?}")
+        }),
+    ))
+    .unwrap();
+    main();
+}

--- a/internal/backends/android-activity/Cargo.toml
+++ b/internal/backends/android-activity/Cargo.toml
@@ -20,10 +20,17 @@ game-activity = ["android-activity/game-activity"]
 native-activity = ["android-activity/native-activity"]
 
 [target.'cfg(target_os = "android")'.dependencies]
-# FIXME: we shoudln't depend on slint, but the other way around
-slint = { workspace = true, features = ["compat-1-2"] }
 i-slint-renderer-skia = { workspace = true }
-i-slint-core = { workspace = true }
+i-slint-core = { workspace = true, features = ["std"] }
 raw-window-handle = { version = "0.5.2" }
 android-activity = { version = "0.5" }
 ndk = { version = "0.8.0", features = ["rwh_05"] }
+
+[package.metadata.docs.rs]
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+]
+features = ["native-activity"]

--- a/internal/backends/android-activity/Cargo.toml
+++ b/internal/backends/android-activity/Cargo.toml
@@ -1,0 +1,29 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+[package]
+name = "i-slint-backend-android-activity"
+description = "OpenGL rendering backend for Slint"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lib]
+path = "lib.rs"
+
+[features]
+game-activity = ["android-activity/game-activity"]
+native-activity = ["android-activity/native-activity"]
+
+[target.'cfg(target_os = "android")'.dependencies]
+# FIXME: we shoudln't depend on slint, but the other way around
+slint = { workspace = true, features = ["compat-1-2"] }
+i-slint-renderer-skia = { workspace = true }
+i-slint-core = { workspace = true }
+raw-window-handle = { version = "0.5.2" }
+android-activity = { version = "0.5" }
+ndk = { version = "0.8.0", features = ["rwh_05"] }

--- a/internal/backends/android-activity/LICENSES/GPL-3.0-only.txt
+++ b/internal/backends/android-activity/LICENSES/GPL-3.0-only.txt
@@ -1,0 +1,1 @@
+../../../../LICENSES/GPL-3.0-only.txt

--- a/internal/backends/android-activity/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
+++ b/internal/backends/android-activity/LICENSES/LicenseRef-Slint-Royalty-free-1.1.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-Royalty-free-1.1.md

--- a/internal/backends/android-activity/LICENSES/LicenseRef-Slint-commercial.md
+++ b/internal/backends/android-activity/LICENSES/LicenseRef-Slint-commercial.md
@@ -1,0 +1,1 @@
+../../../../LICENSES/LicenseRef-Slint-commercial.md

--- a/internal/backends/android-activity/README.md
+++ b/internal/backends/android-activity/README.md
@@ -1,0 +1,7 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+**NOTE**: This library is an **internal** crate of the [Slint project](https://slint.dev).
+This crate should **not be used directly** by applications using Slint.
+You should use the `slint` crate instead.
+
+**WARNING**: This crate does not follow the semver convention for versioning and can
+only be used with `version = "=x.y.z"` in Cargo.toml.

--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -1,0 +1,663 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+#![doc = include_str!("README.md")]
+#![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
+#![cfg(target_os = "android")]
+
+pub use android_activity;
+use android_activity::input::{InputEvent, KeyAction, Keycode, MotionAction, MotionEvent};
+pub use android_activity::AndroidApp;
+use android_activity::{InputStatus, MainEvent, PollEvent};
+use core::ops::ControlFlow;
+use raw_window_handle::HasRawWindowHandle;
+use slint::platform::{Key, WindowAdapter, WindowEvent};
+use slint::{PlatformError, SharedString};
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+pub struct AndroidPlatform {
+    app: AndroidApp,
+    window: Rc<AndroidWindowAdapter>,
+    event_listener: Option<Box<dyn Fn(&PollEvent<'_>)>>,
+}
+
+impl AndroidPlatform {
+    /// Instantiate a new Android backend given the [`android_activity::AndroidApp`]
+    ///
+    /// Pass the returned value to [`slint::platform::set_platform()`]
+    ///
+    /// # Example
+    /// ```
+    /// #[cfg(target_os = "android")]
+    /// #[no_mangle]
+    /// fn android_main(app: i_slint_backend_android_activity::AndroidApp) {
+    ///     slint::platform::set_platform(Box::new(
+    ///         i_slint_backend_android_activity::AndroidPlatform::new(app),
+    ///     ))
+    ///     .unwrap();
+    ///     // ... your slint application ...
+    /// }
+    /// ```
+    pub fn new(app: AndroidApp) -> Self {
+        Self {
+            app: app.clone(),
+            window: Rc::<AndroidWindowAdapter>::new_cyclic(|w| AndroidWindowAdapter {
+                app,
+                window: slint::Window::new(w.clone()),
+                renderer: i_slint_renderer_skia::SkiaRenderer::default(),
+                event_queue: Default::default(),
+                pending_redraw: Default::default(),
+            }),
+            event_listener: None,
+        }
+    }
+
+    /// Instantiate a new Android backend given the [`android_activity::AndroidApp`]
+    /// and a function to process the events.
+    ///
+    /// This is the same as [`AndroidPlatform::new()`], but it allow you to get notified
+    /// of events.
+    ///
+    /// Pass the returned value to [`slint::platform::set_platform()`]
+    ///
+    /// # Example
+    /// ```
+    /// #[cfg(target_os = "android")]
+    /// #[no_mangle]
+    /// fn android_main(app: i_slint_backend_android_activity::AndroidApp) {
+    ///     slint::platform::set_platform(Box::new(
+    ///         i_slint_backend_android_activity::AndroidPlatform::new_with_event_listener(
+    ///             app,
+    ///             |event| { eprintln!("got event {event:?}") }
+    ///         ),
+    ///     ))
+    ///     .unwrap();
+    ///     // ... your slint application ...
+    /// }
+    /// ```
+    pub fn new_with_event_listener(
+        app: AndroidApp,
+        listener: impl Fn(&PollEvent<'_>) + 'static,
+    ) -> Self {
+        let mut this = Self::new(app);
+        this.event_listener = Some(Box::new(listener));
+        this
+    }
+}
+
+impl slint::platform::Platform for AndroidPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        Ok(self.window.clone())
+    }
+    fn run_event_loop(&self) -> Result<(), PlatformError> {
+        loop {
+            let mut timeout = slint::platform::duration_until_next_timer_update();
+            if self.window.window.has_active_animations() {
+                // FIXME: we should not hardcode a value here
+                let frame_duration = std::time::Duration::from_millis(10);
+                timeout = Some(match timeout {
+                    Some(x) => x.min(frame_duration),
+                    None => frame_duration,
+                })
+            }
+            let mut r = Ok(ControlFlow::Continue(()));
+            self.app.poll_events(timeout, |e| {
+                slint::platform::update_timers_and_animations();
+                r = self.window.process_event(&e);
+                if let Some(event_listener) = &self.event_listener {
+                    event_listener(&e)
+                }
+            });
+            if matches!(r.map_err(|e| PlatformError::from(e.to_string()))?, ControlFlow::Break(()))
+            {
+                return Ok(());
+            }
+            if self.window.pending_redraw.take() && self.app.native_window().is_some() {
+                self.window.renderer.render()?;
+            }
+        }
+    }
+
+    fn new_event_loop_proxy(&self) -> Option<Box<dyn slint::platform::EventLoopProxy>> {
+        Some(Box::new(AndroidEventLoopProxy {
+            event_queue: self.window.event_queue.clone(),
+            waker: self.app.create_waker(),
+        }))
+    }
+}
+
+enum Event {
+    Quit,
+    Other(Box<dyn FnOnce() + Send + 'static>),
+}
+
+type EventQueue = Arc<Mutex<Vec<Event>>>;
+
+struct AndroidEventLoopProxy {
+    event_queue: EventQueue,
+    waker: android_activity::AndroidAppWaker,
+}
+
+impl slint::platform::EventLoopProxy for AndroidEventLoopProxy {
+    fn quit_event_loop(&self) -> Result<(), slint::EventLoopError> {
+        self.event_queue.lock().unwrap().push(Event::Quit);
+        self.waker.wake();
+        Ok(())
+    }
+
+    fn invoke_from_event_loop(
+        &self,
+        event: Box<dyn FnOnce() + Send>,
+    ) -> Result<(), slint::EventLoopError> {
+        self.event_queue.lock().unwrap().push(Event::Other(event));
+        self.waker.wake();
+        Ok(())
+    }
+}
+
+struct AndroidWindowAdapter {
+    app: AndroidApp,
+    window: slint::Window,
+    renderer: i_slint_renderer_skia::SkiaRenderer,
+    event_queue: EventQueue,
+    pending_redraw: Cell<bool>,
+}
+
+impl WindowAdapter for AndroidWindowAdapter {
+    fn window(&self) -> &slint::Window {
+        &self.window
+    }
+    fn size(&self) -> slint::PhysicalSize {
+        self.app.native_window().map_or_else(Default::default, |w| slint::PhysicalSize {
+            width: w.width() as u32,
+            height: w.height() as u32,
+        })
+    }
+    fn renderer(&self) -> &dyn slint::platform::Renderer {
+        &self.renderer
+    }
+
+    fn request_redraw(&self) {
+        self.pending_redraw.set(true);
+    }
+
+    fn internal(
+        &self,
+        _: i_slint_core::InternalToken,
+    ) -> Option<&dyn i_slint_core::window::WindowAdapterInternal> {
+        Some(self)
+    }
+}
+
+impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
+    fn input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
+        match request {
+            i_slint_core::window::InputMethodRequest::Enable { .. } => {
+                self.app.show_soft_input(true);
+            }
+            i_slint_core::window::InputMethodRequest::Disable { .. } => {
+                self.app.hide_soft_input(true);
+            }
+            _ => {}
+        };
+    }
+}
+
+impl AndroidWindowAdapter {
+    fn process_event(&self, event: &PollEvent<'_>) -> Result<ControlFlow<()>, PlatformError> {
+        match event {
+            PollEvent::Wake => {
+                let queue = std::mem::take(&mut *self.event_queue.lock().unwrap());
+                for e in queue {
+                    match e {
+                        Event::Quit => return Ok(ControlFlow::Break(())),
+                        Event::Other(o) => o(),
+                    }
+                }
+            }
+            PollEvent::Main(MainEvent::InputAvailable) => {
+                self.process_inputs().map_err(|e| PlatformError::Other(e.to_string()))?
+            }
+            PollEvent::Main(MainEvent::InitWindow { .. }) => {
+                if let Some(w) = self.app.native_window() {
+                    let size =
+                        slint::PhysicalSize { width: w.width() as u32, height: w.height() as u32 };
+
+                    let scale_factor =
+                        self.app.config().density().map(|dpi| dpi as f32 / 160.0).unwrap_or(1.0);
+
+                    if (scale_factor - self.window.scale_factor()).abs() > f32::EPSILON {
+                        self.window
+                            .dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor });
+                        self.window.dispatch_event(WindowEvent::Resized {
+                            size: size.to_logical(scale_factor),
+                        });
+                    }
+
+                    // Safety: This is safe because the handle remains valid; the next rwh release provides `new()` without unsafe.
+                    let window_handle = unsafe {
+                        raw_window_handle::WindowHandle::borrow_raw(
+                            w.raw_window_handle(),
+                            raw_window_handle::ActiveHandle::new_unchecked(),
+                        )
+                    };
+                    // Safety: The Android display handle is empty.
+                    let display_handle = unsafe {
+                        raw_window_handle::DisplayHandle::borrow_raw(
+                            raw_window_handle::RawDisplayHandle::Android(
+                                raw_window_handle::AndroidDisplayHandle::empty(),
+                            ),
+                        )
+                    };
+                    self.renderer.set_window_handle(window_handle, display_handle, size)?;
+                }
+            }
+            PollEvent::Main(
+                MainEvent::WindowResized { .. } | MainEvent::ContentRectChanged { .. },
+            ) => {
+                let size = self.size().to_logical(self.window.scale_factor());
+                self.window.dispatch_event(WindowEvent::Resized { size })
+            }
+            PollEvent::Main(MainEvent::RedrawNeeded { .. }) => {
+                self.pending_redraw.set(false);
+                self.renderer.render()?;
+            }
+            PollEvent::Main(MainEvent::GainedFocus) => {
+                self.window.dispatch_event(WindowEvent::WindowActiveChanged(true));
+            }
+            PollEvent::Main(MainEvent::LostFocus) => {
+                self.window.dispatch_event(WindowEvent::WindowActiveChanged(true));
+            }
+            PollEvent::Main(MainEvent::ConfigChanged { .. }) => {
+                let scale_factor =
+                    self.app.config().density().map(|dpi| dpi as f32 / 160.0).unwrap_or(1.0);
+
+                if (scale_factor - self.window.scale_factor()).abs() > f32::EPSILON {
+                    self.window.dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor });
+                    self.window.dispatch_event(WindowEvent::Resized {
+                        size: self.size().to_logical(scale_factor),
+                    });
+                }
+            }
+            _ => (),
+        }
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn process_inputs(&self) -> Result<(), android_activity::error::AppError> {
+        let mut iter = self.app.input_events_iter()?;
+
+        loop {
+            let read_input = iter.next(|event| match event {
+                InputEvent::KeyEvent(key_event) => match map_key_event(key_event) {
+                    Some(ev) => {
+                        self.window.dispatch_event(ev);
+                        InputStatus::Handled
+                    }
+                    None => InputStatus::Unhandled,
+                },
+                InputEvent::MotionEvent(motion_event) => match motion_event.action() {
+                    MotionAction::Down | MotionAction::ButtonPress | MotionAction::PointerDown => {
+                        self.window.dispatch_event(WindowEvent::PointerPressed {
+                            position: position_for_event(motion_event)
+                                .to_logical(self.window.scale_factor()),
+                            button: slint::platform::PointerEventButton::Left,
+                        });
+                        InputStatus::Handled
+                    }
+                    MotionAction::ButtonRelease | MotionAction::PointerUp => {
+                        self.window.dispatch_event(WindowEvent::PointerReleased {
+                            position: position_for_event(motion_event)
+                                .to_logical(self.window.scale_factor()),
+                            button: slint::platform::PointerEventButton::Left,
+                        });
+                        InputStatus::Handled
+                    }
+                    MotionAction::Up => {
+                        self.window.dispatch_event(WindowEvent::PointerReleased {
+                            position: position_for_event(motion_event)
+                                .to_logical(self.window.scale_factor()),
+                            button: slint::platform::PointerEventButton::Left,
+                        });
+                        // Also send exit to avoid remaining hover state
+                        self.window.dispatch_event(WindowEvent::PointerExited);
+                        InputStatus::Handled
+                    }
+                    MotionAction::Move | MotionAction::HoverMove => {
+                        self.window.dispatch_event(WindowEvent::PointerMoved {
+                            position: position_for_event(motion_event)
+                                .to_logical(self.window.scale_factor()),
+                        });
+                        InputStatus::Handled
+                    }
+                    MotionAction::Cancel | MotionAction::Outside => {
+                        self.window.dispatch_event(WindowEvent::PointerExited);
+                        InputStatus::Handled
+                    }
+                    MotionAction::Scroll => todo!(),
+                    MotionAction::HoverEnter | MotionAction::HoverExit => InputStatus::Unhandled,
+                    _ => InputStatus::Unhandled,
+                },
+                _ => InputStatus::Unhandled,
+            });
+
+            if !read_input {
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn position_for_event(motion_event: &MotionEvent) -> slint::PhysicalPosition {
+    motion_event.pointers().next().map_or_else(Default::default, |p| slint::PhysicalPosition {
+        x: p.x() as i32,
+        y: p.y() as i32,
+    })
+}
+
+fn map_key_event(key_event: &android_activity::input::KeyEvent) -> Option<WindowEvent> {
+    let text = map_key_code(key_event.key_code())?;
+    match key_event.action() {
+        KeyAction::Down => Some(WindowEvent::KeyPressed { text }),
+        KeyAction::Up => Some(WindowEvent::KeyReleased { text }),
+        KeyAction::Multiple => Some(WindowEvent::KeyPressed { text }),
+        _ => None,
+    }
+}
+
+fn map_key_code(code: android_activity::input::Keycode) -> Option<SharedString> {
+    match code {
+        Keycode::Unknown => None,
+        Keycode::SoftLeft => None,
+        Keycode::SoftRight => None,
+        Keycode::Home => None,
+        Keycode::Back => None,
+        Keycode::Call => None,
+        Keycode::Endcall => None,
+        Keycode::Keycode0 => Some("0".into()),
+        Keycode::Keycode1 => Some("1".into()),
+        Keycode::Keycode2 => Some("2".into()),
+        Keycode::Keycode3 => Some("3".into()),
+        Keycode::Keycode4 => Some("4".into()),
+        Keycode::Keycode5 => Some("5".into()),
+        Keycode::Keycode6 => Some("6".into()),
+        Keycode::Keycode7 => Some("7".into()),
+        Keycode::Keycode8 => Some("8".into()),
+        Keycode::Keycode9 => Some("9".into()),
+        Keycode::Star => Some("*".into()),
+        Keycode::Pound => Some("#".into()),
+        Keycode::DpadUp => Some(Key::UpArrow.into()),
+        Keycode::DpadDown => Some(Key::DownArrow.into()),
+        Keycode::DpadLeft => Some(Key::LeftArrow.into()),
+        Keycode::DpadRight => Some(Key::RightArrow.into()),
+        Keycode::DpadCenter => Some(Key::Return.into()),
+        Keycode::VolumeUp => None,
+        Keycode::VolumeDown => None,
+        Keycode::Power => None,
+        Keycode::Camera => None,
+        Keycode::Clear => None,
+        Keycode::A => Some("a".into()),
+        Keycode::B => Some("b".into()),
+        Keycode::C => Some("c".into()),
+        Keycode::D => Some("d".into()),
+        Keycode::E => Some("e".into()),
+        Keycode::F => Some("f".into()),
+        Keycode::G => Some("g".into()),
+        Keycode::H => Some("h".into()),
+        Keycode::I => Some("i".into()),
+        Keycode::J => Some("j".into()),
+        Keycode::K => Some("k".into()),
+        Keycode::L => Some("l".into()),
+        Keycode::M => Some("m".into()),
+        Keycode::N => Some("n".into()),
+        Keycode::O => Some("o".into()),
+        Keycode::P => Some("p".into()),
+        Keycode::Q => Some("q".into()),
+        Keycode::R => Some("r".into()),
+        Keycode::S => Some("s".into()),
+        Keycode::T => Some("t".into()),
+        Keycode::U => Some("u".into()),
+        Keycode::V => Some("v".into()),
+        Keycode::W => Some("w".into()),
+        Keycode::X => Some("x".into()),
+        Keycode::Y => Some("y".into()),
+        Keycode::Z => Some("z".into()),
+        Keycode::Comma => Some(",".into()),
+        Keycode::Period => Some(".".into()),
+        Keycode::AltLeft => Some(Key::Alt.into()),
+        Keycode::AltRight => Some(Key::AltGr.into()),
+        Keycode::ShiftLeft => Some(Key::Shift.into()),
+        Keycode::ShiftRight => Some(Key::ShiftR.into()),
+        Keycode::Tab => Some("\t".into()),
+        Keycode::Space => Some(" ".into()),
+        Keycode::Sym => None,
+        Keycode::Explorer => None,
+        Keycode::Envelope => None,
+        Keycode::Enter => Some(Key::Return.into()),
+        Keycode::Del => Some(Key::Delete.into()),
+        Keycode::Grave => Some("`".into()),
+        Keycode::Minus => Some("-".into()),
+        Keycode::Equals => Some("=".into()),
+        Keycode::LeftBracket => Some("[".into()),
+        Keycode::RightBracket => Some("]".into()),
+        Keycode::Backslash => Some("\\".into()),
+        Keycode::Semicolon => Some(";".into()),
+        Keycode::Apostrophe => Some("'".into()),
+        Keycode::Slash => Some("/".into()),
+        Keycode::At => Some("@".into()),
+        Keycode::Num => None,
+        Keycode::Headsethook => None,
+        Keycode::Focus => None,
+        Keycode::Plus => Some("+".into()),
+        Keycode::Menu => Some(Key::Menu.into()),
+        Keycode::Notification => None,
+        Keycode::Search => None,
+        Keycode::MediaPlayPause => None,
+        Keycode::MediaStop => None,
+        Keycode::MediaNext => None,
+        Keycode::MediaPrevious => None,
+        Keycode::MediaRewind => None,
+        Keycode::MediaFastForward => None,
+        Keycode::Mute => None,
+        Keycode::PageUp => Some(Key::PageUp.into()),
+        Keycode::PageDown => Some(Key::PageDown.into()),
+        Keycode::Pictsymbols => None,
+        Keycode::SwitchCharset => None,
+        Keycode::ButtonA => None,
+        Keycode::ButtonB => None,
+        Keycode::ButtonC => None,
+        Keycode::ButtonX => None,
+        Keycode::ButtonY => None,
+        Keycode::ButtonZ => None,
+        Keycode::ButtonL1 => None,
+        Keycode::ButtonR1 => None,
+        Keycode::ButtonL2 => None,
+        Keycode::ButtonR2 => None,
+        Keycode::ButtonThumbl => None,
+        Keycode::ButtonThumbr => None,
+        Keycode::ButtonStart => None,
+        Keycode::ButtonSelect => None,
+        Keycode::ButtonMode => None,
+        Keycode::Escape => Some(Key::Escape.into()),
+        Keycode::ForwardDel => Some(Key::Backspace.into()),
+        Keycode::CtrlLeft => Some(Key::Control.into()),
+        Keycode::CtrlRight => Some(Key::ControlR.into()),
+        Keycode::CapsLock => None,
+        Keycode::ScrollLock => Some(Key::ScrollLock.into()),
+        Keycode::MetaLeft => Some(Key::Meta.into()),
+        Keycode::MetaRight => Some(Key::MetaR.into()),
+        Keycode::Function => None,
+        Keycode::Sysrq => Some(Key::SysReq.into()),
+        Keycode::Break => None,
+        Keycode::MoveHome => Some(Key::Home.into()),
+        Keycode::MoveEnd => Some(Key::End.into()),
+        Keycode::Insert => Some(Key::Insert.into()),
+        Keycode::Forward => None,
+        Keycode::MediaPlay => None,
+        Keycode::MediaPause => None,
+        Keycode::MediaClose => None,
+        Keycode::MediaEject => None,
+        Keycode::MediaRecord => None,
+        Keycode::F1 => Some(Key::F1.into()),
+        Keycode::F2 => Some(Key::F2.into()),
+        Keycode::F3 => Some(Key::F3.into()),
+        Keycode::F4 => Some(Key::F4.into()),
+        Keycode::F5 => Some(Key::F5.into()),
+        Keycode::F6 => Some(Key::F6.into()),
+        Keycode::F7 => Some(Key::F7.into()),
+        Keycode::F8 => Some(Key::F8.into()),
+        Keycode::F9 => Some(Key::F9.into()),
+        Keycode::F10 => Some(Key::F10.into()),
+        Keycode::F11 => Some(Key::F11.into()),
+        Keycode::F12 => Some(Key::F12.into()),
+        Keycode::NumLock => None,
+        Keycode::Numpad0 => Some("0".into()),
+        Keycode::Numpad1 => Some("1".into()),
+        Keycode::Numpad2 => Some("2".into()),
+        Keycode::Numpad3 => Some("3".into()),
+        Keycode::Numpad4 => Some("4".into()),
+        Keycode::Numpad5 => Some("5".into()),
+        Keycode::Numpad6 => Some("6".into()),
+        Keycode::Numpad7 => Some("7".into()),
+        Keycode::Numpad8 => Some("8".into()),
+        Keycode::Numpad9 => Some("9".into()),
+        Keycode::NumpadDivide => Some("/".into()),
+        Keycode::NumpadMultiply => Some("*".into()),
+        Keycode::NumpadSubtract => Some("-".into()),
+        Keycode::NumpadAdd => Some("+".into()),
+        Keycode::NumpadDot => Some(".".into()),
+        Keycode::NumpadComma => Some(",".into()),
+        Keycode::NumpadEnter => Some("\n".into()),
+        Keycode::NumpadEquals => Some("=".into()),
+        Keycode::NumpadLeftParen => Some("(".into()),
+        Keycode::NumpadRightParen => Some(")".into()),
+        Keycode::VolumeMute => None,
+        Keycode::Info => None,
+        Keycode::ChannelUp => None,
+        Keycode::ChannelDown => None,
+        Keycode::ZoomIn => None,
+        Keycode::ZoomOut => None,
+        Keycode::Tv => None,
+        Keycode::Window => None,
+        Keycode::Guide => None,
+        Keycode::Dvr => None,
+        Keycode::Bookmark => None,
+        Keycode::Captions => None,
+        Keycode::Settings => None,
+        Keycode::TvPower => None,
+        Keycode::TvInput => None,
+        Keycode::StbPower => None,
+        Keycode::StbInput => None,
+        Keycode::AvrPower => None,
+        Keycode::AvrInput => None,
+        Keycode::ProgRed => None,
+        Keycode::ProgGreen => None,
+        Keycode::ProgYellow => None,
+        Keycode::ProgBlue => None,
+        Keycode::AppSwitch => None,
+        Keycode::Button1 => None,
+        Keycode::Button2 => None,
+        Keycode::Button3 => None,
+        Keycode::Button4 => None,
+        Keycode::Button5 => None,
+        Keycode::Button6 => None,
+        Keycode::Button7 => None,
+        Keycode::Button8 => None,
+        Keycode::Button9 => None,
+        Keycode::Button10 => None,
+        Keycode::Button11 => None,
+        Keycode::Button12 => None,
+        Keycode::Button13 => None,
+        Keycode::Button14 => None,
+        Keycode::Button15 => None,
+        Keycode::Button16 => None,
+        Keycode::LanguageSwitch => None,
+        Keycode::MannerMode => None,
+        Keycode::Keycode3dMode => None,
+        Keycode::Contacts => None,
+        Keycode::Calendar => None,
+        Keycode::Music => None,
+        Keycode::Calculator => None,
+        Keycode::ZenkakuHankaku => None,
+        Keycode::Eisu => None,
+        Keycode::Muhenkan => None,
+        Keycode::Henkan => None,
+        Keycode::KatakanaHiragana => None,
+        Keycode::Yen => None,
+        Keycode::Ro => None,
+        Keycode::Kana => None,
+        Keycode::Assist => None,
+        Keycode::BrightnessDown => None,
+        Keycode::BrightnessUp => None,
+        Keycode::MediaAudioTrack => None,
+        Keycode::Sleep => None,
+        Keycode::Wakeup => None,
+        Keycode::Pairing => None,
+        Keycode::MediaTopMenu => None,
+        Keycode::Keycode11 => None,
+        Keycode::Keycode12 => None,
+        Keycode::LastChannel => None,
+        Keycode::TvDataService => None,
+        Keycode::VoiceAssist => None,
+        Keycode::TvRadioService => None,
+        Keycode::TvTeletext => None,
+        Keycode::TvNumberEntry => None,
+        Keycode::TvTerrestrialAnalog => None,
+        Keycode::TvTerrestrialDigital => None,
+        Keycode::TvSatellite => None,
+        Keycode::TvSatelliteBs => None,
+        Keycode::TvSatelliteCs => None,
+        Keycode::TvSatelliteService => None,
+        Keycode::TvNetwork => None,
+        Keycode::TvAntennaCable => None,
+        Keycode::TvInputHdmi1 => None,
+        Keycode::TvInputHdmi2 => None,
+        Keycode::TvInputHdmi3 => None,
+        Keycode::TvInputHdmi4 => None,
+        Keycode::TvInputComposite1 => None,
+        Keycode::TvInputComposite2 => None,
+        Keycode::TvInputComponent1 => None,
+        Keycode::TvInputComponent2 => None,
+        Keycode::TvInputVga1 => None,
+        Keycode::TvAudioDescription => None,
+        Keycode::TvAudioDescriptionMixUp => None,
+        Keycode::TvAudioDescriptionMixDown => None,
+        Keycode::TvZoomMode => None,
+        Keycode::TvContentsMenu => None,
+        Keycode::TvMediaContextMenu => None,
+        Keycode::TvTimerProgramming => None,
+        Keycode::Help => None,
+        Keycode::NavigatePrevious => None,
+        Keycode::NavigateNext => None,
+        Keycode::NavigateIn => None,
+        Keycode::NavigateOut => None,
+        Keycode::StemPrimary => None,
+        Keycode::Stem1 => None,
+        Keycode::Stem2 => None,
+        Keycode::Stem3 => None,
+        Keycode::DpadUpLeft => None,
+        Keycode::DpadDownLeft => None,
+        Keycode::DpadUpRight => None,
+        Keycode::DpadDownRight => None,
+        Keycode::MediaSkipForward => None,
+        Keycode::MediaSkipBackward => None,
+        Keycode::MediaStepForward => None,
+        Keycode::MediaStepBackward => None,
+        Keycode::SoftSleep => None,
+        Keycode::Cut => None,
+        Keycode::Copy => None,
+        Keycode::Paste => None,
+        Keycode::SystemNavigationUp => None,
+        Keycode::SystemNavigationDown => None,
+        Keycode::SystemNavigationLeft => None,
+        Keycode::SystemNavigationRight => None,
+        Keycode::AllApps => None,
+        Keycode::Refresh => None,
+        Keycode::ThumbsUp => None,
+        Keycode::ThumbsDown => None,
+        Keycode::ProfileSwitch => None,
+        _ => None,
+    }
+}

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -33,13 +33,14 @@ accessibility = ["i-slint-backend-winit?/accessibility"]
 default = []
 
 [dependencies]
+cfg-if = "1"
 i-slint-core = { workspace = true }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
 i-slint-backend-winit = { workspace = true, features = ["default"], optional = true }
 i-slint-backend-qt = { workspace = true, features = ["default"], optional = true }
 i-slint-backend-linuxkms = { workspace = true, features = ["default"], optional = true }
 i-slint-renderer-skia = { workspace = true, optional = true }
-
-cfg-if = "1"
 
 [build-dependencies]
 i-slint-common = { workspace = true }

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -11,6 +11,7 @@
     )),
     no_std
 )]
+#![allow(unused)]
 
 extern crate alloc;
 
@@ -18,23 +19,24 @@ use alloc::boxed::Box;
 use i_slint_core::platform::Platform;
 use i_slint_core::platform::PlatformError;
 
-#[cfg(all(feature = "i-slint-backend-qt", not(no_qt)))]
+#[cfg(all(feature = "i-slint-backend-qt", not(no_qt), not(target_os = "android")))]
 fn create_qt_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> {
     Ok(Box::new(default_backend::Backend::new()))
 }
 
-#[cfg(feature = "i-slint-backend-winit")]
+#[cfg(all(feature = "i-slint-backend-winit", not(target_os = "android")))]
 fn create_winit_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> {
     Ok(Box::new(i_slint_backend_winit::Backend::new()?))
 }
 
-#[cfg(feature = "i-slint-backend-linuxkms")]
+#[cfg(all(feature = "i-slint-backend-linuxkms", not(target_os = "android")))]
 fn create_linuxkms_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> {
     Ok(Box::new(i_slint_backend_linuxkms::Backend::new()?))
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(all(feature = "i-slint-backend-qt", not(no_qt)))] {
+    if #[cfg(target_os = "android")] {
+    } else if #[cfg(all(feature = "i-slint-backend-qt", not(no_qt)))] {
         use i_slint_backend_qt as default_backend;
     } else if #[cfg(feature = "i-slint-backend-winit")] {
         use i_slint_backend_winit as default_backend;
@@ -46,11 +48,11 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(any(
+    if #[cfg(all(not(target_os = "android"), any(
             all(feature = "i-slint-backend-qt", not(no_qt)),
             feature = "i-slint-backend-winit",
             feature = "i-slint-backend-linuxkms"
-        ))] {
+        )))] {
         fn create_default_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> {
             use alloc::borrow::Cow;
 

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -39,7 +39,7 @@ lyon_path = "1.0"
 once_cell = "1.5"
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
-raw-window-handle = { version = "0.5", features = ["alloc"] }
+raw-window-handle = { version = "0.5", features = ["std"] }
 
 skia-safe = { version = "0.68.0", features = ["textlayout"] }
 glow = { version = "0.12" }


### PR DESCRIPTION
This is a backend that implement a slint::platform for android-activity

This also adapt the `todo` example so it can be run on android.

In order to run it on android, the `#wasm#` lines in the todo/Cargo.toml need to be removed, and the 
todo example can be run with cargo-apk:   `cargo apk run  -p todo --target aarch64-linux-android --lib` (and the proper env variable needs to be defined for the NDK and the SDK)

This work is sponsored by NLnet


Part of https://github.com/slint-ui/slint/issues/46

