### PR TITLE
Parser: Hint for the mod function when parsing `%`

### DIFF
--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -134,6 +134,12 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
         parse_expression_helper(&mut *p, OperatorPrecedence::Mul);
     }
 
+    if p.nth(0).kind() == SyntaxKind::Percent {
+        p.error("Unexpected '%'. For the unit, it should be attached to the number. If you're looking for the modulo operator, use the 'Math.mod(x, y)' function");
+        p.consume();
+        return false;
+    }
+
     if precedence >= OperatorPrecedence::Add {
         return true;
     }

--- a/internal/compiler/tests/syntax/expressions/percent2.slint
+++ b/internal/compiler/tests/syntax/expressions/percent2.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+component Foo {
+
+    property <int> abc: 45 %;
+    //                     ^error{Unexpected '%'. For the unit, it should be attached to the number. If you're looking for the modulo operator, use the 'Math.mod\(x, y\)' function}
+
+    property <int> def: abc % 8;
+    //                      ^error{Unexpected '%'. For the unit, it should be attached to the number. If you're looking for the modulo operator, use the 'Math.mod\(x, y\)' function}
+    //                        ^^error{Parse error}
+}


### PR DESCRIPTION
Was reported several times:
 - https://github.com/slint-ui/slint/discussions/4190
 - https://github.com/slint-ui/slint/issues/3980