### PR TITLE
lsp: set sortText for CompletionItems

### DIFF
--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -409,6 +409,7 @@ fn resolve_element_scope(
             } else {
                 CompletionItemKind::PROPERTY
             });
+            c.sort_text = Some(format!("#{}", c.label));
             c
         })
         .chain(element.PropertyDeclaration().filter_map(|pr| {


### PR DESCRIPTION
If the sortText isn't there, then label is used to do the sorting [1] which results in a poor auto-complete experience.

This patch sets sortText of the completion item in a way such that the sort order is maintained on the client side.

[1]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem