### PR TITLE
Python: Add support for direct .slint file imports

### DIFF
--- a/api/cpp/docs/Pipfile
+++ b/api/cpp/docs/Pipfile
@@ -1,5 +1,5 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
-# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-commercial
+# SPDX-License-Identifier: MIT
 
 [[source]]
 name = "pypi"

--- a/api/python/tests/test_import.py
+++ b/api/python/tests/test_import.py
@@ -1,0 +1,27 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+import pytest
+from slint import slint as native
+import sys
+import os
+
+
+def test_magic_import():
+    import test_load_file_slint as compiledmodule
+    instance = compiledmodule.App()
+    del instance
+
+
+def test_magic_import_path():
+    oldsyspath = sys.path
+    with pytest.raises(ModuleNotFoundError, match="No module named 'printerdemo_slint'"):
+        import printerdemo_slint
+    try:
+        sys.path.append(os.path.join(os.path.dirname(__file__),
+                        "..", "..", "..", "examples", "printerdemo", "ui"))
+        import printerdemo_slint
+        instance = printerdemo_slint.MainWindow()
+        del instance
+    finally:
+        sys.path = oldsyspath

--- a/examples/printerdemo/python/Pipfile
+++ b/examples/printerdemo/python/Pipfile
@@ -1,0 +1,15 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+slint = { file = "../../../api/python", editable = true }
+
+[dev-packages]
+
+[requires]
+python_version = "3"

--- a/examples/printerdemo/python/README.md
+++ b/examples/printerdemo/python/README.md
@@ -1,0 +1,23 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
+# Intro
+
+This is the Python version of the Slint Printer Demo.
+
+# Prerequisites
+
+ * [Python 3](https://python.org/)
+ * [pip](https://pypi.org/project/pip/)
+ * [Pipenv](https://pipenv.pypa.io/en/latest/installation.html#installing-pipenv)
+
+# Setup
+
+```bash
+pipenv update
+```
+
+# Run
+
+```bash
+pipenv run python main.py
+```

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -405,7 +405,6 @@ lazy_static! {
         ("^\\.mailmap$", LicenseLocation::NoLicense),
         ("^\\.pre-commit-config\\.yaml$", LicenseLocation::NoLicense),
         ("^\\.reuse/dep5$", LicenseLocation::NoLicense), // .reuse files have no license headers
-        ("^api/cpp/docs/Pipfile$", LicenseLocation::NoLicense),
         ("^api/cpp/docs/conf\\.py$", LicenseLocation::NoLicense),
         ("^docs/reference/Pipfile$", LicenseLocation::NoLicense),
         ("^docs/reference/conf\\.py$", LicenseLocation::NoLicense),
@@ -426,6 +425,7 @@ lazy_static! {
         ("(^|/)webpack\\..+\\.js$", LicenseLocation::NoLicense),
         ("(^|/)partitions\\.csv$", LicenseLocation::NoLicense),
         ("(^|/)sdkconfig", LicenseLocation::NoLicense), // auto-generated
+        ("(^|/)Pipfile$", LicenseLocation::Tag(LicenseTagStyle::shell_comment_style())),
 
         // Path prefix matches:
         ("^editors/tree-sitter-slint/corpus/", LicenseLocation::NoLicense), // liberal license


### PR DESCRIPTION
This comes along with the printer demo ported, which uses it.

cc #4134