### PR TITLE
Compiler: Error when assigning to compile time properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project are documented in this file.
    is clicked twice in rapid succession.
  - The `pointer-event` callback in `TouchArea` is now triggered on mouse move
    as well.
- - Error are thrown when trying to modify properties that must be known at compile time
+ - Errors are thrown when trying to modify properties that must be known at compile time.
 
 ## [1.3.2] - 2023-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented in this file.
    is clicked twice in rapid succession.
  - The `pointer-event` callback in `TouchArea` is now triggered on mouse move
    as well.
+ - Error are thrown when trying to modify properties that must be known at compile time
 
 ## [1.3.2] - 2023-12-01
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -345,7 +345,7 @@ export component PopupWindow {
     in property <length> anchor_y;
     in property <length> anchor_height;
     in property <length> anchor_width;*/
-    in property <bool> close-on-click: true;
+    in property <bool> close-on-click: true;  // constexpr hardcoded in typeregister.rs
     //show() is hardcoded in typeregister.rs
 }
 

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1282,7 +1282,14 @@ impl Expression {
                 nr.mark_as_set();
                 let mut lookup = nr.element().borrow().lookup_property(nr.name());
                 lookup.is_local_to_component &= ctx.is_local_element(&nr.element());
-                if lookup.is_valid_for_assignment() {
+                if lookup.property_visibility == PropertyVisibility::Constexpr {
+                    ctx.diag.push_error(
+                        "The property must be known at compile time and cannot be changed at runtime"
+                            .into(),
+                        node,
+                    );
+                    false
+                } else if lookup.is_valid_for_assignment() {
                     if !nr
                         .element()
                         .borrow()

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -402,7 +402,7 @@ impl LookupObject for ElementRc {
             }
         }
         if !matches!(self.borrow().base_type, ElementType::Global) {
-            for (name, ty) in crate::typeregister::reserved_properties() {
+            for (name, ty, _) in crate::typeregister::reserved_properties() {
                 let e = expression_from_reference(
                     NamedReference::new(self, name),
                     &ty,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -441,6 +441,8 @@ pub enum PropertyVisibility {
     Input,
     Output,
     InOut,
+    /// for builtin properties that must be known at compile time and cannot be changed at runtime
+    Constexpr,
     /// For functions, not properties
     Public,
     Protected,
@@ -453,6 +455,7 @@ impl Display for PropertyVisibility {
             PropertyVisibility::Input => f.write_str("input"),
             PropertyVisibility::Output => f.write_str("output"),
             PropertyVisibility::InOut => f.write_str("input output"),
+            PropertyVisibility::Constexpr => f.write_str("constexpr"),
             PropertyVisibility::Public => f.write_str("public"),
             PropertyVisibility::Protected => f.write_str("protected"),
         }

--- a/internal/compiler/tests/syntax/accessibility/accessible_properties.slint
+++ b/internal/compiler/tests/syntax/accessibility/accessible_properties.slint
@@ -5,6 +5,13 @@ Button1 := Rectangle {
     property <bool> cond;
     accessible-role: cond ? button : AccessibleRole.text;
     //               ^error{The `accessible-role` property must be a constant expression}
+
+    rr := Rectangle {
+        init => {
+            self.accessible-role = AccessibleRole.text;
+//          ^error{The property must be known at compile time and cannot be changed at runtime}
+        }
+    }
 }
 
 Button2 := Rectangle {

--- a/internal/compiler/tests/syntax/basic/dialog.slint
+++ b/internal/compiler/tests/syntax/basic/dialog.slint
@@ -36,7 +36,7 @@ MyDiag3 := Dialog {
 
 MyDialog4 := Dialog {
     StandardButton { kind: ok; }
-    Rectangle { dialog-button-role: accept; }
+    r := Rectangle { dialog-button-role: accept; }
     Rectangle { dialog-button-role: none; }
 //                                  ^error{The `dialog-button-role` cannot be set explicitly to none}
     Rectangle { dialog-button-role: true ? accept : reject; }
@@ -44,6 +44,11 @@ MyDialog4 := Dialog {
     Rectangle {
         Rectangle { dialog-button-role: accept; }
 //                                      ^error{dialog-button-role used outside of a Dialog}
+    }
+
+    init => {
+        r.dialog-button-role = DialogButtonRole.action;
+//      ^error{The property must be known at compile time and cannot be changed at runtime}
     }
 }
 

--- a/internal/compiler/tests/syntax/basic/layout2.slint
+++ b/internal/compiler/tests/syntax/basic/layout2.slint
@@ -24,6 +24,11 @@ export X := Rectangle {
 
                 animate x { duration: 100ms; }
 //                      ^error{The property 'x' cannot be set for elements placed in a layout, because the layout is already setting it}
+
+                init => {
+                    self.colspan = 45;
+//                  ^error{The property must be known at compile time and cannot be changed at runtime}
+                }
             }
         }
         Row {

--- a/internal/compiler/tests/syntax/elements/popup.slint
+++ b/internal/compiler/tests/syntax/elements/popup.slint
@@ -2,13 +2,19 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 
-export Bar := Rectangle {
+export component Bar {
     in property <bool> external;
-    PopupWindow {
+    xx := PopupWindow {
         close-on-click: true;
+        init => {
+            xx.close-on-click = true;
+    //      ^error{The property must be known at compile time and cannot be changed at runtime}
+        }
     }
     PopupWindow {
         close-on-click: root.external;
-//                      ^error{The close-on-click property only supports constants at the moment}        
+//                      ^error{The close-on-click property only supports constants at the moment}
     }
+
+
 }

--- a/internal/compiler/tests/syntax/lookup/absolute-position.slint
+++ b/internal/compiler/tests/syntax/lookup/absolute-position.slint
@@ -1,0 +1,17 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component Hello {
+    Rectangle {
+        absolute-position: {x: 45px, y: 78px};
+//      ^error{Cannot assign to output property 'absolute-position'}
+
+    }
+
+    Rectangle {
+        init => {
+            self.absolute-position.x += 45px;
+//          ^error{Self assignment on a output property}
+        }
+    }
+}

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -429,7 +429,7 @@ fn resolve_element_scope(
     if !matches!(element_type, ElementType::Global) {
         result.extend(
             i_slint_compiler::typeregister::reserved_properties()
-                .filter_map(|(k, t)| {
+                .filter_map(|(k, t, _)| {
                     if matches!(t, Type::Function { .. }) {
                         return None;
                     }

--- a/tools/lsp/language/properties.rs
+++ b/tools/lsp/language/properties.rs
@@ -359,6 +359,11 @@ fn get_properties(element: &ElementRc) -> Vec<PropertyInformation> {
             // padding arbitrary items is not yet implemented
             .filter(|x| !x.name.starts_with("padding")),
         );
+        // FIXME: ideally only if parent is a grid layout
+        result.extend(get_reserved_properties(
+            "layout",
+            i_slint_compiler::typeregister::RESERVED_GRIDLAYOUT_PROPERTIES,
+        ));
         result.push(PropertyInformation {
             name: "accessible-role".into(),
             type_name: Type::Enumeration(


### PR DESCRIPTION
Some property need to be known at compile time. We already had checks that the binding is a compile time constant, but there was no check to prevent, say

    self.row = 42;

which wouldn't work or could even cause panic or miscompilation of generated code

Closes #4037