### PR TITLE
Silence error when rendering SVG in an 0x0 size

### DIFF
--- a/internal/backends/linuxkms/fullscreenwindowadapter.rs
+++ b/internal/backends/linuxkms/fullscreenwindowadapter.rs
@@ -8,7 +8,6 @@ use std::pin::Pin;
 use std::rc::Rc;
 
 use i_slint_core::api::{LogicalPosition, PhysicalSize as PhysicalWindowSize};
-use i_slint_core::graphics::euclid;
 use i_slint_core::graphics::Image;
 use i_slint_core::item_rendering::ItemRenderer;
 use i_slint_core::platform::WindowEvent;
@@ -97,7 +96,7 @@ fn mouse_cursor_image() -> Image {
     let mouse_pointer_inner: &i_slint_core::graphics::ImageInner = (&mouse_pointer_svg).into();
     match mouse_pointer_inner {
         i_slint_core::ImageInner::Svg(svg) => {
-            let pixels = svg.render(euclid::Size2D::from_untyped(svg.size())).unwrap();
+            let pixels = svg.render(None).unwrap();
             let cache_key = svg.cache_key();
             let mouse_pointer_pixel_image = i_slint_core::graphics::ImageInner::EmbeddedImage {
                 cache_key: cache_key.clone(),

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -56,7 +56,7 @@ pub(crate) fn as_skia_image(
             let (target_width, target_height) = target_size_fn();
             let target_size = LogicalSize::from_lengths(target_width, target_height) * scale_factor;
             let target_size = i_slint_core::graphics::fit_size(image_fit, target_size, svg.size());
-            let pixels = match svg.render(target_size.cast()).ok()? {
+            let pixels = match svg.render(Some(target_size.cast())).ok()? {
                 SharedImageBuffer::RGB8(_) => unreachable!(),
                 SharedImageBuffer::RGBA8(_) => unreachable!(),
                 SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels,


### PR DESCRIPTION
Make the size argument to svg::render optional to mean that it is the default size of the image.
Otherwise, passing None as the size to ImageInner::render_to_buffer would not render the image which is possible in some backend (eg: the button image icon with the qt backend)

And if the image is really rendered on an empty because of layouting or so, we don't need to show a warning anyway.

Fix #3790