### PR TITLE
Disable the Qt backend on windows and mac

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -108,7 +108,7 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 ## This backend also provides the `qt` style.
 ## It requires Qt 5.15 or later to be installed. If Qt is not installed, the
 ## backend will not be operational.
-## This backend is only available on Linux-like. This feature has no effect on other platforms.
+## This backend is only available on Linux-like operating systems. This feature has no effect on other platforms.
 backend-qt = ["i-slint-backend-selector/i-slint-backend-qt", "std"]
 
 ## The [winit](https://crates.io/crates/log) crate is used for the event loop and windowing system integration.

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -105,9 +105,10 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 #! Here are the cargo features controlling the backend:
 
 ## The Qt backend feature uses Qt for the windowing system integration and rendering.
-## This backend also provides the `native` style.
+## This backend also provides the `qt` style.
 ## It requires Qt 5.15 or later to be installed. If Qt is not installed, the
-## backend will not be operational
+## backend will not be operational.
+## This backend is only available on Linux-like. This feature has no effect on other platforms.
 backend-qt = ["i-slint-backend-selector/i-slint-backend-qt", "std"]
 
 ## The [winit](https://crates.io/crates/log) crate is used for the event loop and windowing system integration.

--- a/docs/install_qt.md
+++ b/docs/install_qt.md
@@ -26,25 +26,12 @@ typically located in the `bin` sub-directory of a Qt installation that was produ
 Alternatively, you can set the `QMAKE` environment variable to point to the `qmake` executable.
 (more info: <https://docs.rs/qttypes/*/qttypes/#finding-qt> )
 
-### Linux
-
 Many distributions may provide Qt 5.15 in the distribution package. In that case you can install these packages
 and there isn't much more to do. On many distributions, you also need the **-dev** packages. For distributions that
 split the packages in different modules, you just need `qtbase` (for QtWidgets) and `qtsvg` for the SVG plugin.
 
 If when running your Slint application you get an error that libQt5Core.so.5 or such can't be found, you need to
 adjust the `LD_LIBRARY_PATH` environment variable to contain a path that contains the Qt libraries.
-
-### macOS
-
-In addition to either having `qmake` in your `PATH` or setting `QMAKE`, you also need to modify the `DYLD_FRAMEWORK_PATH`
-environment variable. It needs to be set to the `lib` directory of your Qt installation, for example `$HOME/Qt/6.2.0/macos/lib`,
-in order for the dynamic linker to find the Qt libraries when starting an application.
-
-### Windows
-
-For Windows it's necessary to have the `bin` directory of your Qt installation in the list of paths in the `PATH`
-environment variable, in order for the build system to locate `qmake` and to find the Qt DLLs when starting an application.
 
 ## How To Disable the Qt Backend
 

--- a/docs/reference/src/advanced/backend_qt.md
+++ b/docs/reference/src/advanced/backend_qt.md
@@ -4,8 +4,7 @@
 The Qt backend uses the [Qt](https://www.qt.io) library to interact with the windowing system, for
 rendering, as well as widget style for a native look and feel.
 
-The Qt backend supports practically all relevant operating systems and windowing systems, including
-macOS, Windows, Linux with Wayland and X11, and direct full-screen rendering via KMS or proprietary drivers.
+The Qt backend is only available on linux-like system
 
 The Qt backend only supports software rendering at the moment. That means it runs with any graphics driver,
 but it does not utilize GPU hardware acceleration.
@@ -17,3 +16,8 @@ The Qt backend reads and interprets the following environment variables:
 | Name               | Accepted Values | Description                                                        |
 |--------------------|-----------------|--------------------------------------------------------------------|
 | `SLINT_FULLSCREEN` | any value       | If this variable is set, every window is shown in fullscreen mode. |
+
+## How To Disable the Qt Backend
+
+By setting the `SLINT_NO_QT` environment variable when building Slint, the Qt backend won't be compiled and
+no attempt will be made to find Qt on the system. This will also disable the warning stating that Qt wasn't found.

--- a/docs/reference/src/advanced/backend_qt.md
+++ b/docs/reference/src/advanced/backend_qt.md
@@ -4,7 +4,7 @@
 The Qt backend uses the [Qt](https://www.qt.io) library to interact with the windowing system, for
 rendering, as well as widget style for a native look and feel.
 
-The Qt backend is only available on linux-like system
+The Qt backend is only available on Linux-like operating systems.
 
 The Qt backend only supports software rendering at the moment. That means it runs with any graphics driver,
 but it does not utilize GPU hardware acceleration.

--- a/docs/reference/src/advanced/backends_and_renderers.md
+++ b/docs/reference/src/advanced/backends_and_renderers.md
@@ -22,7 +22,7 @@ capabilities and their configuration options, see the respective sub-pages.
 
 | Backend Name | Description                                                                                             | Built-in by Default   |
 |--------------|---------------------------------------------------------------------------------------------------------|-----------------------|
-| qt           | The Qt library is used for windowing system integration, rendering, and native widget styling.          | Yes (if Qt installed) |
+| qt           | On Linux, The Qt library is used for windowing system integration, rendering, and native widget styling.| Yes (if Qt installed) |
 | winit        | The [winit](https://docs.rs/winit/latest/winit/) library is used to interact with the windowing system. | Yes                   |
 | linuxkms     | Linux's KMS/DRI infrastructure is used for rendering. No windowing system or compositor is required.    | No                    |
 

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -41,7 +41,7 @@ i-slint-backend-winit = { workspace = true, features = ["default"], optional = t
 i-slint-backend-linuxkms = { workspace = true, features = ["default"], optional = true }
 i-slint-renderer-skia = { workspace = true, optional = true }
 
-[target.'cfg(not(any(target_os = "android", target_os="windows", target_os = "macos")))'.dependencies]
+[target.'cfg(not(any(target_os = "android", target_os = "windows", target_os = "macos")))'.dependencies]
 i-slint-backend-qt = { workspace = true, features = ["default"], optional = true }
 
 [build-dependencies]

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -38,9 +38,11 @@ i-slint-core = { workspace = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 i-slint-backend-winit = { workspace = true, features = ["default"], optional = true }
-i-slint-backend-qt = { workspace = true, features = ["default"], optional = true }
 i-slint-backend-linuxkms = { workspace = true, features = ["default"], optional = true }
 i-slint-renderer-skia = { workspace = true, optional = true }
+
+[target.'cfg(not(any(target_os = "android", target_os="windows", target_os = "macos")))'.dependencies]
+i-slint-backend-qt = { workspace = true, features = ["default"], optional = true }
 
 [build-dependencies]
 i-slint-common = { workspace = true }


### PR DESCRIPTION
The Qt style is no longer the default anyway on these platforms

The users are reporting problems when Qt is in the path and it tries to load the wrong one (eg, mingw as opposed to msvc)

Fixes #3802
Fixes #3539
Fixes #3739