### PR TITLE
LinuxKMS: Remove set_event_loop_quit_on_last_window_closed implementation

### DIFF
--- a/internal/backends/linuxkms/calloop_backend.rs
+++ b/internal/backends/linuxkms/calloop_backend.rs
@@ -260,11 +260,6 @@ impl i_slint_core::platform::Platform for Backend {
         Ok(())
     }
 
-    fn set_event_loop_quit_on_last_window_closed(&self, quit_on_last_window_closed: bool) {
-        QUIT_ON_LAST_WINDOW_CLOSED
-            .store(quit_on_last_window_closed, std::sync::atomic::Ordering::Relaxed);
-    }
-
     fn new_event_loop_proxy(&self) -> Option<Box<dyn i_slint_core::platform::EventLoopProxy>> {
         Some(Box::new(self.proxy.clone()))
     }
@@ -304,8 +299,5 @@ impl AsFd for Device {
         unsafe { BorrowedFd::borrow_raw(self.fd) }
     }
 }
-
-pub(crate) static QUIT_ON_LAST_WINDOW_CLOSED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(true);
 
 pub type EventLoopHandle<'a> = calloop::LoopHandle<'a, LoopData>;

--- a/internal/backends/linuxkms/fullscreenwindowadapter.rs
+++ b/internal/backends/linuxkms/fullscreenwindowadapter.rs
@@ -65,10 +65,6 @@ impl WindowAdapter for FullscreenWindowAdapter {
             {
                 self.window.dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor });
             }
-        } else if crate::calloop_backend::QUIT_ON_LAST_WINDOW_CLOSED
-            .load(std::sync::atomic::Ordering::Relaxed)
-        {
-            i_slint_core::api::quit_event_loop().ok();
         }
         Ok(())
     }


### PR DESCRIPTION
This is now handled in i-slint-core.

Amends 9ff13faee81a4b2165e8a5e49d808b317d3ba63b