### PR TITLE
Fix missing invocation of init callbacks due to inlining

### DIFF
--- a/tests/cases/callbacks/init.slint
+++ b/tests/cases/callbacks/init.slint
@@ -36,8 +36,9 @@ Sub3 := Rectangle {
 }
 
 Container := Rectangle {
+    in property <string> name-inside: "container";
     init => {
-        InitOrder.observed-order += "|container";
+        InitOrder.observed-order += "|" + self.name-inside;
     }
     @children
 }

--- a/tests/cases/callbacks/init.slint
+++ b/tests/cases/callbacks/init.slint
@@ -61,7 +61,9 @@ TestCase := Rectangle {
     }
 
     Container {
-
+        init => {
+            InitOrder.observed-order += "|container-instantiation";
+        }
     }
 
     Rectangle {
@@ -79,7 +81,7 @@ TestCase := Rectangle {
 
     property <string> test_global_prop_value: InitOrder.observed-order;
 
-    property <string> expected_static_order: "start|sub1|sub2|subsub|sub3|root|sub1-use-site|container|element";
+    property <string> expected_static_order: "start|sub1|sub2|subsub|sub3|container|root|sub1-use-site|container-instantiation|element";
 
     property <bool> test: InitOrder.observed-order == expected_static_order;
 }

--- a/tests/cases/callbacks/init.slint
+++ b/tests/cases/callbacks/init.slint
@@ -61,8 +61,9 @@ TestCase := Rectangle {
     }
 
     Container {
+        property <string> name-outside: "container-instantiation";
         init => {
-            InitOrder.observed-order += "|container-instantiation";
+            InitOrder.observed-order += "|" + self.name-outside;
         }
     }
 


### PR DESCRIPTION
When a component declares an init callback as well as the element that instantiates it, the init callback of the container would not get invoked if the container was inlined:

```
component InlinedContainer {
    init => { ... } // not invoked
    @children // force inlining
}

component UseSite {
    InlinedContainer {
        init => { ... }
    }
}
```

That's because the inlining happens very early, before the init callbacks are collected into the init code. And during inlining that would be treated like a property binding and the "binding" at the element site overrides the one at the component site.

One natural approach would be to move the init code collection to an earlier place before inlining, but that isn't possible because the boundaries of the compiler components (Rc<Component>) aren't set up yet (repeated component extraction phase happens much later).

An alternative would be to re-introduce the init callback code in ElementRc and place it in there at *::from_node() time.

This patch chooses to solve this at the inlining time: When we're in the first phase of the inlining (the optional one), do what with the init binding what collect_init_code would do later: Move it straight into the init_code of the component we're inlining into.

Fixes #4317