### PR TITLE
Fix typescript errors shown in VS code when editing node test files

### DIFF
--- a/api/node/__test__/tsconfig.json
+++ b/api/node/__test__/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
-        "module": "CommonJS",
+        "module": "nodenext",
         "target": "esnext",
         "declaration": true,
     },
     "include": [
-        "index.ts"
+        "*.mts"
     ],
 }

--- a/api/node/__test__/tsconfig.json
+++ b/api/node/__test__/tsconfig.json
@@ -2,7 +2,6 @@
     "compilerOptions": {
         "module": "nodenext",
         "target": "esnext",
-        "declaration": true,
     },
     "include": [
         "*.mts"

--- a/api/node/package.json
+++ b/api/node/package.json
@@ -39,6 +39,9 @@
       "--loader=ts-node/esm"
     ],
     "timeout": "2m",
+    "environmentVariables": {
+      "TS_NODE_PROJECT": "./__test__/tsconfig.json"
+    },
     "workerThreads": false
   },
   "dependencies": {


### PR DESCRIPTION
The nodenext module resolution was only passed to ts-node, but vscode didn't see it. Use a dedicated tsconfig.json for vscode as well as ts-node.