### PR TITLE
Clip button texts

### DIFF
--- a/internal/compiler/widgets/cupertino-base/button.slint
+++ b/internal/compiler/widgets/cupertino-base/button.slint
@@ -123,6 +123,7 @@ export component Button {
             vertical-alignment: center;
             text: root.text;
             color: root.text-color;
+            overflow: elide;
 
             animate color { duration: 150ms; }
         }

--- a/internal/compiler/widgets/fluent-base/button.slint
+++ b/internal/compiler/widgets/fluent-base/button.slint
@@ -80,6 +80,7 @@ export component Button {
                 vertical-alignment: center;
                 text: root.text;
                 color: root.text-color;
+                overflow: elide;
 
                 animate color { duration: 150ms; }
             }

--- a/internal/compiler/widgets/material-base/button.slint
+++ b/internal/compiler/widgets/material-base/button.slint
@@ -82,6 +82,7 @@ export component Button {
             vertical-alignment: center;
             horizontal-alignment: center;
             font-weight: MaterialFontSettings.label-large.font-weight;
+            overflow: elide;
 
             animate color { duration: 250ms; easing: ease; }
         }


### PR DESCRIPTION
Add `overflow: elide;` to button texts to prevent buttons from overflowing. Feel free to close this PR if such a behaviour should be implemented in a custom component.