### PR TITLE
api: give proper panic message to a function that can panic from bad use

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -706,8 +706,15 @@ mod weak_handle {
         /// some other instance still holds a strong reference and the current thread
         /// is the thread that created this component.
         /// Otherwise, this function panics.
+        #[track_caller]
         pub fn unwrap(&self) -> T {
-            self.upgrade().unwrap()
+            #[cfg(feature = "std")]
+            if std::thread::current().id() != self.thread {
+                panic!(
+                    "Trying to upgrade a Weak from a different thread that the one it belongs to"
+                );
+            }
+            T::from_inner(self.inner.upgrade().expect("The Weak doesn't hold a valid component"))
         }
 
         /// A helper function to allow creation on `component_factory::Component` from

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -711,7 +711,7 @@ mod weak_handle {
             #[cfg(feature = "std")]
             if std::thread::current().id() != self.thread {
                 panic!(
-                    "Trying to upgrade a Weak from a different thread that the one it belongs to"
+                    "Trying to upgrade a Weak from a different thread than the one it belongs to"
                 );
             }
             T::from_inner(self.inner.upgrade().expect("The Weak doesn't hold a valid component"))


### PR DESCRIPTION
Also use `#[track_caller]` as the source location should point to the user's source code as this is where the bug is