### PR TITLE
Fix build of generated C++ code when using transitions on int properties with esp-idf

### DIFF
--- a/api/cpp/include/slint_properties.h
+++ b/api/cpp/include/slint_properties.h
@@ -17,7 +17,7 @@ namespace slint::private_api {
 using cbindgen_private::StateInfo;
 
 inline void slint_property_set_animated_binding_helper(
-        const cbindgen_private::PropertyHandleOpaque *handle, void (*binding)(void *, int32_t *),
+        const cbindgen_private::PropertyHandleOpaque *handle, void (*binding)(void *, int *),
         void *user_data, void (*drop_user_data)(void *),
         const cbindgen_private::PropertyAnimation *animation_data,
         cbindgen_private::PropertyAnimation (*transition_data)(void *, uint64_t *))

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -276,7 +276,7 @@ unsafe fn c_set_animated_binding<T: InterpolatedPropertyValue + Clone>(
 #[no_mangle]
 pub unsafe extern "C" fn slint_property_set_animated_binding_int(
     handle: &PropertyHandleOpaque,
-    binding: extern "C" fn(*mut c_void, *mut i32),
+    binding: extern "C" fn(*mut c_void, *mut core::ffi::c_int),
     user_data: *mut c_void,
     drop_user_data: Option<extern "C" fn(*mut c_void)>,
     animation_data: Option<&PropertyAnimation>,


### PR DESCRIPTION
The energy monitor declares a transition on an animated int property, for which Property<int>::set_animated_binding_for_transition is called, which in turn calls slint_property_set_animated_binding_helper. The latter is overloaded for various property types, such as float, Color, or Brush, and then calls specialized functions from ffi, such as

slint_property_set_animated_binding_(int|float|etc.).

slint_property_set_animated_binding_int uses i32 in Rust, which cbindgen maps to int32_t, so the
slint_property_set_animated_binding_helper overload also uses int32_t.

Unfortunately, with esp-idf, int32_t is a distinct type from int, and the overload resolution fails.

As remedy, this change uses c_int instead of i32 in the Rust ffi, which maps to int.

This seems easier than changing Property<int> to Property<int32_t> :-)