### PR TITLE
LSP: Also close the popup on wasm

### DIFF
--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -276,6 +276,9 @@ pub fn set_preview_factory(
     callback: Box<dyn Fn(ComponentInstance)>,
     design_mode: bool,
 ) {
+    // Ensure that the popup is closed as it is related to the old factory
+    i_slint_core::window::WindowInner::from_pub(ui.window()).close_popup();
+
     let factory = slint::ComponentFactory::new(move |ctx: FactoryContext| {
         let instance = compiled.create_embedded(ctx).unwrap();
         configure_handle_for_design_mode(&instance, design_mode);

--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -350,13 +350,8 @@ pub fn update_preview_area(compiled: slint_interpreter::ComponentDefinition, des
 
         let shared_handle = preview_state.handle.clone();
 
-        let ui = preview_state.ui.as_ref().unwrap();
-
-        // Ensure that the popup is closed as it is related to the old factory
-        i_slint_core::window::WindowInner::from_pub(ui.window()).close_popup();
-
         super::set_preview_factory(
-            ui,
+            preview_state.ui.as_ref().unwrap(),
             compiled,
             Box::new(move |instance| {
                 shared_handle.replace(Some(instance));


### PR DESCRIPTION
Move the code to close the popup in the function that is common with native and wasm 

Amend af34e4f18213dee73f9b5adb240bb180f6243bab