### PR TITLE
live preview: Do import handling in drop_location

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -135,29 +135,11 @@ pub struct PreviewComponent {
 #[allow(unused)]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub enum LspToPreviewMessage {
-    SetContents {
-        url: VersionedUrl,
-        contents: String,
-    },
-    /// Adjust any selection in the document with `url` that is at or behind `offset` by `delta`
-    AdjustSelection {
-        url: VersionedUrl,
-        start_offset: u32,
-        end_offset: u32,
-        new_length: u32,
-    },
-    SetConfiguration {
-        config: PreviewConfig,
-    },
+    SetContents { url: VersionedUrl, contents: String },
+    SetConfiguration { config: PreviewConfig },
     ShowPreview(PreviewComponent),
-    HighlightFromEditor {
-        url: Option<Url>,
-        offset: u32,
-    },
-    KnownComponents {
-        url: Option<VersionedUrl>,
-        components: Vec<ComponentInformation>,
-    },
+    HighlightFromEditor { url: Option<Url>, offset: u32 },
+    KnownComponents { url: Option<VersionedUrl>, components: Vec<ComponentInformation> },
 }
 
 #[allow(unused)]
@@ -168,15 +150,6 @@ pub struct Diagnostic {
     pub line: usize,
     pub column: usize,
     pub level: String,
-}
-
-#[allow(unused)]
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-pub struct ComponentAddition {
-    pub component_type: String,
-    pub import_path: Option<String>, // Url fails to convert reliably:-/
-    pub insert_position: VersionedPosition,
-    pub component_text: String,
 }
 
 #[allow(unused)]
@@ -196,37 +169,25 @@ impl PropertyChange {
 #[allow(unused)]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub enum PreviewToLspMessage {
-    Status {
-        message: String,
-        health: crate::lsp_ext::Health,
-    },
-    Diagnostics {
-        uri: Url,
-        diagnostics: Vec<lsp_types::Diagnostic>,
-    },
-    ShowDocument {
-        file: Url,
-        selection: lsp_types::Range,
-    },
-    PreviewTypeChanged {
-        is_external: bool,
-    },
-    RequestState {
-        unused: bool,
-    }, // send all documents!
-    AddComponent {
-        label: Option<String>,
-        component: ComponentAddition,
-    },
+    /// Show a status message in the editor
+    Status { message: String, health: crate::lsp_ext::Health },
+    /// Report diagnostics to editor.
+    Diagnostics { uri: Url, diagnostics: Vec<lsp_types::Diagnostic> },
+    /// Show a document in the editor.
+    ShowDocument { file: Url, selection: lsp_types::Range },
+    /// Switch between native and WASM preview (if supported)
+    PreviewTypeChanged { is_external: bool },
+    /// Request all documents and configuration to be sent from the LSP to the
+    /// Preview.
+    RequestState { unused: bool },
+    /// Update an existing Element (REMOVE THIS)
     UpdateElement {
         label: Option<String>,
         position: VersionedPosition,
         properties: Vec<PropertyChange>,
     },
-    RemoveElement {
-        label: Option<String>,
-        position: VersionedPosition,
-    },
+    /// Pass a `WorkspaceEdit` on to the editor
+    SendWorkspaceEdit { label: Option<String>, edit: lsp_types::WorkspaceEdit },
 }
 
 /// Information on the Element types available

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -3,7 +3,7 @@
 
 // cSpell: ignore descr rfind unindented
 
-mod completion;
+pub mod completion;
 mod component_catalog;
 pub mod element_edit;
 mod formatting;

--- a/tools/lsp/language/element_edit.rs
+++ b/tools/lsp/language/element_edit.rs
@@ -6,39 +6,14 @@
 use crate::Context;
 
 use crate::common::{self, Result};
-use crate::language::{self, completion};
+use crate::language;
 use crate::util;
 
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
 
 use i_slint_compiler::object_tree::ElementRc;
-use lsp_types::{TextEdit, Url, WorkspaceEdit};
-
-pub fn notify_preview_about_text_edit(
-    server_notifier: &crate::ServerNotifier,
-    edit: &TextEdit,
-    source_file: &i_slint_compiler::diagnostics::SourceFile,
-) {
-    let new_length = edit.new_text.len() as u32;
-    let (start_offset, end_offset) = {
-        let so =
-            source_file.offset(edit.range.start.line as usize, edit.range.start.character as usize);
-        let eo =
-            source_file.offset(edit.range.end.line as usize, edit.range.end.character as usize);
-        (std::cmp::min(so, eo) as u32, std::cmp::max(so, eo) as u32)
-    };
-
-    let Ok(url) = Url::from_file_path(source_file.path()) else {
-        return;
-    };
-    server_notifier.send_message_to_preview(common::LspToPreviewMessage::AdjustSelection {
-        url: common::VersionedUrl::new(url, source_file.version()),
-        start_offset,
-        end_offset,
-        new_length,
-    });
-}
+use lsp_types::{Url, WorkspaceEdit};
 
 pub fn element_at_source_code_position(
     dc: &mut language::DocumentCache,
@@ -65,42 +40,6 @@ pub fn element_at_source_code_position(
     })?)
 }
 
-pub fn add_component(ctx: &Context, component: common::ComponentAddition) -> Result<WorkspaceEdit> {
-    let document_url = component.insert_position.url();
-    let dc = ctx.document_cache.borrow();
-    let file = Url::to_file_path(document_url)
-        .map_err(|_| "Failed to convert URL to file path".to_string())?;
-
-    if &dc.document_version(document_url) != component.insert_position.version() {
-        return Err("Document version mismatch.".into());
-    }
-
-    let doc = dc
-        .documents
-        .get_document(&file)
-        .ok_or_else(|| "Document URL not found in cache".to_string())?;
-    let mut edits = Vec::with_capacity(2);
-    if let Some(edit) =
-        completion::create_import_edit(doc, &component.component_type, &component.import_path)
-    {
-        if let Some(sf) = doc.node.as_ref().map(|n| &n.source_file) {
-            notify_preview_about_text_edit(&ctx.server_notifier, &edit, sf);
-        }
-        edits.push(edit);
-    }
-
-    let source_file = doc.node.as_ref().unwrap().source_file.clone();
-
-    let ip = util::map_position(&source_file, component.insert_position.offset().into());
-    edits.push(TextEdit {
-        range: lsp_types::Range::new(ip.clone(), ip),
-        new_text: component.component_text,
-    });
-
-    common::create_workspace_edit_from_source_file(&source_file, edits)
-        .ok_or("Could not create workspace edit".into())
-}
-
 pub fn update_element(
     ctx: &Context,
     position: common::VersionedPosition,
@@ -115,21 +54,4 @@ pub fn update_element(
         &properties,
     )?;
     Ok(e.ok_or_else(|| "Failed to create workspace edit".to_string())?)
-}
-
-pub fn remove_element(ctx: &Context, position: common::VersionedPosition) -> Result<WorkspaceEdit> {
-    let element = element_at_source_code_position(&mut ctx.document_cache.borrow_mut(), &position)?;
-
-    let e = element.borrow();
-    let Some(node) = e.debug.get(0).map(|(n, _)| n) else {
-        return Err("No node found".into());
-    };
-
-    let Some(range) = util::map_node(node) else {
-        return Err("Could not map element node".into());
-    };
-    let edits = vec![TextEdit { range, new_text: String::new() }];
-
-    common::create_workspace_edit_from_source_file(&node.source_file, edits)
-        .ok_or("Could not create workspace edit".into())
 }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -465,14 +465,6 @@ async fn handle_preview_to_lsp_message(
         M::RequestState { .. } => {
             crate::language::request_state(ctx);
         }
-        M::AddComponent { label, component } => {
-            let _ = send_workspace_edit(
-                ctx.server_notifier.clone(),
-                label,
-                element_edit::add_component(ctx, component),
-            )
-            .await;
-        }
         M::UpdateElement { label, position, properties } => {
             let _ = send_workspace_edit(
                 ctx.server_notifier.clone(),
@@ -481,13 +473,8 @@ async fn handle_preview_to_lsp_message(
             )
             .await;
         }
-        M::RemoveElement { label, position } => {
-            let _ = send_workspace_edit(
-                ctx.server_notifier.clone(),
-                label,
-                element_edit::remove_element(ctx, position),
-            )
-            .await;
+        M::SendWorkspaceEdit { label, edit } => {
+            let _ = send_workspace_edit(ctx.server_notifier.clone(), label, Ok(edit)).await;
         }
     }
     Ok(())

--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -4,16 +4,53 @@
 use i_slint_core::lengths::{LogicalLength, LogicalPoint};
 use slint_interpreter::ComponentInstance;
 
+use crate::common;
+use crate::language::completion;
+use crate::preview::{self, element_selection};
+use crate::util;
+
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
 
-use super::element_selection::{
-    collect_all_element_nodes_covering, is_root_element_node, ElementRcNode,
-};
+pub struct TextOffsetAdjustment {
+    pub start_offset: u32,
+    pub end_offset: u32,
+    pub new_text_length: u32,
+}
+
+impl TextOffsetAdjustment {
+    pub fn new(
+        edit: &lsp_types::TextEdit,
+        source_file: &i_slint_compiler::diagnostics::SourceFile,
+    ) -> Self {
+        let new_text_length = edit.new_text.len() as u32;
+        let (start_offset, end_offset) = {
+            let so = source_file
+                .offset(edit.range.start.line as usize, edit.range.start.character as usize);
+            let eo =
+                source_file.offset(edit.range.end.line as usize, edit.range.end.character as usize);
+            (std::cmp::min(so, eo) as u32, std::cmp::max(so, eo) as u32)
+        };
+
+        Self { start_offset, end_offset, new_text_length }
+    }
+
+    pub fn adjust(&self, offset: u32) -> u32 {
+        // This is a bit simplistic: We ignore special cases like the offset
+        // being in the area that gets removed.
+        // Worst case: Some unexpected element gets selected. We can live with that.
+        if offset >= self.start_offset {
+            let old_length = self.end_offset - self.start_offset;
+            offset + self.new_text_length - old_length
+        } else {
+            offset
+        }
+    }
+}
 
 pub struct DropInformation {
-    pub target_element_node: ElementRcNode,
-    pub insertion_position: crate::common::VersionedPosition,
+    pub target_element_node: element_selection::ElementRcNode,
+    pub insertion_position: common::VersionedPosition,
 }
 
 fn find_drop_location(
@@ -23,22 +60,23 @@ fn find_drop_location(
 ) -> Option<DropInformation> {
     let target_element_node = {
         let mut result = None;
-        for sc in &collect_all_element_nodes_covering(x, y, &component_instance) {
+        for sc in &element_selection::collect_all_element_nodes_covering(x, y, &component_instance)
+        {
             let Some(en) = sc.as_element_node() else {
                 continue;
             };
 
-            if en.with_element_node(|n| super::is_element_node_ignored(n)) {
+            if en.with_element_node(|n| preview::is_element_node_ignored(n)) {
                 continue;
             }
 
-            if !super::element_selection::is_same_file_as_root_node(&component_instance, &en) {
+            if !element_selection::is_same_file_as_root_node(&component_instance, &en) {
                 continue;
             }
 
             if en.with_element_node(|n| {
                 n.child_node(i_slint_compiler::parser::SyntaxKind::ChildrenPlaceholder).is_some()
-            }) && !is_root_element_node(&component_instance, &en)
+            }) && !element_selection::is_root_element_node(&component_instance, &en)
             {
                 continue;
             }
@@ -49,23 +87,19 @@ fn find_drop_location(
         result
     }?;
 
-    let insertion_position = {
-        let elem = target_element_node.element.borrow();
-
-        let (node, _) = elem.debug.get(target_element_node.debug_index)?;
-
+    let insertion_position = target_element_node.with_element_node(|node| {
         let last_token = crate::util::last_non_ws_token(node)?;
 
         let url = lsp_types::Url::from_file_path(node.source_file.path()).ok()?;
-        let Some((version, _)) = crate::preview::get_url_from_cache(&url) else {
+        let Some((version, _)) = preview::get_url_from_cache(&url) else {
             return None;
         };
 
-        crate::common::VersionedPosition::new(
+        Some(common::VersionedPosition::new(
             crate::common::VersionedUrl::new(url, version),
             Into::<u32>::into(last_token.text_range().end()).saturating_sub(1),
-        )
-    };
+        ))
+    })?;
 
     Some(DropInformation { target_element_node, insertion_position })
 }
@@ -81,19 +115,21 @@ pub struct DropData {
     /// The offset to select next. This is different from the insert position
     /// due to indentation, etc.
     pub selection_offset: u32,
+    pub path: std::path::PathBuf,
 }
 
 /// Find a location in a file that would be a good place to insert the new component at
 ///
-/// Return a tuple containing the ComponentAddition info for the LSP and extra info for
-/// the live preview in the DropData struct.
+/// Return a WorkspaceEdit to send to the editor and extra info for the live preview in
+/// the DropData struct.
 pub fn drop_at(
     x: f32,
     y: f32,
     component_type: String,
     import_path: String,
-) -> Option<(crate::common::ComponentAddition, DropData)> {
-    let component_instance = super::component_instance()?;
+) -> Option<(lsp_types::WorkspaceEdit, DropData)> {
+    let component_instance = preview::component_instance()?;
+    let tl = component_instance.definition().type_loader();
     let drop_info = find_drop_location(&component_instance, x, y)?;
 
     let properties = {
@@ -125,7 +161,7 @@ pub fn drop_at(
         .unwrap_or_default()
     );
 
-    let component_text = if properties.is_empty() {
+    let new_text = if properties.is_empty() {
         format!("{}{} {{ }}\n", indentation, component_type)
     } else {
         let mut to_insert = format!("{}{} {{\n", indentation, component_type);
@@ -136,20 +172,28 @@ pub fn drop_at(
         to_insert
     };
 
-    let selection_offset = drop_info.insertion_position.offset()
-        + component_text
-            .chars()
-            .take_while(|c| c.is_whitespace())
-            .map(|c| c.len_utf8())
-            .sum::<usize>() as u32;
+    let mut selection_offset = drop_info.insertion_position.offset()
+        + new_text.chars().take_while(|c| c.is_whitespace()).map(|c| c.len_utf8()).sum::<usize>()
+            as u32;
+
+    let (path, _) = drop_info.target_element_node.path_and_offset();
+
+    let doc = tl.get_document(&path)?;
+    let mut edits = Vec::with_capacity(2);
+    if let Some(edit) = completion::create_import_edit(doc, &component_type, &Some(import_path)) {
+        if let Some(sf) = doc.node.as_ref().map(|n| &n.source_file) {
+            selection_offset = TextOffsetAdjustment::new(&edit, sf).adjust(selection_offset);
+        }
+        edits.push(edit);
+    }
+
+    let source_file = doc.node.as_ref().unwrap().source_file.clone();
+
+    let ip = util::map_position(&source_file, drop_info.insertion_position.offset().into());
+    edits.push(lsp_types::TextEdit { range: lsp_types::Range::new(ip.clone(), ip), new_text });
 
     Some((
-        crate::common::ComponentAddition {
-            component_type,
-            component_text,
-            import_path: if import_path.is_empty() { None } else { Some(import_path) },
-            insert_position: drop_info.insertion_position,
-        },
-        DropData { selection_offset },
+        common::create_workspace_edit_from_source_file(&source_file, edits)?,
+        DropData { selection_offset, path },
     ))
 }

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -295,13 +295,6 @@ impl SlintServer {
             M::RequestState { .. } => {
                 crate::language::request_state(&self.ctx);
             }
-            M::AddComponent { label, component } => {
-                send_workspace_edit(
-                    self.ctx.server_notifier.clone(),
-                    label,
-                    element_edit::add_component(&self.ctx, component),
-                );
-            }
             M::UpdateElement { label, position, properties } => {
                 send_workspace_edit(
                     self.ctx.server_notifier.clone(),
@@ -309,12 +302,8 @@ impl SlintServer {
                     element_edit::update_element(&self.ctx, position, properties),
                 );
             }
-            M::RemoveElement { label, position } => {
-                send_workspace_edit(
-                    self.ctx.server_notifier.clone(),
-                    label,
-                    element_edit::remove_element(&self.ctx, position),
-                );
+            M::SendWorkspaceEdit { label, edit } => {
+                send_workspace_edit(self.ctx.server_notifier.clone(), label, Ok(edit));
             }
         }
         Ok(())


### PR DESCRIPTION
Remove the AddComponent and the AdjustSelection messages from the communication between LSP and preview.

Also remove the code to delete an element.