### PR TITLE
android: fix cursor and handle color

### DIFF
--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -7,6 +7,8 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.graphics.BlendMode;
+import android.graphics.BlendModeColorFilter;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.text.Editable;
@@ -84,6 +86,14 @@ class InputHandle extends ImageView {
 
     public void hide() {
         mPopupWindow.dismiss();
+    }
+
+    public void setHandleColor(int color) {
+        Drawable drawable = getDrawable();
+        if (drawable != null) {
+            drawable.setColorFilter(new BlendModeColorFilter(color, BlendMode.SRC_IN));
+            setImageDrawable(drawable);
+        }
     }
 }
 
@@ -213,6 +223,12 @@ class SlintInputView extends View {
             mHandle.hide();
         }
     }
+
+    public void setHandleColor(int color) {
+        if (mHandle != null) {
+            mHandle.setHandleColor(color);
+        }
+    }
 }
 
 public class SlintAndroidJavaHelper {
@@ -270,6 +286,16 @@ public class SlintAndroidJavaHelper {
                 int selEnd = Math.max(cursor_position, anchor_position);
                 mInputView.setText(text, selStart, selEnd, preedit_start, preedit_end, input_type);
                 mInputView.setCursorPos(rect_x, rect_y, rect_w, rect_h, show_cursor_handles);
+
+            }
+        });
+    }
+
+    public void set_handle_color(int color) {
+        mActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                mInputView.setHandleColor(color);
             }
         });
     }

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use i_slint_core::api::{PhysicalPosition, PhysicalSize};
-use i_slint_core::graphics::euclid;
+use i_slint_core::graphics::{euclid, Color};
 use i_slint_core::items::InputType;
 use i_slint_core::platform::WindowAdapter;
 use i_slint_core::SharedString;
@@ -189,6 +189,18 @@ impl JavaHelper {
             let width = env.get_field(&rect, "right", "I")?.i()? - x;
             let height = env.get_field(&rect, "bottom", "I")?.i()? - y;
             Ok((PhysicalPosition::new(x as _, y as _), PhysicalSize::new(width as _, height as _)))
+        })
+    }
+
+    pub fn set_handle_color(&self, color: Color) -> Result<(), jni::errors::Error> {
+        self.with_jni_env(|env, helper| {
+            env.call_method(
+                helper,
+                "set_handle_color",
+                "(I)V",
+                &[JValue::from(color.as_argb_encoded() as jint)],
+            )?;
+            Ok(())
         })
     }
 }

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -489,7 +489,8 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
         let font_request =
             text_input.font_request(&WindowInner::from_pub(&self.window).window_adapter());
 
-        let paint = match self.brush_to_paint(text_input.color(), max_width, max_height) {
+        let text_color = text_input.color();
+        let paint = match self.brush_to_paint(text_color.clone(), max_width, max_height) {
             Some(paint) => paint,
             None => return,
         };
@@ -544,7 +545,10 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
             .translate(layout_top_left.to_vector());
 
             let cursor_paint = match self.brush_to_paint(
-                text_input.color(),
+                #[cfg(not(target_os = "android"))]
+                text_color,
+                #[cfg(target_os = "android")]
+                Brush::SolidColor(text_input.selection_background_color().with_alpha(1.)),
                 cursor_rect.width_length(),
                 cursor_rect.height_length(),
             ) {


### PR DESCRIPTION
On android, the handle is the same as the cursor color and the cursor color is usually the "accent" color.
We can't know the accent color from the native code, but we know the selection color which is the accent color with a lesser opacity.