### PR TITLE
Fix panic in the interpreter when using `visible` in a ListView

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1416,7 +1416,7 @@ fn generate_item_tree(
                 static ITEM_ARRAY : sp::OnceBox<
                     [vtable::VOffset<#inner_component_id, ItemVTable, vtable::AllowPin>; #item_array_len]
                 > = sp::OnceBox::new();
-                &*ITEM_ARRAY.get_or_init(|| Box::new([#(#item_array),*]))
+                &*ITEM_ARRAY.get_or_init(|| sp::Box::new([#(#item_array),*]))
             }
 
             #window_adapter_functions

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -127,21 +127,34 @@ impl RepeatedItemTree for ErasedItemTreeBox {
         generativity::make_guard!(guard);
         let s = self.unerase(guard);
 
-        s.description
-            .set_property(s.borrow(), "y", Value::Number(offset_y.get() as f64))
-            .expect("cannot set y");
-        let h: f32 = s
-            .description
-            .get_property(s.borrow(), "height")
-            .expect("missing height")
-            .try_into()
-            .expect("height not the right type");
-        let w: f32 = s
-            .description
-            .get_property(s.borrow(), "width")
-            .expect("missing width")
-            .try_into()
-            .expect("width not the right type");
+        let geom = s.description.original.root_element.borrow().geometry_props.clone().unwrap();
+
+        crate::eval::store_property(
+            s.borrow_instance(),
+            &geom.y.element(),
+            geom.y.name(),
+            Value::Number(offset_y.get() as f64),
+        )
+        .expect("cannot set y");
+
+        let h: f32 = crate::eval::load_property(
+            s.borrow_instance(),
+            &geom.height.element(),
+            geom.height.name(),
+        )
+        .expect("missing height")
+        .try_into()
+        .expect("height not the right type");
+
+        let w: f32 = crate::eval::load_property(
+            s.borrow_instance(),
+            &geom.width.element(),
+            geom.width.name(),
+        )
+        .expect("missing width")
+        .try_into()
+        .expect("width not the right type");
+
         let h = LogicalLength::new(h);
         let w = LogicalLength::new(w);
         *offset_y += h;

--- a/tests/cases/layout/issue_2537_visible_in_listview.slint
+++ b/tests/cases/layout/issue_2537_visible_in_listview.slint
@@ -1,0 +1,46 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+// FIXME: currently the layout is broken, but at least it shouldn't panic
+
+import { ListView } from "std-widgets.slint";
+
+export struct Box {
+    visible: bool,
+}
+
+export component TestCase inherits Window {
+    in property<[Box]> boxes: [{visible: false}, {visible: true}, {visible: false}, { visible: true }];
+    preferred-width: 150px;
+    preferred-height: 150px;
+    out property<int> val;
+    ListView {
+        for box[i] in root.boxes: Rectangle {
+                height: 25px;
+                visible: box.visible;
+                Text { text: i; }
+                TouchArea { clicked => {val*=10;val+=i;}}
+        }
+    }
+
+}
+
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 5., 205.);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 5., 205.);
+```
+
+```js
+var instance = new slint.TestCase();
+slintlib.private_api.send_mouse_click(instance, 5., 205.);
+```
+
+*/

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -37,7 +37,7 @@ fn main() -> std::io::Result<()> {
             write!(
                 output,
                 r"
-#[test] {} fn t_{}() -> Result<(), Box<dyn std::error::Error>> {{
+#[test] {} fn t_{}() -> std::result::Result<(), std::boxed::Box<dyn std::error::Error>> {{
     use i_slint_backend_testing as slint_testing;
     slint_testing::init();
     {}


### PR DESCRIPTION
This doesn't solve the issue #2537, but at least prevent the panic

Drive by change to fix compile when a struct is named `Box`