### PR TITLE
Add in property for StandardButton text

### DIFF
--- a/internal/compiler/widgets/common/standardbutton.slint
+++ b/internal/compiler/widgets/common/standardbutton.slint
@@ -5,6 +5,7 @@ import { StyleMetrics, Button } from "std-widgets-impl.slint";
 
 export component StandardButton {
     in property <StandardButtonKind> kind;
+    in property <string> text <=> btn.text;
     in property <bool> enabled <=> btn.enabled;
     out property <bool> has-focus <=> btn.has-focus;
     out property <bool> pressed <=> btn.pressed;

--- a/internal/compiler/widgets/qt/button.slint
+++ b/internal/compiler/widgets/qt/button.slint
@@ -28,6 +28,7 @@ export component Button {
 
 export component StandardButton {
     in property <StandardButtonKind> kind <=> native.standard-button-kind;
+    in property <string> text <=> native.text;
     in property <bool> enabled <=> native.enabled;
     out property <bool> has-focus <=> native.has-focus;
     out property <bool> pressed <=> native.pressed;


### PR DESCRIPTION
It is necessary for `slint-viewer` to be able to translate the text of buttons from `StandardButton` or customize their text:
```
btn_exit := StandardButton {
    kind: close;
    text: @tr("EXIT");
}
```