### PR TITLE
Rename `border-...-radius` to `...-border-radius`

### DIFF
--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -589,7 +589,7 @@ When not part of a layout, its width and height default to 100% of the parent el
 -   **`background`** (_in_ _brush_): The background brush of this `Rectangle`, typically a color. (default value: `transparent`)
 -   **`border-color`** (_in_ _brush_): The color of the border. (default value: `transparent`)
 -   **`border-radius`** (_in_ _length_): The size of the radius. (default value: 0)
--   **`border-top-left-radius`**, **`border-top-right-radius`**, **`border-bottom-left-radius`** and **`border-bottom-right-radius`** (_in_ _length_): Set these properties to override the radius for specific corners.
+-   **`top-left-border-radius`**, **`top-right-border-radius`**, **`bottom-left-border-radius`** and **`bottom-right-border-radius`** (_in_ _length_): Set these properties to override the radius for specific corners.
 -   **`border-width`** (_in_ _length_): The width of the border. (default value: 0)
 -   **`clip`** (_in_ _bool_): By default, when an element is bigger or outside another element, it's still shown. When this property is set to `true`, the children of this `Rectangle` are clipped to the border of the rectangle. (default value: `false`)
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -36,10 +36,10 @@ component BasicBorderRectangle inherits Rectangle {
 }
 
 component BorderRectangle inherits BasicBorderRectangle {
-    in property <length> border-top-left-radius;
-    in property <length> border-top-right-radius;
-    in property <length> border-bottom-left-radius;
-    in property <length> border-bottom-right-radius;
+    in property <length> top-left-border-radius;
+    in property <length> top-right-border-radius;
+    in property <length> bottom-left-border-radius;
+    in property <length> bottom-right-border-radius;
     //-default_size_binding:expands_to_parent_geometry
 }
 
@@ -210,10 +210,10 @@ export component TextInput {
 
 export component Clip {
     in property <length> border-radius;
-    in property <length> border-top-left-radius;
-    in property <length> border-top-right-radius;
-    in property <length> border-bottom-left-radius;
-    in property <length> border-bottom-right-radius;
+    in property <length> top-left-border-radius;
+    in property <length> top-right-border-radius;
+    in property <length> bottom-left-border-radius;
+    in property <length> bottom-right-border-radius;
     in property <length> border-width;
     in property <bool> clip;
     //-default_size_binding:expands_to_parent_geometry

--- a/internal/compiler/passes/border_radius.rs
+++ b/internal/compiler/passes/border_radius.rs
@@ -9,10 +9,10 @@ use crate::object_tree::Component;
 use std::rc::Rc;
 
 const BORDER_RADIUS_PROPERTIES: [&str; 4] = [
-    "border-top-left-radius",
-    "border-top-right-radius",
-    "border-bottom-right-radius",
-    "border-bottom-left-radius",
+    "top-left-border-radius",
+    "top-right-border-radius",
+    "bottom-right-border-radius",
+    "bottom-left-border-radius",
 ];
 
 pub fn handle_border_radius(root_component: &Rc<Component>, _diag: &mut BuildDiagnostics) {

--- a/internal/compiler/passes/clip.rs
+++ b/internal/compiler/passes/clip.rs
@@ -81,10 +81,10 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
         .collect();
     for optional_binding in [
         "border-radius",
-        "border-top-left-radius",
-        "border-top-right-radius",
-        "border-bottom-right-radius",
-        "border-bottom-left-radius",
+        "top-left-border-radius",
+        "top-right-border-radius",
+        "bottom-right-border-radius",
+        "bottom-left-border-radius",
         "border-width",
     ]
     .iter()

--- a/internal/compiler/passes/resolve_native_classes.rs
+++ b/internal/compiler/passes/resolve_native_classes.rs
@@ -155,7 +155,7 @@ fn select_minimal_class() {
     assert_eq!(
         select_minimal_class_based_on_property_usage(
             &rect.native_class,
-            ["border-top-left-radius".to_owned(), "x".to_owned()].iter()
+            ["top-left-border-radius".to_owned(), "x".to_owned()].iter()
         )
         .class_name,
         "BorderRectangle",

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -429,10 +429,10 @@ pub struct BorderRectangle {
     pub background: Property<Brush>,
     pub border_width: Property<LogicalLength>,
     pub border_radius: Property<LogicalLength>,
-    pub border_top_left_radius: Property<LogicalLength>,
-    pub border_top_right_radius: Property<LogicalLength>,
-    pub border_bottom_left_radius: Property<LogicalLength>,
-    pub border_bottom_right_radius: Property<LogicalLength>,
+    pub top_left_border_radius: Property<LogicalLength>,
+    pub top_right_border_radius: Property<LogicalLength>,
+    pub bottom_left_border_radius: Property<LogicalLength>,
+    pub bottom_right_border_radius: Property<LogicalLength>,
     pub border_color: Property<Brush>,
     pub cached_rendering_data: CachedRenderingData,
 }
@@ -504,10 +504,10 @@ impl RenderBorderRectangle for BorderRectangle {
     }
     fn border_radius(self: Pin<&Self>) -> LogicalBorderRadius {
         LogicalBorderRadius::from_lengths(
-            self.border_top_left_radius(),
-            self.border_top_right_radius(),
-            self.border_bottom_right_radius(),
-            self.border_bottom_left_radius(),
+            self.top_left_border_radius(),
+            self.top_right_border_radius(),
+            self.bottom_right_border_radius(),
+            self.bottom_left_border_radius(),
         )
     }
     fn border_color(self: Pin<&Self>) -> Brush {
@@ -855,10 +855,10 @@ declare_item_vtable! {
 /// The implementation of the `Clip` element
 pub struct Clip {
     pub border_radius: Property<LogicalLength>,
-    pub border_top_left_radius: Property<LogicalLength>,
-    pub border_top_right_radius: Property<LogicalLength>,
-    pub border_bottom_left_radius: Property<LogicalLength>,
-    pub border_bottom_right_radius: Property<LogicalLength>,
+    pub top_left_border_radius: Property<LogicalLength>,
+    pub top_right_border_radius: Property<LogicalLength>,
+    pub bottom_left_border_radius: Property<LogicalLength>,
+    pub bottom_right_border_radius: Property<LogicalLength>,
     pub border_width: Property<LogicalLength>,
     pub cached_rendering_data: CachedRenderingData,
     pub clip: Property<bool>,
@@ -935,10 +935,10 @@ impl Item for Clip {
 impl Clip {
     pub fn logical_border_radius(self: Pin<&Self>) -> LogicalBorderRadius {
         LogicalBorderRadius::from_lengths(
-            self.border_top_left_radius(),
-            self.border_top_right_radius(),
-            self.border_bottom_right_radius(),
-            self.border_bottom_left_radius(),
+            self.top_left_border_radius(),
+            self.top_right_border_radius(),
+            self.bottom_right_border_radius(),
+            self.bottom_left_border_radius(),
         )
     }
 }

--- a/tests/cases/properties/border_radius.slint
+++ b/tests/cases/properties/border_radius.slint
@@ -4,13 +4,13 @@
 export component TestCase {
     rect := Rectangle { 
         border-radius: 45px;
-        border-top-left-radius: 98px;
+        top-left-border-radius: 98px;
     }
 
-    out property<bool> tl_ok: rect.border-top-left-radius == 98px;
-    out property<bool> tr_ok: rect.border-top-right-radius == 45px;
-    out property<bool> br_ok: rect.border-bottom-right-radius == 45px;
-    out property<bool> bl_ok: rect.border-bottom-left-radius == 45px;
+    out property<bool> tl_ok: rect.top-left-border-radius == 98px;
+    out property<bool> tr_ok: rect.top-right-border-radius == 45px;
+    out property<bool> br_ok: rect.bottom-right-border-radius == 45px;
+    out property<bool> bl_ok: rect.bottom-left-border-radius == 45px;
 
     out property<bool> test: tl_ok && tr_ok && br_ok && bl_ok;
 }

--- a/tests/screenshots/cases/software/basic/border.slint
+++ b/tests/screenshots/cases/software/basic/border.slint
@@ -12,6 +12,6 @@ TestCase := Window {
     GridLayout {
         Rectangle { background: red; border-color: white; border-width: 1px; }
         Rectangle { background: #080c; border-radius: 8px; border-width: 5px; border-color: #d005; }
-        Rectangle { background: blue; border-top-right-radius: 2px; border-bottom-left-radius: 4px; border-width: 4px; border-color: orange; }
+        Rectangle { background: blue; top-right-border-radius: 2px; bottom-left-border-radius: 4px; border-width: 4px; border-color: orange; }
     }
 }


### PR DESCRIPTION
As per API review:
This is how you phrase it in english without dashes. It is consistent with `horizontal-alignment`.