### PR TITLE
Enable Skia renderer for C++ package

### DIFF
--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -49,7 +49,7 @@ jobs:
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
         cmakeListsTxtPath: CMakeLists.txt
-        cmakeAppendedArgs: '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+        cmakeAppendedArgs: '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DSLINT_FEATURE_RENDERER_SKIA=ON'
         buildDirectory: ${{ runner.workspace }}/cppbuild
         buildWithCMakeArgs: '--config Release'
     - name: cpack


### PR DESCRIPTION
It's not enabled by default due to complicated build setup but on GitHub Actions it works.