### PR TITLE
linuxkms: Improve animation and input handling performance

### DIFF
--- a/internal/backends/linuxkms/calloop_backend.rs
+++ b/internal/backends/linuxkms/calloop_backend.rs
@@ -154,7 +154,7 @@ impl i_slint_core::platform::Platform for Backend {
         &self,
     ) -> Result<std::rc::Rc<dyn i_slint_core::window::WindowAdapter>, PlatformError> {
         #[cfg(feature = "libseat")]
-        let device_accessor = |device: &std::path::Path| -> Result<Arc<dyn AsFd>, PlatformError> {
+        let device_accessor = |device: &std::path::Path| -> Result<Rc<dyn AsFd>, PlatformError> {
             let device = self
                 .seat
                 .borrow_mut()
@@ -171,11 +171,11 @@ impl i_slint_core::platform::Platform for Backend {
                 .map_err(|e| format!("Error making device fd non-blocking: {e}"))?;
 
             // Safety: We take ownership of the now shared FD, ... although we should be using libseat's close_device....
-            Ok(Arc::new(unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) }))
+            Ok(Rc::new(unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) }))
         };
 
         #[cfg(not(feature = "libseat"))]
-        let device_accessor = |device: &std::path::Path| -> Result<Arc<dyn AsFd>, PlatformError> {
+        let device_accessor = |device: &std::path::Path| -> Result<Rc<dyn AsFd>, PlatformError> {
             let device = OpenOptions::new()
                 .custom_flags((nix::fcntl::OFlag::O_NOCTTY | nix::fcntl::OFlag::O_CLOEXEC).bits())
                 .read(true)
@@ -183,7 +183,7 @@ impl i_slint_core::platform::Platform for Backend {
                 .open(device)
                 .map_err(|e| format!("Error opening device: {e}"))?;
 
-            Ok(Arc::new(device))
+            Ok(Rc::new(device))
         };
 
         // This could be per-screen, once we support multiple outputs

--- a/internal/backends/linuxkms/calloop_backend.rs
+++ b/internal/backends/linuxkms/calloop_backend.rs
@@ -246,7 +246,7 @@ impl i_slint_core::platform::Platform for Backend {
 
             if let Some(adapter) = self.window.borrow().as_ref() {
                 adapter.register_event_loop(event_loop.handle())?;
-                adapter.render_if_needed(mouse_position_property.as_ref())?;
+                adapter.clone().render_if_needed(mouse_position_property.as_ref())?;
             };
 
             let next_timeout = i_slint_core::platform::duration_until_next_timer_update();

--- a/internal/backends/linuxkms/display.rs
+++ b/internal/backends/linuxkms/display.rs
@@ -17,7 +17,10 @@ pub trait Presenter {
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
     );
     // Present updated front-buffer to the screen
-    fn present(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+    fn present_with_next_frame_callback(
+        &self,
+        ready_for_next_animation_frame: Box<dyn FnOnce()>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }
 
 #[cfg(any(feature = "renderer-skia-opengl", feature = "renderer-femtovg"))]

--- a/internal/backends/linuxkms/display.rs
+++ b/internal/backends/linuxkms/display.rs
@@ -1,9 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+use std::rc::Rc;
+
 use i_slint_core::api::PhysicalSize;
+use i_slint_core::platform::PlatformError;
 
 pub trait Presenter {
+    fn is_ready_to_present(&self) -> bool;
+    fn register_page_flip_handler(
+        self: Rc<Self>,
+        event_loop_handle: crate::calloop_backend::EventLoopHandle,
+    ) -> Result<calloop::RegistrationToken, PlatformError>;
     // Present updated front-buffer to the screen
     fn present(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/internal/backends/linuxkms/display.rs
+++ b/internal/backends/linuxkms/display.rs
@@ -11,7 +11,11 @@ pub trait Presenter {
     fn register_page_flip_handler(
         self: Rc<Self>,
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<calloop::RegistrationToken, PlatformError>;
+    ) -> Result<(), PlatformError>;
+    fn unregister_page_flip_handler(
+        &self,
+        event_loop_handle: crate::calloop_backend::EventLoopHandle,
+    );
     // Present updated front-buffer to the screen
     fn present(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/internal/backends/linuxkms/display.rs
+++ b/internal/backends/linuxkms/display.rs
@@ -12,10 +12,6 @@ pub trait Presenter {
         self: Rc<Self>,
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
     ) -> Result<(), PlatformError>;
-    fn unregister_page_flip_handler(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    );
     // Present updated front-buffer to the screen
     fn present_with_next_frame_callback(
         &self,

--- a/internal/backends/linuxkms/display/egldisplay.rs
+++ b/internal/backends/linuxkms/display/egldisplay.rs
@@ -3,7 +3,7 @@
 
 use std::cell::Cell;
 use std::os::fd::{AsFd, BorrowedFd};
-use std::sync::Arc;
+use std::rc::Rc;
 
 use crate::DeviceOpener;
 use drm::control::Device;
@@ -13,7 +13,7 @@ use i_slint_core::platform::PlatformError;
 
 // Wrapped needed because gbm::Device<T> wants T to be sized.
 #[derive(Clone)]
-pub struct SharedFd(Arc<dyn AsFd>);
+pub struct SharedFd(Rc<dyn AsFd>);
 impl AsFd for SharedFd {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()

--- a/internal/backends/linuxkms/display/egldisplay.rs
+++ b/internal/backends/linuxkms/display/egldisplay.rs
@@ -56,29 +56,45 @@ pub struct EglDisplay {
     gbm_device: gbm::Device<SharedFd>,
     drm_device: SharedFd,
     pub size: PhysicalWindowSize,
+    page_flip_handler_registration_token: RefCell<Option<calloop::RegistrationToken>>,
 }
 
 impl super::Presenter for EglDisplay {
     fn register_page_flip_handler(
         self: Rc<Self>,
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<calloop::RegistrationToken, PlatformError> {
+    ) -> Result<(), PlatformError> {
+        if self.page_flip_handler_registration_token.borrow().is_some() {
+            return Ok(());
+        }
         let self_weak = Rc::downgrade(&self);
-        crate::calloop_backend::FileDescriptorActivityNotifier::new(
-            &event_loop_handle,
-            calloop::Interest::READ,
-            self.gbm_device.0.clone(),
-            Box::new(move || {
-                if let Some(this) = self_weak.upgrade() {
-                    for event in this.gbm_device.receive_events().unwrap() {
-                        if matches!(event, drm::control::Event::PageFlip(..)) {
-                            *this.page_flip_state.borrow_mut() = PageFlipState::ReadyForNextBuffer;
-                            break;
+        *self.page_flip_handler_registration_token.borrow_mut() =
+            Some(crate::calloop_backend::FileDescriptorActivityNotifier::new(
+                &event_loop_handle,
+                calloop::Interest::READ,
+                self.gbm_device.0.clone(),
+                Box::new(move || {
+                    if let Some(this) = self_weak.upgrade() {
+                        for event in this.gbm_device.receive_events().unwrap() {
+                            if matches!(event, drm::control::Event::PageFlip(..)) {
+                                *this.page_flip_state.borrow_mut() =
+                                    PageFlipState::ReadyForNextBuffer;
+                                break;
+                            }
                         }
                     }
-                }
-            }),
-        )
+                }),
+            )?);
+        Ok(())
+    }
+
+    fn unregister_page_flip_handler(
+        &self,
+        event_loop_handle: crate::calloop_backend::EventLoopHandle,
+    ) {
+        if let Some(token) = self.page_flip_handler_registration_token.take() {
+            event_loop_handle.remove(token);
+        }
     }
 
     fn present(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -300,5 +316,6 @@ pub fn try_create_egl_display(
         gbm_device,
         drm_device,
         size: window_size,
+        page_flip_handler_registration_token: RefCell::new(None),
     })
 }

--- a/internal/backends/linuxkms/display/egldisplay.rs
+++ b/internal/backends/linuxkms/display/egldisplay.rs
@@ -100,8 +100,11 @@ impl EglDisplay {
             *self.page_flip_state.borrow_mut() = PageFlipState::InitialBufferPosted;
 
             if let Some(next_animation_frame_callback) = self.next_animation_frame_callback.take() {
+                // We can render the next frame right away, if needed, since we have at least two buffers. The callback
+                // will decide (will check if animation is running). However invoke the callback through the event loop
+                // instead of directly, so that if it decides to set `needs_redraw` to true, the event loop will process it.
                 i_slint_core::timers::Timer::single_shot(
-                    std::time::Duration::from_millis(16),
+                    std::time::Duration::default(),
                     move || {
                         next_animation_frame_callback();
                     },

--- a/internal/backends/linuxkms/display/egldisplay.rs
+++ b/internal/backends/linuxkms/display/egldisplay.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 use std::cell::Cell;
-use std::os::fd::{AsFd, BorrowedFd};
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::rc::Rc;
 
 use crate::DeviceOpener;
@@ -13,7 +13,7 @@ use i_slint_core::platform::PlatformError;
 
 // Wrapped needed because gbm::Device<T> wants T to be sized.
 #[derive(Clone)]
-pub struct SharedFd(Rc<dyn AsFd>);
+pub struct SharedFd(Rc<OwnedFd>);
 impl AsFd for SharedFd {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()

--- a/internal/backends/linuxkms/fullscreenwindowadapter.rs
+++ b/internal/backends/linuxkms/fullscreenwindowadapter.rs
@@ -103,6 +103,15 @@ impl FullscreenWindowAdapter {
                     item_renderer.restore_state();
                 }
             })?;
+
+            if self.window.has_active_animations() {
+                self.needs_redraw.set(true);
+                // Wake up event loop
+                i_slint_core::timers::Timer::single_shot(
+                    std::time::Duration::from_millis(16),
+                    || {},
+                );
+            }
         }
         Ok(())
     }

--- a/internal/backends/linuxkms/fullscreenwindowadapter.rs
+++ b/internal/backends/linuxkms/fullscreenwindowadapter.rs
@@ -31,10 +31,6 @@ pub trait FullscreenRenderer {
         &self,
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
     ) -> Result<(), PlatformError>;
-    fn unregister_page_flip_handler(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    );
 }
 
 pub struct FullscreenWindowAdapter {
@@ -132,13 +128,6 @@ impl FullscreenWindowAdapter {
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
     ) -> Result<(), PlatformError> {
         self.renderer.register_page_flip_handler(event_loop_handle)
-    }
-
-    pub fn unregister_event_loop(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) {
-        self.renderer.unregister_page_flip_handler(event_loop_handle)
     }
 }
 

--- a/internal/backends/linuxkms/fullscreenwindowadapter.rs
+++ b/internal/backends/linuxkms/fullscreenwindowadapter.rs
@@ -29,7 +29,11 @@ pub trait FullscreenRenderer {
     fn register_page_flip_handler(
         &self,
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<Option<calloop::RegistrationToken>, PlatformError>;
+    ) -> Result<(), PlatformError>;
+    fn unregister_page_flip_handler(
+        &self,
+        event_loop_handle: crate::calloop_backend::EventLoopHandle,
+    );
 }
 
 pub struct FullscreenWindowAdapter {
@@ -116,11 +120,18 @@ impl FullscreenWindowAdapter {
         Ok(())
     }
 
-    pub fn register_page_flip_handler(
+    pub fn register_event_loop(
         &self,
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<Option<calloop::RegistrationToken>, PlatformError> {
+    ) -> Result<(), PlatformError> {
         self.renderer.register_page_flip_handler(event_loop_handle)
+    }
+
+    pub fn unregister_event_loop(
+        &self,
+        event_loop_handle: crate::calloop_backend::EventLoopHandle,
+    ) {
+        self.renderer.unregister_page_flip_handler(event_loop_handle)
     }
 }
 

--- a/internal/backends/linuxkms/lib.rs
+++ b/internal/backends/linuxkms/lib.rs
@@ -11,7 +11,7 @@ mod fullscreenwindowadapter;
 use std::os::fd::AsFd;
 
 #[cfg(target_os = "linux")]
-type DeviceOpener<'a> = dyn Fn(&std::path::Path) -> Result<std::sync::Arc<dyn AsFd>, i_slint_core::platform::PlatformError>
+type DeviceOpener<'a> = dyn Fn(&std::path::Path) -> Result<std::rc::Rc<dyn AsFd>, i_slint_core::platform::PlatformError>
     + 'a;
 
 #[cfg(target_os = "linux")]

--- a/internal/backends/linuxkms/lib.rs
+++ b/internal/backends/linuxkms/lib.rs
@@ -8,10 +8,10 @@
 mod fullscreenwindowadapter;
 
 #[cfg(target_os = "linux")]
-use std::os::fd::AsFd;
+use std::os::fd::OwnedFd;
 
 #[cfg(target_os = "linux")]
-type DeviceOpener<'a> = dyn Fn(&std::path::Path) -> Result<std::rc::Rc<dyn AsFd>, i_slint_core::platform::PlatformError>
+type DeviceOpener<'a> = dyn Fn(&std::path::Path) -> Result<std::rc::Rc<OwnedFd>, i_slint_core::platform::PlatformError>
     + 'a;
 
 #[cfg(target_os = "linux")]

--- a/internal/backends/linuxkms/renderer/femtovg.rs
+++ b/internal/backends/linuxkms/renderer/femtovg.rs
@@ -186,7 +186,9 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for FemtoVGRendererAdapt
         &self,
         rotation: RenderingRotation,
         draw_mouse_cursor_callback: &dyn Fn(&mut dyn ItemRenderer),
+        ready_for_next_animation_frame: Box<dyn FnOnce()>,
     ) -> Result<(), PlatformError> {
+        self.egl_display.set_next_animation_frame_callback(ready_for_next_animation_frame);
         self.renderer.render_transformed_with_post_callback(
             rotation.degrees(),
             rotation.translation_after_rotation(self.egl_display.size),

--- a/internal/backends/linuxkms/renderer/femtovg.rs
+++ b/internal/backends/linuxkms/renderer/femtovg.rs
@@ -208,11 +208,4 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for FemtoVGRendererAdapt
     ) -> Result<(), PlatformError> {
         self.egl_display.clone().register_page_flip_handler(event_loop_handle)
     }
-
-    fn unregister_page_flip_handler(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) {
-        self.egl_display.unregister_page_flip_handler(event_loop_handle)
-    }
 }

--- a/internal/backends/linuxkms/renderer/femtovg.rs
+++ b/internal/backends/linuxkms/renderer/femtovg.rs
@@ -203,7 +203,14 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for FemtoVGRendererAdapt
     fn register_page_flip_handler(
         &self,
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<Option<calloop::RegistrationToken>, PlatformError> {
-        Ok(Some(self.egl_display.clone().register_page_flip_handler(event_loop_handle)?))
+    ) -> Result<(), PlatformError> {
+        self.egl_display.clone().register_page_flip_handler(event_loop_handle)
+    }
+
+    fn unregister_page_flip_handler(
+        &self,
+        event_loop_handle: crate::calloop_backend::EventLoopHandle,
+    ) {
+        self.egl_display.unregister_page_flip_handler(event_loop_handle)
     }
 }

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -141,13 +141,4 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SkiaRendererAdapter 
             Ok(())
         }
     }
-
-    fn unregister_page_flip_handler(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) {
-        if let Some(presenter) = self.presenter.as_ref() {
-            presenter.unregister_page_flip_handler(event_loop_handle);
-        }
-    }
 }

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -126,11 +126,20 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SkiaRendererAdapter 
     fn register_page_flip_handler(
         &self,
         event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<Option<calloop::RegistrationToken>, PlatformError> {
+    ) -> Result<(), PlatformError> {
         if let Some(presenter) = self.presenter.as_ref() {
-            Ok(Some(presenter.clone().register_page_flip_handler(event_loop_handle)?))
+            presenter.clone().register_page_flip_handler(event_loop_handle)
         } else {
-            Ok(None)
+            Ok(())
+        }
+    }
+
+    fn unregister_page_flip_handler(
+        &self,
+        event_loop_handle: crate::calloop_backend::EventLoopHandle,
+    ) {
+        if let Some(presenter) = self.presenter.as_ref() {
+            presenter.unregister_page_flip_handler(event_loop_handle);
         }
     }
 }


### PR DESCRIPTION
When an animation is running, we would

a) block while waiting back buffer we rendered into to become the visible front buffer
b) always schedule a 16 ms time to render again, regardless of whether any other time would expire sooner.

Apart from not expiring timers correctly and costing time, it would also mean that any input events that arrive during the blocking wait would not get processed, which sometimes raises a lib input warning.

The patches in this series address this by using a more modern mechanism:

1. After posting a back buffer for display, return straight to the event loop.
2. The DRM FD is added to the poll/select call, so if we get activity on it, we'll process the page flip events and re-render if needed (animation is running).
3. Meanwhile, any lib input events will still be processed.