### PR TITLE
LSP preview: make sure that we always update the preview with the latest state

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -31,7 +31,7 @@ pub trait PreviewApi {
 
 /// The Component to preview
 #[allow(unused)]
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct PreviewComponent {
     /// The file name to preview
     pub path: PathBuf,


### PR DESCRIPTION
If a preview command is issued while we were compiling, we need to recompile.