### PR TITLE
Fix initial rendering of the live-preview

### DIFF
--- a/tools/lsp/ui/draw-area.slint
+++ b/tools/lsp/ui/draw-area.slint
@@ -81,6 +81,18 @@ export component DrawArea {
                 width: i-preview-area-container.width;
                 height: i-preview-area-container.height;
 
+
+                // Also make a condition that abuses the fact that the init callback
+                // is called every time the condition is dirty, to make sure that the size
+                // is within the bounds.
+                // Querty the preview-area to make sure this is evaluated when it changes
+                if i-preview-area-container.has-component && root.preview-area == i-preview-area-container.component-factory : Rectangle {
+                    init => {
+                        i-preview-area-container.width = clamp(i-preview-area-container.width, i-preview-area-container.min-width, i-preview-area-container.max-width);
+                        i-preview-area-container.height = clamp(i-preview-area-container.height, i-preview-area-container.min-height, i-preview-area-container.max-height);
+                    }
+                }
+
                 i-preview-area-container := ComponentContainer {
 
                     property <bool> is-resizable: (self.min-width != self.max-width && self.min-height != self.max-height) && self.has-component;
@@ -95,17 +107,6 @@ export component DrawArea {
                     init => {
                         self.width = max(self.preferred-width, self.min-width);
                         self.height = max(self.preferred-height, self.min-height);
-                    }
-                }
-
-                // Also make a condition that abuses the fact that the init callback
-                // is called every time the condition is dirty, to make sure that the size
-                // is within the bounds.
-                // Querty the preview-area to make sure this is evaluated when it changes
-                if i-preview-area-container.has-component && root.preview-area == i-preview-area-container.component-factory : Rectangle {
-                    init => {
-                        i-preview-area-container.width = clamp(i-preview-area-container.width, i-preview-area-container.min-width, i-preview-area-container.max-width);
-                        i-preview-area-container.height = clamp(i-preview-area-container.height, i-preview-area-container.min-height, i-preview-area-container.max-height);
                     }
                 }
 


### PR DESCRIPTION
The hack to sets the preview area's width and height through the init callback was run _after_ rendering the component container and during evaluation of the dirty tracker. The latter sets itself to dirty = false after evaluation, so it's never dirty despite the width and height having changed.

As a workaround for 1.4.1, move the init callback hack to before render() is called.