### PR TITLE
Revert the use of enums in the printer demo

### DIFF
--- a/examples/printerdemo/cpp/main.cpp
+++ b/examples/printerdemo/cpp/main.cpp
@@ -39,7 +39,7 @@ int main()
         char time_buf[100] = { 0 };
         std::strftime(time_buf, sizeof(time_buf), "%H:%M:%S %d/%m/%Y", std::localtime(&now));
         PrinterQueueItem item;
-        item.status = JobStatus::Waiting;
+        item.status = "waiting";
         item.progress = 0;
         item.title = std::move(name);
         item.owner = "joe@example.com";
@@ -59,7 +59,7 @@ int main()
             if (top_item.progress > 100) {
                 printer_queue->erase(0);
             } else {
-                top_item.status = JobStatus::Printing;
+                top_item.status = "printing";
                 printer_queue->set_row_data(0, top_item);
             }
         }

--- a/examples/printerdemo/cpp_interpreted/main.cpp
+++ b/examples/printerdemo/cpp_interpreted/main.cpp
@@ -76,7 +76,7 @@ int main()
         char time_buf[100] = { 0 };
         std::strftime(time_buf, sizeof(time_buf), "%H:%M:%S %d/%m/%Y", std::localtime(&now));
 
-        slint::interpreter::Struct item { { "status", Value(slint::SharedString("WAITING...")) },
+        slint::interpreter::Struct item { { "status", Value(slint::SharedString("waiting")) },
                                           { "progress", Value(0.) },
                                           { "title", args[0] },
                                           { "owner", slint::SharedString("joe@example.com") },
@@ -98,7 +98,7 @@ int main()
             auto top_item = *(*printer_queue->row_data(0)).to_struct();
             auto progress = *top_item.get_field("progress")->to_number() + 1.;
             top_item.set_field("progress", progress);
-            top_item.set_field("status", slint::SharedString("PRINTING"));
+            top_item.set_field("status", slint::SharedString("printing"));
             if (progress > 100) {
                 printer_queue->erase(0);
             } else {

--- a/examples/printerdemo/rust/lib.rs
+++ b/examples/printerdemo/rust/lib.rs
@@ -25,7 +25,7 @@ struct PrinterQueueData {
 impl PrinterQueueData {
     fn push_job(&self, title: slint::SharedString) {
         self.data.push(PrinterQueueItem {
-            status: JobStatus::Waiting,
+            status: "waiting".into(),
             progress: 0,
             title,
             owner: env!("CARGO_PKG_AUTHORS").into(),
@@ -86,7 +86,7 @@ pub fn main() {
                 if printer_queue.data.row_count() > 0 {
                     let mut top_item = printer_queue.data.row_data(0).unwrap();
                     top_item.progress += 1;
-                    top_item.status = JobStatus::Waiting;
+                    top_item.status = "printing".into();
                     if top_item.progress > 100 {
                         printer_queue.data.remove(0);
                         if printer_queue.data.row_count() == 0 {

--- a/examples/printerdemo/ui/printer_queue.slint
+++ b/examples/printerdemo/ui/printer_queue.slint
@@ -3,13 +3,8 @@
 
 import { DemoPalette, PushButton } from "./common.slint";
 
-enum JobStatus {
-    Waiting,
-    Printing
-}
-
 export struct PrinterQueueItem  {
-    status: JobStatus,
+    status: string,
     progress: int,
     title: string,
     owner: string,
@@ -20,15 +15,15 @@ export struct PrinterQueueItem  {
 
 export global PrinterQueue  {
     in property <[PrinterQueueItem]> printer-queue: [
-        { status: JobStatus.Printing, progress: 63, title: "210106-FinalPresentation.pdf", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
-        { status: JobStatus.Waiting, title: "Adressliste.docx", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
-        { status: JobStatus.Waiting, title: "Salaries.pdf", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
+        { status: "printing", progress: 63, title: "210106-FinalPresentation.pdf", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
+        { status: "waiting", title: "Adressliste.docx", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
+        { status: "waiting", title: "Salaries.pdf", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
     ];
 
-    public pure function statusString(status: JobStatus) -> string {
-        if (status == JobStatus.Printing) {
+    public pure function statusString(status: string) -> string {
+        if (status == "printing") {
             @tr("PRINTING")
-        } else if (status == JobStatus.Waiting) {
+        } else if (status == "waiting") {
             @tr("WAITING...")
         } else {
             @tr("Unknown job status")


### PR DESCRIPTION
This reverts commit 060f63ad561e04aab8aeb11668266f0f3d94a0f9, as it broke the C++ interpreted demo and makes it impossible to implement the demo "fully" in JavaScript and Python.

cc #4777