### PR TITLE
Bump AccessKit dependencies

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -68,8 +68,8 @@ wasm-bindgen = { version = "0.2" }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { workspace = true, optional = true, default-features = false, features = ["egl", "wgl"] }
 glutin-winit = { version = "0.4.2", optional = true, default-features = false, features = ["egl", "wgl"] }
-accesskit = { version = "0.12.1", optional = true }
-accesskit_winit = { version = "0.17.0", optional = true }
+accesskit = { version = "0.12.2", optional = true }
+accesskit_winit = { version = "0.18.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # For GL rendering


### PR DESCRIPTION
This brings lazy initialization of the accesskit adapter on Linux/dbus.

cc #3867