### PR TITLE
lsp: Find images not loading in native preview

### DIFF
--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -53,7 +53,7 @@ const SHOW_PREVIEW_COMMAND: &str = "slint/showPreview";
 const SET_BINDING_COMMAND: &str = "slint/setBinding";
 
 pub fn uri_to_file(uri: &lsp_types::Url) -> Option<PathBuf> {
-    let Ok(path) = uri.to_file_path() else { return None };
+    let path = uri.to_file_path().ok()?;
     let cleaned_path = clean_path(&path);
     Some(cleaned_path)
 }

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -401,7 +401,9 @@ async fn reload_preview_impl(
         Box::pin(async move { get_path_from_cache(&path).map(Result::Ok) })
     });
 
-    let path = component.url.to_string().into();
+    // to_file_path on a WASM Url just returns the URL as the path!
+    let path = component.url.to_file_path().unwrap_or(PathBuf::from(&component.url.to_string()));
+
     let compiled = if let Some(mut from_cache) = get_url_from_cache(&component.url) {
         if let Some(component_name) = &component.component {
             from_cache = format!(


### PR DESCRIPTION
I broke that when using URLs more consistently. Our path is either a path or a URL is so easy to break.