### PR TITLE
Cleanups and fixes to the Node.js model mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to this project are documented in this file.
 
  - Fixed MapModel rowData() calling map function even if the source model returned undefined.
  - Better error reporting when the backend cannot be created.
+ - Reading model properties now always returns a `Model<T>`, regardless of whether an array was previously assigned.
+ - `Model<T>` now implements `Iterable<T>`.
 
 ### LSP
 

--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -427,6 +427,8 @@ test('ArrayModel', (t) => {
   let instance = definition!.create();
   t.not(instance, null);
 
+  t.deepEqual(Array.from(new ArrayModel([3, 2, 1])), [3, 2, 1]);
+
   instance!.setProperty("int-model", new ArrayModel([10, 9, 8]));
 
   let intArrayModel = instance!.getProperty("int-model") as ArrayModel<number>;
@@ -608,10 +610,12 @@ test('model from array', (t) => {
 
   instance!.setProperty("int-array", [10, 9, 8]);
   let wrapped_int_model = instance!.getProperty("int-array");
+  t.deepEqual(Array.from(wrapped_int_model), [10, 9, 8]);
   t.deepEqual(wrapped_int_model.rowCount(), 3);
   t.deepEqual(wrapped_int_model.rowData(0), 10);
   t.deepEqual(wrapped_int_model.rowData(1), 9);
   t.deepEqual(wrapped_int_model.rowData(2), 8);
+  t.deepEqual(Array.from(wrapped_int_model), [10, 9, 8]);
 
   instance!.setProperty("string-array", ["Simon", "Olivier", "Auri", "Tobias", "Florian"]);
   let wrapped_string_model = instance!.getProperty("string-array");

--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -607,10 +607,20 @@ test('model from array', (t) => {
   t.not(instance, null);
 
   instance!.setProperty("int-array", [10, 9, 8]);
-  t.deepEqual(instance!.getProperty("int-array"), [10, 9, 8]);
+  let wrapped_int_model = instance!.getProperty("int-array");
+  t.deepEqual(wrapped_int_model.rowCount(), 3);
+  t.deepEqual(wrapped_int_model.rowData(0), 10);
+  t.deepEqual(wrapped_int_model.rowData(1), 9);
+  t.deepEqual(wrapped_int_model.rowData(2), 8);
 
   instance!.setProperty("string-array", ["Simon", "Olivier", "Auri", "Tobias", "Florian"]);
-  t.deepEqual(instance!.getProperty("string-array"), ["Simon", "Olivier", "Auri", "Tobias", "Florian"]);
+  let wrapped_string_model = instance!.getProperty("string-array");
+  t.deepEqual(wrapped_string_model.rowCount(), 5);
+  t.deepEqual(wrapped_string_model.rowData(0), "Simon");
+  t.deepEqual(wrapped_string_model.rowData(1), "Olivier");
+  t.deepEqual(wrapped_string_model.rowData(2), "Auri");
+  t.deepEqual(wrapped_string_model.rowData(3), "Tobias");
+  t.deepEqual(wrapped_string_model.rowData(4), "Florian");
 })
 
 test('invoke callback', (t) => {

--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -430,6 +430,7 @@ test('ArrayModel', (t) => {
   instance!.setProperty("int-model", new ArrayModel([10, 9, 8]));
 
   let intArrayModel = instance!.getProperty("int-model") as ArrayModel<number>;
+  t.deepEqual(intArrayModel.rowCount(), 3);
   t.deepEqual(intArrayModel.values(), new ArrayModel([10, 9, 8]).values());
 
   instance!.setProperty("string-model", new ArrayModel(["Simon", "Olivier", "Auri", "Tobias", "Florian"]));

--- a/api/node/cover.md
+++ b/api/node/cover.md
@@ -252,15 +252,16 @@ The types used for properties in .slint design markup each translate to specific
 | `angle` | `Number` | The angle in degrees |
 | `relative-font-size` | `Number` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
 | structure | `Object` | Structures are mapped to JavaScript objects where each structure field is a property. |
-| array | `Array` or any implementation of {@link Model} | |
+| array | {@link Model} | |
 
 ### Arrays and Models
 
 [Array properties](../slint/src/language/syntax/types#arrays-and-models) can be set from JavaScript by passing
 either `Array` objects or implementations of the {@link Model} interface.
 
-When passing a JavaScript `Array` object, the contents of the array are copied. Any changes to the JavaScript afterwards will not be visible on the Slint side. Similarly, reading a Slint array property from JavaScript that was
-previously initialised from a JavaScript `Array`, will return a newly allocated JavaScript `Array`.
+When passing a JavaScript `Array` object, the contents of the array are copied. Any changes to the JavaScript afterwards will not be visible on the Slint side. 
+
+Reading a Slint array property from JavaScript will always return a @{link Model}.
 
 ```js
 component.model = [1, 2, 3];
@@ -269,7 +270,7 @@ component.model = [1, 2, 3];
 component.model = component.model.concat(4);
 ```
 
-Another option is to set an object that implements the {@link Model} interface. Rreading a Slint array property from JavaScript that was previously initialised from a {@link Model} object, will return a reference to the model.
+Another option is to set an object that implements the {@link Model} interface.
 
 ### Globals
 

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -117,6 +117,31 @@ export interface ImageData {
     get height(): number;
 }
 
+class ModelIterator<T> implements Iterator<T> {
+    private row: number;
+    private model: Model<T>;
+
+    constructor(model: Model<T>) {
+        this.model = model;
+        this.row = 0;
+    }
+
+    public next(): IteratorResult<T> {
+        if (this.row < this.model.rowCount()) {
+            let row = this.row;
+            this.row++;
+            return {
+                done: false,
+                value: this.model.rowData(row)
+            }
+        }
+        return {
+            done: true,
+            value: undefined
+        }
+    }
+}
+
 /**
  * Model<T> is the interface for feeding dynamic data into
  * `.slint` views.
@@ -176,7 +201,7 @@ export interface ImageData {
  *}
  * ```
  */
-export abstract class Model<T> {
+export abstract class Model<T> implements Iterable<T> {
     /**
      * @hidden
      */
@@ -219,6 +244,10 @@ export abstract class Model<T> {
         console.log(
             "setRowData called on a model which does not re-implement this method. This happens when trying to modify a read-only model"
         );
+    }
+
+    [Symbol.iterator](): Iterator<T> {
+        return new ModelIterator(this);
     }
 
     /**

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -177,16 +177,13 @@ export interface ImageData {
  * ```
  */
 export abstract class Model<T> {
-    private modelInner: napi.RustModel;
-
     /**
      * @hidden
      */
-    notify: NullPeer;
+    modelNotify: napi.ExternalObject<napi.SharedModelNotify>;
 
     constructor() {
-        this.notify = new NullPeer();
-        this.modelInner = new napi.RustModel(this);
+        this.modelNotify = napi.jsModelNotifyNew(this);
     }
 
     // /**
@@ -229,7 +226,7 @@ export abstract class Model<T> {
      * @param row index of the changed row.
      */
     protected notifyRowDataChanged(row: number): void {
-        this.modelInner.notify_row_data_changed(row);
+        napi.jsModelNotifyRowDataChanged(this.modelNotify, row);
     }
 
     /**
@@ -238,7 +235,7 @@ export abstract class Model<T> {
      * @param count the number of added items.
      */
     protected notifyRowAdded(row: number, count: number): void {
-        this.modelInner.notify_row_added(row, count);
+        napi.jsModelNotifyRowAdded(this.modelNotify, row, count);
     }
 
     /**
@@ -247,25 +244,15 @@ export abstract class Model<T> {
      * @param count the number of removed items.
      */
     protected notifyRowRemoved(row: number, count: number): void {
-        this.modelInner.notify_row_removed(row, count);
+        napi.jsModelNotifyRowRemoved(this.modelNotify, row, count);
     }
 
     /**
      * Notifies the view that the complete data must be reload.
      */
     protected notifyReset(): void {
-        this.modelInner.notify_reset();
+        napi.jsModelNotifyReset(this.modelNotify);
     }
-}
-
-/**
- * @hidden
- */
-class NullPeer {
-    rowDataChanged(row: number): void {}
-    rowAdded(row: number, count: number): void {}
-    rowRemoved(row: number, count: number): void {}
-    reset(): void {}
 }
 
 /**
@@ -496,7 +483,6 @@ export class MapModel<T, U> extends Model<U> {
         super();
         this.sourceModel = sourceModel;
         this.#mapFunction = mapFunction;
-        this.notify = this.sourceModel.notify;
     }
 
     /**

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -177,16 +177,16 @@ export interface ImageData {
  * ```
  */
 export abstract class Model<T> {
+    private modelInner: napi.RustModel;
+
     /**
      * @hidden
      */
     notify: NullPeer;
 
-    #modelInner: napi.RustModel;
-
     constructor() {
         this.notify = new NullPeer();
-        this.#modelInner = new napi.RustModel();
+        this.modelInner = new napi.RustModel(this);
     }
 
     // /**
@@ -229,7 +229,7 @@ export abstract class Model<T> {
      * @param row index of the changed row.
      */
     protected notifyRowDataChanged(row: number): void {
-        this.#modelInner.notify_row_data_changed(row);
+        this.modelInner.notify_row_data_changed(row);
     }
 
     /**
@@ -238,7 +238,7 @@ export abstract class Model<T> {
      * @param count the number of added items.
      */
     protected notifyRowAdded(row: number, count: number): void {
-        this.#modelInner.notify_row_added(row, count);
+        this.modelInner.notify_row_added(row, count);
     }
 
     /**
@@ -247,14 +247,14 @@ export abstract class Model<T> {
      * @param count the number of removed items.
      */
     protected notifyRowRemoved(row: number, count: number): void {
-        this.#modelInner.notify_row_removed(row, count);
+        this.modelInner.notify_row_removed(row, count);
     }
 
     /**
      * Notifies the view that the complete data must be reload.
      */
     protected notifyReset(): void {
-        this.#modelInner.notify_reset();
+        this.modelInner.notify_reset();
     }
 }
 

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -348,6 +348,19 @@ export class ArrayModel<T> extends Model<T> {
         this.notifyRowAdded(size, arguments.length);
     }
 
+    /**
+     * Removes the last element from the array and returns it.
+     * 
+     * @returns The removed element or undefined if the array is empty.
+     */
+    pop(): T | undefined {
+        let last = this.#array.pop();
+        if (last !== undefined) {
+            this.notifyRowRemoved(this.#array.length, 1);
+        }
+        return last;
+    }
+
     // FIXME: should this be named splice and have the splice api?
     /**
      * Removes the specified number of element from the array that's backing

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -182,8 +182,11 @@ export abstract class Model<T> {
      */
     notify: NullPeer;
 
+    #modelInner: napi.RustModel;
+
     constructor() {
         this.notify = new NullPeer();
+        this.#modelInner = new napi.RustModel();
     }
 
     // /**
@@ -226,7 +229,7 @@ export abstract class Model<T> {
      * @param row index of the changed row.
      */
     protected notifyRowDataChanged(row: number): void {
-        this.notify.rowDataChanged(row);
+        this.#modelInner.notify_row_data_changed(row);
     }
 
     /**
@@ -235,7 +238,7 @@ export abstract class Model<T> {
      * @param count the number of added items.
      */
     protected notifyRowAdded(row: number, count: number): void {
-        this.notify.rowAdded(row, count);
+        this.#modelInner.notify_row_added(row, count);
     }
 
     /**
@@ -244,14 +247,14 @@ export abstract class Model<T> {
      * @param count the number of removed items.
      */
     protected notifyRowRemoved(row: number, count: number): void {
-        this.notify.rowRemoved(row, count);
+        this.#modelInner.notify_row_removed(row, count);
     }
 
     /**
      * Notifies the view that the complete data must be reload.
      */
     protected notifyReset(): void {
-        this.notify.reset();
+        this.#modelInner.notify_reset();
     }
 }
 

--- a/api/node/src/interpreter/value.rs
+++ b/api/node/src/interpreter/value.rs
@@ -75,7 +75,7 @@ pub fn to_js_unknown(env: &Env, value: &Value) -> Result<JsUnknown> {
                 maybe_js_model
             } else {
                 let model_wrapper: ReadOnlyRustModel = model.clone().into();
-                Ok(model_wrapper.into_instance(*env)?.as_object(*env).into_unknown())
+                model_wrapper.into_js(env)
             }
         }
         _ => env.get_undefined().map(|v| v.into_unknown()),

--- a/api/node/src/interpreter/value.rs
+++ b/api/node/src/interpreter/value.rs
@@ -1,12 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-use crate::{JsModel, RgbaColor, SlintBrush, SlintImageData};
+use crate::{js_into_rust_model, rust_into_js_model, RgbaColor, SlintBrush, SlintImageData};
 use i_slint_compiler::langtype::Type;
 use i_slint_core::graphics::{Image, Rgba8Pixel, SharedPixelBuffer};
 use i_slint_core::model::{Model, ModelRc, SharedVectorModel};
 use i_slint_core::{Brush, Color, SharedVector};
-use napi::{bindgen_prelude::*, Env, JsBoolean, JsNumber, JsObject, JsString, JsUnknown, Result};
+use napi::bindgen_prelude::*;
+use napi::{Env, JsBoolean, JsNumber, JsObject, JsString, JsUnknown, Result};
 use napi_derive::napi;
 use slint_interpreter::Value;
 
@@ -67,14 +68,22 @@ pub fn to_js_unknown(env: &Env, value: &Value) -> Result<JsUnknown> {
             Ok(SlintBrush::from(brush.clone()).into_instance(*env)?.as_object(*env).into_unknown())
         }
         Value::Model(model) => {
-            if let Some(js_model) = model.as_any().downcast_ref::<JsModel>() {
-                let model: Object = js_model.model().get()?;
-                Ok(model.into_unknown())
+            if let Some(maybe_js_model) = rust_into_js_model(model) {
+                maybe_js_model
             } else {
                 let mut vec = vec![];
 
-                for i in 0..model.row_count() {
-                    vec.push(to_js_unknown(env, &model.row_data(i).unwrap())?);
+                let row_count = model.row_count();
+
+                for i in 0..row_count {
+                    vec.push(to_js_unknown(
+                        env,
+                        &model.row_data(i).ok_or_else(|| {
+                            napi::Error::from_reason(format!(
+                                "Model unexpectedly returned None for index {i} (len {row_count})",
+                            ))
+                        })?,
+                    )?);
                 }
 
                 Ok(Array::from_vec(env, vec)?.coerce_to_object()?.into_unknown())
@@ -249,11 +258,9 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
                     &vec,
                 )))))
             } else {
-                let model = unknown.coerce_to_object()?;
-                let _: JsFunction = model.get("rowCount")?.unwrap();
-                let _: JsFunction = model.get("rowData")?.unwrap();
-
-                Ok(Value::Model(ModelRc::new(JsModel::new(*env, model, *a.to_owned())?)))
+                let rust_model =
+                    unknown.coerce_to_object().and_then(|obj| js_into_rust_model(env, &obj, &a))?;
+                Ok(Value::Model(rust_model))
             }
         }
         Type::Enumeration(_) => todo!(),

--- a/api/node/src/types/model.rs
+++ b/api/node/src/types/model.rs
@@ -4,13 +4,62 @@
 use std::rc::{Rc, Weak};
 
 use i_slint_compiler::langtype::Type;
-use i_slint_core::model::Model;
+use i_slint_core::model::{Model, ModelNotify};
 use napi::{
     bindgen_prelude::Object, Env, JsFunction, JsNumber, JsUnknown, NapiRaw, Result, ValueType,
 };
 use slint_interpreter::Value;
 
 use crate::{to_js_unknown, to_value, RefCountedReference};
+
+#[napi]
+pub struct RustModel {
+    notify: ModelNotify,
+}
+
+#[napi]
+impl RustModel {
+    #[napi(constructor)]
+    pub fn new() -> Self {
+        Self { notify: Default::default() }
+    }
+
+    #[napi]
+    pub fn notify_row_data_changed(&self, row: u32) {
+        self.notify.row_changed(row as usize);
+    }
+
+    #[napi]
+    pub fn notify_row_added(&self, row: u32, count: u32) {
+        self.notify.row_added(row as usize, count as usize);
+    }
+
+    #[napi]
+    pub fn notify_row_removed(&self, row: u32, count: u32) {
+        self.notify.row_removed(row as usize, count as usize);
+    }
+
+    #[napi]
+    pub fn notify_reset(&self) {
+        self.notify.reset();
+    }
+}
+
+impl Model for RustModel {
+    type Data = slint_interpreter::Value;
+
+    fn row_count(&self) -> usize {
+        todo!()
+    }
+
+    fn row_data(&self, row: usize) -> Option<Self::Data> {
+        todo!()
+    }
+
+    fn model_tracker(&self) -> &dyn i_slint_core::model::ModelTracker {
+        &self.notify
+    }
+}
 
 pub struct JsModel {
     model: RefCountedReference,

--- a/api/node/src/types/model.rs
+++ b/api/node/src/types/model.rs
@@ -119,6 +119,23 @@ impl Model for JsModel {
         }
     }
 
+    fn set_row_data(&self, row: usize, data: Self::Data) {
+        let model: Object = self.js_impl.get().unwrap();
+        let set_row_data_fn = model
+            .get::<&str, JsFunction>("setRowData")
+            .expect("Node.js: JavaScript Model<T> implementation is missing setRowData property")
+            .expect("Node.js: Model<T> implementation's setRowData property is not a function");
+        set_row_data_fn
+            .call::<JsUnknown>(
+                Some(&model),
+                &[
+                    self.env.create_double(row as f64).unwrap().into_unknown(),
+                    to_js_unknown(&self.env, &data).unwrap(),
+                ],
+            )
+            .expect("Node.js: JavaScript Model<T>'s setRowData function threw an exception");
+    }
+
     fn model_tracker(&self) -> &dyn i_slint_core::model::ModelTracker {
         &**self.shared_model_notify
     }

--- a/tests/cases/crashes/layout_deleted_item.slint
+++ b/tests/cases/crashes/layout_deleted_item.slint
@@ -64,9 +64,9 @@ assert!(!instance.get_hover());
 
 ```js
 var instance = new slint.TestCase({
-    clicked: function() { var x = instance.model; x.pop(); instance.model = x; }
+    clicked: function() { var x = instance.model; x.remove(x.length - 1, 1); instance.model = x; }
 });
-instance.model = [1, 2];
+instance.model = new slintlib.ArrayModel([1, 2]);
 slintlib.private_api.send_mouse_click(instance, 5., 5.);
 assert.equal(instance.model.length, 1);
 assert(instance.hover);

--- a/tests/cases/crashes/layout_deleted_item.slint
+++ b/tests/cases/crashes/layout_deleted_item.slint
@@ -63,10 +63,11 @@ assert!(!instance.get_hover());
 ```
 
 ```js
+let model = new slintlib.ArrayModel([1, 2]);
 var instance = new slint.TestCase({
-    clicked: function() { var x = instance.model; x.remove(x.length - 1, 1); instance.model = x; }
+    clicked: function() { model.pop(); }
 });
-instance.model = new slintlib.ArrayModel([1, 2]);
+instance.model = model;
 slintlib.private_api.send_mouse_click(instance, 5., 5.);
 assert.equal(instance.model.length, 1);
 assert(instance.hover);

--- a/tests/cases/models/write_to_model.slint
+++ b/tests/cases/models/write_to_model.slint
@@ -138,9 +138,9 @@ var instance = new slint.TestCase({});
 slintlib.private_api.send_mouse_click(instance, 15., 5.);
 assert.equal(instance.clicked_score, 792);
 
-assert.equal(instance.model[1].score, 792.);
+assert.equal(instance.model.rowData(1).score, 792.);
 instance.manual_score_update(1, 100);
-assert.equal(instance.model[1].score, 892.);
+assert.equal(instance.model.rowData(1).score, 892.);
 
 let another_model = new slintlib.ArrayModel([
     {account: "a1", name: "hello", score: 111.},

--- a/tests/cases/models/write_to_model_sub_component.slint
+++ b/tests/cases/models/write_to_model_sub_component.slint
@@ -49,7 +49,7 @@ assert_eq(*the_model->row_data(1) , 2+8);
 var instance = new slint.TestCase({});
 instance.mod = [1, 2, 3];
 slintlib.private_api.send_mouse_click(instance, 50., 50.);
-assert.equal(instance.mod[1], 2+8);
+assert.equal(instance.mod.rowData(1), 2+8);
 ```
 
 

--- a/tests/cases/types/array.slint
+++ b/tests/cases/types/array.slint
@@ -29,13 +29,15 @@ TestCase := Rectangle {
 /*
 ```js
 var instance = new slint.TestCase({});
-assert.deepEqual(instance.p1, [12, 13]);
-assert.deepEqual(instance.p2, [14, 15.5]);
-assert.deepEqual(instance.p3, []);
-assert.deepEqual(instance.p4, [{a: 1, b: 0}, {a: 42, b: 10}]);
-assert.deepEqual(instance.p5, { prop: [{hello: "hello", world: 0}, { hello: "", world: 42}], xxx: 0 });
+assert.deepEqual(Array.from(instance.p1), [12, 13]);
+assert.deepEqual(Array.from(instance.p2), [14, 15.5]);
+assert.deepEqual(Array.from(instance.p3), []);
+assert.deepEqual(Array.from(instance.p4), [{a: 1, b: 0}, {a: 42, b: 10}]);
+let p5val = instance.p5;
+p5val.prop = Array.from(p5val.prop);
+assert.deepEqual(p5val, { prop: [{hello: "hello", world: 0}, { hello: "", world: 42}], xxx: 0 });
 
 instance.p3 = ["Hello", "World"];
-assert.deepEqual(instance.p3, ["Hello", "World"]);
+assert.deepEqual(Array.from(instance.p3), ["Hello", "World"]);
 ```
 */


### PR DESCRIPTION
This series changes two aspects:

Internally, the model mapping is changed so that every time a ModelRc is needed in Rust, we obtain a clone of a shared `Rc<ModelNotify>` and create a `slint::Model` impl around it.

Externally, Model<T> now supports the Iterable protocol, so that one can use for example `Array.from` to turn a model into an array, or use the model in a `for` loop. Additionally, the getter for a model property now _always_ returns an object that provides the same API as `Model<T>`.


These changes are done in preparation for refactoring `MapModel`, so that it can correctly react to changes in the source model (in the future).