### PR TITLE
Fix lookup relative to the manifest path in .rs file

### DIFF
--- a/internal/compiler/tests/typeloader/dependency_local.slint
+++ b/internal/compiler/tests/typeloader/dependency_local.slint
@@ -3,4 +3,4 @@
 
 import { AnotherType } from "./incpath/dependency_from_incpath.slint";
 
-export SubType := AnotherType {}
+export component SubType inherits AnotherType {}

--- a/internal/compiler/tests/typeloader/incpath/dependency_from_incpath.slint
+++ b/internal/compiler/tests/typeloader/incpath/dependency_from_incpath.slint
@@ -3,4 +3,4 @@
 
 import { SomeRect } from "./local_helper_type.slint";
 
-export AnotherType := SomeRect {}
+export component AnotherType inherits SomeRect {}

--- a/internal/compiler/tests/typeloader/incpath/local_helper_type.slint
+++ b/internal/compiler/tests/typeloader/incpath/local_helper_type.slint
@@ -1,4 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-export SomeRect := Rectangle {}
+export component SomeRect inherits Rectangle {}


### PR DESCRIPTION
For the slint! macro, we need to lookup files in the manifest path. The base_directory function regressed in commit 0ff8e2c. This was not cought by the test because it had falled back to the `pwd` with a warning, as we used to load ressources relative to `pwd` as a fallback.
So also check that there are no warning (meaning updating the rest of the test so that there isn't any warnings)

Fix #4045