### PR TITLE
README: Move the MadeWithSlint gallery up right below the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ is derived from our design goals:
 
 We invite you to use Slint and be part of its community.
 
+Visit [#MadeWithSlint](https://madewithslint.com) to view some of the projects
+using Slint and join us in the Slint community.
+
 ## Current Status
 
 Slint is in active development. The state of support for each platform is as
@@ -176,12 +179,6 @@ We have a few tools to help with the development of .slint files:
 
 Please check our [Editors README](./editors/README.md) for tips on how to
 configure your favorite editor to work well with Slint.
-
-## #MadeWithSlint
-
-Visit <https://madewithslint.com> to view some of the projects using Slint.
-Contact us or open a pull request on <https://github.com/slint-ui/madewithslint>
-to add yours.
 
 ## License
 


### PR DESCRIPTION
description

Remove instructions on how to add your project: That is pretty obvious on the website already, so I think it's not needed to repeat it in the project readme.

This was the part we kept discussing in the last PR ;-)

This time the MadeWithSlint link is below the project description. It helps to answer "What is this and what can I do with it?" in that place IMHO.