### PR TITLE
Fluent: fix disabled LineEdit

### DIFF
--- a/internal/compiler/widgets/fluent-base/lineedit.slint
+++ b/internal/compiler/widgets/fluent-base/lineedit.slint
@@ -47,7 +47,7 @@ export component LineEdit {
         disabled when !root.enabled : {
             i-background.background: FluentPalette.control-disabled;
             i-background.border-color: FluentPalette.border;
-            i-base.color: FluentPalette.text-disabled;
+            i-base.text-color: FluentPalette.text-disabled;
             i-base.selection-foreground-color: FluentPalette.text-on-accent-disabled;
             i-base.placeholder-color: FluentPalette.text-disabled;
         }


### PR DESCRIPTION
The `color` is the Rectangle's deprecated alias to background. I wonder why we don't get a warning though. It was meant to change the text-color