### PR TITLE
Improve support for deno lsp

### DIFF
--- a/api/node/package.json
+++ b/api/node/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "compile": "esbuild index.ts --bundle --external:*.node --format=cjs --platform=node --outfile=index.js",
+    "compile": "esbuild index.ts --bundle --external:*.node --format=cjs --platform=node --outfile=index.js && tsc --declaration --emitDeclarationOnly",
     "build": "napi build --platform --release --js rust-module.js --dts rust-module.d.ts && npm run compile",
     "build:debug": "napi build --platform --js rust-module.js --dts rust-module.d.ts && npm run compile && npm run syntax_check",
     "install": "npm run build",


### PR DESCRIPTION
Now if you run `npm run compile` also a `index.d.ts` file is created. It improves the support for deno. Without it the deno lsp has trouble with type from the slint package e.g. `slint.ImageData`. With the the generated `index.d.ts` it works fine with deno lsp.