### PR TITLE
Fix panic when loading unsupported images that are embedded in generated code

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2124,7 +2124,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                     quote!(sp::Image::default())
                 }
                 crate::expression_tree::ImageReference::AbsolutePath(path) => {
-                    quote!(sp::Image::load_from_path(::std::path::Path::new(#path)).unwrap())
+                    quote!(sp::Image::load_from_path(::std::path::Path::new(#path)).unwrap_or_default())
                 }
                 crate::expression_tree::ImageReference::EmbeddedData { resource_id, extension } => {
                     let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", resource_id);

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -834,9 +834,7 @@ impl BorrowedOpenGLTextureBuilder {
 #[cfg(feature = "image-decoders")]
 pub fn load_image_from_embedded_data(data: Slice<'static, u8>, format: Slice<'_, u8>) -> Image {
     self::cache::IMAGE_CACHE.with(|global_cache| {
-        global_cache.borrow_mut().load_image_from_embedded_data(data, format).unwrap_or_else(|| {
-            panic!("internal error: embedded image data is not supported by run-time library",)
-        })
+        global_cache.borrow_mut().load_image_from_embedded_data(data, format).unwrap_or_default()
     })
 }
 

--- a/tests/cases/elements/image.slint
+++ b/tests/cases/elements/image.slint
@@ -13,12 +13,16 @@ TestCase := Rectangle {
         source-clip-x: 20;
     }
 
+    img3 := Image {
+        source: @image-url("image.slint");
+    }
+
     out property <image> with-border: @image-url("dog.jpg", nine-slice(12 13 14 15));
 
     property <length> img_width: img.width;
     property <length> img_height: img.height;
     property <bool> test: img2.source-clip-height * 1px == img2.height && img2.source-clip-width * 1px == img2.width &&
-         img2.width/1px == img2.source.width - 20;
+         img2.width/1px == img2.source.width - 20 && img3.source.width == 0 && img3.source.height == 0;
 }
 
 /*


### PR DESCRIPTION
The call to load the image already prints a message to stderr, so don't panic but return a null image instead.

cc #4846