### PR TITLE
Fix copy & paste in wasm builds

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -256,6 +256,12 @@ impl i_slint_core::platform::Platform for Backend {
         Some(Box::new(Proxy))
     }
 
+    #[cfg(target_arch = "wasm32")]
+    fn set_clipboard_text(&self, text: &str, clipboard: i_slint_core::platform::Clipboard) {
+        crate::wasm_input_helper::set_clipboard_text(text.into(), clipboard);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     fn set_clipboard_text(&self, text: &str, clipboard: i_slint_core::platform::Clipboard) {
         crate::event_loop::with_window_target(|event_loop_target| {
             if let Some(mut clipboard) = event_loop_target.clipboard(clipboard) {
@@ -266,6 +272,12 @@ impl i_slint_core::platform::Platform for Backend {
         .ok();
     }
 
+    #[cfg(target_arch = "wasm32")]
+    fn clipboard_text(&self, clipboard: i_slint_core::platform::Clipboard) -> Option<String> {
+        crate::wasm_input_helper::get_clipboard_text(clipboard)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     fn clipboard_text(&self, clipboard: i_slint_core::platform::Clipboard) -> Option<String> {
         crate::event_loop::with_window_target(|event_loop_target| {
             Ok(event_loop_target


### PR DESCRIPTION
Commit f24014a2ddcd135fb28a1b86167a53d86e878d0f made the insert function private. Let's solve this differently by creating a private WASM clipboard and invoking copy() and paste() on the Text item instead.

The first attempt was implementing a ClipboardProvider just for the wasm build, just like with SilentClipboard, but unfortunately that doesn't work because in the backend's set_clipboard_text()/clipboard_text() functions, there's no currently running winit event loop that we could access, becaused the call stack starts directly at the DOM event handler, not in our winit event handler.