### PR TITLE
C++ package: use Qt on Linux, not on Windows/Mac

### DIFF
--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -35,11 +35,11 @@ jobs:
             - uses: ./.github/actions/install-linux-dependencies
               with:
                   old-ubuntu: true
-            - name: Install Qt (cached)
-              if: matrix.os != 'ubuntu-20.04'
+            - name: Install Qt (Ubuntu)
               uses: jurplel/install-qt-action@v3
+              if: matrix.os == 'ubuntu-20.04'
               with:
-                  version: 6.5.1
+                  version: 5.15.2
                   cache: true
             - uses: ./.github/actions/setup-rust
             - uses: baptiste0928/cargo-install@v3


### PR DESCRIPTION
Commit 4b4a7d6ff2d1927ca53bd5be7fdf4f5bf15a8e63 attempted to remove the Qt from the C++ package on Windows, but infortunately, it removed the setup of Qt on Linux instead of Windows.

As a result, 1.4.x binary packages on Linux are not build with Qt, and on Windows are build with Qt but no longer ship Qt so are broken

In the master branch we no longer use Qt by default already on Windows even if it is installed.
But this patch restore the fact that the binary package are built with Qt on Linux