### PR TITLE
CI: prospective fix for esp-idf libc version invompatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -520,7 +520,7 @@ jobs:
 
   esp-idf:
     runs-on: ubuntu-22.04
-    container: espressif/idf:release-v5.1
+    container: espressif/idf:latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
xtansa rust 1.75 toolchain uses ubuntu 22.4, but the docker umage has ubuntu 20.4 Hopefully updating the docker image should fix the problem