### PR TITLE
Fix svg loading on android after update of resvg

### DIFF
--- a/internal/common/Cargo.toml
+++ b/internal/common/Cargo.toml
@@ -25,7 +25,7 @@ fontdb = { workspace = true, optional = true }
 derive_more = { version = "0.99.5", optional = true }
 cfg-if = { version = "1", optional = true }
 
-[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
+[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32", target_os = "android")))'.dependencies]
 libloading = { version = "0.8.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/internal/common/sharedfontdb.rs
+++ b/internal/common/sharedfontdb.rs
@@ -14,7 +14,8 @@ pub struct FontDatabase {
         target_family = "windows",
         target_os = "macos",
         target_os = "ios",
-        target_arch = "wasm32"
+        target_arch = "wasm32",
+        target_os = "android",
     )))]
     pub fontconfig_fallback_families: Vec<String>,
     // Default font families to use instead of SansSerif when SLINT_DEFAULT_FONT env var is set.
@@ -57,7 +58,8 @@ thread_local! {
     target_family = "windows",
     target_os = "macos",
     target_os = "ios",
-    target_arch = "wasm32"
+    target_arch = "wasm32",
+    target_os = "android",
 )))]
 mod fontconfig;
 
@@ -110,7 +112,8 @@ fn init_fontdb() -> FontDatabase {
         target_family = "windows",
         target_os = "macos",
         target_os = "ios",
-        target_arch = "wasm32"
+        target_arch = "wasm32",
+        target_os = "android",
     )))]
     let mut fontconfig_fallback_families = Vec::new();
 
@@ -120,7 +123,12 @@ fn init_fontdb() -> FontDatabase {
         font_db.load_font_data(data.to_vec());
         font_db.set_sans_serif_family("DejaVu Sans");
     }
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(target_os = "android")]
+    {
+        font_db.load_fonts_dir("/system/fonts");
+        font_db.set_sans_serif_family("Roboto");
+    }
+    #[cfg(not(any(target_arch = "wasm32", target_arch = "android")))]
     {
         font_db.load_system_fonts();
         cfg_if::cfg_if! {
@@ -128,7 +136,8 @@ fn init_fontdb() -> FontDatabase {
                 target_family = "windows",
                 target_os = "macos",
                 target_os = "ios",
-                target_arch = "wasm32"
+                target_arch = "wasm32",
+                target_os = "android",
             )))] {
                 match fontconfig::find_families("sans-serif") {
                     Ok(mut fallback_families) => {
@@ -161,7 +170,8 @@ fn init_fontdb() -> FontDatabase {
             target_family = "windows",
             target_os = "macos",
             target_os = "ios",
-            target_arch = "wasm32"
+            target_arch = "wasm32",
+            target_os = "android",
         )))]
         fontconfig_fallback_families,
         default_font_family_ids,

--- a/internal/core/graphics/image/svg.rs
+++ b/internal/core/graphics/image/svg.rs
@@ -83,11 +83,9 @@ fn with_svg_options<T>(callback: impl FnOnce(&usvg::Options) -> T) -> T {
 }
 
 fn fixup_text(mut tree: usvg::Tree) -> usvg::Tree {
-    if tree.has_text_nodes() {
-        i_slint_common::sharedfontdb::FONT_DB.with(|db| {
-            tree.postprocess(Default::default(), &db.borrow());
-        })
-    }
+    i_slint_common::sharedfontdb::FONT_DB.with(|db| {
+        tree.postprocess(Default::default(), &db.borrow());
+    });
     tree
 }
 

--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -424,7 +424,8 @@ impl FontCache {
         target_family = "windows",
         target_os = "macos",
         target_os = "ios",
-        target_arch = "wasm32"
+        target_arch = "wasm32",
+        target_os = "android",
     )))]
     fn font_fallbacks_for_request(
         &self,
@@ -444,7 +445,7 @@ impl FontCache {
         })
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(target_arch = "wasm32", target_os = "android"))]
     fn font_fallbacks_for_request(
         &self,
         _family: Option<&SharedString>,


### PR DESCRIPTION
It would incoditionally try to load the FONTDB that can't load any font from the system using libloading

Instead, hardcode the path to the font to a known android font