### PR TITLE
Fix panic when shutting down process on Linux

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -47,7 +47,6 @@ scoped-tls-hkt = "0.1"
 winit = { version = "0.29.4", default-features = false }
 raw-window-handle = { version = "0.5", features = ["alloc"] }
 scopeguard =  { version = "1.1.0", default-features = false }
-send_wrapper = { workspace = true }
 
 # For the FemtoVG renderer
 i-slint-renderer-femtovg = { workspace = true, features = ["default"], optional = true }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -211,7 +211,7 @@ pub fn unregister_window(id: winit::window::WindowId) {
     });
 }
 
-fn window_by_id(id: winit::window::WindowId) -> Option<Rc<WinitWindowAdapter>> {
+pub fn window_by_id(id: winit::window::WindowId) -> Option<Rc<WinitWindowAdapter>> {
     ALL_WINDOWS.with(|windows| windows.borrow().get(&id).and_then(|weakref| weakref.upgrade()))
 }
 


### PR DESCRIPTION
Commit 41bfe66447e91a0e5cdd329758c13841848f84bb bumped accesskit dependencies, which introduced a version that uses threads.

That means the action handler as well as the initial tree update source closure are destroyed in a thread that's not the ui thread. That means we destruct a SenderWrapper<Weak<WinitWindowAdapter>> in a thread that is not the same as the one the wrapper was created in, which causes Drop for SendWrapper to panic.

Replace the use of SendWrapper here with safely copyable window ids.