### PR TITLE
Path: Don't subtract stroke_width from the viewbox

### DIFF
--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -135,8 +135,8 @@ impl Path {
 
         let stroke_width = self.stroke_width();
         let geometry = self_rc.geometry();
-        let bounds_width = (geometry.width_length() - stroke_width).max(LogicalLength::zero());
-        let bounds_height = (geometry.height_length() - stroke_width).max(LogicalLength::zero());
+        let bounds_width = geometry.width_length().max(LogicalLength::zero());
+        let bounds_height = geometry.height_length().max(LogicalLength::zero());
         let offset =
             LogicalVector::from_lengths(stroke_width / 2 as Coord, stroke_width / 2 as Coord);
 


### PR DESCRIPTION
I think that the viewbox should be the bound of the rendering, including the stroke width and caps.

If the viewbox is configured to be 100px wide with a stroke-width of 1px and that I do LineTo 99 from 0, then the shapes will have a physical_offset of 0.5px which means that 99.5+stroke_width/2 == 100px as expected.

This allows setting the viewbox to the Path dimensions to keep the identity transform for rendering and use UI coordinates directly in the path commands.