### PR TITLE
vtable: Fix soundess issue of VRc::into_dyn for `!Send` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,8 @@ slint-cpp = { version = "=1.5.0", path = "api/cpp", default-features = false }
 slint-interpreter = { version = "=1.5.0", path = "internal/interpreter", default_features = false }
 slint-macros = { version = "=1.5.0", path = "api/rs/macros", default-features = false }
 
+vtable = { version = "0.2", path = "helper_crates/vtable", default-features = false }
+
 bytemuck = { version = "1.13.1" }
 cbindgen = { version = "0.26", default-features = false }
 css-color-parser2 = { version = "1.0.1" }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -167,7 +167,7 @@ i-slint-backend-selector = { workspace = true }
 
 const-field-offset = { version = "0.1.2", path = "../../../helper_crates/const-field-offset" }
 document-features = { version = "0.2.0", optional = true }
-vtable = { version = "0.1.6", path = "../../../helper_crates/vtable" }
+vtable = { workspace = true }
 
 once_cell = { version = "1.5", default-features = false, features = ["alloc"] }
 pin-weak = { version = "1.1", default-features = false }

--- a/api/wasm-interpreter/Cargo.toml
+++ b/api/wasm-interpreter/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib"]
 slint-interpreter = { workspace = true, features = ["std", "backend-winit", "renderer-femtovg", "compat-1-2", "internal"] }
 send_wrapper = { workspace = true }
 
-vtable = { version = "0.1.6", path="../../helper_crates/vtable" }
+vtable = { workspace = true }
 
 console_error_panic_hook = { version = "0.1.6", optional = true }
 js-sys = "0.3.44"

--- a/helper_crates/vtable/CHANGELOG.md
+++ b/helper_crates/vtable/CHANGELOG.md
@@ -3,6 +3,10 @@
 # Changelog
 All notable changes to this crate will be documented in this file.
 
+## [0.2.0]
+
+ - Make `Dyn` not Send or Sync, thereby fixing a soundness hole
+
 ## [0.1.12] - 2024-02-26
 
  - Fix error reported by miri

--- a/helper_crates/vtable/Cargo.toml
+++ b/helper_crates/vtable/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "vtable"
-version = "0.1.12"
+version = "0.2.0"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ homepage = "https://slint.dev"
 [lib]
 
 [dependencies]
-vtable-macro = { version = "=0.1.12", path = "./macro" }
+vtable-macro = { version = "=0.2.0", path = "./macro" }
 const-field-offset = { version = "0.1", path = "../const-field-offset" }
 stable_deref_trait = { version = "1.2.0", default-features = false }
 portable-atomic = "1"

--- a/helper_crates/vtable/macro/Cargo.toml
+++ b/helper_crates/vtable/macro/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "vtable-macro"
-version = "0.1.12"
+version = "0.2.0"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/internal/backends/qt/Cargo.toml
+++ b/internal/backends/qt/Cargo.toml
@@ -27,7 +27,7 @@ i-slint-core-macros = { workspace = true }
 i-slint-core = { workspace = true }
 
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
-vtable = { version = "0.1.8", path = "../../../helper_crates/vtable" }
+vtable = { workspace = true }
 
 cpp = { version = "0.5.5", optional = true }
 lyon_path = { version = "1", optional = true }

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -21,5 +21,5 @@ default = []
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["default"] }
-vtable = { version = "0.1.8", path = "../../../helper_crates/vtable" }
+vtable = { workspace = true }
 image = { version = "0.24.0", default-features = false, features = ["png", "jpeg"] }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -35,7 +35,6 @@ i-slint-core-macros = { workspace = true, features = ["default"] }
 i-slint-common = { workspace = true, features = ["default"] }
 
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
-vtable = { version = "0.1.6", path = "../../../helper_crates/vtable" }
 
 cfg-if = "1"
 derive_more = "0.99.5"

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -51,7 +51,7 @@ i-slint-common = { workspace = true, features = ["default"] }
 i-slint-core-macros = { workspace = true, features = ["default"] }
 
 const-field-offset = { version = "0.1", path = "../../helper_crates/const-field-offset" }
-vtable = { version = "0.1.9", path = "../../helper_crates/vtable" }
+vtable = { workspace = true }
 
 portable-atomic = { version = "1", features = ["critical-section"] }
 auto_enums = "0.8.0"

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -117,7 +117,7 @@ i-slint-common = { workspace = true }
 i-slint-core = { workspace = true, features = ["default", "rtti"] }
 i-slint-backend-selector = { workspace = true, features = ["rtti"] }
 
-vtable = { version = "0.1.6", path="../../helper_crates/vtable" }
+vtable = { workspace = true }
 
 derive_more = "0.99.5"
 generativity = "1"

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -24,7 +24,6 @@ i-slint-core-macros = { workspace = true, features = ["default"] }
 i-slint-common = { workspace = true, features = ["default"] }
 
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
-vtable = { version = "0.1.6", path = "../../../helper_crates/vtable" }
 
 cfg-if = "1"
 derive_more = "0.99.5"

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -32,7 +32,7 @@ i-slint-core-macros = { workspace = true, features = ["default"] }
 i-slint-common = { workspace = true, features = ["default"] }
 
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
-vtable = { version = "0.1.6", path = "../../../helper_crates/vtable" }
+vtable = { workspace = true }
 
 cfg-if = "1"
 derive_more = "0.99.5"

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -56,8 +56,6 @@ i-slint-core = { workspace = true }
 slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility"] }
 i-slint-backend-selector = { workspace = true }
 
-vtable = { version = "0.1.6", path="../../helper_crates/vtable" }
-
 clap = { version = "4.0", features = ["derive", "wrap_help"] }
 codemap = "0.1"
 codemap-diagnostic = "0.1.1"


### PR DESCRIPTION
Dyn is currently Send+Sync, so `VRc<WhateverVTable, Dyn>` is also Send+Sync. So we shouldn't really allow conversion between `VRc<WhateverVTable, SomeThingNotSend>` to `VRc<_, Dyn>` that can be sent between threads

This is a breaking change of the vtable crate, but also a soundness fix