### PR TITLE
compiler: Don't panic when using `foo.focus(something)`

### DIFF
--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -168,9 +168,8 @@ impl<'a> LocalFocusForwards<'a> {
             ) = function.as_ref()
             {
                 if arguments.len() != 1 {
-                    panic!(
-                        "internal compiler error: Invalid argument generated for SetFocusItem call"
-                    );
+                    assert!(self.diag.has_error(), "Invalid argument generated for SetFocusItem call");
+                    return
                 }
                 if let Expression::ElementReference(weak_focus_target) = &arguments[0] {
                     let mut focus_target = weak_focus_target.upgrade().expect(

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -168,8 +168,11 @@ impl<'a> LocalFocusForwards<'a> {
             ) = function.as_ref()
             {
                 if arguments.len() != 1 {
-                    assert!(self.diag.has_error(), "Invalid argument generated for SetFocusItem call");
-                    return
+                    assert!(
+                        self.diag.has_error(),
+                        "Invalid argument generated for SetFocusItem call"
+                    );
+                    return;
                 }
                 if let Expression::ElementReference(weak_focus_target) = &arguments[0] {
                     let mut focus_target = weak_focus_target.upgrade().expect(

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -896,6 +896,8 @@ impl Expression {
             (Self::from_expression_node(n.clone(), ctx), Some(NodeOrToken::from((*n).clone())))
         });
 
+        let mut adjust_arg_count = 0;
+
         let function = match function {
             Expression::BuiltinMacroReference(mac, n) => {
                 arguments.extend(sub_expr);
@@ -903,6 +905,7 @@ impl Expression {
             }
             Expression::MemberFunction { base, base_node, member } => {
                 arguments.push((*base, base_node));
+                adjust_arg_count = 1;
                 member
             }
             _ => Box::new(function),
@@ -915,8 +918,8 @@ impl Expression {
                     ctx.diag.push_error(
                         format!(
                             "The callback or function expects {} arguments, but {} are provided",
-                            args.len(),
-                            arguments.len()
+                            args.len() - adjust_arg_count,
+                            arguments.len() - adjust_arg_count,
                         ),
                         &node,
                     );

--- a/internal/compiler/tests/syntax/focus/focus_wrong_args.slint
+++ b/internal/compiler/tests/syntax/focus/focus_wrong_args.slint
@@ -1,0 +1,22 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+
+
+export component WrongFocus {
+
+    fs := FocusScope {}
+
+    ta := TouchArea {
+        clicked => {
+            fs.focus(0);
+//          ^error{The callback or function expects 0 arguments, but 1 are provided}
+            ta.focus();
+//             ^error{focus\(\) can only be called on focusable elements}
+            ta.focus(0);
+//          ^error{The callback or function expects 0 arguments, but 1 are provided}
+        }
+    }
+
+
+}


### PR DESCRIPTION
Just ignore the case where focus has more argument that planed as it has been reported as an error earlier.

Also fix the error message for calling member function with the wrong number of argument to not include the base in the count.

Fix #4883