### PR TITLE
Python: Create a property type wrapper for component instances

### DIFF
--- a/api/python/slint/__init__.py
+++ b/api/python/slint/__init__.py
@@ -12,6 +12,107 @@ class CompileError(Exception):
         self.diagnostics = diagnostics
 
 
+class Component:
+    def show(self):
+        self.__instance__.show()
+
+    def hide(self):
+        self.__instance__.hide()
+
+    def run(self):
+        self.__instance__.run()
+
+
+def _normalize_prop(name):
+    return name.replace("-", "_")
+
+
+def _build_global_class(compdef, global_name):
+    properties_and_callbacks = {}
+
+    for prop_name in compdef.global_properties(global_name).keys():
+        python_prop = _normalize_prop(prop_name)
+        if python_prop in properties_and_callbacks:
+            logging.warning(f"Duplicated property {prop_name}")
+            continue
+
+        def getter(self): return self.__instance__.get_global_property(
+            global_name, prop_name)
+
+        def setter(self, value): return self.__instance__.set_global_property(
+            global_name, prop_name, value)
+
+        properties_and_callbacks[python_prop] = property(getter, setter)
+
+    for callback_name in compdef.global_callbacks(global_name):
+        python_prop = _normalize_prop(callback_name)
+        if python_prop in properties_and_callbacks:
+            logging.warning(f"Duplicated property {prop_name}")
+            continue
+
+        def getter(self):
+            def call(*args):
+                return self.__instance__.invoke_global(global_name, callback_name, *args)
+            return call
+
+        def setter(self, value): return self.__instance__.set_global_callback(
+            global_name, callback_name, value)
+
+        properties_and_callbacks[python_prop] = property(getter, setter)
+
+    return type("SlintGlobalClassWrapper", (), properties_and_callbacks)
+
+
+def _build_class(compdef):
+
+    def cls_init(self, **kwargs):
+        self.__instance__ = compdef.create()
+
+    properties_and_callbacks = {
+        "__init__": cls_init
+    }
+
+    for prop_name in compdef.properties.keys():
+        python_prop = _normalize_prop(prop_name)
+        if python_prop in properties_and_callbacks:
+            logging.warning(f"Duplicated property {prop_name}")
+            continue
+
+        def getter(self): return self.__instance__.get_property(prop_name)
+
+        def setter(self, value): return self.__instance__.set_property(
+            prop_name, value)
+
+        properties_and_callbacks[python_prop] = property(getter, setter)
+
+    for callback_name in compdef.callbacks:
+        python_prop = _normalize_prop(callback_name)
+        if python_prop in properties_and_callbacks:
+            logging.warning(f"Duplicated property {prop_name}")
+            continue
+
+        def getter(self):
+            def call(*args):
+                return self.__instance__.invoke(callback_name, *args)
+            return call
+
+        def setter(self, value): return self.__instance__.set_callback(
+            callback_name, value)
+
+        properties_and_callbacks[python_prop] = property(getter, setter)
+
+    for global_name in compdef.globals:
+        global_class = _build_global_class(compdef, global_name)
+
+        def global_getter(self):
+            wrapper = global_class()
+            setattr(wrapper, "__instance__", self.__instance__)
+            return wrapper
+        properties_and_callbacks[global_name] = property(global_getter)
+
+    return type("SlintClassWrapper", (Component,), properties_and_callbacks)
+
+
 def load_file(path, quiet=False, style=None, include_paths=None, library_paths=None, translation_domain=None):
     compiler = native.ComponentCompiler()
 
@@ -38,11 +139,10 @@ def load_file(path, quiet=False, style=None, include_paths=None, library_paths=N
             if errors:
                 raise CompileError(f"Could not compile {path}", diagnostics)
 
+    wrapper_class = _build_class(compdef)
+
     module = types.SimpleNamespace()
-    setattr(module, compdef.name, type("SlintMetaClass", (), {
-        "__compdef": compdef,
-        "__new__": lambda cls: cls.__compdef.create()
-    }))
+    setattr(module, compdef.name, wrapper_class)
 
     return module
 

--- a/api/python/tests/test_instance.py
+++ b/api/python/tests/test_instance.py
@@ -166,6 +166,6 @@ if __name__ == "__main__":
     module = slint.load_file(
         "../../examples/printerdemo/ui/printerdemo.slint")
     instance = module.MainWindow()
-    instance.set_global_callback(
-        "PrinterQueue", "start-job", lambda title: print(f"new print job {title}"))
+    instance.PrinterQueue.start_job = lambda title: print(
+        f"new print job {title}")
     instance.run()

--- a/api/python/tests/test_load_file.py
+++ b/api/python/tests/test_load_file.py
@@ -20,3 +20,21 @@ def test_load_file(caplog):
 def test_load_file_fail():
     with pytest.raises(CompileError, match="Could not compile non-existent.slint"):
         load_file("non-existent.slint")
+
+
+def test_load_file_wrapper():
+    module = load_file(os.path.join(os.path.dirname(
+        __spec__.origin), "test_load_file.slint"), quiet=False)
+
+    instance = module.App()
+
+    assert instance.hello == "World"
+    instance.hello = "Ok"
+    assert instance.hello == "Ok"
+
+    instance.say_hello = lambda x: "from here: " + x
+    assert instance.say_hello("wohoo") == "from here: wohoo"
+
+    assert instance.MyGlobal.global_prop == "This is global"
+
+    del instance

--- a/api/python/tests/test_load_file.slint
+++ b/api/python/tests/test_load_file.slint
@@ -1,7 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
+export global MyGlobal {
+    in-out property <string> global-prop: "This is global";
+}
+
 export component App {
+    in-out property <string> hello: "World";
+    callback say-hello(string);
     Rectangle {
         color: red;
     }


### PR DESCRIPTION
Map properties and callbacks to attributes with getters and setters.

cc #4134