### PR TITLE
winit: Change window activation to default to false on for HTML canva…

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -215,7 +215,11 @@ impl WinitWindowAdapter {
                         canvas_id
                     )
                 })?;
-            window_builder = window_builder.with_canvas(Some(html_canvas))
+            window_builder = window_builder
+                .with_canvas(Some(html_canvas))
+                // Don't activate the window by default, as that will cause the page to scroll,
+                // ignoring any existing anchors.
+                .with_active(false)
         };
 
         Ok(window_builder)


### PR DESCRIPTION
…s usage

Don't activate the canvas by default, as that causes winit to call focus() on the DOM element, which in turn will forcibly scroll the browser window. That means any existing anchors are ignored and the user's scroll preference is disturbed.

Fixes #4431