### PR TITLE
testing: Add a method to the testing interface to query the mocked time

### DIFF
--- a/api/cpp/include/slint_testing.h
+++ b/api/cpp/include/slint_testing.h
@@ -17,6 +17,12 @@ inline void mock_elapsed_time(int64_t time_in_ms)
 {
     cbindgen_private::slint_mock_elapsed_time(time_in_ms);
 }
+
+inline uint64_t get_mocked_time()
+{
+    return cbindgen_private::slint_get_mocked_time();
+}
+
 template<typename Component>
 inline void send_mouse_click(const Component *component, float x, float y)
 {

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -240,6 +240,7 @@ pub fn init_with_event_loop() {
 mod for_unit_test {
     use i_slint_core::api::ComponentHandle;
     use i_slint_core::platform::WindowEvent;
+    pub use i_slint_core::tests::slint_get_mocked_time as get_mocked_time;
     pub use i_slint_core::tests::slint_mock_elapsed_time as mock_elapsed_time;
     use i_slint_core::window::WindowInner;
     use i_slint_core::SharedString;

--- a/internal/core/animations.rs
+++ b/internal/core/animations.rs
@@ -219,6 +219,11 @@ impl Instant {
             .with(|p| p.get().map(|p| p.duration_since_start()))
             .unwrap_or_default()
     }
+
+    /// Return the number of milliseconds this `Instant` is after the backend has started
+    pub fn as_millis(&self) -> u64 {
+        self.0
+    }
 }
 
 /// The AnimationDriver

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -24,6 +24,12 @@ pub extern "C" fn slint_mock_elapsed_time(time_in_ms: u64) {
     crate::timers::TimerList::maybe_activate_timers(tick);
 }
 
+/// Return the current mocked time.
+#[no_mangle]
+pub extern "C" fn slint_get_mocked_time() -> u64 {
+    crate::animations::CURRENT_ANIMATION_DRIVER.with(|driver| driver.current_tick()).as_millis()
+}
+
 /// Simulate a click on a position within the component.
 #[no_mangle]
 pub extern "C" fn slint_send_mouse_click(


### PR DESCRIPTION
I find this helpful when debugging tests using mocked time.