### PR TITLE
Work around gettext-rs not compiling on macOS with latest xcode

### DIFF
--- a/examples/gallery/Cargo.toml
+++ b/examples/gallery/Cargo.toml
@@ -15,6 +15,10 @@ path = "main.rs"
 name = "gallery"
 
 [dependencies]
+slint = { path = "../../api/rs/slint" }
+
+# Disable gettext on macOS due to https://github.com/Koka/gettext-rs/issues/114
+[target.'cfg(not(target_os = "macos"))'.dependencies]
 slint = { path = "../../api/rs/slint", features=["gettext"] }
 
 [build-dependencies]


### PR DESCRIPTION
gettext doesn't compile anymore:
```
/var/folders/x6/97fjm0c540s7yn9zlv7fp9k00000gn/T/tc81e-0/gettext/libtextstyle/lib/obstack.c:351:31: error: incompatible function pointer types initializing 'void (*)(void) __attribute__((noreturn))' with an expression of type 'void (void)' [-Wincompatible-function-pointer-types]
  __attribute_noreturn__ void (*obstack_alloc_failed_handler) (void)
```
This works around it by not enabling it on macOS in the gallery.