### PR TITLE
Work around build issues with espressif_lvgl_port >= 1.5.0

### DIFF
--- a/examples/carousel/esp-idf/s2-kaluga-kit/main/idf_component.yml
+++ b/examples/carousel/esp-idf/s2-kaluga-kit/main/idf_component.yml
@@ -6,4 +6,4 @@ dependencies:
   idf: ">=5.1"
   espressif/esp32_s2_kaluga_kit:
     version: "^2.2.4"
-
+  espressif/esp_lvgl_port: "=1.4.0"

--- a/examples/carousel/esp-idf/s3-box/main/idf_component.yml
+++ b/examples/carousel/esp-idf/s3-box/main/idf_component.yml
@@ -6,3 +6,4 @@ dependencies:
   idf: ">=5.1"
   espressif/esp-box:
     version: "^2.3"
+  espressif/esp_lvgl_port: "=1.4.0"

--- a/examples/carousel/esp-idf/s3-usb-otg/main/idf_component.yml
+++ b/examples/carousel/esp-idf/s3-usb-otg/main/idf_component.yml
@@ -6,3 +6,4 @@ dependencies:
   idf: ">=5.1"
   espressif/esp32_s3_usb_otg:
     version: "^1.4.4"
+  espressif/esp_lvgl_port: "=1.4.0"

--- a/examples/printerdemo_mcu/esp-idf/main/idf_component.yml
+++ b/examples/printerdemo_mcu/esp-idf/main/idf_component.yml
@@ -5,3 +5,4 @@
 dependencies:
   idf: ">=5.1"
   espressif/esp-box: "^2.3"
+  espressif/esp_lvgl_port: "=1.4.0"


### PR DESCRIPTION
esp-box fails to build with 1.5.0/lvgl9. Even thought 1.5 was marked as
yanked, it still shows up. So temporarily pin the examples to 1.4.0.