### PR TITLE
LSP preview: workaround the resize handler not working

### DIFF
--- a/tools/lsp/ui/resizer.slint
+++ b/tools/lsp/ui/resizer.slint
@@ -37,7 +37,9 @@ export component Resizer {
         @children
     }
 
-    if root.is-resizable: Rectangle {
+    Rectangle {
+        visible: is-resizable;
+
         ResizeHandle { // N
             resize(x-offset, y-offset) => { root.resize(root.width, y-offset * -1.0 + root.height); }
             mouse-cursor: MouseCursor.n-resize;


### PR DESCRIPTION
If resizing makes the value of is-resizable dirty, we would hit issue #3953 and the handle would be re-created and the drag operation aborted