### PR TITLE
Janitor: Update the image crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ css-color-parser2 = { version = "1.0.1" }
 fontdb = { version = "0.16.0", default-features = false }
 fontdue = { version = "0.8.0" }
 glutin = { version = "0.31.1", default-features = false }
+image = { version = "0.25", default-features = false, features = [ "png", "jpeg" ] }
 itertools = { version = "0.12" }
 resvg = { version= "0.40.0", default-features = false, features = ["text"] }
 send_wrapper = { version = "0.6.0" }

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -55,7 +55,7 @@ i-slint-core = { workspace = true, features = ["ffi"] }
 slint-interpreter = { workspace = true, features = ["ffi", "compat-1-2"], optional = true }
 raw-window-handle = { version = "0.5", optional = true }
 # Enable image-rs' default features to make all image formats to C++ users
-image = { version = "0.24.0", optional = true }
+image = { workspace = true, optional = true, features = ["default"] }
 
 esp-backtrace = { version = "0.11.0", features = ["panic-handler", "println"], optional = true }
 esp-println = { version = "0.9.0", default-features = false, features = ["uart"], optional = true }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -25,6 +25,7 @@ default = [
   "backend-default",
   "renderer-femtovg",
   "renderer-software",
+  "image-default-formats",
   "accessibility",
   "compat-1-2",
 ]
@@ -34,7 +35,8 @@ default = [
 ## Newer patch version may put current functionality behind a new feature
 ## that would be enabled by default only if this feature was added.
 ## [More info in this blog post](https://slint.dev/blog/rust-adding-default-cargo-feature.html)
-"compat-1-2" = []
+"compat-1-6" = []
+"compat-1-2" = ["compat-1-6", "image-default-formats"]
 "compat-1-0" = ["compat-1-2", "renderer-software"]
 
 ## Enable use of the Rust standard library.
@@ -83,6 +85,10 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 ## [HasWindowHandle](raw_window_handle_06::HasWindowHandle) and
 ## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation.
 raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
+
+## Enable all formats from the `image` crate. To increase what is supported from [`Image::load_from_path`]
+## or in `@image-url`.
+image-default-formats = ["i-slint-core/image-default-formats"]
 
 #! ### Backends
 

--- a/examples/imagefilter/rust/Cargo.toml
+++ b/examples/imagefilter/rust/Cargo.toml
@@ -16,7 +16,7 @@ name = "imagefilter"
 
 [dependencies]
 slint = { path = "../../../api/rs/slint" }
-image = { version = "0.24.0", default-features = false, features = [ "png" ] }
+image = { workspace = true }
 
 [build-dependencies]
 slint-build = { path = "../../../api/rs/build" }

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -22,4 +22,3 @@ default = []
 [dependencies]
 i-slint-core = { workspace = true, features = ["default"] }
 vtable = { workspace = true }
-image = { version = "0.24.0", default-features = false, features = ["png", "jpeg"] }

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -55,7 +55,7 @@ url = "2.2.1"
 linked_hash_set = "0.1.4"
 
 # for processing and embedding the rendered image (texture)
-image = { version = "0.24", optional = true }
+image = { workspace = true, optional = true, features = ["default"] }
 resvg = { workspace = true, optional = true }
 # font embedding
 fontdue = { workspace = true, optional = true }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -81,7 +81,7 @@ unicode-script = { version = "0.5.3", optional = true }
 integer-sqrt = { version = "0.1.5" }
 bytemuck = { workspace = true, optional = true, features = ["derive"] }
 
-image = { version = "0.24.0", optional = true, default-features = false, features = [ "png", "jpeg" ] }
+image = { workspace = true, optional = true, default-features = false }
 clru = { version = "0.6.0", optional = true }
 
 resvg = { workspace = true, optional = true }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -38,6 +38,7 @@ software-renderer = ["bytemuck"]
 software-renderer-rotation = []
 
 image-decoders = ["dep:image", "dep:clru"]
+image-default-formats = ["image?/default-formats"]
 svg = ["dep:resvg", "shared-fontdb"]
 
 box-shadow-cache = []

--- a/tests/screenshots/Cargo.toml
+++ b/tests/screenshots/Cargo.toml
@@ -21,7 +21,7 @@ name = "test-driver-screenshot"
 slint = { workspace = true, features = ["std", "compat-1-2"] }
 i-slint-core = { workspace = true, features = ["default", "software-renderer", "software-renderer-rotation"] }
 i-slint-backend-testing = { workspace = true, features = ["default"] }
-image = { version = "0.24.0", default-features = false, features = ["png", "jpeg"] }
+image = { workspace = true }
 crossterm = "0.27"
 
 [build-dependencies]

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -101,7 +101,7 @@ lsp-server = "0.7"
 once_cell = "1.9.0"
 
 # Enable image-rs' default features to make all image formats available for the preview
-image = { version = "0.24.0", optional = true }
+image = { workspace = true, optional = true, features = ["default"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.5"

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -67,7 +67,7 @@ env_logger = "0.10.0"
 itertools = { workspace = true }
 
 # Enable image-rs' default features to make all image formats available for preview
-image = { version = "0.24.0" }
+image = { workspace = true, features = ["default"] }
 
 [[bin]]
 name = "slint-viewer"


### PR DESCRIPTION
Note: this could be a breaking change if someone did

```toml
image = { version = "0.24", features = [...] }
```

to enable more features decoder of the image to support more file format in slint