### PR TITLE
Cupertino TabWidget: Tweaked visual appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project are documented in this file.
  - Image: Added `ImageFit.preserve`
  - Image: Added `horizontal-` and `vertical-alignment`
  - Image: Added support for 9 slice scaling
+ - Cupertino TabWidget: Tweaked visual appearance
 
 ### Widgets
 

--- a/internal/compiler/widgets/cupertino-base/styling.slint
+++ b/internal/compiler/widgets/cupertino-base/styling.slint
@@ -58,6 +58,10 @@ export global CupertinoPalette {
     out property <brush> decent-border: dark-color-scheme ? #ffffff14 : #00000014;
     out property <brush> control-background-thumb: dark-color-scheme ? #cacaca : #ffffff;
     out property <brush> separator: dark-color-scheme ? #000000 : #d9d9d9;
+    out property <brush> bar-background: dark-color-scheme ? #393939 : #ececec;
+    out property <brush> bar-border: dark-color-scheme ? @linear-gradient(180deg, #484848 0%, #434343 80%, #686868 100%) : #e2e2e2;
+    out property <brush> inner-border: dark-color-scheme ? #2e2e2e : #d7d7d7;
+    out property <brush> inner-shadow: dark-color-scheme ? #313131 : #ececed;
 
     // FIXME: dark color
     out property <brush> dimmer: @linear-gradient(180deg, #FFFFFFFF 100%, #FFFFFF00 0%);

--- a/internal/compiler/widgets/cupertino-base/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino-base/tabwidget.slint
@@ -39,7 +39,7 @@ export component TabImpl inherits Rectangle {
     private property <bool> is-current: root.tab-index == root.current;
 
     min-width: max(160px, i-text.min-width);
-    min-height: max(30px, i-text.min-height);
+    min-height: max(20px, i-text.min-height);
     horizontal-stretch: 1;
     vertical-stretch: 0;
     accessible-role: tab;
@@ -49,24 +49,18 @@ export component TabImpl inherits Rectangle {
         clip: true;
         width: 100%;
         height: 100%;
-        background: root.is-current ? CupertinoPalette.background :
-            i-touch-area.has-hover ? CupertinoPalette.hover : CupertinoPalette.quaternary-background;
+        background: root.is-current ? CupertinoPalette.control-background : transparent;
+        border-radius: 5px;
 
         animate background { duration: 150ms; easing: linear; }
     }
 
-    Rectangle {
-        x: parent.width - self.width;
+    if (!root.is-current && root.tab-index < root.num-tabs  - 1) : Rectangle {
+        x: root.width - self.width;
+        y: (parent.height - self.height) / 2;
         width: 1px;
-        height: 100%;
-        background: CupertinoPalette.border;
-    }
-
-    if (!root.is-current) : Rectangle {
-        y: 0px;
-        background: @linear-gradient(180deg, #00000033 0%, #00000005 100%);
-        width: 100%;
-        height: 2px;
+        height: root.height - 6px;
+        background: CupertinoPalette.inner-border;
     }
 
     i-touch-area := TouchArea {
@@ -84,8 +78,8 @@ export component TabImpl inherits Rectangle {
         i-text := Text {
             vertical-alignment: center;
             horizontal-alignment: center;
-            font-size: root.is-current ? CupertinoFontSettings.body-strong.font-size : CupertinoFontSettings.body.font-size;
-            font-weight: root.is-current ? CupertinoFontSettings.body-strong.font-weight : CupertinoFontSettings.body.font-weight;
+            font-size: CupertinoFontSettings.body-strong.font-size;
+            font-weight: CupertinoFontSettings.body-strong.font-weight;
             color: CupertinoPalette.foreground;
         }
     }
@@ -100,15 +94,29 @@ export component TabBarImpl {
     accessible-role: tab;
     accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current;
 
-    HorizontalLayout {
-        @children
-    }
 
     Rectangle {
-        y: parent.height - self.height;
-        background: CupertinoPalette.separator;
+        border-radius: 7px;
+        border-color: CupertinoPalette.bar-border;
+        background: CupertinoPalette.bar-background;
+        border-width: 1px;
         width: 100%;
-        height: 1px;
+        height: 100%;
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: parent.border-width;
+            width: parent.width - 2 * parent.border-radius;
+            height: 1px;
+            background: CupertinoPalette.inner-shadow;
+        }
+    }
+
+    HorizontalLayout {
+        min-height: 22px;
+        padding: 1px;
+
+        @children
     }
 
     i-focus-scope := FocusScope {


### PR DESCRIPTION
There are two variants of the macOS TabView. But the one that was implemented for the cupertino style is only partial used. Now the TabWidget of the cupertino style is displayed in the variant that is more common used on macOS e.g. on the settings.

<img width="477" alt="image" src="https://github.com/slint-ui/slint/assets/6715107/622342a2-c2c4-4e72-b0c5-f2176d6df767">
