### PR TITLE
Clean up Node.js port build system

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,9 +135,6 @@ jobs:
     - name: Build node plugin in debug
       run: npm run build:debug
       working-directory: ./api/node
-    - name: Typescript check
-      working-directory: ./api/node
-      run: npm run syntax_check
     - name: Run node tests
       working-directory: ./api/node
       run: npm test

--- a/api/node/.gitignore
+++ b/api/node/.gitignore
@@ -1,4 +1,4 @@
-rust-module.js
+rust-module.cjs
 rust-module.d.ts
 index.js
 docs/

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -2,16 +2,19 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 import test from 'ava'
-const path = require('node:path');
+import * as path from 'node:path';
+import { fileURLToPath } from 'url';
 
-import { loadFile, CompileError } from '../index'
+import { loadFile, CompileError } from '../index.js'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 test('loadFile', (t) => {
-    let demo = loadFile(path.join(__dirname, "resources/test.slint")) as any;
+    let demo = loadFile(path.join(dirname, "resources/test.slint")) as any;
     let test = new demo.Test();
     t.is(test.check, "Test");
 
-    let errorPath = path.join(__dirname, "resources/error.slint");
+    let errorPath = path.join(dirname, "resources/error.slint");
 
     const error = t.throws(() => {
         loadFile(errorPath)
@@ -46,7 +49,7 @@ test('loadFile', (t) => {
 })
 
 test('constructor parameters', (t) => {
-    let demo = loadFile(path.join(__dirname, "resources/test-constructor.slint")) as any;
+    let demo = loadFile(path.join(dirname, "resources/test-constructor.slint")) as any;
     let hello = "";
     let test = new demo.Test({ say_hello: function () { hello = "hello"; }, check: "test" });
 
@@ -58,7 +61,7 @@ test('constructor parameters', (t) => {
 
 test('component instances and modules are sealed', (t) => {
     "use strict";
-    let demo = loadFile(path.join(__dirname, "resources/test.slint")) as any;
+    let demo = loadFile(path.join(dirname, "resources/test.slint")) as any;
 
     t.throws(() => {
         demo.no_such_property = 42;

--- a/api/node/__test__/compiler.spec.mts
+++ b/api/node/__test__/compiler.spec.mts
@@ -3,7 +3,7 @@
 
 import test from 'ava'
 
-import { private_api } from '../index'
+import { private_api } from '../index.js'
 
 test('get/set include paths', (t) => {
   let compiler = new private_api.ComponentCompiler;

--- a/api/node/__test__/eventloop.spec.mts
+++ b/api/node/__test__/eventloop.spec.mts
@@ -7,7 +7,7 @@ import test from 'ava'
 import * as http from 'http';
 import fetch from "node-fetch";
 
-import { runEventLoop, quitEventLoop, private_api } from '../index'
+import { runEventLoop, quitEventLoop, private_api } from '../index.js'
 
 
 test.serial('merged event loops with timer', async (t) => {
@@ -41,7 +41,7 @@ test.serial('merged event loops with networking', async (t) => {
             let port = (server.address() as any).port;
             console.log(`server ready at ${host}:${port}`);
 
-            fetch(`http://${host}:${port}/`).then(async (response) => {
+            (fetch as any)(`http://${host}:${port}/`).then(async (response) => {
                 return response.text();
             }).then((text) => {
                 received_response = text;

--- a/api/node/__test__/globals.spec.mts
+++ b/api/node/__test__/globals.spec.mts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 import test from 'ava';
-const path = require('node:path');
+import * as path from 'node:path';
 
-import { private_api } from '../index'
+import { private_api } from '../index.js'
 
 test('get/set global properties', (t) => {
 
@@ -109,7 +109,7 @@ test('invoke global callback', (t) => {
   t.not(instance, null);
 
   t.throws(() => {
-    instance!.setGlobalCallback("MyGlobal", "great", () => {})
+    instance!.setGlobalCallback("MyGlobal", "great", () => { })
   },
     {
       code: "GenericFailure",
@@ -132,7 +132,7 @@ test('invoke global callback', (t) => {
   });
 
   t.throws(() => {
-    instance!.setGlobalCallback("Global", "bye", () => {})
+    instance!.setGlobalCallback("Global", "bye", () => { })
   },
     {
       code: "GenericFailure",

--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 import test from 'ava';
-const path = require('node:path');
-var Jimp = require("jimp");
+import * as path from 'node:path';
+import { fileURLToPath } from 'url';
+import Jimp = require("jimp");
 
-import { private_api, ImageData, ArrayModel } from '../index'
+import { private_api, ImageData, ArrayModel } from '../index.js'
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
 
 test('get/set string properties', (t) => {
   let compiler = new private_api.ComponentCompiler;
@@ -182,8 +186,7 @@ test('get/set image properties', async (t) => {
     in-out property <image> image: @image-url("resources/rgb.png");
     in property <image> external-image;
     out property <bool> external-image-ok: self.external-image.width == 64 && self.external-image.height == 64;
-  }
-  `, __filename);
+  }`, filename);
   t.not(definition, null);
 
   let instance = definition!.create();
@@ -195,7 +198,7 @@ test('get/set image properties', async (t) => {
     t.deepEqual((slintImage as private_api.SlintImageData).height, 64);
     t.true((slintImage as ImageData).path.endsWith("rgb.png"));
 
-    let image = await Jimp.read(path.join(__dirname, "resources/rgb.png"));
+    let image = await Jimp.read(path.join(dirname, "resources/rgb.png"));
 
     // Sanity check: setProperty fails when passed definitely a non-image
     t.throws(() => {
@@ -290,7 +293,7 @@ test('get/set brush properties', (t) => {
     t.deepEqual(ref_color.alpha, 255);
   }
 
-  instance!.setProperty("ref", { color: { red: 110, green: 120, blue: 125, alpha: 255 }});
+  instance!.setProperty("ref", { color: { red: 110, green: 120, blue: 125, alpha: 255 } });
 
   instance_ref = instance!.getProperty("ref");
 
@@ -341,7 +344,7 @@ test('get/set brush properties', (t) => {
   };
 
   t.throws(() => {
-    instance.setProperty("ref-color", { red: "abc", blue: 0, green: 0, alpha: 0} );
+    instance.setProperty("ref-color", { red: "abc", blue: 0, green: 0, alpha: 0 });
   },
     {
       code: 'NumberExpected',
@@ -350,7 +353,7 @@ test('get/set brush properties', (t) => {
   );
 
   t.throws(() => {
-    instance.setProperty("ref-color", { red: 0, blue: true, green: 0, alpha: 0} );
+    instance.setProperty("ref-color", { red: 0, blue: true, green: 0, alpha: 0 });
   },
     {
       code: 'NumberExpected',
@@ -359,7 +362,7 @@ test('get/set brush properties', (t) => {
   );
 
   t.throws(() => {
-    instance.setProperty("ref-color", { red: 0, blue: 0, green: true, alpha: 0} );
+    instance.setProperty("ref-color", { red: 0, blue: 0, green: true, alpha: 0 });
   },
     {
       code: 'NumberExpected',
@@ -368,7 +371,7 @@ test('get/set brush properties', (t) => {
   );
 
   t.throws(() => {
-    instance.setProperty("ref-color", { red: 0, blue: 0, green: 0, alpha: new private_api.SlintRgbaColor()} );
+    instance.setProperty("ref-color", { red: 0, blue: 0, green: 0, alpha: new private_api.SlintRgbaColor() });
   },
     {
       code: 'NumberExpected',
@@ -377,7 +380,7 @@ test('get/set brush properties', (t) => {
   );
 
   t.throws(() => {
-    instance.setProperty("ref-color", { blue: 0, green: 0, alpha: 0} );
+    instance.setProperty("ref-color", { blue: 0, green: 0, alpha: 0 });
   },
     {
       code: 'GenericFailure',
@@ -386,7 +389,7 @@ test('get/set brush properties', (t) => {
   );
 
   t.throws(() => {
-    instance.setProperty("ref-color", { red: 0, green: 0, alpha: 0} );
+    instance.setProperty("ref-color", { red: 0, green: 0, alpha: 0 });
   },
     {
       code: 'GenericFailure',
@@ -394,7 +397,7 @@ test('get/set brush properties', (t) => {
     }
   );
 
-  instance.setProperty("ref-color", { red: 0,  green: 0, blue: 0 } );
+  instance.setProperty("ref-color", { red: 0, green: 0, blue: 0 });
   instance_ref = instance!.getProperty("ref-color");
 
   if (t.true((instance_ref instanceof private_api.SlintBrush))) {

--- a/api/node/__test__/types.spec.mts
+++ b/api/node/__test__/types.spec.mts
@@ -3,7 +3,7 @@
 
 import test from 'ava';
 
-import { private_api, ArrayModel } from '../index'
+import { private_api, ArrayModel } from '../index.js'
 
 test('SlintColor from fromRgb', (t) => {
   let color = private_api.SlintRgbaColor.fromRgb(100, 110, 120);

--- a/api/node/__test__/window.spec.mts
+++ b/api/node/__test__/window.spec.mts
@@ -3,17 +3,17 @@
 
 import test from 'ava'
 
-import { private_api, Window } from '../index'
+import { private_api, Window } from '../index.js'
 
 test('Window constructor', (t) => {
     t.throws(() => {
         new private_api.Window()
-        },
+    },
         {
             code: "GenericFailure",
             message: "Window can only be created by using a Component."
         }
-        );
+    );
 })
 
 test('Window show / hide', (t) => {

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -1,13 +1,20 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import * as napi from "./rust-module";
+import * as napi from "./rust-module.cjs";
+const {
+    Diagnostic,
+    DiagnosticLevel,
+    RgbaColor,
+    Brush
+} = napi;
+
 export {
     Diagnostic,
     DiagnosticLevel,
     RgbaColor,
     Brush
-} from "./rust-module";
+};
 
 /**
  *  Represents a two-dimensional point.
@@ -61,7 +68,7 @@ export interface Window {
      * Returns the visibility state of the window. This function can return false even if you previously called show()
      * on it, for example if the user minimized the window.
      */
-     get visible(): boolean;
+    get visible(): boolean;
 
     /**
      * Shows the window on the screen. An additional strong reference on the
@@ -374,10 +381,10 @@ class Component implements ComponentHandle {
         return this.#instance.window();
     }
 
-     /**
-     * @hidden
-     */
-     get component_instance(): napi.ComponentInstance {
+    /**
+    * @hidden
+    */
+    get component_instance(): napi.ComponentInstance {
         return this.#instance;
     }
 
@@ -721,7 +728,7 @@ export namespace private_api {
     export import Window = napi.Window;
 
     export import SlintBrush = napi.SlintBrush;
-    export import SlintRgbaColor  = napi.SlintRgbaColor;
+    export import SlintRgbaColor = napi.SlintRgbaColor;
     export import SlintSize = napi.SlintSize;
     export import SlintPoint = napi.SlintPoint;
     export import SlintImageData = napi.SlintImageData;

--- a/api/node/package.json
+++ b/api/node/package.json
@@ -10,14 +10,13 @@
     "url": "https://github.com/slint-ui/slint"
   },
   "devDependencies": {
-    "@swc-node/register": "^1.5.5",
-    "@swc/core": "^1.3.32",
+    "@ava/typescript": "^4.1.0",
     "@types/node": "^20.8.6",
     "@types/node-fetch": "^2.6.7",
     "ava": "^5.3.0",
     "jimp": "^0.22.8",
+    "ts-node": "^10.9.1",
     "typedoc": "^0.25.2",
-    "esbuild": "^0.19.5",
     "typescript": "^5.2.2"
   },
   "engines": {
@@ -25,27 +24,22 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "compile_dts": "tsc index.ts --target esnext --module nodenext --moduleResolution nodenext --declaration --emitDeclarationOnly",
-    "compile": "esbuild index.ts --bundle --external:*.node --format=cjs --platform=node --outfile=index.js && npm run compile_dts",
-    "build": "napi build --platform --release --js rust-module.js --dts rust-module.d.ts",
-    "build:debug": "napi build --platform --js rust-module.js --dts rust-module.d.ts && npm run compile && npm run syntax_check",
+    "compile": "tsc",
+    "build": "napi build --platform --release --js rust-module.cjs --dts rust-module.d.ts",
+    "build:debug": "napi build --platform --js rust-module.cjs --dts rust-module.d.ts && npm run compile",
     "install": "npm run build",
     "docs": "npm run build && typedoc --hideGenerator --treatWarningsAsErrors --readme cover.md index.ts",
-    "test": "ava",
-    "syntax_check": "tsc -noEmit"
+    "test": "ava"
   },
   "ava": {
-    "require": [
-      "@swc-node/register"
-    ],
-    "extensions": [
-      "ts"
+    "extensions": {
+      "mts": "module"
+    },
+    "nodeArguments": [
+      "--loader=ts-node/esm"
     ],
     "timeout": "2m",
-    "workerThreads": false,
-    "environmentVariables": {
-      "TS_NODE_PROJECT": "./tsconfig.json"
-    }
+    "workerThreads": false
   },
   "dependencies": {
     "@napi-rs/cli": "^2.16.5"

--- a/api/node/tsconfig.json
+++ b/api/node/tsconfig.json
@@ -1,7 +1,15 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "CommonJS",
         "target": "esnext",
-        "esModuleInterop": true,
+        "declaration": true,
+    },
+    "include": [
+        "index.ts"
+    ],
+    "ts-node": {
+        "compilerOptions": {
+            "module": "nodenext"
+        }
     }
 }

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -457,6 +457,7 @@ lazy_static! {
         ("\\.license$", LicenseLocation::NoLicense),
         ("\\.md$", LicenseLocation::Tag(LicenseTagStyle::html_comment_style())),
         ("\\.mjs$", LicenseLocation::Tag(LicenseTagStyle::c_style_comment_style())),
+        ("\\.mts$", LicenseLocation::Tag(LicenseTagStyle::c_style_comment_style())),
         ("\\.pdf$", LicenseLocation::NoLicense),
         ("\\.png$", LicenseLocation::NoLicense),
         ("\\.mo$", LicenseLocation::NoLicense),


### PR DESCRIPTION
- Instead of building index.js with esbuild and generating types with tsc, use tsc to build index.js and index.d.ts.
- Use ts-node instead of swc for typescript based tests, as that works with es modules.
- Remove "syntax_check" target from package.json as that's now implied with "compile".
- Sadly this requires one "as any" cast as tsc somehow fails to determine the right type info for node-fetch.

Unfortunately index.js can't be an ES module without breaking
compatiblity. It would imply that the Node.js port can't be used with
require() anymore. So even thought that would simplify things further,
it's not part of this PR.
