### PR TITLE
Use custom runner to flash and update espflash command

### DIFF
--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -180,8 +180,7 @@ When flashing, with `esplash`, you will be prompted to select a USB port. If thi
 To compile and run the demo:
 
 ```sh
-cargo +esp build -p printerdemo_mcu --target xtensa-esp32s2-none-elf --no-default-features --features=mcu-board-support/esp32-s2-kaluga-1 --release --config examples/mcu-board-support/esp32_s2_kaluga_1/cargo-config.toml
-espflash --monitor target/xtensa-esp32s2-none-elf/release/printerdemo_mcu
+cargo +esp run -p printerdemo_mcu --target xtensa-esp32s2-none-elf --no-default-features --features=mcu-board-support/esp32-s2-kaluga-1 --release --config examples/mcu-board-support/esp32_s2_kaluga_1/cargo-config.toml
 ```
 
 The device needs to be connected with the two USB cables (one for power, one for data)
@@ -191,6 +190,5 @@ The device needs to be connected with the two USB cables (one for power, one for
 To compile and run the demo:
 
 ```sh
-cargo +esp build -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box --release --config examples/mcu-board-support/esp32_s3_box/cargo-config.toml
-espflash --monitor target/xtensa-esp32s3-none-elf/release/printerdemo_mcu
+cargo +esp run -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box --release --config examples/mcu-board-support/esp32_s3_box/cargo-config.toml
 ```

--- a/examples/mcu-board-support/esp32_s2_kaluga_1/cargo-config.toml
+++ b/examples/mcu-board-support/esp32_s2_kaluga_1/cargo-config.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 [target.xtensa-esp32s2-none-elf]
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 
 rustflags = [
     # Enable the atomic codegen option for Xtensa

--- a/examples/mcu-board-support/esp32_s3_box/cargo-config.toml
+++ b/examples/mcu-board-support/esp32_s3_box/cargo-config.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 [target.xtensa-esp32s3-none-elf]
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 rustflags = [
     "-C", "force-frame-pointers",
     "-C", "link-arg=-nostartfiles",


### PR DESCRIPTION
- The `espflash` flashing command was updated after v2.0, you now need to do `espflash flash`
- Use the custom runner instead of using `espflash` on the resulting binary.