### PR TITLE
Fix unsound behavior of the interpreter when accessing a deleted parent

### DIFF
--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -201,7 +201,7 @@ fn box_layout_data(
             rep.0.as_ref().ensure_updated(|| {
                 let instance = crate::dynamic_item_tree::instantiate(
                     rep.1.clone(),
-                    Some(component.borrow()),
+                    component.self_weak().get().cloned(),
                     None,
                     None,
                     Default::default(),

--- a/tests/cases/models/delete_from_clicked.slint
+++ b/tests/cases/models/delete_from_clicked.slint
@@ -76,6 +76,17 @@ assert_eq(instance.global<Glob>().get_value(), "world");
 ```
 
 
+```js
+var instance = new slint.TestCase({});
+let model = new slintlib.ArrayModel(["hello", "world"]);
+instance.Glob.model = model;
+instance.Glob.clicked = (val) => {
+    assert.equal(val, "world");
+    model.remove(1, 1);
+};
+slintlib.private_api.send_mouse_click(instance, 150., 150.);
+assert.equal(instance.Glob.value, "world");
+```
 
 
 */


### PR DESCRIPTION
We were having a reference to the parent item tree, assuming the parent
was living longer than the item tree. But this is not the case if
there existed a ItemRc to one item in the inner part.

So use a Weak for the parent instead.


The test is unrelated. I thought it would reproduce the bug but it doesn't
(although the FIXME line in the test probably does)

I was investigating #4300 when noticing this