### PR TITLE
Fix squashed usage graphs in iot dashboard when previewing

### DIFF
--- a/examples/iot-dashboard/iot-dashboard.slint
+++ b/examples/iot-dashboard/iot-dashboard.slint
@@ -518,6 +518,7 @@ export component UsageDiagram inherits Box {
             drop-shadow-offset-y: 6px;
             drop-shadow-blur: 6px;
             drop-shadow-color: Skin.palette.weekdayBox;
+            min-height: 50px;
         }
 
     }


### PR DESCRIPTION
Provide a minimum height for the boxes, so that the graphs are always visible. The graphs are painted on top of the boxes, but the boxes define the geometry.