### PR TITLE
Fix animation expression not being visited for use count of property

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -269,6 +269,15 @@ inline LayoutInfo LayoutInfo::merge(const LayoutInfo &other) const
                         std::max(preferred, other.preferred),
                         std::min(stretch, other.stretch) };
 }
+inline bool operator==(const EasingCurve &a, const EasingCurve &b)
+{
+    if (a.tag != b.tag) {
+        return false;
+    } else if (a.tag == EasingCurve::Tag::CubicBezier) {
+        return std::equal(a.cubic_bezier._0, a.cubic_bezier._0 + 4, b.cubic_bezier._0);
+    }
+    return true;
+}
 }
 
 namespace private_api {

--- a/examples/gallery/ui/pages/easings_page.slint
+++ b/examples/gallery/ui/pages/easings_page.slint
@@ -51,9 +51,7 @@ export component EasingsPage inherits Page {
     title: "Easings";
     description: "Easing demos";
 
-    private property <int> curr-duration: 1000;
-    // Swap to the line below to crash the Rust code generator
-    // private property <int> curr-duration: slider.value;
+    private property <int> curr-duration: slider.value;
 
     VerticalLayout {
         padding: 10px;

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -377,6 +377,7 @@ impl CppType for Type {
             }
             Type::Brush => Some("slint::Brush".to_owned()),
             Type::LayoutCache => Some("slint::SharedVector<float>".into()),
+            Type::Easing => Some("slint::cbindgen_private::EasingCurve".into()),
             _ => None,
         }
     }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -114,6 +114,7 @@ fn rust_primitive_type(ty: &Type) -> Option<proc_macro2::TokenStream> {
 fn rust_property_type(ty: &Type) -> Option<proc_macro2::TokenStream> {
     match ty {
         Type::LogicalLength => Some(quote!(sp::LogicalLength)),
+        Type::Easing => Some(quote!(sp::EasingCurve)),
         _ => rust_primitive_type(ty),
     }
 }

--- a/tests/cases/properties/animation_props_depends.slint
+++ b/tests/cases/properties/animation_props_depends.slint
@@ -1,0 +1,38 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+component Slider {
+    in-out property <int> value;
+    TouchArea {
+        clicked => { value += 1; }
+    }
+}
+
+export global Glob { in-out property <bool> cond; }
+
+component Animated {
+    public function animate() {
+        r.x += 500px;
+    }
+
+    in property <easing> ease;
+    in property <int> duration;
+    in property <duration> delay;
+    r := Rectangle {
+        background: Glob.cond ? blue : red;
+        animate background { easing: ease; duration: duration * 1ms;   }
+        animate x { easing: ease; duration: 260ms; delay: delay; }
+    }
+}
+
+export component Main {
+    slider1 := Slider {}
+    slider2 := Slider {}
+    property <int> value1: slider1.value;
+    property <int> value2: slider2.value;
+    public function anunimate() { a1.animate(); }
+    HorizontalLayout {
+        a1 := Animated { ease: ease-out; duration: value1; delay: value2 * 2ms; }
+        Animated { ease: ease-in; duration: value1; delay: value2 * 2ms; }
+    }
+}


### PR DESCRIPTION
resulting in properties being optimized when they shouldn't