### PR TITLE
live preview: Fix moving of elements

### DIFF
--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -162,7 +162,7 @@ fn element_source_range(element: &ElementRc) -> Option<(SourceFile, TextRange)> 
 }
 
 // Return the real root element, skipping any WindowElement that got added
-fn root_element(component_instance: &ComponentInstance) -> ElementRc {
+pub fn root_element(component_instance: &ComponentInstance) -> ElementRc {
     let root_element = component_instance.definition().root_component().root_element.clone();
     if !root_element.borrow().node.is_empty() {
         return root_element;

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -71,6 +71,20 @@ pub fn find_element_indent(element: &ElementRc) -> Option<String> {
     None
 }
 
+/// Try to find the parent of element `child` below `root`.
+pub fn search_for_parent_element(root: &ElementRc, child: &ElementRc) -> Option<ElementRc> {
+    for c in &root.borrow().children {
+        if std::rc::Rc::ptr_eq(c, child) {
+            return Some(root.clone());
+        }
+
+        if let Some(parent) = search_for_parent_element(c, child) {
+            return Some(parent);
+        }
+    }
+    None
+}
+
 /// Given a node within an element, return the Type for the Element under that node.
 /// (If node is an element, return the Type for that element, otherwise the type of the element under it)
 /// Will return `Foo` in the following example where `|` is the cursor.


### PR DESCRIPTION
The positioning needs to happen relative to the position of the parent element, not using global coordinates.