### PR TITLE
Python: Add support for a @slint.callback decorator to conveniently associated callbacks with python methods

### DIFF
--- a/api/python/tests/test_callback_decorators.py
+++ b/api/python/tests/test_callback_decorators.py
@@ -1,0 +1,30 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+from slint import load_file, CompileError
+import slint
+import os
+
+
+def test_callback_decorators(caplog):
+    module = load_file(os.path.join(os.path.dirname(
+        __spec__.origin), "test_load_file.slint"), quiet=False)
+
+    class SubClass(module.App):
+        @slint.callback()
+        def say_hello_again(self, arg):
+            return "say_hello_again:" + arg
+
+        @slint.callback(name="say-hello")
+        def renamed(self, arg):
+            return "renamed:" + arg
+
+        @slint.callback(global_name="MyGlobal", name="global-callback")
+        def global_callback(self, arg):
+            return "global:" + arg
+
+    instance = SubClass()
+    assert instance.invoke_say_hello("ok") == "renamed:ok"
+    assert instance.invoke_say_hello_again("ok") == "say_hello_again:ok"
+    assert instance.invoke_global_callback("ok") == "global:ok"
+    del instance

--- a/api/python/tests/test_load_file.slint
+++ b/api/python/tests/test_load_file.slint
@@ -3,11 +3,29 @@
 
 export global MyGlobal {
     in-out property <string> global-prop: "This is global";
+    callback global-callback(string) -> string;
 }
 
 export component App {
     in-out property <string> hello: "World";
-    callback say-hello(string);
+    callback say-hello(string) -> string;
+    callback say_hello_again(string) -> string;
+
+    callback invoke-say-hello(string) -> string;
+    invoke-say-hello(arg) => {
+        return self.say-hello(arg);
+    }
+
+    callback invoke-say-hello-again(string) -> string;
+    invoke-say-hello-again(arg) => {
+        return self.say-hello-again(arg);
+    }
+
+    callback invoke-global-callback(string) -> string;
+    invoke-global-callback(arg) => {
+        return MyGlobal.global-callback(arg);
+    }
+
     Rectangle {
         color: red;
     }

--- a/examples/printerdemo/python/main.py
+++ b/examples/printerdemo/python/main.py
@@ -6,6 +6,7 @@ from datetime import timedelta, datetime
 import os
 import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "ui"))
+import slint
 from slint import Color, ListModel, Timer, TimerMode
 import printerdemo_slint
 # autopep8: on
@@ -23,14 +24,15 @@ class MainWindow(printerdemo_slint.MainWindow):
         # Copy the read-only mock data from the UI into a mutable ListModel
         self.printer_queue = ListModel(self.PrinterQueue.printer_queue)
         self.PrinterQueue.printer_queue = self.printer_queue
-        self.PrinterQueue.start_job = self.push_job
-        self.PrinterQueue.cancel_job = self.remove_job
         self.print_progress_timer = Timer()
         self.print_progress_timer.start(
             TimerMode.Repeated, timedelta(seconds=1), self.update_jobs)
 
-        self.quit = lambda: self.hide()
+    @slint.callback
+    def quit(self):
+        self.hide()
 
+    @slint.callback(global_name="PrinterQueue", name="start_job")
     def push_job(self, title):
         self.printer_queue.append({
             "status": "waiting",
@@ -42,7 +44,8 @@ class MainWindow(printerdemo_slint.MainWindow):
             "submission_date": str(datetime.now()),
         })
 
-    def remove_job(self, index):
+    @slint.callback(global_name="PrinterQueue")
+    def cancel_job(self, index):
         del self.printer_queue[index]
 
     def update_jobs(self):


### PR DESCRIPTION

cc #4134