### PR TITLE
Fix wrongly optimized properties with aliases

### DIFF
--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -496,6 +496,12 @@ fn get_property_analysis(elem: &ElementRc, p: &str) -> crate::object_tree::Prope
     let mut a = elem.borrow().property_analysis.borrow().get(p).cloned().unwrap_or_default();
     let mut elem = elem.clone();
     loop {
+        if let Some(d) = elem.borrow().property_declarations.get(p) {
+            if let Some(nr) = &d.is_alias {
+                a.merge(&get_property_analysis(&nr.element(), nr.name()));
+            }
+            return a;
+        }
         let base = elem.borrow().base_type.clone();
         match base {
             ElementType::Native(n) => {

--- a/tests/cases/issues/issue_4072_optimized_alias.slint
+++ b/tests/cases/issues/issue_4072_optimized_alias.slint
@@ -1,0 +1,38 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+component Wrapper inherits Rectangle {
+    border-color: blue;
+    border-width: 1px;
+    in-out property <string> text <=> text.text;
+    callback edited <=> text.edited;
+    text := TextInput {}
+}
+
+
+export component TestCase {
+    width: 50px;
+    height: 50px;
+    in-out property <int> text: 6;
+    callback edited();
+
+    VerticalLayout {
+        Wrapper {
+            text: root.text;
+            edited => {
+                root.text = self.text.to-float();
+            }
+        }
+    }
+}
+
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 25., 25.);
+slint_testing::send_keyboard_char(&instance, '4', true);
+assert_eq!(instance.get_text(), 64);
+```
+
+*/


### PR DESCRIPTION
If we don't see that a native property is modified, it could get inlined and we wouldn't detect changes

Fix #4072