### PR TITLE
Improve rendering performance of the energy monitor

### DIFF
--- a/examples/energy-monitor/ui/widgets/balance_chart.slint
+++ b/examples/energy-monitor/ui/widgets/balance_chart.slint
@@ -55,6 +55,7 @@ export component BalanceChart {
         y: 0px;
         count: x-axis-model.length;
         height: root.zero;
+        cache-rendering-hint: true;
     }
 
     ChartPattern {
@@ -63,6 +64,7 @@ export component BalanceChart {
         y: i-zero-pattern.height;
         count: x-axis-model.length;
         height: root.height - i_zero_pattern.height;
+        cache-rendering-hint: true;
     }
 
     ChartAxis {
@@ -76,35 +78,38 @@ export component BalanceChart {
         y-unit: root.y-unit;
     }
 
-    HorizontalLayout {
-        padding-left: 6px;
-        padding-right: 6px;
-        spacing: 10px;
+    Rectangle {
+        cache-rendering-hint: true;
+        HorizontalLayout {
+            padding-left: 6px;
+            padding-right: 6px;
+            spacing: 10px;
 
-        for value[index] in model : Rectangle {
-            private property <float> display-value;
+            for value[index] in model : Rectangle {
+                private property <float> display-value;
 
-            if(value > 0.0) : UpBar {
-                width: 100%;
-                y: zero - self.height;
-                height: parent.height * (display-value / (root.max - root.min));
-            }
-
-            if(value < 0.0) : DownBar {
-                y: zero;
-                width: 100%;
-                height: parent.height * (-1 * value / (root.max - root.min));
-            }
-
-            states [
-                active when active : {
-                    display-value: value;
-
-                    in {
-                        animate display-value { duration: Theme.durations.slow; easing: ease-in-out; }
-                    }
+                if(value > 0.0) : UpBar {
+                    width: 100%;
+                    y: zero - self.height;
+                    height: parent.height * (display-value / (root.max - root.min));
                 }
-            ]
+
+                if(value < 0.0) : DownBar {
+                    y: zero;
+                    width: 100%;
+                    height: parent.height * (-1 * value / (root.max - root.min));
+                }
+
+                states [
+                    active when active : {
+                        display-value: value;
+
+                        in {
+                            animate display-value { duration: Theme.durations.slow; easing: ease-in-out; }
+                        }
+                    }
+                ]
+            }
         }
     }
 }

--- a/examples/energy-monitor/ui/widgets/bar_chart.slint
+++ b/examples/energy-monitor/ui/widgets/bar_chart.slint
@@ -36,6 +36,8 @@ export component BarChart {
     in property <float> max;
     in property <bool> active;
 
+    cache-rendering-hint: true;
+
     ChartPattern {
         count: model.length / 2;
     }

--- a/examples/energy-monitor/ui/widgets/page_scroll_view.slint
+++ b/examples/energy-monitor/ui/widgets/page_scroll_view.slint
@@ -64,6 +64,7 @@ export component PageContainer {
 
     min-width: 320px;
     min-height: 240px;
+    cache-rendering-hint: true;
 
     i-rect := Rectangle {
         height: parent.height;
@@ -92,6 +93,7 @@ export component PageContainer {
             i-rect.y: (self.height - selected-height) /2 + selected-h-offset;
             out { animate i-rect.y, i-rect.height { duration: Theme.durations.medium; } }
             in { animate i-rect.y, i-rect.height { duration: Theme.durations.medium; } }
+            cache-rendering-hint: false;
         }
         shrink when selected != -1 : {
             horizontal-stretch: 0;


### PR DESCRIPTION
The use of gradients in the design to implement bar charts prevents Skia from batching, which means that each bar is a separate draw call.

Since we barely change the model data, use a cache-rendering-hint to batch the bar charts by hand into a texture.

Similarly, when scrolling on the main screen, we don't need to re-draw each page individually until we're selecting.

This boosts the scrolling performance from 13fps to 30fps on an stm32mp157.

See #4944 for separate docs about this.