### PR TITLE
Acessibility: added AccessibilityAction and SupportedAccessibilityAction

### DIFF
--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -86,6 +86,8 @@ resvg = { workspace = true, optional = true }
 fontdb = { workspace = true, optional = true }
 serde = { version = "1.0.163", features = ["derive"], optional = true }
 
+bitflags = { version = "2.4.2" }
+
 [target.'cfg(target_family = "unix")'.dependencies]
 gettext-rs = { version = "0.7", optional = true, features = ["gettext-system"] }
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -40,10 +40,6 @@ pub enum AccessibilityAction {
     CustomAction,
     Decrement,
     Increment,
-    // FIXME: Can it be currently supported?
-    HideToolTip,
-    // FIXME: Can it be currently supported?
-    ShowToolTip,
     ReplaceSelectedText(SharedString),
     ScrollBackward,
     ScrollDown,
@@ -55,11 +51,7 @@ pub enum AccessibilityAction {
     ScrollToPoint(LogicalPoint),
     SetScrollOffset(LogicalVector),
     SetTextSelection(Option<core::ops::Range<i32>>),
-    // FIXME: Do we need this?
-    SetSequentialFocusNavigationStartingPoint,
-    SetValue(f64),
-    // FIXME: Can it be currently supported?
-    ShowContextMenu,
+    SetValue(f64)
 }
 
 bitflags! {
@@ -73,8 +65,6 @@ bitflags! {
         const CustomAction = 0b00000111;
         const Decrement = 0b00001000;
         const Increment = 0b00001001;
-        const HideToolTip = 0b00001010;
-        const ShowToolTip = 0b00001011;
         const ReplaceSelectedText = 0b00001100;
         const ScrollBackward = 0b00001101;
         const ScrollDown = 0b00001110;
@@ -86,9 +76,7 @@ bitflags! {
         const ScrollToPoint = 0b00010011;
         const SetScrollOffset = 0b00010100;
         const SetTextSelection = 0b00010101;
-        const SetSequentialFocusNavigationStartingPoint = 0b00010110;
         const SetValue = 0b00010111;
-        const ShowContextMenu = 0b00011000;
     }
 }
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -8,7 +8,6 @@ use alloc::vec::Vec;
 
 use crate::{
     items::ItemRc,
-    lengths::{LogicalPoint, LogicalVector},
     SharedString,
 };
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -6,7 +6,13 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use crate::items::ItemRc;
+use crate::{
+    items::ItemRc,
+    lengths::{LogicalPoint, LogicalVector},
+    SharedString,
+};
+
+use bitflags::bitflags;
 
 // The property names of the accessible-properties
 #[repr(u32)]
@@ -22,6 +28,68 @@ pub enum AccessibleStringProperty {
     ValueMaximum,
     ValueMinimum,
     ValueStep,
+}
+
+// Defines an accessibility action.
+pub enum AccessibilityAction {
+    Default,
+    Focus,
+    Blur,
+    Collapse,
+    Expand,
+    CustomAction,
+    Decrement,
+    Increment,
+    // FIXME: Can it be currently supported?
+    HideToolTip,
+    // FIXME: Can it be currently supported?
+    ShowToolTip,
+    ReplaceSelectedText(SharedString),
+    ScrollBackward,
+    ScrollDown,
+    ScrollForward,
+    ScrollLeft,
+    ScrollRight,
+    ScrollUp,
+    ScrollIntoView,
+    ScrollToPoint(LogicalPoint),
+    SetScrollOffset(LogicalVector),
+    SetTextSelection(Option<core::ops::Range<i32>>),
+    // FIXME: Do we need this?
+    SetSequentialFocusNavigationStartingPoint,
+    SetValue(f64),
+    // FIXME: Can it be currently supported?
+    ShowContextMenu,
+}
+
+bitflags! {
+    // Define a accessibility actions that currently supported by Slint.
+    pub struct SupportedAccessibilityAction: u32 {
+        const Default = 0b00000001;
+        const Focus = 0b00000010;
+        const Blur = 0b00000011;
+        const Collapse = 0b00000100;
+        const Expand = 0b00000110;
+        const CustomAction = 0b00000111;
+        const Decrement = 0b00001000;
+        const Increment = 0b00001001;
+        const HideToolTip = 0b00001010;
+        const ShowToolTip = 0b00001011;
+        const ReplaceSelectedText = 0b00001100;
+        const ScrollBackward = 0b00001101;
+        const ScrollDown = 0b00001110;
+        const ScrollForward = 0b00001110;
+        const ScrollLeft = 0b00001111;
+        const ScrollRight = 0b00010000;
+        const ScrollUp = 0b00010001;
+        const ScrollIntoView = 0b00010010;
+        const ScrollToPoint = 0b00010011;
+        const SetScrollOffset = 0b00010100;
+        const SetTextSelection = 0b00010101;
+        const SetSequentialFocusNavigationStartingPoint = 0b00010110;
+        const SetValue = 0b00010111;
+        const ShowContextMenu = 0b00011000;
+    }
 }
 
 /// Find accessible descendents of `root_item`.

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -57,26 +57,26 @@ pub enum AccessibilityAction {
 bitflags! {
     // Define a accessibility actions that currently supported by Slint.
     pub struct SupportedAccessibilityAction: u32 {
-        const Default = 0b00000001;
-        const Focus = 0b00000010;
-        const Blur = 0b00000011;
-        const Collapse = 0b00000100;
-        const Expand = 0b00000110;
-        const CustomAction = 0b00000111;
-        const Decrement = 0b00001000;
-        const Increment = 0b00001001;
-        const ReplaceSelectedText = 0b00001100;
-        const ScrollBackward = 0b00001101;
-        const ScrollDown = 0b00001110;
-        const ScrollForward = 0b00001110;
-        const ScrollLeft = 0b00001111;
-        const ScrollRight = 0b00010000;
-        const ScrollUp = 0b00010001;
-        const ScrollIntoView = 0b00010010;
-        const ScrollToPoint = 0b00010011;
-        const SetScrollOffset = 0b00010100;
-        const SetTextSelection = 0b00010101;
-        const SetValue = 0b00010111;
+        const Default = 1;
+        const Focus = 1 << 1;
+        const Blur = 1 << 2;
+        const Collapse = 1 << 4;
+        const Expand = 1 << 5;
+        const CustomAction = 1 << 6;
+        const Decrement = 1 << 7;
+        const Increment = 1 << 8;
+        const ReplaceSelectedText = 1 << 9;
+        const ScrollBackward = 1 << 10;
+        const ScrollDown = 1 << 11;
+        const ScrollForward = 1 << 12;
+        const ScrollLeft = 1 << 13;
+        const ScrollRight = 1 << 14;
+        const ScrollUp = 1 << 15;
+        const ScrollIntoView = 1 << 16;
+        const ScrollToPoint = 1 << 17;
+        const SetScrollOffset = 1 << 18;
+        const SetTextSelection = 1 << 19;
+        const SetValue = 1 << 20;
     }
 }
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -34,22 +34,9 @@ pub enum AccessibleStringProperty {
 pub enum AccessibilityAction {
     Default,
     Focus,
-    Blur,
-    Collapse,
-    Expand,
-    CustomAction,
     Decrement,
     Increment,
     ReplaceSelectedText(SharedString),
-    ScrollBackward,
-    ScrollDown,
-    ScrollForward,
-    ScrollLeft,
-    ScrollRight,
-    ScrollUp,
-    ScrollIntoView,
-    ScrollToPoint(LogicalPoint),
-    SetScrollOffset(LogicalVector),
     SetTextSelection(Option<core::ops::Range<i32>>),
     SetValue(f64),
 }
@@ -59,24 +46,11 @@ bitflags! {
     pub struct SupportedAccessibilityAction: u32 {
         const Default = 1;
         const Focus = 1 << 1;
-        const Blur = 1 << 2;
-        const Collapse = 1 << 4;
-        const Expand = 1 << 5;
-        const CustomAction = 1 << 6;
-        const Decrement = 1 << 7;
-        const Increment = 1 << 8;
-        const ReplaceSelectedText = 1 << 9;
-        const ScrollBackward = 1 << 10;
-        const ScrollDown = 1 << 11;
-        const ScrollForward = 1 << 12;
-        const ScrollLeft = 1 << 13;
-        const ScrollRight = 1 << 14;
-        const ScrollUp = 1 << 15;
-        const ScrollIntoView = 1 << 16;
-        const ScrollToPoint = 1 << 17;
-        const SetScrollOffset = 1 << 18;
-        const SetTextSelection = 1 << 19;
-        const SetValue = 1 << 20;
+        const Decrement = 1 << 2;
+        const Increment = 1 << 3;
+        const ReplaceSelectedText = 1 << 4;
+        const SetTextSelection = 1 << 5;
+        const SetValue = 1 << 6;
     }
 }
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -51,7 +51,7 @@ pub enum AccessibilityAction {
     ScrollToPoint(LogicalPoint),
     SetScrollOffset(LogicalVector),
     SetTextSelection(Option<core::ops::Range<i32>>),
-    SetValue(f64)
+    SetValue(f64),
 }
 
 bitflags! {

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -6,10 +6,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use crate::{
-    items::ItemRc,
-    SharedString,
-};
+use crate::{items::ItemRc, SharedString};
 
 use bitflags::bitflags;
 


### PR DESCRIPTION
The adds only the enums / structs needed to implement accessibility actions. There is no functionality yet. This is the first step to implement #2872. The enum is a copy of the available accessibility actions provides by accesskit, before merging we need to check what is really needed for Slint and can be already implemented with the current feature set.