### PR TITLE
Don't crash the opengl_texture example when making the window very small

### DIFF
--- a/examples/opengl_texture/scene.slint
+++ b/examples/opengl_texture/scene.slint
@@ -25,6 +25,8 @@ export component App inherits Window {
         image := Image {
             preferred-width: 640px;
             preferred-height: 640px;
+            min-width: 64px;
+            min-height: 64px;
             width: 100%;
             //height: 100%;
         }


### PR DESCRIPTION
Provide a reasonable minimum size for the image.

Fixes #4195