### PR TITLE
live preview: Use env var to turn on experimental features in live pr…

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -198,7 +198,6 @@
         "vscode:prepublish": "npm run build:wasm_lsp-release && npm run compile && shx echo \"GPL-3.0-only OR LicenseRef-Slint-commercial\" > LICENSE.txt",
         "build:lsp": "cargo build -p slint-lsp",
         "build:lsp-release": "cargo build --release -p slint-lsp",
-        "build:wasm_experimental_lsp": "env-var wasm-pack build --dev     --target web ../../tools/lsp --out-dir {{npm_config_local_prefix}}/out -- --no-default-features --features backend-winit,renderer-femtovg,preview,experimental",
         "build:wasm_lsp": "env-var wasm-pack build --dev     --target web ../../tools/lsp --out-dir {{npm_config_local_prefix}}/out -- --no-default-features --features backend-winit,renderer-femtovg,preview",
         "build:wasm_lsp-release": "env-var wasm-pack build --release --target web ../../tools/lsp --out-dir {{npm_config_local_prefix}}/out -- --no-default-features --features backend-winit,renderer-femtovg,preview",
         "compile": "node ./esbuild.js",

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -34,7 +34,6 @@ name = "slint_lsp_wasm"
 [features]
 # Remove once MSRV > 1.70 (1.70 does not yet work!):
 slint = []
-experimental = []
 backend-qt = ["slint/backend-qt", "preview"]
 
 backend-winit = ["slint/backend-winit", "preview"]

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -33,7 +33,7 @@ pub fn create_ui(style: String) -> Result<PreviewUi, PlatformError> {
     ui.set_known_styles(style_model.into());
     ui.set_current_style(style.clone().into());
     ui.set_experimental(
-        std::env::var_os("SLINT_PREVIEW_ENABLE_EXPERIMENTAL_FEATURES")
+        std::env::var_os("SLINT_ENABLE_EXPERIMENTAL_FEATURES")
             .map(|s| !s.is_empty() && s != "0")
             .unwrap_or(false),
     );

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -32,8 +32,11 @@ pub fn create_ui(style: String) -> Result<PreviewUi, PlatformError> {
 
     ui.set_known_styles(style_model.into());
     ui.set_current_style(style.clone().into());
-    #[cfg(feature = "experimental")]
-    ui.set_experimental(true);
+    ui.set_experimental(
+        std::env::var_os("SLINT_PREVIEW_ENABLE_EXPERIMENTAL_FEATURES")
+            .map(|s| !s.is_empty() && s != "0")
+            .unwrap_or(false),
+    );
 
     ui.on_style_changed(super::change_style);
     ui.on_show_document(|file, line, column| {


### PR DESCRIPTION
…eview

Set `SLINT_PREVIEW_ENABLE_EXPERIMENTAL_FEATURES` to anything but `0` in your environment to turn on experimental mode.