### PR TITLE
Fix regression with empty array

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -517,6 +517,15 @@ public:
     }
 };
 
+// Specialize for the empty array. We can't have a Model<void>, but `int` will work for our purpose
+template<>
+class ArrayModel<0, void> : public Model<int>
+{
+public:
+    size_t row_count() const override { return 0; }
+    std::optional<int> row_data(size_t) const override { return {}; }
+};
+
 /// Model to be used when we just want to repeat without data.
 struct UIntModel : Model<int>
 {

--- a/internal/compiler/tests/syntax/lookup/conversion.slint
+++ b/internal/compiler/tests/syntax/lookup/conversion.slint
@@ -50,4 +50,14 @@ export X := Rectangle {
 //                               ^error{Cannot convert string to int}  (FIXME: error location)
 //                               ^^error{Cannot convert string to int}  (FIXME: duplicated)
 
+    property <int> arr1: [];
+//                       ^error{Cannot convert \[void\] to int}
+
+    property <{a: int}> arr2: {a: []};
+    //                        ^error{Cannot convert \[void\] to int}
+
+    property <int> arr3: false ? [] : 45;  //(FIXME: error not ideal)
+//                                    ^error{Cannot convert float to \[void\]}
+//                       ^^error{Cannot convert void to int}
+
 }

--- a/tests/cases/models/array.slint
+++ b/tests/cases/models/array.slint
@@ -7,13 +7,17 @@ export TestCase := Rectangle {
     property<int> n: ints[ints[4] - ints[1]];
     property<int> operations: ints.length < 1 ? ints.length : ints.length + ints.length;
     property<[{a: [int]}]> empty_model;
-    property<[[int]]> array_of_array: [ints, ints, ints];
+    property<[{a: [int]}]> empty_model2 : [];
+    property<[{a: [int]}]> empty_model3 : [{a:[]}];
+    property<[[int]]> array_of_array: [ints, ints, ints, []];
 
     property<bool> test: num_ints == 5 && operations == 10
         && hello_world == (["", "world"])[1] && empty_model.length == 0 && empty_model[45].a.length == 0
-        && array_of_array[1][1] == 2;
+        && array_of_array[1][1] == 2 && [].length == 0;
     property<int> third_int: ints[2];
     property<string> hello_world: [{t: "hello"}, {t: "world"}][1].t;
+
+    for xxx in (third_int == 0) ? ints : [] : Rectangle {}
 }
 
 /*


### PR DESCRIPTION
Regression noticed in this line:
https://github.com/Tricked-dev/stardew-mod-manager/blob/3f97d98bfff8c56161c9f5afcf003a580af34ff6/ui/tabs/downloads.slint#L77

The following used to work:

```slint
import { Button, VerticalBox } from "std-widgets.slint";
export component Demo {
    in property <[int]> mods;
    VerticalBox {
        alignment: start;
        for xxx in true ? mods : [] : HorizontalLayout { alignment: center; Button { text: "OK!"; } }
    }
}
```

But we fixed array conversion and this caused a regression with empty array