### PR TITLE
Add support for writing tests that run with all styles

### DIFF
--- a/tests/cases/widgets/spinbox_basic.slint
+++ b/tests/cases/widgets/spinbox_basic.slint
@@ -1,0 +1,42 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+
+import { SpinBox } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    box := SpinBox {}
+    forward-focus: box;
+    out property <bool> spinbox-focused <=> box.has_focus;
+    callback edited <=> box.edited;
+}
+
+/*
+
+
+```rust
+use slint::platform::Key;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_spinbox_focused());
+
+let edits = Rc::new(RefCell::new(Vec::new()));
+
+instance.on_edited({
+    let edits = edits.clone();
+    move |val| {
+    edits.borrow_mut().push(val);
+}});
+
+slint_testing::send_keyboard_char(&instance, '4', true);
+slint_testing::send_keyboard_char(&instance, Key::Return.into(), true);
+
+assert_eq!(edits.borrow().clone(), vec![40]);
+
+```
+
+*/

--- a/tests/cases/widgets/spinbox_basic.slint
+++ b/tests/cases/widgets/spinbox_basic.slint
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 
+// FIXME: Ignore the SpinBox test with the Qt style because it doesn't support editing
+//ignore: style-qt
+
 import { SpinBox } from "std-widgets.slint";
 export component TestCase inherits Window {
     width: 100px;

--- a/tests/driver/cpp/build.rs
+++ b/tests/driver/cpp/build.rs
@@ -42,7 +42,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut tests_file = BufWriter::new(std::fs::File::create(&tests_file_path)?);
 
-    for testcase in test_driver_lib::collect_test_cases("cases")? {
+    for testcase in test_driver_lib::collect_test_cases("cases")?.into_iter().filter(|testcase| {
+        // Style testing not supported yet
+        testcase.requested_style.is_none()
+    }) {
         let test_function_name = testcase.identifier();
         let ignored = testcase.is_ignored("cpp");
 
@@ -55,6 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 cppdriver::test(&test_driver_lib::TestCase{{
                     absolute_path: std::path::PathBuf::from(r#"{absolute_path}"#),
                     relative_path: std::path::PathBuf::from(r#"{relative_path}"#),
+                    requested_style: None,
                 }}).unwrap();
             }}
 

--- a/tests/driver/interpreter/build.rs
+++ b/tests/driver/interpreter/build.rs
@@ -9,7 +9,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut tests_file = std::fs::File::create(&tests_file_path)?;
 
-    for testcase in test_driver_lib::collect_test_cases("cases")? {
+    for testcase in test_driver_lib::collect_test_cases("cases")?.into_iter().filter(|testcase| {
+        // Style testing not supported yet
+        testcase.requested_style.is_none()
+    }) {
         let test_function_name = testcase.identifier();
         let ignored = testcase.is_ignored("interpreter");
 
@@ -22,6 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 interpreter::test(&test_driver_lib::TestCase{{
                     absolute_path: std::path::PathBuf::from(r#"{absolute_path}"#),
                     relative_path: std::path::PathBuf::from(r#"{relative_path}"#),
+                    requested_style: None,
                 }}).unwrap();
             }}
         "##,

--- a/tests/driver/interpreter/main.rs
+++ b/tests/driver/interpreter/main.rs
@@ -20,7 +20,12 @@ macro_rules! test_example {
                     absolute_path = legacy.into();
                 }
             }
-            interpreter::test(&test_driver_lib::TestCase { absolute_path, relative_path }).unwrap();
+            interpreter::test(&test_driver_lib::TestCase {
+                absolute_path,
+                relative_path,
+                requested_style: None,
+            })
+            .unwrap();
         }
     };
 }

--- a/tests/driver/nodejs/build.rs
+++ b/tests/driver/nodejs/build.rs
@@ -18,7 +18,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut tests_file = std::fs::File::create(&tests_file_path)?;
 
-    for testcase in test_driver_lib::collect_test_cases("cases")? {
+    for testcase in test_driver_lib::collect_test_cases("cases")?.into_iter().filter(|testcase| {
+        // Style testing not supported yet
+        testcase.requested_style.is_none()
+    }) {
         println!("cargo:rerun-if-changed={}", testcase.absolute_path.display());
         let test_function_name = testcase.identifier();
         let ignored = testcase.is_ignored("js");
@@ -32,6 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 nodejs::test(&test_driver_lib::TestCase{{
                     absolute_path: std::path::PathBuf::from(r#"{absolute_path}"#),
                     relative_path: std::path::PathBuf::from(r#"{relative_path}"#),
+                    requested_style: None,
                 }}).unwrap();
             }}
         "##,

--- a/tests/screenshots/build.rs
+++ b/tests/screenshots/build.rs
@@ -29,7 +29,11 @@ pub fn collect_test_cases() -> std::io::Result<Vec<test_driver_lib::TestCase>> {
         }
         if let Some(ext) = absolute_path.extension() {
             if ext == "60" || ext == "slint" {
-                results.push(test_driver_lib::TestCase { absolute_path, relative_path });
+                results.push(test_driver_lib::TestCase {
+                    absolute_path,
+                    relative_path,
+                    requested_style: None,
+                });
             }
         }
     }


### PR DESCRIPTION
Tests under tests/cases/for_each_style are run with all styles at least in the Rust driver.

Amends 6bb9905191e3ac1e63839ce434be55c1c3940e63 to include a test that using edited works.