### PR TITLE
CI: work around tree sitter tests failing with 0.20.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -407,7 +407,7 @@ jobs:
     - uses: robinraju/release-downloader@v1.7
       with:
         repository: "tree-sitter/tree-sitter"
-        latest: true
+        tag: "v0.20.8"
         fileName: "tree-sitter-linux-x64.gz"
         out-file-path: ${{ runner.workspace }}
     - name: Extract tree-sitter-cli


### PR DESCRIPTION
Pin to the previous release, instead of always using the latest.