### PR TITLE
Slintpad: resize the cansvas after showing the UI

### DIFF
--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -164,7 +164,11 @@ function getPreviewHtml(
         }
     });
 
-    preview_connector.show_ui().then(() => vscode.postMessage({ command: 'preview_ready' }));
+    preview_connector.show_ui().then(() => {
+        canvas.style.width = "100%";
+        canvas.style.height = "100%";
+        vscode.postMessage({ command: 'preview_ready' });
+    });
 
     </script>
 </head>

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -25,11 +25,6 @@ export class PreviewWidget extends Widget {
         canvas.style.height = "100%";
         canvas.style.outline = "none";
         canvas.style.touchAction = "none";
-        canvas.width = canvas.offsetWidth;
-        canvas.height = canvas.offsetHeight;
-
-        canvas.dataset.slintAutoResizeToPreferred = "false";
-
         node.appendChild(canvas);
 
         return node;
@@ -56,6 +51,9 @@ export class PreviewWidget extends Widget {
             // when searching the document.
             this.#previewer.show_ui().then(() => {
                 console.info("UI should be up!");
+                const canvas = document.getElementById(canvas_id) as HTMLCanvasElement;
+                canvas.style.width = "100%";
+                canvas.style.height = "100%";
             });
         });
     }

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -51,7 +51,7 @@ export class PreviewWidget extends Widget {
             // when searching the document.
             this.#previewer.show_ui().then(() => {
                 console.info("UI should be up!");
-                const canvas = document.getElementById(canvas_id) as HTMLCanvasElement;
+                const canvas = document.getElementById(canvas_id) as HTMLElement;
                 canvas.style.width = "100%";
                 canvas.style.height = "100%";
             });


### PR DESCRIPTION
Right now, the winit window adaptor will force a px value on the width and height once the ui is up.
We should then override that again with 100% after the UI is shown