### PR TITLE
Make the parentheses optional in if else statement

### DIFF
--- a/internal/compiler/parser/statements.rs
+++ b/internal/compiler/parser/statements.rs
@@ -68,9 +68,7 @@ fn parse_if_statement(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::ConditionalExpression);
     debug_assert_eq!(p.peek().as_str(), "if");
     p.expect(SyntaxKind::Identifier);
-    p.expect(SyntaxKind::LParent);
     parse_expression(&mut *p);
-    p.expect(SyntaxKind::RParent);
     {
         let mut p = p.start_node(SyntaxKind::Expression);
         parse_code_block(&mut *p);

--- a/internal/compiler/parser/statements.rs
+++ b/internal/compiler/parser/statements.rs
@@ -24,7 +24,17 @@ pub fn parse_statement(p: &mut impl Parser) -> bool {
     }
     let checkpoint = p.checkpoint();
 
-    if p.peek().as_str() == "if" && p.nth(1).kind() == SyntaxKind::LParent {
+    if p.peek().as_str() == "if"
+        && !matches!(
+            p.nth(1).kind(),
+            SyntaxKind::Dot
+                | SyntaxKind::Comma
+                | SyntaxKind::Semicolon
+                | SyntaxKind::RBrace
+                | SyntaxKind::RBracket
+                | SyntaxKind::RParent
+        )
+    {
         let mut p = p.start_node(SyntaxKind::Expression);
         parse_if_statement(&mut *p);
         return true;

--- a/tests/cases/conditional/stm2.slint
+++ b/tests/cases/conditional/stm2.slint
@@ -1,0 +1,98 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+TestCase := Rectangle {
+    property<int> value;
+    property<int> result : 3;
+    callback action;
+    action => {
+        if value == 5 {
+            result += 1;
+            result += 1;
+        }
+
+        if value != 8 {
+
+        } else {
+            result += 33;
+        }
+    }
+
+    callback xxx;
+    xxx => {
+        if false {
+            action();
+        }
+
+        if true {
+            result -=1;
+        } else {
+            action();
+        }
+    }
+
+    callback elseif(int) -> int;
+    elseif(v) => {
+        if v == 1 {
+            41
+        } else if v == 2 {
+            42
+        } else {
+            43
+        }
+    }
+}
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+instance.invoke_action();
+assert_eq(instance.get_result(), 3);
+instance.set_value(5);
+instance.invoke_action();
+assert_eq(instance.get_result(), 5);
+instance.set_value(8);
+instance.invoke_action();
+assert_eq(instance.get_result(), 5+33);
+instance.invoke_xxx();
+assert_eq(instance.get_result(), 5+33-1);
+assert_eq(instance.invoke_elseif(1), 41);
+assert_eq(instance.invoke_elseif(2), 42);
+assert_eq(instance.invoke_elseif(3), 43);
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+instance.invoke_action();
+assert_eq!(instance.get_result(), 3);
+instance.set_value(5);
+instance.invoke_action();
+assert_eq!(instance.get_result(), 5);
+instance.set_value(8);
+instance.invoke_action();
+assert_eq!(instance.get_result(), 5+33);
+instance.invoke_xxx();
+assert_eq!(instance.get_result(), 5+33-1);
+assert_eq!(instance.invoke_elseif(1), 41);
+assert_eq!(instance.invoke_elseif(2), 42);
+assert_eq!(instance.invoke_elseif(3), 43);
+```
+
+```js
+var instance = new slint.TestCase({});
+instance.action();
+assert.equal(instance.result, 3);
+instance.value = 5;
+instance.action();
+assert.equal(instance.result, 5);
+instance.value = 8;
+instance.action();
+assert.equal(instance.result, 5+33);
+instance.xxx();
+assert.equal(instance.result, 5+33-1);
+assert.equal(instance.elseif(1), 41);
+assert.equal(instance.elseif(2), 42);
+assert.equal(instance.elseif(3), 43);
+```
+*/

--- a/tools/fmt/fmt.rs
+++ b/tools/fmt/fmt.rs
@@ -1147,7 +1147,6 @@ A := B {
 }
 "#,
         );
-        // FIXME: this doesn't format through the if_else parser
         assert_formatting(
             r#"A := B { c => { if !abc{nothing}else   if  true{if 0== 8 {}    } else{  } } } "#,
             r#"A := B {

--- a/tools/fmt/fmt.rs
+++ b/tools/fmt/fmt.rs
@@ -532,9 +532,7 @@ fn format_conditional_expression(
     let mut sub = node.children_with_tokens();
     if has_if {
         let ok = whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?
-            && whitespace_to(&mut sub, SyntaxKind::LParent, writer, state, " ")?
-            && whitespace_to(&mut sub, SyntaxKind::Expression, writer, state, "")?
-            && whitespace_to(&mut sub, SyntaxKind::RParent, writer, state, "")?
+            && whitespace_to(&mut sub, SyntaxKind::Expression, writer, state, " ")?
             && whitespace_to(&mut sub, SyntaxKind::Expression, writer, state, " ")?;
         if !ok {
             finish_node(sub, writer, state)?;
@@ -557,9 +555,7 @@ fn format_conditional_expression(
                     SyntaxMatch::NotFound => false,
                     // "if"
                     SyntaxMatch::Found(SyntaxKind::Identifier) => {
-                        whitespace_to(&mut sub, SyntaxKind::LParent, writer, state, " ")?
-                            && whitespace_to(&mut sub, SyntaxKind::Expression, writer, state, "")?
-                            && whitespace_to(&mut sub, SyntaxKind::RParent, writer, state, "")?
+                        whitespace_to(&mut sub, SyntaxKind::Expression, writer, state, " ")?
                             && whitespace_to(&mut sub, SyntaxKind::CodeBlock, writer, state, " ")?
                     }
                     SyntaxMatch::Found(_) => true,
@@ -1144,6 +1140,22 @@ A := B {
             nothing
         } else if (true) {
             if (0 == 8) {
+            }
+        } else {
+        }
+    }
+}
+"#,
+        );
+        // FIXME: this doesn't format through the if_else parser
+        assert_formatting(
+            r#"A := B { c => { if !abc{nothing}else   if  true{if 0== 8 {}    } else{  } } } "#,
+            r#"A := B {
+    c => {
+        if !abc {
+            nothing
+        } else if true {
+            if 0 == 8 {
             }
         } else {
         }


### PR DESCRIPTION
resolve #4062 

Not complete, this will break formatter.
It seems like formatter can't identify if without parentheses.