### PR TITLE
LSP: rename and fix the hide toolbar option

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -94,9 +94,9 @@
                     },
                     "description": "The command line arguments passed to the Slint LSP server"
                 },
-                "slint.preview.show_ui": {
+                "slint.preview.hide_ui": {
                     "type": "boolean",
-                    "description": "Show the toolbar of the preview"
+                    "description": "Hide the toolbar of the preview"
                 },
                 "slint.preview.style": {
                     "type": "string",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -96,6 +96,7 @@
                 },
                 "slint.preview.hide_ui": {
                     "type": "boolean",
+                    "default": false,
                     "description": "Hide the toolbar of the preview"
                 },
                 "slint.preview.style": {
@@ -104,6 +105,7 @@
                 },
                 "slint.preview.providedByEditor": {
                     "type": "boolean",
+                    "default": false,
                     "description": "Instead of letting the Language Server display the preview in a native window, show the preview in an editor tab using web-assembly.  This has no effect for the web extension where the preview is always provided by the editor."
                 },
                 "slint.includePaths": {

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -19,7 +19,7 @@ pub trait PreviewApi {
     fn load_preview(&self, component: PreviewComponent);
     fn config_changed(
         &self,
-        show_preview_ui: bool,
+        hide_ui: Option<bool>,
         style: &str,
         include_paths: &[PathBuf],
         library_paths: &HashMap<String, PathBuf>,
@@ -28,12 +28,6 @@ pub trait PreviewApi {
 
     /// What is the current component to preview?
     fn current_component(&self) -> Option<PreviewComponent>;
-
-    /// Return the currently configured `show_preview_ui` value.
-    ///
-    /// This is not ideal, but we can not access the configuration without
-    /// a round trip into the editor.
-    fn show_preview_ui(&self) -> bool;
 }
 
 /// The Component to preview

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -11,19 +11,21 @@ use std::{
 pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[derive(Default, Clone, PartialEq, Debug, serde::Deserialize, serde::Serialize)]
+pub struct PreviewConfig {
+    pub hide_ui: Option<bool>,
+    pub style: String,
+    pub include_paths: Vec<PathBuf>,
+    pub library_paths: HashMap<String, PathBuf>,
+}
+
 /// API used by the LSP to talk to the Preview. The other direction uses the
 /// ServerNotifier
 pub trait PreviewApi {
     fn set_use_external_previewer(&self, use_external: bool);
     fn set_contents(&self, path: &Path, contents: &str);
     fn load_preview(&self, component: PreviewComponent);
-    fn config_changed(
-        &self,
-        hide_ui: Option<bool>,
-        style: &str,
-        include_paths: &[PathBuf],
-        library_paths: &HashMap<String, PathBuf>,
-    );
+    fn config_changed(&self, config: PreviewConfig);
     fn highlight(&self, path: Option<PathBuf>, offset: u32) -> Result<()>;
 
     /// What is the current component to preview?
@@ -40,12 +42,6 @@ pub struct PreviewComponent {
     /// If None, then the last component is going to be shown.
     pub component: Option<String>,
 
-    /// The list of include paths
-    pub include_paths: Vec<PathBuf>,
-
-    /// The map of library paths
-    pub library_paths: HashMap<String, PathBuf>,
-
     /// The style name for the preview
     pub style: String,
 }
@@ -53,27 +49,10 @@ pub struct PreviewComponent {
 #[allow(unused)]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub enum LspToPreviewMessage {
-    SetContents {
-        path: String,
-        contents: String,
-    },
-    SetConfiguration {
-        show_preview_ui: bool,
-        style: String,
-        include_paths: Vec<String>,
-        library_paths: Vec<(String, String)>,
-    },
-    ShowPreview {
-        path: String,
-        component: Option<String>,
-        style: String,
-        include_paths: Vec<String>,
-        library_paths: Vec<(String, String)>,
-    },
-    HighlightFromEditor {
-        path: Option<String>,
-        offset: u32,
-    },
+    SetContents { path: String, contents: String },
+    SetConfiguration { config: PreviewConfig },
+    ShowPreview { path: String, component: Option<String>, style: String },
+    HighlightFromEditor { path: Option<String>, offset: u32 },
 }
 
 #[allow(unused)]

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -90,7 +90,7 @@ pub fn request_state(ctx: &std::rc::Rc<Context>) {
         }
         let style = documents.compiler_config.style.clone().unwrap_or_default();
         ctx.preview.config_changed(
-            ctx.preview.show_preview_ui(),
+            None,
             &style,
             &documents.compiler_config.include_paths,
             &documents.compiler_config.library_paths,
@@ -1222,7 +1222,7 @@ pub async fn load_configuration(ctx: &Context) -> Result<()> {
         .await?;
 
     let document_cache = &mut ctx.document_cache.borrow_mut();
-    let mut show_preview_ui = false;
+    let mut hide_ui = None;
     for v in r {
         if let Some(o) = v.as_object() {
             if let Some(ip) = o.get("includePaths").and_then(|v| v.as_array()) {
@@ -1246,10 +1246,7 @@ pub async fn load_configuration(ctx: &Context) -> Result<()> {
                     document_cache.documents.compiler_config.style = Some(style.into());
                 }
             }
-            show_preview_ui = o
-                .get("preview")
-                .and_then(|v| v.as_object()?.get("show_ui")?.as_bool())
-                .unwrap_or_default();
+            hide_ui = o.get("preview").and_then(|v| v.as_object()?.get("hide_ui")?.as_bool());
         }
     }
 
@@ -1260,7 +1257,7 @@ pub async fn load_configuration(ctx: &Context) -> Result<()> {
     let cc = &document_cache.documents.compiler_config;
     let empty_string = String::new();
     ctx.preview.config_changed(
-        show_preview_ui,
+        hide_ui,
         cc.style.as_ref().unwrap_or(&empty_string),
         &cc.include_paths,
         &cc.library_paths,

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -321,7 +321,7 @@ fn main_loop(connection: Connection, init_param: InitializeParams, cli_args: Cli
         CompilerConfiguration::new(i_slint_compiler::generator::OutputFormat::Interpreter);
 
     compiler_config.style =
-        Some(if cli_args.style.is_empty() { "fluent".into() } else { cli_args.style });
+        Some(if cli_args.style.is_empty() { "native".into() } else { cli_args.style });
     compiler_config.include_paths = cli_args.include_paths;
     let preview_notifier = preview.clone();
     compiler_config.open_import_fallback = Some(Rc::new(move |path| {

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -11,10 +11,8 @@ use slint_interpreter::{DiagnosticLevel, PlatformError};
 
 slint::include_modules!();
 
-pub fn create_ui(style: String, show_preview_ui: bool) -> Result<PreviewUi, PlatformError> {
+pub fn create_ui(style: String) -> Result<PreviewUi, PlatformError> {
     let ui = PreviewUi::new()?;
-
-    ui.set_show_preview_ui(show_preview_ui);
 
     // design mode:
     ui.on_design_mode_changed(super::set_design_mode);

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -4,7 +4,7 @@
 //! This wasm library can be loaded from JS to load and display the content of .slint files
 #![cfg(target_arch = "wasm32")]
 
-use std::{cell::RefCell, collections::HashMap, future::Future, path::PathBuf, pin::Pin, rc::Rc};
+use std::{cell::RefCell, future::Future, path::PathBuf, pin::Pin, rc::Rc};
 
 use wasm_bindgen::prelude::*;
 
@@ -75,7 +75,7 @@ impl PreviewConnector {
                         reject_c.take().call1(&JsValue::UNDEFINED,
                             &JsValue::from("PreviewConnector already set up.")).unwrap_throw();
                     } else {
-                        match super::ui::create_ui(style, true) {
+                        match super::ui::create_ui(style) {
                             Ok(ui) => {
                                 ui.on_show_document(|url, line, column| ask_editor_to_show_document(url.as_str().to_string(), line as u32, column as u32, line as u32, column as u32));
                                 preview_state.borrow_mut().ui = Some(ui);
@@ -125,24 +125,12 @@ impl PreviewConnector {
                 super::set_contents(&PathBuf::from(&path), contents);
                 Ok(())
             }
-            M::SetConfiguration { show_preview_ui, style, include_paths, library_paths } => {
-                let ip: Vec<PathBuf> = include_paths.iter().map(PathBuf::from).collect();
-                let lp: HashMap<String, PathBuf> =
-                    library_paths.iter().map(|(n, p)| (n.clone(), PathBuf::from(p))).collect();
-                super::config_changed(show_preview_ui, &style, &ip, &lp);
+            M::SetConfiguration { config } => {
+                super::config_changed(config);
                 Ok(())
             }
-            M::ShowPreview { path, component, style, include_paths, library_paths } => {
-                let pc = PreviewComponent {
-                    path: PathBuf::from(path),
-                    component,
-                    style,
-                    include_paths: include_paths.iter().map(PathBuf::from).collect(),
-                    library_paths: library_paths
-                        .iter()
-                        .map(|(n, p)| (n.clone(), PathBuf::from(p)))
-                        .collect(),
-                };
+            M::ShowPreview { path, component, style } => {
+                let pc = PreviewComponent { path: PathBuf::from(path), component, style };
                 super::load_preview(pc);
                 Ok(())
             }

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -15,7 +15,7 @@ export component PreviewUi inherits Window {
     in property<string> status-text;
     in property<component-factory> preview-area;
     in-out property<string> current-style;
-    in property<bool> show-preview-ui;
+    in property<bool> show-preview-ui : true;
 
     callback design-mode-changed(/* enabled */ bool);
     callback style-changed();

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -95,18 +95,20 @@ impl PreviewApi for Previewer {
 
     fn config_changed(
         &self,
-        show_preview_ui: bool,
+        hide_ui: Option<bool>,
         style: &str,
         include_paths: &[PathBuf],
         library_paths: &HashMap<String, PathBuf>,
     ) {
-        *self.show_preview_ui.borrow_mut() = show_preview_ui;
+        if let Some(hide_ui) = hide_ui {
+            *self.show_preview_ui.borrow_mut() = !hide_ui;
+        }
 
         #[cfg(feature = "preview-external")]
         let _ = self.server_notifier.send_notification(
             "slint/lsp_to_preview".to_string(),
             crate::common::LspToPreviewMessage::SetConfiguration {
-                show_preview_ui,
+                show_preview_ui: *self.show_preview_ui.borrow(),
                 style: style.to_string(),
                 include_paths: include_paths
                     .iter()
@@ -133,10 +135,6 @@ impl PreviewApi for Previewer {
 
     fn current_component(&self) -> Option<crate::common::PreviewComponent> {
         self.to_show.borrow().clone()
-    }
-
-    fn show_preview_ui(&self) -> bool {
-        *self.show_preview_ui.borrow()
     }
 }
 


### PR DESCRIPTION
 - rename the command line option to --no-toolbar
 - Make it default to not hide the toolbar (so it is visible by default)