### PR TITLE
fluent: make scrollbars overlay

### DIFF
--- a/internal/compiler/widgets/fluent-base/scrollview.slint
+++ b/internal/compiler/widgets/fluent-base/scrollview.slint
@@ -144,13 +144,11 @@ export component ScrollView {
     preferred-width: 100%;
 
     i-flickable := Flickable {
-        x: 2px;
-        y: 2px;
         interactive: false;
         viewport-y <=> i-vertical-bar.value;
         viewport-x <=> i-horizontal-bar.value;
-        width: parent.width - i-vertical-bar.width;
-        height: parent.height - i-horizontal-bar.height;
+        width: parent.width;
+        height: parent.height;
 
         @children
     }
@@ -158,7 +156,7 @@ export component ScrollView {
     i-vertical-bar := ScrollBar {
         enabled: root.enabled;
         width: 14px;
-        x: i-flickable.width + i-flickable.x;
+        x: i-flickable.width + i-flickable.x - self.width;
         y: i-flickable.y;
         height:  i-flickable.height;
         horizontal: false;
@@ -171,7 +169,7 @@ export component ScrollView {
         enabled: root.enabled;
         width:  i-flickable.width;
         height: 14px;
-        y: i-flickable.height + i-flickable.y;
+        y: i-flickable.height + i-flickable.y - self.height;
         x: i-flickable.x;
         horizontal: true;
         maximum:  i-flickable.viewport-width - i-flickable.width;


### PR DESCRIPTION
* Instead of always reserve place for the scrollbars the scrollbars now are overlays the content
* The scrollbars are transparent and in not hovered state very small so I think that is ok for now

Fixes #3830  