### PR TITLE
Fix warning in Rust 1.77 with unused exported globals

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1194,6 +1194,7 @@ fn generate_global(global: &llr::GlobalComponent, root: &llr::PublicComponent) -
 
         let aliases = global.aliases.iter().map(|name| ident(name));
         quote!(
+            #[allow(unused)]
             pub struct #public_component_id<'a>(&'a ::core::pin::Pin<sp::Rc<#inner_component_id>>);
 
             impl<'a> #public_component_id<'a> {


### PR DESCRIPTION
Rust 1.77 added a warning when tuple values are not used.