### PR TITLE
Android: cursor handle

### DIFF
--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -71,7 +71,7 @@ impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
         match request {
             i_slint_core::window::InputMethodRequest::Enable(props) => {
                 self.java_helper
-                    .set_imm_data(&props)
+                    .set_imm_data(&props, self.window.scale_factor())
                     .unwrap_or_else(|e| print_jni_error(&self.app, e));
                 self.java_helper
                     .show_or_hide_soft_input(true)
@@ -79,7 +79,7 @@ impl i_slint_core::window::WindowAdapterInternal for AndroidWindowAdapter {
             }
             i_slint_core::window::InputMethodRequest::Update(props) => {
                 self.java_helper
-                    .set_imm_data(&props)
+                    .set_imm_data(&props, self.window.scale_factor())
                     .unwrap_or_else(|e| print_jni_error(&self.app, e));
             }
             i_slint_core::window::InputMethodRequest::Disable => {

--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -203,11 +203,15 @@ class SlintInputView extends View {
 
     private InputHandle mHandle;
 
-    public void setCursorPos(int rect_x, int rect_y, int rect_w, int rect_h) {
-        if (mHandle == null) {
-            mHandle = new InputHandle(this, android.R.attr.textSelectHandle);
+    public void setCursorPos(int rect_x, int rect_y, int rect_w, int rect_h, boolean show) {
+        if (show) {
+            if (mHandle == null) {
+                mHandle = new InputHandle(this, android.R.attr.textSelectHandle);
+            }
+            mHandle.setPosition(rect_x + rect_w / 2, rect_y + rect_h + 2 * rect_w);
+        } else if (mHandle != null) {
+            mHandle.hide();
         }
-        mHandle.setPosition(rect_x + rect_w / 2, rect_y + rect_h + 2 * rect_w);
     }
 }
 
@@ -257,7 +261,7 @@ public class SlintAndroidJavaHelper {
     static public native void moveCursorHandle(int id, int pos_x, int pos_y);
 
     public void set_imm_data(String text, int cursor_position, int anchor_position, int preedit_start, int preedit_end,
-            int rect_x, int rect_y, int rect_w, int rect_h, int input_type) {
+            int rect_x, int rect_y, int rect_w, int rect_h, int input_type, boolean show_cursor_handles) {
 
         mActivity.runOnUiThread(new Runnable() {
             @Override
@@ -265,7 +269,7 @@ public class SlintAndroidJavaHelper {
                 int selStart = Math.min(cursor_position, anchor_position);
                 int selEnd = Math.max(cursor_position, anchor_position);
                 mInputView.setText(text, selStart, selEnd, preedit_start, preedit_end, input_type);
-                mInputView.setCursorPos(rect_x, rect_y, rect_w, rect_h);
+                mInputView.setCursorPos(rect_x, rect_y, rect_w, rect_h, show_cursor_handles);
             }
         });
     }

--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -3,19 +3,15 @@
 
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.content.Context;
 import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.text.Editable;
 import android.text.Selection;
 import android.text.SpannableStringBuilder;
-import android.util.DisplayMetrics;
-import android.util.TypedValue;
 import android.view.inputmethod.InputMethodManager;
 import android.app.Activity;
 import android.widget.FrameLayout;
@@ -28,6 +24,8 @@ class InputHandle extends ImageView {
     private float mPressedX;
     private float mPressedY;
     private SlintInputView mRootView;
+    private int cursorX;
+    private int cursorY;
 
     public InputHandle(SlintInputView rootView, int attr) {
         super(rootView.getContext());
@@ -57,14 +55,14 @@ class InputHandle extends ImageView {
     public boolean onTouchEvent(MotionEvent ev) {
         switch (ev.getActionMasked()) {
             case MotionEvent.ACTION_DOWN: {
-                mPressedX = ev.getRawX();
-                mPressedY = ev.getRawY();
+                mPressedX = ev.getRawX() - cursorX;
+                mPressedY = ev.getRawY() - cursorY;
                 break;
             }
 
             case MotionEvent.ACTION_MOVE: {
-                // setSelectionAt
-                // (Math.round(ev.getRawX() - mPressedX), Math.round(ev.getRawY() - mPressedY));
+                SlintAndroidJavaHelper.moveCursorHandle(0, Math.round(ev.getRawX() - mPressedX),
+                        Math.round(ev.getRawY() - mPressedY));
                 break;
             }
             case MotionEvent.ACTION_UP:
@@ -75,7 +73,9 @@ class InputHandle extends ImageView {
     }
 
     public void setPosition(int x, int y) {
-        DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
+        cursorX = x;
+        cursorY = y;
+
         y += mPopupWindow.getHeight();
         x -= mPopupWindow.getWidth() / 2;
         mPopupWindow.showAtLocation(mRootView, 0, x, y);
@@ -253,6 +253,8 @@ public class SlintAndroidJavaHelper {
             int preeditOffset);
 
     static public native void setDarkMode(boolean dark);
+
+    static public native void moveCursorHandle(int id, int pos_x, int pos_y);
 
     public void set_imm_data(String text, int cursor_position, int anchor_position, int preedit_start, int preedit_end,
             int rect_x, int rect_y, int rect_w, int rect_h, int input_type) {

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -111,6 +111,7 @@ impl JavaHelper {
         &self,
         data: &i_slint_core::window::InputMethodProperties,
         scale_factor: f32,
+        show_cursor_handles: bool,
     ) -> Result<(), jni::errors::Error> {
         self.with_jni_env(|env, helper| {
             let mut text = data.text.to_string();
@@ -153,7 +154,7 @@ impl JavaHelper {
             env.call_method(
                 helper,
                 "set_imm_data",
-                "(Ljava/lang/String;IIIIIIIII)V",
+                "(Ljava/lang/String;IIIIIIIIIZ)V",
                 &[
                     JValue::Object(&text),
                     JValue::from(to_utf16(cursor_position) as jint),
@@ -165,6 +166,7 @@ impl JavaHelper {
                     JValue::from(cur_size.width as jint),
                     JValue::from(cur_size.height as jint),
                     JValue::from(input_type),
+                    JValue::from(show_cursor_handles as jboolean),
                 ],
             )?;
 
@@ -215,6 +217,7 @@ extern "system" fn Java_SlintAndroidJavaHelper_updateText(
 
     i_slint_core::api::invoke_from_event_loop(move || {
         if let Some(adaptor) = CURRENT_WINDOW.with_borrow(|x| x.upgrade()) {
+            adaptor.show_cursor_handles.set(false);
             let runtime_window = i_slint_core::window::WindowInner::from_pub(&adaptor.window);
             let event = if preedit_start != preedit_end {
                 let adjust = |pos| if pos <= preedit_start { pos } else if pos >= preedit_end { pos - preedit_end + preedit_start } else { preedit_start } as i32;

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -103,6 +103,7 @@ impl JavaHelper {
     pub fn set_imm_data(
         &self,
         data: &i_slint_core::window::InputMethodProperties,
+        scale_factor: f32
     ) -> Result<(), jni::errors::Error> {
         self.with_jni_env(|env, helper| {
             let mut text = data.text.to_string();
@@ -138,6 +139,10 @@ impl JavaHelper {
                 }
                 _ => 0 as jint,
             };
+
+            let cur_origin = data.cursor_rect_origin.to_physical(scale_factor);
+            let cur_size = data.cursor_rect_size.to_physical(scale_factor);
+
             env.call_method(
                 helper,
                 "set_imm_data",
@@ -148,10 +153,10 @@ impl JavaHelper {
                     JValue::from(to_utf16(anchor_position) as jint),
                     JValue::from(to_utf16(data.preedit_offset) as jint),
                     JValue::from(to_utf16(data.preedit_offset + data.preedit_text.len()) as jint),
-                    JValue::from(data.cursor_rect_origin.x as jint),
-                    JValue::from(data.cursor_rect_origin.y as jint),
-                    JValue::from(data.cursor_rect_size.width as jint),
-                    JValue::from(data.cursor_rect_size.height as jint),
+                    JValue::from(cur_origin.x as jint),
+                    JValue::from(cur_origin.y as jint),
+                    JValue::from(cur_size.width as jint),
+                    JValue::from(cur_size.height as jint),
                     JValue::from(input_type),
                 ],
             )?;

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1001,7 +1001,7 @@ impl TextInput {
         new_cursor_pos != last_cursor_pos
     }
 
-    fn set_cursor_position(
+    pub fn set_cursor_position(
         self: Pin<&Self>,
         new_position: i32,
         reset_preferred_x_pos: bool,
@@ -1426,7 +1426,7 @@ impl TextInput {
         )
     }
 
-    fn byte_offset_for_position(
+    pub fn byte_offset_for_position(
         self: Pin<&Self>,
         pos: LogicalPoint,
         window_adapter: &Rc<dyn WindowAdapter>,

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1121,8 +1121,10 @@ impl TextInput {
         let cursor_position = self.cursor_position(&text);
         let anchor_position = self.anchor_position(&text);
         let cursor_relative = self.cursor_rect_for_byte_offset(cursor_position, window_adapter);
-        let cursor_rect_origin =
-            crate::api::LogicalPosition::from_euclid(self_rc.map_to_window(cursor_relative.origin));
+        let geometry = self_rc.geometry();
+        let cursor_rect_origin = crate::api::LogicalPosition::from_euclid(
+            self_rc.map_to_window(cursor_relative.origin + geometry.origin.to_vector()),
+        );
         let cursor_rect_size = crate::api::LogicalSize::from_euclid(cursor_relative.size);
 
         InputMethodProperties {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -372,7 +372,7 @@ pub struct WindowInner {
     mouse_input_state: Cell<MouseInputState>,
     pub(crate) modifiers: Cell<InternalKeyboardModifierState>,
 
-    /// itemRC will retrieve on wasms
+    /// ItemRC that currently have the focus. (possibly a, instance of TextInput)
     pub focus_item: RefCell<crate::item_tree::ItemWeak>,
     /// The last text that was sent to the input method
     pub(crate) last_ime_text: RefCell<SharedString>,
@@ -1006,12 +1006,12 @@ impl WindowInner {
         self.pinned_fields.scale_factor.set(factor)
     }
 
-    /// Returns the scale factor set on the window, as provided by the windowing system.
+    /// Reads the global property `TextInputInterface.text-input-focused`
     pub fn text_input_focused(&self) -> bool {
         self.pinned_fields.as_ref().project_ref().text_input_focused.get()
     }
 
-    /// Sets the scale factor for the window. This is set by the backend or for testing.
+    /// Sets the global property `TextInputInterface.text-input-focused`
     pub fn set_text_input_focused(&self, value: bool) {
         self.pinned_fields.text_input_focused.set(value)
     }


### PR DESCRIPTION
This patch show a cursor handle so that it can be dragged with the finger.

Right now there is only one handle (there should be two if and only if there is a selection)

