### PR TITLE
Fix missing error when calling argb() with too many arguments

### DIFF
--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -187,8 +187,11 @@ fn rgb_macro(
     args: Vec<(Expression, Option<NodeOrToken>)>,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
-    if args.len() < 3 {
-        diag.push_error("Needs 3 or 4 argument".into(), &node);
+    if args.len() < 3 || args.len() > 4 {
+        diag.push_error(
+            format!("This function needs 3 or 4 arguments, but {} were provided", args.len()),
+            &node,
+        );
         return Expression::Invalid;
     }
     let mut arguments: Vec<_> = args

--- a/internal/compiler/tests/syntax/lookup/color.slint
+++ b/internal/compiler/tests/syntax/lookup/color.slint
@@ -38,5 +38,17 @@ export X := Rectangle {
 //                  ^error{Cannot take reference to a namespace}
         property<color> xxx: Colors.xxx;
 //                                  ^error{'xxx' is not a member of the namespace Colors}
+
+        property<color> c1: rgba();
+//                          ^error{This function needs 3 or 4 arguments, but 0 were provided}
+        property<color> c2: rgb(45);
+//                          ^error{This function needs 3 or 4 arguments, but 1 were provided}
+        property<color> c3: Colors.rgb(45,45);
+//                          ^error{This function needs 3 or 4 arguments, but 2 were provided}
+        property<color> c4: Colors.rgba(1,2,3,4,5);
+//                          ^error{This function needs 3 or 4 arguments, but 5 were provided}
+
+
     }
+
 }


### PR DESCRIPTION
This is technically a breaking change if someone was calling it with too many args by mistake, but i think it's fine to do this as a bugfix