### PR TITLE
esp-idf: Add support for line-by-line rendering

### DIFF
--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -15,15 +15,19 @@
  * - `size` is the size of the screen
  * - `panel` is a handle to the display.
  * - `touch` is a handle to the touch screen, if the device has a touch screen
- * - `buffer1` is a buffer of at least the size of the frame in which the slint scene will be drawn.
- *    Slint will take care to flush it to the screen
+ * - `buffer1`, if specified, is a buffer of at least the size of the frame in which the slint scene
+ * will be drawn. Slint will take care to flush it to the screen
  * - `buffer2`, if specified, is a second buffer to be used with double buffering,
  *    both buffer1 and buffer2 should then be obtained with `esp_lcd_rgb_panel_get_frame_buffer`
  * - `rotation` applies a transformation while rendering in the buffer
+ *
+ * If no buffer1 is specified, Slint assumes that no direct framebuffers are accessible and instead
+ * will render line-by-line, by allocating a line buffer with MALLOC_CAP_INTERNAL, and flush it to
+ * the screen with esp_lcd_panel_draw_bitmap.
  */
 void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     std::optional<esp_lcd_touch_handle_t> touch,
-                    std::span<slint::platform::Rgb565Pixel> buffer1,
+                    std::optional<std::span<slint::platform::Rgb565Pixel>> buffer1 = {},
                     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2 = {}
 #ifdef SLINT_FEATURE_EXPERIMENTAL
                     ,

--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -15,22 +15,28 @@
  * - `size` is the size of the screen
  * - `panel` is a handle to the display.
  * - `touch` is a handle to the touch screen, if the device has a touch screen
- * - `buffer1`, if specified, is a buffer of at least the size of the frame in which the slint scene
- * will be drawn. Slint will take care to flush it to the screen
+ * - `buffer1`, is a buffer of at least the size of the frame in which the slint scene
+ *    will be drawn. Slint will take care to flush it to the screen
  * - `buffer2`, if specified, is a second buffer to be used with double buffering,
  *    both buffer1 and buffer2 should then be obtained with `esp_lcd_rgb_panel_get_frame_buffer`
  * - `rotation` applies a transformation while rendering in the buffer
- *
- * If no buffer1 is specified, Slint assumes that no direct framebuffers are accessible and instead
- * will render line-by-line, by allocating a line buffer with MALLOC_CAP_INTERNAL, and flush it to
- * the screen with esp_lcd_panel_draw_bitmap.
  */
 void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     std::optional<esp_lcd_touch_handle_t> touch,
-                    std::optional<std::span<slint::platform::Rgb565Pixel>> buffer1 = {},
+                    std::span<slint::platform::Rgb565Pixel> buffer1 = {},
                     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2 = {}
 #ifdef SLINT_FEATURE_EXPERIMENTAL
                     ,
                     slint::platform::SoftwareRenderer::RenderingRotation rotation = {}
 #endif
 );
+
+#ifdef SLINT_FEATURE_EXPERIMENTAL
+/**
+ * Same as the other overload but do rendering line-by-line, by allocating a line buffer with
+ * MALLOC_CAP_INTERNAL, and flush it to the screen with esp_lcd_panel_draw_bitmap. (experimental)
+ */
+void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
+                    std::optional<esp_lcd_touch_handle_t> touch,
+                    slint::platform::SoftwareRenderer::RenderingRotation rotation = {});
+#endif

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -255,6 +255,7 @@ void EspPlatform::run_event_loop()
                             }
                         }
                     }
+#ifdef SLINT_FEATURE_EXPERIMENTAL
                 } else {
                     std::unique_ptr<slint::platform::Rgb565Pixel, void (*)(void *)> lb(
                             static_cast<slint::platform::Rgb565Pixel *>(
@@ -272,6 +273,7 @@ void EspPlatform::run_event_loop()
                         esp_lcd_panel_draw_bitmap(panel_handle, line_start, line_y, line_end,
                                                   line_y + 1, lb.get());
                     });
+#endif
                 }
             }
 
@@ -313,7 +315,7 @@ TaskHandle_t EspPlatform::task = {};
 
 void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     std::optional<esp_lcd_touch_handle_t> touch,
-                    std::optional<std::span<slint::platform::Rgb565Pixel>> buffer1,
+                    std::span<slint::platform::Rgb565Pixel> buffer1,
                     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2
 #ifdef SLINT_FEATURE_EXPERIMENTAL
                     ,
@@ -328,3 +330,13 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
 #endif
                                                                 ));
 }
+
+#ifdef SLINT_FEATURE_EXPERIMENTAL
+void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
+                    std::optional<esp_lcd_touch_handle_t> touch,
+                    slint::platform::SoftwareRenderer::RenderingRotation rotation)
+{
+    slint::platform::set_platform(std::make_unique<EspPlatform>(size, panel, touch, std::nullopt,
+                                                                std::nullopt, rotation));
+}
+#endif

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -631,6 +631,7 @@ public:
         return PhysicalRegion { r };
     }
 
+#    ifdef SLINT_FEATURE_EXPERIMENTAL
     /// Render the window scene, line by line. The provided Callback will be invoked for each line
     /// that needs to rendered.
     ///
@@ -669,7 +670,6 @@ public:
         return PhysicalRegion { r };
     }
 
-#    ifdef SLINT_FEATURE_EXPERIMENTAL
     /// This enum describes the rotation that is applied to the buffer when rendering.
     /// To be used in set_rendering_rotation()
     enum class RenderingRotation {

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -402,6 +402,7 @@ mod software_renderer {
         i_slint_core::graphics::euclid::rect(orig.x, orig.y, size.width as i32, size.height as i32)
     }
 
+    #[cfg(feature = "experimental")]
     #[no_mangle]
     pub unsafe extern "C" fn slint_software_renderer_render_by_line_rgb565(
         r: SoftwareRendererOpaque,


### PR DESCRIPTION
Rendering by line into a line buffer that's in IRAM can be faster than accessing framebuffers in slower PSRAM, so offer this by allowing users to omit even the initial framebuffer.