### PR TITLE
Material style: fix text color

### DIFF
--- a/internal/compiler/widgets/common/common.slint
+++ b/internal/compiler/widgets/common/common.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
-import { StyleMetrics, ScrollView } from "std-widgets-impl.slint";
+import { StyleMetrics, ScrollView, Palette } from "std-widgets-impl.slint";
 
 export component TextEdit inherits ScrollView {
     in property <TextWrap> wrap <=> i-text-input.wrap;
@@ -53,6 +53,8 @@ export component TextEdit inherits ScrollView {
         color: self.enabled ? StyleMetrics.textedit-text-color : StyleMetrics.textedit-text-color-disabled;
         single-line: false;
         wrap: word-wrap;
+        selection-background-color: Palette.selection-background;
+        selection-foreground-color: Palette.selection-foreground;
 
         edited => {
             root.edited(self.text);

--- a/internal/compiler/widgets/cosmic-light/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic-light/std-widgets-impl.slint
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 import { StyleMetrics, ScrollView, Button, ListItem, Palette } from "../cosmic-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, ListItem }
+export { StyleMetrics, ScrollView, Button, ListItem, Palette }

--- a/internal/compiler/widgets/fluent-light/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent-light/std-widgets-impl.slint
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
 
 import { StyleMetrics, ScrollView, Button, ListItem, Palette } from "../fluent-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, ListItem }
+export { StyleMetrics, ScrollView, Button, ListItem, Palette }

--- a/internal/compiler/widgets/material-base/lineedit.slint
+++ b/internal/compiler/widgets/material-base/lineedit.slint
@@ -51,7 +51,6 @@ export component LineEdit {
         focused when root.has-focus : {
             i-background.border-width: 2px;
             i-background.border-color: MaterialPalette.accent-background;
-            i-base.text-color: MaterialPalette.accent-background;
         }
     ]
 


### PR DESCRIPTION
The text color for the text input that has the focus is the normal "on-surface" color according to https://m3.material.io/components/text-fields/specs

Also fix the selection color of the TextEdit