### PR TITLE
Throw an error when returning no value when one is expected.

### DIFF
--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -208,7 +208,11 @@ impl Expression {
         ctx: &mut LookupCtx,
     ) -> Expression {
         let return_type = ctx.return_type().clone();
-        Expression::ReturnStatement(node.Expression().map(|n| {
+        let e = node.Expression();
+        if e.is_none() && !matches!(return_type, Type::Void | Type::Invalid) {
+            ctx.diag.push_error(format!("Must return a value of type '{return_type}'"), &node);
+        }
+        Expression::ReturnStatement(e.map(|n| {
             Box::new(Self::from_expression_node(n, ctx).maybe_convert_to(
                 return_type,
                 &node,

--- a/internal/compiler/tests/syntax/basic/return.slint
+++ b/internal/compiler/tests/syntax/basic/return.slint
@@ -13,4 +13,22 @@ export X := Rectangle {
         return 42phx;
 //      ^error{Cannot convert physical-length to string. Divide by 1phx to convert to a plain number}
     }
+
+
+    // Issue 3962
+    FocusScope {
+        key-released(event) => {
+            if (!self.visible) {
+                return;
+//              ^error{Must return a value of type 'enum EventResult'}
+            }
+            accept
+        }
+
+        enabled: {
+            return;
+//          ^error{Must return a value of type 'bool'}
+            true;
+        }
+    }
 }


### PR DESCRIPTION
Previously we were likely to get error in the compiled code anyway. (although the interpreter worked fine)

Fixes #3962