### PR TITLE
C++ Interpreter: Add support for setting the translation domain

### DIFF
--- a/api/cpp/include/slint-interpreter.h
+++ b/api/cpp/include/slint-interpreter.h
@@ -980,6 +980,13 @@ public:
         return s;
     }
 
+    /// Sets the domain used for translations.
+    void set_translation_domain(std::string_view domain)
+    {
+        cbindgen_private::slint_interpreter_component_compiler_set_translation_domain(
+                &inner, slint::private_api::string_to_slice(domain));
+    }
+
     /// Returns the include paths the component compiler is currently configured with.
     slint::SharedVector<slint::SharedString> include_paths() const
     {

--- a/api/cpp/tests/interpreter.cpp
+++ b/api/cpp/tests/interpreter.cpp
@@ -284,6 +284,12 @@ SCENARIO("Component Compiler")
         REQUIRE(compiler.style() == "fluent");
     }
 
+    SECTION("configure translation domain")
+    {
+        // Make sure this compiles.
+        compiler.set_translation_domain("cpptests");
+    }
+
     SECTION("Compile failure from source")
     {
         auto result = compiler.build_from_source("Syntax Error!!", "");

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -705,6 +705,16 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_set_style(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn slint_interpreter_component_compiler_set_translation_domain(
+    compiler: &mut ComponentCompilerOpaque,
+    translation_domain: Slice<u8>,
+) {
+    compiler
+        .as_component_compiler_mut()
+        .set_translation_domain(std::str::from_utf8(&translation_domain).unwrap().to_string())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_get_style(
     compiler: &ComponentCompilerOpaque,
     style_out: &mut SharedString,


### PR DESCRIPTION
This maps straight to the Rust API.