### PR TITLE
Interpreter: fix panic when a custom enum has the same name as a builtin one

### DIFF
--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1030,11 +1030,15 @@ pub(crate) fn generate_item_tree<'id>(
                             $(
                                 stringify!($Name) => property_info::<i_slint_core::items::$Name>(),
                             )*
-                            _ => property_info::<Value>(),
+                            x => unreachable!("Unknown non-builtin enum {x}"),
                         }
                     }
                 }
-                i_slint_common::for_each_enums!(match_enum_type)
+                if e.node.is_some() {
+                    property_info::<Value>()
+                } else {
+                    i_slint_common::for_each_enums!(match_enum_type)
+                }
             }
             Type::LayoutCache => property_info::<SharedVector<f32>>(),
             Type::Function { .. } => continue,

--- a/tests/cases/types/enums.slint
+++ b/tests/cases/types/enums.slint
@@ -3,11 +3,16 @@
 
 export enum Foo { bli, bla, blu }
 
+// (override the builtin 'InputType')
+export enum InputType { Xxx, Yyy, Zzz }
+
 export component TestCase  {
     in-out property<Foo> foo: Foo.bla;
     in-out property<Foo> default;
 
-    out property <bool> test: foo == Foo.bla && default == Foo.bli;
+    in-out property<InputType> input-type: InputType.Xxx;
+
+    out property <bool> test: foo == Foo.bla && default == Foo.bli && input-type == InputType.Xxx;
 }
 
 /*


### PR DESCRIPTION

As seen in https://github.com/nununoisy/gb-presenter-rs/blob/v0.6.0/src/gui/slint/main.slint#L6