### PR TITLE
Reduce WindowAdapter API slightly

### DIFF
--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -243,6 +243,12 @@ public:
             return out;
         }
 
+        /// Returns true if the window should be shown fullscreen; false otherwise.
+        bool fullscreen() const
+        {
+            return cbindgen_private::slint_window_properties_get_fullscreen(inner());
+        }
+
         /// This struct describes the layout constraints of a window.
         ///
         /// It is the return value of WindowProperties::layout_constraints().

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -111,6 +111,11 @@ pub extern "C" fn slint_window_properties_get_background(
     *out = wp.background();
 }
 
+#[no_mangle]
+pub extern "C" fn slint_window_properties_get_fullscreen(wp: &WindowProperties) -> bool {
+    wp.fullscreen();
+}
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 /// a Repr(C) variant of slint::platform::LayoutConstraints

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -113,7 +113,7 @@ pub extern "C" fn slint_window_properties_get_background(
 
 #[no_mangle]
 pub extern "C" fn slint_window_properties_get_fullscreen(wp: &WindowProperties) -> bool {
-    wp.fullscreen();
+    wp.fullscreen()
 }
 
 #[repr(C)]

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1530,11 +1530,7 @@ impl WindowAdapter for QtWindow {
     fn set_visible(&self, visible: bool) -> Result<(), PlatformError> {
         if visible {
             let widget_ptr = self.widget_ptr();
-            let fullscreen = std::env::var("SLINT_FULLSCREEN").is_ok();
-            cpp! {unsafe [widget_ptr as "QWidget*", fullscreen as "bool"] {
-                if (fullscreen) {
-                    widget_ptr->setWindowState(widget_ptr->windowState() | Qt::WindowFullScreen);
-                }
+            cpp! {unsafe [widget_ptr as "QWidget*"] {
                 widget_ptr->show();
             }};
             let qt_platform_name = cpp! {unsafe [] -> qttypes::QString as "QString" {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -189,11 +189,6 @@ impl WinitWindowAdapter {
     ) -> Result<WindowBuilder, PlatformError> {
         let mut window_builder = WindowBuilder::new().with_transparent(true).with_visible(false);
 
-        if std::env::var("SLINT_FULLSCREEN").is_ok() {
-            window_builder =
-                window_builder.with_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
-        }
-
         window_builder = window_builder.with_title("Slint Window".to_string());
 
         #[cfg(target_arch = "wasm32")]

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -499,6 +499,12 @@ impl WindowAdapter for WinitWindowAdapter {
         }
 
         self.with_window_handle(&mut |winit_window| {
+            if properties.fullscreen() {
+                winit_window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
+            } else {
+                winit_window.set_fullscreen(None);
+            }
+
             // If we're in fullscreen state, don't try to resize the window but maintain the surface
             // size we've been assigned to from the windowing system. Weston/Wayland don't like it
             // when we create a surface that's bigger than the screen due to constraints (#532).
@@ -551,14 +557,6 @@ impl WindowAdapter for WinitWindowAdapter {
                 }
             }
         });
-    }
-
-    fn set_fullscreen(&self, fullscreen: bool) {
-        if fullscreen {
-            self.winit_window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
-        } else {
-            self.winit_window.set_fullscreen(None);
-        }
     }
 
     fn internal(&self, _: corelib::InternalToken) -> Option<&dyn WindowAdapterInternal> {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -448,7 +448,7 @@ impl Window {
 
     /// Set or unset the window to display fullscreen.
     pub fn set_fullscreen(&self, fullscreen: bool) {
-        self.0.window_adapter().set_fullscreen(fullscreen);
+        self.0.set_fullscreen(fullscreen);
     }
 
     /// Dispatch a window event to the scene.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -417,7 +417,7 @@ impl WindowInner {
                     "i_slint_core::Window::text_input_focused",
                 ),
             }),
-            fullscreen: Default::default(),
+            fullscreen: Cell::new(std::env::var("SLINT_FULLSCREEN").is_ok()),
             focus_item: Default::default(),
             cursor_blinker: Default::default(),
             active_popup: Default::default(),

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -417,7 +417,10 @@ impl WindowInner {
                     "i_slint_core::Window::text_input_focused",
                 ),
             }),
+            #[cfg(feature = "std")]
             fullscreen: Cell::new(std::env::var("SLINT_FULLSCREEN").is_ok()),
+            #[cfg(not(feature = "std"))]
+            fullscreen: Cell::new(false),
             focus_item: Default::default(),
             cursor_blinker: Default::default(),
             active_popup: Default::default(),

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -132,9 +132,6 @@ pub trait WindowAdapter {
     /// be called again.
     fn update_window_properties(&self, _properties: WindowProperties<'_>) {}
 
-    /// Set to display the window as fullscreen.
-    fn set_fullscreen(&self, _fullscreen: bool) {}
-
     #[doc(hidden)]
     fn internal(&self, _: crate::InternalToken) -> Option<&dyn WindowAdapterInternal> {
         None
@@ -280,6 +277,11 @@ impl<'a> WindowProperties<'a> {
             ),
         }
     }
+
+    /// Returns true if the window should be shown fullscreen; false otherwise.
+    pub fn fullscreen(&self) -> bool {
+        self.0.fullscreen.get()
+    }
 }
 
 struct WindowPropertiesTracker {
@@ -363,6 +365,7 @@ pub struct WindowInner {
     cursor_blinker: RefCell<pin_weak::rc::PinWeak<crate::input::TextCursorBlinker>>,
 
     pinned_fields: Pin<Box<WindowPinnedFields>>,
+    fullscreen: Cell<bool>,
     active_popup: RefCell<Option<PopupWindow>>,
     had_popup_on_press: Cell<bool>,
     close_requested: Callback<(), CloseRequestResponse>,
@@ -414,6 +417,7 @@ impl WindowInner {
                     "i_slint_core::Window::text_input_focused",
                 ),
             }),
+            fullscreen: Default::default(),
             focus_item: Default::default(),
             cursor_blinker: Default::default(),
             active_popup: Default::default(),
@@ -1007,6 +1011,12 @@ impl WindowInner {
             CloseRequestResponse::HideWindow => true,
             CloseRequestResponse::KeepWindowShown => false,
         }
+    }
+
+    /// Set or unset the window to display fullscreen.
+    pub fn set_fullscreen(&self, enabled: bool) {
+        self.fullscreen.set(enabled);
+        self.update_window_properties()
     }
 
     /// Returns the upgraded window adapter


### PR DESCRIPTION
Move the set_fullscreen function added to the WindowAdapter trait in 779aff0b3904db1e882f5f7f5ab3db2e38e2d8e6 to be a function in WindowProperties instead.
That way it'll be easier in the future to extend this with other window states without having to modify or break the WindowAdapter trait API.