### PR TITLE
Rename WindowRotation to RenderingRotation in the software renderer

### DIFF
--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -27,6 +27,6 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2 = {}
 #ifdef SLINT_FEATURE_EXPERIMENTAL
                     ,
-                    slint::platform::SoftwareRenderer::WindowRotation rotation = {}
+                    slint::platform::SoftwareRenderer::RenderingRotation rotation = {}
 #endif
 );

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -203,8 +203,10 @@ void EspPlatform::run_event_loop()
             if (std::exchange(m_window->needs_redraw, false)) {
                 auto rotated = false
 #ifdef SLINT_FEATURE_EXPERIMENTAL
-                        || rotation == slint::platform::SoftwareRenderer::RenderingRotation::Rotate90
-                        || rotation == slint::platform::SoftwareRenderer::RenderingRotation::Rotate270
+                        || rotation
+                                == slint::platform::SoftwareRenderer::RenderingRotation::Rotate90
+                        || rotation
+                                == slint::platform::SoftwareRenderer::RenderingRotation::Rotate270
 #endif
                         ;
                 auto region =

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -21,7 +21,7 @@ struct EspPlatform : public slint::platform::Platform
                 std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2 = {}
 #ifdef SLINT_FEATURE_EXPERIMENTAL
                 ,
-                slint::platform::SoftwareRenderer::WindowRotation rotation = {}
+                slint::platform::SoftwareRenderer::RenderingRotation rotation = {}
 #endif
                 )
         : size(size),
@@ -50,7 +50,7 @@ private:
     std::span<slint::platform::Rgb565Pixel> buffer1;
     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2;
 #ifdef SLINT_FEATURE_EXPERIMENTAL
-    slint::platform::SoftwareRenderer::WindowRotation rotation;
+    slint::platform::SoftwareRenderer::RenderingRotation rotation;
 #endif
     class EspWindowAdapter *m_window = nullptr;
 
@@ -92,7 +92,7 @@ std::unique_ptr<slint::platform::WindowAdapter> EspPlatform::create_window_adapt
     auto window = std::make_unique<EspWindowAdapter>(buffer_type, size);
     m_window = window.get();
 #ifdef SLINT_FEATURE_EXPERIMENTAL
-    m_window->m_renderer.set_window_rotation(rotation);
+    m_window->m_renderer.set_rendering_rotation(rotation);
 #endif
     return window;
 }
@@ -203,8 +203,8 @@ void EspPlatform::run_event_loop()
             if (std::exchange(m_window->needs_redraw, false)) {
                 auto rotated = false
 #ifdef SLINT_FEATURE_EXPERIMENTAL
-                        || rotation == slint::platform::SoftwareRenderer::WindowRotation::Rotate90
-                        || rotation == slint::platform::SoftwareRenderer::WindowRotation::Rotate270
+                        || rotation == slint::platform::SoftwareRenderer::RenderingRotation::Rotate90
+                        || rotation == slint::platform::SoftwareRenderer::RenderingRotation::Rotate270
 #endif
                         ;
                 auto region =
@@ -283,7 +283,7 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2
 #ifdef SLINT_FEATURE_EXPERIMENTAL
                     ,
-                    slint::platform::SoftwareRenderer::WindowRotation rotation
+                    slint::platform::SoftwareRenderer::RenderingRotation rotation
 #endif
 )
 {

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -608,8 +608,8 @@ public:
 
 #    ifdef SLINT_FEATURE_EXPERIMENTAL
     /// This enum describes the rotation that is applied to the buffer when rendering.
-    /// To be used in set_window_rotation()
-    enum class WindowRotation {
+    /// To be used in set_rendering_rotation()
+    enum class RenderingRotation {
         /// No rotation
         NoRotation = 0,
         /// Rotate 90° to the left
@@ -623,9 +623,9 @@ public:
     /// Set how the window need to be rotated in the buffer.
     ///
     /// This is typically used to implement screen rotation in software
-    void set_window_rotation(WindowRotation rotation)
+    void set_rendering_rotation(RenderingRotation rotation)
     {
-        cbindgen_private::slint_software_renderer_set_window_rotation(inner,
+        cbindgen_private::slint_software_renderer_set_rendering_rotation(inner,
                                                                       static_cast<int>(rotation));
     }
 #    endif

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -625,8 +625,8 @@ public:
     /// This is typically used to implement screen rotation in software
     void set_rendering_rotation(RenderingRotation rotation)
     {
-        cbindgen_private::slint_software_renderer_set_rendering_rotation(inner,
-                                                                      static_cast<int>(rotation));
+        cbindgen_private::slint_software_renderer_set_rendering_rotation(
+                inner, static_cast<int>(rotation));
     }
 #    endif
 };

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -387,17 +387,17 @@ mod software_renderer {
 
     #[cfg(feature = "experimental")]
     #[no_mangle]
-    pub unsafe extern "C" fn slint_software_renderer_set_window_rotation(
+    pub unsafe extern "C" fn slint_software_renderer_set_rendering_rotation(
         r: SoftwareRendererOpaque,
         rotation: i32,
     ) {
-        use i_slint_core::software_renderer::WindowRotation;
+        use i_slint_core::software_renderer::RenderingRotation;
         let renderer = &*(r as *const SoftwareRenderer);
-        renderer.set_window_rotation(match rotation {
-            90 => WindowRotation::Rotate90,
-            180 => WindowRotation::Rotate180,
-            270 => WindowRotation::Rotate270,
-            _ => WindowRotation::NoRotation,
+        renderer.set_rendering_rotation(match rotation {
+            90 => RenderingRotation::Rotate90,
+            180 => RenderingRotation::Rotate180,
+            270 => RenderingRotation::Rotate270,
+            _ => RenderingRotation::NoRotation,
         });
     }
 

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -68,10 +68,10 @@ mod internal {
     use super::*;
     /// This enum describes the rotation that should be applied to the contents rendered by the software renderer.
     ///
-    /// Argument to be passed in [`SoftwareRenderer::set_window_rotation`].
+    /// Argument to be passed in [`SoftwareRenderer::set_rendering_rotation`].
     #[non_exhaustive]
     #[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
-    pub enum WindowRotation {
+    pub enum RenderingRotation {
         /// No rotation
         #[default]
         NoRotation,
@@ -85,11 +85,11 @@ mod internal {
 }
 
 #[cfg(feature = "software-renderer-rotation")]
-pub use internal::WindowRotation;
+pub use internal::RenderingRotation;
 #[cfg(not(feature = "software-renderer-rotation"))]
-use internal::WindowRotation;
+use internal::RenderingRotation;
 
-impl WindowRotation {
+impl RenderingRotation {
     fn is_transpose(self) -> bool {
         matches!(self, Self::Rotate90 | Self::Rotate270)
     }
@@ -102,17 +102,17 @@ impl WindowRotation {
     /// Angle of the rotation in degrees
     fn angle(self) -> f32 {
         match self {
-            WindowRotation::NoRotation => 0.,
-            WindowRotation::Rotate90 => 90.,
-            WindowRotation::Rotate180 => 180.,
-            WindowRotation::Rotate270 => 270.,
+            RenderingRotation::NoRotation => 0.,
+            RenderingRotation::Rotate90 => 90.,
+            RenderingRotation::Rotate180 => 180.,
+            RenderingRotation::Rotate270 => 270.,
         }
     }
 }
 
 #[derive(Copy, Clone)]
 struct RotationInfo {
-    orientation: WindowRotation,
+    orientation: RenderingRotation,
     screen_size: PhysicalSize,
 }
 
@@ -226,7 +226,7 @@ pub struct SoftwareRenderer {
     /// Only used if repaint_buffer_type == RepaintBufferType::SwappedBuffers
     prev_frame_dirty: Cell<DirtyRegion>,
     maybe_window_adapter: RefCell<Option<Weak<dyn crate::window::WindowAdapter>>>,
-    rotation: Cell<WindowRotation>,
+    rotation: Cell<RenderingRotation>,
     rendering_metrics_collector: Option<Rc<RenderingMetricsCollector>>,
 }
 
@@ -278,13 +278,13 @@ impl SoftwareRenderer {
     #[cfg(feature = "software-renderer-rotation")]
     // This API is under a feature flag because it is experimental for now.
     // It should be a property of the Window instead (set via dispatch_event?)
-    pub fn set_window_rotation(&self, rotation: WindowRotation) {
+    pub fn set_rendering_rotation(&self, rotation: RenderingRotation) {
         self.rotation.set(rotation)
     }
 
-    /// Return the current rotation. See [`Self::set_window_rotation()`]
+    /// Return the current rotation. See [`Self::set_rendering_rotation()`]
     #[cfg(feature = "software-renderer-rotation")]
-    pub fn window_rotation(&self) -> WindowRotation {
+    pub fn rendering_rotation(&self) -> RenderingRotation {
         self.rotation.get()
     }
 
@@ -989,7 +989,7 @@ struct SceneTexture<'a> {
     /// The alpha of this color is ignored. (it is supposed to be mixed in `Self::alpha`)
     color: Color,
     alpha: u8,
-    rotation: WindowRotation,
+    rotation: RenderingRotation,
 }
 
 enum SharedBufferData {
@@ -1012,7 +1012,7 @@ struct SharedBufferCommand {
     source_rect: PhysicalRect,
     colorize: Color,
     alpha: u8,
-    rotation: WindowRotation,
+    rotation: RenderingRotation,
 }
 
 impl SharedBufferCommand {
@@ -1305,7 +1305,7 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
         scale_factor: ScaleFactor,
         window: &'a WindowInner,
         processor: T,
-        orientation: WindowRotation,
+        orientation: RenderingRotation,
     ) -> Self {
         Self {
             processor,

--- a/tests/screenshots/testing.rs
+++ b/tests/screenshots/testing.rs
@@ -15,7 +15,7 @@ use i_slint_core::{
     item_rendering::DirtyRegion,
     platform::PlatformError,
     renderer::RendererSealed,
-    software_renderer::{LineBufferProvider, MinimalSoftwareWindow, WindowRotation},
+    software_renderer::{LineBufferProvider, MinimalSoftwareWindow, RenderingRotation},
 };
 
 pub struct SwrTestingBackend {
@@ -58,14 +58,14 @@ pub fn image_buffer(path: &str) -> Result<SharedPixelBuffer<Rgb8Pixel>, image::I
 
 pub fn screenshot(
     window: Rc<MinimalSoftwareWindow>,
-    rotated: WindowRotation,
+    rotated: RenderingRotation,
 ) -> SharedPixelBuffer<Rgb8Pixel> {
     let size = window.size();
     let width = size.width;
     let height = size.height;
 
     let mut buffer = match rotated {
-        WindowRotation::Rotate90 | WindowRotation::Rotate270 => {
+        RenderingRotation::Rotate90 | RenderingRotation::Rotate270 => {
             SharedPixelBuffer::<Rgb8Pixel>::new(height, width)
         }
         _ => SharedPixelBuffer::<Rgb8Pixel>::new(width, height),
@@ -78,9 +78,9 @@ pub fn screenshot(
             Point2D::new(0., 0.),
             Point2D::new(width as f32, height as f32),
         ));
-        renderer.set_window_rotation(rotated);
+        renderer.set_rendering_rotation(rotated);
         renderer.render(buffer.make_mut_slice(), width as usize);
-        renderer.set_window_rotation(WindowRotation::NoRotation);
+        renderer.set_rendering_rotation(RenderingRotation::NoRotation);
     });
 
     buffer
@@ -127,7 +127,7 @@ pub struct TestCaseOptions {
 fn compare_images(
     reference_path: &str,
     screenshot: &SharedPixelBuffer<Rgb8Pixel>,
-    rotated: WindowRotation,
+    rotated: RenderingRotation,
     options: &TestCaseOptions,
 ) -> Result<(), String> {
     let compare = || {
@@ -141,17 +141,20 @@ fn compare_images(
                 screenshot.size()
             ));
         }
-        if reference.as_bytes() == screenshot.as_bytes() && rotated != WindowRotation::NoRotation {
+        if reference.as_bytes() == screenshot.as_bytes() && rotated != RenderingRotation::NoRotation
+        {
             return Ok(());
         }
 
         let idx = |x: u32, y: u32| -> u32 {
             match rotated {
-                WindowRotation::Rotate90 => x * reference.width() + reference.width() - y - 1,
-                WindowRotation::Rotate180 => {
+                RenderingRotation::Rotate90 => x * reference.width() + reference.width() - y - 1,
+                RenderingRotation::Rotate180 => {
                     (reference.height() - y - 1) * reference.width() + reference.width() - x - 1
                 }
-                WindowRotation::Rotate270 => (reference.height() - x - 1) * reference.width() + y,
+                RenderingRotation::Rotate270 => {
+                    (reference.height() - x - 1) * reference.width() + y
+                }
                 _ => y * reference.width() + x,
             }
         };
@@ -164,7 +167,8 @@ fn compare_images(
             )
         };
 
-        let (failed_pixel_count, max_color_difference) = if rotated != WindowRotation::NoRotation {
+        let (failed_pixel_count, max_color_difference) = if rotated != RenderingRotation::NoRotation
+        {
             let mut failure_count = 0usize;
             let mut max_color_difference = 0.0f32;
             for y in 0..screenshot.height() {
@@ -187,7 +191,7 @@ fn compare_images(
             return Ok(());
         }
         let percentage_different = failed_pixel_count * 100 / reference.as_slice().len();
-        if rotated != WindowRotation::NoRotation
+        if rotated != RenderingRotation::NoRotation
             && (percentage_different <= 1 || max_color_difference < options.rotation_threshold)
         {
             return Ok(());
@@ -224,7 +228,7 @@ fn compare_images(
     let result = compare();
 
     if result.is_err()
-        && rotated == WindowRotation::NoRotation
+        && rotated == RenderingRotation::NoRotation
         && std::env::var("SLINT_CREATE_SCREENSHOTS").map_or(false, |var| var == "1")
     {
         eprintln!("saving rendered image as comparison to reference failed");
@@ -247,10 +251,10 @@ pub fn assert_with_render(
     options: &TestCaseOptions,
 ) {
     for rotation in [
-        WindowRotation::NoRotation,
-        WindowRotation::Rotate180,
-        WindowRotation::Rotate90,
-        WindowRotation::Rotate270,
+        RenderingRotation::NoRotation,
+        RenderingRotation::Rotate180,
+        RenderingRotation::Rotate90,
+        RenderingRotation::Rotate270,
     ] {
         let rendering = screenshot(window.clone(), rotation);
         if let Err(reason) = compare_images(path, &rendering, rotation, options) {
@@ -268,7 +272,7 @@ pub fn assert_with_render_by_line(
     let mut rendering = SharedPixelBuffer::<Rgb8Pixel>::new(s.width, s.height);
 
     screenshot_render_by_line(window.clone(), None, &mut rendering);
-    if let Err(reason) = compare_images(path, &rendering, WindowRotation::NoRotation, options) {
+    if let Err(reason) = compare_images(path, &rendering, RenderingRotation::NoRotation, options) {
         panic!("Image comparison failure for line-by-line rendering for {path}: {reason}");
     }
 
@@ -284,7 +288,7 @@ pub fn assert_with_render_by_line(
         ));
     }
     screenshot_render_by_line(window, Some(region.cast()), &mut rendering);
-    if let Err(reason) = compare_images(path, &rendering, WindowRotation::NoRotation, options) {
+    if let Err(reason) = compare_images(path, &rendering, RenderingRotation::NoRotation, options) {
         panic!("Partial rendering image comparison failure for line-by-line rendering for {path}: {reason}");
     }
 }
@@ -316,7 +320,7 @@ pub fn screenshot_render_by_line(
 }
 
 pub fn save_screenshot(path: &str, window: Rc<MinimalSoftwareWindow>) {
-    let buffer = screenshot(window.clone(), WindowRotation::NoRotation);
+    let buffer = screenshot(window.clone(), RenderingRotation::NoRotation);
     image::save_buffer(
         path,
         buffer.as_bytes(),


### PR DESCRIPTION
Same term as we're going to use in the linuxkms backend.