### PR TITLE
Fix compiler panic when there is a component called "Window"

### DIFF
--- a/internal/compiler/passes/clip.rs
+++ b/internal/compiler/passes/clip.rs
@@ -18,7 +18,7 @@ pub fn handle_clip(
     diag: &mut BuildDiagnostics,
 ) {
     let native_clip =
-        type_register.lookup_element("Clip").unwrap().as_builtin().native_class.clone();
+        type_register.lookup_builtin_element("Clip").unwrap().as_builtin().native_class.clone();
 
     crate::object_tree::recurse_elem_including_sub_components(
         component,

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -23,7 +23,7 @@ pub fn ensure_window(
         return; // already a window, nothing to do
     }
 
-    let window_type = type_register.lookup_element("Window").unwrap();
+    let window_type = type_register.lookup_builtin_element("Window").unwrap();
 
     let win_elem = component.root_element.clone();
 

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -16,7 +16,7 @@ pub fn lower_popups(
     type_register: &TypeRegister,
     diag: &mut BuildDiagnostics,
 ) {
-    let window_type = type_register.lookup_element("Window").unwrap();
+    let window_type = type_register.lookup_builtin_element("Window").unwrap();
 
     recurse_elem_including_sub_components_no_borrow(
         component,

--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -33,7 +33,7 @@ fn create_box_shadow_element(
 
     let mut element = Element {
         id: format!("{}-shadow", sibling_element.borrow().id),
-        base_type: type_register.lookup_element("BoxShadow").unwrap(),
+        base_type: type_register.lookup_builtin_element("BoxShadow").unwrap(),
         enclosing_component: sibling_element.borrow().enclosing_component.clone(),
         bindings: shadow_property_bindings
             .into_iter()

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -26,7 +26,7 @@ pub fn handle_visible(
     }
 
     let native_clip =
-        type_register.lookup_element("Clip").unwrap().as_builtin().native_class.clone();
+        type_register.lookup_builtin_element("Clip").unwrap().as_builtin().native_class.clone();
 
     crate::object_tree::recurse_elem_including_sub_components(
         component,

--- a/tests/cases/elements/popupwindow.slint
+++ b/tests/cases/elements/popupwindow.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+// The presense of this component shouldn't break anything
+component Window {}
+
 Combo := Rectangle {
     property <color> inner_color;
     my_popup := PopupWindow {
@@ -21,7 +24,7 @@ TestCase := Rectangle {
     for x in [1, 2] :  Combo { }
 }
 
-ComplexTestCase := Window {
+ComplexTestCase := Rectangle {
     TestCase {
         cob := Combo {
             PopupWindow {
@@ -34,7 +37,7 @@ ComplexTestCase := Window {
     TestCase {  }
 }
 
-TypeConversionTestCase := Window {
+TypeConversionTestCase := Rectangle {
     height: 400px;
     popup := PopupWindow {
         y: root.height / 2;
@@ -42,5 +45,5 @@ TypeConversionTestCase := Window {
     }
     TouchArea {
         clicked => { popup.show() }
-     }
+    }
 }

--- a/tests/cases/input/clip_mouse.slint
+++ b/tests/cases/input/clip_mouse.slint
@@ -1,6 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+component Clip {
+    // the presence of a Clip element should not impact the rest
+}
 
 MaybeClip := Rectangle {
     width: 10phx;

--- a/tests/cases/input/visible_mouse.slint
+++ b/tests/cases/input/visible_mouse.slint
@@ -1,6 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+component Clip {
+    // the presence of a Clip element should not impact the rest
+}
+
 
 MaybeVisible := Rectangle {
     width: 10phx;


### PR DESCRIPTION
the ensure_window and popupwindow passes were looking up the "Window" builtin in the global register instead of in the builtin register, causing the presence of an user-defined "Window" to cause panic.

The "Clip" and "BoxShadow" calls are not affected because they were looking up in the builtin reguister, but using the appropriate function is more future-proof

Fix #3916