### PR TITLE
Optional C++ namespaces

### DIFF
--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -14,12 +14,13 @@ function(SLINT_TARGET_SOURCES target)
     # Parse the NAMESPACE argument
     cmake_parse_arguments(SLINT_TARGET_SOURCES "" "NAMESPACE" "" ${ARGN})
 
-    # Remove the NAMESPACE argument from the list
     if (DEFINED SLINT_TARGET_SOURCES_NAMESPACE)
+        # Remove the NAMESPACE argument from the list
         list(FIND ARGN "NAMESPACE" _index)
         list(REMOVE_AT ARGN ${_index})
         list(FIND ARGN "${SLINT_TARGET_SOURCES_NAMESPACE}" _index)
         list(REMOVE_AT ARGN ${_index})
+        # If the namespace is not empty, add the --cpp-namespace argument
         set(_SLINT_CPP_NAMESPACE_ARG "--cpp-namespace=${SLINT_TARGET_SOURCES_NAMESPACE}")
     endif()
 

--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -11,6 +11,17 @@ set_property(CACHE DEFAULT_SLINT_EMBED_RESOURCES PROPERTY STRINGS
 #     INITIALIZE_FROM_VARIABLE DEFAULT_SLINT_EMBED_RESOURCES)
 
 function(SLINT_TARGET_SOURCES target)
+    # Parse the NAMESPACE argument
+    cmake_parse_arguments(SLINT_TARGET_SOURCES "" "NAMESPACE" "" ${ARGN})
+
+    # Remove the NAMESPACE argument from the list
+    if (DEFINED SLINT_TARGET_SOURCES_NAMESPACE)
+        list(FIND ARGN "NAMESPACE" _index)
+        list(REMOVE_AT ARGN ${_index})
+        list(FIND ARGN "${SLINT_TARGET_SOURCES_NAMESPACE}" _index)
+        list(REMOVE_AT ARGN ${_index})
+    endif()
+
     foreach (it IN ITEMS ${ARGN})
         get_filename_component(_SLINT_BASE_NAME ${it} NAME_WE)
         get_filename_component(_SLINT_ABSOLUTE ${it} REALPATH BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
@@ -20,6 +31,10 @@ function(SLINT_TARGET_SOURCES target)
         set(global_fallback "${DEFAULT_SLINT_EMBED_RESOURCES}")
         set(embed "$<IF:$<STREQUAL:${t_prop},>,${global_fallback},${t_prop}>")
 
+        if (DEFINED SLINT_TARGET_SOURCES_NAMESPACE)
+            set(_SLINT_CPP_NAMESPACE_ARG "--cpp-namespace=${SLINT_TARGET_SOURCES_NAMESPACE}")
+        endif()
+
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
             COMMAND Slint::slint-compiler ${_SLINT_ABSOLUTE}
@@ -28,6 +43,7 @@ function(SLINT_TARGET_SOURCES target)
                 --style ${_SLINT_STYLE}
                 --embed-resources=${embed}
                 --translation-domain="${target}"
+                ${_SLINT_CPP_NAMESPACE_ARG}
             DEPENDS Slint::slint-compiler ${_SLINT_ABSOLUTE}
             COMMENT "Generating ${_SLINT_BASE_NAME}.h"
             DEPFILE ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d

--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -20,6 +20,7 @@ function(SLINT_TARGET_SOURCES target)
         list(REMOVE_AT ARGN ${_index})
         list(FIND ARGN "${SLINT_TARGET_SOURCES_NAMESPACE}" _index)
         list(REMOVE_AT ARGN ${_index})
+        set(_SLINT_CPP_NAMESPACE_ARG "--cpp-namespace=${SLINT_TARGET_SOURCES_NAMESPACE}")
     endif()
 
     foreach (it IN ITEMS ${ARGN})
@@ -30,10 +31,6 @@ function(SLINT_TARGET_SOURCES target)
         set(t_prop "$<TARGET_PROPERTY:${target},SLINT_EMBED_RESOURCES>")
         set(global_fallback "${DEFAULT_SLINT_EMBED_RESOURCES}")
         set(embed "$<IF:$<STREQUAL:${t_prop},>,${global_fallback},${t_prop}>")
-
-        if (DEFINED SLINT_TARGET_SOURCES_NAMESPACE)
-            set(_SLINT_CPP_NAMESPACE_ARG "--cpp-namespace=${SLINT_TARGET_SOURCES_NAMESPACE}")
-        endif()
 
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h

--- a/api/cpp/docs/cmake_reference.md
+++ b/api/cpp/docs/cmake_reference.md
@@ -5,22 +5,25 @@
 ## `slint_target_sources`
 
 ```
-slint_target_sources(<target> <files>....)
+slint_target_sources(<target> <files>.... [NAMESPACE namespace])
 ```
 
 Use this function to tell cmake about the .slint files of your application, similar to the builtin cmake [target_sources](https://cmake.org/cmake/help/latest/command/target_sources.html) function.
 The function takes care of running the slint-compiler to convert `.slint` files to `.h` files in the build directory,
 and extend  the include directories of your target so that the generated file is found when including it in your application.
 
+The optional NAMESPACE argument will put the generated components in the given C++ namespace.
 
 Given a file called `the_window.slint`, the following example will create a file called `the_window.h` that can
-be included from your .cpp file.
+be included from your .cpp file. Assuming the `the_window.slint` contains a component `TheWindow`, the output
+C++ class will be put in the namespace `ui`, resulting to `ui::TheWindow`.
 
 ```cmake
 add_executable(my_application main.cpp)
 target_link_libraries(my_application PRIVATE Slint::Slint)
-slint_target_sources(my_application the_window.slint)
+slint_target_sources(my_application the_window.slint NAMESPACE ui)
 ```
+
 
 ## Resource Embedding
 

--- a/examples/todo/cpp/CMakeLists.txt
+++ b/examples/todo/cpp/CMakeLists.txt
@@ -10,4 +10,4 @@ endif()
 
 add_executable(todo main.cpp)
 target_link_libraries(todo PRIVATE Slint::Slint)
-slint_target_sources(todo ../ui/todo.slint)
+slint_target_sources(todo ../ui/todo.slint NAMESPACE todo_ui)

--- a/examples/todo/cpp/main.cpp
+++ b/examples/todo/cpp/main.cpp
@@ -5,7 +5,8 @@
 
 int main()
 {
-    auto demo = MainWindow::create();
+    auto demo = todo_ui::MainWindow::create();
+    using todo_ui::TodoItem;
 
     auto todo_model = std::make_shared<slint::VectorModel<TodoItem>>(std::vector {
             TodoItem { "Implement the .slint file", true },

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -18,15 +18,15 @@ use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, Document, ElementRc};
 
 #[cfg(feature = "cpp")]
-mod cpp;
+pub mod cpp;
 
 #[cfg(feature = "rust")]
 pub mod rust;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OutputFormat {
     #[cfg(feature = "cpp")]
-    Cpp,
+    Cpp(cpp::Config),
     #[cfg(feature = "rust")]
     Rust,
     Interpreter,
@@ -37,7 +37,7 @@ impl OutputFormat {
     pub fn guess_from_extension(path: &std::path::Path) -> Option<Self> {
         match path.extension().and_then(|ext| ext.to_str()) {
             #[cfg(feature = "cpp")]
-            Some("cpp") | Some("cxx") | Some("h") | Some("hpp") => Some(Self::Cpp),
+            Some("cpp") | Some("cxx") | Some("h") | Some("hpp") => Some(Self::Cpp(cpp::Config::default())),
             #[cfg(feature = "rust")]
             Some("rs") => Some(Self::Rust),
             _ => None,
@@ -50,7 +50,7 @@ impl std::str::FromStr for OutputFormat {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             #[cfg(feature = "cpp")]
-            "cpp" => Ok(Self::Cpp),
+            "cpp" => Ok(Self::Cpp(cpp::Config::default())),
             #[cfg(feature = "rust")]
             "rust" => Ok(Self::Rust),
             "llr" => Ok(Self::Llr),
@@ -74,8 +74,8 @@ pub fn generate(
 
     match format {
         #[cfg(feature = "cpp")]
-        OutputFormat::Cpp => {
-            let output = cpp::generate(doc);
+        OutputFormat::Cpp(config) => {
+            let output = cpp::generate(doc, config);
             write!(destination, "{}", output)?;
         }
         #[cfg(feature = "rust")]

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -37,7 +37,9 @@ impl OutputFormat {
     pub fn guess_from_extension(path: &std::path::Path) -> Option<Self> {
         match path.extension().and_then(|ext| ext.to_str()) {
             #[cfg(feature = "cpp")]
-            Some("cpp") | Some("cxx") | Some("h") | Some("hpp") => Some(Self::Cpp(cpp::Config::default())),
+            Some("cpp") | Some("cxx") | Some("h") | Some("hpp") => {
+                Some(Self::Cpp(cpp::Config::default()))
+            }
             #[cfg(feature = "rust")]
             Some("rs") => Some(Self::Rust),
             _ => None,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -8,7 +8,6 @@
 
 use std::fmt::Write;
 
-
 /// The configuration for the C++ code generator
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Config {
@@ -534,10 +533,7 @@ fn handle_property_init(
 
 /// Returns the text of the C++ code produced by the given root component
 pub fn generate(doc: &Document, config: Config) -> impl std::fmt::Display {
-    let mut file = File {
-        namespace: config.namespace.clone(),
-        ..Default::default()
-    };
+    let mut file = File { namespace: config.namespace.clone(), ..Default::default() };
 
     file.includes.push("<array>".into());
     file.includes.push("<limits>".into());

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -105,7 +105,7 @@ mod cpp_ast {
                 write!(f, "\n{}", d)?;
             }
             if let Some(namespace) = &self.namespace {
-                writeln!(f, "}} // end {}", namespace)?;
+                writeln!(f, "}} // namespace {}", namespace)?;
                 INDENTATION.with(|x| x.set(x.get() - 1));
             }
 

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -147,16 +147,15 @@ impl CompilerConfiguration {
 
         let cpp_namespace = match output_format {
             #[cfg(feature = "cpp")]
-            crate::generator::OutputFormat::Cpp(config) => 
-                match config.namespace {
-                    Some(namespace) => Some(namespace),
-                    None => match std::env::var("SLINT_CPP_NAMESPACE") {
-                        Ok(namespace) => Some(namespace),
-                        Err(_) => None,
-                    }
-                }
-            _ => None
-            };
+            crate::generator::OutputFormat::Cpp(config) => match config.namespace {
+                Some(namespace) => Some(namespace),
+                None => match std::env::var("SLINT_CPP_NAMESPACE") {
+                    Ok(namespace) => Some(namespace),
+                    Err(_) => None,
+                },
+            },
+            _ => None,
+        };
 
         Self {
             embed_resources,

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -146,6 +146,7 @@ impl CompilerConfiguration {
         let enable_component_containers = enable_experimental_features;
 
         let cpp_namespace = match output_format {
+            #[cfg(feature = "cpp")]
             crate::generator::OutputFormat::Cpp(config) => 
                 match config.namespace {
                     Some(namespace) => Some(namespace),

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -94,6 +94,9 @@ pub struct CompilerConfiguration {
 
     /// The domain used as one of the parameter to the translate function
     pub translation_domain: Option<String>,
+
+    /// C++ namespace
+    pub cpp_namespace: Option<String>,
 }
 
 impl CompilerConfiguration {
@@ -142,6 +145,18 @@ impl CompilerConfiguration {
 
         let enable_component_containers = enable_experimental_features;
 
+        let cpp_namespace = match output_format {
+            crate::generator::OutputFormat::Cpp(config) => 
+                match config.namespace {
+                    Some(namespace) => Some(namespace),
+                    None => match std::env::var("SLINT_CPP_NAMESPACE") {
+                        Ok(namespace) => Some(namespace),
+                        Err(_) => None,
+                    }
+                }
+            _ => None
+            };
+
         Self {
             embed_resources,
             include_paths: Default::default(),
@@ -154,6 +169,7 @@ impl CompilerConfiguration {
             accessibility: true,
             enable_component_containers,
             translation_domain: None,
+            cpp_namespace,
         }
     }
 }

--- a/tests/cases/exports/cpp_namespace.slint
+++ b/tests/cases/exports/cpp_namespace.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+//cpp-namespace: my::ui
+//ignore: rust,js
+export component TestCase inherits Rectangle {
+    in-out property <bool> condition : false;
+}
+
+/*
+```cpp
+auto handle = my::ui::TestCase::create();
+const my::ui::TestCase &instance = *handle;
+instance.set_condition(true);
+assert_eq(instance.get_condition(), true);
+```
+
+*/

--- a/tests/cases/exports/cpp_namespace.slint
+++ b/tests/cases/exports/cpp_namespace.slint
@@ -3,16 +3,34 @@
 
 //cpp-namespace: my::ui
 //ignore: rust,js
+struct TestStruct {
+    condition: bool,
+}
+
+enum TestEnum {
+    A,
+    B,
+    C
+}
+
 export component TestCase inherits Rectangle {
-    in-out property <bool> condition : false;
+    in-out property <TestStruct> test_struct;
+    in-out property <TestEnum> test_enum;
 }
 
 /*
 ```cpp
 auto handle = my::ui::TestCase::create();
 const my::ui::TestCase &instance = *handle;
-instance.set_condition(true);
-assert_eq(instance.get_condition(), true);
+my::ui::TestStruct test_struct {.condition = false};
+test_struct.condition = true;
+instance.set_test_struct(test_struct);
+assert(instance.get_test_struct() == test_struct);
+instance.set_test_enum(my::ui::TestEnum::A);
+auto test_enum = instance.get_test_enum();
+test_enum = my::ui::TestEnum::B;
+instance.set_test_enum(test_enum);
+assert(instance.get_test_enum() == my::ui::TestEnum::B);
 ```
 
 */

--- a/tests/driver/cpp/cppdriver.rs
+++ b/tests/driver/cpp/cppdriver.rs
@@ -20,7 +20,8 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
 
     let mut diag = BuildDiagnostics::default();
     let syntax_node = parser::parse(source.clone(), Some(&testcase.absolute_path), None, &mut diag);
-    let output_format = generator::OutputFormat::Cpp(generator::cpp::Config { namespace: cpp_namespace });
+    let output_format =
+        generator::OutputFormat::Cpp(generator::cpp::Config { namespace: cpp_namespace });
 
     let mut compiler_config = CompilerConfiguration::new(output_format.clone());
     compiler_config.include_paths = include_paths;

--- a/tests/driver/driverlib/lib.rs
+++ b/tests/driver/driverlib/lib.rs
@@ -254,8 +254,7 @@ fn test_extract_cpp_namespace() {
     //cpp-namespace: ui
     Blah {}
 ";
-    
-    let r = extract_cpp_namespace(source);
-        assert_eq!(r, Some("ui".to_string()));
-}
 
+    let r = extract_cpp_namespace(source);
+    assert_eq!(r, Some("ui".to_string()));
+}

--- a/tests/driver/driverlib/lib.rs
+++ b/tests/driver/driverlib/lib.rs
@@ -238,3 +238,24 @@ fn test_extract_ignores() {
     let r = extract_ignores(source).collect::<Vec<_>>();
     assert_eq!(r, ["cpp", "rust", "nodejs"]);
 }
+
+pub fn extract_cpp_namespace(source: &str) -> Option<String> {
+    lazy_static::lazy_static! {
+        static ref RX: Regex = Regex::new(r"//cpp-namespace:\s*(.+)\s*\n").unwrap();
+    }
+    RX.captures(source).map(|mat| mat.get(1).unwrap().as_str().trim().to_string())
+}
+
+#[test]
+fn test_extract_cpp_namespace() {
+    assert!(extract_cpp_namespace("something").is_none());
+
+    let source = r"
+    //cpp-namespace: ui
+    Blah {}
+";
+    
+    let r = extract_cpp_namespace(source);
+        assert_eq!(r, Some("ui".to_string()));
+}
+

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -78,7 +78,18 @@ fn main() -> std::io::Result<()> {
         diag.print();
         std::process::exit(-1);
     }
-    let mut compiler_config = CompilerConfiguration::new(args.format.clone());
+
+    let mut format = args.format.clone();
+
+    if args.cpp_namespace.is_some() {
+        if args.format != format {
+            println!("C++ namespace option was set. Output format will be C++.");
+        }
+        format =
+            generator::OutputFormat::Cpp(generator::cpp::Config { namespace: args.cpp_namespace });
+    }
+
+    let mut compiler_config = CompilerConfiguration::new(format.clone());
     compiler_config.translation_domain = args.translation_domain;
 
     // Override defaults from command line:
@@ -106,10 +117,10 @@ fn main() -> std::io::Result<()> {
     let diag = diag.check_and_exit_on_error();
 
     if args.output == std::path::Path::new("-") {
-        generator::generate(args.format, &mut std::io::stdout(), &doc)?;
+        generator::generate(format, &mut std::io::stdout(), &doc)?;
     } else {
         generator::generate(
-            args.format,
+            format,
             &mut BufWriter::new(std::fs::File::create(&args.output)?),
             &doc,
         )?;

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -82,7 +82,7 @@ fn main() -> std::io::Result<()> {
     let mut format = args.format.clone();
 
     if args.cpp_namespace.is_some() {
-        if !matches(format, generator::OutputFormat::Cpp(...)) {
+        if !matches!(format, generator::OutputFormat::Cpp(...)) {
             eprintln!("C++ namespace option was set. Output format will be C++.");
         }
         format =

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -82,7 +82,7 @@ fn main() -> std::io::Result<()> {
     let mut format = args.format.clone();
 
     if args.cpp_namespace.is_some() {
-        if args.format != format {
+        if !matches(format, generator::OutputFormat::Cpp(...)) {
             eprintln!("C++ namespace option was set. Output format will be C++.");
         }
         format =

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -83,7 +83,7 @@ fn main() -> std::io::Result<()> {
 
     if args.cpp_namespace.is_some() {
         if args.format != format {
-            println!("C++ namespace option was set. Output format will be C++.");
+            eprintln!("C++ namespace option was set. Output format will be C++.");
         }
         format =
             generator::OutputFormat::Cpp(generator::cpp::Config { namespace: args.cpp_namespace });

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -82,7 +82,7 @@ fn main() -> std::io::Result<()> {
     let mut format = args.format.clone();
 
     if args.cpp_namespace.is_some() {
-        if !matches!(format, generator::OutputFormat::Cpp(...)) {
+        if !matches!(format, generator::OutputFormat::Cpp(..)) {
             eprintln!("C++ namespace option was set. Output format will be C++.");
         }
         format =

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -62,6 +62,10 @@ struct Cli {
     /// Translation domain
     #[arg(long = "translation-domain", action)]
     translation_domain: Option<String>,
+
+    /// C++ namespace
+    #[arg(long = "cpp-namespace", name = "C++ namespace")]
+    cpp_namespace: Option<String>,
 }
 
 fn main() -> std::io::Result<()> {
@@ -74,7 +78,7 @@ fn main() -> std::io::Result<()> {
         diag.print();
         std::process::exit(-1);
     }
-    let mut compiler_config = CompilerConfiguration::new(args.format);
+    let mut compiler_config = CompilerConfiguration::new(args.format.clone());
     compiler_config.translation_domain = args.translation_domain;
 
     // Override defaults from command line:


### PR DESCRIPTION
As a little exercise, I tried implement support for C++ namespace for c++ code generated from slint-files.
Not entirely sure, if this is the right way, though.
I am also wondering how to change the CMake API to support C++ namespaces.
I would like to change the `slint_target_sources` to:
```cmake
slint_target_sources(${target} my/ui/mainwindow.slint 
NAMESPACE
my::ui)
```

Or, shall the namespace "my::ui" be derived automatically when e.g. "my/ui" when it is given in the sources?
