### PR TITLE
Implement KeyEvent.repeat

### DIFF
--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -329,7 +329,19 @@ public:
     {
         private_api::assert_main_thread();
         cbindgen_private::slint_windowrc_dispatch_key_event(
-                &inner.handle(), cbindgen_private::KeyEventType::KeyPressed, &text);
+                &inner.handle(), cbindgen_private::KeyEventType::KeyPressed, &text, false);
+    }
+
+    /// Dispatch an auto-repeated key press event to the scene.
+    ///
+    /// Use this when you're implementing your own backend and want to forward user input events.
+    ///
+    /// The \a text is the unicode representation of the key.
+    void dispatch_key_press_repeat_event(const SharedString &text)
+    {
+        private_api::assert_main_thread();
+        cbindgen_private::slint_windowrc_dispatch_key_event(
+                &inner.handle(), cbindgen_private::KeyEventType::KeyPressed, &text, true);
     }
 
     /// Dispatch a key release event to the scene.
@@ -341,7 +353,7 @@ public:
     {
         private_api::assert_main_thread();
         cbindgen_private::slint_windowrc_dispatch_key_event(
-                &inner.handle(), cbindgen_private::KeyEventType::KeyReleased, &text);
+                &inner.handle(), cbindgen_private::KeyEventType::KeyReleased, &text, false);
     }
 
     /// Dispatches a pointer or mouse press event to the scene.

--- a/examples/cpp/platform_qt/main.cpp
+++ b/examples/cpp/platform_qt/main.cpp
@@ -229,7 +229,11 @@ public:
             paintEvent(static_cast<QPaintEvent *>(e));
             return true;
         } else if (e->type() == QEvent::KeyPress) {
-            window().dispatch_key_press_event(key_event_text(static_cast<QKeyEvent *>(e)));
+            auto ke = static_cast<QKeyEvent *>(e);
+            if (ke->isAutoRepeat())
+                window().dispatch_key_press_repeat_event(key_event_text(ke));
+            else
+                window().dispatch_key_press_event(key_event_text(ke));
             return true;
         } else if (e->type() == QEvent::KeyRelease) {
             window().dispatch_key_release_event(key_event_text(static_cast<QKeyEvent *>(e)));

--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -413,9 +413,12 @@ fn position_for_event(motion_event: &MotionEvent) -> PhysicalPosition {
 
 fn map_key_event(key_event: &android_activity::input::KeyEvent) -> Option<WindowEvent> {
     let text = map_key_code(key_event.key_code())?;
+    let repeat = key_event.repeat_count() > 0;
     match key_event.action() {
+        KeyAction::Down if repeat => Some(WindowEvent::KeyPressRepeated { text }),
         KeyAction::Down => Some(WindowEvent::KeyPressed { text }),
         KeyAction::Up => Some(WindowEvent::KeyReleased { text }),
+        KeyAction::Multiple if repeat => Some(WindowEvent::KeyPressRepeated { text }),
         KeyAction::Multiple => Some(WindowEvent::KeyPressed { text }),
         _ => None,
     }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -315,6 +315,9 @@ impl EventLoopState {
                 let text = i_slint_common::for_each_special_keys!(winit_key_to_char);
 
                 window.window().dispatch_event(match event.state {
+                    winit::event::ElementState::Pressed if event.repeat => {
+                        corelib::platform::WindowEvent::KeyPressRepeated { text }
+                    }
                     winit::event::ElementState::Pressed => {
                         corelib::platform::WindowEvent::KeyPressed { text }
                     }

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -172,7 +172,12 @@ impl WasmInputHelper {
                 }
 
                 shared_state2.borrow_mut().has_key_down = true;
-                window_adapter.window().dispatch_event(WindowEvent::KeyPressed { text });
+                let win_event = if e.repeat() {
+                    WindowEvent::KeyPressRepeated { text }
+                } else {
+                    WindowEvent::KeyPressed { text }
+                };
+                window_adapter.window().dispatch_event(win_event);
             }
         });
 

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -90,6 +90,8 @@ macro_rules! for_each_builtin_structs {
                     text: SharedString,
                     /// The keyboard modifiers active at the time of the key press event.
                     modifiers: KeyboardModifiers,
+                    /// Whether or not this event is for a key press repeat event.
+                    repeat: bool,
                 }
                 private {
                     /// Indicates whether the key was pressed or released

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -488,6 +488,15 @@ impl Window {
             crate::platform::WindowEvent::KeyPressed { text } => {
                 self.0.process_key_input(crate::input::KeyEvent {
                     text,
+                    repeat: false,
+                    event_type: KeyEventType::KeyPressed,
+                    ..Default::default()
+                })
+            }
+            crate::platform::WindowEvent::KeyPressRepeated { text } => {
+                self.0.process_key_input(crate::input::KeyEvent {
+                    text,
+                    repeat: true,
                     event_type: KeyEventType::KeyPressed,
                     ..Default::default()
                 })

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -291,6 +291,17 @@ pub enum WindowEvent {
         /// ```
         text: SharedString,
     },
+    /// A key press was auto-repeated.
+    KeyPressRepeated {
+        /// The unicode representation of the key pressed.
+        ///
+        /// # Example
+        /// A specific key can be mapped to a unicode by using the [`Key`] enum
+        /// ```rust
+        /// let _ = slint::platform::WindowEvent::KeyPressRepeated { text: slint::platform::Key::Shift.into() };
+        /// ```
+        text: SharedString,
+    },
     /// A key was released.
     KeyReleased {
         /// The unicode representation of the key released.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1325,10 +1325,12 @@ pub mod ffi {
         handle: *const WindowAdapterRcOpaque,
         event_type: crate::input::KeyEventType,
         text: &SharedString,
+        repeat: bool,
     ) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
         window_adapter.window().0.process_key_input(crate::items::KeyEvent {
             text: text.clone(),
+            repeat,
             event_type,
             ..Default::default()
         });

--- a/tests/cases/text/key_repeat.slint
+++ b/tests/cases/text/key_repeat.slint
@@ -1,0 +1,53 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+TestCase := Window {
+    width: 100phx;
+    height: 100phx;
+    ti := FocusScope {
+        key-pressed(event) => {
+            pressed = true;
+            repeat = event.repeat;
+            accept;
+        }
+        key-released(event) => {
+            pressed = false;
+            repeat = event.repeat;
+            accept;
+        }
+    }
+
+    property <bool> input_focused: ti.has_focus;
+    property <bool> pressed;
+    property <bool> repeat;
+}
+
+/*
+```rust
+use slint::platform::WindowEvent;
+
+let instance = TestCase::new().unwrap();
+
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_input_focused());
+
+instance.window().dispatch_event(WindowEvent::KeyPressed { text: 'a'.into() });
+assert_eq!(instance.get_pressed(), true);
+assert_eq!(instance.get_repeat(), false);
+
+instance.set_pressed(false);
+instance.window().dispatch_event(WindowEvent::KeyPressRepeated { text: 'a'.into() });
+assert_eq!(instance.get_pressed(), true);
+assert_eq!(instance.get_repeat(), true);
+
+instance.set_pressed(false);
+instance.window().dispatch_event(WindowEvent::KeyPressRepeated { text: 'a'.into() });
+assert_eq!(instance.get_pressed(), true);
+assert_eq!(instance.get_repeat(), true);
+
+instance.window().dispatch_event(WindowEvent::KeyReleased { text: 'a'.into() });
+assert_eq!(instance.get_pressed(), false);
+assert_eq!(instance.get_repeat(), false);
+
+```
+*/


### PR DESCRIPTION
Now that winit was upgraded do 0.29 we can use its KeyEvent::repeat field.

Also feed Qt's QKeyEvent::isAutoRepeat() in the Qt backend.

Fixes #3065