### PR TITLE
C++: Added `ComponentInstance::definition()` getter to retrieve the `ComponentDefinition` for an instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project are documented in this file.
    as well.
  - Errors are thrown when trying to modify properties that must be known at compile time.
 
+### C++
+
+ - Added `ComponentInstance::definition()` getter to retrieve the `ComponentDefinition` for an instance.
+
 ## [1.3.2] - 2023-12-01
 
 ### General

--- a/api/cpp/include/slint-interpreter.h
+++ b/api/cpp/include/slint-interpreter.h
@@ -542,6 +542,8 @@ inline Struct::iterator::~iterator()
     }
 }
 
+class ComponentDefinition;
+
 /// The ComponentInstance represents a running instance of a component.
 ///
 /// You can create an instance with the ComponentDefinition::create() function.
@@ -806,6 +808,9 @@ public:
             return {};
         }
     }
+
+    /// Return the ComponentDefinition that was used to create this instance.
+    inline ComponentDefinition definition() const;
 };
 
 /// ComponentDefinition is a representation of a compiled component from .slint markup.
@@ -819,6 +824,7 @@ public:
 class ComponentDefinition
 {
     friend class ComponentCompiler;
+    friend class ComponentInstance;
 
     using ComponentDefinitionOpaque = slint::cbindgen_private::ComponentDefinitionOpaque;
     ComponentDefinitionOpaque inner;
@@ -924,6 +930,13 @@ public:
         return {};
     }
 };
+
+inline ComponentDefinition ComponentInstance::definition() const
+{
+    cbindgen_private::ComponentDefinitionOpaque result;
+    cbindgen_private::slint_interpreter_component_instance_component_definition(inner(), &result);
+    return ComponentDefinition(result);
+}
 
 /// ComponentCompiler is the entry point to the Slint interpreter that can be used
 /// to load .slint files or compile them on-the-fly from a string

--- a/api/cpp/tests/interpreter.cpp
+++ b/api/cpp/tests/interpreter.cpp
@@ -331,6 +331,13 @@ SCENARIO("Component Definition Properties")
     auto callback_names = comp_def.callbacks();
     REQUIRE(callback_names.size() == 1);
     REQUIRE(callback_names[0] == "dummy");
+
+    auto instance = comp_def.create();
+    ComponentDefinition new_comp_def = instance->definition();
+    auto new_props = new_comp_def.properties();
+    REQUIRE(new_props.size() == 1);
+    REQUIRE(new_props[0].property_name == "test");
+    REQUIRE(new_props[0].property_type == Value::Type::String);
 }
 
 SCENARIO("Component Definition Properties / Two-way bindings")

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -520,6 +520,16 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_create(
     std::ptr::write(out, def.as_component_definition().create().unwrap())
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn slint_interpreter_component_instance_component_definition(
+    inst: &ErasedItemTreeBox,
+    component_definition_ptr: *mut ComponentDefinitionOpaque,
+) {
+    generativity::make_guard!(guard);
+    let definition = ComponentDefinition { inner: inst.unerase(guard).description().into() };
+    std::ptr::write(component_definition_ptr as *mut ComponentDefinition, definition);
+}
+
 #[vtable::vtable]
 #[repr(C)]
 pub struct ModelAdaptorVTable {


### PR DESCRIPTION
Fixes #4087