### PR TITLE
Fix build with only backend-linuxkms

### DIFF
--- a/internal/backends/linuxkms/Cargo.toml
+++ b/internal/backends/linuxkms/Cargo.toml
@@ -27,7 +27,7 @@ default = []
 [dependencies]
 i-slint-core = { workspace = true, features = ["default", "image-decoders", "svg"] }
 i-slint-common = { workspace = true, features = ["default"] }
-i-slint-renderer-skia = { workspace = true, features = ["default"], optional = true }
+i-slint-renderer-skia = { workspace = true, features = ["default", "kms"], optional = true }
 i-slint-renderer-femtovg = { workspace = true, features = ["default"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -23,6 +23,7 @@ wayland = ["glutin/wayland", "softbuffer/wayland", "softbuffer/wayland-dlopen"]
 x11 = ["glutin/x11", "glutin/glx", "softbuffer/x11", "softbuffer/x11-dlopen"]
 opengl = ["skia-safe/gl"]
 vulkan = ["skia-safe/vulkan", "ash", "vulkano"]
+kms = ["softbuffer/kms"]
 default = []
 
 [dependencies]


### PR DESCRIPTION
Activate the kms feature of softbuffer correctly, when building without default features.