### PR TITLE
Wrap all non-test uses of  in a BufWriter/BufReader for efficiency

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -2,21 +2,25 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 use anyhow::Context;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::iter::Extend;
 use std::path::{Path, PathBuf};
 
 // cSpell: ignore compat constexpr corelib deps sharedvector pathdata
 
 fn enums(path: &Path) -> anyhow::Result<()> {
-    let mut enums_priv = std::fs::File::create(path.join("slint_enums_internal.h"))
-        .context("Error creating slint_enums_internal.h file")?;
+    let mut enums_priv = BufWriter::new(
+        std::fs::File::create(path.join("slint_enums_internal.h"))
+            .context("Error creating slint_enums_internal.h file")?,
+    );
     writeln!(enums_priv, "#pragma once")?;
     writeln!(enums_priv, "// This file is auto-generated from {}", file!())?;
     writeln!(enums_priv, "#include \"slint_enums.h\"")?;
     writeln!(enums_priv, "namespace slint::cbindgen_private {{")?;
-    let mut enums_pub = std::fs::File::create(path.join("slint_enums.h"))
-        .context("Error creating slint_enums.h file")?;
+    let mut enums_pub = BufWriter::new(
+        std::fs::File::create(path.join("slint_enums.h"))
+            .context("Error creating slint_enums.h file")?,
+    );
     writeln!(enums_pub, "#pragma once")?;
     writeln!(enums_pub, "// This file is auto-generated from {}", file!())?;
     writeln!(enums_pub, "namespace slint {{")?;
@@ -81,14 +85,18 @@ namespace slint::platform::key_codes {{
 }
 
 fn builtin_structs(path: &Path) -> anyhow::Result<()> {
-    let mut structs_pub = std::fs::File::create(path.join("slint_builtin_structs.h"))
-        .context("Error creating slint_builtin_structs.h file")?;
+    let mut structs_pub = BufWriter::new(
+        std::fs::File::create(path.join("slint_builtin_structs.h"))
+            .context("Error creating slint_builtin_structs.h file")?,
+    );
     writeln!(structs_pub, "#pragma once")?;
     writeln!(structs_pub, "// This file is auto-generated from {}", file!())?;
     writeln!(structs_pub, "namespace slint {{")?;
 
-    let mut structs_priv = std::fs::File::create(path.join("slint_builtin_structs_internal.h"))
-        .context("Error creating slint_builtin_structs_internal.h file")?;
+    let mut structs_priv = BufWriter::new(
+        std::fs::File::create(path.join("slint_builtin_structs_internal.h"))
+            .context("Error creating slint_builtin_structs_internal.h file")?,
+    );
     writeln!(structs_priv, "#pragma once")?;
     writeln!(structs_priv, "// This file is auto-generated from {}", file!())?;
     writeln!(structs_priv, "#include \"slint_builtin_structs.h\"")?;

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -52,7 +52,7 @@ compile_error!(
 
 use std::collections::HashMap;
 use std::env;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use i_slint_compiler::diagnostics::BuildDiagnostics;
@@ -355,7 +355,7 @@ pub fn compile_with_config(
         );
 
     let file = std::fs::File::create(&output_file_path).map_err(CompileError::SaveError)?;
-    let mut code_formatter = CodeFormatter::new(file);
+    let mut code_formatter = CodeFormatter::new(BufWriter::new(file));
     let generated = i_slint_compiler::generator::rust::generate(&doc);
 
     for x in &diag.all_loaded_files {

--- a/internal/compiler/build.rs
+++ b/internal/compiler/build.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 use std::fs::read_dir;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 fn main() -> std::io::Result<()> {
@@ -14,7 +14,7 @@ fn main() -> std::io::Result<()> {
     let output_file_path = Path::new(&std::env::var_os("OUT_DIR").unwrap())
         .join(Path::new("included_library").with_extension("rs"));
 
-    let mut file = std::fs::File::create(&output_file_path)?;
+    let mut file = BufWriter::new(std::fs::File::create(&output_file_path)?);
     write!(
         file,
         r#"

--- a/tools/fmt/main.rs
+++ b/tools/fmt/main.rs
@@ -17,7 +17,7 @@
 
 use i_slint_compiler::diagnostics::BuildDiagnostics;
 use i_slint_compiler::parser::{syntax_nodes, SyntaxNode};
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use clap::Parser;
@@ -43,7 +43,7 @@ fn main() -> std::io::Result<()> {
         let source = std::fs::read_to_string(&path)?;
 
         if args.inline {
-            let file = std::fs::File::create(&path)?;
+            let file = BufWriter::new(std::fs::File::create(&path)?);
             process_file(source, path, file)?
         } else {
             process_file(source, path, std::io::stdout())?

--- a/tools/updater/main.rs
+++ b/tools/updater/main.rs
@@ -11,7 +11,7 @@ use i_slint_compiler::object_tree::{self, Component, Document, ElementRc};
 use i_slint_compiler::parser::{syntax_nodes, NodeOrToken, SyntaxKind, SyntaxNode};
 use i_slint_compiler::typeloader::TypeLoader;
 use std::cell::RefCell;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::rc::Rc;
 
@@ -50,7 +50,7 @@ fn main() -> std::io::Result<()> {
         let source = std::fs::read_to_string(path)?;
 
         if args.inline {
-            let file = std::fs::File::create(path)?;
+            let file = BufWriter::new(std::fs::File::create(path)?);
             process_file(source, path, file, &args)?
         } else {
             process_file(source, path, std::io::stdout(), &args)?

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -9,6 +9,7 @@ use slint_interpreter::{
     ComponentDefinition, ComponentHandle, ComponentInstance, SharedString, Value,
 };
 use std::collections::HashMap;
+use std::io::{BufReader, BufWriter};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -153,7 +154,7 @@ fn main() -> Result<()> {
         if data_path == std::path::Path::new("-") {
             serde_json::to_writer_pretty(std::io::stdout(), &obj)?;
         } else {
-            serde_json::to_writer_pretty(std::fs::File::create(data_path)?, &obj)?;
+            serde_json::to_writer_pretty(BufWriter::new(std::fs::File::create(data_path)?), &obj)?;
         }
     }
 
@@ -296,7 +297,7 @@ fn load_data(
     let json: serde_json::Value = if data_path == std::path::Path::new("-") {
         serde_json::from_reader(std::io::stdin())?
     } else {
-        serde_json::from_reader(std::fs::File::open(data_path)?)?
+        serde_json::from_reader(BufReader::new(std::fs::File::open(data_path)?))?
     };
 
     let types = c.properties_and_callbacks().collect::<HashMap<_, _>>();

--- a/xtask/src/slintdocs.rs
+++ b/xtask/src/slintdocs.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use std::ffi::OsString;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<()> {
@@ -142,7 +142,8 @@ pub fn generate_enum_docs() -> Result<(), Box<dyn std::error::Error>> {
     let root = super::root_dir();
 
     let path = root.join("docs/reference/src/language/builtins/enums.md");
-    let mut file = std::fs::File::create(&path).context(format!("error creating {path:?}"))?;
+    let mut file =
+        BufWriter::new(std::fs::File::create(&path).context(format!("error creating {path:?}"))?);
 
     file.write_all(
         br#"<!-- Generated with `cargo xtask slintdocs` from internal/commons/enums.rs -->
@@ -226,7 +227,8 @@ This structure represents a point with x and y coordinate\n
     let root = super::root_dir();
 
     let path = root.join("docs/reference/src/language/builtins/structs.md");
-    let mut file = std::fs::File::create(&path).context(format!("error creating {path:?}"))?;
+    let mut file =
+        BufWriter::new(std::fs::File::create(&path).context(format!("error creating {path:?}"))?);
 
     file.write_all(
         br#"<!-- Generated with `cargo xtask slintdocs` from internal/common/builtin_structs.rs -->


### PR DESCRIPTION
This PR improves performance by buffering all uses of `std::fs::File` outside tests. Note that files are not buffered by default in Rust.