### PR TITLE
esp-idf: poll for touch events if there's no touch interrupt assigned

### DIFF
--- a/api/cpp/esp-idf/slint/CMakeLists.txt
+++ b/api/cpp/esp-idf/slint/CMakeLists.txt
@@ -4,8 +4,7 @@
 idf_component_register(
     SRCS "src/slint-esp.cpp"
     INCLUDE_DIRS "include"
-    REQUIRES "esp_lcd" "esp_lcd_touch"
-    PRIV_REQUIRES "esp_timer")
+    REQUIRES "esp_lcd" "esp_lcd_touch")
 
 if (CONFIG_IDF_TARGET_ARCH_XTENSA)
     set(Rust_CARGO_TARGET "xtensa-${IDF_TARGET}-none-elf")


### PR DESCRIPTION
This is implemented by falling back to a polling timer and changing the Slint animation/timer update mechanism to also use a timer. That way we don't have to call update_timers_and_animations() every time the app wakes up to poll for touch.

The use of esp timers also has the advantage of offering better precision. The FreeRTOS timers are as granular as the tick, which is 5ms.