### PR TITLE
Node.js: Avoid unnecessary cloning of Type

### DIFF
--- a/api/node/src/interpreter/component_instance.rs
+++ b/api/node/src/interpreter/component_instance.rs
@@ -57,7 +57,7 @@ impl JsComponentInstance {
             })?;
 
         self.inner
-            .set_property(&prop_name, super::value::to_value(&env, js_value, ty)?)
+            .set_property(&prop_name, super::value::to_value(&env, js_value, &ty)?)
             .map_err(|e| Error::from_reason(format!("{e}")))?;
 
         Ok(())
@@ -105,7 +105,7 @@ impl JsComponentInstance {
             .set_global_property(
                 global_name.as_str(),
                 &prop_name,
-                super::value::to_value(&env, js_value, ty)?,
+                super::value::to_value(&env, js_value, &ty)?,
             )
             .map_err(|e| Error::from_reason(format!("{e}")))?;
 
@@ -151,7 +151,7 @@ impl JsComponentInstance {
                             .unwrap();
 
                         if let Some(return_type) = &return_type {
-                            super::to_value(&env, result, *(*return_type).clone()).unwrap()
+                            super::to_value(&env, result, return_type).unwrap()
                         } else {
                             Value::Void
                         }
@@ -206,7 +206,7 @@ impl JsComponentInstance {
                             .unwrap();
 
                         if let Some(return_type) = &return_type {
-                            super::to_value(&env, result, *(*return_type).clone()).unwrap()
+                            super::to_value(&env, result, return_type).unwrap()
                         } else {
                             Value::Void
                         }
@@ -244,7 +244,7 @@ impl JsComponentInstance {
             let args = arguments
                 .into_iter()
                 .zip(args.into_iter())
-                .map(|(a, ty)| super::value::to_value(&env, a, ty))
+                .map(|(a, ty)| super::value::to_value(&env, a, &ty))
                 .collect::<Result<Vec<_>, _>>()?;
             if args.len() != count {
                 return Err(napi::Error::from_reason(
@@ -301,7 +301,7 @@ impl JsComponentInstance {
             let args = arguments
                 .into_iter()
                 .zip(args.into_iter())
-                .map(|(a, ty)| super::value::to_value(&env, a, ty))
+                .map(|(a, ty)| super::value::to_value(&env, a, &ty))
                 .collect::<Result<Vec<_>, _>>()?;
             if args.len() != count {
                 return Err(napi::Error::from_reason(

--- a/api/node/src/interpreter/value.rs
+++ b/api/node/src/interpreter/value.rs
@@ -84,7 +84,7 @@ pub fn to_js_unknown(env: &Env, value: &Value) -> Result<JsUnknown> {
     }
 }
 
-pub fn to_value(env: &Env, unknown: JsUnknown, typ: Type) -> Result<Value> {
+pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
     match typ {
         Type::Float32
         | Type::Int32
@@ -230,7 +230,7 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: Type) -> Result<Value> {
                                 js_object.get_property(
                                     env.create_string(&pro_name.replace('-', "_"))?,
                                 )?,
-                                pro_ty.clone(),
+                                pro_ty,
                             )?,
                         ))
                     })
@@ -243,7 +243,7 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: Type) -> Result<Value> {
                 let mut vec = vec![];
 
                 for i in 0..array.len() {
-                    vec.push(to_value(env, array.get(i)?.unwrap(), *a.to_owned())?);
+                    vec.push(to_value(env, array.get(i)?.unwrap(), a)?);
                 }
                 Ok(Value::Model(ModelRc::new(SharedVectorModel::from(SharedVector::from_slice(
                     &vec,

--- a/api/node/src/types/model.rs
+++ b/api/node/src/types/model.rs
@@ -75,7 +75,7 @@ impl Model for JsModel {
                 if res.get_type().unwrap() == ValueType::Undefined {
                     None
                 } else {
-                    to_value(&self.env, res, self.data_type.clone()).ok()
+                    to_value(&self.env, res, &self.data_type).ok()
                 }
             })
     }


### PR DESCRIPTION
There's no need to consume the Type in the value conversion.