### PR TITLE
Minor polish to the earrings page in the widgets gallery

### DIFF
--- a/examples/gallery/ui/pages/easings_page.slint
+++ b/examples/gallery/ui/pages/easings_page.slint
@@ -1,8 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-import {Page} from "page.slint";
-import {Button, HorizontalBox, Slider, ScrollView} from "std-widgets.slint";
+import { Page } from "page.slint";
+import { Button, HorizontalBox, Slider, ScrollView } from "std-widgets.slint";
 
 component EaseTest inherits HorizontalLayout {
     padding: 10px;

--- a/examples/gallery/ui/pages/easings_page.slint
+++ b/examples/gallery/ui/pages/easings_page.slint
@@ -59,49 +59,47 @@ export component EasingsPage inherits Page {
         padding: 10px;
         spacing: 10px;
 
-        Button {
-            text: "Animate All";
-            clicked => {
-                linear-test.animate();
-                ease-in-quad-test.animate();
-                ease-out-quad-test.animate();
-                ease-in-out-quad-test.animate();
-                ease-test.animate();
-                ease-in-test.animate();
-                ease-out-test.animate();
-                ease-in-out-test.animate();
-                ease-in-quart-test.animate();
-                ease-out-quart-test.animate();
-                ease-in-out-quart-test.animate();
-                ease-in-quint-test.animate();
-                ease-out-quint-test.animate();
-                ease-in-out-quint-test.animate();
-                ease-in-expo-test.animate();
-                ease-out-expo-test.animate();
-                ease-in-out-expo-test.animate();
-                ease-in-sine-test.animate();
-                ease-out-sine-test.animate();
-                ease-in-out-sine-test.animate();
-                ease-in-back-test.animate();
-                ease-out-back-test.animate();
-                ease-in-out-back-test.animate();
-                ease-in-circ-test.animate();
-                ease-out-circ-test.animate();
-                ease-in-out-circ-test.animate();
-                ease-in-elastic-test.animate();
-                ease-out-elastic-test.animate();
-                ease-in-out-elastic-test.animate();
-                ease-in-bounce-test.animate();
-                ease-out-bounce-test.animate();
-                ease-in-out-bounce-test.animate();
+        HorizontalBox {
+            Button {
+                text: "Animate All";
+                clicked => {
+                    linear-test.animate();
+                    ease-in-quad-test.animate();
+                    ease-out-quad-test.animate();
+                    ease-in-out-quad-test.animate();
+                    ease-test.animate();
+                    ease-in-test.animate();
+                    ease-out-test.animate();
+                    ease-in-out-test.animate();
+                    ease-in-quart-test.animate();
+                    ease-out-quart-test.animate();
+                    ease-in-out-quart-test.animate();
+                    ease-in-quint-test.animate();
+                    ease-out-quint-test.animate();
+                    ease-in-out-quint-test.animate();
+                    ease-in-expo-test.animate();
+                    ease-out-expo-test.animate();
+                    ease-in-out-expo-test.animate();
+                    ease-in-sine-test.animate();
+                    ease-out-sine-test.animate();
+                    ease-in-out-sine-test.animate();
+                    ease-in-back-test.animate();
+                    ease-out-back-test.animate();
+                    ease-in-out-back-test.animate();
+                    ease-in-circ-test.animate();
+                    ease-out-circ-test.animate();
+                    ease-in-out-circ-test.animate();
+                    ease-in-elastic-test.animate();
+                    ease-out-elastic-test.animate();
+                    ease-in-out-elastic-test.animate();
+                    ease-in-bounce-test.animate();
+                    ease-out-bounce-test.animate();
+                    ease-in-out-bounce-test.animate();
+                }
             }
-        }
-
-        HorizontalLayout {
-            spacing: 10px;
-            Text { text: "Duration"; }
+            Text { text: "Duration:"; vertical-alignment: center ;}
             slider := Slider { minimum: 100; maximum: 5000; value: 1000; }
-            Text { text: "" + round(slider.value) + "ms"; }
+            Text { text: "" + round(slider.value) + "ms"; vertical-alignment: center; }
         }
     }
 

--- a/examples/gallery/ui/pages/easings_page.slint
+++ b/examples/gallery/ui/pages/easings_page.slint
@@ -60,7 +60,7 @@ export component EasingsPage inherits Page {
         spacing: 10px;
 
         Button {
-            text: "Animate All!";
+            text: "Animate All";
             clicked => {
                 linear-test.animate();
                 ease-in-quad-test.animate();


### PR DESCRIPTION
Apply some polish to the label text and button sizes.

Before:

<img width="700" alt="before" src="https://github.com/slint-ui/slint/assets/1486/c73af668-2d74-47d4-83f4-23c709bc425b">

After:

<img width="700" alt="after" src="https://github.com/slint-ui/slint/assets/1486/37024b82-4292-4532-9b65-f0aa9c869725">
