### PR TITLE
Material style: make the ScrollView pan with the finger

### DIFF
--- a/internal/compiler/widgets/material-base/scrollview.slint
+++ b/internal/compiler/widgets/material-base/scrollview.slint
@@ -109,7 +109,6 @@ export component ScrollView {
 
     i-flickable := Flickable {
         x:0;y:0;
-        interactive: false;
         viewport-y <=> i-vertical-bar.value;
         viewport-x <=> i-horizontal-bar.value;
         width: parent.width - i-vertical-bar.width - 4px;


### PR DESCRIPTION
Other style are more desktop oriented, but this is important on android to pan with the finger