### PR TITLE
Visit the geometry property as root from binding_analysis

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -162,6 +162,12 @@ fn analyze_element(
     for nr in elem.borrow().accessibility_props.0.values() {
         process_property(&PropertyPath::from(nr.clone()), context, reverse_aliases, diag);
     }
+    if let Some(g) = elem.borrow().geometry_props.as_ref() {
+        process_property(&g.x.clone().into(), context, reverse_aliases, diag);
+        process_property(&g.y.clone().into(), context, reverse_aliases, diag);
+        process_property(&g.width.clone().into(), context, reverse_aliases, diag);
+        process_property(&g.height.clone().into(), context, reverse_aliases, diag);
+    }
 
     if let Some(component) = elem.borrow().enclosing_component.upgrade() {
         if Rc::ptr_eq(&component.root_element, elem) {

--- a/tests/cases/crashes/issue_4002_width_alias.slint
+++ b/tests/cases/crashes/issue_4002_width_alias.slint
@@ -1,0 +1,16 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+global ResizeState {
+    in property <length> handle-size: 10px;
+}
+
+component ResizeHandle {
+    width <=> ResizeState.handle-size;
+}
+
+export component Resizer {
+    ResizeHandle {
+        x: 50px;
+    }
+}


### PR DESCRIPTION
We need to visit them from there to mark them as used externally, otherwise the remove_alias passes might remove them.

Fixes #4002