### PR TITLE
Update to skia-safe 0.69

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -42,7 +42,7 @@ pin-weak = "1"
 scoped-tls-hkt = "0.1"
 raw-window-handle = { version = "0.5", features = ["std"] }
 
-skia-safe = { version = "0.68.0", features = ["textlayout"] }
+skia-safe = { version = "0.69.0", features = ["textlayout"] }
 glow = { version = "0.13" }
 unicode-segmentation = { version = "1.8.0" }
 
@@ -58,7 +58,7 @@ bytemuck = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["impl-default", "dwrite", "d3d12", "dxgi", "dxgi1_2", "dxgi1_3", "dxgi1_4", "d3d12sdklayers", "synchapi", "winbase"] }
-skia-safe = { version = "0.68.0", features = ["d3d"] }
+skia-safe = { version = "0.69.0", features = ["d3d"] }
 wio = { version = "0.2.2" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -69,10 +69,10 @@ metal = { version = "0.27.0" }
 foreign-types = { version = "0.5.0" }
 objc = { version = "0.2.7" }
 core-graphics-types = { version = "0.1.1" }
-skia-safe = { version = "0.68.0", features = ["metal"] }
+skia-safe = { version = "0.69.0", features = ["metal"] }
 
 [target.'cfg(not(any(target_os = "macos", target_family = "windows")))'.dependencies]
-skia-safe = { version = "0.68.0", features = ["gl"] }
+skia-safe = { version = "0.69.0", features = ["gl"] }
 
 [build-dependencies]
 cfg_aliases = "0.1.0"


### PR DESCRIPTION
This updates Skia to milestone 120. For more details see https://github.com/rust-skia/rust-skia/releases/tag/0.69.0