### PR TITLE
C++: Permit passing a value to VectorModel::set_vector by value

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -538,7 +538,7 @@ public:
     }
 
     /// Replaces the underlying VectorModel's vector with \a array.
-    void set_vector(std::vector<ModelData> &&array)
+    void set_vector(std::vector<ModelData> array)
     {
         data = std::move(array);
         this->reset();

--- a/api/cpp/tests/models.cpp
+++ b/api/cpp/tests/models.cpp
@@ -524,4 +524,8 @@ TEST_CASE("VectorModel clear and replace")
     REQUIRE(observer->changed_rows.empty());
     REQUIRE(observer->removed_rows.empty());
     REQUIRE(observer->model_reset);
+
+    // Test that taking a vector by value compiles
+    std::vector<int> new_data { 5, 6, 7, 8 };
+    model->set_vector(new_data);
 }


### PR DESCRIPTION
The previous signature would not allow that, but we should allow it for consistency with the constructor.