### PR TITLE
Skia: Clean up pre present notify callback API

### DIFF
--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -546,7 +546,7 @@ pub mod skia {
     #[no_mangle]
     pub unsafe extern "C" fn slint_skia_renderer_render(r: SkiaRendererOpaque) {
         let r = &*(r as *const SkiaRenderer);
-        r.render(None).unwrap();
+        r.render().unwrap();
     }
 
     #[no_mangle]

--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -118,7 +118,7 @@ impl i_slint_core::platform::Platform for AndroidPlatform {
                 return Ok(());
             }
             if self.window.pending_redraw.take() && self.app.native_window().is_some() {
-                self.window.renderer.render(None)?;
+                self.window.renderer.render()?;
             }
         }
     }
@@ -282,7 +282,7 @@ impl AndroidWindowAdapter {
             }
             PollEvent::Main(MainEvent::RedrawNeeded { .. }) => {
                 self.pending_redraw.set(false);
-                self.renderer.render(None)?;
+                self.renderer.render()?;
             }
             PollEvent::Main(MainEvent::GainedFocus) => {
                 self.window.dispatch_event(WindowEvent::WindowActiveChanged(true));

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -149,7 +149,7 @@ impl SwapChain {
     fn render_and_present<T>(
         &mut self,
         callback: impl FnOnce(&mut skia_safe::Surface, &mut skia_safe::gpu::DirectContext) -> T,
-        pre_present_callback: Option<Box<dyn FnOnce()>>,
+        pre_present_callback: &RefCell<Option<Box<dyn FnMut()>>>,
     ) -> Result<T, PlatformError> {
         let current_fence_value = self.fence_values[self.current_buffer_index];
 
@@ -170,7 +170,7 @@ impl SwapChain {
         );
         self.gr_context.submit(None);
 
-        if let Some(pre_present_callback) = pre_present_callback {
+        if let Some(pre_present_callback) = pre_present_callback.borrow_mut().as_mut() {
             pre_present_callback();
         }
 
@@ -449,7 +449,7 @@ impl super::Surface for D3DSurface {
         &self,
         _size: PhysicalWindowSize,
         callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
-        pre_present_callback: Option<Box<dyn FnOnce()>>,
+        pre_present_callback: &RefCell<Option<Box<dyn FnMut()>>>,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         self.swap_chain.borrow_mut().render_and_present(
             |surface, gr_context| callback(surface.canvas(), Some(gr_context)),

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -82,7 +82,7 @@ impl super::Surface for MetalSurface {
         &self,
         _size: PhysicalWindowSize,
         callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
-        pre_present_callback: Option<Box<dyn FnOnce()>>,
+        pre_present_callback: &RefCell<Option<Box<dyn FnMut()>>>,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         autoreleasepool(|| {
             let drawable = match self.layer.next_drawable() {
@@ -125,7 +125,7 @@ impl super::Surface for MetalSurface {
 
             gr_context.submit(None);
 
-            if let Some(pre_present_callback) = pre_present_callback {
+            if let Some(pre_present_callback) = pre_present_callback.borrow_mut().as_mut() {
                 pre_present_callback();
             }
 

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -127,7 +127,7 @@ impl super::Surface for OpenGLSurface {
         &self,
         size: PhysicalWindowSize,
         callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
-        pre_present_callback: Option<Box<dyn FnOnce()>>,
+        pre_present_callback: &RefCell<Option<Box<dyn FnMut()>>>,
     ) -> Result<(), PlatformError> {
         self.ensure_context_current()?;
 
@@ -158,7 +158,7 @@ impl super::Surface for OpenGLSurface {
         callback(skia_canvas, Some(gr_context));
         skia_canvas.restore();
 
-        if let Some(pre_present_callback) = pre_present_callback {
+        if let Some(pre_present_callback) = pre_present_callback.borrow_mut().as_mut() {
             pre_present_callback();
         }
 

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -44,7 +44,7 @@ impl super::Surface for SoftwareSurface {
         &self,
         size: PhysicalWindowSize,
         callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
-        pre_present_callback: Option<Box<dyn FnOnce()>>,
+        pre_present_callback: &RefCell<Option<Box<dyn FnMut()>>>,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         let Some((width, height)) = size.width.try_into().ok().zip(size.height.try_into().ok())
         else {
@@ -77,7 +77,7 @@ impl super::Surface for SoftwareSurface {
 
         callback(surface_borrow.canvas(), None);
 
-        if let Some(pre_present_callback) = pre_present_callback {
+        if let Some(pre_present_callback) = pre_present_callback.borrow_mut().as_mut() {
             pre_present_callback();
         }
 

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -238,7 +238,7 @@ impl super::Surface for VulkanSurface {
         &self,
         size: PhysicalWindowSize,
         callback: &dyn Fn(&skia_safe::Canvas, Option<&mut skia_safe::gpu::DirectContext>),
-        pre_present_callback: Option<Box<dyn FnOnce()>>,
+        pre_present_callback: &RefCell<Option<Box<dyn FnMut()>>>,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         let gr_context = &mut self.gr_context.borrow_mut();
 
@@ -340,7 +340,7 @@ impl super::Surface for VulkanSurface {
 
         gr_context.submit(None);
 
-        if let Some(pre_present_callback) = pre_present_callback {
+        if let Some(pre_present_callback) = pre_present_callback.borrow_mut().as_mut() {
             pre_present_callback();
         }
 


### PR DESCRIPTION
Move this back out of render() again and make it stateful in the renderer. Reduces the amount of book-keeping required and it's always the same callback anyway.