### PR TITLE
winit: Fix `FocusScope`'s `key-released` not being invoked when releasing the space bar key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project are documented in this file.
 ### General
 
 - LinuxKMS backend: Added support rendering output rotation via the `SLINT_KMS_ROTATION` environment variable.
-
+- Winit backend: Fixed `key-released` in `FocusScope` not being invoked when releasing the space bar key.
+- 
 ### Slint Language
 
  - Fixed wrong text input in cupertino SpinBox

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -302,6 +302,9 @@ impl EventLoopState {
                     match key_code {
                         $($(winit::keyboard::Key::Named(winit::keyboard::NamedKey::$winit) $(if event.location == winit::keyboard::KeyLocation::$pos)? => $char.into(),)*)*
                         winit::keyboard::Key::Character(str) => str.as_str().into(),
+                        // Space is handled separately: When pressed, event.text would be Some(" ") and all is well. But when released,
+                        // event.text is always empty, so we'd never produce a release event.
+                        winit::keyboard::Key::Named(winit::keyboard::NamedKey::Space) => " ".into(),
                         _ => {
                             if let Some(text) = &event.text {
                                 text.as_str().into()


### PR DESCRIPTION
Upon pressing, event.text is set and all is well. But when the space bar is released, event.text is always empty and we would not dispatch an event.