### PR TITLE
formatting fixes and improvements

### DIFF
--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -687,14 +687,13 @@ fn format_repeated_element(
     let mut sub = node.children_with_tokens();
     whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?;
     whitespace_to(&mut sub, SyntaxKind::DeclaredIdentifier, writer, state, " ")?;
-    // FIXME: [index] should not have a whitespace in front
-    let el = whitespace_to_one_of(
-        &mut sub,
-        &[SyntaxKind::Identifier, SyntaxKind::RepeatedIndex],
-        writer,
-        state,
-        " ",
-    )?;
+
+    let (kind, prefix_whitespace) = if node.child_node(SyntaxKind::RepeatedIndex).is_some() {
+        (SyntaxKind::RepeatedIndex, "")
+    } else {
+        (SyntaxKind::Identifier, " ")
+    };
+    let el = whitespace_to_one_of(&mut sub, &[kind], writer, state, prefix_whitespace)?;
 
     if let SyntaxMatch::Found(SyntaxKind::RepeatedIndex) = el {
         whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, " ")?;
@@ -717,9 +716,9 @@ fn format_repeated_index(
     state: &mut FormatState,
 ) -> Result<(), std::io::Error> {
     let mut sub = node.children_with_tokens();
-    whitespace_to(&mut sub, SyntaxKind::LBrace, writer, state, "")?;
+    whitespace_to(&mut sub, SyntaxKind::LBracket, writer, state, "")?;
     whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?;
-    whitespace_to(&mut sub, SyntaxKind::RBrace, writer, state, "")?;
+    whitespace_to(&mut sub, SyntaxKind::RBracket, writer, state, "")?;
     Ok(())
 }
 
@@ -1188,7 +1187,7 @@ A := B {
         "#,
             r#"
 A := B {
-    for number [index] in [1, 2, 3]: C {
+    for number[index] in [1, 2, 3]: C {
         d: number * index;
     }
 }


### PR DESCRIPTION
- states with multiple state element are now formatted properly
- arrays with trailing commas no longer result in error
- large arrays (len=80) and arrays with trailing comma are formatted with new line
- `for` with index no longer errors out and is formatted properly
- property animations are now supported
- object literals are now supported. big literals (len=80) and literals with trailing comma are broken into multiple lines

With these patches I can run `slint-lsp format` on slint files in examples and the result seems to be acceptable.

Closes #3900