### PR TITLE
janitor: Fix wanrings about unused members

### DIFF
--- a/helper_crates/const-field-offset/macro/macro.rs
+++ b/helper_crates/const-field-offset/macro/macro.rs
@@ -218,6 +218,7 @@ pub fn const_field_offset(input: TokenStream) -> TokenStream {
             },
             Some(quote! {
                     /// Make sure that Unpin is not implemented
+                    #[allow(dead_code)]
                     pub struct __MustNotImplUnpin<'__dummy_lifetime> (
                         #(#types, )*
                         ::core::marker::PhantomData<&'__dummy_lifetime ()>
@@ -245,7 +246,7 @@ pub fn const_field_offset(input: TokenStream) -> TokenStream {
     // Build the output, possibly using quasi-quotation
     let expanded = quote! {
         #[doc = #doc]
-        #[allow(missing_docs, non_camel_case_types)]
+        #[allow(missing_docs, non_camel_case_types, dead_code)]
         #struct_vis struct #field_struct_name {
             #(#vis #fields : #crate_::FieldOffset<#struct_name, #types, #pin_flag>,)*
         }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -309,7 +309,7 @@ impl crate::properties::PropertyDirtyHandler for WindowRedrawTracker {
 /// This enum describes the different ways a popup can be rendered by the back-end.
 enum PopupWindowLocation {
     /// The popup is rendered in its own top-level window that is know to the windowing system.
-    TopLevel(Rc<dyn WindowAdapter>),
+    TopLevel { _adapter: Rc<dyn WindowAdapter> },
     /// The popup is rendered as an embedded child window at the given position.
     ChildWindow(LogicalPoint),
 }
@@ -780,7 +780,7 @@ impl WindowInner {
 
             let popup_component =
                 self.active_popup.borrow().as_ref().and_then(|popup| match popup.location {
-                    PopupWindowLocation::TopLevel(_) => None,
+                    PopupWindowLocation::TopLevel { .. } => None,
                     PopupWindowLocation::ChildWindow(coordinates) => {
                         Some((popup.component.clone(), coordinates))
                     }
@@ -893,7 +893,7 @@ impl WindowInner {
 
             Some(window_adapter) => {
                 WindowInner::from_pub(window_adapter.window()).set_component(popup_componentrc);
-                PopupWindowLocation::TopLevel(window_adapter)
+                PopupWindowLocation::TopLevel { _adapter: window_adapter }
             }
         };
 


### PR DESCRIPTION
I get warnings about unused members using the nightly compiler, one for each member in all structs that derive the `FieldOffsets` macro. That is a lot.

This fixes that as well as the one occurrence of that same warning in unrelated code.