### PR TITLE
Work around gbm display not working on Vivante gbm drivers

### DIFF
--- a/internal/backends/linuxkms/Cargo.toml
+++ b/internal/backends/linuxkms/Cargo.toml
@@ -18,8 +18,8 @@ path = "lib.rs"
 [features]
 renderer-skia = ["renderer-skia-vulkan", "renderer-skia-opengl"]
 renderer-skia-vulkan = ["i-slint-renderer-skia/vulkan", "vulkano"]
-renderer-skia-opengl = ["i-slint-renderer-skia/opengl", "drm", "gbm", "glutin", "raw-window-handle"]
-renderer-femtovg = ["i-slint-renderer-femtovg", "drm", "gbm", "glutin", "raw-window-handle"]
+renderer-skia-opengl = ["i-slint-renderer-skia/opengl", "drm", "gbm", "gbm-sys", "glutin", "raw-window-handle"]
+renderer-femtovg = ["i-slint-renderer-femtovg", "drm", "gbm", "gbm-sys", "glutin", "raw-window-handle"]
 libseat = ["dep:libseat"]
 
 #default = ["renderer-skia", "renderer-femtovg"]
@@ -40,5 +40,6 @@ nix = { version = "0.27.0", features=["fs"] }
 vulkano = { version = "0.34.0", optional = true, default-features = false }
 drm = { version = "0.9.0", optional = true }
 gbm = { version = "0.12.0", optional = true, default-features = false, features = ["drm-support"] }
+gbm-sys = { version = "0.2.2", optional = true }
 glutin = { workspace = true, optional = true, default-features = false, features = ["libloading", "egl"] }
 raw-window-handle = { version = "0.5.2", optional = true }

--- a/internal/backends/linuxkms/display/gbmdisplay.rs
+++ b/internal/backends/linuxkms/display/gbmdisplay.rs
@@ -57,10 +57,17 @@ impl super::Presenter for GbmDisplay {
         &self,
         ready_for_next_animation_frame: Box<dyn FnOnce()>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Workaround for https://github.com/Smithay/gbm.rs/issues/36:
+        // call gbm_sys::gbm_surface_lock_front_buffer() directly to
+        // avoid the failing has_free_buffers() check on the vivante gbm backend.
+
         let mut front_buffer = unsafe {
-            self.gbm_surface
-                .lock_front_buffer()
-                .map_err(|e| format!("Error locking gmb surface front buffer: {e}"))?
+            let surface = self.gbm_surface.as_raw() as _;
+            let bo = gbm_sys::gbm_surface_lock_front_buffer(surface);
+            if bo.is_null() {
+                return Err(format!("Could not lock gbm front buffer").into());
+            }
+            gbm_rs_workaround::GbmBo { bo, surface }
         };
 
         // TODO: support modifiers
@@ -117,5 +124,132 @@ impl raw_window_handle::HasDisplayHandle for GbmDisplay {
                 gbm_display_handle,
             ))
         })
+    }
+}
+
+// Workaround for https://github.com/Smithay/gbm.rs/issues/36 : A wrapper around gbm_sys::gbm_bo
+// so that we can call gbm_sys::gbm_surface_lock_front_buffer() directly.
+mod gbm_rs_workaround {
+    use super::OwnedFramebufferHandle;
+
+    pub(super) struct GbmBo {
+        pub(super) bo: *mut gbm_sys::gbm_bo,
+        pub(super) surface: *mut gbm_sys::gbm_surface,
+    }
+
+    impl Drop for GbmBo {
+        fn drop(&mut self) {
+            unsafe {
+                gbm_sys::gbm_surface_release_buffer(self.surface, self.bo);
+            }
+        }
+    }
+
+    impl GbmBo {
+        pub(super) fn set_userdata(
+            &mut self,
+            fb: OwnedFramebufferHandle,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            // Take old user data first
+            let old_userdata = unsafe { gbm_sys::gbm_bo_get_user_data(self.bo) };
+
+            unsafe extern "C" fn destroy_helper(
+                _: *mut gbm_sys::gbm_bo,
+                user_data: *mut std::ffi::c_void,
+            ) {
+                let fb_raw = user_data as *mut OwnedFramebufferHandle;
+                drop(Box::from_raw(fb_raw));
+            }
+
+            let boxed_fb = Box::new(fb);
+            unsafe {
+                gbm_sys::gbm_bo_set_user_data(
+                    self.bo,
+                    Box::into_raw(boxed_fb) as _,
+                    Some(destroy_helper),
+                )
+            }
+
+            if !old_userdata.is_null() {
+                drop(unsafe { Box::from_raw(old_userdata as *mut OwnedFramebufferHandle) });
+            }
+
+            Ok(())
+        }
+    }
+
+    impl drm::buffer::Buffer for GbmBo {
+        fn size(&self) -> (u32, u32) {
+            unsafe { (gbm_sys::gbm_bo_get_width(self.bo), gbm_sys::gbm_bo_get_height(self.bo)) }
+        }
+
+        fn format(&self) -> gbm::Format {
+            unsafe { gbm_sys::gbm_bo_get_format(self.bo) }
+                .try_into()
+                .expect("gbm_bo_get_format returned invalid format")
+        }
+
+        fn pitch(&self) -> u32 {
+            unsafe { gbm_sys::gbm_bo_get_stride(self.bo) }
+        }
+
+        fn handle(&self) -> drm::buffer::Handle {
+            unsafe {
+                drm::buffer::Handle::from(std::num::NonZeroU32::new_unchecked(
+                    gbm_sys::gbm_bo_get_handle(self.bo).u32_,
+                ))
+            }
+        }
+    }
+
+    impl drm::buffer::PlanarBuffer for GbmBo {
+        fn size(&self) -> (u32, u32) {
+            unsafe { (gbm_sys::gbm_bo_get_width(self.bo), gbm_sys::gbm_bo_get_height(self.bo)) }
+        }
+
+        fn format(&self) -> gbm::Format {
+            unsafe { gbm_sys::gbm_bo_get_format(self.bo) }
+                .try_into()
+                .expect("gbm_bo_get_format returned invalid format")
+        }
+
+        fn pitches(&self) -> [u32; 4] {
+            let mut pitches = [0, 0, 0, 0];
+            let planes = unsafe { gbm_sys::gbm_bo_get_plane_count(self.bo) };
+
+            for i in 0..planes {
+                let pitch = unsafe { gbm_sys::gbm_bo_get_stride_for_plane(self.bo, i) };
+                pitches[i as usize] = pitch;
+            }
+
+            pitches
+        }
+
+        fn handles(&self) -> [Option<drm::buffer::Handle>; 4] {
+            let mut handles = [None, None, None, None];
+            let planes = unsafe { gbm_sys::gbm_bo_get_plane_count(self.bo) };
+
+            for i in 0..planes {
+                let handle = unsafe { gbm_sys::gbm_bo_get_handle_for_plane(self.bo, i) };
+                handles[i as usize] = Some(drm::buffer::Handle::from(
+                    std::num::NonZeroU32::new(unsafe { handle.u32_ })
+                        .expect("received invalid gbm bo plane handle"),
+                ));
+            }
+
+            handles
+        }
+
+        fn offsets(&self) -> [u32; 4] {
+            let mut offsets = [0, 0, 0, 0];
+            let planes = unsafe { gbm_sys::gbm_bo_get_plane_count(self.bo) };
+
+            for i in 0..planes {
+                let offset = unsafe { gbm_sys::gbm_bo_get_offset(self.bo, i) };
+                offsets[i as usize] = offset;
+            }
+
+            offsets
+        }
     }
 }


### PR DESCRIPTION
gbm.rs' lock_front_buffer calls has_free_buffers before calling the underling C lock_front_buffer function on the gbm surface. This has_free_buffers() check succeeds the first time but always fails after that.

However apart from this check, everything else appears to be working perfectly fine. Projects like weston, ksmcube, Qt, or mutter don't do this check beforehand either, so this patch works around gbm.rs by skipping this.

Unfortunately this requires going to gbm-sys directly and implementing the drm traits that require calling the various gbm_bo_get_* functions to retrieve the buffer details for posting to DRM.