### PR TITLE
Throw an error when a callback aliases itself

### DIFF
--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -92,10 +92,18 @@ fn resolve_alias(
 
     let mut ty = Type::Invalid;
     if let Some(nr) = &nr {
+        let element = nr.element();
+        let same_element = Rc::ptr_eq(&element, elem);
+        if same_element && nr.name() == prop {
+            diag.push_error(
+                format!("Cannot alias to itself"),
+                &elem.borrow().property_declarations[prop].type_node(),
+            );
+            return;
+        }
         ty = nr.ty();
         if matches!(ty, Type::InferredCallback | Type::InferredProperty) {
-            let element = nr.element();
-            if Rc::ptr_eq(&element, elem) {
+            if same_element {
                 resolve_alias(&element, nr.name(), scope, type_register, diag)
             } else {
                 resolve_alias(&element, nr.name(), &recompute_scope(&element), type_register, diag)

--- a/internal/compiler/tests/syntax/lookup/callback_alias_issue4938.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias_issue4938.slint
@@ -1,0 +1,7 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component Xxx {
+    callback issue4938 <=> issue4938;
+//  ^error{Cannot alias to itself}
+}


### PR DESCRIPTION
Instead of panicking
Fixes #4938