### PR TITLE
Fix missing types from Node.js API docs

### DIFF
--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -2,19 +2,16 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 import * as napi from "./rust-module.cjs";
-const {
-    Diagnostic,
-    DiagnosticLevel,
-    RgbaColor,
-    Brush
-} = napi;
-
 export {
     Diagnostic,
     DiagnosticLevel,
     RgbaColor,
     Brush
-};
+} from "./rust-module";
+
+import {
+    Diagnostic
+} from "./rust-module.cjs";
 
 /**
  *  Represents a two-dimensional point.


### PR DESCRIPTION
Commit 84fd6dc08cb71b13d5b8f26a2a83405177e5c8b6 changed the import from "rust-module" to "rust-module.cjs", which unfortunately broke typedoc's visibility into the types. Revert back to using the import without extension. With the given tsconfig files that works now and typedoc publishes the docs for the re-exported types again.

Fixes #4153