### PR TITLE
Make it possible to focus Cupertino and Fluent buttons

### DIFF
--- a/internal/compiler/widgets/cupertino-base/button.slint
+++ b/internal/compiler/widgets/cupertino-base/button.slint
@@ -25,6 +25,7 @@ export component Button {
     vertical-stretch: 0;
     accessible-label: text;
     accessible-role: button;
+    forward-focus: i-focus-scope;
 
     states [
         disabled when !i-touch-area.enabled : {

--- a/internal/compiler/widgets/fluent-base/button.slint
+++ b/internal/compiler/widgets/fluent-base/button.slint
@@ -24,6 +24,7 @@ export component Button {
     vertical-stretch: 0;
     accessible-label: text;
     accessible-role: button;
+    forward-focus: i-focus-scope;
 
     states [
         disabled when !root.enabled : {


### PR DESCRIPTION
The Material button already has the forward-focus.