### PR TITLE
Rust&C++: Fix Return value of complex expression

### DIFF
--- a/internal/compiler/passes/remove_return.rs
+++ b/internal/compiler/passes/remove_return.rs
@@ -158,7 +158,7 @@ fn process_codeblock(
                     value,
                     stmts,
                     has_return_value,
-                    has_value,
+                    !matches!(ty, Type::Void | Type::Invalid),
                 );
             }
         }

--- a/tests/cases/expr/return2.slint
+++ b/tests/cases/expr/return2.slint
@@ -27,6 +27,21 @@ export component StepsFocusScope inherits FocusScope {
 }
 
 
+component Issue4070 {
+    function broken(event: string) -> EventResult {
+        if (event == "a") {  }
+        else if (event == "s") {  }
+        else {
+            debug("returning reject");
+            return reject;
+        }
+        debug("returning accept");
+        accept
+    }
+    out property<bool> test : broken("a") == EventResult.accept;
+}
+
+
 export component TestCase {
 
     function return_false() -> bool { return false; }
@@ -74,7 +89,12 @@ export component TestCase {
 
     }
 
+    i4070 := Issue4070 {}
+
     out property <bool> test: {
+        if (!i4070.test) {
+            return false;
+        }
         if (false) {
             return false;
         }


### PR DESCRIPTION
We were using the has_value of the previous expression of a sequence of expression, instead of using the last expression type to know if there is a value.

Fixes #4070