### PR TITLE
lsp: Use a background from the palette over hard-coded values

### DIFF
--- a/tools/lsp/ui/draw-area.slint
+++ b/tools/lsp/ui/draw-area.slint
@@ -3,7 +3,7 @@
 
 // cSpell: ignore Heade
 
-import { Button, ComboBox, HorizontalBox, ListView, ScrollView, VerticalBox } from "std-widgets.slint";
+import { Button, ComboBox, HorizontalBox, ListView, ScrollView, Palette, VerticalBox } from "std-widgets.slint";
 import { Diagnostics, DiagnosticsOverlay } from "diagnostics-overlay.slint";
 import { Resizer } from "resizer.slint";
 
@@ -50,7 +50,7 @@ export component DrawArea {
         viewport-height: i-drawing-rect.height;
 
         i-drawing-rect := Rectangle {
-            background: root.experimental ? Colors.pink : Colors.white ;
+            background: root.experimental ? Palette.alternate-background.mix(Colors.red, 0.9) : Palette.alternate-background.darker(0.1);
 
             width: max(i-scroll-view.visible-width, i-resizer.width + i-scroll-view.border);
             height: max(i-scroll-view.visible-height, i-resizer.height + i-scroll-view.border);


### PR DESCRIPTION
Apply a bit of tint to make it a bit less likely to match up with the default background color of the contained application.

This fixes the hardcoded color mentioned in #4392, but will not improve dark-mode detection:-)