### PR TITLE
Keep the optimized ElementRc around.

### DIFF
--- a/internal/compiler/passes/move_declarations.rs
+++ b/internal/compiler/passes/move_declarations.rs
@@ -107,11 +107,6 @@ fn do_move_declarations(component: &Rc<Component>) {
         r.bindings.extend(new_root_bindings);
         r.property_analysis.borrow_mut().extend(new_root_property_analysis);
     }
-
-    // By now, the optimized item should be unused
-    #[cfg(debug_assertions)]
-    assert_optimized_item_unused(component.optimized_elements.borrow().as_slice());
-    core::mem::take(&mut *component.optimized_elements.borrow_mut());
 }
 
 fn fixup_reference(nr: &mut NamedReference) {
@@ -168,17 +163,5 @@ fn simplify_optimized_items(items: &[ElementRc]) {
                 unreachable!("Only builtin items should be optimized")
             }
         })
-    }
-}
-
-/// Check there are no longer references to optimized items
-#[cfg(debug_assertions)]
-fn assert_optimized_item_unused(items: &[ElementRc]) {
-    for e in items {
-        recurse_elem(e, &(), &mut |e, _| {
-            assert_eq!(Rc::strong_count(e), 1);
-            // no longer working because we have weak count in the named reference holder
-            //assert_eq!(Rc::weak_count(e), 0);
-        });
     }
 }

--- a/tests/cases/issues/issue_4884_show_popup.slint
+++ b/tests/cases/issues/issue_4884_show_popup.slint
@@ -1,0 +1,42 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+component DialogBox inherits Rectangle {
+    callback show-dialog();
+
+    show-dialog() => {
+        dialog.show();
+    }
+
+    dialog := PopupWindow { }
+}
+
+export component TestCase inherits Window {
+    height: 30px;
+    width: 30px;
+    dialog := DialogBox { }
+    TouchArea {
+        clicked => {
+            dialog.show-dialog();
+        }
+    }
+}
+
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 5., 5.);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 5., 5.);
+```
+
+```js
+var instance = new slint.TestCase();
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+```
+*/


### PR DESCRIPTION
They can be used in as the Popup's parent_element which we need to get to the parent's enclosing Component.
Since that parent_element is not in a RefCell, we can't change it. parent_element is a Weak so if its optimized item is removed, we will not be able to access it.

Fix #4884