### PR TITLE
Docs: remove non-existing properties in TabWidget

### DIFF
--- a/docs/reference/src/language/widgets/tabwidget.md
+++ b/docs/reference/src/language/widgets/tabwidget.md
@@ -6,22 +6,10 @@ a time.
 
 ### Properties
 
--   **`content-min-width`** and **`content-min-height`** (_out_ _length_): The minimum width and height of the contents
--   **`content-width`** and **`content-height`** (_out_ _length_): The width and height of the contents
--   **`content-x`** and **`content-y`** (_out_ _length_): The x and y position of the contents
--   **`current-focused`** (_in_ _int_): The index of the tab that has focus. This tab may or may not be visible.
 -   **`current-index`** (_in_ _int_): The index of the currently visible tab
--   **`tabbar-preferred-width`** and **`tabbar-preferred-height`** (_in_ _length_): The preferred width and height of the tab bar
--   **`tabbar-width`** and **`tabbar-height`** (_out_ _length_): The width and height of the tab bar
--   **`tabbar-x`** and **`tabbar-y`** (_out_ _length_): The x and y position of the tab bar
 
 ### Properties of the `Tab` element
 
--   **`current-focused`** (_out_ _int_): The index of this tab that has focus at this time or -1 if none is focused
--   **`enabled`**: (_in_ _bool_): Defaults to true. When false, the tab can't be activated
--   **`icon`** (_in_ _image_): The image on the tab
--   **`num-tabs`** (_out_ _int_): The number of tabs in the current `TabBar`
--   **`tab-index`** (_out_ _int_): The index of this tab
 -   **`title`** (_in_ _string_): The text written on the tab
 
 ### Example


### PR DESCRIPTION
These were added by commit eec9d31809ab34b7f6f61526a62629f0bc4103cb but they are compiler internal properties that are not available to users, or just don't exist

Discussed in https://github.com/slint-ui/slint/discussions/3995