### PR TITLE
Energy-monitor: android build and wasm simplicifation

### DIFF
--- a/examples/energy-monitor/Cargo.toml
+++ b/examples/energy-monitor/Cargo.toml
@@ -11,8 +11,10 @@ publish = false
 license = "MIT"
 
 [[bin]]
-path = "src/main.rs"
 name = "energy-monitor"
+
+[lib]
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
@@ -22,23 +24,15 @@ weer_api = { version = "0.1", optional = true }
 tokio = { version = "1.25", optional = true, features = ["full"] }
 futures = { version = "0.3.26", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { version = "0.2" }
+web-sys = { version = "0.3", features=["console"] }
+console_error_panic_hook = "0.1.5"
+
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }
 
 [features]
-default = ["slint/default", "network", "chrono"]
+default = ["slint/default", "network", "chrono", "slint/backend-android-activity-05"]
 simulator = ["mcu-board-support", "slint/renderer-software", "slint/backend-winit", "slint/std"]
 network = ["dep:weer_api", "tokio", "futures"]
-
-# Remove the `#wasm#` to uncomment the wasm build.
-# This is commented out by default because we don't want to build it as a library by default
-# The CI has a script that does sed "s/#wasm# //" to generate the wasm build.
-
-#wasm# [lib]
-#wasm# crate-type = ["cdylib"]
-#wasm# path = "src/main.rs"
-#wasm#
-#wasm# [target.'cfg(target_arch = "wasm32")'.dependencies]
-#wasm# wasm-bindgen = { version = "0.2" }
-#wasm# web-sys = { version = "0.3", features=["console"] }
-#wasm# console_error_panic_hook = "0.1.5"

--- a/examples/energy-monitor/README.md
+++ b/examples/energy-monitor/README.md
@@ -1,12 +1,47 @@
 <!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+# Energy Monitor Demo
 
-See the [MCU backend Readme](../mcu-board-support) to see how to run the example on a smaller device like the Raspberry Pi Pico.
+![Energy Monitor Demo Screenshot](https://slint.dev/resources/energy-monitor-screenshot.png "Energy Monitor")
 
-The example can run with the mcu simulator with the following command
+This is a demonstration of the Slint toolkit. This demo can be executed on various platforms.
 
-```cargo run -p energy-monitor --no-default-features --features=simulator --release```
+## Displaying Real-Time Weather Data
 
-## display weather data
+To showcase real-time weather data, you will need an application key from https://www.weatherapi.com/. You can inject the API key by setting the `WEATHER_API` environment variable. The geographical location for the weather data can be set using the `WEATHER_LAT` and `WEATHER_LONG` variables. By default, the location is set to Berlin.
 
-To display real weather data in the demo an application key from https://www.weatherapi.com/ is needed. The api key can be injected by settings the
-`WEATHER_API` environment variable. With the `WEATHER_LAT` and `WEATHER_LONG` variable position can be set, default is Berlin.
+## Platform Compatibility
+
+### Desktop (Windows/Mac/Linux) or Embedded Linux
+
+You can run the demo on a desktop or embedded Linux environment with the following command:
+```sh
+cargo run -p energy-monitor
+```
+
+### Microcontrolers (MCU)
+
+Refer to the [MCU backend Readme](../mcu-board-support) for instructions on how to run the demo on smaller devices like the Raspberry Pi Pico.
+
+To run the MCU-like code on desktop, use the `--features=simulator`
+
+```sh
+cargo run -p energy-monitor --no-default-features --features=simulator --release
+```
+
+### Android
+
+First, [set up your Android environment](https://slint.dev/snapshots/master/docs/rust/slint/android/#building-and-deploying).
+Then, you can run the demo on an Android device with the following command:
+
+```sh
+cargo apk run -p energy-monitor --target aarch64-linux-android --lib
+```
+
+### Web
+
+```sh
+cargo install wasm-pack
+cd examples/energy-monitor/
+wasm-pack build --release --target web --no-default-features --features slint/default,chrono
+python3 -m http.server
+```

--- a/examples/energy-monitor/index.html
+++ b/examples/energy-monitor/index.html
@@ -7,8 +7,7 @@
 <!--
   This is a static html file used to display the wasm build.
   In order to generate the build
-   - uncomment the #wasm# lines in Cargo.toml
-   - Run `wasm-pack build --release --target web` in this directory.
+   - Run `wasm-pack build --release --target web --no-default-features --features slint/default,chrono` in this directory.
 -->
 
 <head>

--- a/examples/energy-monitor/src/lib.rs
+++ b/examples/energy-monitor/src/lib.rs
@@ -1,0 +1,81 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+#![cfg_attr(feature = "mcu-board-support", no_std)]
+
+#[cfg(feature = "mcu-board-support")]
+extern crate alloc;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+pub mod ui {
+    slint::include_modules!();
+}
+
+use slint::*;
+use ui::*;
+
+#[cfg(not(feature = "mcu-board-support"))]
+mod controllers {
+    #[cfg(feature = "chrono")]
+    pub mod header;
+    #[cfg(feature = "network")]
+    pub mod weather;
+}
+#[cfg(not(feature = "mcu-board-support"))]
+use controllers::*;
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
+pub fn main() {
+    // This provides better error messages in debug mode.
+    // It's disabled in release mode so it doesn't bloat up the file size.
+    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    console_error_panic_hook::set_once();
+
+    let window = MainWindow::new().unwrap();
+
+    // let _ to keep the timer alive.
+    #[cfg(all(not(feature = "mcu-board-support"), feature = "chrono"))]
+    let _timer = header::setup(&window);
+
+    #[cfg(all(not(feature = "mcu-board-support"), fature = "network"))]
+    let weather_join = weather::setup(&window);
+
+    let _kiosk_mode_timer = kiosk_timer(&window);
+
+    window.run().unwrap();
+
+    #[cfg(all(not(feature = "mcu-board-support"), feature = "network"))]
+    weather_join.join().unwrap();
+}
+
+fn kiosk_timer(window: &MainWindow) -> Timer {
+    let kiosk_mode_timer = Timer::default();
+    kiosk_mode_timer.start(TimerMode::Repeated, core::time::Duration::from_secs(4), {
+        let window_weak = window.as_weak();
+        move || {
+            if !SettingsAdapter::get(&window_weak.unwrap()).get_kiosk_mode_checked() {
+                return;
+            }
+
+            let current_page = MenuOverviewAdapter::get(&window_weak.unwrap()).get_current_page();
+            let count = MenuOverviewAdapter::get(&window_weak.unwrap()).get_count();
+
+            if current_page >= count - 1 {
+                MenuOverviewAdapter::get(&window_weak.unwrap()).set_current_page(0);
+            } else {
+                MenuOverviewAdapter::get(&window_weak.unwrap()).set_current_page(current_page + 1);
+            }
+        }
+    });
+
+    kiosk_mode_timer
+}
+
+#[cfg(target_os = "android")]
+#[no_mangle]
+fn android_main(app: slint::android::AndroidApp) {
+    slint::android::init(app).unwrap();
+    main();
+}

--- a/examples/energy-monitor/src/main.rs
+++ b/examples/energy-monitor/src/main.rs
@@ -1,89 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
-
-#![cfg_attr(feature = "mcu-board-support", no_std)]
+#![no_std]
 #![cfg_attr(all(feature = "mcu-board-support", not(feature = "simulator")), no_main)]
 
-#[cfg(feature = "mcu-board-support")]
-extern crate alloc;
-
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::*;
-
-pub mod ui {
-    slint::include_modules!();
-}
-
-use slint::*;
-use ui::*;
-
 #[cfg(not(feature = "mcu-board-support"))]
-mod controllers {
-    #[cfg(feature = "chrono")]
-    pub mod header;
-    #[cfg(feature = "network")]
-    pub mod weather;
-}
-#[cfg(not(feature = "mcu-board-support"))]
-use controllers::*;
-
-#[cfg(not(feature = "mcu-board-support"))]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
-    console_error_panic_hook::set_once();
-
-    let window = MainWindow::new().unwrap();
-
-    // let _ to keep the timer alive.
-    #[cfg(feature = "chrono")]
-    let _timer = header::setup(&window);
-
-    #[cfg(feature = "network")]
-    let weather_join = weather::setup(&window);
-
-    let _kiosk_mode_timer = kiosk_timer(&window);
-
-    window.run().unwrap();
-
-    #[cfg(feature = "network")]
-    weather_join.join().unwrap();
+    energy_monitor::main();
 }
 
-#[cfg(any(feature = "mcu-board-support", feature = "simulator"))]
+#[cfg(feature = "mcu-board-support")]
 #[mcu_board_support::entry]
 fn main() -> ! {
     mcu_board_support::init();
-    let window = MainWindow::new().unwrap();
-
-    let _kiosk_mode_timer = kiosk_timer(&window);
-
-    window.run().unwrap();
-
+    energy_monitor::main();
     panic!("The MCU demo should not quit")
-}
-
-fn kiosk_timer(window: &MainWindow) -> Timer {
-    let kiosk_mode_timer = Timer::default();
-    kiosk_mode_timer.start(TimerMode::Repeated, core::time::Duration::from_secs(4), {
-        let window_weak = window.as_weak();
-        move || {
-            if !SettingsAdapter::get(&window_weak.unwrap()).get_kiosk_mode_checked() {
-                return;
-            }
-
-            let current_page = MenuOverviewAdapter::get(&window_weak.unwrap()).get_current_page();
-            let count = MenuOverviewAdapter::get(&window_weak.unwrap()).get_count();
-
-            if current_page >= count - 1 {
-                MenuOverviewAdapter::get(&window_weak.unwrap()).set_current_page(0);
-            } else {
-                MenuOverviewAdapter::get(&window_weak.unwrap()).set_current_page(current_page + 1);
-            }
-        }
-    });
-
-    kiosk_mode_timer
 }


### PR DESCRIPTION
This demo support both mcus, web, desktop and mobile.

Split in a lib.rs so that there are no warnings even if it means some dummy wrapper in main.

Add instructions in the README