### PR TITLE
Re-enable accesskit

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -27,7 +27,7 @@ renderer-skia-opengl = ["renderer-skia", "i-slint-renderer-skia/opengl"]
 renderer-skia-vulkan = ["renderer-skia", "i-slint-renderer-skia/vulkan"]
 renderer-software = ["dep:softbuffer", "dep:imgref", "dep:rgb", "i-slint-core/software-renderer-systemfonts", "dep:bytemuck", "winit/rwh_05"]
 accessibility = ["dep:accesskit",
- #"dep:accesskit_winit"
+  "dep:accesskit_winit"
 ]
 default = []
 
@@ -70,8 +70,8 @@ wasm-bindgen = { version = "0.2" }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { workspace = true, optional = true, default-features = false, features = ["egl", "wgl"] }
 glutin-winit = { version = "0.4.2", optional = true, default-features = false, features = ["egl", "wgl"] }
-accesskit = { version = "0.11.0", optional = true }
-#accesskit_winit = { version = "0.14.0", optional = true }
+accesskit = { version = "0.12.1", optional = true }
+accesskit_winit = { version = "0.16.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # For GL rendering

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -26,9 +26,7 @@ renderer-skia = ["i-slint-renderer-skia", "winit/rwh_05"]
 renderer-skia-opengl = ["renderer-skia", "i-slint-renderer-skia/opengl"]
 renderer-skia-vulkan = ["renderer-skia", "i-slint-renderer-skia/vulkan"]
 renderer-software = ["dep:softbuffer", "dep:imgref", "dep:rgb", "i-slint-core/software-renderer-systemfonts", "dep:bytemuck", "winit/rwh_05"]
-accessibility = ["dep:accesskit",
-  "dep:accesskit_winit"
-]
+accessibility = ["dep:accesskit", "dep:accesskit_winit"]
 default = []
 
 [dependencies]

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -7,6 +7,6 @@ fn main() {
     // Setup cfg aliases
     cfg_aliases! {
        enable_skia_renderer: { any(feature = "renderer-skia", feature = "renderer-skia-opengl", feature = "renderer-skia-vulkan")},
-     // TODO  enable_accesskit: { all(feature = "accessibility", not(target_arch = "wasm32")) },
+       enable_accesskit: { all(feature = "accessibility", not(target_arch = "wasm32")) },
     }
 }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -461,15 +461,9 @@ impl EventLoopState {
 
             Event::WindowEvent { event, window_id } => {
                 if let Some(window) = window_by_id(window_id) {
-                    #[cfg(not(enable_accesskit))]
-                    let process_event = true;
                     #[cfg(enable_accesskit)]
-                    let process_event =
-                        window.accesskit_adapter.on_event(&window.winit_window(), &event);
-
-                    if process_event {
-                        self.process_window_event(window, event);
-                    }
+                    window.accesskit_adapter.process_event(&window.winit_window(), &event);
+                    self.process_window_event(window, event);
                 };
             }
 


### PR DESCRIPTION
Port to the latest accesskit and accesskit_winit:

- Temporarily point to the PR that updates accesskit_winit to winit 0.29.
- NodeId is now a u64 instead of u128, so trim the component/item encoding.
- Adjust to some enum renamings.
- TreeUpdate now always requires a focus node, which we set to the root.