### PR TITLE
Fix PopupWindow close behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to this project are documented in this file.
 
 - LinuxKMS backend: Added support rendering output rotation via the `SLINT_KMS_ROTATION` environment variable.
 - Winit backend: Fixed `key-released` in `FocusScope` not being invoked when releasing the space bar key.
-- 
+- Fix `PopupWindow` close behavior: Close on release when the mouse is on the popup, and close on press when
+  it's outside - to match standard behavior.
+
 ### Slint Language
 
  - Fixed wrong text input in cupertino SpinBox

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -145,7 +145,7 @@ cpp! {{
             if (auto p = dynamic_cast<const SlintWidget*>(parent())) {
                 void *parent_window = p->rust_window;
                 bool close_popup = rust!(Slint_mouseReleaseEventPopup [parent_window: &QtWindow as "void*"] -> bool as "bool" {
-                    parent_window.close_popup_after_click()
+                    parent_window.close_popup_on_click()
                 });
                 if (close_popup) {
                     parent_of_popup_to_close = parent_window;
@@ -1513,8 +1513,8 @@ impl QtWindow {
         WindowInner::from_pub(&self.window).close_popup();
     }
 
-    fn close_popup_after_click(&self) -> bool {
-        WindowInner::from_pub(&self.window).close_popup_after_click()
+    fn close_popup_on_click(&self) -> bool {
+        WindowInner::from_pub(&self.window).close_popup_on_click()
     }
 }
 

--- a/tests/cases/elements/popupwindow_close.slint
+++ b/tests/cases/elements/popupwindow_close.slint
@@ -9,6 +9,8 @@ export component TestCase {
     in-out property <int> click-count;
     in-out property <int> popup-selector: 0;
     in-out property <int> popup-clicked;
+    out property <length> last-underneath-mouse-x: ta.mouse-x;
+    out property <length> last-underneath-mouse-y: ta.mouse-y;
 
     callback do-close;
     do-close => {
@@ -73,7 +75,7 @@ export component TestCase {
         }
     }
 
-    TouchArea {
+    ta := TouchArea {
         clicked => {
             root.click-count = root.click-count + 1;
             if (root.popup-selector == 0) {
@@ -92,6 +94,8 @@ export component TestCase {
 /*
 
 ```rust
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
+
 let instance = TestCase::new().unwrap();
 
 assert_eq!(instance.get_click_count(), 0);
@@ -106,10 +110,44 @@ assert_eq!(instance.get_click_count(), 1);
 assert_eq!(instance.get_popup_created(), true);
 assert_eq!(instance.get_popup_clicked(), 0);
 
-
 // Click to close
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq!(instance.get_click_count(), 1);
+// Subsequent click to verify that it was closed
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq!(instance.get_click_count(), 2);
+assert_eq!(instance.get_popup_clicked(), 1);
+
+// --------- Default popup but verify closed on press when outside
+instance.set_popup_selector(0);
+instance.set_popup_created(false);
+instance.set_click_count(0);
+
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq!(instance.get_last_underneath_mouse_x(), 15.);
+assert_eq!(instance.get_last_underneath_mouse_y(), 15.);
+assert_eq!(instance.get_click_count(), 1);
+assert_eq!(instance.get_popup_created(), true);
+assert_eq!(instance.get_popup_clicked(), 1);
+
+// mouse grabbed, underneath won't notice
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(1.0, 1.0) });
+assert_eq!(instance.get_last_underneath_mouse_x(), 15.);
+assert_eq!(instance.get_last_underneath_mouse_y(), 15.);
+
+// press should close
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(1.0, 1.0), button: PointerEventButton::Left });
+
+// if it was closed, the underneath should receive the move event
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(12.0, 12.0) });
+assert_eq!(instance.get_last_underneath_mouse_x(), 12.);
+assert_eq!(instance.get_last_underneath_mouse_y(), 12.);
+
+slint_testing::mock_elapsed_time(50);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(12.0, 12.0), button: PointerEventButton::Left });
+
+assert_eq!(instance.get_click_count(), 1);
+
 // Subsequent click to verify that it was closed
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq!(instance.get_click_count(), 2);
@@ -119,6 +157,7 @@ assert_eq!(instance.get_popup_clicked(), 1);
 instance.set_popup_selector(1);
 instance.set_popup_created(false);
 instance.set_click_count(0);
+
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq!(instance.get_click_count(), 1);
 assert_eq!(instance.get_popup_created(), true);
@@ -183,43 +222,110 @@ const TestCase &instance = *handle;
 assert_eq(instance.get_click_count(), 0);
 assert_eq(instance.get_popup_created(), false);
 
+// --------- Default popup
 instance.set_popup_selector(0);
 instance.set_popup_created(false);
 instance.set_click_count(0);
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_click_count(), 1);
 assert_eq(instance.get_popup_created(), true);
+assert_eq(instance.get_popup_clicked(), 0);
+
+// Click to close
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_click_count(), 1);
+// Subsequent click to verify that it was closed
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_click_count(), 2);
+assert_eq(instance.get_popup_clicked(), 1);
 
+// --------- Default popup but verify closed on press when outside
+instance.set_popup_selector(0);
+instance.set_popup_created(false);
+instance.set_click_count(0);
+
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_last_underneath_mouse_x(), 15.);
+assert_eq(instance.get_last_underneath_mouse_y(), 15.);
+assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_created(), true);
+assert_eq(instance.get_popup_clicked(), 1);
+
+// mouse grabbed, underneath won't notice
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({1.0, 1.0}));
+assert_eq(instance.get_last_underneath_mouse_x(), 15.);
+assert_eq(instance.get_last_underneath_mouse_y(), 15.);
+
+// press should close
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({1.0, 1.0}), slint::PointerEventButton::Left);
+
+// if it was closed, the underneath should receive the move event
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({12.0, 12.0}));
+assert_eq(instance.get_last_underneath_mouse_x(), 12.);
+assert_eq(instance.get_last_underneath_mouse_y(), 12.);
+
+slint_testing::mock_elapsed_time(50);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({12.0, 12.0}), slint::PointerEventButton::Left);
+
+assert_eq(instance.get_click_count(), 1);
+
+// Subsequent click to verify that it was closed
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_click_count(), 2);
+assert_eq(instance.get_popup_clicked(), 1);
+
+// --------- Popup with close-on-click: false
 instance.set_popup_selector(1);
 instance.set_popup_created(false);
 instance.set_click_count(0);
+
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_click_count(), 1);
 assert_eq(instance.get_popup_created(), true);
+assert_eq(instance.get_popup_clicked(), 1);
+
+// Click outside, nothing happens
 slint_testing::send_mouse_click(&instance, 1., 1.);
 assert_eq(instance.get_click_count(), 1);
+// Click outside again, nothing happens
 slint_testing::send_mouse_click(&instance, 295., 295.);
 assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_clicked(), 1);
+
+// Click on the popup, it's registered and the custom TouchArea calls close()
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_click_count(), 1);
+
+// Subsequent click to verify that it was closed
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_click_count(), 2);
+assert_eq(instance.get_popup_clicked(), 1);
 
+// --------- Popup with close-on-click: false closed externally
 instance.set_popup_selector(2);
 instance.set_popup_created(false);
 instance.set_click_count(0);
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_click_count(), 1);
 assert_eq(instance.get_popup_created(), true);
-slint_testing::send_mouse_click(&instance, 15., 15.);
-assert_eq(instance.get_click_count(), 1);
-slint_testing::send_mouse_click(&instance, 15., 15.);
-assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_clicked(), 1);
 
+// Click outside, nothing happens
+slint_testing::send_mouse_click(&instance, 1., 1.);
+assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_clicked(), 1);
+
+// Click on the popup, it's registered but nothing is done
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_clicked(), 1001);
+
+// Click again to verify that it was _not_ closed
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_clicked(), 2001);
+
+// Close manually and verify that subsequent click is passed through
 instance.invoke_do_close();
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_click_count(), 2);

--- a/tests/cases/elements/popupwindow_context.slint
+++ b/tests/cases/elements/popupwindow_context.slint
@@ -1,0 +1,113 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+import { Palette } from "std-widgets.slint";
+
+export component TestCase {
+    width: 300px;
+    height: 300px;
+
+    in-out property <bool> popup-created;
+    in-out property <int> click-count;
+    in-out property <int> popup-clicked;
+    out property <length> last-underneath-mouse-x: ta.mouse-x;
+    out property <length> last-underneath-mouse-y: ta.mouse-y;
+
+    context-menu := PopupWindow {
+        x: 10px;
+        y: 10px;
+        width: parent.width - 20px;
+        height: parent.height - 20px;
+
+        Rectangle {
+            border-width: 2px;
+            border-color: Palette.alternate-background;
+        }
+
+        Text {
+            text: "I'm a context menu.";
+        }
+        init => {
+            root.popup-created = true;
+        }
+
+        TouchArea {
+            width: 7px; x: 0px;
+            clicked => {
+                root.popup-clicked += 1;
+            }
+        }
+    }
+
+    ta := TouchArea {
+        clicked => {
+            root.click-count += 1;
+        }
+        pointer-event(event) => {
+            if (event.kind == PointerEventKind.down && event.button == PointerEventButton.right) {
+                context-menu.show();
+            }
+        }
+    }
+}
+/*
+
+```rust
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
+
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_click_count(), 0);
+assert_eq!(instance.get_popup_created(), false);
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(15.0, 15.0) });
+assert_eq!(instance.get_last_underneath_mouse_x(), 15.);
+assert_eq!(instance.get_last_underneath_mouse_y(), 15.);
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+assert_eq!(instance.get_popup_created(), true);
+
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+
+// Popup is still visible, as it gets the move event instead of the underlying touch area
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(11.0, 11.0) });
+assert_eq!(instance.get_last_underneath_mouse_x(), 15.);
+assert_eq!(instance.get_last_underneath_mouse_y(), 15.);
+
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq!(instance.get_click_count(), 0);
+// Subsequent click to verify that it was closed
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq!(instance.get_click_count(), 1);
+assert_eq!(instance.get_popup_clicked(), 1);
+
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert_eq(instance.get_click_count(), 0);
+assert_eq(instance.get_popup_created(), false);
+
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({15.0, 15.0}));
+assert_eq(instance.get_last_underneath_mouse_x(), 15.);
+assert_eq(instance.get_last_underneath_mouse_y(), 15.);
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+assert_eq(instance.get_popup_created(), true);
+
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+
+// Popup is still visible, as it gets the move event instead of the underlying touch area
+instance.window().dispatch_pointer_move_event(slint::LogicalPosition({11.0, 11.0}));
+assert_eq(instance.get_last_underneath_mouse_x(), 15.);
+assert_eq(instance.get_last_underneath_mouse_y(), 15.);
+
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_click_count(), 0);
+// Subsequent click to verify that it was closed
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_click_count(), 1);
+assert_eq(instance.get_popup_clicked(), 1);
+```
+
+*/


### PR DESCRIPTION
Close a PopupWindow on press when the mouse is not on the popup. Close it on release if it's in the popup and it wasn't created on press.

These fixes make it possible to implement basic custom context menus with the mouse.