### PR TITLE
Add API for minimize/maximize on Window component

### DIFF
--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -249,6 +249,18 @@ public:
             return cbindgen_private::slint_window_properties_get_fullscreen(inner());
         }
 
+        /// Returns true if the window should be minimized; false otherwise
+        bool minimized() const
+        {
+            return cbindgen_private::slint_window_properties_get_minimized(inner());
+        }
+
+        /// Returns true if the window should be maximized; false otherwise
+        bool maximized() const
+        {
+            return cbindgen_private::slint_window_properties_get_maximized(inner());
+        }
+
         /// This struct describes the layout constraints of a window.
         ///
         /// It is the return value of WindowProperties::layout_constraints().
@@ -372,10 +384,7 @@ public:
     /// Returns a copy of text stored in the system clipboard, if any.
     ///
     /// If the platform doesn't support the specified clipboard, the function should return nullopt
-    virtual std::optional<SharedString> clipboard_text(Clipboard)
-    {
-        return {};
-    }
+    virtual std::optional<SharedString> clipboard_text(Clipboard) { return {}; }
 
     /// Spins an event loop and renders the visible windows.
     virtual void run_event_loop() { }

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -384,7 +384,9 @@ public:
     /// Returns a copy of text stored in the system clipboard, if any.
     ///
     /// If the platform doesn't support the specified clipboard, the function should return nullopt
-    virtual std::optional<SharedString> clipboard_text(Clipboard) { return {}; }
+    virtual std::optional<SharedString> clipboard_text(Clipboard) {
+        return {};
+    }
 
     /// Spins an event loop and renders the visible windows.
     virtual void run_event_loop() { }

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -384,7 +384,8 @@ public:
     /// Returns a copy of text stored in the system clipboard, if any.
     ///
     /// If the platform doesn't support the specified clipboard, the function should return nullopt
-    virtual std::optional<SharedString> clipboard_text(Clipboard) {
+    virtual std::optional<SharedString> clipboard_text(Clipboard)
+    {
         return {};
     }
 

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -113,7 +113,17 @@ pub extern "C" fn slint_window_properties_get_background(
 
 #[no_mangle]
 pub extern "C" fn slint_window_properties_get_fullscreen(wp: &WindowProperties) -> bool {
-    wp.fullscreen()
+    wp.is_fullscreen()
+}
+
+#[no_mangle]
+pub extern "C" fn slint_window_properties_get_minimized(wp: &WindowProperties) -> bool {
+    wp.is_minimized()
+}
+
+#[no_mangle]
+pub extern "C" fn slint_window_properties_get_maximized(wp: &WindowProperties) -> bool {
+    wp.is_maximized()
 }
 
 #[repr(C)]

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -61,6 +61,15 @@ export interface Window {
     /** Gets or sets the physical size of the window on the screen, */
     physicalSize: Size;
 
+    /** Gets or sets the window's fullscreen state **/
+    fullscreen: boolean;
+
+    /** Gets or sets the window's maximized state **/
+    maximized: boolean;
+
+    /** Gets or sets teh window's minimized state **/
+    minimized: boolean;
+
     /**
      * Returns the visibility state of the window. This function can return false even if you previously called show()
      * on it, for example if the user minimized the window.
@@ -78,9 +87,6 @@ export interface Window {
 
     /** Issues a request to the windowing system to re-render the contents of the window. */
     requestRedraw(): void;
-
-    /** Set or unset the window to display fullscreen. */
-    set fullscreen(enable: boolean);
 }
 
 /**

--- a/api/node/src/interpreter/window.rs
+++ b/api/node/src/interpreter/window.rs
@@ -151,7 +151,7 @@ impl JsWindow {
     /// Returns if the window is currently minimized
     #[napi(setter)]
     pub fn minimized(&self) -> bool {
-        self.inner.minimized()
+        self.inner.window().minimized()
     }
 
     /// Minimize or unminimze the window.

--- a/api/node/src/interpreter/window.rs
+++ b/api/node/src/interpreter/window.rs
@@ -126,7 +126,7 @@ impl JsWindow {
 
     /// Returns if the window is currently fullscreen
     #[napi(setter)]
-    pub fn fullscreen(&self) -> bool {
+    pub fn get_fullscreen(&self) -> bool {
         self.inner.window().fullscreen()
     }
 
@@ -138,7 +138,7 @@ impl JsWindow {
 
     /// Returns if the window is currently maximized
     #[napi(setter)]
-    pub fn maximized(&self) -> bool {
+    pub fn get_maximized(&self) -> bool {
         self.inner.window().maximized()
     }
 
@@ -150,7 +150,7 @@ impl JsWindow {
 
     /// Returns if the window is currently minimized
     #[napi(setter)]
-    pub fn minimized(&self) -> bool {
+    pub fn get_minimized(&self) -> bool {
         self.inner.window().minimized()
     }
 

--- a/api/node/src/interpreter/window.rs
+++ b/api/node/src/interpreter/window.rs
@@ -137,7 +137,7 @@ impl JsWindow {
     }
 
     /// Returns if the window is currently maximized
-    #[napi(setter)]
+    #[napi(getter)]
     pub fn get_maximized(&self) -> bool {
         self.inner.window().maximized()
     }
@@ -149,7 +149,7 @@ impl JsWindow {
     }
 
     /// Returns if the window is currently minimized
-    #[napi(setter)]
+    #[napi(getter)]
     pub fn get_minimized(&self) -> bool {
         self.inner.window().minimized()
     }

--- a/api/node/src/interpreter/window.rs
+++ b/api/node/src/interpreter/window.rs
@@ -127,7 +127,7 @@ impl JsWindow {
     /// Returns if the window is currently fullscreen
     #[napi(getter)]
     pub fn get_fullscreen(&self) -> bool {
-        self.inner.window().fullscreen()
+        self.inner.window().is_fullscreen()
     }
 
     /// Set or unset the window to display fullscreen.
@@ -139,7 +139,7 @@ impl JsWindow {
     /// Returns if the window is currently maximized
     #[napi(getter)]
     pub fn get_maximized(&self) -> bool {
-        self.inner.window().maximized()
+        self.inner.window().is_maximized()
     }
 
     /// Maximize or unmaximize the window.
@@ -151,7 +151,7 @@ impl JsWindow {
     /// Returns if the window is currently minimized
     #[napi(getter)]
     pub fn get_minimized(&self) -> bool {
-        self.inner.window().minimized()
+        self.inner.window().is_minimized()
     }
 
     /// Minimize or unminimze the window.

--- a/api/node/src/interpreter/window.rs
+++ b/api/node/src/interpreter/window.rs
@@ -125,7 +125,7 @@ impl JsWindow {
     }
 
     /// Returns if the window is currently fullscreen
-    #[napi(setter)]
+    #[napi(getter)]
     pub fn get_fullscreen(&self) -> bool {
         self.inner.window().fullscreen()
     }

--- a/api/node/src/interpreter/window.rs
+++ b/api/node/src/interpreter/window.rs
@@ -149,9 +149,11 @@ impl JsWindow {
     }
 
     /// Returns if the window is currently minimized
+    #[napi(setter)]
     pub fn minimized(&self) -> bool {
         self.inner.minimized()
     }
+
     /// Minimize or unminimze the window.
     #[napi(setter)]
     pub fn set_minimized(&self, minimized: bool) {

--- a/api/node/src/interpreter/window.rs
+++ b/api/node/src/interpreter/window.rs
@@ -124,9 +124,37 @@ impl JsWindow {
         self.inner.request_redraw();
     }
 
+    /// Returns if the window is currently fullscreen
+    #[napi(setter)]
+    pub fn fullscreen(&self) -> bool {
+        self.inner.window().fullscreen()
+    }
+
     /// Set or unset the window to display fullscreen.
     #[napi(setter)]
     pub fn set_fullscreen(&self, enable: bool) {
         self.inner.window().set_fullscreen(enable)
+    }
+
+    /// Returns if the window is currently maximized
+    #[napi(setter)]
+    pub fn maximized(&self) -> bool {
+        self.inner.window().maximized()
+    }
+
+    /// Maximize or unmaximize the window.
+    #[napi(setter)]
+    pub fn set_maximized(&self, maximized: bool) {
+        self.inner.window().set_maximized(maximized)
+    }
+
+    /// Returns if the window is currently minimized
+    pub fn minimized(&self) -> bool {
+        self.inner.minimized()
+    }
+    /// Minimize or unminimze the window.
+    #[napi(setter)]
+    pub fn set_minimized(&self, minimized: bool) {
+        self.inner.window().set_minimized(minimized)
     }
 }

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -51,7 +51,7 @@ impl WindowAdapter for AndroidWindowAdapter {
     }
 
     fn update_window_properties(&self, properties: WindowProperties<'_>) {
-        let f = properties.fullscreen();
+        let f = properties.is_fullscreen();
         if self.fullscreen.replace(f) != f {
             self.resize();
         }

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1804,19 +1804,12 @@ impl WindowAdapter for QtWindow {
 
         const WIDGET_SIZE_MAX: u32 = 16_777_215;
 
-        let max_size: qttypes::QSize = if maximized {
-            qttypes::QSize { width: WIDGET_SIZE_MAX, height: WIDGET_SIZE_MAX }
-        } else {
-            constraints.max.map_or_else(
-                || qttypes::QSize { width: WIDGET_SIZE_MAX, height: WIDGET_SIZE_MAX },
-                into_qsize,
-            )
-        };
+        let max_size: qttypes::QSize = constraints.max.map_or_else(
+            || qttypes::QSize { width: WIDGET_SIZE_MAX, height: WIDGET_SIZE_MAX },
+            into_qsize,
+        );
 
         cpp! {unsafe [widget_ptr as "QWidget*",  min_size as "QSize", max_size as "QSize"] {
-            // TODO: Setting these causes the following issues:
-            //  - Maximize button is disabled, even if the layout size is "preferred" and not fixed
-            //  - Causes the maximize button to not use the correct width
             widget_ptr->setMinimumSize(min_size);
             widget_ptr->setMaximumSize(max_size);
         }};

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1585,7 +1585,7 @@ impl QtWindow {
             return widget_ptr->isMinimized();
         }};
 
-        if minimized != self.window().minimized() {
+        if minimized != self.window().is_minimized() {
             self.window().set_minimized(minimized);
         }
 
@@ -1593,7 +1593,7 @@ impl QtWindow {
             return widget_ptr->isMaximized();
         }};
 
-        if maximized != self.window().maximized() {
+        if maximized != self.window().is_maximized() {
             self.window().set_maximized(maximized);
         }
 
@@ -1601,7 +1601,7 @@ impl QtWindow {
             return widget_ptr->isFullScreen();
         }};
 
-        if fullscreen != self.window().fullscreen() {
+        if fullscreen != self.window().is_fullscreen() {
             self.window().set_fullscreen(fullscreen);
         }
     }
@@ -1745,9 +1745,9 @@ impl WindowAdapter for QtWindow {
             }
         };
 
-        let fullscreen: bool = properties.fullscreen();
-        let minimized: bool = properties.minimized();
-        let maximized: bool = properties.maximized();
+        let fullscreen: bool = properties.is_fullscreen();
+        let minimized: bool = properties.is_minimized();
+        let maximized: bool = properties.is_maximized();
 
         cpp! {unsafe [widget_ptr as "QWidget*",  title as "QString", size as "QSize", background as "QBrush", no_frame as "bool", always_on_top as "bool",
                       fullscreen as "bool", minimized as "bool", maximized as "bool"] {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -113,7 +113,11 @@ cpp! {{
         void resizeEvent(QResizeEvent *event) override {
             if (!rust_window)
                 return;
-            QSize size = event->size();
+
+            // On windows, the size in the event is not reliable during
+            // fullscreen changes. Querying the widget itself seems to work
+            // better, see: https://stackoverflow.com/questions/52157587/why-qresizeevent-qwidgetsize-gives-different-when-fullscreen
+            QSize size = this->size();
             rust!(Slint_resizeEvent [rust_window: &QtWindow as "void*", size: qttypes::QSize as "QSize"] {
                 rust_window.resize_event(size)
             });
@@ -231,6 +235,7 @@ cpp! {{
         void changeEvent(QEvent *event) override {
             if (!rust_window)
                 return;
+
             if (event->type() == QEvent::ActivationChange) {
                 bool active = isActiveWindow();
                 rust!(Slint_updateWindowActivation [rust_window: &QtWindow as "void*", active: bool as "bool"] {
@@ -244,6 +249,18 @@ cpp! {{
                     }
                 });
             }
+
+            // Entering fullscreen, maximizing or minimizing the window will
+            // trigger a change event. We need to update the internal window
+            // state to match the actual window state.
+            if (event->type() == QEvent::WindowStateChange)
+            {
+                rust!(Slint_syncWindowState [rust_window: &QtWindow as "void*"]{
+                    rust_window.window_state_event();
+                });
+            }
+
+
             QWidget::changeEvent(event);
         }
 
@@ -1554,6 +1571,40 @@ impl QtWindow {
     fn close_popup_on_click(&self) -> bool {
         WindowInner::from_pub(&self.window).close_popup_on_click()
     }
+
+    fn window_state_event(&self) {
+        let widget_ptr = self.widget_ptr();
+
+        // This function is called from the changeEvent slot which triggers whenever
+        // one of these properties changes. To prevent recursive call issues (e.g.,
+        // set_fullscreen -> update_window_properties -> changeEvent ->
+        // window_state_event -> set_fullscreen), we avoid resetting the internal state
+        // when it already matches the Qt state.
+
+        let minimized = cpp! { unsafe [widget_ptr as "QWidget*"] -> bool as "bool" {
+            return widget_ptr->isMinimized();
+        }};
+
+        if minimized != self.window().minimized() {
+            self.window().set_minimized(minimized);
+        }
+
+        let maximized = cpp! { unsafe [widget_ptr as "QWidget*"] -> bool as "bool" {
+            return widget_ptr->isMaximized();
+        }};
+
+        if maximized != self.window().maximized() {
+            self.window().set_maximized(maximized);
+        }
+
+        let fullscreen = cpp! { unsafe [widget_ptr as "QWidget*"] -> bool as "bool" {
+            return widget_ptr->isFullScreen();
+        }};
+
+        if fullscreen != self.window().fullscreen() {
+            self.window().set_fullscreen(fullscreen);
+        }
+    }
 }
 
 impl WindowAdapter for QtWindow {
@@ -1629,6 +1680,7 @@ impl WindowAdapter for QtWindow {
         let logical_size = size.to_logical(self.window().scale_factor());
         let widget_ptr = self.widget_ptr();
         let sz: qttypes::QSize = into_qsize(logical_size);
+
         // Qt uses logical units!
         cpp! {unsafe [widget_ptr as "QWidget*", sz as "QSize"] {
             widget_ptr->resize(sz);
@@ -1664,6 +1716,7 @@ impl WindowAdapter for QtWindow {
             width: window_item.width().get().ceil() as _,
             height: window_item.height().get().ceil() as _,
         };
+
         if size.width == 0 || size.height == 0 {
             let existing_size = cpp!(unsafe [widget_ptr as "QWidget*"] -> qttypes::QSize as "QSize" {
                 return widget_ptr->size();
@@ -1693,24 +1746,35 @@ impl WindowAdapter for QtWindow {
         };
 
         let fullscreen: bool = properties.fullscreen();
+        let minimized: bool = properties.minimized();
+        let maximized: bool = properties.maximized();
 
         cpp! {unsafe [widget_ptr as "QWidget*",  title as "QString", size as "QSize", background as "QBrush", no_frame as "bool", always_on_top as "bool",
-                      fullscreen as "bool"] {
+                      fullscreen as "bool", minimized as "bool", maximized as "bool"] {
+
             if (size != widget_ptr->size()) {
                 widget_ptr->resize(size.expandedTo({1, 1}));
             }
+
             widget_ptr->setWindowFlag(Qt::FramelessWindowHint, no_frame);
             widget_ptr->setWindowFlag(Qt::WindowStaysOnTopHint, always_on_top);
 
             {
-                // Depending on the request, we either set or clear the fullscreen bits.
+                // Depending on the request, we either set or clear the bits.
                 // See also: https://doc.qt.io/qt-6/qt.html#WindowState-enum
-                const auto state = widget_ptr->windowState();
-                if (fullscreen) {
-                    widget_ptr->setWindowState(state | Qt::WindowFullScreen);
-                } else {
-                    widget_ptr->setWindowState(state & ~Qt::WindowFullScreen);
+                auto state = widget_ptr->windowState();
+
+                if (fullscreen != widget_ptr->isFullScreen()) {
+                    state = state ^ Qt::WindowFullScreen;
                 }
+                if (minimized != widget_ptr->isMinimized()) {
+                    state = state ^ Qt::WindowMinimized;
+                }
+                if (maximized != widget_ptr->isMaximized()) {
+                    state = state ^ Qt::WindowMaximized;
+                }
+
+                widget_ptr->setWindowState(state);
             }
 
             widget_ptr->setWindowTitle(title);
@@ -1738,14 +1802,21 @@ impl WindowAdapter for QtWindow {
             into_qsize,
         );
 
-        let widget_size_max: u32 = 16_777_215;
+        const WIDGET_SIZE_MAX: u32 = 16_777_215;
 
-        let max_size: qttypes::QSize = constraints.max.map_or_else(
-            || qttypes::QSize { width: widget_size_max, height: widget_size_max },
-            into_qsize,
-        );
+        let max_size: qttypes::QSize = if maximized {
+            qttypes::QSize { width: WIDGET_SIZE_MAX, height: WIDGET_SIZE_MAX }
+        } else {
+            constraints.max.map_or_else(
+                || qttypes::QSize { width: WIDGET_SIZE_MAX, height: WIDGET_SIZE_MAX },
+                into_qsize,
+            )
+        };
 
         cpp! {unsafe [widget_ptr as "QWidget*",  min_size as "QSize", max_size as "QSize"] {
+            // TODO: Setting these causes the following issues:
+            //  - Maximize button is disabled, even if the layout size is "preferred" and not fixed
+            //  - Causes the maximize button to not use the correct width
             widget_ptr->setMinimumSize(min_size);
             widget_ptr->setMaximumSize(max_size);
         }};

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -259,9 +259,10 @@ impl EventLoopState {
 
                 // Entering fullscreen, maximizing or minimizing the window will
                 // trigger a resize event. We need to update the internal window
-                // state to match the actual window state.
+                // state to match the actual window state. We simulate a "window
+                // state event" since there is not an official event for it yet.
                 // See: https://github.com/rust-windowing/winit/issues/2334
-                window.sync_window_state();
+                window.window_state_event();
             }
             WindowEvent::CloseRequested => {
                 window.window().dispatch_event(corelib::platform::WindowEvent::CloseRequested);

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -251,7 +251,14 @@ impl EventLoopState {
     fn process_window_event(&mut self, window: Rc<WinitWindowAdapter>, event: WindowEvent) {
         let runtime_window = WindowInner::from_pub(window.window());
         match event {
-            WindowEvent::RedrawRequested => self.loop_error = window.draw().err(),
+            WindowEvent::RedrawRequested => {
+                self.loop_error = window.draw().err();
+
+                // Entering fullscreen, maximizing or minimizing the window will
+                // trigger a redraw event. We need to update the internal window
+                // state to match the actual window state.
+                window.sync_window_state();
+            }
             WindowEvent::Resized(size) => {
                 self.loop_error = window.resize_event(size).err();
             }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -253,14 +253,15 @@ impl EventLoopState {
         match event {
             WindowEvent::RedrawRequested => {
                 self.loop_error = window.draw().err();
-
-                // Entering fullscreen, maximizing or minimizing the window will
-                // trigger a redraw event. We need to update the internal window
-                // state to match the actual window state.
-                window.sync_window_state();
             }
             WindowEvent::Resized(size) => {
                 self.loop_error = window.resize_event(size).err();
+
+                // Entering fullscreen, maximizing or minimizing the window will
+                // trigger a resize event. We need to update the internal window
+                // state to match the actual window state.
+                // See: https://github.com/rust-windowing/winit/issues/2334
+                window.sync_window_state();
             }
             WindowEvent::CloseRequested => {
                 window.window().dispatch_event(corelib::platform::WindowEvent::CloseRequested);

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -306,7 +306,7 @@ impl WinitWindowAdapter {
             .set(dark_mode)
     }
 
-    pub fn sync_window_state(&self) {
+    pub fn window_state_event(&self) {
         if let Some(minimized) = self.winit_window.is_minimized() {
             if minimized != self.window().minimized() {
                 self.window().set_minimized(minimized);

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -312,12 +312,22 @@ impl WinitWindowAdapter {
                 self.window().set_minimized(minimized);
             }
         }
-        if let Some(maximized) = self.winit_window.is_minimized() {
+
+        // The method winit::Window::is_maximized returns false when the window
+        // is minimized, even if it was previously maximized. We have to ensure
+        // that we only update the internal maximized state when the window is
+        // not minimized. Otherwise, the window would be restored in a
+        // non-maximized state even if it was maximized before being minimized.
+        if !self.window().minimized() {
+            let maximized = self.winit_window.is_maximized();
             if maximized != self.window().maximized() {
-                self.window().set_minimized(maximized);
+                self.window().set_maximized(maximized);
             }
         }
 
+        // NOTE: Fullscreen overrides maximized so if both are true then the
+        // window will remain in fullscreen. Fullscreen must be false to switch
+        // to maximized.
         let fullscreen = self.winit_window.fullscreen().is_some();
         if fullscreen != self.window().fullscreen() {
             self.window().set_fullscreen(fullscreen);

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -308,7 +308,7 @@ impl WinitWindowAdapter {
 
     pub fn window_state_event(&self) {
         if let Some(minimized) = self.winit_window.is_minimized() {
-            if minimized != self.window().minimized() {
+            if minimized != self.window().is_minimized() {
                 self.window().set_minimized(minimized);
             }
         }
@@ -318,9 +318,9 @@ impl WinitWindowAdapter {
         // that we only update the internal maximized state when the window is
         // not minimized. Otherwise, the window would be restored in a
         // non-maximized state even if it was maximized before being minimized.
-        if !self.window().minimized() {
+        if !self.window().is_minimized() {
             let maximized = self.winit_window.is_maximized();
-            if maximized != self.window().maximized() {
+            if maximized != self.window().is_maximized() {
                 self.window().set_maximized(maximized);
             }
         }
@@ -329,7 +329,7 @@ impl WinitWindowAdapter {
         // window will remain in fullscreen. Fullscreen must be false to switch
         // to maximized.
         let fullscreen = self.winit_window.fullscreen().is_some();
-        if fullscreen != self.window().fullscreen() {
+        if fullscreen != self.window().is_fullscreen() {
             self.window().set_fullscreen(fullscreen);
         }
     }
@@ -490,10 +490,10 @@ impl WindowAdapter for WinitWindowAdapter {
 
         // Only set the window as maximized if the window is not already fullscreen
         if winit_window.fullscreen().is_none() {
-            winit_window.set_maximized(properties.maximized());
+            winit_window.set_maximized(properties.is_maximized());
         }
 
-        winit_window.set_minimized(properties.minimized());
+        winit_window.set_minimized(properties.is_minimized());
 
         if width <= 0. || height <= 0. {
             must_resize = true;
@@ -534,7 +534,7 @@ impl WindowAdapter for WinitWindowAdapter {
         }
 
         self.with_window_handle(&mut |winit_window| {
-            if properties.fullscreen() {
+            if properties.is_fullscreen() {
                 if winit_window.fullscreen().is_none() {
                     winit_window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
                 }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -305,6 +305,24 @@ impl WinitWindowAdapter {
             .as_ref()
             .set(dark_mode)
     }
+
+    pub fn sync_window_state(&self) {
+        if let Some(minimized) = self.winit_window.is_minimized() {
+            if minimized != self.window().minimized() {
+                self.window().set_minimized(minimized);
+            }
+        }
+        if let Some(maximized) = self.winit_window.is_minimized() {
+            if maximized != self.window().maximized() {
+                self.window().set_minimized(maximized);
+            }
+        }
+
+        let fullscreen = self.winit_window.fullscreen().is_some();
+        if fullscreen != self.window().fullscreen() {
+            self.window().set_fullscreen(fullscreen);
+        }
+    }
 }
 
 impl WindowAdapter for WinitWindowAdapter {
@@ -460,6 +478,13 @@ impl WindowAdapter for WinitWindowAdapter {
             winit_window.set_window_level(new_window_level);
         }
 
+        // Only set the window as maximized if the window is not already fullscreen
+        if winit_window.fullscreen().is_none() {
+            winit_window.set_maximized(properties.maximized());
+        }
+
+        winit_window.set_minimized(properties.minimized());
+
         if width <= 0. || height <= 0. {
             must_resize = true;
 
@@ -509,9 +534,10 @@ impl WindowAdapter for WinitWindowAdapter {
                 }
             }
 
-            // If we're in fullscreen state, don't try to resize the window but maintain the surface
-            // size we've been assigned to from the windowing system. Weston/Wayland don't like it
-            // when we create a surface that's bigger than the screen due to constraints (#532).
+            // If we're in fullscreen, don't try to resize the window but
+            // maintain the surface size we've been assigned to from the
+            // windowing system. Weston/Wayland don't like it when we create a
+            // surface that's bigger than the screen due to constraints (#532).
             if winit_window.fullscreen().is_some() {
                 return;
             }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -446,11 +446,6 @@ impl Window {
         crate::window::WindowAdapter::set_size(&*self.0.window_adapter(), size);
     }
 
-    #[deprecated(note = "Please use `is_fullscreen` instead")]
-    pub fn fullscreen(&self) -> bool {
-        self.is_fullscreen()
-    }
-
     /// Returns if the window is currently fullscreen
     pub fn is_fullscreen(&self) -> bool {
         self.0.is_fullscreen()

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -447,8 +447,8 @@ impl Window {
     }
 
     /// Returns if the window is currently fullscreen
-    pub fn fullscreen(&self) -> bool {
-        self.0.fullscreen()
+    pub fn is_fullscreen(&self) -> bool {
+        self.0.is_fullscreen()
     }
 
     /// Set or unset the window to display fullscreen.
@@ -457,8 +457,8 @@ impl Window {
     }
 
     /// Returns if the window is currently maximized
-    pub fn maximized(&self) -> bool {
-        self.0.maximized()
+    pub fn is_maximized(&self) -> bool {
+        self.0.is_maximized()
     }
 
     /// Maximize or unmaximize the window.
@@ -467,8 +467,8 @@ impl Window {
     }
 
     /// Returns if the window is currently minimized
-    pub fn minimized(&self) -> bool {
-        self.0.minimized()
+    pub fn is_minimized(&self) -> bool {
+        self.0.is_minimized()
     }
 
     /// Minimize or unminimze the window.

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -446,6 +446,11 @@ impl Window {
         crate::window::WindowAdapter::set_size(&*self.0.window_adapter(), size);
     }
 
+    #[deprecated(note = "Please use `is_fullscreen` instead")]
+    pub fn fullscreen(&self) -> bool {
+        self.is_fullscreen()
+    }
+
     /// Returns if the window is currently fullscreen
     pub fn is_fullscreen(&self) -> bool {
         self.0.is_fullscreen()

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -446,9 +446,34 @@ impl Window {
         crate::window::WindowAdapter::set_size(&*self.0.window_adapter(), size);
     }
 
+    /// Returns if the window is currently fullscreen
+    pub fn fullscreen(&self) -> bool {
+        self.0.fullscreen()
+    }
+
     /// Set or unset the window to display fullscreen.
     pub fn set_fullscreen(&self, fullscreen: bool) {
         self.0.set_fullscreen(fullscreen);
+    }
+
+    /// Returns if the window is currently maximized
+    pub fn maximized(&self) -> bool {
+        self.0.maximized()
+    }
+
+    /// Maximize or unmaximize the window.
+    pub fn set_maximized(&self, maximized: bool) {
+        self.0.set_maximized(maximized);
+    }
+
+    /// Returns if the window is currently minimized
+    pub fn minimized(&self) -> bool {
+        self.0.minimized()
+    }
+
+    /// Minimize or unminimze the window.
+    pub fn set_minimized(&self, minimized: bool) {
+        self.0.set_minimized(minimized);
     }
 
     /// Dispatch a window event to the scene.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -278,6 +278,7 @@ impl<'a> WindowProperties<'a> {
         }
     }
 
+    /// Returns true if the window should be shown fullscreen; false otherwise.
     #[deprecated(note = "Please use `is_fullscreen` instead")]
     pub fn fullscreen(&self) -> bool {
         self.is_fullscreen()

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -282,6 +282,16 @@ impl<'a> WindowProperties<'a> {
     pub fn fullscreen(&self) -> bool {
         self.0.fullscreen.get()
     }
+
+    /// true if the window is in a maximized state, otherwise false
+    pub fn maximized(&self) -> bool {
+        self.0.maximized.get()
+    }
+
+    /// true if the window is in a minimized state, otherwise false
+    pub fn minimized(&self) -> bool {
+        self.0.minimized.get()
+    }
 }
 
 struct WindowPropertiesTracker {
@@ -368,6 +378,9 @@ pub struct WindowInner {
 
     pinned_fields: Pin<Box<WindowPinnedFields>>,
     fullscreen: Cell<bool>,
+    maximized: Cell<bool>,
+    minimized: Cell<bool>,
+
     active_popup: RefCell<Option<PopupWindow>>,
     had_popup_on_press: Cell<bool>,
     close_requested: Callback<(), CloseRequestResponse>,
@@ -424,6 +437,8 @@ impl WindowInner {
             fullscreen: Cell::new(std::env::var("SLINT_FULLSCREEN").is_ok()),
             #[cfg(not(feature = "std"))]
             fullscreen: Cell::new(false),
+            maximized: Cell::new(false),
+            minimized: Cell::new(false),
             focus_item: Default::default(),
             last_ime_text: Default::default(),
             cursor_blinker: Default::default(),
@@ -1030,9 +1045,36 @@ impl WindowInner {
         }
     }
 
+    /// Returns if the window is currently maximized
+    pub fn fullscreen(&self) -> bool {
+        self.fullscreen.get()
+    }
+
     /// Set or unset the window to display fullscreen.
     pub fn set_fullscreen(&self, enabled: bool) {
         self.fullscreen.set(enabled);
+        self.update_window_properties()
+    }
+
+    /// Returns if the window is currently maximized
+    pub fn maximized(&self) -> bool {
+        self.maximized.get()
+    }
+
+    /// Set the window as maximized or unmaximized
+    pub fn set_maximized(&self, maximized: bool) {
+        self.maximized.set(maximized);
+        self.update_window_properties()
+    }
+
+    /// Returns if the window is currently minimized
+    pub fn minimized(&self) -> bool {
+        self.minimized.get()
+    }
+
+    /// Set the window as minimized or unminimized
+    pub fn set_minimized(&self, minimized: bool) {
+        self.minimized.set(minimized);
         self.update_window_properties()
     }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -279,17 +279,17 @@ impl<'a> WindowProperties<'a> {
     }
 
     /// Returns true if the window should be shown fullscreen; false otherwise.
-    pub fn fullscreen(&self) -> bool {
+    pub fn is_fullscreen(&self) -> bool {
         self.0.fullscreen.get()
     }
 
     /// true if the window is in a maximized state, otherwise false
-    pub fn maximized(&self) -> bool {
+    pub fn is_maximized(&self) -> bool {
         self.0.maximized.get()
     }
 
     /// true if the window is in a minimized state, otherwise false
-    pub fn minimized(&self) -> bool {
+    pub fn is_minimized(&self) -> bool {
         self.0.minimized.get()
     }
 }
@@ -1046,7 +1046,7 @@ impl WindowInner {
     }
 
     /// Returns if the window is currently maximized
-    pub fn fullscreen(&self) -> bool {
+    pub fn is_fullscreen(&self) -> bool {
         self.fullscreen.get()
     }
 
@@ -1057,7 +1057,7 @@ impl WindowInner {
     }
 
     /// Returns if the window is currently maximized
-    pub fn maximized(&self) -> bool {
+    pub fn is_maximized(&self) -> bool {
         self.maximized.get()
     }
 
@@ -1068,7 +1068,7 @@ impl WindowInner {
     }
 
     /// Returns if the window is currently minimized
-    pub fn minimized(&self) -> bool {
+    pub fn is_minimized(&self) -> bool {
         self.minimized.get()
     }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -278,6 +278,11 @@ impl<'a> WindowProperties<'a> {
         }
     }
 
+    #[deprecated(note = "Please use `is_fullscreen` instead")]
+    pub fn fullscreen(&self) -> bool {
+        self.is_fullscreen()
+    }
+
     /// Returns true if the window should be shown fullscreen; false otherwise.
     pub fn is_fullscreen(&self) -> bool {
         self.0.fullscreen.get()


### PR DESCRIPTION
Update the `Window` api to support programmatically minimizing and maximizing windows on the `Qt` and `winit` backends. The following methods are new:

- `Window::set_minimized`
- `Window::minimized`
- `Window::set_maximized`
- `Window::maximized`
- `Window::fullscreen`