### PR TITLE
Added `flicked`-Callback on `Flickable`

### DIFF
--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -166,6 +166,10 @@ interacting with `TouchArea` elements:
 -   **`viewport-height`**, **`viewport-width`** (_in_ _length_): The total size of the scrollable element.
 -   **`viewport-x`**, **`viewport-y`** (_in_ _length_): The position of the scrollable element relative to the `Flickable`. This is usually a negative value.
 
+### Callbacks
+
+-   **`flicked()`**: Invoked when `viewport-x` or `viewport-y` is changed by a user action (dragging, scrolling).
+
 ### Example
 
 ```slint

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -133,6 +133,7 @@ export component Flickable inherits Empty {
     in-out property <length> viewport-x;
     in-out property <length> viewport-y;
     in property <bool> interactive: true;
+    callback flicked();
     //-default_size_binding:expands_to_parent_geometry
 }
 

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -7,6 +7,7 @@
 
 use super::{
     Item, ItemConsts, ItemRc, ItemRendererRef, KeyEventResult, PointerEventButton, RenderingResult,
+    VoidArg,
 };
 use crate::animations::{EasingCurve, Instant};
 use crate::input::{
@@ -22,6 +23,7 @@ use crate::lengths::{
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use crate::window::WindowAdapter;
+use crate::Callback;
 use crate::Property;
 use alloc::boxed::Box;
 use alloc::rc::Rc;
@@ -48,6 +50,9 @@ pub struct Flickable {
     pub viewport_height: Property<LogicalLength>,
 
     pub interactive: Property<bool>,
+
+    pub flicked: Callback<VoidArg>,
+
     data: FlickableDataBox,
 
     /// FIXME: remove this
@@ -302,8 +307,14 @@ impl FlickableData {
 
                     if inner.capture_events || should_capture() {
                         let new_pos = ensure_in_bound(flick, new_pos, flick_rc);
+
+                        let old_pos = (x.get(), y.get());
                         x.set(new_pos.x_length());
                         y.set(new_pos.y_length());
+                        if old_pos.0 != new_pos.x_length() || old_pos.1 != new_pos.y_length() {
+                            (Flickable::FIELD_OFFSETS.flicked).apply_pin(flick).call(&());
+                        }
+
                         inner.capture_events = true;
                         InputEventResult::GrabMouse
                     } else {
@@ -328,8 +339,15 @@ impl FlickableData {
                     LogicalVector::new(delta_x, delta_y)
                 };
                 let new_pos = ensure_in_bound(flick, old_pos + delta, flick_rc);
-                (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick).set(new_pos.x_length());
-                (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick).set(new_pos.y_length());
+
+                let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick);
+                let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick);
+                let old_pos = (viewport_x.get(), viewport_y.get());
+                viewport_x.set(new_pos.x_length());
+                viewport_y.set(new_pos.y_length());
+                if old_pos.0 != new_pos.x_length() || old_pos.1 != new_pos.y_length() {
+                    (Flickable::FIELD_OFFSETS.flicked).apply_pin(flick).call(&());
+                }
                 InputEventResult::EventAccepted
             }
         }
@@ -362,12 +380,15 @@ impl FlickableData {
                     easing: EasingCurve::CubicBezier([0.0, 0.0, 0.58, 1.0]),
                     ..PropertyAnimation::default()
                 };
-                (Flickable::FIELD_OFFSETS.viewport_x)
-                    .apply_pin(flick)
-                    .set_animated_value(final_pos.x_length(), anim.clone());
-                (Flickable::FIELD_OFFSETS.viewport_y)
-                    .apply_pin(flick)
-                    .set_animated_value(final_pos.y_length(), anim);
+
+                let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick);
+                let viewport_y = (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick);
+                let old_pos = (viewport_x.get(), viewport_y.get());
+                viewport_x.set_animated_value(final_pos.x_length(), anim.clone());
+                viewport_y.set_animated_value(final_pos.y_length(), anim);
+                if old_pos.0 != final_pos.x_length() || old_pos.1 != final_pos.y_length() {
+                    (Flickable::FIELD_OFFSETS.flicked).apply_pin(flick).call(&());
+                }
             }
         }
         inner.capture_events = false; // FIXME: should only be set to false once the flick animation is over

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 TestCase := Window {
+
+
     width: 500phx;
     height: 500phx;
     no-frame: false;
@@ -13,6 +15,11 @@ TestCase := Window {
         height: parent.height - 20phx;
         viewport_width: 2100phx;
         viewport_height: 2100phx;
+
+        flicked => {
+            root.flicked += viewport_x/1phx * 100000 + viewport_y/1phx;
+        }
+
         inner_ta := TouchArea {
             x: 150phx;
             y: 150phx;
@@ -33,6 +40,7 @@ TestCase := Window {
     property<bool> inner_ta_pressed: inner_ta.pressed;
     property<bool> inner_ta_has_hover: inner_ta.has_hover;
     property<int> clicked;
+    property <int> flicked;
 }
 
 /*
@@ -195,4 +203,29 @@ if !cfg!(target_os = "macos") {
 }
 ```
 
+```rust
+// Test flicked-Callback behaviour
+use slint::{LogicalPosition, platform::{WindowEvent, PointerEventButton} };
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_flicked(), 0);
+
+// test scrolling behaviour
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: -30.0, delta_y: -50.0 });
+dbg!(instance.get_flicked());
+assert_eq!(instance.get_flicked(), -3000050); //flicked got called after scrolling
+instance.set_flicked(0);
+
+// test dragging bevaviour
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(175.0, 175.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(300);
+assert_eq!(instance.get_flicked(), 0); //flicked didn't get called by just pressing
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(100.0, 120.0) });
+slint_testing::mock_elapsed_time(10000);
+assert_eq!(instance.get_flicked(), -10500105); //flicked got called during drag
+instance.set_flicked(0);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(100.0, 120.0), button: PointerEventButton::Left });
+assert_eq!(instance.get_flicked(), -10500105); //flicked got called after drag
+instance.set_flicked(0);
+
+```
 */


### PR DESCRIPTION
Hello,
as requested in #1462, I've added a `scrolled`-Callback that gets triggered when the `viewport_x`- or `viewport_y` -Properties are changed by a mouse drag or mouse wheel movement.

I was only able to test this change on the Rust API (by adding a debug statement to one of the examples), because my current Nix build setup isn't setup for C++, Python or NodeJs.

Thanks,
pfzetto
