### PR TITLE
Demos: fix duplicate artifact name in Windows

### DIFF
--- a/examples/printerdemo/rust/Cargo.toml
+++ b/examples/printerdemo/rust/Cargo.toml
@@ -17,11 +17,10 @@ name = "printerdemo"
 [lib]
 path = "lib.rs"
 crate-type = ["lib", "cdylib"]
-
+name = "printerdemo_lib"
 
 [dependencies]
 slint = { path = "../../../api/rs/slint", features = ["backend-android-activity-05"] }
-
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"]}
 
 [build-dependencies]

--- a/examples/printerdemo/rust/main.rs
+++ b/examples/printerdemo/rust/main.rs
@@ -5,5 +5,5 @@
 // Just forward to the library in main
 
 fn main() {
-    printerdemo::main();
+    printerdemo_lib::main();
 }

--- a/examples/todo/rust/Cargo.toml
+++ b/examples/todo/rust/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 [lib]
 crate-type = ["lib", "cdylib"]
 path = "lib.rs"
+name = "todo_lib"
 
 [[bin]]
 path = "main.rs"

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -5,5 +5,5 @@
 // Just forward to the library in main
 
 fn main() {
-    todo::main();
+    todo_lib::main();
 }


### PR DESCRIPTION
```
warning: output filename collision.
The bin target `printerdemo` in package `printerdemo v1.5.0 (C:\dev\slint\examples\printerdemo\rust)` has the same output filename as the lib target `printerdemo` in package `printerdemo v1.5.0 (C:\dev\slint\examples\printerdemo\rust)`.
Colliding filename is: C:\dev\slint\target\debug\deps\printerdemo.pdb
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
```