### PR TITLE
Fix missing font fallback handling on Windows when pre-rendering glyphs for the software renderer

### DIFF
--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -300,15 +300,10 @@ fn get_fallback_fonts(fontdb: &sharedfontdb::FontDatabase) -> Vec<fontdue::Font>
 
     #[cfg(target_family = "windows")]
     {
-        fallback_families = [
-            "Segoe UI Emoji",
-            "Segoe UI Symbol",
-            "Arial",
-            "Wingdings",
-        ]
-        .into_iter()
-        .map(Into::into)
-        .collect::<Vec<String>>();
+        fallback_families = ["Segoe UI Emoji", "Segoe UI Symbol", "Arial", "Wingdings"]
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<String>>();
     }
 
     #[cfg(not(any(

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -298,6 +298,19 @@ fn get_fallback_fonts(fontdb: &sharedfontdb::FontDatabase) -> Vec<fontdue::Font>
             .collect::<Vec<String>>();
     }
 
+    #[cfg(target_family = "windows")]
+    {
+        fallback_families = [
+            "Segoe UI Emoji",
+            "Segoe UI Symbol",
+            "Arial",
+            "Wingdings",
+        ]
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<String>>();
+    }
+
     #[cfg(not(any(
         target_family = "windows",
         target_os = "macos",


### PR DESCRIPTION
Add some symbol/emoji fonts for Windows, next to the existing options for macOS and Linux.