### PR TITLE
winit: avoid to poll or call request_redraw too often

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -420,8 +420,9 @@ impl WindowAdapter for WinitWindowAdapter {
     }
 
     fn request_redraw(&self) {
-        self.pending_redraw.set(true);
-        self.with_window_handle(&mut |window| window.request_redraw())
+        if !self.pending_redraw.replace(true) {
+            self.winit_window.request_redraw()
+        }
     }
 
     #[allow(clippy::unnecessary_cast)] // Coord is used!


### PR DESCRIPTION
Otherwise there will be a huge queue of request redraw command that accumulate within winit.
This makes operation such as resizing a bit more soomth

Tested on X11