### PR TITLE
Fix calling builtin member functions on the root item when a window item is injected

### DIFF
--- a/tests/cases/element_ref_on_root_compo.slint
+++ b/tests/cases/element_ref_on_root_compo.slint
@@ -1,0 +1,44 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+// Allow for accessing built-in functions on root elements even with an injected window item
+
+export component TestCase inherits TextInput {
+    width: 100phx;
+    height: 100phx;
+
+    out property<bool> selection-set;
+
+    text: "Hello World";
+    if (true): TouchArea {
+        clicked => {
+            root.select-all();
+            root.selection-set = root.anchor-position-byte-offset == 0 && root.cursor-position-byte-offset == 11;
+        }
+    }
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(!instance.get_selection_set());
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert(instance.get_selection_set());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(!instance.get_selection_set());
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_selection_set());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(!instance.selection_set);
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+assert(instance.selection_set);
+```
+*/


### PR DESCRIPTION
The element references, just like the named references, need to be fixed up.