### PR TITLE
fix bug: error[E0063]: missing field `load_substitutions`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ itertools = { version = "0.12" }
 softbuffer = { version = "0.3.3", default-features = false }
 bytemuck = { version = "1.13.1" }
 glutin = { version = "0.31.1", default-features = false }
+fontdue = { version = "0.8.0" }
 
 [profile.release]
 lto = true

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -58,7 +58,7 @@ linked_hash_set = "0.1.4"
 image = { version = "0.24", optional = true }
 resvg = { workspace = true, optional = true }
 # font embedding
-fontdue = { version = "0.7.1", optional = true }
+fontdue = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
 i-slint-parser-test-macro = { path = "./parser-test-macro" }

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -58,7 +58,7 @@ linked_hash_set = "0.1.4"
 image = { version = "0.24", optional = true }
 resvg = { workspace = true, optional = true }
 # font embedding
-fontdue = { version = "0.8.0", optional = true }
+fontdue = { workspace = true, optional = true }
 
 [dev-dependencies]
 i-slint-parser-test-macro = { path = "./parser-test-macro" }

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -200,7 +200,7 @@ fn embed_glyphs_with_fontdb<'a>(
             fontdb.with_face_data(face_id, |font_data, face_index| {
                 let fontdue_font = match fontdue::Font::from_bytes(
                     font_data,
-                    fontdue::FontSettings { collection_index: face_index, scale: 40. },
+                    fontdue::FontSettings { collection_index: face_index, scale: 40., load_substitutions: true },
                 ) {
                     Ok(fontdue_font) => fontdue_font,
                     Err(fontdue_msg) => {
@@ -321,7 +321,11 @@ fn get_fallback_fonts(fontdb: &sharedfontdb::FontDatabase) -> Vec<fontdue::Font>
                         .with_face_data(face_id, |face_data, face_index| {
                             fontdue::Font::from_bytes(
                                 face_data,
-                                fontdue::FontSettings { collection_index: face_index, scale: 40. },
+                                fontdue::FontSettings {
+                                    collection_index: face_index,
+                                    scale: 40.,
+                                    load_substitutions: true,
+                                },
                             )
                             .ok()
                         })

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -200,7 +200,7 @@ fn embed_glyphs_with_fontdb<'a>(
             fontdb.with_face_data(face_id, |font_data, face_index| {
                 let fontdue_font = match fontdue::Font::from_bytes(
                     font_data,
-                    fontdue::FontSettings { collection_index: face_index, scale: 40., load_substitutions: true },
+                    fontdue::FontSettings { collection_index: face_index, scale: 40., ..Default::default() },
                 ) {
                     Ok(fontdue_font) => fontdue_font,
                     Err(fontdue_msg) => {
@@ -324,7 +324,7 @@ fn get_fallback_fonts(fontdb: &sharedfontdb::FontDatabase) -> Vec<fontdue::Font>
                                 fontdue::FontSettings {
                                     collection_index: face_index,
                                     scale: 40.,
-                                    load_substitutions: true,
+                                    ..Default::default()
                                 },
                             )
                             .ok()

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -19,23 +19,12 @@ categories = ["gui", "development-tools", "no-std"]
 path = "lib.rs"
 
 [features]
-ffi = []                                  # Expose C ABI
+ffi = [] # Expose C ABI
 libm = ["num-traits/libm", "euclid/libm"]
 # Allow the viewer to query at runtime information about item types
 rtti = []
 # Use the standard library
-std = [
-    "euclid/std",
-    "once_cell/std",
-    "scoped-tls-hkt",
-    "lyon_path",
-    "lyon_algorithms",
-    "lyon_geom",
-    "lyon_extra",
-    "dep:web-time",
-    "image-decoders",
-    "svg",
-]
+std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom", "lyon_extra", "dep:web-time", "image-decoders", "svg"]
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
 # from a single core, and not in a interrupt or signal handler.
@@ -43,12 +32,7 @@ unsafe-single-threaded = []
 
 unicode = ["unicode-script", "unicode-linebreak"]
 
-software-renderer-systemfonts = [
-    "shared-fontdb",
-    "rustybuzz",
-    "fontdue",
-    "software-renderer",
-]
+software-renderer-systemfonts = ["shared-fontdb", "rustybuzz", "fontdue", "software-renderer"]
 software-renderer = ["bytemuck"]
 # This is under a feature flag because it is experimental feature.
 software-renderer-rotation = []
@@ -75,19 +59,17 @@ cfg-if = "1"
 derive_more = "0.99.5"
 euclid = { version = "0.22.1", default-features = false }
 lyon_algorithms = { version = "1.0", optional = true }
-lyon_geom = { version = "1.0", optional = true }
+lyon_geom = { version = "1.0", optional = true  }
 lyon_path = { version = "1.0", optional = true }
 lyon_extra = { version = "1.0.1", optional = true }
 num-traits = { version = "0.2", default-features = false }
-once_cell = { version = "1.5", default-features = false, features = [
-    "critical-section",
-] }
+once_cell = { version = "1.5", default-features = false, features = ["critical-section"] }
 pin-project = "1"
 pin-weak = { version = "1.1", default-features = false }
 # Note: the rgb version is extracted in ci.yaml for rustdoc builds
 rgb = "0.8.27"
 scoped-tls-hkt = { version = "0.1", optional = true }
-scopeguard = { version = "1.1.0", default-features = false }
+scopeguard =  { version = "1.1.0", default-features = false }
 slab = { version = "0.4.3", default-features = false }
 static_assertions = "1.1"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
@@ -97,10 +79,7 @@ unicode-script = { version = "0.5.3", optional = true }
 integer-sqrt = { version = "0.1.5" }
 bytemuck = { workspace = true, optional = true, features = ["derive"] }
 
-image = { version = "0.24.0", optional = true, default-features = false, features = [
-    "png",
-    "jpeg",
-] }
+image = { version = "0.24.0", optional = true, default-features = false, features = [ "png", "jpeg" ] }
 clru = { version = "0.6.0", optional = true }
 
 resvg = { workspace = true, optional = true }
@@ -113,7 +92,7 @@ gettext-rs = { version = "0.7", optional = true, features = ["gettext-system"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "0.2", optional = true }
 wasm-bindgen = { version = "0.2" }
-web-sys = { version = "0.3", features = ["HtmlImageElement"] }
+web-sys = { version = "0.3", features = [ "HtmlImageElement" ] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { workspace = true, optional = true, default-features = true }
@@ -121,16 +100,13 @@ rustybuzz = { version = "0.11.0", optional = true }
 fontdue = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = [
-    "std",
-    "compat-1-2",
-] }
-i-slint-backend-testing = { path = "../backends/testing" }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }
+i-slint-backend-testing = { path="../backends/testing" }
 rustybuzz = "0.11.0"
 ttf-parser = "0.20.0"
 fontdb = { workspace = true, default-features = true }
 serde_json = "1.0.96"
 
-image = { version = "0.24.0", default-features = false, features = ["png"] }
+image = { version = "0.24.0", default-features = false, features = [ "png" ] }
 pin-weak = "1"
 tiny-skia = "0.9.0"

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -19,12 +19,23 @@ categories = ["gui", "development-tools", "no-std"]
 path = "lib.rs"
 
 [features]
-ffi = [] # Expose C ABI
+ffi = []                                  # Expose C ABI
 libm = ["num-traits/libm", "euclid/libm"]
 # Allow the viewer to query at runtime information about item types
 rtti = []
 # Use the standard library
-std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom", "lyon_extra", "dep:web-time", "image-decoders", "svg"]
+std = [
+    "euclid/std",
+    "once_cell/std",
+    "scoped-tls-hkt",
+    "lyon_path",
+    "lyon_algorithms",
+    "lyon_geom",
+    "lyon_extra",
+    "dep:web-time",
+    "image-decoders",
+    "svg",
+]
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
 # from a single core, and not in a interrupt or signal handler.
@@ -32,7 +43,12 @@ unsafe-single-threaded = []
 
 unicode = ["unicode-script", "unicode-linebreak"]
 
-software-renderer-systemfonts = ["shared-fontdb", "rustybuzz", "fontdue", "software-renderer"]
+software-renderer-systemfonts = [
+    "shared-fontdb",
+    "rustybuzz",
+    "fontdue",
+    "software-renderer",
+]
 software-renderer = ["bytemuck"]
 # This is under a feature flag because it is experimental feature.
 software-renderer-rotation = []
@@ -59,17 +75,19 @@ cfg-if = "1"
 derive_more = "0.99.5"
 euclid = { version = "0.22.1", default-features = false }
 lyon_algorithms = { version = "1.0", optional = true }
-lyon_geom = { version = "1.0", optional = true  }
+lyon_geom = { version = "1.0", optional = true }
 lyon_path = { version = "1.0", optional = true }
 lyon_extra = { version = "1.0.1", optional = true }
 num-traits = { version = "0.2", default-features = false }
-once_cell = { version = "1.5", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.5", default-features = false, features = [
+    "critical-section",
+] }
 pin-project = "1"
 pin-weak = { version = "1.1", default-features = false }
 # Note: the rgb version is extracted in ci.yaml for rustdoc builds
 rgb = "0.8.27"
 scoped-tls-hkt = { version = "0.1", optional = true }
-scopeguard =  { version = "1.1.0", default-features = false }
+scopeguard = { version = "1.1.0", default-features = false }
 slab = { version = "0.4.3", default-features = false }
 static_assertions = "1.1"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
@@ -79,7 +97,10 @@ unicode-script = { version = "0.5.3", optional = true }
 integer-sqrt = { version = "0.1.5" }
 bytemuck = { workspace = true, optional = true, features = ["derive"] }
 
-image = { version = "0.24.0", optional = true, default-features = false, features = [ "png", "jpeg" ] }
+image = { version = "0.24.0", optional = true, default-features = false, features = [
+    "png",
+    "jpeg",
+] }
 clru = { version = "0.6.0", optional = true }
 
 resvg = { workspace = true, optional = true }
@@ -92,21 +113,24 @@ gettext-rs = { version = "0.7", optional = true, features = ["gettext-system"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "0.2", optional = true }
 wasm-bindgen = { version = "0.2" }
-web-sys = { version = "0.3", features = [ "HtmlImageElement" ] }
+web-sys = { version = "0.3", features = ["HtmlImageElement"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { workspace = true, optional = true, default-features = true }
 rustybuzz = { version = "0.11.0", optional = true }
-fontdue = { version = "0.7.1", optional = true }
+fontdue = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }
-i-slint-backend-testing = { path="../backends/testing" }
+slint = { path = "../../api/rs/slint", default-features = false, features = [
+    "std",
+    "compat-1-2",
+] }
+i-slint-backend-testing = { path = "../backends/testing" }
 rustybuzz = "0.11.0"
 ttf-parser = "0.20.0"
 fontdb = { workspace = true, default-features = true }
 serde_json = "1.0.96"
 
-image = { version = "0.24.0", default-features = false, features = [ "png" ] }
+image = { version = "0.24.0", default-features = false, features = ["png"] }
 pin-weak = "1"
 tiny-skia = "0.9.0"

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -97,7 +97,7 @@ web-sys = { version = "0.3", features = [ "HtmlImageElement" ] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { workspace = true, optional = true, default-features = true }
 rustybuzz = { version = "0.11.0", optional = true }
-fontdue = { version = "0.8.0", optional = true }
+fontdue = { workspace = true, optional = true }
 
 [dev-dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }

--- a/internal/core/software_renderer/fonts/systemfonts.rs
+++ b/internal/core/software_renderer/fonts/systemfonts.rs
@@ -26,7 +26,11 @@ fn get_or_create_fontdue_font(fontdb: &fontdb::Database, id: fontdb::ID) -> Rc<f
                     .with_face_data(id, |face_data, font_index| {
                         fontdue::Font::from_bytes(
                             face_data,
-                            fontdue::FontSettings { collection_index: font_index, scale: 40. },
+                            fontdue::FontSettings {
+                                collection_index: font_index,
+                                scale: 40.,
+                                load_substitutions: true,
+                            },
                         )
                         .expect("fatal: fontdue is unable to parse truetype font")
                         .into()

--- a/internal/core/software_renderer/fonts/systemfonts.rs
+++ b/internal/core/software_renderer/fonts/systemfonts.rs
@@ -29,7 +29,7 @@ fn get_or_create_fontdue_font(fontdb: &fontdb::Database, id: fontdb::ID) -> Rc<f
                             fontdue::FontSettings {
                                 collection_index: font_index,
                                 scale: 40.,
-                                load_substitutions: true,
+                                ..Default::default()
                             },
                         )
                         .expect("fatal: fontdue is unable to parse truetype font")


### PR DESCRIPTION
…ontSettings`

  --> D:\.env\rust\.cargo\registry\src\index.crates.io-6f17d22bba15001f\i-slint-core-1.3.0\software_renderer\fonts\systemfonts.rs:29:29
   |
29 | ...                   fontdue::FontSettings { collection_index: font_index, scale: 40. },
   |                       ^^^^^^^^^^^^^^^^^^^^^ missing `load_substitutions`