### PR TITLE
Call set_resizable before setting the constraints

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -543,12 +543,12 @@ impl WindowAdapter for WinitWindowAdapter {
             };
 
             let resizable = window_is_resizable(new_constraints.min, new_constraints.max);
-
+            // we must call set_resizable before setting the min and max size otherwise setting the min and max size don't work on X11
+            winit_window.set_resizable(resizable);
             let winit_min_inner = new_constraints.min.map(into_size);
             winit_window.set_min_inner_size(winit_min_inner);
             let winit_max_inner = new_constraints.max.map(into_size);
             winit_window.set_max_inner_size(winit_max_inner);
-            winit_window.set_resizable(resizable);
 
             // Auto-resize to the preferred size if users (SlintPad) requests it
             #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Not sure why, but it fixes that applying the constraints is otherwise not working with winit on X11

This is not the first time we do this fix:
723f89d34221e9b243703f8f32d42b82d824b196 and 1891e4489a76ae37165f731aa19a69ec43371f0e