### PR TITLE
slint-viewer: fix the docs for the `-L` option

### DIFF
--- a/tools/viewer/README.md
+++ b/tools/viewer/README.md
@@ -35,7 +35,7 @@ slint-viewer path/to/myfile.slint
    This option is incompatible with `--auto-reload`
  - `--load-data <file>`: Load the values of public properties from a json file.
  - `-I <path>`: Add an include path to look for imported .slint files or images.
- - `-L <library:path>`: Add a library path to look for `@library` imports.
+ - `-L <library=path>`: Add a library path to look for `@library` imports.
  - `--style <style>`: Set the style. Defaults to `native` if the Qt backend is compiled, otherwise `fluent`
  - `--backend <backend>`: Override the Slint rendering backend
  - `--on <callback> <handler>`: Set a callback handler, see [callback handler](#callback-handlers)

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -21,23 +21,24 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 #[derive(Clone, clap::Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    #[arg(short = 'I', name = "include path for other .slint files", number_of_values = 1, action)]
+    /// Include path for other .slint files or images
+    #[arg(short = 'I', value_name = "include path", number_of_values = 1, action)]
     include_paths: Vec<std::path::PathBuf>,
 
-    /// The first argument is the library name, and the second argument is the path to the library.
-    #[arg(short = 'L', name = "library path for @library imports", number_of_values = 1, action)]
+    /// Specify Library location of the '@library' in the form 'library=/path/to/library'
+    #[arg(short = 'L', value_name = "library=path", number_of_values = 1, action)]
     library_paths: Vec<String>,
 
     /// The .slint file to load ('-' for stdin)
-    #[arg(name = "path to .slint file", action)]
+    #[arg(name = "path", action)]
     path: std::path::PathBuf,
 
     /// The style name ('native' or 'fluent')
-    #[arg(long, name = "style name", action)]
+    #[arg(long, value_name = "style name", action)]
     style: Option<String>,
 
     /// The rendering backend
-    #[arg(long, name = "backend", action)]
+    #[arg(long, value_name = "backend", action)]
     backend: Option<String>,
 
     /// Automatically watch the file system, and reload when it changes
@@ -45,11 +46,11 @@ struct Cli {
     auto_reload: bool,
 
     /// Load properties from a json file ('-' for stdin)
-    #[arg(long, name = "load data file", action)]
+    #[arg(long, value_name = "json file", action)]
     load_data: Option<std::path::PathBuf>,
 
     /// Store properties values in a json file at exit ('-' for stdout)
-    #[arg(long, name = "save data file", action)]
+    #[arg(long, value_name = "json file", action)]
     save_data: Option<std::path::PathBuf>,
 
     /// Specify callbacks handler.


### PR DESCRIPTION
The previous help was not useful to document that -L should contain an = 

This is how it looks now:
![image](https://github.com/slint-ui/slint/assets/959326/b81edaa7-b79c-4585-8787-57647531e837)
