### PR TITLE
Fix panic when using foward-focus with non-element binding

### DIFF
--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -92,7 +92,7 @@ impl<'a> LocalFocusForwards<'a> {
 
             let Expression::ElementReference(focus_target) = &forward_focus_binding.expression
             else {
-                assert!(matches!(forward_focus_binding.expression, Expression::Invalid), "internal error: forward-focus property is of type ElementReference but received non-element-reference binding");
+                // resolve expressions pass will produce type error
                 return;
             };
 

--- a/internal/compiler/tests/syntax/focus/focus_invalid.slint
+++ b/internal/compiler/tests/syntax/focus/focus_invalid.slint
@@ -1,8 +1,12 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-
 export X := Rectangle {
     forward-focus: nothingness;
     //             ^error{Unknown unqualified identifier}
+}
+
+export Y := Rectangle {
+    forward-focus: true;
+//                 ^error{Cannot convert bool to element ref}
 }


### PR DESCRIPTION
Since commit 6fefe75a1c18b79869485961a0690f8844844fe5 the handling of forward-focus bindings happens before the resolve_expressions pass, which means that we cannot rely on type mismatch
error handling yet.

Fixes #4475