### PR TITLE
Only enable the Qt backend by default on Linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,15 +58,6 @@ jobs:
       run: sudo apt-get install libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good
     - name: Setup headless display
       uses: pyvista/setup-headless-display-action@v1
-    - name: Set default style
-      if: matrix.os != 'windows-2022'
-      run: |
-          echo "SLINT_STYLE=native" >> $GITHUB_ENV
-    - name: Set default style
-      if: matrix.os == 'windows-2022'
-      run: |
-          echo "SLINT_STYLE=fluent" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "SLINT_NO_QT=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - uses: ./.github/actions/setup-rust
       with:
         toolchain: ${{ matrix.rust_version }}
@@ -117,15 +108,6 @@ jobs:
         cache: true
     - name: Setup headless display
       uses: pyvista/setup-headless-display-action@v1
-    - name: Set default style
-      if: matrix.os != 'windows-2022'
-      run: |
-          echo "SLINT_STYLE=native" >> $GITHUB_ENV
-    - name: Set default style
-      if: matrix.os == 'windows-2022'
-      run: |
-          echo "SLINT_STYLE=fluent" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "SLINT_NO_QT=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - uses: ./.github/actions/install-nodejs
       id: node-install
     - uses: ./.github/actions/setup-rust
@@ -161,7 +143,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/install-linux-dependencies
     - name: Install Qt
-      if: runner.os != 'Windows'
+      if: runner.os == 'Linux'
       uses: jurplel/install-qt-action@v3
       with:
         version: '5.15.2'
@@ -169,15 +151,6 @@ jobs:
         cache: true
     - name: Setup headless display
       uses: pyvista/setup-headless-display-action@v1
-    - name: Set default style
-      if: matrix.os != 'windows-2022'
-      run: |
-          echo "SLINT_STYLE=native" >> $GITHUB_ENV
-    - name: Set default style
-      if: matrix.os == 'windows-2022'
-      run: |
-          echo "SLINT_STYLE=fluent" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "SLINT_NO_QT=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - uses: ./.github/actions/setup-rust
       with:
         key: x-napi-v2-${{ steps.node-install.outputs.node-version }} # the cache key consists of a manually bumpable version and the node version, as the cached rustc artifacts contain linking information where to find node.lib, which is in a versioned directory.
@@ -243,14 +216,7 @@ jobs:
     - uses: ./.github/actions/install-linux-dependencies
       with:
         force-gcc-10: true
-    - name: Install Qt (Ubuntu)
-      uses: jurplel/install-qt-action@v3
-      if: matrix.os == 'ubuntu-22.04'
-      with:
-        version: 5.15.2
-        cache: true
-    - name: Install Qt (cached)
-      if: matrix.os != 'ubuntu-22.04'
+    - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:
         version: 6.5.1
@@ -271,7 +237,7 @@ jobs:
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
         cmakeListsTxtPath: CMakeLists.txt
-        cmakeAppendedArgs: '-DSLINT_BUILD_TESTING=ON -DSLINT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Debug -DSLINT_FEATURE_RENDERER_SKIA=ON'
+        cmakeAppendedArgs: '-DSLINT_BUILD_TESTING=ON -DSLINT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Debug -DSLINT_FEATURE_RENDERER_SKIA=ON -DSLINT_FEATURE_BACKEND_QT=ON'
         buildDirectory: ${{ runner.workspace }}/cppbuild
         buildWithCMakeArgs: '--config Debug'
     - name: ctest
@@ -290,7 +256,6 @@ jobs:
     needs: [cpp_cmake]
     runs-on: ubuntu-22.04
     env:
-      DYLD_FRAMEWORK_PATH: /Users/runner/work/slint/Qt/6.5.1/clang_64/lib
       QT_QPA_PLATFORM: offscreen
       CARGO_INCREMENTAL: false
       CARGO_PROFILE_DEV_DEBUG: 0
@@ -302,7 +267,7 @@ jobs:
     - name: Install Qt (Ubuntu)
       uses: jurplel/install-qt-action@v3
       with:
-        version: 5.15.2
+        version: 6.5.1
         cache: true
     - uses: actions/download-artifact@v4
       with:

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -93,7 +93,11 @@ define_cargo_dependent_feature(renderer-skia-opengl "Enable support for the Skia
 define_cargo_dependent_feature(renderer-skia-vulkan "Enable support for the Skia based rendering engine with its Vulkan backend." OFF "NOT SLINT_FEATURE_FREESTANDING")
 define_cargo_feature(renderer-software "Enable support for the software renderer" OFF)
 
-define_cargo_dependent_feature(backend-qt "Enable Qt based rendering backend" ON "NOT SLINT_FEATURE_FREESTANDING")
+set(SLINT_BACKEND_QT_DEFAULT OFF)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(SLINT_BACKEND_QT_DEFAULT ON)
+endif()
+define_cargo_dependent_feature(backend-qt "Enable Qt based rendering backend" ${SLINT_BACKEND_QT_DEFAULT} "NOT SLINT_FEATURE_FREESTANDING")
 
 define_cargo_dependent_feature(backend-linuxkms "Enable support for the backend that renders a single window fullscreen on Linux. Requires libseat. If you don't have libseat, select `backend-linuxkms-noseat` instead. (Experimental)" OFF "NOT SLINT_FEATURE_FREESTANDING")
 define_cargo_dependent_feature(backend-linuxkms-noseat "Enable support for the backend that renders a single window fullscreen on Linux (Experimental)" OFF "NOT SLINT_FEATURE_FREESTANDING")

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -27,7 +27,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 interpreter = ["slint-interpreter", "std"]
 testing = ["i-slint-backend-testing"] # Enable some function used by the integration tests
 
-backend-qt = ["i-slint-backend-selector/i-slint-backend-qt", "std"]
+backend-qt = ["i-slint-backend-selector/backend-qt", "std"]
 backend-winit = ["i-slint-backend-selector/backend-winit", "std"]
 backend-winit-x11 = ["i-slint-backend-selector/backend-winit-x11", "std"]
 backend-winit-wayland = ["i-slint-backend-selector/backend-winit-wayland", "std"]
@@ -48,7 +48,7 @@ experimental = ["i-slint-core/software-renderer-rotation"]
 default = ["std", "backend-winit", "renderer-femtovg", "backend-qt"]
 
 [dependencies]
-i-slint-backend-selector = { workspace = true, features = ["default"], optional = true }
+i-slint-backend-selector = { workspace = true, optional = true }
 i-slint-backend-testing = { workspace = true, features = ["default"], optional = true }
 i-slint-renderer-skia = {  workspace = true, features = ["default", "x11", "wayland"], optional = true }
 i-slint-core = { workspace = true, features = ["ffi"] }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -22,10 +22,9 @@ path = "lib.rs"
 
 default = [
   "std",
-  "backend-winit",
+  "backend-default",
   "renderer-femtovg",
   "renderer-software",
-  "backend-qt",
   "accessibility",
   "compat-1-2",
 ]
@@ -108,7 +107,7 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 ## This backend also provides the `native` style.
 ## It requires Qt 5.15 or later to be installed. If Qt is not installed, the
 ## backend will not be operational
-backend-qt = ["i-slint-backend-selector/i-slint-backend-qt", "std"]
+backend-qt = ["i-slint-backend-selector/backend-qt", "std", "i-slint-backend-qt"]
 
 ## The [winit](https://crates.io/crates/winit) crate is used for the event loop and windowing system integration.
 ## It supports Windows, macOS, web browsers, X11 and Wayland. X11 and wayland are only available when
@@ -123,6 +122,10 @@ backend-winit-x11 = ["i-slint-backend-selector/backend-winit-x11", "std"]
 ## Simliar to `backend-winit` this enables the winit based event loop but only
 ## with support for the Wayland window system on Unix.
 backend-winit-wayland = ["i-slint-backend-selector/backend-winit-wayland", "std"]
+
+## Alias to a backend and renderer that depends on the platform.
+## Will select the Qt backend on linux if present, and the winit otherwise
+backend-default = ["i-slint-backend-selector/default", "i-slint-backend-qt"]
 
 # deprecated aliases
 renderer-winit-femtovg = ["renderer-femtovg"]
@@ -156,8 +159,8 @@ backend-linuxkms-noseat = ["i-slint-backend-selector/backend-linuxkms-noseat", "
 
 [dependencies]
 i-slint-core = { workspace = true }
-slint-macros = { workspace = true, features = ["default"] }
-i-slint-backend-selector = { workspace = true, features = ["default"] }
+slint-macros = { workspace = true }
+i-slint-backend-selector = { workspace = true }
 
 const-field-offset = { version = "0.1.2", path = "../../../helper_crates/const-field-offset" }
 document-features = { version = "0.2.0", optional = true }
@@ -179,6 +182,10 @@ slint-build = { path = "../build" }
 i-slint-backend-testing = { path = "../../../internal/backends/testing" }
 serde_json = "1.0.96"
 serde = { version = "1.0.163", features = ["derive"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# this line is there to add the "enable" feature by default, but only on linux
+i-slint-backend-qt = { workspace = true, features = [ "enable" ], optional = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = [

--- a/internal/backends/qt/Cargo.toml
+++ b/internal/backends/qt/Cargo.toml
@@ -15,27 +15,26 @@ links = "i_slint_backend_qt" # just so we can pass metadata to the dependee's bu
 
 [features]
 rtti = ["i-slint-core/rtti"]
-default = []
+default = ["enable"]
+enable = ["dep:cpp", "dep:lyon_path", "dep:once_cell", "dep:pin-project", "dep:pin-weak", "dep:qttypes", "dep:cpp_build"]
 
 [lib]
 path = "lib.rs"
 
 [dependencies]
-i-slint-common = { workspace = true, features = ["default"] }
-i-slint-core-macros = { workspace = true, features = ["default"] }
-i-slint-core = { workspace = true, features = ["default"] }
+i-slint-common = { workspace = true }
+i-slint-core-macros = { workspace = true }
+i-slint-core = { workspace = true }
 
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
 vtable = { version = "0.1.8", path = "../../../helper_crates/vtable" }
 
-cpp = "0.5.5"
-lyon_path = "1"
-once_cell = "1"
-pin-project = "1"
-pin-weak = "1"
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-qttypes = { version = "0.2.7", default-features = false }
+cpp = { version = "0.5.5", optional = true }
+lyon_path = { version = "1", optional = true }
+once_cell = { version = "1", optional = true }
+pin-project = { version = "1", optional = true }
+pin-weak = { version = "1", optional = true }
+qttypes = { version = "0.2.7", default-features = false, optional = true }
 
 [build-dependencies]
-cpp_build = "0.5.5"
+cpp_build = { version =  "0.5.5", optional = true }

--- a/internal/backends/qt/build.rs
+++ b/internal/backends/qt/build.rs
@@ -3,6 +3,7 @@
 
 // cSpell: ignore listviewitem stylemetrics
 
+#[cfg(feature = "enable")]
 fn main() {
     println!("cargo:rerun-if-env-changed=SLINT_NO_QT");
     if std::env::var("TARGET").map_or(false, |t| t.starts_with("wasm"))
@@ -58,4 +59,10 @@ fn main() {
     println!("cargo:rerun-if-changed=qt_widgets/tableheadersection.rs");
     println!("cargo:rerun-if-changed=qt_window.rs");
     println!("cargo:SUPPORTS_NATIVE_STYLE=1");
+}
+
+#[cfg(not(feature = "enable"))]
+fn main() {
+    println!("cargo:rustc-cfg=no_qt");
+    return;
 }

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -21,6 +21,7 @@ backend-winit-x11 = ["i-slint-backend-winit/x11"]
 backend-winit-wayland = ["i-slint-backend-winit/wayland"]
 backend-linuxkms = ["i-slint-backend-linuxkms/libseat"]
 backend-linuxkms-noseat = ["i-slint-backend-linuxkms"]
+backend-qt = ["i-slint-backend-qt/enable"]
 
 renderer-femtovg = ["i-slint-backend-winit?/renderer-femtovg", "i-slint-backend-linuxkms?/renderer-femtovg"]
 renderer-skia = ["i-slint-backend-winit?/renderer-skia", "i-slint-backend-linuxkms?/renderer-skia"]
@@ -31,7 +32,8 @@ renderer-software = ["i-slint-backend-winit?/renderer-software", "i-slint-core/s
 rtti = ["i-slint-core/rtti", "i-slint-backend-qt?/rtti"]
 accessibility = ["i-slint-backend-winit?/accessibility"]
 
-default = []
+# note that default enable the i-slint-backend-qt, but not its enable feature
+default = ["i-slint-backend-qt", "backend-winit"]
 
 [dependencies]
 cfg-if = "1"
@@ -39,8 +41,10 @@ i-slint-core = { workspace = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 i-slint-backend-winit = { workspace = true, features = ["default"], optional = true }
-i-slint-backend-qt = { workspace = true, features = ["default"], optional = true }
 i-slint-renderer-skia = { workspace = true, optional = true }
+
+[target.'cfg(not(target_os = "wasm"))'.dependencies]
+i-slint-backend-qt = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 i-slint-backend-linuxkms = { workspace = true, features = ["default"], optional = true }

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -20,7 +20,7 @@ path = "lib.rs"
 
 [features]
 
-default = ["backend-winit", "renderer-femtovg", "backend-qt", "accessibility", "compat-1-2"]
+default = ["backend-default", "renderer-femtovg", "accessibility", "compat-1-2"]
 
 ## Mandatory feature:
 ## This feature is required to keep the compatibility with Slint 1.2
@@ -73,6 +73,11 @@ backend-linuxkms = ["i-slint-backend-selector/backend-linuxkms", "std"]
 ## windowing system. Requires libseat. (Experimental)
 backend-linuxkms-noseat = ["i-slint-backend-selector/backend-linuxkms-noseat", "std"]
 
+## Alias to a backend and renderer that depends on the platform.
+## Will select the Qt backend on linux if present, and the winit otherwise
+backend-default = ["i-slint-backend-selector/default", "i-slint-backend-qt"]
+
+
 ## Make the winit backend capable of rendering using the [femtovg](https://crates.io/crates/femtovg) crate.
 renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg", "std"]
 
@@ -124,6 +129,11 @@ spin_on = { version = "0.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 i-slint-backend-winit = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# this line is there to add the "enable" feature by default, but only on linux
+i-slint-backend-qt = { workspace = true, features = [ "enable" ], optional = true }
+
 
 [dev-dependencies]
 i-slint-backend-testing = { path = "../../internal/backends/testing" }

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -42,6 +42,7 @@ backend-winit-x11 = ["slint/backend-winit-x11", "preview"]
 backend-winit-wayland = ["slint/backend-winit-wayland", "preview"]
 backend-linuxkms = ["slint/backend-linuxkms", "preview"]
 backend-linuxkms-noseat = ["slint/backend-linuxkms-noseat", "preview"]
+backend-default = ["slint/backend-default", "preview"]
 
 renderer-femtovg = ["slint/renderer-femtovg", "preview"]
 renderer-skia = ["slint/renderer-skia", "preview"]
@@ -76,10 +77,10 @@ preview-builtin = ["preview-engine"]
 ## Support the external preview optionally used by e.g. the VSCode plugin
 preview-external = []
 
-default = ["backend-qt", "backend-winit", "renderer-femtovg", "preview"]
+default = ["backend-default", "renderer-femtovg", "preview"]
 
 [dependencies]
-i-slint-compiler = { workspace = true, features = ["default", "display-diagnostics"] }
+i-slint-compiler = { workspace = true, features = ["display-diagnostics"] }
 
 euclid = "0.22"
 itertools = { workspace = true }
@@ -90,8 +91,8 @@ serde_json = "1.0.60"
 dissimilar = "1.0.7"
 
 # for the preview-engine feature
-i-slint-backend-selector = { workspace = true, features = ["default"], optional = true }
-i-slint-common = { workspace = true, features = ["default"], optional = true }
+i-slint-backend-selector = { workspace = true, optional = true }
+i-slint-common = { workspace = true, optional = true }
 i-slint-core = { workspace = true, features = ["std"], optional = true }
 slint = { workspace = true, features = ["compat-1-2"], optional = true }
 slint-interpreter = { workspace = true, features = ["compat-1-2", "highlight", "internal"], optional = true  }

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -15,11 +15,13 @@ categories = ["gui", "development-tools", "command-line-utilities"]
 keywords = ["viewer", "gui", "ui", "toolkit"]
 
 [features]
+backend-default = ["slint-interpreter/backend-default"]
 backend-qt = ["slint-interpreter/backend-qt"]
-
 backend-winit = ["slint-interpreter/backend-winit"]
 backend-winit-x11 = ["slint-interpreter/backend-winit-x11"]
 backend-winit-wayland = ["slint-interpreter/backend-winit-wayland"]
+backend-linuxkms = ["slint-interpreter/backend-linuxkms"]
+backend-linuxkms-noseat = ["slint-interpreter/backend-linuxkms-noseat"]
 
 renderer-femtovg = ["slint-interpreter/renderer-femtovg"]
 renderer-skia = ["slint-interpreter/renderer-skia"]
@@ -39,10 +41,6 @@ renderer-winit-skia-opengl= ["renderer-skia-opengl"]
 renderer-winit-skia-vulkan= ["renderer-skia-vulkan"]
 renderer-winit-software = ["renderer-software"]
 
-
-backend-linuxkms = ["slint-interpreter/backend-linuxkms"]
-backend-linuxkms-noseat = ["slint-interpreter/backend-linuxkms-noseat"]
-
 ## Enable the translations using [gettext](https://www.gnu.org/software/gettext/gettext)
 ##
 ## the `@tr(...)` code from .slint files will be transformed into call to `dgettext`.
@@ -50,13 +48,13 @@ backend-linuxkms-noseat = ["slint-interpreter/backend-linuxkms-noseat"]
 ## so that the viewer can find the translation
 gettext = ["i-slint-core/gettext-rs"]
 
-default = ["backend-qt", "backend-winit", "renderer-femtovg"]
+default = ["backend-default", "renderer-femtovg"]
 
 [dependencies]
-i-slint-compiler = { workspace = true, features = ["default"] }
-i-slint-core = { workspace = true, features = ["default"] }
+i-slint-compiler = { workspace = true }
+i-slint-core = { workspace = true }
 slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility"] }
-i-slint-backend-selector = { workspace = true, features = ["default"] }
+i-slint-backend-selector = { workspace = true }
 
 vtable = { version = "0.1.6", path="../../helper_crates/vtable" }
 


### PR DESCRIPTION
The trick is that the backend selector build by default with the i-slint-backend-qt, but the "enable" feature is only enabled if the qt-backend feature is enabled explicitly, or on linux from the slint or slint-interpreter crate