### PR TITLE
Rename the example binary that needs to run on android

### DIFF
--- a/.github/workflows/embedded_build.yaml
+++ b/.github/workflows/embedded_build.yaml
@@ -77,8 +77,8 @@ jobs:
               with:
                   name: printerdemo-${{ matrix.target }}
                   path: |
-                      target/${{ matrix.target }}/release/printerdemo
-                      target/${{ matrix.target }}/release/todo
+                      target/${{ matrix.target }}/release/printerdemo-bin
+                      target/${{ matrix.target }}/release/todo-bin
                       target/${{ matrix.target }}/release/gallery
                       target/${{ matrix.target }}/release/viewer
                       target/${{ matrix.target }}/release/energy-monitor

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -510,7 +510,7 @@ jobs:
                   name: android-demo
                   path: |
                     target/release/apk/energy-monitor.apk
-                    target/release/apk/todo_lib.apk
+                    target/release/apk/todo.apk
 
 # Purely quality-assurance related jobs, not relevant for release artefacts
     qa-esp-idf:
@@ -553,8 +553,8 @@ jobs:
               working-directory: examples/carousel/esp-idf/s2-kaluga-kit
               run: |
                   . ${IDF_PATH}/export.sh
-                  idf.py build      
-    
+                  idf.py build
+
     qa-tree-sitter-latest:
         uses: ./.github/workflows/tree_sitter.yaml
         with:
@@ -593,4 +593,4 @@ jobs:
                   export BINDGEN_EXTRA_CLANG_ARGS=$OECORE_TUNE_CCARGS
                   mkdir ${{ runner.workspace }}/cppbuild
                   cmake -GNinja -B ${{ runner.workspace }}/cppbuild -S . -DRust_CARGO_TARGET=${{ matrix.target }} -DSLINT_BUILD_TESTING=ON -DSLINT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Debug -DSLINT_FEATURE_RENDERER_SKIA=ON -DSLINT_FEATURE_BACKEND_QT=OFF -DSLINT_FEATURE_BACKEND_LINUXKMS=ON -DSLINT_FEATURE_INTERPRETER=ON
-                  cmake --build ${{ runner.workspace }}/cppbuild          
+                  cmake --build ${{ runner.workspace }}/cppbuild

--- a/api/rs/slint/README.md
+++ b/api/rs/slint/README.md
@@ -59,5 +59,5 @@ You can quickly try out the [examples](/examples) by cloning this repo and runni
 
 ```sh
 # Runs the "printerdemo" example
-cargo run --release --bin printerdemo
+cargo run --release --bin printerdemo-bin
 ```

--- a/docker/Dockerfile.torizon-demos
+++ b/docker/Dockerfile.torizon-demos
@@ -37,7 +37,7 @@ ENV PKG_CONFIG_ALLOW_CROSS=1
 COPY . /slint
 WORKDIR /slint
 RUN mkdir demos \
-    && for demo in printerdemo slide_puzzle gallery opengl_underlay carousel todo energy-monitor; do \
+    && for demo in printerdemo-bin slide_puzzle gallery opengl_underlay carousel todo-bin energy-monitor; do \
     cargo build --release --target $RUST_TOOLCHAIN_ARCH --features slint/renderer-skia,slint/backend-linuxkms-noseat -p $demo || exit 1; \
     cp target/$RUST_TOOLCHAIN_ARCH/release/$demo ./demos/; \
     done
@@ -46,7 +46,7 @@ RUN mkdir demos \
 FROM --platform=$IMAGE_ARCH torizon/$BASE_NAME:3
 
 LABEL org.opencontainers.image.source=https://github.com/slint-ui/slint
-LABEL org.opencontainers.image.description="Container image providing Slint demos for use on Torizon. Run with docker run  --user=torizon -v /run/udev:/run/udev -v /dev:/dev -v /tmp:/tmp --device-cgroup-rule='c 199:* rmw' --device-cgroup-rule='c 226:* rmw' --device-cgroup-rule='c 13:* rmw' --device-cgroup-rule='c 4:* rmw'. Available demos: printerdemo slide_puzzle gallery opengl_underlay carousel todo"
+LABEL org.opencontainers.image.description="Container image providing Slint demos for use on Torizon. Run with docker run  --user=torizon -v /run/udev:/run/udev -v /dev:/dev -v /tmp:/tmp --device-cgroup-rule='c 199:* rmw' --device-cgroup-rule='c 226:* rmw' --device-cgroup-rule='c 13:* rmw' --device-cgroup-rule='c 4:* rmw'. Available demos: printerdemo-bin slide_puzzle gallery opengl_underlay carousel todo-bin"
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install libfontconfig1 libxkbcommon0 libinput10 fonts-noto-core fonts-noto-cjk fonts-noto-cjk-extra fonts-noto-color-emoji fonts-noto-ui-core fonts-noto-ui-extra \

--- a/examples/README.md
+++ b/examples/README.md
@@ -188,7 +188,7 @@ cargo run --release
 or you can run them from anywhere in the Cargo workspace by name:
 
 ```sh
-cargo run --release --bin printerdemo
+cargo run --release --bin printerdemo-bin
 ```
 
 ### Wasm builds

--- a/examples/printerdemo/rust/Cargo.toml
+++ b/examples/printerdemo/rust/Cargo.toml
@@ -12,12 +12,11 @@ license = "MIT"
 
 [[bin]]
 path = "main.rs"
-name = "printerdemo"
+name = "printerdemo-bin"
 
 [lib]
 path = "lib.rs"
 crate-type = ["lib", "cdylib"]
-name = "printerdemo_lib"
 
 [dependencies]
 slint = { path = "../../../api/rs/slint", features = ["backend-android-activity-05"] }

--- a/examples/printerdemo/rust/main.rs
+++ b/examples/printerdemo/rust/main.rs
@@ -5,5 +5,5 @@
 // Just forward to the library in main
 
 fn main() {
-    printerdemo_lib::main();
+    printerdemo::main();
 }

--- a/examples/todo/rust/Cargo.toml
+++ b/examples/todo/rust/Cargo.toml
@@ -13,11 +13,10 @@ license = "MIT"
 [lib]
 crate-type = ["lib", "cdylib"]
 path = "lib.rs"
-name = "todo_lib"
 
 [[bin]]
 path = "main.rs"
-name = "todo"
+name = "todo-bin"
 
 [dependencies]
 slint = { path = "../../../api/rs/slint", features = ["serde", "backend-android-activity-05"] }

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -5,5 +5,5 @@
 // Just forward to the library in main
 
 fn main() {
-    todo_lib::main();
+    todo::main();
 }


### PR DESCRIPTION
 - we can't give a different name to the lib otherwise cargo-apk can't find the .so file
 - the binary can't have the same name as the lib otherwise we get a warning on Windows about duplicated .PDB files (which is why the lib was renamed)