### PR TITLE
Fix Switch element in Cupertino & Fluent style not showing text when font size is large

### DIFF
--- a/internal/compiler/widgets/cupertino-base/switch.slint
+++ b/internal/compiler/widgets/cupertino-base/switch.slint
@@ -25,7 +25,7 @@ export component Switch {
     }
 
     min-width: 26px;
-    min-height: 15px;
+    min-height: max(15px, i-layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 0;
     accessible-label: root.text;

--- a/internal/compiler/widgets/fluent-base/switch.slint
+++ b/internal/compiler/widgets/fluent-base/switch.slint
@@ -24,7 +24,7 @@ export component Switch {
     }
 
     min-width: 40px;
-    min-height: 20px;
+    min-height: max(20px, i-layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 0;
     accessible-label: root.text;


### PR DESCRIPTION
Take the minimum height of the layout into account, like in the material style implementation.

Fixes #4201