### PR TITLE
Fix linuxkms compilation and warnings when no features are enabled

### DIFF
--- a/internal/backends/linuxkms/display.rs
+++ b/internal/backends/linuxkms/display.rs
@@ -80,6 +80,7 @@ impl RenderingRotation {
         }
     }
 
+    #[allow(unused)]
     pub fn translation_after_rotation(&self, screen_size: PhysicalSize) -> (f32, f32) {
         match self {
             RenderingRotation::NoRotation => (0., 0.),

--- a/internal/backends/linuxkms/lib.rs
+++ b/internal/backends/linuxkms/lib.rs
@@ -14,7 +14,7 @@ use std::os::fd::OwnedFd;
 type DeviceOpener<'a> = dyn Fn(&std::path::Path) -> Result<std::rc::Rc<OwnedFd>, i_slint_core::platform::PlatformError>
     + 'a;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "drm"))]
 mod drmoutput;
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Remove a lot of error in rust-analyzer when opening the slint workspace