### PR TITLE
Remove Qt license files from windows tool binary packages

### DIFF
--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -58,7 +58,7 @@ jobs:
             cd ..
             cd ..
             cd tools\${{ github.event.inputs.program || inputs.program }}
-            bash -x ../../scripts/prepare_binary_package.sh ..\..\pkg\slint-${{ github.event.inputs.program || inputs.program }} --with-qt
+            bash -x ../../scripts/prepare_binary_package.sh ..\..\pkg\slint-${{ github.event.inputs.program || inputs.program }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Since they don't ship with Qt anymore,
we can remove LICENSE.Qt and QtThirdPartSoftware_Listing.txt.