### PR TITLE
Fix compiler panic when using `%` size in a flickable

### DIFF
--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -280,10 +280,10 @@ fn fix_percent_size(
     }
     let mut b = binding.borrow_mut();
     if let Some(parent) = parent {
-        debug_assert_eq!(
+        debug_assert!(matches!(
             parent.borrow().lookup_property(property).property_type,
-            Type::LogicalLength
-        );
+            Type::LogicalLength | Type::Invalid
+        ));
         let fill =
             matches!(b.expression, Expression::NumberLiteral(x, _) if (x - 100.).abs() < 0.001);
         b.expression = Expression::BinaryExpression {

--- a/tests/cases/issues/issue_4163_flickable_parent_percent.slint
+++ b/tests/cases/issues/issue_4163_flickable_parent_percent.slint
@@ -1,0 +1,61 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { ListView } from "std-widgets.slint";
+
+component ShowResult inherits Rectangle {
+    width: 50%;
+    height: 100%;
+
+    VerticalLayout {
+        ListView {
+            for file[idx] in [1,2,3]:Rectangle {
+                height: 20px;
+                // width: parent.width;    // change to this line compiles fine
+                width: 100%;  // An error occurred!!!
+            }
+        }
+    }
+}
+export component TestCase inherits Window {
+    width: 326px;
+    height: 326px;
+
+    HorizontalLayout {
+        width: 100%;
+        height: 100%;
+
+        ShowResult {}
+    }
+
+
+    fli := Flickable {
+        viewport-height: 1000px;
+        viewport-width: 2000px;
+        rec := Rectangle {
+            width: 100%;
+            height: parent.height;
+        }
+    }
+
+    out property <bool> test:
+        // The % applies to the viewport
+        rec.width == 2000px &&
+        // While the parent applies to the flickable
+        rec.height == 326px;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+*/

--- a/tests/cases/issues/issue_4163_flickable_parent_percent.slint
+++ b/tests/cases/issues/issue_4163_flickable_parent_percent.slint
@@ -18,7 +18,7 @@ component ShowResult inherits Rectangle {
     }
 }
 export component TestCase inherits Window {
-    width: 326px;
+    width: 300px;
     height: 326px;
 
     HorizontalLayout {
@@ -39,9 +39,7 @@ export component TestCase inherits Window {
     }
 
     out property <bool> test:
-        // The % applies to the viewport
-        rec.width == 2000px &&
-        // While the parent applies to the flickable
+        rec.width == 300px &&
         rec.height == 326px;
 }
 


### PR DESCRIPTION
The viewport of a flickable is of ElementType::Native, and `lookup_property` don't query the builtin reserved properties in that case.

This commit fix the assert by allowing Type::Invalid as well.

Fixes #4163