### PR TITLE
Fix compilation when dividing by zero at compile time

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2524,7 +2524,10 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             format!(r#"slint::SharedString(u8"{}")"#, escape_string(s.as_str()))
         }
         Expression::NumberLiteral(num) => {
-            if *num > 1_000_000_000. {
+            if !num.is_finite() {
+                // just print something
+                "0.0".to_string()
+            } else if num.abs() > 1_000_000_000. {
                 // If the numbers are too big, decimal notation will give too many digit
                 format!("{:+e}", num)
             } else {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1871,7 +1871,8 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         Expression::StringLiteral(s) => {
             quote!(sp::SharedString::from(#s))
         }
-        Expression::NumberLiteral(n) => quote!(#n),
+        Expression::NumberLiteral(n) if n.is_finite() => quote!(#n),
+        Expression::NumberLiteral(_) => quote!(0.),
         Expression::BoolLiteral(b) => quote!(#b),
         Expression::Cast { from, to } => {
             let f = compile_expression(from, ctx);

--- a/tests/cases/expr/math.slint
+++ b/tests/cases/expr/math.slint
@@ -1,12 +1,18 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
- TestCase := Rectangle {
-    property <bool> test_sqrt: sqrt(100) == 10 && Math.sqrt(1) == 1 && sqrt(6.25) == 2.5;
-    property <bool> test_abs: abs(100.5) == 100.5 && Math.abs(-200.5) == 200.5 && abs(0) == 0;
-    property <bool> test_log: log(4,2) == 2 && Math.log(9,3) == 2 && log(64,4) == 3;
-    property <bool> test_pow: pow(4,2) == 16 && Math.pow(9,3) == 729 && pow(4,3) == 64;
-    property <bool> test: test_sqrt && test_abs && test_log && test_pow;
+ export component TestCase  {
+
+    in property <float> thousand: 1000;
+
+    out property <bool> test_sqrt: sqrt(100) == 10 && Math.sqrt(1) == 1 && sqrt(6.25) == 2.5 && abs(sqrt(thousand) - sqrt(1000)) < 0.00001;
+    out property <bool> test_abs: abs(100.5) == 100.5 && Math.abs(-200.5) == 200.5 && abs(0) == 0 && Math.abs(-thousand) == 1000;
+    out property <bool> test_log: log(4,2) == 2 && Math.log(9,3) == 2 && log(64,4) == 3;
+    out property <bool> test_pow: pow(4,2) == 16 && Math.pow(9,3) == 729 && pow(4,3) == 64 && abs(log(pow(thousand, 5), thousand) - 5) < 0.00001;
+
+    out property <int> test_div_zero: 42 / 0;
+
+    out property <bool> test: test_sqrt && test_abs && test_log && test_pow && (test_div_zero) > -1;
 }
 /*
 ```cpp


### PR DESCRIPTION
Rust would have panicked and C++ generated wrong code.

CC #3982