### PR TITLE
align styling resources

### DIFF
--- a/internal/compiler/widgets/cupertino-base/button.slint
+++ b/internal/compiler/widgets/cupertino-base/button.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { CupertinoFontSettings, CupertinoPalette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component Button {
@@ -16,8 +16,8 @@ export component Button {
 
     callback clicked;
 
-    private property <brush> background: primary && root.enabled ? Palette.accent : Palette.surface;
-    private property <brush> text-color: primary && root.enabled ? Palette.on-surface : Palette.foreground;
+    private property <brush> background: primary && root.enabled ? CupertinoPalette.accent : CupertinoPalette.surface;
+    private property <brush> text-color: primary && root.enabled ? CupertinoPalette.on-accent : CupertinoPalette.on-surface;
 
     min-width: max(20px, i-layout.min-width);
     min-height: max(20px, i-layout.min-height);
@@ -29,14 +29,14 @@ export component Button {
 
     states [
         disabled when !i-touch-area.enabled : {
-            root.text-color: Palette.foreground-secondary;
-            root.background: Palette.surface-quaternary;
+            root.text-color: CupertinoPalette.foreground-secondary;
+            root.background: CupertinoPalette.surface-quaternary;
         }
         pressed when root.pressed : {
-            root.background: root.primary ? Palette.accent-secondary : Palette.surface-secondary;
+            root.background: root.primary ? CupertinoPalette.accent-secondary : CupertinoPalette.surface-secondary;
         }
         checked when root.checked : {
-            root.text-color: Palette.accent-secondary;
+            root.text-color: CupertinoPalette.accent-secondary;
         }
     ]
 
@@ -76,7 +76,7 @@ export component Button {
 
         Rectangle {
             border-radius: parent.border-radius;
-            background: Palette.dimmer;
+            background: CupertinoPalette.dimmer;
             opacity: 0.17;
         }
     }
@@ -95,7 +95,7 @@ export component Button {
             border-radius: parent.border-radius;
             background: root.background;
             border-width: 1px;
-            border-color: Palette.decent-border;
+            border-color: CupertinoPalette.decent-border;
             opacity: root.enabled ? 1 : 0.5;
         }
     }
@@ -117,8 +117,8 @@ export component Button {
 
         if (root.text != "") : Text {
             opacity: root.enabled ? 1 : 0.5;
-            font-size: Typography.body.font-size;
-            font-weight: Typography.body.font-weight;
+            font-size: CupertinoFontSettings.body.font-size;
+            font-weight: CupertinoFontSettings.body.font-weight;
             horizontal-alignment: center;
             vertical-alignment: center;
             text: root.text;

--- a/internal/compiler/widgets/cupertino-base/checkbox.slint
+++ b/internal/compiler/widgets/cupertino-base/checkbox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette, Icons } from "styling.slint";
+import { CupertinoFontSettings, CupertinoPalette, Icons } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component CheckBox {
@@ -12,8 +12,8 @@ export component CheckBox {
 
     callback toggled;
 
-    private property <brush> background: checked && root.enabled ? Palette.accent : Palette.surface;
-    private property <brush> icon-color: Palette.on-surface;
+    private property <brush> background: checked && root.enabled ? CupertinoPalette.accent : CupertinoPalette.surface;
+    private property <brush> icon-color: CupertinoPalette.on-accent;
 
     min-height: max(16px, i-layout.min-height);
     accessible-checkable: true;
@@ -24,10 +24,10 @@ export component CheckBox {
     states [
         disabled when !root.enabled : {
             opacity: 0.5;
-            icon-color: Palette.foreground;
+            icon-color: CupertinoPalette.foreground;
         }
         pressed when i-touch-area.pressed : {
-            root.background: root.checked ? Palette.accent-secondary : Palette.surface-secondary;
+            root.background: root.checked ? CupertinoPalette.accent-secondary : CupertinoPalette.surface-secondary;
         }
     ]
 
@@ -63,7 +63,7 @@ export component CheckBox {
                 height: 100%;
                 border-radius: parent.border-radius;
                 border-width: 0.5px;
-                border-color: Palette.border;
+                border-color: CupertinoPalette.border;
             }
         }
 
@@ -95,7 +95,7 @@ export component CheckBox {
 
             Rectangle {
                 border-radius: parent.border-radius;
-                background: Palette.dimmer;
+                background: CupertinoPalette.dimmer;
                 opacity: 0.17;
             }
 
@@ -112,9 +112,9 @@ export component CheckBox {
 
         if (root.text != "") : Text {
             text: root.text;
-            color: Palette.foreground;
-            font-size: Typography.body.font-size;
-            font-weight: Typography.body.font-weight;
+            color: CupertinoPalette.foreground;
+            font-size: CupertinoFontSettings.body.font-size;
+            font-weight: CupertinoFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cupertino-base/combobox.slint
+++ b/internal/compiler/widgets/cupertino-base/combobox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette, Icons } from "styling.slint";
+import { CupertinoFontSettings, CupertinoPalette, Icons } from "styling.slint";
 import { MenuBorder, ListItem, FocusBorder } from "components.slint";
 import { ComboBoxBase } from "../common/combobox-base.slint";
 
@@ -14,7 +14,7 @@ export component ComboBox {
 
     callback selected <=> i-base.selected;
 
-    private property <brush> background: Palette.surface;
+    private property <brush> background: CupertinoPalette.surface;
 
     min-width: max(160px, i-layout.min-width);
     min-height: max(22px, i-layout.min-height);
@@ -24,13 +24,13 @@ export component ComboBox {
 
     states [
         disabled when !root.enabled : {
-            i-text.color: Palette.foreground-secondary;
-            i-top-icon.colorize: Palette.foreground-secondary;
-            i-bottom-icon.colorize: Palette.foreground-secondary;
-            root.background: Palette.surface-tertiary;
+            i-text.color: CupertinoPalette.foreground-secondary;
+            i-top-icon.colorize: CupertinoPalette.foreground-secondary;
+            i-bottom-icon.colorize: CupertinoPalette.foreground-secondary;
+            root.background: CupertinoPalette.surface-tertiary;
         }
         pressed when i-base.pressed : {
-            root.background: Palette.surface-secondary;
+            root.background: CupertinoPalette.surface-secondary;
         }
     ]
 
@@ -66,7 +66,7 @@ export component ComboBox {
             border-radius: parent.border-radius;
             background: root.background;
             border-width: 1px;
-            border-color: Palette.decent-border;
+            border-color: CupertinoPalette.decent-border;
             opacity: root.enabled ? 1 : 0.5;
         }
     }
@@ -81,9 +81,9 @@ export component ComboBox {
         i-text := Text {
             horizontal-alignment: left;
             vertical-alignment: center;
-            font-size: Typography.body.font-size;
-            font-weight: Typography.body.font-weight;
-            color: Palette.foreground;
+            font-size: CupertinoFontSettings.body.font-size;
+            font-weight: CupertinoFontSettings.body.font-weight;
+            color: CupertinoPalette.foreground;
             text: root.current-value;
         }
 
@@ -99,7 +99,7 @@ export component ComboBox {
                 drop-shadow-color: #00000066;
                 drop-shadow-offset-y: 0.5px;
                 border-radius: 4px;
-                background: Palette.accent;
+                background: CupertinoPalette.accent;
 
                 Rectangle {
                     drop-shadow-blur: 2px;
@@ -119,7 +119,7 @@ export component ComboBox {
 
                 Rectangle {
                     border-radius: parent.border-radius;
-                    background: Palette.dimmer;
+                    background: CupertinoPalette.dimmer;
                     opacity: 0.17;
                 }
             }
@@ -130,13 +130,13 @@ export component ComboBox {
 
                 i-top-icon := Image {
                     x: (parent.width - self.width) / 2;
-                    colorize: Palette.on-surface;
+                    colorize: CupertinoPalette.on-accent;
                     source: Icons.chevron-up;
                 }
 
                 i-bottom-icon := Image {
                     x: (parent.width - self.width) / 2;
-                    colorize: Palette.on-surface;
+                    colorize: CupertinoPalette.on-accent;
                     source: Icons.chevron-down;
                 }
             }

--- a/internal/compiler/widgets/cupertino-base/components.slint
+++ b/internal/compiler/widgets/cupertino-base/components.slint
@@ -1,12 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography, Icons } from "styling.slint";
+import { CupertinoPalette, CupertinoFontSettings, Icons } from "styling.slint";
 
 export component FocusBorder inherits Rectangle {
     in property <bool> has-focus;
 
-    background: Palette.accent-tertiary;
+    background: CupertinoPalette.accent-tertiary;
     opacity: 0;
 
     animate opacity { duration: 150ms; }
@@ -22,14 +22,14 @@ export component MenuBorder inherits Rectangle {
     drop-shadow-blur: 22px;
     drop-shadow-color: #00000066;
     drop-shadow-offset-y: 0.5px;
-    background: Palette.background;
+    background: CupertinoPalette.background;
     border-radius: 6px;
 
     Rectangle {
         width: 100%;
         height: 100%;
         border-radius: parent.border-radius;
-        background: Palette.background;
+        background: CupertinoPalette.background;
 
         @children
     }
@@ -39,7 +39,7 @@ export component MenuBorder inherits Rectangle {
         height: 100%;
         border-radius: parent.border-radius;
         border-width: 1px;
-        border-color: Palette.popup-border;
+        border-color: CupertinoPalette.popup-border;
     }
 }
 
@@ -60,9 +60,9 @@ export component ListItem {
 
     states [
         hover when i-touch-area.has-hover : {
-            i-background.background: Palette.accent;
-            i-text.color: Palette.on-surface;
-            i-icon.colorize: Palette.on-surface;
+            i-background.background: CupertinoPalette.accent;
+            i-text.color: CupertinoPalette.on-surface;
+            i-icon.colorize: CupertinoPalette.on-surface;
         }
     ]
 
@@ -82,15 +82,15 @@ export component ListItem {
                 i-icon := Image {
                     image-fit: contain;
                     source: Icons.check-mark;
-                    colorize: Palette.foreground;
+                    colorize: CupertinoPalette.foreground;
                     visible: root.selected;
                     width: 10px;
                 }
 
                 i-text := Text {
-                    color: Palette.foreground;
-                    font-size: Typography.body.font-size;
-                    font-weight: Typography.body.font-weight;
+                    color: CupertinoPalette.foreground;
+                    font-size: CupertinoFontSettings.body.font-size;
+                    font-weight: CupertinoFontSettings.body.font-weight;
                     vertical-alignment: center;
                     horizontal-alignment: left;
                     overflow: elide;

--- a/internal/compiler/widgets/cupertino-base/groupbox.slint
+++ b/internal/compiler/widgets/cupertino-base/groupbox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { CupertinoFontSettings, CupertinoPalette } from "styling.slint";
 
 export component GroupBox {
     in property <string> title <=> label.text;
@@ -14,17 +14,17 @@ export component GroupBox {
 
         label := Text {
             vertical-stretch: 0;
-            color: !root.enabled ? Palette.foreground-secondary : Palette.foreground;
-            font-size: Typography.body-strong.font-size;
-            font-weight: Typography.body-strong.font-weight;
+            color: !root.enabled ? CupertinoPalette.foreground-secondary : CupertinoPalette.foreground;
+            font-size: CupertinoFontSettings.body-strong.font-size;
+            font-weight: CupertinoFontSettings.body-strong.font-weight;
         }
 
         Rectangle {
             vertical-stretch: 1;
             border-radius: 6px;
-            background: Palette.background-secondary;
+            background: CupertinoPalette.background-alt;
             border-width: 1px;
-            border-color: Palette.border;
+            border-color: CupertinoPalette.border;
 
             GridLayout {
                 padding: 8px;

--- a/internal/compiler/widgets/cupertino-base/lineedit.slint
+++ b/internal/compiler/widgets/cupertino-base/lineedit.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { CupertinoFontSettings, CupertinoPalette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component LineEdit {
@@ -45,12 +45,12 @@ export component LineEdit {
 
     states [
         disabled when !root.enabled : {
-            i-text-input.color: Palette.foreground-secondary;
-            i-placeholder.color: Palette.foreground-secondary;
-            i-background.background: Palette.surface-tertiary;
+            i-text-input.color: CupertinoPalette.foreground-secondary;
+            i-placeholder.color: CupertinoPalette.foreground-secondary;
+            i-background.background: CupertinoPalette.surface-tertiary;
         }
         focused when root.has-focus : {
-            i-background.background: Palette.surface;
+            i-background.background: CupertinoPalette.surface;
         }
     ]
 
@@ -63,8 +63,8 @@ export component LineEdit {
     }
 
     i-background := Rectangle {
-        background: Palette.background-secondary;
-        border-color: Palette.border;
+        background: CupertinoPalette.background-alt;
+        border-color: CupertinoPalette.border;
         border-width: 1px;
     }
 
@@ -78,9 +78,9 @@ export component LineEdit {
             i-placeholder := Text {
                 width: 100%;
                 height: 100%;
-                color: Palette.foreground-secondary;
-                font-size: Typography.body.font-size;
-                font-weight: Typography.body.font-weight;
+                color: CupertinoPalette.foreground-secondary;
+                font-size: CupertinoFontSettings.body.font-size;
+                font-weight: CupertinoFontSettings.body.font-weight;
                 visible: root.text == "";
                 vertical-alignment: center;
                 horizontal-alignment: center;
@@ -93,11 +93,11 @@ export component LineEdit {
                 x: min(0px, max(parent.width - self.width, self.computed_x));
                 width: max(parent.width, self.preferred-width);
                 height: 100%;
-                color: Palette.foreground;
+                color: CupertinoPalette.foreground;
                 vertical-alignment: center;
-                font-size: Typography.body.font-size;
-                font-weight: Typography.body.font-weight;
-                selection-background-color: Palette.accent-quaternary;
+                font-size: CupertinoFontSettings.body.font-size;
+                font-weight: CupertinoFontSettings.body.font-weight;
+                selection-background-color: CupertinoPalette.accent-quaternary;
                 selection-foreground-color: self.color;
 
                 accepted => {

--- a/internal/compiler/widgets/cupertino-base/progressindicator.slint
+++ b/internal/compiler/widgets/cupertino-base/progressindicator.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette } from "styling.slint";
+import { CupertinoPalette } from "styling.slint";
 
 export component ProgressIndicator {
     in property <float> progress;
@@ -19,9 +19,9 @@ export component ProgressIndicator {
 
         i-rail := Rectangle {
             border-radius: parent.border-radius;
-            background: Palette.surface-alt;
+            background: CupertinoPalette.surface-alt;
             border-width: 0.5px;
-            border-color: Palette.border;
+            border-color: CupertinoPalette.border;
             clip: true;
 
             Rectangle {
@@ -36,7 +36,7 @@ export component ProgressIndicator {
             height: 100%;
             x: !root.indeterminate ? 0px : -parent.width + (parent.width * mod(animation-tick(), 2s) / 1s);
             border-radius: parent.border-radius;
-            background: Palette.accent;
+            background: CupertinoPalette.accent;
         }
     }
 }

--- a/internal/compiler/widgets/cupertino-base/scrollview.slint
+++ b/internal/compiler/widgets/cupertino-base/scrollview.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Icons } from "styling.slint";
+import { CupertinoPalette, Icons } from "styling.slint";
 
 export component ScrollBar inherits Rectangle {
     in property <bool> enabled;
@@ -20,8 +20,8 @@ export component ScrollBar inherits Rectangle {
 
     states [
         hover when i-touch-area.has-hover : {
-            background: Palette.foreground.with-alpha(0.2);
-            i-border.background: Palette.foreground.with-alpha(0.2);
+            background: CupertinoPalette.foreground.with-alpha(0.2);
+            i-border.background: CupertinoPalette.foreground.with-alpha(0.2);
             pad: 4px;
         }
     ]
@@ -42,10 +42,10 @@ export component ScrollBar inherits Rectangle {
         x: !root.horizontal ? (parent.width - self.width) / 2 : root.offset + (root.track-size - i-thumb.width) * (-root.value / root.maximum);
         y: root.horizontal ? (parent.height - self.height) / 2 : root.offset + (root.track-size - i-thumb.height) * (-root.value / root.maximum);
         border-radius: (root.horizontal ? self.height : self.width) / 2;
-        background: Palette.foreground;
+        background: CupertinoPalette.foreground;
         opacity: 0.6;
         border-width: 0.8px;
-        border-color: Palette.foreground-neg;
+        border-color: CupertinoPalette.foreground-neg;
 
         animate width, height { duration: 100ms; easing: ease-out; }
     }

--- a/internal/compiler/widgets/cupertino-base/slider.slint
+++ b/internal/compiler/widgets/cupertino-base/slider.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette } from "styling.slint";
+import { CupertinoPalette } from "styling.slint";
 
 export component Slider {
     in property <Orientation> orientation: horizontal;
@@ -29,14 +29,14 @@ export component Slider {
             root.opacity: 0.5;
         }
         pressed when (i-touch-area.pressed &&  i-touch-area.has-hover) || i-focus-scope.has-focus : {
-            i-thumb.background: Palette.pressed;
+            i-thumb.background: CupertinoPalette.pressed;
         }
     ]
 
     i-rail := Rectangle {
         width: vertical ? 4px : parent.width;
         height: vertical ? parent.height : 4px;
-        background: Palette.surface-alt;
+        background: CupertinoPalette.surface-alt;
         border-radius: 2px;
 
         Rectangle {
@@ -51,7 +51,7 @@ export component Slider {
         y: vertical ? 0 : (parent.height - self.height) / 2;
         width: vertical ? i-rail.width : i-thumb.x + (i-thumb.width / 2);
         height: vertical ? i-thumb.y + (i-thumb.height / 2) : i-rail.height;
-        background: Palette.accent;
+        background: CupertinoPalette.accent;
         border-radius: i-rail.border-radius;
     }
 
@@ -61,7 +61,7 @@ export component Slider {
         width: 20px;
         height: self.width;
         border-radius: 10px;
-        background: Palette.surface-thumb;
+        background: CupertinoPalette.surface-thumb;
         drop-shadow-blur: 1px;
         drop-shadow-offset-y: 0.25px;
         drop-shadow-color: #0000003D;

--- a/internal/compiler/widgets/cupertino-base/spinbox.slint
+++ b/internal/compiler/widgets/cupertino-base/spinbox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography, Icons } from "styling.slint";
+import { CupertinoPalette, CupertinoFontSettings, Icons } from "styling.slint";
 import { FocusBorder } from "components.slint";
 import { SpinBoxBase } from "../common/spinbox-base.slint";
 
@@ -11,8 +11,8 @@ component SpinBoxButton {
 
     callback clicked <=> i-touch-area.clicked;
 
-    private property <brush> background: Palette.accent;
-    private property <brush> icon-color: Palette.on-surface;
+    private property <brush> background: CupertinoPalette.accent;
+    private property <brush> icon-color: CupertinoPalette.on-accent;
 
     min-width: 16px;
     horizontal-stretch: 0;
@@ -20,10 +20,10 @@ component SpinBoxButton {
     states [
         disabled when !i-touch-area.enabled : {
             opacity: 0.5;
-            icon-color: Palette.foreground-secondary;
+            icon-color: CupertinoPalette.foreground-secondary;
         }
         pressed when i-touch-area.pressed : {
-            root.background: Palette.accent-secondary;
+            root.background: CupertinoPalette.accent-secondary;
         }
     ]
 
@@ -61,7 +61,7 @@ component SpinBoxButton {
 
             Rectangle {
                 border-radius: parent.border-radius;
-                background: Palette.dimmer;
+                background: CupertinoPalette.dimmer;
                 opacity: 0.17;
             }
 
@@ -88,7 +88,7 @@ export component SpinBox {
 
     callback edited(int /* value */);
 
-    private property <brush> background: Palette.surface;
+    private property <brush> background: CupertinoPalette.surface;
 
     min-width: 128px;
     min-height: max(22px, i-layout.min-height);
@@ -102,8 +102,8 @@ export component SpinBox {
 
     states [
         disabled when !root.enabled : {
-            i-text-input.color: Palette.foreground-secondary;
-            root.background: Palette.surface-tertiary;
+            i-text-input.color: CupertinoPalette.foreground-secondary;
+            root.background: CupertinoPalette.surface-tertiary;
         }
     ]
 
@@ -140,7 +140,7 @@ export component SpinBox {
             border-radius: parent.border-radius;
             background: root.background;
             border-width: 1px;
-            border-color: Palette.decent-border;
+            border-color: CupertinoPalette.decent-border;
             opacity: root.enabled ? 1 : 0.5;
         }
     }
@@ -156,10 +156,10 @@ export component SpinBox {
             i-text-input := TextInput {
                 vertical-alignment: center;
                 horizontal-alignment: left;
-                color: Palette.foreground;
-                font-size: Typography.body.font-size;
-                font-weight: Typography.body.font-weight;
-                selection-background-color: Palette.accent-quaternary;
+                color: CupertinoPalette.foreground;
+                font-size: CupertinoFontSettings.body.font-size;
+                font-weight: CupertinoFontSettings.body.font-weight;
+                selection-background-color: CupertinoPalette.accent-quaternary;
                 selection-foreground-color: self.color;
                 horizontal-stretch: 1;
                 text: root.value;

--- a/internal/compiler/widgets/cupertino-base/spinner.slint
+++ b/internal/compiler/widgets/cupertino-base/spinner.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette } from "styling.slint";
+import { CupertinoPalette } from "styling.slint";
 import { SpinnerBase } from "../common/spinner-base.slint";
 
 export component Spinner {
@@ -19,6 +19,6 @@ export component Spinner {
         width: 100%;
         height: 100%;
         stroke-width: 2px;
-        stroke: Palette.accent;
+        stroke: CupertinoPalette.accent;
     }
 }

--- a/internal/compiler/widgets/cupertino-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino-base/std-widgets-impl.slint
@@ -9,17 +9,17 @@ export { Button }
 import { ScrollView } from "scrollview.slint";
 export { ScrollView }
 
-import { Palette, Typography } from "styling.slint";
+import { CupertinoPalette, CupertinoFontSettings } from "styling.slint";
 
 export global StyleMetrics  {
     out property <length> layout-spacing: 10px;
     out property <length> layout-padding: 12px;
     out property <length> text-cursor-width: 1px;
-    out property <color> window-background: Palette.background;
-    out property <color> default-text-color: Palette.foreground;
-    out property <color> textedit-background: Palette.background-secondary;
-    out property <color> textedit-text-color: Palette.foreground;
-    out property <color> textedit-background-disabled: Palette.surface-tertiary;
-    out property <color> textedit-text-color-disabled: Palette.foreground-secondary;
-    out property <bool> dark-color-scheme: Palette.dark-color-scheme;
+    out property <color> window-background: CupertinoPalette.background;
+    out property <color> default-text-color: CupertinoPalette.foreground;
+    out property <color> textedit-background: CupertinoPalette.background-alt;
+    out property <color> textedit-text-color: CupertinoPalette.foreground;
+    out property <color> textedit-background-disabled: CupertinoPalette.surface-tertiary;
+    out property <color> textedit-text-color-disabled: CupertinoPalette.foreground-secondary;
+    out property <bool> dark-color-scheme: CupertinoPalette.dark-color-scheme;
 }

--- a/internal/compiler/widgets/cupertino-base/styling.slint
+++ b/internal/compiler/widgets/cupertino-base/styling.slint
@@ -8,7 +8,7 @@ export struct TextStyle {
     font-weight: int,
 }
 
-export global Typography {
+export global CupertinoFontSettings {
     out property <int> light-font-weight: 300;
     out property <int> regular-font-weight: 400;
     out property <int> semibold-font-weight: 600;
@@ -25,30 +25,33 @@ export global Typography {
     };
 }
 
-export global Palette {
+export global CupertinoPalette {
     in-out property <bool> dark-color-scheme: ColorSchemeSelector.dark-color-scheme;
 
-    // this are the final colors
+    // base palette
     out property <brush> background: dark-color-scheme ? #282828 : #ffffff;
-    out property <brush> background-secondary: dark-color-scheme ? #2c2c2c : #00000005;
+    out property <brush> background-alt: dark-color-scheme ? #2c2c2c : #00000005;
+    out property <brush> foreground: dark-color-scheme ? #ffffff : #000000;
+    out property <brush> accent: dark-color-scheme ? #0055d1 : #007AFF;
+    out property <brush> on-accent: #f0f0f0;
+    out property <brush> surface: dark-color-scheme ? #616161 : #ffffff;
+    out property <brush> on-surface: dark-color-scheme ? #ffffff : #000000;
+    out property <brush> border: dark-color-scheme ? #ffffff26 : #00000026;
+
+    // additional palette
     out property <brush> background-tertiary: dark-color-scheme ? #1e1e1e : #ffffff;
     out property <brush> background-quaternary: dark-color-scheme ? #1c1c1c : #f0f0f0;
-    out property <brush> accent: dark-color-scheme ? #0055d1 : #007AFF;
     out property <brush> accent-secondary: dark-color-scheme ? #2076ee : #0063ea;
     out property <brush> accent-tertiary: dark-color-scheme ? #487aff : #66A1E3;
     out property <brush> accent-quaternary: dark-color-scheme ? #0055d14D : #007AFF4D;
-    out property <brush> foreground: dark-color-scheme ? #ffffff : #000000;
     out property <brush> foreground-neg: dark-color-scheme ? #000000 : #ffffff;
     out property <brush> foreground-secondary: dark-color-scheme ? #ffffff40 : #00000040;
-    out property <brush> surface: dark-color-scheme ? #616161 : #ffffff;
     out property <brush> surface-secondary: dark-color-scheme ? #7a7a7a : #f0f0f0;
     out property <brush> surface-tertiary: dark-color-scheme ? #616161B3 : #ffffffB3;
     out property <brush> surface-quaternary: dark-color-scheme ? #61616180 : #ffffff80;
     out property <brush> surface-alt: dark-color-scheme ? #414141 : #dadada;
-    out property <brush> on-surface: #f0f0f0;
     out property <brush> hover: dark-color-scheme ? #2e2e2e : #e3e3e3;
     out property <brush> pressed: dark-color-scheme ? #b6b6b6 : #f0f0f0;
-    out property <brush> border: dark-color-scheme ? #ffffff26 : #00000026;
     out property <brush> popup-border: dark-color-scheme ? #525252 :#0000000A;
     out property <brush> decent-border: dark-color-scheme ? #ffffff14 : #00000014;
     out property <brush> surface-thumb: dark-color-scheme ? #cacaca : #ffffff;

--- a/internal/compiler/widgets/cupertino-base/switch.slint
+++ b/internal/compiler/widgets/cupertino-base/switch.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { CupertinoFontSettings, CupertinoPalette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component Switch {
@@ -12,8 +12,8 @@ export component Switch {
 
     callback toggled;
 
-    private property <brush> background: checked && root.enabled ? Palette.accent : Palette.surface-alt;
-    private property <color> text-color: Palette.foreground;
+    private property <brush> background: checked && root.enabled ? CupertinoPalette.accent : CupertinoPalette.surface-alt;
+    private property <color> text-color: CupertinoPalette.foreground;
 
     function toggle-checked() {
         if(!root.enabled) {
@@ -39,10 +39,10 @@ export component Switch {
             root.opacity: 0.5;
         }
         pressed when i-touch-area.pressed : {
-            root.background: root.checked ? Palette.accent-secondary : Palette.surface-secondary;
+            root.background: root.checked ? CupertinoPalette.accent-secondary : CupertinoPalette.surface-secondary;
         }
         selected when root.checked : {
-            i-rail.background: Palette.accent;
+            i-rail.background: CupertinoPalette.accent;
         }
     ]
 
@@ -61,7 +61,7 @@ export component Switch {
                     border-radius: parent.border-radius;
                     background: root.background;
                     border-width: 0.5px;
-                    border-color: Palette.border;
+                    border-color: CupertinoPalette.border;
                     clip: true;
 
                     Rectangle {
@@ -79,7 +79,7 @@ export component Switch {
                     height: parent.height - 2px;
                     width: self.height;
                     border-radius: self.height / 2;
-                    background: Palette.surface-thumb;
+                    background: CupertinoPalette.surface-thumb;
                     drop-shadow-blur: 0.5px;
                     drop-shadow-offset-y: 0.25px;
                     drop-shadow-color: #0000001F;
@@ -97,8 +97,8 @@ export component Switch {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: Typography.body.font-size;
-            font-weight: Typography.body.font-weight;
+            font-size: CupertinoFontSettings.body.font-size;
+            font-weight: CupertinoFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/cupertino-base/tableview.slint
+++ b/internal/compiler/widgets/cupertino-base/tableview.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography, Icons } from "styling.slint";
+import { CupertinoPalette, CupertinoFontSettings, Icons } from "styling.slint";
 import { ListView } from "listview.slint";
 
 component TableViewColumn inherits Rectangle {
@@ -15,7 +15,7 @@ component TableViewColumn inherits Rectangle {
 
     states [
         pressed when i-touch-area.pressed : {
-            background: Palette.surface-secondary;
+            background: CupertinoPalette.surface-secondary;
         }
     ]
 
@@ -32,7 +32,7 @@ component TableViewColumn inherits Rectangle {
 
         i-icon := Image {
             image-fit: contain;
-            colorize: Palette.foreground;
+            colorize: CupertinoPalette.foreground;
             visible: root.sort-order != SortOrder.unsorted;
             width: 8px;
             y: (parent.height - self.height) / 2;
@@ -47,14 +47,14 @@ component TableViewColumn inherits Rectangle {
         y: parent.height - self.height;
         width: 100%;
         height: 1px;
-        background: Palette.border;
+        background: CupertinoPalette.border;
     }
 
     if (!root.last) : Rectangle {
         x: parent.width - 1px;
         y: 4px;
         width: 1px;
-        background: Palette.border;
+        background: CupertinoPalette.border;
         height: parent.height - 8px;
 
         animate background { duration: 150ms; }
@@ -98,7 +98,7 @@ component TableViewRow inherits Rectangle {
 
     states [
         selected when root.selected : {
-            i-background.background: Palette.accent;
+            i-background.background: CupertinoPalette.accent;
         }
     ]
 
@@ -112,7 +112,7 @@ component TableViewRow inherits Rectangle {
     }
 
     i-background := Rectangle {
-        background: root.even ? Palette.background-tertiary : Palette.background-secondary;
+        background: root.even ? CupertinoPalette.background-tertiary : CupertinoPalette.background-alt;
     }
 
     i-layout := HorizontalLayout {
@@ -179,7 +179,7 @@ export component StandardTableView {
             clip: true;
             vertical-stretch: 0;
             min-height: i-header-layout.min-height;
-            background: Palette.background-tertiary;
+            background: CupertinoPalette.background-tertiary;
 
             i-header-layout := HorizontalLayout {
                 width: max(self.preferred-width, parent.width);
@@ -205,10 +205,10 @@ export component StandardTableView {
                     Text {
                         vertical-alignment: center;
                         text: column.title;
-                        font-weight: column.sort-order == SortOrder.unsorted ? Typography.body.font-weight :
-                            Typography.body-strong.font-weight;
-                        font-size: Typography.body.font-size;
-                        color: Palette.foreground;
+                        font-weight: column.sort-order == SortOrder.unsorted ? CupertinoFontSettings.body.font-weight :
+                            CupertinoFontSettings.body-strong.font-weight;
+                        font-size: CupertinoFontSettings.body.font-size;
+                        color: CupertinoPalette.foreground;
                         overflow: elide;
                     }
                 }
@@ -247,9 +247,9 @@ export component StandardTableView {
                             overflow: elide;
                             vertical-alignment: center;
                             text: cell.text;
-                            font-weight: Typography.body.font-weight;
-                            font-size: Typography.body.font-size;
-                            color: Palette.foreground;
+                            font-weight: CupertinoFontSettings.body.font-weight;
+                            font-size: CupertinoFontSettings.body.font-size;
+                            color: CupertinoPalette.foreground;
                         }
                     }
                 }

--- a/internal/compiler/widgets/cupertino-base/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino-base/tabwidget.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography } from "styling.slint";
+import { CupertinoPalette, CupertinoFontSettings } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component TabWidgetImpl inherits Rectangle {
@@ -49,8 +49,8 @@ export component TabImpl inherits Rectangle {
         clip: true;
         width: 100%;
         height: 100%;
-        background: root.is-current ? Palette.background :
-            i-touch-area.has-hover ? Palette.hover : Palette.background-quaternary;
+        background: root.is-current ? CupertinoPalette.background :
+            i-touch-area.has-hover ? CupertinoPalette.hover : CupertinoPalette.background-quaternary;
 
         animate background { duration: 150ms; easing: linear; }
     }
@@ -59,7 +59,7 @@ export component TabImpl inherits Rectangle {
         x: parent.width - self.width;
         width: 1px;
         height: 100%;
-        background: Palette.border;
+        background: CupertinoPalette.border;
     }
 
     if (!root.is-current) : Rectangle {
@@ -84,9 +84,9 @@ export component TabImpl inherits Rectangle {
         i-text := Text {
             vertical-alignment: center;
             horizontal-alignment: center;
-            font-size: root.is-current ? Typography.body-strong.font-size : Typography.body.font-size;
-            font-weight: root.is-current ? Typography.body-strong.font-weight : Typography.body.font-weight;
-            color: Palette.foreground;
+            font-size: root.is-current ? CupertinoFontSettings.body-strong.font-size : CupertinoFontSettings.body.font-size;
+            font-weight: root.is-current ? CupertinoFontSettings.body-strong.font-weight : CupertinoFontSettings.body.font-weight;
+            color: CupertinoPalette.foreground;
         }
     }
 }
@@ -106,7 +106,7 @@ export component TabBarImpl {
 
     Rectangle {
         y: parent.height - self.height;
-        background: Palette.separator;
+        background: CupertinoPalette.separator;
         width: 100%;
         height: 1px;
     }

--- a/internal/compiler/widgets/cupertino-base/textedit.slint
+++ b/internal/compiler/widgets/cupertino-base/textedit.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { CupertinoFontSettings, CupertinoPalette } from "styling.slint";
 import { ScrollBar } from "scrollview.slint";
 import { FocusBorder } from "components.slint";
 
@@ -104,11 +104,11 @@ export component TextEdit {
 
     states [
         disabled when !root.enabled : {
-            i-text-input.color: Palette.foreground-secondary;
-            i-background.background: Palette.surface-tertiary;
+            i-text-input.color: CupertinoPalette.foreground-secondary;
+            i-background.background: CupertinoPalette.surface-tertiary;
         }
         focused when root.has-focus : {
-            i-background.background: Palette.surface;
+            i-background.background: CupertinoPalette.surface;
         }
     ]
 
@@ -121,8 +121,8 @@ export component TextEdit {
     }
 
     i-background := Rectangle {
-        background: Palette.background-secondary;
-        border-color: Palette.border;
+        background: CupertinoPalette.background-alt;
+        border-color: CupertinoPalette.border;
         border-width: 1px;
     }
 
@@ -136,10 +136,10 @@ export component TextEdit {
 
         i-text-input := TextInput {
             enabled: true;
-            color: Palette.foreground;
-            font-size: Typography.body.font-size;
-            font-weight: Typography.body.font-weight;
-            selection-background-color: Palette.accent-quaternary;
+            color: CupertinoPalette.foreground;
+            font-size: CupertinoFontSettings.body.font-size;
+            font-weight: CupertinoFontSettings.body.font-weight;
+            selection-background-color: CupertinoPalette.accent-quaternary;
             selection-foreground-color: self.color;
             single-line: false;
             wrap: word-wrap;

--- a/internal/compiler/widgets/fluent-base/button.slint
+++ b/internal/compiler/widgets/fluent-base/button.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { FluentFontSettings, FluentPalette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component Button {
@@ -16,7 +16,7 @@ export component Button {
 
     callback clicked;
 
-    private property <brush> text-color: primary || checked ? Palette.text-on-accent-primary : Palette.text-primary;
+    private property <brush> text-color: primary || checked ? FluentPalette.on-accent : FluentPalette.on-surface;
 
     min-width: max(32px, i-layout.min-width);
     min-height: max(32px, i-layout.min-height);
@@ -28,35 +28,35 @@ export component Button {
 
     states [
         disabled when !root.enabled : {
-            i-background.background: root.primary || root.checked ? Palette.accent-disabled : Palette.control-disabled;
-            i-border.border-color: root.primary || root.checked ? transparent : Palette.control-stroke;
-            root.text-color: root.primary || root.checked ? Palette.text-on-accent-disabled : Palette.text-disabled;
+            i-background.background: root.primary || root.checked ? FluentPalette.accent-disabled : FluentPalette.control-disabled;
+            i-border.border-color: root.primary || root.checked ? transparent : FluentPalette.border;
+            root.text-color: root.primary || root.checked ? FluentPalette.text-on-accent-disabled : FluentPalette.text-disabled;
         }
         pressed when root.pressed : {
-            i-background.background: root.primary || root.checked ? Palette.accent-tertiary : Palette.control-tertiary;
-            i-border.border-color: Palette.control-stroke;
-            root.text-color: root.primary || root.checked ? Palette.text-on-accent-secondary : Palette.text-secondary;
+            i-background.background: root.primary || root.checked ? FluentPalette.accent-tertiary : FluentPalette.control-tertiary;
+            i-border.border-color: FluentPalette.border;
+            root.text-color: root.primary || root.checked ? FluentPalette.text-on-accent-secondary : FluentPalette.text-secondary;
         }
         hover when i-touch-area.has-hover : {
-            i-background.background: root.primary || root.checked ? Palette.accent-secondary : Palette.control-secondary;
+            i-background.background: root.primary || root.checked ? FluentPalette.accent-secondary : FluentPalette.control-secondary;
         }
         checked when root.checked : {
-            i-background.background: Palette.accent-default;
-            i-border.border-color: Palette.accent-control-border;
-            root.text-color: Palette.text-on-accent-primary;
+            i-background.background: FluentPalette.accent;
+            i-border.border-color: FluentPalette.accent-control-border;
+            root.text-color: FluentPalette.on-accent;
         }
     ]
 
     i-background := Rectangle {
         border-radius: 4px;
-        background: root.primary ? Palette.accent-default : Palette.control-default;
+        background: root.primary ? FluentPalette.accent : FluentPalette.surface;
 
         animate background, border-color { duration: 150ms; }
 
         i-border := Rectangle {
             border-radius: parent.border-radius;
             border-width: 1px;
-            border-color: root.primary ? Palette.accent-control-border : Palette.control-border;
+            border-color: root.primary ? FluentPalette.accent-control-border : FluentPalette.control-border;
         }
 
         i-layout := HorizontalLayout {
@@ -74,8 +74,8 @@ export component Button {
             }
 
             if (root.text != ""): Text {
-                font-size: Typography.body.font-size;
-                font-weight: Typography.body.font-weight;
+                font-size: FluentFontSettings.body.font-size;
+                font-weight: FluentFontSettings.body.font-weight;
                 horizontal-alignment: center;
                 vertical-alignment: center;
                 text: root.text;

--- a/internal/compiler/widgets/fluent-base/checkbox.slint
+++ b/internal/compiler/widgets/fluent-base/checkbox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette, Icons } from "styling.slint";
+import { FluentFontSettings, FluentPalette, Icons } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component CheckBox {
@@ -12,7 +12,7 @@ export component CheckBox {
 
     callback toggled;
 
-    private property <color> text-color: Palette.text-secondary;
+    private property <color> text-color: FluentPalette.text-secondary;
 
     min-height: max(32px, i-layout.min-height);
     accessible-checkable: true;
@@ -22,21 +22,21 @@ export component CheckBox {
 
     states [
         disabled when !root.enabled : {
-            i-border.border-color: Palette.control-strong-stroke-disabled;
-            i-background.background: root.checked ? Palette.accent-disabled : Palette.control-alt-disabled;
-            i-icon.colorize: Palette.text-on-accent-disabled;
-            root.text-color: Palette.text-disabled;
+            i-border.border-color: FluentPalette.control-strong-stroke-disabled;
+            i-background.background: root.checked ? FluentPalette.accent-disabled : FluentPalette.control-alt-disabled;
+            i-icon.colorize: FluentPalette.text-on-accent-disabled;
+            root.text-color: FluentPalette.text-disabled;
         }
         pressed when i-touch-area.pressed : {
-            i-border.border-color: Palette.control-strong-stroke-disabled;
-            i-background.background: root.checked ? Palette.accent-tertiary : Palette.control-alt-quartiary;
-            i-icon.colorize: Palette.text-on-accent-secondary;
+            i-border.border-color: FluentPalette.control-strong-stroke-disabled;
+            i-background.background: root.checked ? FluentPalette.accent-tertiary : FluentPalette.control-alt-quartiary;
+            i-icon.colorize: FluentPalette.text-on-accent-secondary;
         }
         hover when i-touch-area.has-hover : {
-            i-background.background: root.checked ?  Palette.accent-secondary : Palette.control-alt-tertiary;
+            i-background.background: root.checked ?  FluentPalette.accent-secondary : FluentPalette.control-alt-tertiary;
         }
         checked when root.checked && root.enabled : {
-            i-background.background: Palette.accent-default;
+            i-background.background: FluentPalette.accent;
         }
     ]
 
@@ -51,13 +51,13 @@ export component CheckBox {
             width: 18px;
             height: self.width;
             y: (parent.height - self.height) / 2;
-            background: Palette.control-alt-secondary;
+            background: FluentPalette.control-alt-secondary;
             border-radius: 2px;
 
             animate background, border-color { duration: 150ms; }
 
             i-border := Rectangle {
-                border-color: Palette.control-strong-stroke;
+                border-color: FluentPalette.control-strong-stroke;
                 border-width: root.checked ? 0 : 1px;
                 border-radius: parent.border-radius;
             }
@@ -66,7 +66,7 @@ export component CheckBox {
                 image-fit: contain;
                 visible: root.checked;
                 source: Icons.check-mark;
-                colorize: Palette.text-on-accent-primary;
+                colorize: FluentPalette.on-accent;
                 width: 12px;
 
                 animate colorize { duration: 150ms; }
@@ -76,8 +76,8 @@ export component CheckBox {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: Typography.body.font-size;
-            font-weight: Typography.body.font-weight;
+            font-size: FluentFontSettings.body.font-size;
+            font-weight: FluentFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/fluent-base/combobox.slint
+++ b/internal/compiler/widgets/fluent-base/combobox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette, Icons } from "styling.slint";
+import { FluentFontSettings, FluentPalette, Icons } from "styling.slint";
 import { MenuBorder, ListItem, FocusBorder } from "components.slint";
 import { ComboBoxBase } from "../common/combobox-base.slint";
 
@@ -22,19 +22,19 @@ export component ComboBox {
 
     states [
         disabled when !root.enabled : {
-            i-background.background: Palette.control-disabled;
-            i-background.border-color: Palette.control-stroke;
-            i-text.color: Palette.text-disabled;
-            i-icon.colorize: Palette.text-disabled;
+            i-background.background: FluentPalette.control-disabled;
+            i-background.border-color: FluentPalette.border;
+            i-text.color: FluentPalette.text-disabled;
+            i-icon.colorize: FluentPalette.text-disabled;
         }
         pressed when i-base.pressed : {
-            i-background.background: Palette.control-alt-tertiary;
-            i-background.border-color: Palette.control-stroke;
-            i-text.color: Palette.text-secondary;
-            i-icon.colorize: Palette.text-tertiary;
+            i-background.background: FluentPalette.control-alt-tertiary;
+            i-background.border-color: FluentPalette.border;
+            i-text.color: FluentPalette.text-secondary;
+            i-icon.colorize: FluentPalette.text-tertiary;
         }
         hover when i-base.has-hover : {
-            i-background.background: Palette.control-secondary;
+            i-background.background: FluentPalette.control-secondary;
         }
     ]
 
@@ -49,9 +49,9 @@ export component ComboBox {
 
     i-background := Rectangle {
         border-radius: 3px;
-        background: Palette.control-default;
+        background: FluentPalette.surface;
         border-width: 1px;
-        border-color: Palette.control-border;
+        border-color: FluentPalette.control-border;
 
         animate border-color { duration: 200ms; }
 
@@ -63,14 +63,14 @@ export component ComboBox {
             i-text := Text {
                 horizontal-alignment: left;
                 vertical-alignment: center;
-                font-size: Typography.body.font-size;
-                font-weight: Typography.body.font-weight;
-                color: Palette.text-primary;
+                font-size: FluentFontSettings.body.font-size;
+                font-weight: FluentFontSettings.body.font-weight;
+                color: FluentPalette.on-surface;
                 text: root.current-value;
             }
 
             i-icon := Image {
-                colorize: Palette.text-secondary;
+                colorize: FluentPalette.text-secondary;
                 width: 12px;
                 source: Icons.dropdown;
                 y: 2px;

--- a/internal/compiler/widgets/fluent-base/components.slint
+++ b/internal/compiler/widgets/fluent-base/components.slint
@@ -1,11 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography } from "styling.slint";
+import { FluentPalette, FluentFontSettings } from "styling.slint";
 
 export component FocusBorder inherits Rectangle {
     border-width: 2px;
-    border-color: Palette.focus-stroke-outer;
+    border-color: FluentPalette.focus-stroke-outer;
 
     Rectangle {
         x: parent.border-width;
@@ -14,21 +14,21 @@ export component FocusBorder inherits Rectangle {
         height: parent.height - 2 * parent.border-width;
         border-width: 1px;
         border-radius: parent.border-radius - 2px;
-        border-color: Palette.focus-stroke-inner;
+        border-color: FluentPalette.focus-stroke-inner;
     }
 }
 
 export component MenuBorder inherits Rectangle {
     border-radius: 7px;
-    background: Palette.acrylic-background;
+    background: FluentPalette.background-alt;
     drop-shadow-blur: 16px;
     drop-shadow-offset-y: 8px;
-    drop-shadow-color: Palette.shadow;
+    drop-shadow-color: FluentPalette.shadow;
 
     Rectangle {
         border-width: 1px;
         border-radius: parent.border-radius;
-        border-color: Palette.surface-stroke-flyout;
+        border-color: FluentPalette.surface-stroke-flyout;
     }
 }
 
@@ -48,15 +48,15 @@ export component ListItem {
 
     states [
         pressed when i-touch-area.pressed : {
-            i-background.background: selected ? Palette.subtle-secondary : Palette.subtle-tertiary;
+            i-background.background: selected ? FluentPalette.subtle-secondary : FluentPalette.subtle-tertiary;
         }
         hover when i-touch-area.has-hover : {
-            i-text.color: Palette.text-secondary;
-            i-background.background: selected ? Palette.subtle-tertiary : Palette.subtle-secondary;
+            i-text.color: FluentPalette.text-secondary;
+            i-background.background: selected ? FluentPalette.subtle-tertiary : FluentPalette.subtle-secondary;
             i-selector.height: root.selected ? 16px : 0;
         }
         selected when root.selected : {
-            i-background.background: Palette.subtle-secondary;
+            i-background.background: FluentPalette.subtle-secondary;
             i-selector.height: 16px;
         }
     ]
@@ -73,9 +73,9 @@ export component ListItem {
             spacing: 4px;
 
             i-text := Text {
-                color: Palette.text-primary;
-                font-size: Typography.body.font-size;
-                font-weight: Typography.body.font-weight;
+                color: FluentPalette.on-surface;
+                font-size: FluentFontSettings.body.font-size;
+                font-weight: FluentFontSettings.body.font-weight;
                 vertical-alignment: center;
                 horizontal-alignment: left;
                 overflow: elide;
@@ -89,7 +89,7 @@ export component ListItem {
             y: (parent.height - self.height) / 2;
             width: 3px;
             height: 0px;
-            background: Palette.accent-default;
+            background: FluentPalette.accent;
             border-radius: 2px;
 
             animate height { duration: 150ms; easing: ease-out; }

--- a/internal/compiler/widgets/fluent-base/groupbox.slint
+++ b/internal/compiler/widgets/fluent-base/groupbox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { FluentFontSettings, FluentPalette } from "styling.slint";
 
 export component GroupBox {
     in property <string> title <=> label.text;
@@ -14,9 +14,9 @@ export component GroupBox {
 
         label := Text {
             vertical-stretch: 0;
-            color: !root.enabled ? Palette.text-disabled : Palette.text-primary;
-            font-size: Typography.body-strong.font-size;
-            font-weight: Typography.body-strong.font-weight;
+            color: !root.enabled ? FluentPalette.text-disabled : FluentPalette.on-surface;
+            font-size: FluentFontSettings.body-strong.font-size;
+            font-weight: FluentFontSettings.body-strong.font-weight;
         }
 
         Rectangle {

--- a/internal/compiler/widgets/fluent-base/lineedit.slint
+++ b/internal/compiler/widgets/fluent-base/lineedit.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { FluentFontSettings, FluentPalette } from "styling.slint";
 
 export component LineEdit {
     in property <bool> enabled <=> i-text-input.enabled;
@@ -44,25 +44,25 @@ export component LineEdit {
 
     states [
         disabled when !root.enabled : {
-            i-background.background: Palette.control-disabled;
-            i-background.border-color: Palette.control-stroke;
-            i-text-input.color: Palette.text-disabled;
-            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
-            i-placeholder.color: Palette.text-disabled;
+            i-background.background: FluentPalette.control-disabled;
+            i-background.border-color: FluentPalette.border;
+            i-text-input.color: FluentPalette.text-disabled;
+            i-text-input.selection-foreground-color: FluentPalette.text-on-accent-disabled;
+            i-placeholder.color: FluentPalette.text-disabled;
         }
         focused when root.has-focus : {
-            i-background.background: Palette.control-input-active;
-            i-background.border-color: Palette.control-stroke;
-            i-focus-border.background: Palette.accent-default;
-            i-placeholder.color: Palette.text-tertiary;
+            i-background.background: FluentPalette.control-input-active;
+            i-background.border-color: FluentPalette.border;
+            i-focus-border.background: FluentPalette.accent;
+            i-placeholder.color: FluentPalette.text-tertiary;
         }
     ]
 
     i-background := Rectangle {
         border-radius: 4px;
-        background: Palette.control-default;
+        background: FluentPalette.surface;
         border-width: 1px;
-        border-color: Palette.text-control-border;
+        border-color: FluentPalette.text-control-border;
 
         i-layout := HorizontalLayout {
             padding-left: 12px;
@@ -74,9 +74,9 @@ export component LineEdit {
                 i-placeholder := Text {
                     width: 100%;
                     height: 100%;
-                    color: Palette.text-secondary;
-                    font-size: Typography.body.font-size;
-                    font-weight: Typography.body.font-weight;
+                    color: FluentPalette.text-secondary;
+                    font-size: FluentFontSettings.body.font-size;
+                    font-weight: FluentFontSettings.body.font-weight;
                     visible: root.text == "";
                     vertical-alignment: center;
                 }
@@ -88,12 +88,12 @@ export component LineEdit {
                     x: min(0px, max(parent.width - self.width, self.computed_x));
                     width: max(parent.width, self.preferred-width);
                     height: 100%;
-                    color: Palette.text-primary;
+                    color: FluentPalette.foreground;
                     vertical-alignment: center;
-                    font-size: Typography.body.font-size;
-                    font-weight: Typography.body.font-weight;
-                    selection-background-color: Palette.accent-selected-text;
-                    selection-foreground-color: Palette.text-on-accent-primary;
+                    font-size: FluentFontSettings.body.font-size;
+                    font-weight: FluentFontSettings.body.font-weight;
+                    selection-background-color: FluentPalette.accent-selected-text;
+                    selection-foreground-color: FluentPalette.on-accent;
 
                     accepted => {
                         root.accepted(self.text);

--- a/internal/compiler/widgets/fluent-base/progressindicator.slint
+++ b/internal/compiler/widgets/fluent-base/progressindicator.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette } from "styling.slint";
+import { FluentPalette } from "styling.slint";
 
 export component ProgressIndicator {
     in property <float> progress;
@@ -18,7 +18,7 @@ export component ProgressIndicator {
 
         i-rail := Rectangle {
             height: 1px;
-            background: Palette.control-stroke;
+            background: FluentPalette.border;
             border-radius: 1px;
         }
 
@@ -27,7 +27,7 @@ export component ProgressIndicator {
             height: 100%;
             x: !root.indeterminate ? 0px : -parent.width + (parent.width * mod(animation-tick(), 2s) / 1s);
             border-radius: 3px;
-            background: Palette.accent-default;
+            background: FluentPalette.accent;
         }
     }
 }

--- a/internal/compiler/widgets/fluent-base/scrollview.slint
+++ b/internal/compiler/widgets/fluent-base/scrollview.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Icons } from "styling.slint";
+import { FluentPalette, Icons } from "styling.slint";
 
 component ScrollViewButton inherits TouchArea {
     in property <image> icon;
@@ -14,7 +14,7 @@ component ScrollViewButton inherits TouchArea {
         y: (parent.height - self.height) / 2;
         width: parent.width;
         source: root.icon;
-        colorize: Palette.control-stroke;
+        colorize: FluentPalette.border;
 
         animate colorize, opacity { duration: 150ms; }
         animate width, height { duration: 150ms; easing: ease-out; }
@@ -27,7 +27,7 @@ component ScrollViewButton inherits TouchArea {
         }
         hover when root.has-hover : {
             opacity: 1;
-            i-icon.colorize: Palette.text-secondary;
+            i-icon.colorize: FluentPalette.text-secondary;
         }
     ]
 }
@@ -49,7 +49,7 @@ component ScrollBar inherits Rectangle {
 
     states [
         hover when i-touch-area.has-hover || i-down-scroll-button.has-hover || i-up-scroll-button.has-hover : {
-            root.background: Palette.acrylic-background;
+            root.background: FluentPalette.background-alt;
             root.size: 6px;
             i-up-scroll-button.opacity: 1;
             i-down-scroll-button.opacity: 1;
@@ -64,7 +64,7 @@ component ScrollBar inherits Rectangle {
         x: !root.horizontal ? parent.width - 4px - self.width : root.offset + (root.track-size - i-thumb.width) * (-root.value / root.maximum);
         y: root.horizontal ? parent.height - 4px - self.height : root.offset + (root.track-size - i-thumb.height) * (-root.value / root.maximum);
         border-radius: (root.horizontal ? self.height : self.width) / 2;
-        background: Palette.control-stroke;
+        background: FluentPalette.border;
 
         animate width, height { duration: 150ms; easing: ease-out; }
     }

--- a/internal/compiler/widgets/fluent-base/slider.slint
+++ b/internal/compiler/widgets/fluent-base/slider.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette } from "styling.slint";
+import { FluentPalette } from "styling.slint";
 
 export component Slider {
     in property <Orientation> orientation: horizontal;
@@ -27,25 +27,25 @@ export component Slider {
 
     states [
         disabled when !root.enabled : {
-            i-track.background: Palette.accent-disabled;
-            i-rail.background: Palette.accent-disabled;
-            i-thumb-inner.background: Palette.accent-disabled;
+            i-track.background: FluentPalette.accent-disabled;
+            i-rail.background: FluentPalette.accent-disabled;
+            i-thumb-inner.background: FluentPalette.accent-disabled;
         }
         pressed when ( i-touch-area.pressed &&  i-touch-area.has-hover) || i-focus-scope.has-focus : {
             i-thumb-inner.width: 10px;
-            i-thumb-inner.background: Palette.accent-tertiary;
-            i-thumb.border-color: Palette.control-stroke;
+            i-thumb-inner.background: FluentPalette.accent-tertiary;
+            i-thumb.border-color: FluentPalette.border;
         }
         hover when i-touch-area.has-hover : {
             i-thumb-inner.width: 14px;
-            i-thumb-inner.background: Palette.accent-secondary;
+            i-thumb-inner.background: FluentPalette.accent-secondary;
         }
     ]
 
     i-rail := Rectangle {
         width: vertical ? 4px : parent.width;
         height: vertical ? parent.height : 4px;
-        background: Palette.control-stroke;
+        background: FluentPalette.border;
         border-radius: 2px;
     }
 
@@ -54,7 +54,7 @@ export component Slider {
         y: vertical ? 0 : (parent.height - self.height) / 2;
         width: vertical ? i-rail.width : i-thumb.x + (i-thumb.width / 2);
         height: vertical ? i-thumb.y + (i-thumb.height / 2) : i-rail.height;
-        background: Palette.accent-default;
+        background: FluentPalette.accent;
         border-radius: i-rail.border-radius;
     }
 
@@ -64,7 +64,7 @@ export component Slider {
         width: 20px;
         height: self.width;
         border-radius: 10px;
-        background: Palette.control-solid;
+        background: FluentPalette.control-solid;
 
         i-thumb-border := Rectangle {
             x: (parent.width - self.width) / 2;
@@ -73,14 +73,14 @@ export component Slider {
             height: self.width;
             border-radius: 10.5px;
             border-width: 1px;
-            border-color: Palette.circle-border;
+            border-color: FluentPalette.circle-border;
         }
 
         i-thumb-inner := Rectangle {
             width: 12px;
             height: self.width;
             border-radius: self.width / 2;
-            background: Palette.accent-default;
+            background: FluentPalette.accent;
 
             animate background, width { duration: 150ms; }
         }

--- a/internal/compiler/widgets/fluent-base/spinbox.slint
+++ b/internal/compiler/widgets/fluent-base/spinbox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography, Icons } from "styling.slint";
+import { FluentPalette, FluentFontSettings, Icons } from "styling.slint";
 import { SpinBoxBase } from "../common/spinbox-base.slint";
 
 component SpinBoxButton {
@@ -14,7 +14,7 @@ component SpinBoxButton {
 
     states [
         pressed when i-touch-area.pressed : {
-            i-background.background: Palette.subtle;
+            i-background.background: FluentPalette.subtle;
         }
     ]
 
@@ -23,7 +23,7 @@ component SpinBoxButton {
 
         i-icon := Image {
             image-fit: contain;
-            colorize: Palette.text-secondary;
+            colorize: FluentPalette.text-secondary;
             width: 12px;
 
             animate colorize { duration: 150ms; }
@@ -54,15 +54,15 @@ export component SpinBox {
 
     states [
         disabled when !root.enabled : {
-            i-background.background: Palette.control-disabled;
-            i-background.border-color: Palette.control-stroke;
-            i-text-input.color: Palette.text-disabled;
-            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
+            i-background.background: FluentPalette.control-disabled;
+            i-background.border-color: FluentPalette.border;
+            i-text-input.color: FluentPalette.text-disabled;
+            i-text-input.selection-foreground-color: FluentPalette.text-on-accent-disabled;
         }
         focused when root.has-focus : {
-            i-background.background: Palette.control-input-active;
-            i-background.border-color: Palette.control-stroke;
-            i-focus-border.background: Palette.accent-default;
+            i-background.background: FluentPalette.control-input-active;
+            i-background.border-color: FluentPalette.border;
+            i-focus-border.background: FluentPalette.accent;
         }
     ]
 
@@ -78,9 +78,9 @@ export component SpinBox {
 
     i-background := Rectangle {
         border-radius: 4px;
-        background: Palette.control-default;
+        background: FluentPalette.surface;
         border-width: 1px;
-        border-color: Palette.text-control-border;
+        border-color: FluentPalette.text-control-border;
 
         i-layout := HorizontalLayout {
             padding-left: 12px;
@@ -95,11 +95,11 @@ export component SpinBox {
                 i-text-input := TextInput {
                     vertical-alignment: center;
                     horizontal-alignment: left;
-                    color: Palette.text-primary;
-                    font-size: Typography.body.font-size;
-                    font-weight: Typography.body.font-weight;
-                    selection-background-color: Palette.accent-selected-text;
-                    selection-foreground-color: Palette.text-on-accent-primary;
+                    color: FluentPalette.on-surface;
+                    font-size: FluentFontSettings.body.font-size;
+                    font-weight: FluentFontSettings.body.font-weight;
+                    selection-background-color: FluentPalette.accent-selected-text;
+                    selection-foreground-color: FluentPalette.on-accent;
                     horizontal-stretch: 1;
                     text: root.value;
                     enabled: root.enabled;

--- a/internal/compiler/widgets/fluent-base/spinner.slint
+++ b/internal/compiler/widgets/fluent-base/spinner.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette } from "styling.slint";
+import { FluentPalette } from "styling.slint";
 import { SpinnerBase } from "../common/spinner-base.slint";
 
 export component Spinner {
@@ -19,6 +19,6 @@ export component Spinner {
         width: 100%;
         height: 100%;
         stroke-width: 2px;
-        stroke: Palette.accent-default;
+        stroke: FluentPalette.accent;
     }
 }

--- a/internal/compiler/widgets/fluent-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent-base/std-widgets-impl.slint
@@ -9,17 +9,17 @@ export { Button }
 import { ScrollView } from "scrollview.slint";
 export { ScrollView }
 
-import { Palette, Typography } from "styling.slint";
+import { FluentPalette, FluentFontSettings } from "styling.slint";
 
 export global StyleMetrics  {
     out property <length> layout-spacing: 8px;
     out property <length> layout-padding: 8px;
     out property <length> text-cursor-width: 1px;
-    out property <color> window-background: Palette.background;
-    out property <color> default-text-color: Palette.text-primary;
-    out property <color> textedit-background: Palette.background;
-    out property <color> textedit-text-color: Palette.text-primary;
-    out property <color> textedit-background-disabled: Palette.control-disabled;
-    out property <color> textedit-text-color-disabled: Palette.text-disabled;
-    out property <bool> dark-color-scheme: Palette.dark-color-scheme;
+    out property <color> window-background: FluentPalette.background;
+    out property <color> default-text-color: FluentPalette.foreground;
+    out property <color> textedit-background: FluentPalette.background;
+    out property <color> textedit-text-color: FluentPalette.foreground;
+    out property <color> textedit-background-disabled: FluentPalette.control-disabled;
+    out property <color> textedit-text-color-disabled: FluentPalette.text-disabled;
+    out property <bool> dark-color-scheme: FluentPalette.dark-color-scheme;
 }

--- a/internal/compiler/widgets/fluent-base/styling.slint
+++ b/internal/compiler/widgets/fluent-base/styling.slint
@@ -8,7 +8,7 @@ export struct TextStyle {
     font-weight: int,
 }
 
-export global Typography {
+export global FluentFontSettings {
     out property <int> light-font-weight: 300;
     out property <int> regular-font-weight: 400;
     out property <int> semibold-font-weight: 600;
@@ -22,30 +22,35 @@ export global Typography {
     };
 }
 
-export global Palette {
+export global FluentPalette {
     in-out property <bool> dark-color-scheme: ColorSchemeSelector.dark-color-scheme;
 
+    // base palette
     out property <brush> background: dark-color-scheme ? #1C1C1C : #FAFAFA;
-    out property <brush> accent-default: dark-color-scheme ? #60CDFF : #005FB8;
+    out property <brush> background-alt: dark-color-scheme ? #2C2C2C : #f0f0f0;
+    out property <brush> foreground: dark-color-scheme ? #FFFFFF : #000000E6;
+    out property <brush> accent: dark-color-scheme ? #60CDFF : #005FB8;
+    out property <brush> on-accent: dark-color-scheme ? #000000 : #FFFFFF;
+    out property <brush> surface: dark-color-scheme ? #FFFFFF0F : #FFFFFFB3;
+    out property <brush> on-surface: dark-color-scheme ? #FFFFFF : #000000E6;
+    out property <brush> border: dark-color-scheme ? #FFFFFF14 : #00000073;
+
+    // additional palette
     out property <brush> accent-secondary: dark-color-scheme ? #60CDFFE6 : #005FB8E6;
     out property <brush> accent-tertiary: dark-color-scheme ? #60CDFFCC : #005FB8CC;
     out property <brush> accent-disabled: dark-color-scheme ? #FFFFFF29 : #00000038;
     out property <brush> accent-control-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF14 90.67%, #00000024 100%)
         : @linear-gradient(180deg, #FFFFFF14 90.67%, #00000066 100%);
     out property <brush> accent-selected-text: #0078D4;
-    out property <brush> control-default: dark-color-scheme ? #FFFFFF0F : #FFFFFFB3;
     out property <brush> control-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF17 0%, #00000012 8.33%)
         : @linear-gradient(180deg, #0000000F 90.58%, #00000029 100%);
-    out property <brush> text-on-accent-primary: dark-color-scheme ? #000000 : #FFFFFF;
     out property <brush> text-on-accent-secondary: dark-color-scheme ? #00000080 : #FFFFFFB3;
     out property <brush> text-on-accent-disabled: dark-color-scheme ? #FFFFFF87 : #FFFFFF;
-    out property <brush> text-primary: dark-color-scheme ? #FFFFFF : #000000E6;
     out property <brush> text-secondary: dark-color-scheme ? #FFFFFFC9 : #00000099;
     out property <brush> text-tertiary: dark-color-scheme ? #FFFFFF8A : #00000073;
     out property <brush> text-disabled: dark-color-scheme ? #FFFFFF5E : #0000005E;
     out property <brush> text-control-border: dark-color-scheme ? @linear-gradient(180deg, #FFFFFF14 99.98%, #FFFFFF8A 100%, #FFFFFF8A 100%)
         : @linear-gradient(180deg, #0000000F 99.99%, #00000073 100%, #00000073 100%);
-    out property <brush> control-stroke: dark-color-scheme ? #FFFFFF14 : #00000073;
     out property <brush> control-secondary: dark-color-scheme ? #FFFFFF14 : #F9F9F980;
     out property <brush> control-tertiary: dark-color-scheme ? #FFFFFF08 : #F9F9F94D;
     out property <brush> control-disabled: dark-color-scheme ? #FFFFFF0A : #F9F9F94D;
@@ -72,9 +77,6 @@ export global Palette {
     out property <brush> layer-on-mica-base-alt: dark-color-scheme ? #3A3A3A73 : #FFFFFFB3;
     out property <brush> layer-on-mica-base-alt-secondary: dark-color-scheme ? #FFFFFF0F : #0000000A;
     out property <brush> card-stroke: dark-color-scheme ? #0000001A : #0000000F;
-
-    // fallback values for the acrylic brushes
-    out property <brush> acrylic-background: dark-color-scheme ? #2C2C2C : #f0f0f0;
 }
 
 export global Icons {

--- a/internal/compiler/widgets/fluent-base/switch.slint
+++ b/internal/compiler/widgets/fluent-base/switch.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { FluentFontSettings, FluentPalette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component Switch {
@@ -12,7 +12,7 @@ export component Switch {
 
     callback toggled;
 
-    private property <color> text-color: Palette.text-secondary;
+    private property <color> text-color: FluentPalette.text-secondary;
 
     function toggle-checked() {
         if(!root.enabled) {
@@ -35,30 +35,30 @@ export component Switch {
 
     states [
         disabled when !root.enabled : {
-            i-rail.background: root.checked ? Palette.accent-disabled : transparent;
-            i-rail.border-color: Palette.control-strong-stroke-disabled;
-            i-thumb.background: Palette.text-disabled;
-            root.text-color: Palette.text-disabled;
-            i-thumb.background: root.checked ? Palette.text-on-accent-disabled : Palette.text-secondary;
+            i-rail.background: root.checked ? FluentPalette.accent-disabled : transparent;
+            i-rail.border-color: FluentPalette.control-strong-stroke-disabled;
+            i-thumb.background: FluentPalette.text-disabled;
+            root.text-color: FluentPalette.text-disabled;
+            i-thumb.background: root.checked ? FluentPalette.text-on-accent-disabled : FluentPalette.text-secondary;
         }
         pressed when i-touch-area.pressed : {
-            i-rail.background: root.checked ? Palette.accent-tertiary : Palette.control-alt-quartiary;
+            i-rail.background: root.checked ? FluentPalette.accent-tertiary : FluentPalette.control-alt-quartiary;
             i-thumb.width: 17px;
             i-thumb.height: 14px;
             i-thumb.border-width: root.checked ? 1px : 0;
-            i-thumb.background: root.checked ? Palette.text-on-accent-primary : Palette.text-secondary;
+            i-thumb.background: root.checked ? FluentPalette.on-accent : FluentPalette.text-secondary;
         }
         hover when i-touch-area.has-hover : {
-            i-rail.background:  root.checked ? Palette.accent-secondary : Palette.control-alt-tertiary;
+            i-rail.background:  root.checked ? FluentPalette.accent-secondary : FluentPalette.control-alt-tertiary;
             i-thumb.width: 14px;
             i-thumb.border-width: root.checked ? 1px : 0;
-            i-thumb.background: root.checked ? Palette.text-on-accent-primary : Palette.text-secondary;
+            i-thumb.background: root.checked ? FluentPalette.on-accent : FluentPalette.text-secondary;
         }
         selected when root.checked : {
-            i-rail.background: Palette.accent-default;
+            i-rail.background: FluentPalette.accent;
             i-thumb.border-width: 1px;
-            i-thumb.border-color: Palette.circle-border;
-            i-thumb.background: Palette.text-on-accent-primary;
+            i-thumb.border-color: FluentPalette.circle-border;
+            i-thumb.background: FluentPalette.on-accent;
         }
     ]
 
@@ -75,8 +75,8 @@ export component Switch {
                 i-rail := Rectangle {
                     border-radius: 10px;
                     border-width: root.checked ? 0 : 1px;
-                    border-color: Palette.control-strong-stroke;
-                    background: Palette.control-alt-secondary;
+                    border-color: FluentPalette.control-strong-stroke;
+                    background: FluentPalette.control-alt-secondary;
                 }
 
                 i-thumb := Rectangle {
@@ -85,8 +85,8 @@ export component Switch {
                     width: 12px;
                     height: self.width;
                     border-radius: self.height / 2;
-                    background: Palette.text-secondary;
-                    border-color: Palette.circle-border;
+                    background: FluentPalette.text-secondary;
+                    border-color: FluentPalette.circle-border;
 
                     animate background, width { duration: 150ms; easing: linear; }
                 }
@@ -101,8 +101,8 @@ export component Switch {
         if (root.text != "") : Text {
             text: root.text;
             color: root.text-color;
-            font-size: Typography.body.font-size;
-            font-weight: Typography.body.font-weight;
+            font-size: FluentFontSettings.body.font-size;
+            font-weight: FluentFontSettings.body.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
         }

--- a/internal/compiler/widgets/fluent-base/tableview.slint
+++ b/internal/compiler/widgets/fluent-base/tableview.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography, Icons } from "styling.slint";
+import { FluentPalette, FluentFontSettings, Icons } from "styling.slint";
 import { ListView } from "listview.slint";
 
 component TableViewColumn inherits Rectangle {
@@ -10,14 +10,14 @@ component TableViewColumn inherits Rectangle {
     callback clicked <=> i-touch-area.clicked;
     callback adjust_size(length);
 
-    background: Palette.background;
+    background: FluentPalette.background;
 
     states [
         pressed when i-touch-area.pressed : {
-            background: Palette.control-secondary;
+            background: FluentPalette.control-secondary;
         }
         hover when i-touch-area.has-hover : {
-            background: Palette.sub-title-tertiary;
+            background: FluentPalette.sub-title-tertiary;
         }
     ]
 
@@ -36,7 +36,7 @@ component TableViewColumn inherits Rectangle {
 
         i-icon := Image {
             image-fit: contain;
-            colorize: Palette.text-secondary;
+            colorize: FluentPalette.text-secondary;
             visible: root.sort-order != SortOrder.unsorted;
             width: 12px;
             y: (parent.height - self.height) / 2;
@@ -51,7 +51,7 @@ component TableViewColumn inherits Rectangle {
         y: parent.height - self.height;
         width: 100%;
         height: 1px;
-        background: Palette.divider;
+        background: FluentPalette.divider;
     }
 
     Rectangle {
@@ -60,7 +60,7 @@ component TableViewColumn inherits Rectangle {
 
         states [
             hover when i-movable-touch-area.has-hover : {
-                background: Palette.control-secondary;
+                background: FluentPalette.control-secondary;
             }
         ]
 
@@ -102,18 +102,18 @@ component TableViewRow inherits Rectangle {
     min-width: i-layout.min-width;
     min-height: max(34px, i-layout.min-height);
     border-radius: 4px;
-    background: root.even ? Palette.control-default : transparent;
+    background: root.even ? FluentPalette.surface : transparent;
 
     states [
         pressed when i-touch-area.pressed : {
-            root.background: selected ? Palette.subtle-secondary : Palette.subtle-tertiary;
+            root.background: selected ? FluentPalette.subtle-secondary : FluentPalette.subtle-tertiary;
         }
         hover when i-touch-area.has-hover : {
-            root.background: selected ? Palette.subtle-tertiary : Palette.subtle-secondary;
+            root.background: selected ? FluentPalette.subtle-tertiary : FluentPalette.subtle-secondary;
             i-selector.height: root.selected ? 16px : 0;
         }
         selected when root.selected : {
-            root.background: Palette.subtle-secondary;
+            root.background: FluentPalette.subtle-secondary;
             i-selector.height: 16px;
         }
     ]
@@ -136,7 +136,7 @@ component TableViewRow inherits Rectangle {
         y: (parent.height - self.height) / 2;
         width: 3px;
         height: 0px;
-        background: Palette.accent-default;
+        background: FluentPalette.accent;
         border-radius: 2px;
 
         animate height { duration: 150ms; easing: ease-out; }
@@ -227,9 +227,9 @@ export component StandardTableView {
                     Text {
                         vertical-alignment: center;
                         text: column.title;
-                        font-weight: Typography.body.font-weight;
-                        font-size: Typography.body.font-size;
-                        color: Palette.text-secondary;
+                        font-weight: FluentFontSettings.body.font-weight;
+                        font-size: FluentFontSettings.body.font-size;
+                        color: FluentPalette.text-secondary;
                         overflow: elide;
                     }
                 }
@@ -268,9 +268,9 @@ export component StandardTableView {
                             overflow: elide;
                             vertical-alignment: center;
                             text: cell.text;
-                            font-weight: Typography.body.font-weight;
-                            font-size: Typography.body.font-size;
-                            color: mod(idx, 2) == 0 ? Palette.text-primary : Palette.text-secondary;
+                            font-weight: FluentFontSettings.body.font-weight;
+                            font-size: FluentFontSettings.body.font-size;
+                            color: mod(idx, 2) == 0 ? FluentPalette.on-surface : FluentPalette.text-secondary;
                         }
                     }
                 }

--- a/internal/compiler/widgets/fluent-base/tabwidget.slint
+++ b/internal/compiler/widgets/fluent-base/tabwidget.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography } from "styling.slint";
+import { FluentPalette, FluentFontSettings } from "styling.slint";
 import { FocusBorder } from "components.slint";
 
 export component TabWidgetImpl inherits Rectangle {
@@ -56,9 +56,9 @@ export component TabImpl inherits Rectangle {
             height: parent.height + self.border-radius;
             border-radius: 7px;
             border-width: root.is-current ? 1px : 0px;
-            border-color: Palette.card-stroke;
-            background: i-touch-area.pressed || root.is-current ? Palette.layer-on-mica-base-alt :
-                i-touch-area.has-hover ? Palette.layer-on-mica-base-alt-secondary : transparent;
+            border-color: FluentPalette.card-stroke;
+            background: i-touch-area.pressed || root.is-current ? FluentPalette.layer-on-mica-base-alt :
+                i-touch-area.has-hover ? FluentPalette.layer-on-mica-base-alt-secondary : transparent;
         }
     }
 
@@ -77,9 +77,9 @@ export component TabImpl inherits Rectangle {
         i-text := Text {
             vertical-alignment: center;
             horizontal-alignment: left;
-            font-size: root.is-current ? Typography.body-strong.font-size : Typography.body.font-size;
-            font-weight: root.is-current ? Typography.body-strong.font-weight : Typography.body.font-weight;
-            color: root.is-current ? Palette.text-primary : Palette.text-secondary;
+            font-size: root.is-current ? FluentFontSettings.body-strong.font-size : FluentFontSettings.body.font-size;
+            font-weight: root.is-current ? FluentFontSettings.body-strong.font-weight : FluentFontSettings.body.font-weight;
+            color: root.is-current ? FluentPalette.on-surface : FluentPalette.text-secondary;
         }
     }
 
@@ -87,14 +87,14 @@ export component TabImpl inherits Rectangle {
         x: (parent.width - self.width);
         width: 2px;
         height: 16px;
-        background: Palette.divider;
+        background: FluentPalette.divider;
     }
 
     if (!root.is-current && !i-touch-area.has-hover && !i-touch-area.pressed) : Rectangle {
         y: (parent.height - self.height);
         width: 100%;
         height: 1px;
-        background: Palette.divider;
+        background: FluentPalette.divider;
     }
 
     // focus border

--- a/internal/compiler/widgets/fluent-base/textedit.slint
+++ b/internal/compiler/widgets/fluent-base/textedit.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Typography, Palette } from "styling.slint";
+import { FluentFontSettings, FluentPalette } from "styling.slint";
 import { ScrollView } from "scrollview.slint";
 
 export component TextEdit {
@@ -47,15 +47,15 @@ export component TextEdit {
 
     states [
         disabled when !root.enabled : {
-            i-background.background: Palette.control-disabled;
-            i-background.border-color: Palette.control-stroke;
-            i-text-input.color: Palette.text-disabled;
-            i-text-input.selection-foreground-color: Palette.text-on-accent-disabled;
+            i-background.background: FluentPalette.control-disabled;
+            i-background.border-color: FluentPalette.border;
+            i-text-input.color: FluentPalette.text-disabled;
+            i-text-input.selection-foreground-color: FluentPalette.text-on-accent-disabled;
         }
         focused when root.has-focus : {
-            i-background.background: Palette.control-input-active;
-            i-background.border-color: Palette.control-stroke;
-            i-focus-border.background: Palette.accent-default;
+            i-background.background: FluentPalette.control-input-active;
+            i-background.border-color: FluentPalette.border;
+            i-focus-border.background: FluentPalette.accent;
         }
     ]
 
@@ -63,9 +63,9 @@ export component TextEdit {
         width: 100%;
         height: 100%;
         border-radius: 4px;
-        background: Palette.control-default;
+        background: FluentPalette.surface;
         border-width: 1px;
-        border-color: Palette.text-control-border;
+        border-color: FluentPalette.text-control-border;
 
         i-scroll-view := ScrollView {
             x: 12px;
@@ -77,11 +77,11 @@ export component TextEdit {
 
             i-text-input := TextInput {
                 enabled: true;
-                color: Palette.text-primary;
-                font-size: Typography.body.font-size;
-                font-weight: Typography.body.font-weight;
-                selection-background-color: Palette.accent-selected-text;
-                selection-foreground-color: Palette.text-on-accent-primary;
+                color: FluentPalette.foreground;
+                font-size: FluentFontSettings.body.font-size;
+                font-weight: FluentFontSettings.body.font-weight;
+                selection-background-color: FluentPalette.accent-selected-text;
+                selection-foreground-color: FluentPalette.on-accent;
                 single-line: false;
                 wrap: word-wrap;
 

--- a/internal/compiler/widgets/material-base/button.slint
+++ b/internal/compiler/widgets/material-base/button.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 import { StateLayer } from "components.slint";
-import { Typography, Palette, Elevation } from "styling.slint";
+import { MaterialFontSettings, MaterialPalette, Elevation } from "styling.slint";
 
 // Default button widget with Material Design Filled Button look and feel.
 export component Button {
@@ -17,7 +17,7 @@ export component Button {
 
     callback clicked;
 
-    private property <brush> text-color: root.primary ? Palette.on-primary : Palette.on-secondary-container;
+    private property <brush> text-color: root.primary ? MaterialPalette.on-accent : MaterialPalette.on-surface;
     private property <float> text-opacity: 1.0;
 
     min-height: max(40px, i-layout.min-height);
@@ -28,13 +28,13 @@ export component Button {
 
     states [
         disabled when !root.enabled : {
-            i-background.background: Palette.on-surface;
+            i-background.background: MaterialPalette.on-background-alt;
             i-background.opacity: 0.12;
             root.text-opacity: 0.38;
-            root.text-color: Palette.on-surface;
+            root.text-color: MaterialPalette.on-surface;
         }
         checked when root.checked: {
-            root.text-color: Palette.on-primary;
+            root.text-color: MaterialPalette.on-accent;
         }
     ]
 
@@ -42,7 +42,7 @@ export component Button {
         width: 100%;
         height: 100%;
         border-radius: 20px;
-        background: root.primary ? Palette.primary : Palette.secondary-container;
+        background: root.primary ? MaterialPalette.accent : MaterialPalette.surface;
         drop-shadow-color: transparent;
         drop-shadow-blur: Elevation.level0;
         drop-shadow-offset-y: 1px;
@@ -51,9 +51,9 @@ export component Button {
     i-state-layer := StateLayer {
         has-ripple: true;
         border-radius: i-background.border-radius;
-        background: Palette.on-secondary-container;
-        ripple-color: Palette.secondary-ripple;
-        selection-background: Palette.primary;
+        background: MaterialPalette.on-background-alt;
+        ripple-color: MaterialPalette.secondary-ripple;
+        selection-background: MaterialPalette.accent;
         focusable: true;
 
         clicked => {
@@ -81,7 +81,7 @@ export component Button {
             opacity: root.text-opacity;
             vertical-alignment: center;
             horizontal-alignment: center;
-            font-weight: Typography.label-large.font-weight;
+            font-weight: MaterialFontSettings.label-large.font-weight;
 
             animate color { duration: 250ms; easing: ease; }
         }

--- a/internal/compiler/widgets/material-base/checkbox.slint
+++ b/internal/compiler/widgets/material-base/checkbox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography, Icons } from "styling.slint";
+import { MaterialPalette, MaterialFontSettings, Icons } from "styling.slint";
 
 // Selection control that can be toggled between checked und unchecked by click.
 export component CheckBox {
@@ -23,46 +23,46 @@ export component CheckBox {
         disabled-selected when !root.enabled && root.checked  : {
             i-container.border-width: 0px;
             i-container.border-color: transparent;
-            i-container.background: Palette.primary;
+            i-container.background: MaterialPalette.accent;
             i-container.opacity: 0.38;
             i-text.opacity: 0.38;
-            i-text.color: Palette.primary;
+            i-text.color: MaterialPalette.accent;
         }
         disabled when !root.enabled : {
             i-container.opacity: 0.38;
             i-text.opacity: 0.38;
-            i-text.color: Palette.primary;
+            i-text.color: MaterialPalette.accent;
         }
         pressed when i-touch-area.pressed && !root.checked : {
             i-state-layer.opacity: 0.12;
         }
         pressed-selected when i-touch-area.pressed && root.checked : {
             i-state-layer.opacity: 0.12;
-            i-state-layer.background: Palette.on-surface;
+            i-state-layer.background: MaterialPalette.on-surface;
             i-container.border-width: 0px;
             i-container.border-color: transparent;
-            i-container.background: Palette.primary;
+            i-container.background: MaterialPalette.accent;
         }
         hover-selected when i-touch-area.has-hover && root.checked : {
             i-state-layer.opacity: 0.08;
             i-container.border-width: 0px;
             i-container.border-color: transparent;
-            i-container.background: Palette.primary;
+            i-container.background: MaterialPalette.accent;
         }
         hover when i-touch-area.has-hover && !root.checked : {
-            i-state-layer.background: Palette.on-surface;
+            i-state-layer.background: MaterialPalette.on-surface;
             i-state-layer.opacity: 0.08;
         }
         selected when !i-touch-area.has-hover && root.checked : {
             i-container.border-width: 0px;
             i-container.border-color: transparent;
-            i-container.background: Palette.primary;
+            i-container.background: MaterialPalette.accent;
         }
         focused-selected when i-focus-scope.has-focus && root.checked : {
             i-state-layer.opacity: 0.12;
         }
         focused when i-focus-scope.has-focus && !root.checked : {
-            i-state-layer.background: Palette.on-surface;
+            i-state-layer.background: MaterialPalette.on-surface;
             i-state-layer.opacity: 0.12;
         }
     ]
@@ -82,7 +82,7 @@ export component CheckBox {
                     height: 100%;
                     border-radius: 2px;
                     border-width: 2px;
-                    border-color: Palette.on-surface-variant;
+                    border-color: MaterialPalette.on-surface-variant;
                 }
 
                 i-state-layer := Rectangle {
@@ -91,7 +91,7 @@ export component CheckBox {
                     x: (parent.width - self.width) / 2;
                     y: (parent.height - self.height) / 2;
                     opacity: 0;
-                    background: Palette.primary;
+                    background: MaterialPalette.accent;
                     border-radius: 20px;
 
                     animate opacity { duration: 300ms; easing: ease; }
@@ -103,14 +103,14 @@ export component CheckBox {
                     width: 80%;
                     height: 80%;
                     source: Icons.check-mark;
-                    colorize: Palette.on-primary;
+                    colorize: MaterialPalette.on-accent;
 
                     states [
                         disabled when !root.enabled : {
-                            colorize: Palette.on-surface;
+                            colorize: MaterialPalette.on-surface;
                         }
                         hover-selected when i-touch-area.has-hover && root.checked : {
-                            colorize: Palette.on-primary;
+                            colorize: MaterialPalette.on-accent;
                         }
                     ]
                 }
@@ -118,12 +118,12 @@ export component CheckBox {
         }
 
         i-text := Text {
-            color: Palette.on-surface;
+            color: MaterialPalette.on-surface;
             horizontal-alignment: left;
             vertical-alignment: center;
             vertical-stretch: 1;
-            font-size: Typography.title-small.font-size;
-            font-weight: Typography.title-small.font-weight;
+            font-size: MaterialFontSettings.title-small.font-size;
+            font-weight: MaterialFontSettings.title-small.font-weight;
         }
     }
 

--- a/internal/compiler/widgets/material-base/combobox.slint
+++ b/internal/compiler/widgets/material-base/combobox.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 
-import { Palette, Typography, Elevation, Icons } from "styling.slint";
+import { MaterialPalette, MaterialFontSettings, Elevation, Icons } from "styling.slint";
 import { ListItem } from "components.slint";
 import { ComboBoxBase } from "../common/combobox-base.slint";
 
@@ -23,16 +23,16 @@ export component ComboBox {
 
     states [
         disabled when !root.enabled : {
-            i-background.border-color: Palette.on-surface;
+            i-background.border-color: MaterialPalette.on-surface;
             i-background.opacity: 0.38;
             i-label.opacity: 0.38;
             i-icon.opacity: 0.38;
         }
         focused when root.has-focus : {
             i-background.border-width: 2px;
-            i-background.border-color: Palette.primary;
-            i-label.color: Palette.primary;
-            i-icon.colorize: Palette.primary;
+            i-background.border-color: MaterialPalette.accent;
+            i-label.color: MaterialPalette.accent;
+            i-icon.colorize: MaterialPalette.accent;
         }
     ]
 
@@ -50,7 +50,7 @@ export component ComboBox {
         height: 100%;
         border-radius: 4px;
         border-width: 1px;
-        border-color: Palette.outline;
+        border-color: MaterialPalette.border;
     }
 
     i-layout := HorizontalLayout {
@@ -60,12 +60,12 @@ export component ComboBox {
 
         i-label := Text {
             text <=> root.current-value;
-            color: Palette.on-surface;
+            color: MaterialPalette.on-surface;
             vertical-alignment: center;
             // FIXME after Roboto font can be loaded
-            // font-family: Typography.body-large.font;
-            font-size: Typography.body-large.font-size;
-            font-weight: Typography.body-large.font-weight;
+            // font-family: MaterialFontSettings.body-large.font;
+            font-size: MaterialFontSettings.body-large.font-size;
+            font-weight: MaterialFontSettings.body-large.font-weight;
         }
 
         i-icon := Image {
@@ -73,7 +73,7 @@ export component ComboBox {
             height: 24px;
             y: (parent.height - self.height) / 2;
             source: Icons.expand-more;
-            colorize: Palette.on-surface;
+            colorize: MaterialPalette.on-surface;
         }
     }
 
@@ -83,8 +83,8 @@ export component ComboBox {
         width: root.width;
 
         i-popup-container := Rectangle {
-            background: Palette.surface;
-            drop-shadow-color: Palette.shadow;
+            background: MaterialPalette.surface;
+            drop-shadow-color: MaterialPalette.shadow;
             drop-shadow-blur: Elevation.level2;
             drop-shadow-offset-y: 1px;
             border-radius: 4px;

--- a/internal/compiler/widgets/material-base/components.slint
+++ b/internal/compiler/widgets/material-base/components.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography } from "styling.slint";
+import { MaterialPalette, MaterialFontSettings } from "styling.slint";
 
 export component Ripple inherits Rectangle {
     in property <length> ripple-x;
@@ -37,7 +37,7 @@ export component StateLayer inherits TouchArea {
     in property <length> border-radius;
     out property <bool> has-focus <=> i-focus-scope.has-focus;
     in-out property <brush> background;
-    in-out property < bool> checked;
+    in-out property <bool> checked;
 
     forward-focus: i-focus-scope;
 
@@ -101,17 +101,11 @@ export component ListItem inherits Rectangle {
 
     height: max(48px, i-layout.min-height);
 
-    states [
-        selected when root.selected : {
-            i-state-layer.background: Palette.secondary-container;
-        }
-    ]
-
     i-state-layer := StateLayer {
         checked: root.selected;
-        background: Palette.primary;
-        selection-background: Palette.secondary-container;
-        ripple-color: Palette.primary-ripple;
+        background: MaterialPalette.accent;
+        selection-background: MaterialPalette.surface;
+        ripple-color: MaterialPalette.accent-ripple;
         has-ripple: true;
     }
 
@@ -121,12 +115,12 @@ export component ListItem inherits Rectangle {
 
         label := Text {
             text: root.text;
-            color: Palette.on-surface;
+            color: MaterialPalette.on-surface;
             vertical-alignment: center;
             // FIXME after Roboto font can be loaded
-            //font-family: Typography.label-large.font;
-            font-size: Typography.label-large.font-size;
-            font-weight: Typography.label-large.font-weight;
+            //font-family: MaterialFontSettings.label-large.font;
+            font-size: MaterialFontSettings.label-large.font-size;
+            font-weight: MaterialFontSettings.label-large.font-weight;
         }
     }
 }

--- a/internal/compiler/widgets/material-base/groupbox.slint
+++ b/internal/compiler/widgets/material-base/groupbox.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography } from "styling.slint";
+import { MaterialPalette, MaterialFontSettings } from "styling.slint";
 
 // A container widget with a title.
 export component GroupBox {
@@ -10,7 +10,7 @@ export component GroupBox {
 
     states [
         disabled when !root.enabled : {
-            i-background.border-color: Palette.on-surface;
+            i-background.border-color: MaterialPalette.on-surface;
             i-background.opacity: 0.38;
             i-text.opacity: 0.38;
         }
@@ -20,11 +20,11 @@ export component GroupBox {
         spacing: 4px;
 
         i-text := Text {
-            color: Palette.on-surface;
+            color: MaterialPalette.on-surface;
             // FIXME after Roboto font can be loaded
-            //font-family: Typography.body-small.font;
-            font-size: Typography.body-large.font-size;
-            font-weight: Typography.body-small.font-weight;
+            //font-family: MaterialFontSettings.body-small.font;
+            font-size: MaterialFontSettings.body-large.font-size;
+            font-weight: MaterialFontSettings.body-small.font-weight;
             overflow: elide;
             horizontal-alignment: center;
         }
@@ -32,9 +32,9 @@ export component GroupBox {
         i-background := Rectangle {
             border-radius: 16px;
             border-width: 1px;
-            border-color: Palette.outline;
+            border-color: MaterialPalette.border;
             vertical-stretch: 1;
-            background: Palette.surface;
+            background: MaterialPalette.background-alt;
 
             HorizontalLayout {
                 padding: 16px;

--- a/internal/compiler/widgets/material-base/lineedit.slint
+++ b/internal/compiler/widgets/material-base/lineedit.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography } from "styling.slint";
+import { MaterialPalette, MaterialFontSettings } from "styling.slint";
 
 // Single line text input field with Material Design Outline TextField look and feel.
 export component LineEdit {
@@ -39,15 +39,15 @@ export component LineEdit {
 
     states [
         disabled when !root.enabled : {
-            i-background.border-color: Palette.on-surface;
+            i-background.border-color: MaterialPalette.on-surface;
             i-background.opacity: 0.38;
             i-text-input.opacity: 0.38;
             i-placeholder.opacity: 0.38;
         }
         focused when root.has-focus : {
             i-background.border-width: 2px;
-            i-background.border-color: Palette.primary;
-            i-text-input.color: Palette.primary;
+            i-background.border-color: MaterialPalette.accent;
+            i-text-input.color: MaterialPalette.accent;
         }
     ]
 
@@ -56,7 +56,7 @@ export component LineEdit {
         height: 100%;
         border-radius: 4px;
         border-width: 1px;
-        border-color: Palette.outline;
+        border-color: MaterialPalette.border;
     }
 
     i-layout := HorizontalLayout {
@@ -69,9 +69,9 @@ export component LineEdit {
             i-placeholder := Text {
                 width: 100%;
                 height: 100%;
-                color: Palette.outline-variant;
-                font-size: Typography.body-large.font-size;
-                font-weight: Typography.body-large.font-weight;
+                color: MaterialPalette.border-variant;
+                font-size: MaterialFontSettings.body-large.font-size;
+                font-weight: MaterialFontSettings.body-large.font-weight;
                 visible: false;
                 vertical-alignment: center;
 
@@ -89,11 +89,11 @@ export component LineEdit {
                 x: min(0px, max(parent.width - self.width, self.computed_x));
                 width: max(parent.width, self.preferred-width);
                 height: 100%;
-                color: Palette.on-surface;
+                color: MaterialPalette.foreground;
                 vertical-alignment: center;
-                font-size: Typography.body-large.font-size;
-                font-weight: Typography.body-large.font-weight;
-                selection-foreground-color: Palette.primary;
+                font-size: MaterialFontSettings.body-large.font-size;
+                font-weight: MaterialFontSettings.body-large.font-weight;
+                selection-foreground-color: MaterialPalette.accent;
 
                 accepted => {
                     root.accepted(self.text);

--- a/internal/compiler/widgets/material-base/progressindicator.slint
+++ b/internal/compiler/widgets/material-base/progressindicator.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette } from "styling.slint";
+import { MaterialPalette } from "styling.slint";
 
 export component ProgressIndicator {
     in property <float> progress;
@@ -14,11 +14,11 @@ export component ProgressIndicator {
     accessible-value: root.progress;
 
     i-background := Rectangle {
-        background: Palette.surface-variant;
+        background: MaterialPalette.surface-variant;
         clip: true;
 
         i-track := Rectangle {
-            background: Palette.primary;
+            background: MaterialPalette.accent;
             x: !root.indeterminate ? 0px : -parent.width + (parent.width * mod(animation-tick(), 2s) / 1s);
             y: (parent.height - self.height) / 2;
             width: !root.indeterminate ?  parent.width * min(1, max(0, root.progress)) : parent.width;

--- a/internal/compiler/widgets/material-base/scrollview.slint
+++ b/internal/compiler/widgets/material-base/scrollview.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 
-import { Palette } from "styling.slint";
+import { MaterialPalette } from "styling.slint";
 
 component ScrollBar inherits Rectangle {
     in-out property <bool> horizontal;
@@ -14,7 +14,7 @@ component ScrollBar inherits Rectangle {
 
     states [
         disabled when !i-touch-area.enabled : {
-            i-background.border-color: Palette.on-surface;
+            i-background.border-color: MaterialPalette.on-surface;
             i-handle.opacity: 0.12;
         }
         hover when i-touch-area.has-hover : {
@@ -28,7 +28,7 @@ component ScrollBar inherits Rectangle {
     i-state-layer := Rectangle {
         width: 100%;
         height: 100%;
-        background: Palette.primary;
+        background: MaterialPalette.accent;
         border-radius: 4px;
         opacity: 0;
         visible: i-handle.width > 0 && i-handle.height > 0;
@@ -46,7 +46,7 @@ component ScrollBar inherits Rectangle {
             width: 100%;
             height: 100%;
             border-radius: 4px;
-            border-color: Palette.outline;
+            border-color: MaterialPalette.border;
             border-width: 1px;
         }
     }
@@ -104,7 +104,7 @@ export component ScrollView {
     preferred-width: 100%;
 
     Rectangle {
-        background: Palette.surface;
+        background: MaterialPalette.background-alt;
     }
 
     i-flickable := Flickable {

--- a/internal/compiler/widgets/material-base/slider.slint
+++ b/internal/compiler/widgets/material-base/slider.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 
-import { Palette, Elevation } from "styling.slint";
+import { MaterialPalette, Elevation } from "styling.slint";
 
 // Allows to select a value from a range of values.
 export component Slider {
@@ -26,10 +26,10 @@ export component Slider {
 
     states [
         disabled when !root.enabled : {
-            i-handle.background: Palette.on-surface;
+            i-handle.background: MaterialPalette.on-surface;
             i-handle.drop-shadow-blur: Elevation.level0;
-            i-track.background: Palette.on-surface;
-            i-background.background: Palette.on-surface;
+            i-track.background: MaterialPalette.on-surface;
+            i-background.background: MaterialPalette.on-surface;
             root.opacity: 0.38;
         }
         pressed when (i-touch-area.pressed && i-touch-area.i-handle-hover) || i-focus-scope.has-focus : {
@@ -37,13 +37,13 @@ export component Slider {
             i-handle.drop-shadow-blur: Elevation.level0;
         }
         hover when i-touch-area.i-handle-hover : {
-            i-state-layer.background: Palette.on-surface;
+            i-state-layer.background: MaterialPalette.on-surface;
             i-state-layer.opacity: 0.08;
         }
     ]
 
     i-background := Rectangle {
-        background: Palette.surface-variant;
+        background: MaterialPalette.surface-variant;
         opacity: 0.38;
         x: (parent.width - self.width) / 2;
         y: (parent.height - self.height) / 2;
@@ -53,7 +53,7 @@ export component Slider {
     }
 
     i-track := Rectangle {
-        background: Palette.primary;
+        background: MaterialPalette.accent;
         x: vertical ? (parent.width - self.width) / 2 : i-background.x;
         y: vertical ? i-background.y : (parent.height - self.height) / 2;
         width: vertical? i-background.width : i-handle.x + (i-handle.width / 2);
@@ -63,7 +63,7 @@ export component Slider {
 
     i-state-layer := Rectangle {
         opacity: 0;
-        background: Palette.primary;
+        background: MaterialPalette.accent;
         x: vertical ? (parent.width - self.width) / 2 : i-handle.x - (self.width - i-handle.width) / 2;
         y: vertical ? i-handle.y - (self.height - i-handle.height) / 2 : (parent.height - self.height) / 2;
         width: 40px;
@@ -74,13 +74,13 @@ export component Slider {
     }
 
     i-handle := Rectangle {
-        background: Palette.primary;
+        background: MaterialPalette.accent;
         x: vertical ? (parent.width - self.width) / 2 : (parent.width - i-handle.width) * (root.value - root.minimum) / (root.maximum - root.minimum);
         y: vertical ? (parent.height - i-handle.height) * (root.value - root.minimum) / (root.maximum - root.minimum) : (parent.height - self.height) / 2;
         width: vertical ? root.width : root.height;
         height: vertical ? root.width : root.height;
         border-radius: max(self.width, self.height) / 2;
-        drop-shadow-color: Palette.shadow;
+        drop-shadow-color: MaterialPalette.shadow;
         drop-shadow-blur: Elevation.level1;
         drop-shadow-offset-y: 1px;
 

--- a/internal/compiler/widgets/material-base/spinbox.slint
+++ b/internal/compiler/widgets/material-base/spinbox.slint
@@ -1,14 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography, Icons } from "styling.slint";
+import { MaterialPalette, MaterialFontSettings, Icons } from "styling.slint";
 import { SpinBoxBase } from "../common/spinbox-base.slint";
 
 component SpinBoxButton inherits Rectangle {
     in-out property <bool> pressed: self.enabled && i-touch-area.pressed;
     in-out property <bool> enabled <=> i-touch-area.enabled;
     in-out property <float> icon-opacity: 1;
-    in-out property <brush> icon-fill: Palette.on-primary;
+    in-out property <brush> icon-fill: MaterialPalette.on-accent;
 
     callback clicked <=> i-touch-area.clicked;
 
@@ -16,10 +16,10 @@ component SpinBoxButton inherits Rectangle {
 
     states [
         disabled when !root.enabled : {
-            i-background.background: Palette.on-surface;
+            i-background.background: MaterialPalette.on-surface;
             i-background.opacity: 0.12;
             icon-opacity: 0.38;
-            icon-fill: Palette.on-surface;
+            icon-fill: MaterialPalette.on-surface;
         }
         pressed when i-touch-area.pressed : {
             i-state-layer.opacity: 0.12;
@@ -33,7 +33,7 @@ component SpinBoxButton inherits Rectangle {
         width: 100%;
         height: 100%;
         border-radius: max(self.width, self.height) / 2;
-        background: Palette.primary;
+        background: MaterialPalette.accent;
     }
 
     i-state-layer := Rectangle {
@@ -43,7 +43,7 @@ component SpinBoxButton inherits Rectangle {
         width: i-background.width;
         height: i-background.height;
         border-radius: i-background.border-radius;
-        background: Palette.on-primary;
+        background: MaterialPalette.on-accent;
 
         animate opacity { duration: 250ms; easing: ease; }
      }
@@ -81,14 +81,14 @@ export component SpinBox {
 
     states [
         disabled when !root.enabled : {
-            i-background.border-color: Palette.on-surface;
+            i-background.border-color: MaterialPalette.on-surface;
             i-background.opacity: 0.38;
             i-text-input.opacity: 0.38;
         }
         focused when root.has-focus : {
             i-background.border-width: 2px;
-            i-background.border-color: Palette.primary;
-            i-text-input.color: Palette.primary;
+            i-background.border-color: MaterialPalette.accent;
+            i-text-input.color: MaterialPalette.accent;
         }
     ]
 
@@ -105,7 +105,7 @@ export component SpinBox {
     i-background := Rectangle {
         border-radius: 4px;
         border-width: 1px;
-        border-color: Palette.outline;
+        border-color: MaterialPalette.border;
 
         i-layout := HorizontalLayout {
             padding-top: 8px;
@@ -122,11 +122,11 @@ export component SpinBox {
                     horizontal-alignment: left;
                     text: root.value;
                     // height: 100%;
-                    color: Palette.on-surface;
+                    color: MaterialPalette.on-surface;
                     // FIXME after Roboto font can be loaded
-                    //font-family: Typography.body-large.font;
-                    font-size: Typography.body-large.font-size;
-                    font-weight: Typography.body-large.font-weight;
+                    //font-family: MaterialFontSettings.body-large.font;
+                    font-size: MaterialFontSettings.body-large.font-size;
+                    font-weight: MaterialFontSettings.body-large.font-weight;
                     enabled: root.enabled;
                     horizontal-stretch: 1;
 

--- a/internal/compiler/widgets/material-base/spinner.slint
+++ b/internal/compiler/widgets/material-base/spinner.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette } from "styling.slint";
+import { MaterialPalette } from "styling.slint";
 import { SpinnerBase } from "../common/spinner-base.slint";
 
 export component Spinner {
@@ -19,6 +19,6 @@ export component Spinner {
         width: 100%;
         height: 100%;
         stroke-width: 2px;
-        stroke: Palette.primary;
+        stroke: MaterialPalette.accent;
     }
 }

--- a/internal/compiler/widgets/material-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material-base/std-widgets-impl.slint
@@ -5,7 +5,7 @@
 import { Button } from "button.slint";
 import { CheckBox } from "checkbox.slint";
 import { ScrollView } from "scrollview.slint";
-import { Palette } from "styling.slint";
+import { MaterialPalette } from "styling.slint";
 import { Switch } from "switch.slint";
 
 export { Button, CheckBox, ScrollView, Switch }
@@ -15,12 +15,12 @@ export global StyleMetrics  {
     out property <length> layout-padding: 16px;
     out property <length> text-cursor-width: 2px;
 
-    out property <color> default-text-color: Palette.on-surface;
+    out property <color> default-text-color: MaterialPalette.foreground;
     out property <color> textedit-background: transparent;
-    out property <color> textedit-text-color: Palette.on-surface;
+    out property <color> textedit-text-color: MaterialPalette.foreground;
     out property <color> textedit-background-disabled: transparent;
-    out property <color> textedit-text-color-disabled: Palette.on-surface;
-    out property <bool> dark-color-scheme: Palette.dark-color-scheme;
+    out property <color> textedit-text-color-disabled: MaterialPalette.foreground;
+    out property <bool> dark-color-scheme: MaterialPalette.dark-color-scheme;
     out property <string> default-font-family: "Roboto";
-    out property <color> window-background: Palette.background;
+    out property <color> window-background: MaterialPalette.background;
 }

--- a/internal/compiler/widgets/material-base/styling.slint
+++ b/internal/compiler/widgets/material-base/styling.slint
@@ -10,7 +10,7 @@ struct TextStyle  {
     font-weight: int
 }
 
-export global Typography {
+export global MaterialFontSettings {
     out property <TextStyle> label-large: {
         font-size: 14 * 0.0625rem,
         font-weight: 500
@@ -39,22 +39,26 @@ export global Elevation {
     out property <length> level2: 2px;
 }
 
-export global Palette {
+export global MaterialPalette {
+    // base palette
     out property <brush> background: !root.dark-color-scheme ? #f8f3f9 : #2a282d;
-    out property <brush> surface: !root.dark-color-scheme ? #FFFBFE : #1C1B1F;
+    out property <brush> background-alt: !root.dark-color-scheme ? #FFFBFE : #1C1B1F;
+    out property <brush> foreground: !root.dark-color-scheme ? #1C1B1F : #E6E1E5;
+    out property <brush> accent: !root.dark-color-scheme ? #6750A4 : #D0BCFF;
+    out property <brush> on-accent: !root.dark-color-scheme ? #FFFFFF : #371E73;
+    out property <brush> surface: !root.dark-color-scheme ? #E8DEF8 : #4A4458;
+    out property <brush> on-surface: !root.dark-color-scheme ? #1E192B : #E8DEF8;
+    out property <brush> border: !root.dark-color-scheme ? #79747E : #938F99;
+
+    // additional palette
     out property <brush> surface-variant: !root.dark-color-scheme ? #E7E0EC.darker(0.2) : #49454F;
-    out property <brush> on-surface: !root.dark-color-scheme ? #1C1B1F : #E6E1E5;
     out property <brush> on-surface-variant: !root.dark-color-scheme ? #49454E : #CAC4D0;
     out property <brush> surface-tint: !root.dark-color-scheme ? #6750A4 : #D0BCFF;
-    out property <brush> primary: !root.dark-color-scheme ? #6750A4 : #D0BCFF;
-    out property <brush> primary-container: !root.dark-color-scheme ? #4F378B : #4F378B;
-    out property <brush> primary-ripple: !root.dark-color-scheme ? #D0BCFF : #6750A4;
-    out property <brush> on-primary: !root.dark-color-scheme ? #FFFFFF : #371E73;
+    out property <brush> accent-container: !root.dark-color-scheme ? #4F378B : #4F378B;
+    out property <brush> accent-ripple: !root.dark-color-scheme ? #D0BCFF : #6750A4;
     out property <brush> shadow: #000000;
-    out property <brush> outline: !root.dark-color-scheme ? #79747E : #938F99;
-    out property <brush> outline-variant: !root.dark-color-scheme ? #C4C7C5 : #444746;
-    out property <brush> secondary-container:  !root.dark-color-scheme ? #E8DEF8 : #4A4458;
-    out property <brush> on-secondary-container:  !root.dark-color-scheme ? #1E192B : #E8DEF8;
+    out property <brush> border-variant: !root.dark-color-scheme ? #C4C7C5 : #444746;
+    out property <brush> on-background-alt: !root.dark-color-scheme ? #1C1B1F : #E6E1E5;
     out property <brush> secondary-ripple: !root.dark-color-scheme ? #fffc : #000000;
     in-out property <bool> dark-color-scheme: ColorSchemeSelector.dark-color-scheme;
 }

--- a/internal/compiler/widgets/material-base/switch.slint
+++ b/internal/compiler/widgets/material-base/switch.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { Palette, Typography } from "styling.slint";
+import { MaterialPalette, MaterialFontSettings } from "styling.slint";
 
 export component Switch {
     in property <string> text <=> i-label.text;
@@ -32,7 +32,7 @@ export component Switch {
     states [
         disabled-selected when !root.enabled && root.checked  : {
             i-label.opacity: 0.38;
-            i-label.color: Palette.primary;
+            i-label.color: MaterialPalette.accent;
             track.opacity: 0.12;
             i-handle.opacity: 0.38;
             i-handle.width: 24px;
@@ -40,55 +40,55 @@ export component Switch {
         }
         disabled when !root.enabled : {
             i-label.opacity: 0.38;
-            i-label.color: Palette.primary;
+            i-label.color: MaterialPalette.accent;
             track.opacity: 0.12;
             i-handle.opacity: 0.38;
         }
         pressed when i-touch-area.pressed && !root.checked : {
             state-layer.opacity: 0.12;
-            i-handle.background: Palette.on-surface-variant;
+            i-handle.background: MaterialPalette.on-surface-variant;
             i-handle.width: 28px;
             i-handle.x: track.border-width;
         }
         pressed-selected when i-touch-area.pressed && root.checked : {
             state-layer.opacity: 0.12;
-            state-layer.background: Palette.on-surface;
-            track.background: Palette.primary;
-            track.border-color: Palette.primary;
-            i-handle.background: Palette.primary-container;
+            state-layer.background: MaterialPalette.on-surface;
+            track.background: MaterialPalette.accent;
+            track.border-color: MaterialPalette.accent;
+            i-handle.background: MaterialPalette.accent-container;
             i-handle.width: 28px;
             i-handle.x: track.width - 28px - 4px;
         }
         hover-selected when i-touch-area.has-hover && root.checked : {
             state-layer.opacity: 0.08;
-            track.background: Palette.primary;
-            track.border-color: Palette.primary;
-            i-handle.background: Palette.primary-container;
+            track.background: MaterialPalette.accent;
+            track.border-color: MaterialPalette.accent;
+            i-handle.background: MaterialPalette.accent-container;
             i-handle.width: 24px;
             i-handle.x: track.width - 24px - 4px;
         }
         hover when i-touch-area.has-hover && !root.checked : {
-            state-layer.background: Palette.on-surface;
+            state-layer.background: MaterialPalette.on-surface;
             state-layer.opacity: 0.08;
-            i-handle.background: Palette.on-surface-variant;
+            i-handle.background: MaterialPalette.on-surface-variant;
         }
         selected when !i-touch-area.has-hover && root.checked : {
-            track.background: Palette.primary;
-            track.border-color: Palette.primary;
-            i-handle.background: Palette.primary-container;
+            track.background: MaterialPalette.accent;
+            track.border-color: MaterialPalette.accent;
+            i-handle.background: MaterialPalette.accent-container;
             i-handle.width: 24px;
             i-handle.x: track.width - 24px - 4px;
         }
         focused-selected when i-focus-scope.has-focus && root.checked : {
             state-layer.opacity: 0.12;
-            track.background: Palette.primary;
-            track.border-color: Palette.primary;
-            i-handle.background: Palette.primary-container;
+            track.background: MaterialPalette.accent;
+            track.border-color: MaterialPalette.accent;
+            i-handle.background: MaterialPalette.accent-container;
             i-handle.width: 24px;
             i-handle.x: track.width - 24px - 4px;
         }
         focused when i-focus-scope.has-focus && !root.checked : {
-            state-layer.background: Palette.on-surface;
+            state-layer.background: MaterialPalette.on-surface;
             state-layer.opacity: 0.12;
         }
     ]
@@ -106,8 +106,8 @@ export component Switch {
                 track := Rectangle {
                     border-radius: 16px;
                     border-width: 2px;
-                    border-color: Palette.outline;
-                    background: Palette.surface-variant;
+                    border-color: MaterialPalette.border;
+                    background: MaterialPalette.surface-variant;
                 }
 
                 i-handle := Rectangle {
@@ -116,7 +116,7 @@ export component Switch {
                     width: 16px;
                     height: self.width;
                     border-radius: self.width / 2;
-                    background: Palette.outline;
+                    background: MaterialPalette.border;
 
                     state-layer := Rectangle {
                         width: 40px;
@@ -124,7 +124,7 @@ export component Switch {
                         x: (parent.width - self.width) / 2;
                         y: (parent.height - self.height) / 2;
                         opacity: 0;
-                        background: Palette.primary;
+                        background: MaterialPalette.accent;
                         border-radius: 20px;
 
                         animate opacity { duration: 300ms; easing: ease; }
@@ -137,12 +137,12 @@ export component Switch {
             }
 
             i-label := Text {
-                color: Palette.on-surface;
+                color: MaterialPalette.on-surface;
                 horizontal-alignment: left;
                 vertical-alignment: center;
                 vertical-stretch: 0;
-                font-size: Typography.title-small.font-size;
-                font-weight: Typography.title-small.font-weight;
+                font-size: MaterialFontSettings.title-small.font-size;
+                font-weight: MaterialFontSettings.title-small.font-weight;
             }
         }
     }

--- a/internal/compiler/widgets/material-base/tableview.slint
+++ b/internal/compiler/widgets/material-base/tableview.slint
@@ -4,7 +4,7 @@
 import { LineEditInner } from "../common/common.slint";
 import { ScrollView } from "std-widgets-impl.slint";
 import { StateLayer } from "components.slint";
-import { Palette, Icons } from "styling.slint";
+import { MaterialPalette, Icons } from "styling.slint";
 
 component TableViewColumn inherits Rectangle {
     in property <SortOrder> sort-order: SortOrder.unsorted;
@@ -13,9 +13,9 @@ component TableViewColumn inherits Rectangle {
     callback adjust-size(/* size */ length);
 
     i-state-layer := StateLayer {
-        background: Palette.primary;
-        selection-background: Palette.secondary-container;
-        ripple-color: Palette.primary-ripple;
+        background: MaterialPalette.accent;
+        selection-background: MaterialPalette.background-alt;
+        ripple-color: MaterialPalette.accent-ripple;
         has-ripple: true;
     }
 
@@ -36,7 +36,7 @@ component TableViewColumn inherits Rectangle {
             source: root.sort-order == SortOrder.ascending ?
                 Icons.arrow-upward :
                 Icons.arrow-downward;
-            colorize: Palette.on-surface;
+            colorize: MaterialPalette.on-surface;
         }
     }
 
@@ -45,13 +45,13 @@ component TableViewColumn inherits Rectangle {
         y: parent.height - self.height;
         width: 100%;
         height: 1px;
-        background: Palette.outline;
+        background: MaterialPalette.border;
     }
 
     Rectangle {
         x: parent.width - 1px;
         width: 1px;
-        background: i-movable-touch-area.has-hover ? Palette.outline : transparent;
+        background: i-movable-touch-area.has-hover ? MaterialPalette.border : transparent;
 
         animate background { duration: 250ms; }
 
@@ -85,7 +85,7 @@ component TableViewCell inherits Rectangle {
         y: parent.height - self.height;
         width: 100%;
         height: 1px;
-        background: Palette.outline;
+        background: MaterialPalette.border;
     }
 }
 
@@ -99,17 +99,11 @@ component TableViewRow inherits Rectangle {
 
     min-height: max(42px, i-layout.min-height);
 
-    states [
-        selected when root.selected : {
-            i-state-layer.background: Palette.secondary-container;
-        }
-    ]
-
     i-state-layer := StateLayer {
         checked: root.selected;
-        background: Palette.primary;
-        selection-background: Palette.secondary-container;
-        ripple-color: Palette.primary-ripple;
+        background: MaterialPalette.accent;
+        selection-background: MaterialPalette.surface;
+        ripple-color: MaterialPalette.accent-ripple;
         has-ripple: true;
     }
 

--- a/internal/compiler/widgets/material-base/tabwidget.slint
+++ b/internal/compiler/widgets/material-base/tabwidget.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 
-import { Palette, Typography } from "styling.slint";
+import { MaterialPalette, MaterialFontSettings } from "styling.slint";
 
 export component TabWidgetImpl inherits Rectangle {
     in property <length> tabbar-preferred-height;
@@ -42,7 +42,7 @@ export component TabImpl inherits Rectangle {
     accessible-label: root.title;
 
     i-container := Rectangle {
-        background: Palette.surface;
+        background: MaterialPalette.background-alt;
     }
 
     i-state-layer := Rectangle {
@@ -50,7 +50,7 @@ export component TabImpl inherits Rectangle {
         width: 100%;
         height: 100%;
         border-radius: i-container.border-radius;
-        background: Palette.primary;
+        background: MaterialPalette.accent;
 
         animate opacity { duration: 250ms; easing: ease; }
      }
@@ -61,11 +61,11 @@ export component TabImpl inherits Rectangle {
 
         i-text := Text {
             vertical-alignment: center;
-            color: !root.active ? Palette.on-surface : Palette.primary;
+            color: !root.active ? MaterialPalette.on-surface : MaterialPalette.accent;
             // FIXME after Roboto font can be loaded
-            //font-family: Typography.title-small.font;
-            font-size: Typography.title-small.font-size;
-            font-weight: Typography.title-small.font-weight;
+            //font-family: MaterialFontSettings.title-small.font;
+            font-size: MaterialFontSettings.title-small.font-size;
+            font-weight: MaterialFontSettings.title-small.font-weight;
 
             animate color { duration: 250ms; easing: ease; }
         }
@@ -76,7 +76,7 @@ export component TabImpl inherits Rectangle {
         width: 100%;
         height: 3px;
         y: parent.height - self.height;
-        background: Palette.primary;
+        background: MaterialPalette.accent;
 
         animate opacity { duration: 250ms; easing: ease; }
     }


### PR DESCRIPTION
* Renamed `Palette` of each style to `{StyleName}Palette`
* Renamed `Typography` of each style to `{StyleName}FontSettings`
* Aligned base brush names
 
This is a preparation for exporting a common `Palette` global that give access to style interdependent brush settings. Check #3687.

Right now the base brushes are consist of eight brushes that have the same purpose on each style. This are the brushes that should be exported in a common Palette. On purpose there are only eight brushes right now. It can be evaluated to export more brushes if possible in the future. But right now I think these eight brushes are a really good beginning to give users the possibility to create style independent custom widgets.