### PR TITLE
tree-sitter: Clean up grammar and improve queries

### DIFF
--- a/editors/tree-sitter-slint/README.md
+++ b/editors/tree-sitter-slint/README.md
@@ -1,0 +1,46 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial -->
+
+# tree-sitter support for SLint
+
+> Tree-sitter is a parser generator tool and an incremental parsing library. It
+> can build a concrete syntax tree for a source file and efficiently update the
+> syntax tree as the source file is edited.
+
+                                                (taken from tree-sitter page)
+
+Use with vim/helix/... other editors.
+
+## Inject into Rust
+
+This tree-sitter configuration can be injected into rust, so that the `slint!`
+macro gets highlighted.
+
+In `neovim` with the `nvim-treesitter` plugin this is done with the
+
+`:TSEditQueryUserAfter injections rust` to create/edit the rust injection
+configuration. Copy and paste this into the new file:
+
+```tree-sitter
+;; Inject the slint language into the `slint!` macro:
+(macro_invocation
+  macro: [
+    (
+      (scoped_identifier
+        path: (_) @_macro_path
+        name: (_) @_macro_name
+      )
+    )
+    ((identifier) @_macro_name @macro_path)
+  ]
+  ((token_tree) @injection.content
+  (#eq? @_macro_name "slint")
+  (#eq? @_macro_path "slint")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.language "slint")
+  (#set! injection.combined)
+  (#set! injection.include-children)
+  )
+)
+```
+
+Please send PRs when you find out how to do the same with other editors.

--- a/editors/tree-sitter-slint/corpus/empty.txt
+++ b/editors/tree-sitter-slint/corpus/empty.txt
@@ -25,7 +25,8 @@ Line comment with line continuation
 (sourcefile
   (comment)
   (import_statement
-    (user_type_identifier)
+    (import_type
+      (user_type_identifier))
     (string_value)))
 
 ================================================================================

--- a/editors/tree-sitter-slint/corpus/lookup.txt
+++ b/editors/tree-sitter-slint/corpus/lookup.txt
@@ -1,6 +1,6 @@
-================================================================================
+==================
 global_lookup
-================================================================================
+==================
 
 global MyGlobal := {
     property<int> bar: 5;
@@ -28,25 +28,26 @@ TestCase := Rectangle {
     property<int> p2: foo.foo_prop;
 
 }
---------------------------------------------------------------------------------
+---
 
 (sourcefile
   (global_definition
     (user_type_identifier)
-    (property
-      (type
-        (builtin_type_identifier))
-      (var_identifier)
-      (value
-        (int_value)))
-    (property
-      (type
-        (builtin_type_identifier))
-      (var_identifier)
-      (value
-        (int_value)))
-    (callback
-      (var_identifier)))
+    (global_block
+      (property
+        (type
+          (builtin_type_identifier))
+        (simple_identifier)
+        (value
+          (int_value)))
+      (property
+        (type
+          (builtin_type_identifier))
+        (simple_identifier)
+        (value
+          (int_value)))
+      (callback
+        (simple_identifier))))
   (component_definition
     (user_type_identifier)
     (user_type_identifier)
@@ -54,26 +55,29 @@ TestCase := Rectangle {
       (property
         (type
           (builtin_type_identifier))
-        (var_identifier)
-        (var_identifier
-          (post_identifier)))
+        (simple_identifier)
+        (member_access
+          (simple_identifier)
+          (simple_identifier)))
       (for_loop
-        (var_identifier)
+        (simple_indexed_identifier
+          (simple_identifier))
         (for_range
           (value
             (int_value)))
         (component
           (user_type_identifier)
           (block
-            (assignment_expr
-              (var_identifier)
-              (assignment_prec_operator)
-              (mult_binary_expression
-                (add_binary_expression
-                  (var_identifier)
-                  (add_prec_operator)
-                  (var_identifier
-                    (post_identifier)))
+            (property_assignment
+              (simple_identifier)
+              (binary_expression
+                (parens_op
+                  (binary_expression
+                    (simple_identifier)
+                    (add_prec_operator)
+                    (member_access
+                      (simple_identifier)
+                      (simple_identifier))))
                 (mult_prec_operator)
                 (value
                   (length_value)))))))))
@@ -82,20 +86,20 @@ TestCase := Rectangle {
     (user_type_identifier)
     (block
       (callback
-        (var_identifier))
+        (simple_identifier))
       (callback_event
-        (var_identifier)
-        (block
-          (var_identifier
-            (post_identifier
-              (function_call
-                (var_identifier)
-                (call_signature))))))
+        (simple_identifier)
+        (imperative_block
+          (member_access
+            (simple_identifier)
+            (function_call
+              (simple_identifier)
+              (arguments)))))
       (component
         (user_type_identifier)
         (block))
       (component
-        (var_identifier)
+        (simple_identifier)
         (user_type_identifier)
         (block))
       (component
@@ -104,27 +108,29 @@ TestCase := Rectangle {
       (property
         (type
           (builtin_type_identifier))
-        (var_identifier)
-        (add_binary_expression
-          (mult_binary_expression
+        (simple_identifier)
+        (binary_expression
+          (binary_expression
             (value
               (int_value))
             (mult_prec_operator)
-            (var_identifier
-              (post_identifier)))
+            (member_access
+              (simple_identifier)
+              (simple_identifier)))
           (add_prec_operator)
           (value
             (int_value))))
       (property
         (type
           (builtin_type_identifier))
-        (var_identifier)
-        (var_identifier
-          (post_identifier))))))
+        (simple_identifier)
+        (member_access
+          (simple_identifier)
+          (simple_identifier))))))
 
-================================================================================
+==================
 id_lookup
-================================================================================
+==================
 
  TestCase := Rectangle {
 
@@ -139,7 +145,7 @@ id_lookup
     property<int> p1: foo.inner;
     property<int> p2: self.foo *10 + foo.foo * 100 + bar *1000;
 }
---------------------------------------------------------------------------------
+---
 
 (sourcefile
   (component_definition
@@ -149,87 +155,398 @@ id_lookup
       (property
         (type
           (builtin_type_identifier))
-        (var_identifier)
+        (simple_identifier)
         (value
           (int_value)))
       (property
         (type
           (builtin_type_identifier))
-        (var_identifier)
+        (simple_identifier)
         (value
           (int_value)))
       (component
-        (var_identifier)
+        (simple_identifier)
         (user_type_identifier)
         (block
           (property
             (type
               (builtin_type_identifier))
-            (var_identifier)
+            (simple_identifier)
             (value
               (int_value)))
           (property
             (type
               (builtin_type_identifier))
-            (var_identifier)
+            (simple_identifier)
             (value
               (int_value)))
           (property
             (type
               (builtin_type_identifier))
-            (var_identifier)
-            (add_binary_expression
-              (add_binary_expression
-                (mult_binary_expression
-                  (var_identifier)
+            (simple_identifier)
+            (binary_expression
+              (binary_expression
+                (binary_expression
+                  (simple_identifier)
                   (mult_prec_operator)
                   (value
                     (int_value)))
                 (add_prec_operator)
-                (mult_binary_expression
-                  (var_identifier
+                (binary_expression
+                  (member_access
                     (reference_identifier)
-                    (post_identifier))
+                    (simple_identifier))
                   (mult_prec_operator)
                   (value
                     (int_value))))
               (add_prec_operator)
-              (mult_binary_expression
-                (var_identifier
+              (binary_expression
+                (member_access
                   (reference_identifier)
-                  (post_identifier))
+                  (simple_identifier))
                 (mult_prec_operator)
                 (value
                   (int_value)))))))
       (property
         (type
           (builtin_type_identifier))
-        (var_identifier)
-        (var_identifier
-          (post_identifier)))
+        (simple_identifier)
+        (member_access
+          (simple_identifier)
+          (simple_identifier)))
       (property
         (type
           (builtin_type_identifier))
-        (var_identifier)
-        (add_binary_expression
-          (add_binary_expression
-            (mult_binary_expression
-              (var_identifier
+        (simple_identifier)
+        (binary_expression
+          (binary_expression
+            (binary_expression
+              (member_access
                 (reference_identifier)
-                (post_identifier))
+                (simple_identifier))
               (mult_prec_operator)
               (value
                 (int_value)))
             (add_prec_operator)
-            (mult_binary_expression
-              (var_identifier
-                (post_identifier))
+            (binary_expression
+              (member_access
+                (simple_identifier)
+                (simple_identifier))
               (mult_prec_operator)
               (value
                 (int_value))))
           (add_prec_operator)
-          (mult_binary_expression
-            (var_identifier)
+          (binary_expression
+            (simple_identifier)
             (mult_prec_operator)
             (value
               (int_value))))))))
+
+==================
+rust_names
+==================
+
+// Just use some of the internal names used in Slint to make sure it still compiles
+
+import { Button, ComboBox } from "std-widgets.slint";
+
+export struct Some {}
+export struct None { s: Some }
+export struct Option { n: None }
+export struct Component {o: Option }
+export struct Model { c: Component }
+export struct Result { m: Model }
+export struct Ok { r: Result }
+export struct Property { value: string }
+export struct PropertyAnimation { property: Property }
+export struct Callback {}
+export struct Rc {}
+export struct Weak {}
+export enum WindowAdaptor { Window }
+export struct WindowItem {}
+export struct Slint { slint: string }
+export struct LayoutInfo { layout: int }
+export struct BoxLayoutData { layout: length }
+
+
+
+export enum Slice { xxx }
+export enum Coord { xxx }
+//export enum vtable { a, b, c }
+export struct AccessibleRole { value: Coord }
+export enum Default { a, b, c }
+
+
+export global ComponentInstance {
+    out property <Ok> ok;
+}
+
+export global GridLayoutCellData {
+    callback begin;
+}
+
+export component SharedString {
+    out property <Property> slint: { value: "foobar" };
+    property ok <=> ComponentInstance.ok;
+}
+
+export global ItemVTable {}
+
+export component TestCase  {
+
+    in property <Default> def: Default.b;
+    out property <BoxLayoutData> blt: { layout: 45phx };
+
+    slint := SharedString {}
+    Button { text: "hello" + 42; }
+    ComboBox {}
+
+    in-out property <int> Err;
+    animate Err { duration: 45s; }
+
+    out property <bool> test: slint.slint.value == "foobar";
+
+
+
+}
+---
+
+(sourcefile
+  (comment)
+  (import_statement
+    (import_type
+      (user_type_identifier))
+    (import_type
+      (user_type_identifier))
+    (string_value))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (user_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (user_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (user_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (user_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (user_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (user_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (builtin_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (user_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block))
+  (export)
+  (enum_definition
+    (user_type_identifier)
+    (enum_block
+      (simple_identifier)))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (builtin_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (builtin_type_identifier))))
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (builtin_type_identifier))))
+  (export)
+  (enum_definition
+    (user_type_identifier)
+    (enum_block
+      (simple_identifier)))
+  (export)
+  (enum_definition
+    (user_type_identifier)
+    (enum_block
+      (simple_identifier)))
+  (comment)
+  (export)
+  (struct_definition
+    (user_type_identifier)
+    (struct_block
+      (simple_identifier)
+      (type
+        (user_type_identifier))))
+  (export)
+  (enum_definition
+    (user_type_identifier)
+    (enum_block
+      (simple_identifier)
+      (simple_identifier)
+      (simple_identifier)))
+  (export)
+  (global_definition
+    (user_type_identifier)
+    (global_block
+      (property
+        (visibility_modifier)
+        (type
+          (user_type_identifier))
+        (simple_identifier))))
+  (export)
+  (global_definition
+    (user_type_identifier)
+    (global_block
+      (callback
+        (simple_identifier))))
+  (export)
+  (component_definition
+    (user_type_identifier)
+    (block
+      (property
+        (visibility_modifier)
+        (type
+          (user_type_identifier))
+        (simple_identifier)
+        (value
+          (anon_struct_block
+            (simple_identifier)
+            (value
+              (string_value)))))
+      (binding_alias
+        (simple_identifier)
+        (member_access
+          (simple_identifier)
+          (simple_identifier)))))
+  (export)
+  (global_definition
+    (user_type_identifier)
+    (global_block))
+  (export)
+  (component_definition
+    (user_type_identifier)
+    (block
+      (property
+        (visibility_modifier)
+        (type
+          (user_type_identifier))
+        (simple_identifier)
+        (member_access
+          (simple_identifier)
+          (simple_identifier)))
+      (property
+        (visibility_modifier)
+        (type
+          (user_type_identifier))
+        (simple_identifier)
+        (value
+          (anon_struct_block
+            (simple_identifier)
+            (value
+              (physical_length_value)))))
+      (component
+        (simple_identifier)
+        (user_type_identifier)
+        (block))
+      (component
+        (user_type_identifier)
+        (block
+          (property_assignment
+            (simple_identifier)
+            (binary_expression
+              (value
+                (string_value))
+              (add_prec_operator)
+              (value
+                (int_value))))))
+      (component
+        (user_type_identifier)
+        (block))
+      (property
+        (visibility_modifier)
+        (type
+          (builtin_type_identifier))
+        (simple_identifier))
+      (animate_statement
+        (simple_identifier)
+        (animate_body
+          (animate_option
+            (animate_option_identifier)
+            (value
+              (duration_value)))))
+      (property
+        (visibility_modifier)
+        (type
+          (builtin_type_identifier))
+        (simple_identifier)
+        (binary_expression
+          (member_access
+            (member_access
+              (simple_identifier)
+              (simple_identifier))
+            (simple_identifier))
+          (comparison_operator)
+          (value
+            (string_value)))))))

--- a/editors/tree-sitter-slint/queries/folds.scm
+++ b/editors/tree-sitter-slint/queries/folds.scm
@@ -1,0 +1,14 @@
+; Copyright © SixtyFPS GmbH <info@slint.dev>
+; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+[
+  (anon_struct_block)
+  (block)
+  (callback_event)
+  (component)
+  (enum_block)
+  (function_definition)
+  (global_definition)
+  (imperative_block)
+  (struct_block)
+] @folds

--- a/editors/tree-sitter-slint/queries/highlights.scm
+++ b/editors/tree-sitter-slint/queries/highlights.scm
@@ -5,45 +5,73 @@
 
 ; Different types:
 (string_value) @string @spell
+(escape_sequence) @string.escape
+
+(color_value) @constant
+[(children_identifier) (easing_kind_identifier)] @constant.builtin
 (bool_value) @boolean
-(int_value) @number
+[(int_value) (length_value) (physical_length_value) (duration_value) (angle_value) (relative_font_size_value)] @number
+(simple_identifier) @property @spell
+(escape_sequence) @string.escape
+(purity) @type.qualifier
+(visibility) @type.qualifier
+(animate_option_identifier) @keyword
+
 [(float_value) (percent_value)] @float
 
 (builtin_type_identifier) @type.builtin
 (reference_identifier) @variable.builtin
-(user_type_identifier) @spell
-(type [(type_list) (user_type_identifier) (type_anon_struct)]) @type
+(type [(type_list) (user_type_identifier) (anon_struct_block)]) @type @spell
+(user_type_identifier) @type @spell
+(visibility_modifier) @type.qualifier
 [(comparison_operator) (mult_prec_operator) (add_prec_operator) (unary_prec_operator) (assignment_prec_operator)] @operator
 
 ; Functions and callbacks
+(argument) @parameter
 (function_call) @function.call
-(parameter) @parameter
-(function ("function" @keyword))
-(callback ("callback" @keyword))
-(block ("return" @keyword.return))
 
 ; definitions
-(callback name: ((_) @spell))
-(function name: ((_) @spell))
-(property name: ((_) @property @spell))
+(callback name: ((_) @function @spell))
 (component id: ((_) @variable @spell))
-(struct_definition (type_anon_struct name: ((_) @field)))
-(global_definition (["global" ":="] @include @keyword))
-(struct_definition (["struct" ":="] @include @keyword))
-(property (["property" "<" ">"] @keyword))
-(visibility_modifier) @type.qualifier
+(enum_definition name: ((_) @type))
+(function_definition name: ((_) @function @spell))
+(property name: ((_) @property @spell))
+(struct_definition name: ((_) @type))
+(typed_identifier name: ((_) @variable @spell))
+(typed_identifier type: ((_) @type))
+
+(binary_expression op: ((_) @operator))
+(component (":=" @operator))
+(component_definition ([":="] @operator))
+(global_definition (":=" @operator))
+(struct_definition (":=" @operator))
+(unary_expression op: ((_) @operator))
+
+(if_statement (["if" ":" "else"] @conditional))
+(ternary_expression (["?" ":"] @conditional.ternary))
 
 ; Keywords:
 [ ";" "." "," ] @punctuation.delimiter
 [ "(" ")" "[" "]" "{" "}" ] @punctuation.bracket
 
-(ternary_expression (["?" ":"] @conditional.ternary))
-(if_statement (["if" ":" "else"] @conditional))
-(for_loop (["for" "in" ":"] @repeat @keyword))
+[(linear_gradient_identifier) (radial_gradient_identifier) (radial_gradient_kind)] @keyword
+(export) @include @keyword
 
-(animate_statement (["animate"] @keyword))
-(component_definition (["component" "inherits" ":="] @keyword))
-(export_statement (["export" "as"] @include @keyword))
+(animate_option (":" @keyword))
+(animate_statement ("animate" @keyword))
+(assignment_expr name: ((_) @property))
+(callback ("callback" @keyword))
+(component_definition (["component" "inherits"] @keyword))
+(enum_definition ("enum" @keyword))
+(for_loop (["for" "in" ":"] @repeat @keyword))
+(function_definition ("function" @keyword))
+(function_call name: ((_) @function.call))
+(global_definition ("global" @keyword))
+(image_call ("@image-url" @keyword))
+(imperative_block ("return" @keyword.return))
 (import_statement (["import" "from" "as"] @include @keyword))
+(property (["property" "<" ">"] @keyword))
 (states_definition (["states" "when"] @keyword))
+(struct_definition ("struct" @keyword))
+(tr ("@tr" @keyword))
 (transitions_definition (["transitions" "in" "out"] @keyword))

--- a/editors/tree-sitter-slint/queries/indents.scm
+++ b/editors/tree-sitter-slint/queries/indents.scm
@@ -1,8 +1,27 @@
 ; Copyright © SixtyFPS GmbH <info@slint.dev>
 ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-"{" @indent
+[
+  (arguments)
+  (block)
+  (enum_block)
+  (global_block)
+  (imperative_block)
+  (struct_block)
+  (typed_identifier)
+] @indent.begin
 
-"}" @indent_end
+([
+  (block)
+  (enum_block)
+  (global_block)
+  (imperative_block)
+  (struct_block)
+] "}" @indent.end)
 
-(comment) @auto
+([
+  (arguments)
+  (typed_identifier)
+] ")" @indent.end)
+
+(string_value) @indent.auto

--- a/editors/tree-sitter-slint/queries/injections.scm
+++ b/editors/tree-sitter-slint/queries/injections.scm
@@ -1,0 +1,5 @@
+; Copyright © SixtyFPS GmbH <info@slint.dev>
+; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/editors/tree-sitter-slint/queries/locals.scm
+++ b/editors/tree-sitter-slint/queries/locals.scm
@@ -1,16 +1,49 @@
 ; Copyright © SixtyFPS GmbH <info@slint.dev>
 ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
 
-; Functions and callbacks
-(typed_identifier name: ((_) @definition.parameter))
+[
+  (anon_struct_block)
+  (block)
+  (callback_event)
+  (component)
+  (enum_block)
+  (function_definition)
+  (global_definition)
+  (imperative_block)
+  (struct_block)
+] @local.scope
 
-; definitions
-(callback name: ((_) @definition.method) (#set! "definition.method.scope" "parent"))
-(function name: ((_) @definition.method) (#set! "definition.method.scope" "parent"))
-(property name: ((_) @definition.var) (#set! "definition.var.scope" "parent"))
-(component id: ((_) @definition.var) (#set! "definition.var.scope" "parent"))
-(global_definition name: ((user_type_identifier) @definition.type) (#set! "definition.method.scope" "parent"))
-(struct_definition name: ((user_type_identifier) @definition.type) (#set! "definition.type.scope" "global"))
-(struct_definition (type_anon_struct name: ((_) @definition.var)))
+(anon_struct_block (_) @local.definition.field)
+(argument) @local.definition.var
+(callback name: (_) @local.definition.member)
+(component_definition name: (_) @local.definition.type)
+(enum_definition name: (_) @local.definition.type)
+(enum_block (_) @local.definition.field)
+(function_definition name: (_) @local.definition.function)
+(global_definition name: (_) @local.definition.type)
+(import_type import_name: (_) !local_name) @local.definition.import
+(import_type import_name: (_) local_name: ((_) @local.definition.import))
+(property name: (_) @local.definition.field)
+(struct_block (_) @local.definition.field)
+(struct_definition name: (_) @local.definition.type)
+(typed_identifier name: (_) @local.definition.var)
 
-(block) @scope
+(argument (_) @local.reference)
+(binary_expression left: (_) @local.reference)
+(binary_expression right: (_) @local.reference)
+(callback_event name: (_) @local.reference)
+(component type: (_) @local.reference (#set! reference.kind "type"))
+(component_definition base_type: (_) @local.reference (#set! reference.kind "type"))
+(function_call name: (_) @local.reference)
+(index_op index: (_) @local.reference)
+(index_op left: (_) @local.reference)
+(member_access base: (_) @local.reference)
+(member_access member: (_) @local.reference)
+(parens_op left: (_) @local.reference)
+(property type: (_) @local.reference (#set! reference.kind "type"))
+(property_assignment property: (_) @local.reference (#set! reference.kind "field"))
+(property_assignment value: (_) @local.reference)
+(struct_block (_) @local.reference (#set! reference.kind "type"))
+(tr percent: (_) @local.reference)
+(typed_identifier type: (_) @local.reference (#set! reference.kind "type"))
+(unary_expression left: (_) @local.reference)


### PR DESCRIPTION
Clean up the `grammar.js` file and improve the queries.

Document how to inject `slint` into the rust parser to get highlighting for the `slint!` macro in rust files.