### PR TITLE
live preview: Fix select-behind being eaten by drag-area

### DIFF
--- a/tools/lsp/ui/draw-area.slint
+++ b/tools/lsp/ui/draw-area.slint
@@ -32,6 +32,7 @@ component SelectionFrame {
     height: root.selection.height;
 
     callback update-geometry(/* x */ length, /* y */ length, /* width */ length, /* height */ length);
+    callback select-behind(/* x */ length, /* y */ length, /* enter component? */ bool, /* same file? */ bool);
 
     if !selection.is-primary || !experimental: Rectangle {
         x: 0;
@@ -41,6 +42,10 @@ component SelectionFrame {
     }
 
     if selection.is-primary && experimental: Resizer {
+        double-clicked(x, y, modifiers) => {
+            root.select-behind(self.absolute-position.x + x, self.absolute-position.y + y, modifiers.control, modifiers.shift);
+        }
+
         is-moveable: true;
         is-resizable: true;
 
@@ -188,7 +193,7 @@ export component DrawArea {
                         // This needs to fire AFTER clicked and double-clicked to work :-/
                         if (event.kind == PointerEventKind.up) {
                             if (self.selection-kind == SelectionKind.select_up_or_down) {
-                                root.select_behind(self.selection-x, self.selection-y, event.modifiers.control, event.modifiers.shift);
+                                root.select-behind(self.selection-x, self.selection-y, event.modifiers.control, event.modifiers.shift);
                             } else if (self.selection-kind == SelectionKind.select-at) {
                                 root.select-at(self.selection-x, self.selection-y, event.modifiers.control);
                             }
@@ -206,6 +211,8 @@ export component DrawArea {
                         update-geometry(x, y, w, h) => {
                             root.selected-element-update-geometry(x, y, w, h);
                         }
+
+                        select-behind(x, y, c, f) => { root.select-behind(x, y, c, f); }
                     }
                 }
             }

--- a/tools/lsp/ui/resizer.slint
+++ b/tools/lsp/ui/resizer.slint
@@ -55,6 +55,7 @@ export component Resizer {
     out property <length> handle-size: ResizeState.handle-size;
 
     callback update-geometry(/* x */ length, /* y */ length, /* width */ length, /* height */ length, /* done */ bool);
+    callback double-clicked(/* x */ length, /* y */ length, /* modifiers */ KeyboardModifiers);
 
     // Private!
     in-out property <length> top: self.y-position;
@@ -73,9 +74,14 @@ export component Resizer {
         if root.is-moveable: TouchArea {
             private property <length> x-offset: self.mouse-x - self.pressed-x;
             private property <length> y-offset: self.mouse-y - self.pressed-y;
+            private property <KeyboardModifiers> modifiers;
             private property <bool> has-moved;
 
             mouse-cursor: MouseCursor.move;
+
+            double-clicked() => {
+                root.double-clicked(self.mouse-x, self.mouse-y, self.modifiers);
+            }
 
             moved() => {
                 root.update-geometry(root.x-position + x-offset, root.y-position + y-offset, root.width, root.height, false);
@@ -84,6 +90,8 @@ export component Resizer {
 
             pointer-event(event) => {
                 resize-area.moving = self.pressed;
+                self.modifiers = event.modifiers;
+
                 if self.has-moved && event.button == PointerEventButton.left && event.kind == PointerEventKind.up {
                     root.update-geometry(root.x-position + x-offset, root.y-position + y-offset, root.width, root.height, true);
                     self.has-moved = false;


### PR DESCRIPTION
Fix select-behind being eaten by the drasg area in the Resizer used to move the selected element.