### PR TITLE
Fix slint compiler panic in chiptrack

### DIFF
--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1191,7 +1191,7 @@ impl Expression {
     /// This function is used to find a type that's suitable for casting each instance of a bunch of expressions
     /// to a type that captures most aspects. For example for an array of object literals the result is a merge of
     /// all seen fields.
-    fn common_target_type_for_type_list(types: impl Iterator<Item = Type>) -> Type {
+    pub fn common_target_type_for_type_list(types: impl Iterator<Item = Type>) -> Type {
         types.fold(Type::Invalid, |target_type, expr_ty| {
             if target_type == expr_ty {
                 target_type

--- a/tests/cases/expr/return2.slint
+++ b/tests/cases/expr/return2.slint
@@ -3,15 +3,31 @@
 
 export global Foo {
     in-out property<bool> bo: false;
-    pure function return_bool() -> bool {
+    public pure function return_bool() -> bool {
         if (bo) {
             return true;
         }
         false
     }
+
+    callback cycle_instrument_param_end();
 }
 
-component TestCase {
+
+// extracted from chiptrack
+export component StepsFocusScope inherits FocusScope {
+    callback root_key_released(KeyEvent) -> EventResult;
+    key_released(e) => {
+        if (e.text == Key.Control) { Foo.cycle_instrument_param_end(); }
+        else {
+            return root_key_released(e);
+        }
+        accept
+    }
+}
+
+
+export component TestCase {
 
     function return_false() -> bool { return false; }
 
@@ -80,6 +96,14 @@ component TestCase {
         return false;
         false;
     }
+
+    out property <bool> check_ok;
+    public function test-key() -> bool {
+        fs.key-released({text: "hi"}) == EventResult.reject
+    }
+    fs := StepsFocusScope {
+        root-key-released(e) => { check-ok = e.text == "hi"; EventResult.reject }
+    }
 }
 
 
@@ -90,6 +114,10 @@ const TestCase &instance = *handle;
 assert(instance.get_test());
 instance.invoke_proceed();
 assert_eq(instance.get_val(), "1234");
+
+assert_eq(instance.invoke_test_key(), true);
+assert_eq(instance.get_check_ok(), true);
+
 ```
 
 ```rust
@@ -97,6 +125,12 @@ let instance = TestCase::new().unwrap();
 assert!(instance.get_test());
 instance.invoke_proceed();
 assert_eq!(instance.get_val(), "1234");
+
+instance.global::<Foo<'_>>().on_cycle_instrument_param_end(|| panic!("should not happen"));
+assert_eq!(instance.invoke_test_key(), true);
+assert_eq!(instance.get_check_ok(), true);
+
+
 ```
 
 


### PR DESCRIPTION
If a branch that always return has a "void value" and the side that doesn't return has a value, we need to synthetize a default value so the struct is complete, even if that value is not used.