### PR TITLE
Use raw-window-handle 0.6 for accesskit

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -69,7 +69,7 @@ wasm-bindgen = { version = "0.2" }
 glutin = { workspace = true, optional = true, default-features = false, features = ["egl", "wgl"] }
 glutin-winit = { version = "0.4.2", optional = true, default-features = false, features = ["egl", "wgl"] }
 accesskit = { version = "0.12.1", optional = true }
-accesskit_winit = { version = "0.16.0", optional = true }
+accesskit_winit = { version = "0.17.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # For GL rendering


### PR DESCRIPTION
The new release defaults to using rwh 0.6, which implicitly also enables rhw_06 on winit.