### PR TITLE
Update skia-safe

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -42,7 +42,7 @@ pin-weak = "1"
 scoped-tls-hkt = "0.1"
 raw-window-handle = { version = "0.5", features = ["std"] }
 
-skia-safe = { version = "0.71.0", features = ["textlayout", "gl"] }
+skia-safe = { version = "0.72.0", features = ["textlayout", "gl"] }
 glow = { version = "0.13" }
 unicode-segmentation = { version = "1.8.0" }
 
@@ -57,8 +57,8 @@ softbuffer = { workspace = true, default-features = false }
 bytemuck = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
-windows = { version = "0.52.0", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
-skia-safe = { version = "0.71.0", features = ["d3d"] }
+windows = { version = "0.54.0", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
+skia-safe = { version = "0.72.0", features = ["d3d"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = { version = "0.25.0" }
@@ -68,10 +68,10 @@ metal = { version = "0.27.0" }
 foreign-types = { version = "0.5.0" }
 objc = { version = "0.2.7" }
 core-graphics-types = { version = "0.1.1" }
-skia-safe = { version = "0.71.0", features = ["metal"] }
+skia-safe = { version = "0.72.0", features = ["metal"] }
 
 [target.'cfg(not(any(target_os = "macos", target_family = "windows")))'.dependencies]
-skia-safe = { version = "0.71.0", features = ["gl"] }
+skia-safe = { version = "0.72.0", features = ["gl"] }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -4,7 +4,7 @@
 use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::platform::PlatformError;
 use std::cell::RefCell;
-use windows::core::ComInterface;
+use windows::core::Interface;
 use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_0;
 use windows::Win32::Graphics::Dxgi::Common::DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN;
 


### PR DESCRIPTION
This brings in Skia Milestone 123 and fixes the use of directwrite on Windows. For more details, see https://github.com/rust-skia/rust-skia/releases/tag/0.72.0