### PR TITLE
fmt follow up fixes

### DIFF
--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -924,14 +924,29 @@ fn format_property_animation(
         && whitespace_to(&mut sub, SyntaxKind::QualifiedName, writer, state, " ")?
         && whitespace_to(&mut sub, SyntaxKind::LBrace, writer, state, " ")?;
 
-    state.indentation_level += 1;
-    state.new_line();
+    let bindings = node.children().fold(0, |acc, e| {
+        if e.kind() == SyntaxKind::Binding {
+            return acc + 1;
+        }
+        acc
+    });
+
+    if bindings > 1 {
+        state.indentation_level += 1;
+        state.new_line();
+    } else {
+        state.insert_whitespace(" ");
+    }
 
     for n in sub {
         if n.kind() == SyntaxKind::RBrace {
-            state.indentation_level -= 1;
             state.whitespace_to_add = None;
-            state.new_line();
+            if bindings > 1 {
+                state.indentation_level -= 1;
+                state.new_line();
+            } else {
+                state.insert_whitespace(" ");
+            }
             fold(n, writer, state)?;
             state.new_line();
         } else {
@@ -1528,13 +1543,17 @@ component ABC {
             r#"
 export component MainWindow inherits Window {
     animate background { duration: 800ms;}
+    animate x { duration: 100ms; easing: ease-out-bounce; }
     Rectangle {}
 }
 "#,
             r#"
 export component MainWindow inherits Window {
-    animate background {
-        duration: 800ms;
+    animate background { duration: 800ms; }
+
+    animate x {
+        duration: 100ms;
+        easing: ease-out-bounce;
     }
 
     Rectangle { }

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -761,6 +761,12 @@ fn format_array(
     let mut sub = node.children_with_tokens().peekable();
     whitespace_to(&mut sub, SyntaxKind::LBracket, writer, state, "")?;
 
+    let is_empty_array = node.children().count() == 0;
+    if is_empty_array {
+        whitespace_to(&mut sub, SyntaxKind::RBracket, writer, state, "")?;
+        return Ok(());
+    }
+
     if is_large_array || has_trailing_comma {
         state.indentation_level += 1;
         state.new_line();
@@ -1702,6 +1708,22 @@ export component MainWindow inherits Rectangle {
         duration: 170ms;
         easing: cubic-bezier(0.17,0.76,0.4,1.75);
     }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn empty_array() {
+        assert_formatting(
+            r#"
+export component MainWindow2 inherits Rectangle {
+    in property <[string]> model: [ ];
+}
+"#,
+            r#"
+export component MainWindow2 inherits Rectangle {
+    in property <[string]> model: [];
 }
 "#,
         );

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -1719,6 +1719,7 @@ export component MainWindow inherits Rectangle {
             r#"
 export component MainWindow inherits Rectangle {
     animate x , y { duration: 170ms; easing: cubic-bezier(0.17,0.76,0.4,1.75); }
+    animate x , y { duration: 170ms;}
 }
 "#,
             r#"
@@ -1727,6 +1728,7 @@ export component MainWindow inherits Rectangle {
         duration: 170ms;
         easing: cubic-bezier(0.17,0.76,0.4,1.75);
     }
+    animate x, y { duration: 170ms; }
 }
 "#,
         );

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -696,9 +696,9 @@ fn format_repeated_element(
     } else {
         (SyntaxKind::Identifier, " ")
     };
-    let el = whitespace_to_one_of(&mut sub, &[kind], writer, state, prefix_whitespace)?;
+    whitespace_to(&mut sub, kind, writer, state, prefix_whitespace)?;
 
-    if let SyntaxMatch::Found(SyntaxKind::RepeatedIndex) = el {
+    if kind == SyntaxKind::RepeatedIndex {
         whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, " ")?;
     }
 


### PR DESCRIPTION
- property animation with 1 binding is now kept on a single line
- empty lines are preserved
- property animation with multiple properties is formatted
- handle empty arrays
- fix length calculation of arrays/obj-literals to figure out if its large

After these changes, the fmt can run on all files in `examples` directory without errors.