### PR TITLE
Restructure tree sitter tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -365,35 +365,10 @@ jobs:
         uses: ./.github/workflows/wasm_demos.yaml
 
     tree-sitter:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-            - uses: robinraju/release-downloader@v1.9
-              with:
-                  repository: "tree-sitter/tree-sitter"
-                  tag: "v0.20.9"
-                  fileName: "tree-sitter-linux-x64.gz"
-                  out-file-path: ${{ runner.workspace }}
-            - name: Extract tree-sitter-cli
-              run: |
-                  gunzip tree-sitter-linux-x64.gz
-                  chmod 755 tree-sitter-linux-x64
-                  mv tree-sitter-linux-x64 tree-sitter
-              working-directory: ${{ runner.workspace }}
-            - name: Generate tree-sitter corpus
-              run: find ../../tests/cases -type d -exec ./test-to-corpus.py --tests-directory {} \;
-              working-directory: editors/tree-sitter-slint
-            - name: Generate tree-sitter parser
-              run: ${{ runner.workspace }}/tree-sitter generate
-              working-directory: editors/tree-sitter-slint
-            - name: Run tree-sitter tests
-              run: ${{ runner.workspace }}/tree-sitter test -u
-              working-directory: editors/tree-sitter-slint
-            - name: Check for parse ERRORs from tree-sitter
-              run: sh -c "! grep -q ERROR corpus/*.txt"
-              working-directory: editors/tree-sitter-slint
+        uses: ./.github/workflows/tree_sitter.yaml
+        with:
+            latest: false
+            tag: "v0.20.9"
 
     # Checkout a old version of the tests and example, then run the slint-updater on them
     # and check that it worked with the interpreter test.

--- a/.github/workflows/nightly_tree_sitter.yaml
+++ b/.github/workflows/nightly_tree_sitter.yaml
@@ -1,0 +1,15 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+name: Nightly run of tree sitter tests against latest tree sitter release
+on:
+    workflow_dispatch:
+
+    schedule:
+        - cron: "0 2 * * *"
+
+jobs:
+    test:
+        uses: ./.github/workflows/tree_sitter.yaml
+        with:
+          latest: true

--- a/.github/workflows/tree_sitter.yaml
+++ b/.github/workflows/tree_sitter.yaml
@@ -1,0 +1,49 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+name: "Tree Sitter Test"
+on:
+    #  push:
+    #  pull_request:
+    workflow_call:
+        inputs:
+            tag:
+                type: string
+                description: tree sitter release tag to use            
+            latest:
+                type: boolean
+                description: Use the latest tree-sitter release
+                default: true
+
+jobs:
+    spellcheck:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - uses: robinraju/release-downloader@v1.9
+              with:
+                  repository: "tree-sitter/tree-sitter"
+                  tag: ${{ inputs.tag }}
+                  latest: ${{ inputs.latest }}
+                  fileName: "tree-sitter-linux-x64.gz"
+                  out-file-path: ${{ runner.workspace }}
+            - name: Extract tree-sitter-cli
+              run: |
+                  gunzip tree-sitter-linux-x64.gz
+                  chmod 755 tree-sitter-linux-x64
+                  mv tree-sitter-linux-x64 tree-sitter
+              working-directory: ${{ runner.workspace }}
+            - name: Generate tree-sitter corpus
+              run: find ../../tests/cases -type d -exec ./test-to-corpus.py --tests-directory {} \;
+              working-directory: editors/tree-sitter-slint
+            - name: Generate tree-sitter parser
+              run: ${{ runner.workspace }}/tree-sitter generate
+              working-directory: editors/tree-sitter-slint
+            - name: Run tree-sitter tests
+              run: ${{ runner.workspace }}/tree-sitter test -u
+              working-directory: editors/tree-sitter-slint
+            - name: Check for parse ERRORs from tree-sitter
+              run: sh -c "! grep -q ERROR corpus/*.txt"
+              working-directory: editors/tree-sitter-slint

--- a/.github/workflows/tree_sitter.yaml
+++ b/.github/workflows/tree_sitter.yaml
@@ -16,7 +16,7 @@ on:
                 default: true
 
 jobs:
-    spellcheck:
+    tree-sitter-tests:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
- For the main CI, pin a tree sitter version that's know to work.
- Additionally, schedule a nightly run against the latest version of tree sitter, so that we can find issues before the next release.