### PR TITLE
Fix SharedString::end() throwing an exception when MSVC iterator debugging is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ All notable changes to this project are documented in this file.
  - Added `loadSource` function (#3971)
  - Added `requestRedraw` to Window (#3940)
 
+### C++ API
+
+ - Fixed `SharedString::end()` throwing an exception when MSVC iterator debugging is enabled.
+
 ### LSP
 
  - Fix "recursion detected" panic in the preview with `forward-focus`. (#3950)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project are documented in this file.
 
 ### C++ API
 
- - Fixed `SharedString::end()` throwing an exception when MSVC iterator debugging is enabled.
+ - Fixed undefined behavior in `SharedString::end()`
 
 ### LSP
 

--- a/api/cpp/include/slint_string.h
+++ b/api/cpp/include/slint_string.h
@@ -106,7 +106,8 @@ struct SharedString
     /// pointer, but it is suitable for comparison.
     const char *end() const
     {
-        return &*std::string_view(*this).end();
+        std::string_view view(*this);
+        return view.data() + view.size();
     }
 
     /// \return true if the string contains no characters; false otherwise.

--- a/api/cpp/tests/CMakeLists.txt
+++ b/api/cpp/tests/CMakeLists.txt
@@ -17,6 +17,8 @@ macro(slint_test NAME)
     target_compile_definitions(test_${NAME} PRIVATE
         SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"
     )
+    # Use debug version of run-time library to enable MSVC iterator debugging
+    set_property(TARGET test_${NAME} PROPERTY MSVC_RUNTIME_LIBRARY MultiThreadedDebugDLL)
     add_test(NAME test_${NAME} COMMAND test_${NAME})
 
     if(MSVC)

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -39,6 +39,12 @@ SCENARIO("SharedString API")
         REQUIRE(str == "Hello 🦊!");
         REQUIRE(std::string_view(str.data()) == "Hello 🦊!");
     }
+
+    SECTION("begin/end")
+    {
+        str = "Hello";
+        REQUIRE(str.begin() != str.end());
+    }
 }
 
 TEST_CASE("Basic SharedVector API", "[vector]")

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -43,7 +43,7 @@ SCENARIO("SharedString API")
     SECTION("begin/end")
     {
         str = "Hello";
-        REQUIRE(str.begin() + std.size() == str.end());
+        REQUIRE(str.begin() + str.size() == str.end());
     }
 }
 

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -43,7 +43,7 @@ SCENARIO("SharedString API")
     SECTION("begin/end")
     {
         str = "Hello";
-        REQUIRE(str.begin() + str.size() == str.end());
+        REQUIRE(str.begin() + std::string_view(str).size() == str.end());
     }
 }
 

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -43,7 +43,7 @@ SCENARIO("SharedString API")
     SECTION("begin/end")
     {
         str = "Hello";
-        REQUIRE(str.begin() != str.end());
+        REQUIRE(str.begin() + std.size() == str.end());
     }
 }
 


### PR DESCRIPTION
Don't dereference end() of a string_view.

The test included in this PR will hang in the CI (because a message box pops up), without the fix applied.