### PR TITLE
Fix interpreter overwriting index property

### DIFF
--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -153,12 +153,12 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         }
         Expression::RepeaterIndexReference { element } => load_property_helper(local_context.component_instance,
             &element.upgrade().unwrap().borrow().base_type.as_component().root_element,
-            "index",
+            crate::dynamic_item_tree::SPECIAL_PROPERTY_INDEX,
         )
         .unwrap(),
         Expression::RepeaterModelReference { element } => load_property_helper(local_context.component_instance,
             &element.upgrade().unwrap().borrow().base_type.as_component().root_element,
-            "model_data",
+            crate::dynamic_item_tree::SPECIAL_PROPERTY_MODEL_DATA,
         )
         .unwrap(),
         Expression::FunctionParameterReference { index, .. } => {

--- a/tests/cases/models/issue_4961_model_index_property.slint
+++ b/tests/cases/models/issue_4961_model_index_property.slint
@@ -1,0 +1,54 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.1 OR LicenseRef-Slint-commercial
+
+export component TestCase {
+    width: 100px;
+    height: 100px;
+    out property <string> clicked_value;
+    l := VerticalLayout {
+        for val[i] in [10,20,30] : TouchArea {
+            // issue 4961 was about index, but also add other names that are comonly used
+            property <string> index: "index" + i;
+            property <string> model-data: "model-data" + val;
+            property <string> model: "model" + val;
+            property <string> value: "value" + val;
+            property <string> idx: "idx" +i;
+            txt := Text { text: index+model-data+model+value+idx; }
+            clicked => { clicked_value = txt.text; }
+            height: txt.text != "" ? val*1px : 0px;
+        }
+    }
+
+    out property <bool> test: l.preferred-height == 10px+20px+30px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert(instance.get_test());
+
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_clicked_value(), "index0model-data10model10value10idx0");
+
+
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_clicked_value(), "index0model-data10model10value10idx0");
+
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+assert.equal(instance.clicked_value, "index0model-data10model10value10idx0");
+```
+*/


### PR DESCRIPTION
Use a `$` sing in the name of special property so that they do not replace user defined properties

The scale_factor property was unused since 9fd7d35b0d2d81711c8a0c62bc9dd821655e6e8c or even before

Fixes #4961