### PR TITLE
Making iot-dashboard more friendly for tall windows

### DIFF
--- a/examples/iot-dashboard/main.slint
+++ b/examples/iot-dashboard/main.slint
@@ -44,6 +44,7 @@ import { MenuBar, TopBar, Usage, IndoorTemperature, Humidity, MyDevices,
 
 
 component MainContent inherits VerticalLayout {
+    alignment: start;
     spacing: 24px;
     TopBar {
         Clock {


### PR DESCRIPTION
Align the main content to the start (top) to avoid stretching.