### PR TITLE
Prospective fix for C++ package creation

### DIFF
--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -21,6 +21,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macOS-11, windows-2022]
+        include:
+          - os: ubuntu-20-04
+            package_suffix: linux
+          - os: macOS-11
+            package_suffix: macos
+          - os: windows-2022
+            package_suffix: windows
+        
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -60,5 +68,5 @@ jobs:
     - name: "Upload C++ packages"
       uses: actions/upload-artifact@v4
       with:
-          name: cpp_bin
+          name: cpp_bin-${{ matrix.package_suffix }}
           path: ${{ runner.workspace }}/cppbuild/Slint-cpp-*

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -404,7 +404,13 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: cpp_bin
+          name: cpp_bin-linux
+      - uses: actions/download-artifact@v4
+        with:
+          name: cpp_bin-macos
+      - uses: actions/download-artifact@v4
+        with:
+          name: cpp_bin-windows
       - uses: actions/download-artifact@v4
         with:
           name: slint-viewer-linux


### PR DESCRIPTION
upload-artifact v4 requires a unique artifact name, instead of "merging": https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new

So assign os version independent suffixes and use those in the release step.