### PR TITLE
lsp: Add a way to ignore nodes

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -3,6 +3,10 @@
 
 //! Data structures common between LSP and previewer
 
+use i_slint_compiler::{
+    object_tree::Element,
+    parser::{syntax_nodes, SyntaxKind},
+};
 use lsp_types::Url;
 
 use std::{collections::HashMap, path::PathBuf};
@@ -10,6 +14,21 @@ use std::{collections::HashMap, path::PathBuf};
 pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
 pub type UrlVersion = Option<i32>;
+
+/// Use this in nodes you want the language server and preview to
+/// ignore a node for code analysis purposes.
+pub const NODE_IGNORE_COMMENT: &str = "@lsp:ignore-node";
+
+/// Filter nodes that are marked up to be ignored from the list of nodes.
+pub fn filter_ignore_nodes_in_element(
+    element: &Element,
+) -> impl Iterator<Item = &syntax_nodes::Element> {
+    element.node.iter().filter(move |e| {
+        !e.children().any(|n| {
+            n.kind() == SyntaxKind::Comment && format!("{}", n.text()).contains(NODE_IGNORE_COMMENT)
+        })
+    })
+}
 
 /// A versioned file
 #[derive(Clone, serde::Deserialize, serde::Serialize)]

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -261,7 +261,8 @@ async fn reload_preview_impl(
     let compiled = if let Some(mut from_cache) = get_url_from_cache(&component.url) {
         if let Some(component_name) = &component.component {
             from_cache = format!(
-                "{from_cache}\nexport component _Preview inherits {component_name} {{ }}\n"
+                "{from_cache}\nexport component _SLINT_LivePreview inherits {component_name} {{ /* {} */ }}\n",
+                crate::common::NODE_IGNORE_COMMENT,
             );
         }
         builder.build_from_source(from_cache, path).await


### PR DESCRIPTION
... and use it e.g. for the nodes the preview adds into the code itself.

Now that we mark the preview helper we add into the file as `ignore`, we can make sure we never try to navigate to it. It was text that got appended to the actual source code, so the editor tended to jump to the end of the document when selecting the root element. That was created by merging the artifical Preview node and the real root node, with the artificial node being stored first.