### PR TITLE
Node.js: Fix exception thrown when converting a Rust model into a Js Model

### DIFF
--- a/api/node/src/types/model.rs
+++ b/api/node/src/types/model.rs
@@ -228,7 +228,8 @@ impl ReadOnlyRustModel {
         // Implement Iterator protocol by hand until it's stable in napi-rs
         let iterator_symbol = env
             .get_global()
-            .and_then(|global| global.get_named_property::<JsObject>("Symbol"))
+            .and_then(|global| global.get_named_property::<JsFunction>("Symbol"))
+            .and_then(|symbol_function| symbol_function.coerce_to_object())
             .and_then(|symbol_obj| symbol_obj.get::<&str, JsSymbol>("iterator"))?
             .expect("fatal: Unable to find Symbol.iterator");
 


### PR DESCRIPTION
The wrapper returned should behave like Model<T>, which now also a @@iterator key. That key is generated by simulation the evaluation of `Symbol.iterator`, by first looking up `Symbol` in the global object, and then `iterator`. When retrieving `Symbol` we casted it to a `JsObject`, but commit
https://github.com/napi-rs/napi-rs/commit/aeb0b4766d9554519eb4002e02910ebb2b4a0b36 upstream tightened the cast by adding an extract check, which fails. Symbol is not a plain object, it's in fact a function (by use of `Symbol()`).