### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -559,7 +559,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Android API level 30
-        run: sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "platforms;android-30"
+        run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "platforms;android-30"
       - name: Cache cargo-apk
         id: cargo-apk-cache
         uses: actions/cache@v3


### PR DESCRIPTION
Try installing the Android API level 30 without sudo, as that appears to sometimes fail with

    sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper

Amends 2efd2bc3c8d14a94dd80b12bc0eea123721fdba8