### PR TITLE
Properly send exit events when mouse is outside of a PopupWindow 

### DIFF
--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -4,14 +4,15 @@
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 
+use i_slint_core::api::PhysicalSize;
 use i_slint_core::graphics::euclid::{Point2D, Size2D};
 use i_slint_core::graphics::FontRequest;
 use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
+use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::{Renderer, RendererSealed};
-use i_slint_core::window::WindowAdapterInternal;
-use i_slint_core::window::{InputMethodRequest, WindowAdapter};
+use i_slint_core::window::{InputMethodRequest, WindowAdapter, WindowAdapterInternal};
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Mutex;
@@ -30,6 +31,7 @@ impl i_slint_core::platform::Platform for TestingBackend {
             window: i_slint_core::api::Window::new(self_weak.clone() as _),
             size: Default::default(),
             ime_requests: Default::default(),
+            mouse_cursor: Default::default(),
         }))
     }
 
@@ -77,8 +79,9 @@ impl i_slint_core::platform::Platform for TestingBackend {
 
 pub struct TestingWindow {
     window: i_slint_core::api::Window,
-    size: core::cell::Cell<PhysicalSize>,
+    size: Cell<PhysicalSize>,
     pub ime_requests: RefCell<Vec<InputMethodRequest>>,
+    pub mouse_cursor: Cell<i_slint_core::items::MouseCursor>,
 }
 
 impl WindowAdapterInternal for TestingWindow {
@@ -88,6 +91,10 @@ impl WindowAdapterInternal for TestingWindow {
 
     fn input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
         self.ime_requests.borrow_mut().push(request)
+    }
+
+    fn set_mouse_cursor(&self, cursor: i_slint_core::items::MouseCursor) {
+        self.mouse_cursor.set(cursor);
     }
 }
 
@@ -312,5 +319,3 @@ pub fn access_testing_window<R>(
 }
 
 pub use for_unit_test::*;
-use i_slint_core::api::PhysicalSize;
-use i_slint_core::platform::PlatformError;

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -532,7 +532,7 @@ pub struct MouseInputState {
 
 /// Try to handle the mouse grabber. Return None if the event has been handled, otherwise
 /// return the event that must be handled
-fn handle_mouse_grab(
+pub(crate) fn handle_mouse_grab(
     mouse_event: MouseEvent,
     window_adapter: &Rc<dyn WindowAdapter>,
     mouse_input_state: &mut MouseInputState,
@@ -598,7 +598,7 @@ fn handle_mouse_grab(
     None
 }
 
-fn send_exit_events(
+pub(crate) fn send_exit_events(
     old_input_state: &MouseInputState,
     new_input_state: &mut MouseInputState,
     mut pos: Option<LogicalPoint>,
@@ -640,17 +640,8 @@ pub fn process_mouse_input(
     component: ItemTreeRc,
     mouse_event: MouseEvent,
     window_adapter: &Rc<dyn WindowAdapter>,
-    mut mouse_input_state: MouseInputState,
+    mouse_input_state: MouseInputState,
 ) -> MouseInputState {
-    if matches!(mouse_event, MouseEvent::Released { .. }) {
-        mouse_input_state = process_delayed_event(window_adapter, mouse_input_state);
-    }
-
-    let Some(mouse_event) = handle_mouse_grab(mouse_event, window_adapter, &mut mouse_input_state)
-    else {
-        return mouse_input_state;
-    };
-
     let mut result = MouseInputState::default();
     let root = ItemRc::new(component.clone(), 0);
     let r = send_mouse_event_to_item(mouse_event, root, window_adapter, &mut result, false);

--- a/tests/cases/elements/popupwindow_cursor.slint
+++ b/tests/cases/elements/popupwindow_cursor.slint
@@ -1,0 +1,62 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component TestCase {
+    width: 300px;
+    height: 300px;
+
+    popup := PopupWindow {
+        x: 100px;
+        y: 10px;
+        width: 100px;
+        height: parent.height - 20px;
+        Rectangle { background: blue; }
+        TouchArea {
+            y: 0px; x: 0px;
+            height: 50px;
+            width: 50px;
+            mouse-cursor: not-allowed;
+        }
+    }
+
+    TouchArea {
+        mouse-cursor: help;
+        x: 0px;
+        width: 150px;
+        clicked => {
+            popup.show()
+        }
+
+    }
+
+}
+/*
+
+```rust
+use slint::{platform::WindowEvent, LogicalPosition};
+use slint::private_unstable_api::re_exports::MouseCursor;
+
+let instance = TestCase::new().unwrap();
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(35.0, 35.0) });
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Help);
+slint_testing::send_mouse_click(&instance, 35., 35.);
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(135.0, 35.0) });
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::NotAllowed);
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(35.0, 35.0) });
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
+
+// Close the popup
+
+slint_testing::send_mouse_click(&instance, 135., 35.);
+// FIXME: it takes two events to get that correctly
+// assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Help);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(135.0, 35.0) });
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Help);
+```
+
+*/

--- a/tests/cases/elements/toucharea.slint
+++ b/tests/cases/elements/toucharea.slint
@@ -120,32 +120,39 @@ assert_eq(instance.get_touch3(), 1);
 
 ```rust
 use slint::{platform::WindowEvent, platform::PointerEventButton, platform::Key, LogicalPosition};
+use slint::private_unstable_api::re_exports::MouseCursor;
 
 
 let instance = TestCase::new().unwrap();
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
+
 // does not click on anything
 slint_testing::send_mouse_click(&instance, 5., 5.);
 assert_eq!(instance.get_touch1(), 0);
 assert_eq!(instance.get_touch2(), 0);
 assert_eq!(instance.get_touch3(), 0);
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
 
 // click on second one
 slint_testing::send_mouse_click(&instance, 101., 101.);
 assert_eq!(instance.get_touch1(), 0);
 assert_eq!(instance.get_touch2(), 1);
 assert_eq!(instance.get_touch3(), 0);
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Pointer);
 
 // click on first one only
 slint_testing::send_mouse_click(&instance, 108., 108.);
 assert_eq!(instance.get_touch1(), 1);
 assert_eq!(instance.get_touch2(), 1);
 assert_eq!(instance.get_touch3(), 0);
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Move);
 
 // click on the third
 slint_testing::send_mouse_click(&instance, 106., 103.);
 assert_eq!(instance.get_touch1(), 1);
 assert_eq!(instance.get_touch2(), 1);
 assert_eq!(instance.get_touch3(), 1);
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
 
 assert_eq!(instance.get_pointer_event_test().as_str(), "downleftclickupleft");
 

--- a/tests/cases/focus/focus_change.slint
+++ b/tests/cases/focus/focus_change.slint
@@ -32,7 +32,7 @@ TestCase := Rectangle {
 
 /*
 ```rust
-use slint::private_unstable_api::re_exports::{InputMethodRequest, InputType};
+use slint::private_unstable_api::re_exports::{InputMethodRequest, InputType, MouseCursor};
 
 let instance = TestCase::new().unwrap();
 assert!(!instance.get_input1_focused());
@@ -46,6 +46,7 @@ let mut ime_requests = slint_testing::access_testing_window(instance.window(), |
 assert!(matches!(ime_requests.next(), Some(InputMethodRequest::Enable(props)) if props.input_type == InputType::Text));
 assert!(matches!(ime_requests.next(), Some(InputMethodRequest::Update(..))));
 assert!(ime_requests.next().is_none());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Text);
 
 slint_testing::send_keyboard_string_sequence(&instance, "Only for field 1");
 assert_eq!(instance.get_input1_text(), "Only for field 1");
@@ -74,6 +75,7 @@ assert!(instance.get_input3_focused());
 let mut ime_requests = slint_testing::access_testing_window(instance.window(), |window| window.ime_requests.take()).into_iter();
 assert!(matches!(ime_requests.next(), Some(InputMethodRequest::Disable)));
 assert!(ime_requests.next().is_none());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Text);
 
 ```
 

--- a/tests/cases/issues/issue_2717_has-hover.slint
+++ b/tests/cases/issues/issue_2717_has-hover.slint
@@ -16,7 +16,7 @@ export component TestCase inherits Window {
         y: 100px;
         x: 220px;
         opacity: 0.75;
-        area := TouchArea {}
+        area := TouchArea { mouse-cursor: copy;}
     }
 
     Rectangle {
@@ -27,6 +27,7 @@ export component TestCase inherits Window {
         y: 100px;
         x: 280px;
         secondArea := TouchArea {
+            mouse-cursor: alias;
             Rectangle {
                 width: 100px;
                 height: 100px;
@@ -43,40 +44,50 @@ export component TestCase inherits Window {
 /*
 ```rust
 use slint::{LogicalPosition, platform::{WindowEvent, PointerEventButton}};
+use slint::private_unstable_api::re_exports::MouseCursor;
 let instance = TestCase::new().unwrap();
 assert!(!instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(50.0, 50.0) });
 assert!(!instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(240.0, 150.0) });
 assert!(instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Copy);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(290.0, 150.0) });
 // We Since the touch area are not children, only one is active
 assert!(!instance.get_has_hover1());
 assert!(instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+//FIXME: it currently takes two events for the mouse cursor to change when going from one MouseArea to another
+//assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Alias);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(330.0, 150.0) });
 assert!(!instance.get_has_hover1());
 assert!(instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Alias);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(370.0, 150.0) });
 assert!(!instance.get_has_hover1());
 // here 2 and 3 are both active since one is a children of the other
 assert!(instance.get_has_hover2());
 assert!(instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(390.0, 150.0) });
 assert!(!instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(510.0, 150.0) });
 assert!(!instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
 
 // Now grab
 let button = PointerEventButton::Left;
@@ -84,30 +95,37 @@ instance.window().dispatch_event(WindowEvent::PointerPressed { position: Logical
 assert!(instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Copy);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(290.0, 150.0) });
 assert!(instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Copy);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(330.0, 150.0) });
 assert!(instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Copy);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(370.0, 150.0) });
 assert!(instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Copy);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(390.0, 150.0) });
 assert!(instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Copy);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(510.0, 150.0) });
 assert!(instance.get_has_hover1());
 assert!(!instance.get_has_hover2());
 assert!(!instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Copy);
 instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(370.0, 150.0), button });
 assert!(!instance.get_has_hover1());
 assert!(instance.get_has_hover2());
 assert!(instance.get_has_hover3());
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
 
 ```
 */


### PR DESCRIPTION
... for non-native PopupWindow.

We first need to handle the grabbed event regardless of popup window.

Then, if we are outside of the popup window, we should send exit events
so that, for example, the has-hover and mouse cursor get properly
updated.

Fixes https://github.com/slint-ui/slint/pull/3934