### PR TITLE
Add support for mapping image properties

### DIFF
--- a/api/python/errors.rs
+++ b/api/python/errors.rs
@@ -86,3 +86,17 @@ impl From<slint_interpreter::SetCallbackError> for PySetCallbackError {
         Self(err)
     }
 }
+
+pub struct PyLoadImageError(pub slint_interpreter::LoadImageError);
+
+impl From<PyLoadImageError> for PyErr {
+    fn from(err: PyLoadImageError) -> Self {
+        pyo3::exceptions::PyRuntimeError::new_err(err.0.to_string())
+    }
+}
+
+impl From<slint_interpreter::LoadImageError> for PyLoadImageError {
+    fn from(err: slint_interpreter::LoadImageError) -> Self {
+        Self(err)
+    }
+}

--- a/api/python/image.rs
+++ b/api/python/image.rs
@@ -1,0 +1,55 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+use pyo3::prelude::*;
+
+#[pyclass(unsendable)]
+pub struct PyImage {
+    pub image: slint_interpreter::Image,
+}
+
+#[pymethods]
+impl PyImage {
+    #[new]
+    fn py_new() -> PyResult<Self> {
+        Ok(Self { image: Default::default() })
+    }
+
+    #[getter]
+    fn size(&self) -> PyResult<(u32, u32)> {
+        Ok(self.image.size().into())
+    }
+
+    #[getter]
+    fn width(&self) -> PyResult<u32> {
+        Ok(self.image.size().width)
+    }
+
+    #[getter]
+    fn height(&self) -> PyResult<u32> {
+        Ok(self.image.size().height)
+    }
+
+    #[getter]
+    fn path(&self) -> PyResult<Option<&std::path::Path>> {
+        Ok(self.image.path())
+    }
+
+    #[staticmethod]
+    fn load_from_path(path: std::path::PathBuf) -> Result<Self, crate::errors::PyLoadImageError> {
+        let image = slint_interpreter::Image::load_from_path(&path)?;
+        Ok(Self { image })
+    }
+
+    #[staticmethod]
+    fn load_from_svg_data(data: &[u8]) -> Result<Self, crate::errors::PyLoadImageError> {
+        let image = slint_interpreter::Image::load_from_svg_data(data)?;
+        Ok(Self { image })
+    }
+}
+
+impl From<&slint_interpreter::Image> for PyImage {
+    fn from(image: &slint_interpreter::Image) -> Self {
+        Self { image: image.clone() }
+    }
+}

--- a/api/python/lib.rs
+++ b/api/python/lib.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+mod image;
 mod interpreter;
 use interpreter::{ComponentCompiler, PyDiagnostic, PyDiagnosticLevel, PyValueType};
 mod errors;
@@ -28,6 +29,7 @@ fn slint(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     .map_err(|e| errors::PyPlatformError(e))?;
 
     m.add_class::<ComponentCompiler>()?;
+    m.add_class::<image::PyImage>()?;
     m.add_class::<PyValueType>()?;
     m.add_class::<PyDiagnosticLevel>()?;
     m.add_class::<PyDiagnostic>()?;

--- a/api/python/slint/__init__.py
+++ b/api/python/slint/__init__.py
@@ -8,3 +8,5 @@ def load_file(path):
     compdef = compiler.build_from_path(path)
     instance = compdef.create()
     return instance    
+
+Image = native.PyImage

--- a/api/python/value.rs
+++ b/api/python/value.rs
@@ -34,7 +34,9 @@ impl<'a> ToPyObject for PyValueRef<'a> {
             slint_interpreter::Value::Number(num) => num.into_py(py),
             slint_interpreter::Value::String(str) => str.into_py(py),
             slint_interpreter::Value::Bool(b) => b.into_py(py),
-            slint_interpreter::Value::Image(_) => todo!(),
+            slint_interpreter::Value::Image(image) => {
+                crate::image::PyImage::from(image).into_py(py)
+            }
             slint_interpreter::Value::Model(_) => todo!(),
             slint_interpreter::Value::Struct(structval) => structval
                 .iter()
@@ -60,6 +62,10 @@ impl FromPyObject<'_> for PyValue {
                 ob.extract::<&'_ str>().map(|s| slint_interpreter::Value::String(s.into()))
             })
             .or_else(|_| ob.extract::<f64>().map(|num| slint_interpreter::Value::Number(num)))
+            .or_else(|_| {
+                ob.extract::<PyRef<'_, crate::image::PyImage>>()
+                    .map(|pyimg| slint_interpreter::Value::Image(pyimg.image.clone()))
+            })
             .or_else(|_| {
                 ob.extract::<&PyDict>().and_then(|dict| {
                     let dict_items: Result<Vec<(String, slint_interpreter::Value)>, PyErr> = dict


### PR DESCRIPTION
This exposes a slint.Image class, which has a load_from_path class method as well as size/width/height properties.

cc #4202