### PR TITLE
Don't require inlining if an animated property is private and local

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -536,7 +536,10 @@ fn component_requires_inlining(component: &Rc<Component>) -> bool {
             let lookup_result = root_element.borrow().lookup_property(prop);
             if !lookup_result.is_valid()
                 || !lookup_result.is_local_to_component
-                || !matches!(lookup_result.property_visibility, PropertyVisibility::Private | PropertyVisibility::Output)
+                || !matches!(
+                    lookup_result.property_visibility,
+                    PropertyVisibility::Private | PropertyVisibility::Output
+                )
             {
                 // If there is an animation, we currently inline so that if this property
                 // is set with a binding, it is merged

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -533,9 +533,15 @@ fn component_requires_inlining(component: &Rc<Component>) -> bool {
             return true;
         }
         if binding.animation.is_some() {
-            // If there is an animation, we currently inline so that if this property
-            // is set with a binding, it is merged
-            return true;
+            let lookup_result = root_element.borrow().lookup_property(prop);
+            if !lookup_result.is_valid()
+                || !lookup_result.is_local_to_component
+                || !matches!(lookup_result.property_visibility, PropertyVisibility::Private)
+            {
+                // If there is an animation, we currently inline so that if this property
+                // is set with a binding, it is merged
+                return true;
+            }
         }
     }
 

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -536,7 +536,7 @@ fn component_requires_inlining(component: &Rc<Component>) -> bool {
             let lookup_result = root_element.borrow().lookup_property(prop);
             if !lookup_result.is_valid()
                 || !lookup_result.is_local_to_component
-                || !matches!(lookup_result.property_visibility, PropertyVisibility::Private)
+                || !matches!(lookup_result.property_visibility, PropertyVisibility::Private | PropertyVisibility::Output)
             {
                 // If there is an animation, we currently inline so that if this property
                 // is set with a binding, it is merged


### PR DESCRIPTION
This avoids inlining Button elements from our widget set.

This is covered by tests/cases/properties/animation_merging.slint