### PR TITLE
Add support for raw-window-handle

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -22,7 +22,7 @@ jobs:
             - name: Set up rgb crate rustdoc link
               run: |
                   rgb_version=`grep 'rgb = '  internal/core/Cargo.toml | sed 's/^.*"\(.*\)"/\1/'`
-                  echo "RUSTDOCFLAGS=$RUSTDOCFLAGS --extern-html-root-url rgb=https://docs.rs/rgb/$rgb_version/ --extern-html-root-url android_activity=https://docs.rs/android-activity/0.5/ -Z unstable-options" >> $GITHUB_ENV
+                  echo "RUSTDOCFLAGS=$RUSTDOCFLAGS --extern-html-root-url rgb=https://docs.rs/rgb/$rgb_version/ --extern-html-root-url android_activity=https://docs.rs/android-activity/0.5/ --extern-html-root-url raw_window_handle=https://docs.rs/raw_window_handle/0.6 -Z unstable-options" >> $GITHUB_ENV
             - uses: ./.github/actions/install-nodejs
             - name: Cache mdbook and mdbook-linkcheck
               uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,8 @@ strum = { version = "0.26.1", default-features = false, features = ["derive"] }
 toml_edit = { version = "0.22.7" }
 cfg_aliases = { version = "0.2.0" }
 
+rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["alloc"] }
+
 [profile.release]
 lto = true
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ strum = { version = "0.26.1", default-features = false, features = ["derive"] }
 toml_edit = { version = "0.22.7" }
 cfg_aliases = { version = "0.2.0" }
 
-rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["alloc"] }
+raw-window-handle-06 = { package = "raw-window-handle", version = "0.6", features = ["alloc"] }
 
 [profile.release]
 lto = true

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -79,8 +79,9 @@ unsafe-single-threaded = ["i-slint-core/unsafe-single-threaded"]
 accessibility = ["i-slint-backend-selector/accessibility"]
 
 ## Enable integration with [raw-window-handle](raw_window_handle_06) version 0.6. This provides a
+## [`Window::window_handle()`] function that returns a struct that implements
 ## [HasWindowHandle](raw_window_handle_06::HasWindowHandle) and
-## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation for slint::Window.
+## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation.
 raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
 
 #! ### Backends

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -208,4 +208,4 @@ rustdoc-args = [
   "--html-in-header",
   "docs/resources/slint-docs-highlight.html",
 ]
-features = ["document-features", "log", "gettext", "renderer-software", "renderer-femtovg"]
+features = ["document-features", "log", "gettext", "renderer-software", "renderer-femtovg", "raw-window-handle-06"]

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -78,9 +78,10 @@ unsafe-single-threaded = ["i-slint-core/unsafe-single-threaded"]
 ## APIs to support screen readers and other assistive technologies.
 accessibility = ["i-slint-backend-selector/accessibility"]
 
-### Enable integration with raw-window-handle version 0.6. This provides a HasWindowHandle and
-### HasDisplayHandle implementation for slint::Window.
-raw-window-handle-06 = ["i-slint-backend-selector/raw-window-handle-06"]
+## Enable integration with [raw-window-handle](raw_window_handle_06) version 0.6. This provides a
+## [HasWindowHandle](raw_window_handle_06::HasWindowHandle) and
+## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation for slint::Window.
+raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
 
 #! ### Backends
 
@@ -178,6 +179,8 @@ pin-weak = { version = "1.1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 
 log = { version = "0.4.17", optional = true }
+
+raw-window-handle-06 = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 # FemtoVG is disabled on android because it doesn't compile without setting RUST_FONTCONFIG_DLOPEN=on

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -78,6 +78,10 @@ unsafe-single-threaded = ["i-slint-core/unsafe-single-threaded"]
 ## APIs to support screen readers and other assistive technologies.
 accessibility = ["i-slint-backend-selector/accessibility"]
 
+### Enable integration with raw-window-handle version 0.6. This provides a HasWindowHandle and
+### HasDisplayHandle implementation for slint::Window.
+rwh_06 = ["i-slint-core/rwh_06", "i-slint-backend-selector/rwh_06"]
+
 #! ### Backends
 
 #! Slint needs a backend that will act as liaison between Slint and the OS.

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -80,7 +80,7 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 
 ### Enable integration with raw-window-handle version 0.6. This provides a HasWindowHandle and
 ### HasDisplayHandle implementation for slint::Window.
-rwh_06 = ["i-slint-core/rwh_06", "i-slint-backend-selector/rwh_06"]
+raw-window-handle-06 = ["i-slint-backend-selector/raw-window-handle-06"]
 
 #! ### Backends
 

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -32,6 +32,8 @@ renderer-software = ["i-slint-backend-winit?/renderer-software", "i-slint-core/s
 rtti = ["i-slint-core/rtti", "i-slint-backend-qt?/rtti"]
 accessibility = ["i-slint-backend-winit?/accessibility"]
 
+rwh_06 = ["i-slint-backend-winit?/rwh_06"]
+
 # note that default enable the i-slint-backend-qt, but not its enable feature
 default = ["i-slint-backend-qt", "backend-winit"]
 

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -32,7 +32,7 @@ renderer-software = ["i-slint-backend-winit?/renderer-software", "i-slint-core/s
 rtti = ["i-slint-core/rtti", "i-slint-backend-qt?/rtti"]
 accessibility = ["i-slint-backend-winit?/accessibility"]
 
-rwh_06 = ["i-slint-backend-winit?/rwh_06"]
+raw-window-handle-06 = ["i-slint-core/raw-window-handle-06", "i-slint-backend-winit?/raw-window-handle-06"]
 
 # note that default enable the i-slint-backend-qt, but not its enable feature
 default = ["i-slint-backend-qt", "backend-winit"]

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -27,6 +27,7 @@ renderer-skia-opengl = ["renderer-skia", "i-slint-renderer-skia/opengl"]
 renderer-skia-vulkan = ["renderer-skia", "i-slint-renderer-skia/vulkan"]
 renderer-software = ["dep:softbuffer", "dep:imgref", "dep:rgb", "i-slint-core/software-renderer-systemfonts", "dep:bytemuck", "winit/rwh_05"]
 accessibility = ["dep:accesskit", "dep:accesskit_winit"]
+rwh_06 = ["dep:rwh_06", "winit/rwh_06"]
 default = []
 
 [dependencies]
@@ -58,6 +59,8 @@ imgref = { version = "1.6.1", optional = true }
 rgb = { version = "0.8.27", optional = true }
 bytemuck = { workspace = true, optional = true, features = ["derive"] }
 
+rwh_06 = { workspace = true, optional = true }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap", "ClipboardEvent", "DataTransfer"] }
 wasm-bindgen = { version = "0.2" }
@@ -77,7 +80,7 @@ cocoa = { version = "0.25.0" }
 cfg_aliases = { workspace = true }
 
 [dev-dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "backend-winit", "renderer-software"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "backend-winit", "renderer-software", "rwh_06"] }
 
 [package.metadata.docs.rs]
 features = ["wayland", "renderer-software"]

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -27,7 +27,7 @@ renderer-skia-opengl = ["renderer-skia", "i-slint-renderer-skia/opengl"]
 renderer-skia-vulkan = ["renderer-skia", "i-slint-renderer-skia/vulkan"]
 renderer-software = ["dep:softbuffer", "dep:imgref", "dep:rgb", "i-slint-core/software-renderer-systemfonts", "dep:bytemuck", "winit/rwh_05"]
 accessibility = ["dep:accesskit", "dep:accesskit_winit"]
-rwh_06 = ["dep:rwh_06", "winit/rwh_06"]
+raw-window-handle-06 = ["dep:raw-window-handle-06", "winit/rwh_06"]
 default = []
 
 [dependencies]
@@ -59,7 +59,7 @@ imgref = { version = "1.6.1", optional = true }
 rgb = { version = "0.8.27", optional = true }
 bytemuck = { workspace = true, optional = true, features = ["derive"] }
 
-rwh_06 = { workspace = true, optional = true }
+raw-window-handle-06 = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap", "ClipboardEvent", "DataTransfer"] }
@@ -80,7 +80,7 @@ cocoa = { version = "0.25.0" }
 cfg_aliases = { workspace = true }
 
 [dev-dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "backend-winit", "renderer-software", "rwh_06"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "backend-winit", "renderer-software", "raw-window-handle-06"] }
 
 [package.metadata.docs.rs]
 features = ["wayland", "renderer-software"]

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -415,7 +415,7 @@ fn test_window_accessor_and_rwh() {
     let app = App::new().unwrap();
     let slint_window = app.window();
     assert!(slint_window.has_winit_window());
-    use rwh_06::{HasDisplayHandle, HasWindowHandle};
+    use raw_window_handle_06::{HasDisplayHandle, HasWindowHandle};
     assert!(slint_window.window_handle().is_ok());
     assert!(slint_window.display_handle().is_ok());
 }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -415,7 +415,8 @@ fn test_window_accessor_and_rwh() {
     let app = App::new().unwrap();
     let slint_window = app.window();
     assert!(slint_window.has_winit_window());
+    let handle = slint_window.window_handle();
     use raw_window_handle_06::{HasDisplayHandle, HasWindowHandle};
-    assert!(slint_window.window_handle().is_ok());
-    assert!(slint_window.display_handle().is_ok());
+    assert!(handle.window_handle().is_ok());
+    assert!(handle.display_handle().is_ok());
 }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -408,11 +408,14 @@ mod testui {
 // Sorry, can't test with rust test harness and multiple threads.
 #[cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios")))]
 #[test]
-fn test_window_accessor() {
+fn test_window_accessor_and_rwh() {
     slint::platform::set_platform(Box::new(crate::Backend::new().unwrap())).unwrap();
 
     use testui::*;
     let app = App::new().unwrap();
     let slint_window = app.window();
     assert!(slint_window.has_winit_window());
+    use rwh_06::{HasDisplayHandle, HasWindowHandle};
+    assert!(slint_window.window_handle().is_ok());
+    assert!(slint_window.display_handle().is_ok());
 }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -618,14 +618,18 @@ impl WindowAdapter for WinitWindowAdapter {
         Some(self)
     }
 
-    #[cfg(feature = "rwh_06")]
-    fn window_handle_06(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
-        rwh_06::HasWindowHandle::window_handle(&self.winit_window)
+    #[cfg(feature = "raw-window-handle-06")]
+    fn window_handle_06(
+        &self,
+    ) -> Result<raw_window_handle_06::WindowHandle<'_>, raw_window_handle_06::HandleError> {
+        raw_window_handle_06::HasWindowHandle::window_handle(&self.winit_window)
     }
 
-    #[cfg(feature = "rwh_06")]
-    fn display_handle_06(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
-        rwh_06::HasDisplayHandle::display_handle(&self.winit_window)
+    #[cfg(feature = "raw-window-handle-06")]
+    fn display_handle_06(
+        &self,
+    ) -> Result<raw_window_handle_06::DisplayHandle<'_>, raw_window_handle_06::HandleError> {
+        raw_window_handle_06::HasDisplayHandle::display_handle(&self.winit_window)
     }
 }
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -617,6 +617,16 @@ impl WindowAdapter for WinitWindowAdapter {
     fn internal(&self, _: corelib::InternalToken) -> Option<&dyn WindowAdapterInternal> {
         Some(self)
     }
+
+    #[cfg(feature = "rwh_06")]
+    fn window_handle_06(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
+        rwh_06::HasWindowHandle::window_handle(&self.winit_window)
+    }
+
+    #[cfg(feature = "rwh_06")]
+    fn display_handle_06(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
+        rwh_06::HasDisplayHandle::display_handle(&self.winit_window)
+    }
 }
 
 impl WindowAdapterInternal for WinitWindowAdapter {

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -24,7 +24,7 @@ libm = ["num-traits/libm", "euclid/libm"]
 # Allow the viewer to query at runtime information about item types
 rtti = []
 # Use the standard library
-std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom", "lyon_extra", "dep:web-time", "image-decoders", "svg"]
+std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom", "lyon_extra", "dep:web-time", "image-decoders", "svg", "rwh_06?/std"]
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
 # from a single core, and not in a interrupt or signal handler.
@@ -43,6 +43,8 @@ svg = ["dep:resvg", "shared-fontdb"]
 box-shadow-cache = []
 
 shared-fontdb = ["i-slint-common/shared-fontdb"]
+
+rwh_06 = ["dep:rwh_06"]
 
 default = ["std", "unicode"]
 
@@ -85,6 +87,8 @@ clru = { version = "0.6.0", optional = true }
 resvg = { workspace = true, optional = true }
 fontdb = { workspace = true, optional = true }
 serde = { version = "1.0.163", features = ["derive"], optional = true }
+
+rwh_06 = { workspace = true, optional = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 gettext-rs = { version = "0.7", optional = true, features = ["gettext-system"] }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -24,7 +24,7 @@ libm = ["num-traits/libm", "euclid/libm"]
 # Allow the viewer to query at runtime information about item types
 rtti = []
 # Use the standard library
-std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom", "lyon_extra", "dep:web-time", "image-decoders", "svg", "rwh_06?/std"]
+std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom", "lyon_extra", "dep:web-time", "image-decoders", "svg", "raw-window-handle-06?/std"]
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
 # from a single core, and not in a interrupt or signal handler.
@@ -44,7 +44,7 @@ box-shadow-cache = []
 
 shared-fontdb = ["i-slint-common/shared-fontdb"]
 
-rwh_06 = ["dep:rwh_06"]
+raw-window-handle-06 = ["dep:raw-window-handle-06"]
 
 default = ["std", "unicode"]
 
@@ -88,7 +88,7 @@ resvg = { workspace = true, optional = true }
 fontdb = { workspace = true, optional = true }
 serde = { version = "1.0.163", features = ["derive"], optional = true }
 
-rwh_06 = { workspace = true, optional = true }
+raw-window-handle-06 = { workspace = true, optional = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 gettext-rs = { version = "0.7", optional = true, features = ["gettext-system"] }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -573,6 +573,36 @@ impl Window {
     }
 }
 
+#[cfg(feature = "rwh_06")]
+impl rwh_06::HasWindowHandle for Window {
+    fn window_handle<'a>(&'a self) -> Result<rwh_06::WindowHandle<'a>, rwh_06::HandleError> {
+        let adapter = self.0.window_adapter();
+        let wh = adapter.window_handle_06()?;
+        // Safety: The Rc<dyn WindowAdapter> owns this slint::Window (&self). Therefore the caller of
+        // this function must also have a strong reference to the window adapter. The adapter above
+        // was created from a self weak and is the same as the Rc<dyn WindowAdapter> of the caller.
+        #[allow(unsafe_code)]
+        Ok(unsafe {
+            core::mem::transmute::<rwh_06::WindowHandle<'_>, rwh_06::WindowHandle<'a>>(wh)
+        })
+    }
+}
+
+#[cfg(feature = "rwh_06")]
+impl rwh_06::HasDisplayHandle for Window {
+    fn display_handle<'a>(&'a self) -> Result<rwh_06::DisplayHandle<'a>, rwh_06::HandleError> {
+        let adapter = self.0.window_adapter();
+        let wh = adapter.display_handle_06()?;
+        // Safety: The Rc<dyn WindowAdapter> owns this slint::Window (&self). Therefore the caller of
+        // this function must also have a strong reference to the window adapter. The adapter above
+        // was created from a self weak and is the same as the Rc<dyn WindowAdapter> of the caller.
+        #[allow(unsafe_code)]
+        Ok(unsafe {
+            core::mem::transmute::<rwh_06::DisplayHandle<'_>, rwh_06::DisplayHandle<'a>>(wh)
+        })
+    }
+}
+
 pub use crate::SharedString;
 
 /// This trait is used to obtain references to global singletons exported in `.slint`

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -324,9 +324,12 @@ pub enum SetRenderingNotifierError {
     AlreadySet,
 }
 
-/// This struct represents a persistent handle to a window and implements the traits
-/// for exposing raw window handles.
+/// This struct represents a persistent handle to a window and implements the
+/// [`raw_window_handle_06::HasWindowHandle`] and [`raw_window_handle_06::HasDisplayHandle`]
+/// traits for accessing exposing raw window and display handles.
+/// Obtain an instance of this by calling [`Window::window_handle()`].
 #[cfg(feature = "raw-window-handle-06")]
+#[derive(Clone)]
 pub struct WindowHandle {
     adapter: alloc::rc::Rc<dyn WindowAdapter>,
 }
@@ -598,9 +601,8 @@ impl Window {
     }
 
     /// Returns a struct that implements the raw window handle traits to access the windowing system specific window
-    /// and display handles.
+    /// and display handles. This function is only accessible if you enable the `raw-window-handle-06` crate feature.
     #[cfg(feature = "raw-window-handle-06")]
-
     pub fn window_handle(&self) -> WindowHandle {
         WindowHandle { adapter: self.0.window_adapter() }
     }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -573,9 +573,11 @@ impl Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
-impl rwh_06::HasWindowHandle for Window {
-    fn window_handle<'a>(&'a self) -> Result<rwh_06::WindowHandle<'a>, rwh_06::HandleError> {
+#[cfg(feature = "raw-window-handle-06")]
+impl raw_window_handle_06::HasWindowHandle for Window {
+    fn window_handle<'a>(
+        &'a self,
+    ) -> Result<raw_window_handle_06::WindowHandle<'a>, raw_window_handle_06::HandleError> {
         let adapter = self.0.window_adapter();
         let wh = adapter.window_handle_06()?;
         // Safety: The Rc<dyn WindowAdapter> owns this slint::Window (&self). Therefore the caller of
@@ -583,14 +585,19 @@ impl rwh_06::HasWindowHandle for Window {
         // was created from a self weak and is the same as the Rc<dyn WindowAdapter> of the caller.
         #[allow(unsafe_code)]
         Ok(unsafe {
-            core::mem::transmute::<rwh_06::WindowHandle<'_>, rwh_06::WindowHandle<'a>>(wh)
+            core::mem::transmute::<
+                raw_window_handle_06::WindowHandle<'_>,
+                raw_window_handle_06::WindowHandle<'a>,
+            >(wh)
         })
     }
 }
 
-#[cfg(feature = "rwh_06")]
-impl rwh_06::HasDisplayHandle for Window {
-    fn display_handle<'a>(&'a self) -> Result<rwh_06::DisplayHandle<'a>, rwh_06::HandleError> {
+#[cfg(feature = "raw-window-handle-06")]
+impl raw_window_handle_06::HasDisplayHandle for Window {
+    fn display_handle<'a>(
+        &'a self,
+    ) -> Result<raw_window_handle_06::DisplayHandle<'a>, raw_window_handle_06::HandleError> {
         let adapter = self.0.window_adapter();
         let wh = adapter.display_handle_06()?;
         // Safety: The Rc<dyn WindowAdapter> owns this slint::Window (&self). Therefore the caller of
@@ -598,7 +605,10 @@ impl rwh_06::HasDisplayHandle for Window {
         // was created from a self weak and is the same as the Rc<dyn WindowAdapter> of the caller.
         #[allow(unsafe_code)]
         Ok(unsafe {
-            core::mem::transmute::<rwh_06::DisplayHandle<'_>, rwh_06::DisplayHandle<'a>>(wh)
+            core::mem::transmute::<
+                raw_window_handle_06::DisplayHandle<'_>,
+                raw_window_handle_06::DisplayHandle<'a>,
+            >(wh)
         })
     }
 }

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -221,7 +221,7 @@ fn translate_gettext(string: &str, ctx: &str, domain: &str, n: i32, plural: &str
 }
 
 #[cfg(feature = "gettext-rs")]
-/// Initialize the translation by calling the [`bindtextdomain`](https://man7.org/linux/man-pages/man3/bindtextdomain.3.html) function from gettext
+/// Initialize the translation by calling the [`bindtextdomain`](https://man7.org/unix/man-pages/man3/bindtextdomain.3.html) function from gettext
 pub fn gettext_bindtextdomain(_domain: &str, _dirname: std::path::PathBuf) -> std::io::Result<()> {
     #[cfg(target_family = "unix")]
     {

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -221,7 +221,7 @@ fn translate_gettext(string: &str, ctx: &str, domain: &str, n: i32, plural: &str
 }
 
 #[cfg(feature = "gettext-rs")]
-/// Initialize the translation by calling the [`bindtextdomain`](https://man7.org/unix/man-pages/man3/bindtextdomain.3.html) function from gettext
+/// Initialize the translation by calling the [`bindtextdomain`](https://man7.org/linux/man-pages/man3/bindtextdomain.3.html) function from gettext
 pub fn gettext_bindtextdomain(_domain: &str, _dirname: std::path::PathBuf) -> std::io::Result<()> {
     #[cfg(target_family = "unix")]
     {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -139,15 +139,19 @@ pub trait WindowAdapter {
     }
 
     /// Re-implement this to support exposing raw window handles (version 0.6).
-    #[cfg(feature = "rwh_06")]
-    fn window_handle_06(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
-        Err(rwh_06::HandleError::NotSupported)
+    #[cfg(feature = "raw-window-handle-06")]
+    fn window_handle_06(
+        &self,
+    ) -> Result<raw_window_handle_06::WindowHandle<'_>, raw_window_handle_06::HandleError> {
+        Err(raw_window_handle_06::HandleError::NotSupported)
     }
 
     /// Re-implement this to support exposing raw display handles (version 0.6).
-    #[cfg(feature = "rwh_06")]
-    fn display_handle_06(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
-        Err(rwh_06::HandleError::NotSupported)
+    #[cfg(feature = "raw-window-handle-06")]
+    fn display_handle_06(
+        &self,
+    ) -> Result<raw_window_handle_06::DisplayHandle<'_>, raw_window_handle_06::HandleError> {
+        Err(raw_window_handle_06::HandleError::NotSupported)
     }
 }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -137,6 +137,18 @@ pub trait WindowAdapter {
     fn internal(&self, _: crate::InternalToken) -> Option<&dyn WindowAdapterInternal> {
         None
     }
+
+    /// Re-implement this to support exposing raw window handles (version 0.6).
+    #[cfg(feature = "rwh_06")]
+    fn window_handle_06(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
+        Err(rwh_06::HandleError::NotSupported)
+    }
+
+    /// Re-implement this to support exposing raw display handles (version 0.6).
+    #[cfg(feature = "rwh_06")]
+    fn display_handle_06(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
+        Err(rwh_06::HandleError::NotSupported)
+    }
 }
 
 /// Implementation details behind [`WindowAdapter`], but since this

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -109,7 +109,7 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 
 ### Enable integration with raw-window-handle version 0.6. This provides a HasWindowHandle and
 ### HasDisplayHandle implementation for slint::Window.
-rwh_06 = ["i-slint-core/rwh_06", "i-slint-backend-selector/rwh_06"]
+raw-window-handle-06 = ["i-slint-backend-selector/raw-window-handle-06"]
 
 ## Features used internally by Slint tooling that are not stable and come without
 ## any stability guarantees whatsoever.

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -107,6 +107,10 @@ renderer-winit-software = ["renderer-software"]
 ## APIs to support screen readers and other assistive technologies.
 accessibility = ["i-slint-backend-selector/accessibility"]
 
+### Enable integration with raw-window-handle version 0.6. This provides a HasWindowHandle and
+### HasDisplayHandle implementation for slint::Window.
+rwh_06 = ["i-slint-core/rwh_06", "i-slint-backend-selector/rwh_06"]
+
 ## Features used internally by Slint tooling that are not stable and come without
 ## any stability guarantees whatsoever.
 internal = []

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -147,4 +147,4 @@ i-slint-backend-testing = { path = "../../internal/backends/testing" }
 spin_on = "0.1"
 
 [package.metadata.docs.rs]
-features = ["display-diagnostics", "document-features"]
+features = ["display-diagnostics", "document-features", "raw-window-handle-06"]

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -107,9 +107,10 @@ renderer-winit-software = ["renderer-software"]
 ## APIs to support screen readers and other assistive technologies.
 accessibility = ["i-slint-backend-selector/accessibility"]
 
-### Enable integration with raw-window-handle version 0.6. This provides a HasWindowHandle and
-### HasDisplayHandle implementation for slint::Window.
-raw-window-handle-06 = ["i-slint-backend-selector/raw-window-handle-06"]
+## Enable integration with [raw-window-handle](raw_window_handle_06) version 0.6. This provides a
+## [HasWindowHandle](raw_window_handle_06::HasWindowHandle) and
+## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation for slint::Window.
+raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
 
 ## Features used internally by Slint tooling that are not stable and come without
 ## any stability guarantees whatsoever.
@@ -130,6 +131,7 @@ once_cell = "1.5"
 thiserror = "1"
 document-features = { version = "0.2.0", optional = true }
 spin_on = { version = "0.1", optional = true }
+raw-window-handle-06 = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 i-slint-backend-winit = { workspace = true }

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -108,8 +108,9 @@ renderer-winit-software = ["renderer-software"]
 accessibility = ["i-slint-backend-selector/accessibility"]
 
 ## Enable integration with [raw-window-handle](raw_window_handle_06) version 0.6. This provides a
+## [`Window::window_handle()`] function that returns a struct that implements
 ## [HasWindowHandle](raw_window_handle_06::HasWindowHandle) and
-## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation for slint::Window.
+## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation.
 raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
 
 ## Features used internally by Slint tooling that are not stable and come without


### PR DESCRIPTION
Add a `rwh_06` feature to the Rust API crates, which adds support for version 0.6 of rwh to slint::Window, by delegation to the backend.

HasDisplayHandle could also be provided on the backend, but that can be done separately if needed.

Fixes #877