### PR TITLE
Input method: re-send the text if we notice that the text has changed when rendering

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -357,6 +357,8 @@ pub struct WindowInner {
 
     /// itemRC will retrieve on wasms
     pub focus_item: RefCell<crate::item_tree::ItemWeak>,
+    /// The last text that was sent to the input method
+    pub(crate) last_ime_text: RefCell<SharedString>,
     /// Don't let ComponentContainers's instantiation change the focus.
     /// This is a workaround for a recursion when instantiating ComponentContainer because the
     /// init code for the component might have code that sets the focus, but we don't want that
@@ -422,6 +424,7 @@ impl WindowInner {
             #[cfg(not(feature = "std"))]
             fullscreen: Cell::new(false),
             focus_item: Default::default(),
+            last_ime_text: Default::default(),
             cursor_blinker: Default::default(),
             active_popup: Default::default(),
             had_popup_on_press: Default::default(),


### PR DESCRIPTION
Otherwise, programatic changes to the text are not told to the input methods.
This is important in the case of the todo example on android. For example if one type
`foo<enter>bar`, the enter will cause foo to be added in the list, and the text will be cleared. But then when typing bar, the input method things "foo" is still in the text and "foo" will be re-added