### PR TITLE
Fix rust warning

### DIFF
--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -42,7 +42,7 @@ use lsp_types::{
     DocumentSymbol, DocumentSymbolResponse, Hover, InitializeParams, InitializeResult, OneOf,
     Position, PrepareRenameResponse, PublishDiagnosticsParams, RenameOptions,
     SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions, ServerCapabilities,
-    ServerInfo, TextDocumentSyncCapability, TextEdit, Url, WorkDoneProgressOptions, WorkspaceEdit,
+    ServerInfo, TextDocumentSyncCapability, TextEdit, Url, WorkDoneProgressOptions,
 };
 use std::cell::RefCell;
 use std::collections::HashMap;


### PR DESCRIPTION
warning: unused import: `WorkspaceEdit`
  --> tools/lsp/language.rs:45:85
   |
45 |     ServerInfo, TextDocumentSyncCapability, TextEdit, Url, WorkDoneProgressOptions, WorkspaceEdit,
   |                                                                                     ^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
