### PR TITLE
Select macOS 11 as deployment target in central place

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
     branches: [master, "feature/*"]
   workflow_dispatch:
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: 11
+
 jobs:
   build_and_test:
     env:

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: 11
+
 jobs:
   cmake_package:
     env:

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -23,6 +23,7 @@ on:
 
 env:
   SLINT_BINARY_FEATURES: "backend-winit,renderer-femtovg,renderer-skia,renderer-software"
+  MACOSX_DEPLOYMENT_TARGET: 11
 
 jobs:
   slint-viewer-binary:

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -27,6 +27,9 @@ on:
         description: features to enable for build
         default: "backend-winit,renderer-femtovg,renderer-skia"
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: 11
+
 jobs:
   build_windows:
     runs-on: windows-2022


### PR DESCRIPTION
... for all workflos that run macOS jobs.

Latest GH images somehow seem to have "lost" the minimum deployment
target (either setting or maybe the sysroot), so set it explicitly.
That is a good idea for us to do anymore for a more deterministic
deployment.