### PR TITLE
Android: send the input type to the input method

### DIFF
--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -19,6 +19,7 @@ class SlintInputView extends View {
     private int mAnchorPosition = 0;
     private String mPreedit = "";
     private int mPreeditOffset;
+    private int mInputType = EditorInfo.TYPE_CLASS_TEXT;
 
     public SlintInputView(Context context) {
         super(context);
@@ -33,7 +34,7 @@ class SlintInputView extends View {
 
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-        outAttrs.inputType = EditorInfo.TYPE_CLASS_TEXT;
+        outAttrs.inputType = mInputType;
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI;
         outAttrs.initialSelStart = mCursorPosition;
         outAttrs.initialSelEnd = mAnchorPosition;
@@ -100,21 +101,29 @@ class SlintInputView extends View {
         };
     }
 
-    public void setText(String text, int cursorPosition, int anchorPosition, String preedit, int preeditOffset) {
+    public void setText(String text, int cursorPosition, int anchorPosition, String preedit, int preeditOffset,
+            int inputType) {
+        boolean restart = mInputType != inputType || !mText.equals(text);
+        boolean update_selection = mCursorPosition != cursorPosition || mAnchorPosition != anchorPosition;
         mText = text;
         mCursorPosition = cursorPosition;
         mAnchorPosition = anchorPosition;
         mPreedit = preedit;
         mPreeditOffset = preeditOffset;
+        mInputType = inputType;
 
         InputMethodManager imm = (InputMethodManager) this.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-        ExtractedText extractedText = new ExtractedText();
-        extractedText.text = mText;
-        extractedText.startOffset = mPreeditOffset;
-        extractedText.selectionStart = mCursorPosition;
-        extractedText.selectionEnd = mAnchorPosition;
-        imm.updateExtractedText(this, 0, extractedText);
-        imm.updateSelection(this, cursorPosition, anchorPosition, cursorPosition, anchorPosition);
+        if (restart) {
+            imm.restartInput(this);
+        } else if (update_selection) {
+            ExtractedText extractedText = new ExtractedText();
+            extractedText.text = mText;
+            extractedText.startOffset = mPreeditOffset;
+            extractedText.selectionStart = mCursorPosition;
+            extractedText.selectionEnd = mAnchorPosition;
+            imm.updateExtractedText(this, 0, extractedText);
+            imm.updateSelection(this, cursorPosition, anchorPosition, cursorPosition, anchorPosition);
+        }
     }
 
     @Override
@@ -186,7 +195,7 @@ public class SlintAndroidJavaHelper {
                 mInputView.setLayoutParams(layoutParams);
                 int selStart = Math.min(cursor_position, anchor_position);
                 int selEnd = Math.max(cursor_position, anchor_position);
-                mInputView.setText(text, selStart, selEnd, preedit, preedit_offset);
+                mInputView.setText(text, selStart, selEnd, preedit, preedit_offset, input_type);
             }
         });
     }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -527,7 +527,7 @@ impl Item for TextInput {
                 if self.read_only() || event.modifiers.control {
                     return KeyEventResult::EventIgnored;
                 }
-                self.delete_selection(window_adapter, self_rc);
+                self.delete_selection(window_adapter, self_rc, TextChangeNotify::SkipCallbacks);
 
                 let mut text: String = self.text().into();
 
@@ -685,6 +685,16 @@ impl From<KeyboardModifiers> for AnchorMode {
             Self::MoveAnchor
         }
     }
+}
+
+/// Argument to [`TextInput::delete_selection`] that determines whether to trigger the
+/// `edited` and cursor position callbacks and issue an input method request update.
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum TextChangeNotify {
+    /// Trigger the callbacks.
+    TriggerCallbacks,
+    /// Skip triggering the callbacks, as a subsequent operation will trigger them.
+    SkipCallbacks,
 }
 
 fn safe_byte_offset(unsafe_byte_offset: i32, text: &str) -> usize {
@@ -940,13 +950,14 @@ impl TextInput {
         if !self.has_selection() {
             self.move_cursor(step, AnchorMode::KeepAnchor, window_adapter, self_rc);
         }
-        self.delete_selection(window_adapter, self_rc);
+        self.delete_selection(window_adapter, self_rc, TextChangeNotify::TriggerCallbacks);
     }
 
-    pub fn delete_selection(
+    fn delete_selection(
         self: Pin<&Self>,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
+        trigger_callbacks: TextChangeNotify,
     ) {
         let text: String = self.text().into();
         if text.is_empty() {
@@ -961,8 +972,12 @@ impl TextInput {
         let text = [text.split_at(anchor).0, text.split_at(cursor).1].concat();
         self.text.set(text.into());
         self.anchor_position_byte_offset.set(anchor as i32);
-        self.set_cursor_position(anchor as i32, true, window_adapter, self_rc);
-        Self::FIELD_OFFSETS.edited.apply_pin(self).call(&());
+        if trigger_callbacks == TextChangeNotify::TriggerCallbacks {
+            self.set_cursor_position(anchor as i32, true, window_adapter, self_rc);
+            Self::FIELD_OFFSETS.edited.apply_pin(self).call(&());
+        } else {
+            self.cursor_position_byte_offset.set(anchor as i32);
+        }
     }
 
     pub fn anchor_position(self: Pin<&Self>, text: &str) -> usize {
@@ -1027,7 +1042,7 @@ impl TextInput {
         if text_to_insert.is_empty() {
             return;
         }
-        self.delete_selection(window_adapter, self_rc);
+        self.delete_selection(window_adapter, self_rc, TextChangeNotify::SkipCallbacks);
         let mut text: String = self.text().into();
         let cursor_pos = self.selection_anchor_and_cursor().1;
         if text_to_insert.contains('\n') && self.single_line() {
@@ -1044,7 +1059,7 @@ impl TextInput {
 
     pub fn cut(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>, self_rc: &ItemRc) {
         self.copy(window_adapter, self_rc);
-        self.delete_selection(window_adapter, self_rc);
+        self.delete_selection(window_adapter, self_rc, TextChangeNotify::TriggerCallbacks);
     }
 
     pub fn set_selection_offsets(


### PR DESCRIPTION
Also avoid flickering of the input method when inserting text by preventing sending an imput method event right after deleting the selection