### PR TITLE
CI: update github action dependencies

### DIFF
--- a/.github/actions/install-nodejs/action.yaml
+++ b/.github/actions/install-nodejs/action.yaml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: "16"
     - id: node-version

--- a/.github/actions/test-online-editor/action.yaml
+++ b/.github/actions/test-online-editor/action.yaml
@@ -28,11 +28,11 @@ runs:
   using: composite
   steps:
     - name: Download the WASM binaries
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.wasm-binaries }}
     - name: Download the slintpad artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.slintpad-artifact }}
         path: tools/slintpad/dist
@@ -70,7 +70,7 @@ runs:
       env:
         DEBUG: "cypress:server:args"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: cypress-screenshots-chrome

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -19,7 +19,7 @@ jobs:
       SLINT_NO_QT: 1
       CARGO_INCREMENTAL: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up rgb crate rustdoc link
       run: |
         rgb_version=`grep 'rgb = '  internal/core/Cargo.toml | sed 's/^.*"\(.*\)"/\1/'`
@@ -107,7 +107,7 @@ jobs:
           npm run docs
       working-directory: api/node
     - name: "Upload Docs Artifacts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: docs
           path: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-linux-dependencies
     - name: Install Qt
       if: runner.os != 'Windows'
@@ -82,7 +82,7 @@ jobs:
       shell: bash
     - name: Archive screenshots after failed tests
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: screenshots-${{matrix.os}}
           path: |
@@ -103,7 +103,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-linux-dependencies
     - name: Install Qt
       if: runner.os != 'Windows'
@@ -155,7 +155,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-linux-dependencies
     - name: Install Qt
       if: runner.os != 'Windows'
@@ -200,7 +200,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
@@ -236,7 +236,7 @@ jobs:
         os: [ubuntu-22.04, macos-12, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
@@ -278,7 +278,7 @@ jobs:
       working-directory: ${{ runner.workspace }}/cppbuild
       run: cmake --build . --config Debug --target package
     - name: "Create C++ packages artifact"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: cpp_bin-${{ matrix.os }}
           path: ${{ runner.workspace }}/cppbuild/Slint-cpp-*
@@ -292,7 +292,7 @@ jobs:
       CARGO_INCREMENTAL: false
       CARGO_PROFILE_DEV_DEBUG: 0
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
@@ -301,7 +301,7 @@ jobs:
       with:
         version: 5.15.2
         cache: true
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: cpp_bin-ubuntu-22.04
         path: cpp-package
@@ -336,7 +336,7 @@ jobs:
           - feature: stm32h735g
             target: thumbv7em-none-eabihf
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-rust
       with:
         target: ${{matrix.target}}
@@ -346,7 +346,7 @@ jobs:
   mcu_esp:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: esp-rs/xtensa-toolchain@v1.5
       with:
@@ -362,11 +362,11 @@ jobs:
   ffi_32bit_build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-rust
       with:
         target: armv7-unknown-linux-gnueabihf
-    - uses: baptiste0928/cargo-install@v2
+    - uses: baptiste0928/cargo-install@v3
       with:
         crate: cross
     - name: Check
@@ -377,7 +377,7 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-rust
       with:
         toolchain: stable
@@ -397,7 +397,7 @@ jobs:
   tree-sitter:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: robinraju/release-downloader@v1.7
@@ -438,7 +438,7 @@ jobs:
         from_version: ['0.3.0']
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: ./.github/actions/install-linux-dependencies
@@ -501,7 +501,7 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-linux-dependencies
     - uses: ./.github/actions/setup-rust
     - name: run the formatter
@@ -518,7 +518,7 @@ jobs:
     runs-on: ubuntu-22.04
     container: espressif/idf:release-v5.2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
@@ -553,7 +553,7 @@ jobs:
   android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Android API level 30
         run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "platforms;android-30"
       - name: Cache cargo-apk

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-20.04, macOS-11, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/install-linux-dependencies
       with:
         old-ubuntu: true
@@ -34,7 +34,7 @@ jobs:
         version: 6.5.1
         cache: true
     - uses: ./.github/actions/setup-rust
-    - uses: baptiste0928/cargo-install@v2
+    - uses: baptiste0928/cargo-install@v3
       with:
         crate: cargo-about
     - name: Prepare licenses
@@ -58,7 +58,7 @@ jobs:
       working-directory: ${{ runner.workspace }}/cppbuild
       run: cmake --build . --config Release --target package
     - name: "Upload C++ packages"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: cpp_bin
           path: ${{ runner.workspace }}/cppbuild/Slint-cpp-*

--- a/.github/workflows/crater.yaml
+++ b/.github/workflows/crater.yaml
@@ -123,7 +123,7 @@ jobs:
             os: windows-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-linux-dependencies
         with:
           extra-packages: libpango1.0-dev libatk1.0-dev libgtk-3-dev alsa-utils libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libjack-jackd2-dev autoconf libxcb-xrm0 libxcb-xrm-dev automake  libxcb-keysyms1-dev libxcb-util0-dev libxcb-icccm4-dev libyajl-dev libstartup-notification0-dev libxcb-randr0-dev libev-dev libxcb-cursor-dev libxcb-xinerama0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev libasound2-dev pkg-config nasm libsoup2.4-dev

--- a/.github/workflows/embedded_build.yaml
+++ b/.github/workflows/embedded_build.yaml
@@ -23,7 +23,7 @@ jobs:
       SLINT_NO_QT: 1
       SLINT_STYLE: fluent
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to GitHub Container Registry
@@ -59,7 +59,7 @@ jobs:
           - aarch64-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-rust
       with:
         target: ${{ matrix.target }}
@@ -67,13 +67,13 @@ jobs:
       if: matrix.target != 'riscv64gc-unknown-linux-gnu'
       run: |
           echo "EXTRA_ARGS=--features slint/renderer-skia" >> $GITHUB_ENV
-    - uses: baptiste0928/cargo-install@v2
+    - uses: baptiste0928/cargo-install@v3
       with:
         crate: cross
     - name: Build
       run: cross build --release --target=${{ matrix.target }} ${{ env.EXTRA_ARGS }} --features slint/backend-linuxkms-noseat -p energy-monitor -p printerdemo -p todo -p slint-viewer -p gallery
     - name: "Upload printerdemo artifact"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: printerdemo-${{ matrix.target }}
           path: |

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -88,7 +88,7 @@ jobs:
             artifact_name: slint-lsp-x86_64-pc-windows-msvc.exe
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-rust
       with:
         target: ${{ matrix.toolchain }}
@@ -102,7 +102,7 @@ jobs:
           mkdir bin
           cp target/${{ matrix.toolchain }}/release/${{ matrix.binary_built }} bin/${{ matrix.artifact_name }}
     - name: "Upload LSP Artifact"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: vscode-lsp-binary-${{ matrix.toolchain }}
           path: |
@@ -113,7 +113,7 @@ jobs:
       SLINT_NO_QT: 1
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-rust
       with:
         target: x86_64-apple-darwin
@@ -127,7 +127,7 @@ jobs:
           mkdir bin
           cp -a target/release/bundle/osx/Slint\ Live\ Preview.app bin
     - name: "Upload LSP Artifact"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: vscode-lsp-binary-x86_64-apple-darwin
           path: |
@@ -138,7 +138,7 @@ jobs:
       SLINT_NO_QT: 1
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-rust
       with:
         target: aarch64-apple-darwin
@@ -149,7 +149,7 @@ jobs:
           mkdir bin
           cp -a target/aarch64-apple-darwin/release/slint-lsp bin/slint-lsp-aarch64-apple-darwin
     - name: "Upload LSP Artifact"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: vscode-lsp-binary-aarch64-apple-darwin
           path: |
@@ -159,13 +159,13 @@ jobs:
     needs: [build_vscode_lsp_macos_x86_64, build_vscode_lsp_macos_aarch64]
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: "src"
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: vscode-lsp-binary-x86_64-apple-darwin
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: vscode-lsp-binary-aarch64-apple-darwin
         path: bin
@@ -184,7 +184,7 @@ jobs:
     - name: "Remove temporary source checkout"
       run: rm -rf src
     - name: "Upload LSP macOS bundle Artifact"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: vscode-lsp-binary-darwin
           path: .
@@ -199,11 +199,11 @@ jobs:
           - aarch64-unknown-linux-gnu
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-rust
       with:
         target: ${{ matrix.target }}
-    - uses: baptiste0928/cargo-install@v2
+    - uses: baptiste0928/cargo-install@v3
       with:
         crate: cross
     - name: Build LSP
@@ -213,7 +213,7 @@ jobs:
           mkdir bin
           cp target/${{ matrix.target }}/release/slint-lsp bin/slint-lsp-${{ matrix.target }}
     - name: "Upload LSP Artifact"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: vscode-lsp-binary-${{ matrix.target }}
           path: |
@@ -224,24 +224,24 @@ jobs:
     runs-on: macos-11
     if: ${{ needs.check-for-secrets.outputs.has-openvsx-pat == 'yes' && needs.check-for-secrets.outputs.has-vscode-marketplace-pat == 'yes' }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
       with:
         name: vscode-lsp-binary-x86_64-unknown-linux-gnu
         path: editors/vscode/bin
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: vscode-lsp-binary-x86_64-pc-windows-msvc
         path: editors/vscode/bin
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: vscode-lsp-binary-darwin
         path: editors/vscode/bin
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: vscode-lsp-binary-armv7-unknown-linux-gnueabihf
         path: editors/vscode/bin
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: vscode-lsp-binary-aarch64-unknown-linux-gnu
         path: editors/vscode/bin
@@ -278,7 +278,7 @@ jobs:
         extensionFile: ${{ steps.publishToVSCM.outputs.vsixPath }}
         packagePath: ''
     - name: "Upload extension artifact"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: slint-vscode.zip
           path: |
@@ -288,9 +288,9 @@ jobs:
 #    if: github.event.inputs.private != 'true'
 #    runs-on: ubuntu-20.04
 #    steps:
-#      - uses: actions/checkout@v3
+#      - uses: actions/checkout@v4
 #      - name: Upload artifact
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #            name: tree-sitter-slint
 #            path: editors/tree-sitter-slint
@@ -300,17 +300,17 @@ jobs:
     needs: [docs, wasm_demo, wasm, check-for-secrets]
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: docs
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: slintpad
           path: slintpad
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wasm
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wasm_demo
       - name: Extract Version
@@ -402,25 +402,25 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cpp_bin
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: slint-viewer-linux
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: slint-viewer-windows
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: slint-viewer-macos
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: slint-lsp-linux
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: slint-lsp-windows
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: slint-lsp-macos
       - name: Extract files

--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -30,7 +30,7 @@ jobs:
     - uses: ./.github/actions/install-linux-dependencies
     - uses: ./.github/actions/setup-rust
     # Setup .npmrc file to publish to npm
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
@@ -82,7 +82,7 @@ jobs:
         with:
           target: ${{ matrix.rust-target }}
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
@@ -119,7 +119,7 @@ jobs:
           fi    
           npm pack
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries-${{ matrix.rust-target }}
           path: "api/node/npm/${{ matrix.napi-rs-target }}/*.tgz"
@@ -135,7 +135,7 @@ jobs:
     - uses: ./.github/actions/install-linux-dependencies
     - uses: ./.github/actions/setup-rust
     # Setup .npmrc file to publish to npm
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
@@ -161,27 +161,27 @@ jobs:
       run: |
         npx napi create-npm-dir -t . -c ./binaries.json
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: binaries-x86_64-unknown-linux-gnu
         path: api/node/
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: binaries-x86_64-apple-darwin
         path: api/node/
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: binaries-aarch64-apple-darwin
         path: api/node/  
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: binaries-x86_64-pc-windows-msvc
         path: api/node/  
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: binaries-i686-pc-windows-msvc
         path: api/node/      
@@ -196,7 +196,7 @@ jobs:
       run: |
           cargo xtask node_package $PKG_EXTRA_ARGS
     - name: "Upload npm package Artifact"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: slint-ui-node-package
           path: |

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -57,7 +57,7 @@ jobs:
   build_windows:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           target: x86_64-pc-windows-msvc
@@ -66,7 +66,7 @@ jobs:
         with:
           version: 6.5.1
           cache: true
-      - uses: baptiste0928/cargo-install@v2
+      - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
       - name: Build
@@ -84,7 +84,7 @@ jobs:
             bash -x ../../scripts/prepare_binary_package.sh ..\..\pkg\slint-${{ github.event.inputs.program || inputs.program }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: slint-${{ github.event.inputs.program || inputs.program }}-windows
             path: |
@@ -93,7 +93,7 @@ jobs:
   build_linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-linux-dependencies
         with:
           old-ubuntu: true
@@ -105,7 +105,7 @@ jobs:
         with:
           version: 5.15.2
           cache: true
-      - uses: baptiste0928/cargo-install@v2
+      - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
       - name: Build
@@ -119,7 +119,7 @@ jobs:
       - name: Tar artifacts to preserve permissions
         run: tar czvf slint-${{ github.event.inputs.program || inputs.program }}-linux.tar.gz slint-${{ github.event.inputs.program || inputs.program }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: slint-${{ github.event.inputs.program || inputs.program }}-linux
             path: slint-${{ github.event.inputs.program || inputs.program }}-linux.tar.gz
@@ -127,14 +127,14 @@ jobs:
   build_macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
           target: x86_64-apple-darwin
       - uses: ./.github/actions/setup-rust
         with:
           target: aarch64-apple-darwin
-      - uses: baptiste0928/cargo-install@v2
+      - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-about
       - name: Build x86_64
@@ -161,7 +161,7 @@ jobs:
       - name: Tar artifacts to preserve permissions
         run: tar czvf slint-${{ github.event.inputs.program || inputs.program }}-macos.tar.gz slint-${{ github.event.inputs.program || inputs.program }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: slint-${{ github.event.inputs.program || inputs.program }}-macos
             path: slint-${{ github.event.inputs.program || inputs.program }}-macos.tar.gz

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -11,7 +11,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: streetsidesoftware/cspell-action@v1.2.4
       with:
         config: './cspell.json'

--- a/.github/workflows/torizon_demos.yaml
+++ b/.github/workflows/torizon_demos.yaml
@@ -39,7 +39,7 @@ jobs:
             base_image_suffix: "-vivante"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: "install gettext tools"
         run: sudo apt install gettext
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
 
       - name: "gallery: Run slint-tr-extractor"

--- a/.github/workflows/upgrade_version.yaml
+++ b/.github/workflows/upgrade_version.yaml
@@ -14,7 +14,7 @@ jobs:
   upgrade_version_number:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Do replacements
       run: |
         # Each Cargo.toml need to have the version updated

--- a/.github/workflows/upload_esp_idf_component.yaml
+++ b/.github/workflows/upload_esp_idf_component.yaml
@@ -10,7 +10,7 @@ jobs:
   upload_components:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Upload component
       uses: espressif/upload-components-ci-action@v1
       with:

--- a/.github/workflows/wasm_demos.yaml
+++ b/.github/workflows/wasm_demos.yaml
@@ -19,7 +19,7 @@ jobs:
       RUSTFLAGS: ${{ github.event.inputs.rustflags || inputs.rustflags }}
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-rust
       with:
         target: wasm32-unknown-unknown
@@ -84,7 +84,7 @@ jobs:
         wasm-pack build --release --target web --no-default-features --features slint/default,chrono
       working-directory: examples/energy-monitor
     - name: "Upload Demo Artifacts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: wasm_demo
           path: |

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -20,7 +20,7 @@ jobs:
       RUSTFLAGS: ${{ github.event.inputs.rustflags || inputs.rustflags }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-nodejs
       - uses: ./.github/actions/setup-rust
         with:
@@ -39,7 +39,7 @@ jobs:
         working-directory: tools/slintpad
 
       - name: "Upload wasm Artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wasm
           path: |
@@ -50,10 +50,10 @@ jobs:
     needs: [wasm]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-nodejs
       - name: Download wasm_lsp Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wasm
       - uses: actions/cache@v3
@@ -72,7 +72,7 @@ jobs:
         working-directory: tools/slintpad
 
       - name: "Upload slintpad Artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: slintpad
           path: tools/slintpad/dist/
@@ -81,10 +81,10 @@ jobs:
     needs: [wasm]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-nodejs
       - name: Download wasm_lsp Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wasm
       - uses: actions/cache@v3
@@ -112,7 +112,7 @@ jobs:
   #     options: --user 1001
   #
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #     - uses: ./.github/actions/test-slintpad
   #       with:
   #         browser: "firefox"
@@ -127,7 +127,7 @@ jobs:
   #     options: --user 1001
   #
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #     - uses: ./.github/actions/test-slintpad
   #       with:
   #         browser: "chrome"

--- a/.github/workflows/yocto_build.yaml
+++ b/.github/workflows/yocto_build.yaml
@@ -22,7 +22,7 @@ jobs:
             target: armv7-unknown-linux-gnueabihf
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Fetch Yocto SDK
       run: |
           # Fetch pre-built SDK built via populate_sdk for core-image-weston with setup from https://github.com/slint-ui/meta-slint/blob/main/.github/workflows/ci.yml


### PR DESCRIPTION
Looked at warning of actions that still uses old node version and update the onces that had a new release