### PR TITLE
Add code signing for macOS tool binaries

### DIFF
--- a/.github/actions/codesign/action.yaml
+++ b/.github/actions/codesign/action.yaml
@@ -1,0 +1,43 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+---
+name: Apple Codesign Binary
+description: Sign the given binary with the developer certificate
+
+inputs:
+  binary:
+    description: 'Path to binary'
+    required: true
+    default: ""
+  certificate:
+    description: "certificate secret"
+    required: true
+  certificate_password:
+    description: "certificate password"
+    required: true
+  keychain_password:
+    description: "keychain password to use"
+    required: true
+  developer_id:
+    description: "developer id to use"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Codesign binary
+      shell: bash    
+      env:
+          CERT: ${{ inputs.certificate }}
+          CERT_PW: ${{ inputs.certificate_password }}
+          KEYCHAIN_PW: ${{ inputs.keychain_password }}
+          DEV_ID: ${{ inputs.developer_id }}
+      run: |
+        echo -n "$CERT" | base64 --decode -o certificate.p12
+        security create-keychain -p $KEYCHAIN_PW build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p $KEYCHAIN_PW build.keychain
+        security import certificate.p12 -k build.keychain -P $CERT_PW -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PW build.keychain
+        /usr/bin/codesign --force -s $DEV_ID "${{ inputs.binary }}" -v  

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -31,10 +31,20 @@ jobs:
     uses: ./.github/workflows/slint_tool_binary.yaml
     with:
       program: "viewer"
+    secrets:
+      certificate: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+      certificate_password: ${{ secrets.APPLE_CERTIFICATE_P12_PASSWORD }}
+      keychain_password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+      developer_id: ${{ secrets.APPLE_DEV_ID }}         
   slint-lsp-binary:
     uses: ./.github/workflows/slint_tool_binary.yaml
     with:
       program: "lsp"
+    secrets:
+      certificate: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+      certificate_password: ${{ secrets.APPLE_CERTIFICATE_P12_PASSWORD }}
+      keychain_password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+      developer_id: ${{ secrets.APPLE_DEV_ID }}         
   docs:
     uses: ./.github/workflows/build_docs.yaml
   wasm_demo:
@@ -149,6 +159,9 @@ jobs:
     needs: [build_vscode_lsp_macos_x86_64, build_vscode_lsp_macos_aarch64]
     runs-on: macos-11
     steps:
+    - uses: actions/checkout@v3
+      with:
+        path: "src"
     - uses: actions/download-artifact@v3
       with:
         name: vscode-lsp-binary-x86_64-apple-darwin
@@ -161,6 +174,15 @@ jobs:
         lipo -create -output tmp Slint\ Live\ Preview.app/Contents/MacOS/slint-lsp bin/slint-lsp-aarch64-apple-darwin
         mv tmp Slint\ Live\ Preview.app/Contents/MacOS/slint-lsp
         rm -rf bin
+    - uses: ./src/.github/actions/codesign
+      with:
+        binary: "Slint Live Preview.app"
+        certificate: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+        certificate_password: ${{ secrets.APPLE_CERTIFICATE_P12_PASSWORD }}
+        keychain_password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+        developer_id: ${{ secrets.APPLE_DEV_ID }}         
+    - name: "Remove temporary source checkout"
+      run: rm -rf src
     - name: "Upload LSP macOS bundle Artifact"
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -17,6 +17,10 @@ on:
         description: features to enable for build
         # Keep in sync with features in nightly_snapshot.yaml and cpp_package.yaml
         default: "backend-winit,renderer-femtovg,renderer-skia,renderer-software"
+      codesign:
+        type: boolean
+        description: Sign binaries on macOS (false for manual builds)
+        default: false
 
   workflow_call:
     inputs:
@@ -28,7 +32,24 @@ on:
         description: features to enable for build
         # Keep in sync with features in nightly_snapshot.yaml and cpp_package.yaml
         default: "backend-winit,renderer-femtovg,renderer-skia,renderer-software"
-
+      codesign:
+        type: boolean
+        description: Sign binaries on macOS
+        default: true
+    secrets:
+      certificate:
+        description: "certificate secret"
+        required: false
+      certificate_password:
+        description: "certificate password"
+        required: false
+      keychain_password:
+        description: "keychain password to use"
+        required: false
+      developer_id:
+        description: "developer id to use"
+        required: false
+      
 env:
   MACOSX_DEPLOYMENT_TARGET: "11.0"
 
@@ -126,6 +147,14 @@ jobs:
             cd ..
             cd tools/${{ github.event.inputs.program || inputs.program }}
             ../../scripts/prepare_binary_package.sh ../../slint-${{ github.event.inputs.program || inputs.program }}
+      - uses: ./.github/actions/codesign
+        if: ${{ github.event.inputs.codesign == 'true' }}
+        with:
+          binary: slint-${{ github.event.inputs.program || inputs.program }}/slint-${{ github.event.inputs.program || inputs.program }}
+          certificate: ${{ github.event.inputs.certificate }}
+          certificate_password: ${{ github.event.inputs.certificate_password }}
+          keychain_password: ${{ github.event.inputs.keychain_password }}
+          developer_id: ${{ github.event.inputs.developer_id }}          
       - name: Tar artifacts to preserve permissions
         run: tar czvf slint-${{ github.event.inputs.program || inputs.program }}-macos.tar.gz slint-${{ github.event.inputs.program || inputs.program }}
       - name: Upload artifact


### PR DESCRIPTION
This signs the slint-lsp/slint-viewer binaries as well as the lipo'ed binary for the VS code extension.

cc #4240