### PR TITLE
Fix the `non_local_definitions` warnings with rust nightly

### DIFF
--- a/helper_crates/const-field-offset/macro/macro.rs
+++ b/helper_crates/const-field-offset/macro/macro.rs
@@ -217,13 +217,14 @@ pub fn const_field_offset(input: TokenStream) -> TokenStream {
                 })
             },
             Some(quote! {
+                const _ : () = {
                     /// Make sure that Unpin is not implemented
                     #[allow(dead_code)]
-                    pub struct __MustNotImplUnpin<'__dummy_lifetime> (
-                        #(#types, )*
+                    struct __MustNotImplUnpin<'__dummy_lifetime> (
                         ::core::marker::PhantomData<&'__dummy_lifetime ()>
                     );
                     impl<'__dummy_lifetime> Unpin for #struct_name where __MustNotImplUnpin<'__dummy_lifetime> : Unpin {};
+                };
             }),
             quote!(#crate_::AllowPin),
             quote!(new_from_offset_pinned),
@@ -256,7 +257,6 @@ pub fn const_field_offset(input: TokenStream) -> TokenStream {
             /// Return a struct containing the offset of for the fields of this struct
             pub const FIELD_OFFSETS : #field_struct_name = {
                 #ensure_pin_safe;
-                #ensure_no_unpin;
                 let mut len = 0usize;
                 #field_struct_name {
                     #( #fields : {
@@ -272,6 +272,7 @@ pub fn const_field_offset(input: TokenStream) -> TokenStream {
         }
 
         #pinned_drop_impl
+        #ensure_no_unpin
     };
 
     #[cfg(feature = "field-offset-trait")]

--- a/helper_crates/const-field-offset/src/lib.rs
+++ b/helper_crates/const-field-offset/src/lib.rs
@@ -117,6 +117,32 @@ mod tests {
     }
 }
 
+/**
+Test that one can't implement Unpin for pinned struct
+
+This should work:
+
+```
+#[derive(const_field_offset::FieldOffsets)]
+#[repr(C)]
+#[pin]
+struct MyStructPin { a: u32 }
+```
+
+But this not:
+
+```compile_fail
+#[derive(const_field_offset::FieldOffsets)]
+#[repr(C)]
+#[pin]
+struct MyStructPin { a: u32 }
+impl Unpin for MyStructPin {};
+```
+
+*/
+#[cfg(doctest)]
+const NO_IMPL_UNPIN: u32 = 0;
+
 #[doc(hidden)]
 #[cfg(feature = "field-offset-trait")]
 mod internal {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1428,11 +1428,14 @@ fn generate_item_tree(
             #window_adapter_functions
         }
 
+        const _ : () = {
+            use slint::private_unstable_api::re_exports::*;
+            ItemTreeVTable_static!(static VT for self::#inner_component_id);
+        };
+
         impl sp::PinnedDrop for #inner_component_id {
             fn drop(self: core::pin::Pin<&mut #inner_component_id>) {
-                use slint::private_unstable_api::re_exports::*;
-                ItemTreeVTable_static!(static VT for self::#inner_component_id);
-                new_vref!(let vref : VRef<sp::ItemTreeVTable> for sp::ItemTree = self.as_ref().get_ref());
+                sp::vtable::new_vref!(let vref : VRef<sp::ItemTreeVTable> for sp::ItemTree = self.as_ref().get_ref());
                 if let Some(wa) = self.maybe_window_adapter_impl() {
                     sp::unregister_item_tree(self.as_ref(), vref, Self::item_array(), &wa);
                 }

--- a/internal/compiler/parser-test-macro/lib.rs
+++ b/internal/compiler/parser-test-macro/lib.rs
@@ -5,7 +5,6 @@
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 
 extern crate proc_macro;
-use core::iter::IntoIterator;
 use core::str::FromStr;
 use proc_macro::{Delimiter, TokenStream, TokenTree};
 

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1045,18 +1045,7 @@ pub(crate) mod ffi {
 
 #[cfg(test)]
 mod tests {
-    #![allow(unsafe_code)]
-
     use super::*;
-
-    use crate::accessibility::AccessibleStringProperty;
-    use crate::items::AccessibleRole;
-    use crate::layout::{LayoutInfo, Orientation};
-    use crate::slice::Slice;
-    use crate::window::WindowAdapterRc;
-    use crate::SharedString;
-
-    use vtable::VRc;
 
     struct TestItemTree {
         parent_component: Option<ItemTreeRc>,

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -333,8 +333,6 @@ impl<T: Clone + InterpolatedPropertyValue + 'static> Property<T> {
 #[cfg(test)]
 mod animation_tests {
     use super::*;
-    use crate::items::PropertyAnimation;
-    use std::rc::Rc;
 
     #[derive(Default)]
     struct Component {

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -1098,7 +1098,6 @@ mod tests {
     use super::*;
     use crate::fmt::writer::FileWriter;
     use i_slint_compiler::diagnostics::BuildDiagnostics;
-    use i_slint_compiler::parser::syntax_nodes;
 
     // FIXME more descriptive errors when an assertion fails
     fn assert_formatting(unformatted: &str, formatted: &str) {

--- a/tools/lsp/language/formatting.rs
+++ b/tools/lsp/language/formatting.rs
@@ -81,7 +81,7 @@ pub fn format_document(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lsp_types::{Position, Range, TextEdit};
+    use lsp_types::{Position, Range};
 
     /// Given an unformatted source text, return text edits that will turn the source into formatted text
     fn get_formatting_edits(source: &str) -> Option<Vec<TextEdit>> {


### PR DESCRIPTION
Fixes #4706

This at least fix it in generated code by us. There are still warning in the code generated by the `scoped_tls_hkt::scoped_thread_local` that we use, but it should be fixed there.