### PR TITLE
Fluent combobox: always put the first item on top

### DIFF
--- a/internal/compiler/widgets/fluent-base/combobox.slint
+++ b/internal/compiler/widgets/fluent-base/combobox.slint
@@ -87,7 +87,9 @@ export component ComboBox {
 
     i-popup := PopupWindow {
         x: 0;
-        y: -46px;
+        // Position the popup so that the first element is over the popup.
+        // Ideally it should be so that the current element is over the popup.
+        y: -4px;
         width: root.width;
 
         MenuBorder {


### PR DESCRIPTION
Currently it's always the second, but that's not great. Ideally it should be the current active element, but that's hard to compute

This becomes extra-relevent when our preview UI has a combobox on the top and that it is clipped to the window by winit

Fixes https://github.com/slint-ui/slint/issues/3345