### PR TITLE
TextInput: Don't call insert for empty compositing event

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1011,6 +1011,9 @@ impl TextInput {
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) {
+        if text_to_insert.is_empty() {
+            return;
+        }
         self.delete_selection(window_adapter, self_rc);
         let mut text: String = self.text().into();
         let cursor_pos = self.selection_anchor_and_cursor().1;


### PR DESCRIPTION
So that we don't erase selection or call edited unless there is something typed.

Workaround a bug in which plasma/wayland sends many empty ime event:
```
WindowEvent { window_id: WindowId(WindowId(94309690701616)), event: Ime(Preedit("", None)) }
```

Fixes #4184