### PR TITLE
node/api: export loadSource api

### DIFF
--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -9,6 +9,7 @@ import { loadFile, loadSource, CompileError } from '../index.js'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// loadFile api
 test('loadFile', (t) => {
     let demo = loadFile(path.join(dirname, "resources/test.slint")) as any;
     let test = new demo.Test();
@@ -48,49 +49,7 @@ test('loadFile', (t) => {
     ]);
 })
 
-test('loadSource', (t) => {
-    const source = `export component Test {
-        out property <string> check: "Test";
-    }`
-    let demo = loadSource(source, 'api.spec.ts') as any;
-    let test = new demo.Test();
-    t.is(test.check, "Test");
-
-    let errorPath = path.join(__dirname, "resources/error.slint");
-
-    const error = t.throws(() => {
-        loadFile(errorPath)
-    },
-        { instanceOf: CompileError }
-    );
-
-    t.is(error?.message, "Could not compile " + errorPath);
-    t.deepEqual(error?.diagnostics, [
-        {
-            columnNumber: 18,
-            level: 0,
-            lineNumber: 7,
-            message: 'Missing type. The syntax to declare a property is `property <type> name;`. Only two way bindings can omit the type',
-            fileName: errorPath
-        },
-        {
-            columnNumber: 22,
-            level: 0,
-            lineNumber: 7,
-            message: 'Syntax error: expected \';\'',
-            fileName: errorPath
-        },
-        {
-            columnNumber: 22,
-            level: 0,
-            lineNumber: 7,
-            message: 'Parse error',
-            fileName: errorPath
-        },
-    ]);
-})
-
-test('constructor parameters', (t) => {
+test('loadFile constructor parameters', (t) => {
     let demo = loadFile(path.join(dirname, "resources/test-constructor.slint")) as any;
     let hello = "";
     let test = new demo.Test({ say_hello: function () { hello = "hello"; }, check: "test" });
@@ -101,9 +60,93 @@ test('constructor parameters', (t) => {
     t.is(hello, "hello");
 })
 
-test('component instances and modules are sealed', (t) => {
+test('loadFile component instances and modules are sealed', (t) => {
     "use strict";
     let demo = loadFile(path.join(dirname, "resources/test.slint")) as any;
+
+    t.throws(() => {
+        demo.no_such_property = 42;
+    }, { instanceOf: TypeError });
+
+    let test = new demo.Test();
+    t.is(test.check, "Test");
+
+    t.throws(() => {
+        test.no_such_callback = () => { };
+    }, { instanceOf: TypeError });
+})
+
+
+// loadSource api
+test('loadSource', (t) => {
+    const source = `export component Test {
+        out property <string> check: "Test";
+    }`
+    const path = 'api.spec.ts';
+    let demo = loadSource(source, path) as any;
+    let test = new demo.Test();
+    t.is(test.check, "Test");
+
+    const errorSource = `export component Error {
+        out property bool> check: "Test";
+    }`
+
+    const error = t.throws(() => {
+        loadSource(errorSource, path)
+    },
+        { instanceOf: CompileError }
+    );
+
+    t.is(error?.message, "Could not compile " + path);
+    // console.log(error?.diagnostics)
+    t.deepEqual(error?.diagnostics, [
+        {
+            columnNumber: 22,
+            level: 0,
+            lineNumber: 2,
+            message: 'Missing type. The syntax to declare a property is `property <type> name;`. Only two way bindings can omit the type',
+            fileName: path
+        },
+        {
+            columnNumber: 26,
+            level: 0,
+            lineNumber: 2,
+            message: 'Syntax error: expected \';\'',
+            fileName: path
+        },
+        {
+            columnNumber: 26,
+            level: 0,
+            lineNumber: 2,
+            message: 'Parse error',
+            fileName: path
+        },
+    ]);
+})
+
+test('loadSource constructor parameters', (t) => {
+    const source = `export component Test {
+        callback say_hello();
+        in-out property <string> check;
+    }`
+    const path = 'api.spec.ts';
+    let demo = loadSource(source, path) as any;
+    let hello = "";
+    let test = new demo.Test({ say_hello: function () { hello = "hello"; }, check: "test" });
+
+    test.say_hello();
+
+    t.is(test.check, "test");
+    t.is(hello, "hello");
+})
+
+test('loadSource component instances and modules are sealed', (t) => {
+    "use strict";
+    const source = `export component Test {
+        out property <string> check: "Test";
+    }`
+    const path = 'api.spec.ts';
+    let demo = loadSource(source, path) as any;
 
     t.throws(() => {
         demo.no_such_property = 42;

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -5,7 +5,7 @@ import test from 'ava'
 import * as path from 'node:path';
 import { fileURLToPath } from 'url';
 
-import { loadFile, CompileError } from '../index.js'
+import { loadFile, loadSource, CompileError } from '../index.js'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -15,6 +15,48 @@ test('loadFile', (t) => {
     t.is(test.check, "Test");
 
     let errorPath = path.join(dirname, "resources/error.slint");
+
+    const error = t.throws(() => {
+        loadFile(errorPath)
+    },
+        { instanceOf: CompileError }
+    );
+
+    t.is(error?.message, "Could not compile " + errorPath);
+    t.deepEqual(error?.diagnostics, [
+        {
+            columnNumber: 18,
+            level: 0,
+            lineNumber: 7,
+            message: 'Missing type. The syntax to declare a property is `property <type> name;`. Only two way bindings can omit the type',
+            fileName: errorPath
+        },
+        {
+            columnNumber: 22,
+            level: 0,
+            lineNumber: 7,
+            message: 'Syntax error: expected \';\'',
+            fileName: errorPath
+        },
+        {
+            columnNumber: 22,
+            level: 0,
+            lineNumber: 7,
+            message: 'Parse error',
+            fileName: errorPath
+        },
+    ]);
+})
+
+test('loadSource', (t) => {
+    const source = `export component Test {
+        out property <string> check: "Test";
+    }`
+    let demo = loadSource(source, 'api.spec.ts') as any;
+    let test = new demo.Test();
+    t.is(test.check, "Test");
+
+    let errorPath = path.join(__dirname, "resources/error.slint");
 
     const error = t.throws(() => {
         loadFile(errorPath)


### PR DESCRIPTION
I wanted to be able to write the `slint DSL` directly in the js file, luckily the `buildFromSource` api is provided, this PR will use `buildFromSource` and export to `loadSource`