### PR TITLE
Detect binding loops that applies to the Window itself

### DIFF
--- a/demos/usecases/ui/app.slint
+++ b/demos/usecases/ui/app.slint
@@ -22,8 +22,6 @@ export component App inherits Window {
     background: UsecasesPalette.use-material ? Palette.alternate-background : Palette.background;
 
     main-view := MainView {
-        width: 100%;
-        height: 100%;
         break-layout: root.width < 480px;
     }
 

--- a/demos/usecases/ui/views/main_view.slint
+++ b/demos/usecases/ui/views/main_view.slint
@@ -14,6 +14,9 @@ export global MainViewAdapter {
 export component MainView {
     in property <bool> break-layout;
 
+    preferred-height: 100%;
+    preferred-width: 100%;
+
     forward-focus: focus-scope;
     focus-scope := FocusScope { }
 

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout.slint
@@ -20,6 +20,7 @@ TC := Rectangle {
 
 
 export Test := Rectangle {
+//             ^error{The binding for the property 'width' is part of a binding loop}
     VerticalLayout {
 //  ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}  // FIXME: That's an internal property, but people might understand
 //  ^^error{The binding for the property 'min-width' is part of a binding loop}
@@ -37,6 +38,7 @@ export Test := Rectangle {
 //       ^^^^error{The binding for the property 'preferred-height' is part of a binding loop}
 //       ^^^^^error{The binding for the property 'width' is part of a binding loop}
 //       ^^^^^^error{The binding for the property 'layout-cache' is part of a binding loop}
+//       ^^^^^^^error{The binding for the property 'width' is part of a binding loop}
         Text {
             text: "hello \{l.preferred-width/1px}x\{l.preferred-height/1px}";
 //                ^error{The binding for the property 'text' is part of a binding loop}

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout2.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout2.slint
@@ -26,13 +26,22 @@ Wrap := Rectangle {
     property <bool> test: square.width == square.height;
 }
 
-export Test := Rectangle {
+export Test := Window {
+//             ^error{The binding for the property 'layoutinfo-v' is part of a binding loop}
+//             ^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+
     property <image> source;
     GridLayout {
 //  ^error{The binding for the property 'layout-cache-h' is part of a binding loop}
 //  ^^error{The binding for the property 'width' is part of a binding loop}
 //  ^^^error{The binding for the property 'layout-cache-v' is part of a binding loop}
 //  ^^^^error{The binding for the property 'height' is part of a binding loop}
+//  ^^^^^error{The binding for the property 'width' is part of a binding loop}
+//  ^^^^^^error{The binding for the property 'layoutinfo-v' is part of a binding loop}
+//  ^^^^^^^error{The binding for the property 'height' is part of a binding loop}
+//  ^^^^^^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+
+
         Image {
             source: root.source;
         }

--- a/internal/compiler/tests/syntax/analysis/binding_loop_layout_if.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_layout_if.slint
@@ -23,12 +23,17 @@ component WrapperInherited inherits Rectangle {
 }
 
 export component Test inherits Window {
+//                             ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
 
     VerticalLayout {
+//  ^error{The binding for the property 'width' is part of a binding loop}
+//  ^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
         HorizontalLayout {
 //      ^error{The binding for the property 'width' is part of a binding loop}
 //      ^^error{The binding for the property 'width' is part of a binding loop}
 //      ^^^error{The binding for the property 'layout-cache' is part of a binding loop}
+//      ^^^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+//      ^^^^^error{The binding for the property 'width' is part of a binding loop}
             WrapperInherited { }
             Wrapper { }
 //          ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}

--- a/internal/compiler/tests/syntax/analysis/binding_loop_window.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_window.slint
@@ -1,0 +1,25 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue #2902
+
+import { HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+export component MainWindow inherits Window {
+//                                   ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+
+    HorizontalBox {
+//  ^error{The binding for the property 'width' is part of a binding loop}
+//  ^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+
+        VerticalBox {
+
+            width: parent.width;
+//                 ^error{The binding for the property 'width' is part of a binding loop}
+            //height: parent.height;
+            Text {
+                text: "Test";
+            }
+        }
+    }
+}

--- a/internal/compiler/tests/syntax/analysis/binding_loop_window2.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_window2.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue #3898
+export component LspCrash inherits Window {
+//                                 ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+
+    HorizontalLayout {
+//  ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
+        padding-left: parent.width * 0.015;
+//                    ^error{The binding for the property 'padding-left' is part of a binding loop}
+        Rectangle {}
+    }
+}


### PR DESCRIPTION
The Window geometry depends on its constraints, so its constraints cannot depends on its geometry

This fixes Infinitely growing layout, and other panics

Fixes #3989
Fixes #2902