### PR TITLE
Fix cross build of rust-skia in cross docker containers

### DIFF
--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -20,3 +20,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes software-propert
     git config --global safe.directory '*'
 
 ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+
+# In the absence of a sysroot, the header files we install earlier (such as libfontconfig1-dev:arm64) are in /usr/include
+# so remember to teach bindgen to also look there, despite its --target.
+ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu=-I/usr/include

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -20,3 +20,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes software-propert
     git config --global safe.directory '*'
 
 ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig
+
+# In the absence of a sysroot, the header files we install earlier (such as libfontconfig1-dev:armhf) are in /usr/include
+# so remember to teach bindgen to also look there, despite its --target.
+ENV BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf=-I/usr/include

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -20,3 +20,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes software-propert
     git config --global safe.directory '*'
 
 ENV PKG_CONFIG_PATH=/usr/lib/riscv64-linux-gnu/pkgconfig
+
+# In the absence of a sysroot, the header files we install earlier (such as libfontconfig1-dev:riscv64) are in /usr/include
+# so remember to teach bindgen to also look there, despite its --target.
+ENV BINDGEN_EXTRA_CLANG_ARGS_riscv64gc_unknown_linux_gnu=-I/usr/include


### PR DESCRIPTION
Since skia-bindings-0.71.0, bindings.cpp includes SkFontMgr_fontconfig.h, which in turn includes fontconfig/fontconfig.h.

In cross docker containers, the fontconfig headers are installed in /usr/include - there's no sysroot.

For the actual build of bindings.cpp, this is fine - gcc will search in /usr/include and find it.

For the bindgen phase, certain clang versions do not look in -I/usr/include by default when a --target is present - generally a sensible approach probably. However in this very setup, it's okay, so teach bindgen about it by setting BINDGEN_EXTRA_CLANG_ARGS_target. Typically that's used to pass for example `--sysroot=`, but we're using it to explicitly add /usr/include.