### PR TITLE
winit: WindowAdapter::set_visible shouldn't do anything if it is already in that state

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -340,6 +340,10 @@ impl WindowAdapter for WinitWindowAdapter {
     }
 
     fn set_visible(&self, visible: bool) -> Result<(), PlatformError> {
+        if visible == self.shown.get() {
+            return Ok(());
+        }
+
         self.shown.set(visible);
         if visible {
             let winit_window = self.winit_window();


### PR DESCRIPTION
calling show() on a visible window or hide() on a hidden window shouldn't do anything.
Especially currently it would resize to the preferred size. So that makes the preview UI to alsways resize to the preferred size because we always call show()