### PR TITLE
C++: Add convenience functions to clear and replace the VectorModel's vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project are documented in this file.
 ### C++
 
  - Added `ComponentInstance::definition()` getter to retrieve the `ComponentDefinition` for an instance.
+ - Added `slint::VectorModel::clear()` and `slint::VectorModel::set_vector()` to conveniently clear or replace the underlying data.
 
 ### LSP
 

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -539,6 +539,22 @@ public:
         data.insert(data.begin() + index, value);
         this->row_added(index, 1);
     }
+
+    /// Erases all rows from the VectorModel.
+    void clear()
+    {
+        if (!data.empty()) {
+            data.clear();
+            this->reset();
+        }
+    }
+
+    /// Replaces the underlying VectorModel's vector with \a array.
+    void set_vector(std::vector<ModelData> &&array)
+    {
+        data = std::move(array);
+        this->reset();
+    }
 };
 
 template<typename ModelData>

--- a/api/cpp/tests/models.cpp
+++ b/api/cpp/tests/models.cpp
@@ -494,3 +494,34 @@ SCENARIO("Reverse Model Change")
     REQUIRE(reverse_model->row_data(2) == 10);
     REQUIRE(reverse_model->row_data(3) == 3);
 }
+
+TEST_CASE("VectorModel clear and replace")
+{
+    using namespace slint::private_api;
+
+    auto model = std::make_shared<slint::VectorModel<int>>(std::vector<int> { 0, 1, 2, 3, 4 });
+
+    auto observer = std::make_shared<ModelObserver>();
+    model->attach_peer(observer);
+
+    REQUIRE(model->row_count() == 5);
+    model->clear();
+    REQUIRE(model->row_count() == 0);
+    REQUIRE(observer->added_rows.empty());
+    REQUIRE(observer->changed_rows.empty());
+    REQUIRE(observer->removed_rows.empty());
+    REQUIRE(observer->model_reset);
+    observer->clear();
+
+    model->clear();
+    REQUIRE(!observer->model_reset);
+    observer->clear();
+
+    model->set_vector({ 2, 3, 4 });
+    REQUIRE(model->row_count() == 3);
+    REQUIRE(model->row_data(1) == 3);
+    REQUIRE(observer->added_rows.empty());
+    REQUIRE(observer->changed_rows.empty());
+    REQUIRE(observer->removed_rows.empty());
+    REQUIRE(observer->model_reset);
+}


### PR DESCRIPTION
This was requested by a customer recently and it seems rather straight-forward to implement and offer. `clear()` mirrors `std::vector::clear()` and `set_vector` mirrors the `set_vec` we have in Rust.