### PR TITLE
Const propagation of min and max

### DIFF
--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -129,6 +129,19 @@ fn simplify_expression(expr: &mut Expression) -> bool {
             }
             can_inline
         }
+        Expression::MinMax { op, lhs, rhs, ty: _ } => {
+            let can_inline = simplify_expression(lhs) && simplify_expression(rhs);
+            if let (Expression::NumberLiteral(lhs, u), Expression::NumberLiteral(rhs, _)) =
+                (&**lhs, &**rhs)
+            {
+                let v = match op {
+                    MinMaxOp::Min => lhs.min(*rhs),
+                    MinMaxOp::Max => lhs.max(*rhs),
+                };
+                *expr = Expression::NumberLiteral(v, *u);
+            }
+            can_inline
+        }
         Expression::CallbackReference { .. } => false,
         Expression::ElementReference { .. } => false,
         // FIXME


### PR DESCRIPTION
Since we generate a lot of max(min, preferred) in the geometry code, this allow to simplify some expressions in the generated code