### PR TITLE
vtable: fix UB detected as miri errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -553,3 +553,15 @@ jobs:
                   sed -i "s/#wasm# //" Cargo.toml
                   cargo apk build -p printerdemo --target aarch64-linux-android --lib
               working-directory: examples/printerdemo/rust
+
+    miri:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: ./.github/actions/setup-rust
+              with:
+                  toolchain: nightly
+                  key: miri
+                  components: miri
+            - name: Run Miri
+              run: cargo miri test -p vtable -p const-field-offset -p i-slint-common

--- a/helper_crates/vtable/macro/macro.rs
+++ b/helper_crates/vtable/macro/macro.rs
@@ -439,8 +439,8 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
                             // Safety: The vtable is valid and inner is a type corresponding to the vtable,
                             // which was allocated such that drop is expected.
                             unsafe {
-                                let ptr = &*ptr;
-                                (ptr.vtable.as_ref().#ident)(VRefMut::from_raw(ptr.vtable, ptr.ptr)) }
+                                let (vtable, ptr) = ((*ptr).vtable, (*ptr).ptr);
+                                (vtable.as_ref().#ident)(VRefMut::from_raw(vtable, ptr)) }
                         }
                         fn new_box<X: HasStaticVTable<#vtable_name>>(value: X) -> VBox<#vtable_name> {
                             // Put the object on the heap and get a pointer to it


### PR DESCRIPTION
We can't create references for things that aren't represented by the reference. Even if we never dereference that reference.

Also add a miri test in the CI that runs the test on crate which are error free.