### PR TITLE
C++: FilterModel with deferred filtering

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -555,7 +555,9 @@ struct FilterModelInner : private_api::ModelChangeListener
     FilterModelInner(std::shared_ptr<slint::Model<ModelData>> source_model,
                      std::function<bool(const ModelData &)> filter_fn,
                      slint::FilterModel<ModelData> &target_model)
-        : source_model(source_model), filter_fn(filter_fn), target_model(target_model) { }
+        : source_model(source_model), filter_fn(filter_fn), target_model(target_model)
+    {
+    }
 
     void row_added(size_t index, size_t count) override
     {

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -555,13 +555,15 @@ struct FilterModelInner : private_api::ModelChangeListener
     FilterModelInner(std::shared_ptr<slint::Model<ModelData>> source_model,
                      std::function<bool(const ModelData &)> filter_fn,
                      slint::FilterModel<ModelData> &target_model)
-        : source_model(source_model), filter_fn(filter_fn), target_model(target_model)
-    {
-        update_mapping();
-    }
+        : source_model(source_model), filter_fn(filter_fn), target_model(target_model) { }
 
     void row_added(size_t index, size_t count) override
     {
+        if (filtered_rows_dirty) {
+            reset();
+            return;
+        }
+
         if (count == 0) {
             return;
         }
@@ -592,6 +594,11 @@ struct FilterModelInner : private_api::ModelChangeListener
     }
     void row_changed(size_t index) override
     {
+        if (filtered_rows_dirty) {
+            reset();
+            return;
+        }
+
         auto existing_row = std::lower_bound(accepted_rows.begin(), accepted_rows.end(), index);
         auto existing_row_index = std::distance(accepted_rows.begin(), existing_row);
         bool is_contained = existing_row != accepted_rows.end() && *existing_row == index;
@@ -609,6 +616,11 @@ struct FilterModelInner : private_api::ModelChangeListener
     }
     void row_removed(size_t index, size_t count) override
     {
+        if (filtered_rows_dirty) {
+            reset();
+            return;
+        }
+
         auto mapped_row_start = std::lower_bound(accepted_rows.begin(), accepted_rows.end(), index);
         auto mapped_row_end =
                 std::lower_bound(accepted_rows.begin(), accepted_rows.end(), index + count);
@@ -631,12 +643,17 @@ struct FilterModelInner : private_api::ModelChangeListener
     }
     void reset() override
     {
+        filtered_rows_dirty = true;
         update_mapping();
         target_model.Model<ModelData>::reset();
     }
 
     void update_mapping()
     {
+        if (!filtered_rows_dirty) {
+            return;
+        }
+
         accepted_rows.clear();
         for (size_t i = 0, count = source_model->row_count(); i < count; ++i) {
             if (auto data = source_model->row_data(i)) {
@@ -645,8 +662,11 @@ struct FilterModelInner : private_api::ModelChangeListener
                 }
             }
         }
+
+        filtered_rows_dirty = false;
     }
 
+    bool filtered_rows_dirty = true;
     std::shared_ptr<slint::Model<ModelData>> source_model;
     std::function<bool(const ModelData &)> filter_fn;
     std::vector<size_t> accepted_rows;
@@ -674,10 +694,15 @@ public:
         inner->source_model->attach_peer(inner);
     }
 
-    size_t row_count() const override { return inner->accepted_rows.size(); }
+    size_t row_count() const override
+    {
+        inner->update_mapping();
+        return inner->accepted_rows.size();
+    }
 
     std::optional<ModelData> row_data(size_t i) const override
     {
+        inner->update_mapping();
         if (i >= inner->accepted_rows.size())
             return {};
         return inner->source_model->row_data(inner->accepted_rows[i]);
@@ -685,6 +710,7 @@ public:
 
     void set_row_data(size_t i, const ModelData &value) override
     {
+        inner->update_mapping();
         inner->source_model->set_row_data(inner->accepted_rows[i], value);
     }
 
@@ -694,7 +720,11 @@ public:
 
     /// Given the \a filtered_row index, this function returns the corresponding row index in the
     /// source model.
-    int unfiltered_row(int filtered_row) const { return inner->accepted_rows[filtered_row]; }
+    int unfiltered_row(int filtered_row) const
+    {
+        inner->update_mapping();
+        return inner->accepted_rows[filtered_row];
+    }
 
     /// Returns the source model of this filter model.
     std::shared_ptr<Model<ModelData>> source_model() const { return inner->source_model; }


### PR DESCRIPTION
Avoids to invoke filtering function until `slint::FilterModel` and its subclasses are completely constructed, deferring it to first model usage.
See issue #4983 for more details.

A basic program to demonstrate the problem and the fix:
```Slint
// appwindow.slint

import { ListView, VerticalBox, Switch, HorizontalBox, LineEdit, Button } from "std-widgets.slint";

export component AppWindow inherits Window {
    in property <[int]> model;
    in-out property only-evens <=> only-evens-switch.checked;
    in-out property ascending <=> ascending-switch.checked;
    callback only-evens-changed <=> only-evens-switch.toggled;
    callback ascending-changed <=> ascending-switch.toggled;
    callback add-element(int);
    callback remove-element(int);

    VerticalBox {
        only-evens-switch := Switch {
            text: "Only evens";
        }

        ascending-switch := Switch {
            text: "Ascending";
        }

        HorizontalBox {
            element-edit := LineEdit {
                input-type: InputType.number;
            }

            Button {
                text: "Add";
                clicked => {
                    root.add-element(element-edit.text.to-float())
                }
            }

            Button {
                text: "Remove";
                clicked => {
                    root.remove-element(element-edit.text.to-float())
                }
            }
        }

        ListView {
            for item in root.model: Text {
                text: item;
            }
        }
    }
}
```
```C++
// main.cpp

#include <memory>
#include <utility>

#include <print>

#include "appwindow.h"
#include "slint.h"

class MyFilterModel: public slint::FilterModel<int>
{
    bool onlyEvens{false};

    [[nodiscard]] auto filter(const int& element) const -> bool
    {
        std::println("Filtering with onlyEvens={}; {} -> {}", onlyEvens, element, (!onlyEvens || element % 2 == 0));

        return !onlyEvens || element % 2 == 0;
    }

  public:
    MyFilterModel(std::shared_ptr<Model<int>> source_model):
      slint::FilterModel<int>{std::move(source_model), [this](const int& element) { return filter(element); }}
    {
        std::println("MyFilterModel initialized, onlyEvens={}", onlyEvens);
    }

    [[nodiscard]] auto getOnlyEvens() const -> bool { return onlyEvens; }

    void setOnlyEvens(bool value)
    {
        std::println("Updating filter; {} -> {}", onlyEvens, value);

        onlyEvens = value;
        reset();
    }
};

class MySortModel: public slint::SortModel<int>
{
    bool ascending{true};

    [[nodiscard]] auto sort(const int& first, const int& second) const -> bool
    {
        std::println("Sorting with ascending={}; {} | {} -> {}", ascending, first, second, (ascending ? first < second : first >= second));

        return ascending ? first < second : first > second;
    }

  public:
    MySortModel(std::shared_ptr<Model<int>> source_model):
      slint::SortModel<int>{std::move(source_model),
                            [this](const int& first, const int& second) { return sort(first, second); }}
    {
        std::println("MySortModel initialized, ascending={}", ascending);
    }

    [[nodiscard]] auto getAscending() const -> bool { return ascending; }

    void setAscending(bool value)
    {
        std::println("Updating sort; {} -> {}", ascending, value);

        ascending = value;
        reset();
    }
};

auto main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) -> int
{
    auto appWindow{AppWindow::create()};

    const auto model{std::make_shared<slint::VectorModel<int>>(std::vector<int>{1, 2, 3, 4, 5})};
    const auto filterModel{std::make_shared<MyFilterModel>(model)};
    const auto sortModel{std::make_shared<MySortModel>(filterModel)};

    appWindow->on_add_element([model](const int& element){
        model->push_back(element);
    });
    appWindow->on_remove_element([model](const int& element){
        for(auto idx{0U}; idx<model->row_count(); ++idx){
            if(model->row_data(idx)!=element){
                continue;
            }
            model->erase(idx);
            return;
        }
    });

    appWindow->set_only_evens(filterModel->getOnlyEvens());
    appWindow->on_only_evens_changed([appWindow, filterModel]() {
        filterModel->setOnlyEvens(appWindow->get_only_evens());
    });
    appWindow->set_ascending(sortModel->getAscending());
    appWindow->on_ascending_changed([appWindow, sortModel]() { sortModel->setAscending(appWindow->get_ascending()); });
    appWindow->set_model(sortModel);

    appWindow->run();

    return 0;
}
```
Output before the fix:
```
Filtering with onlyEvens=true; 1 -> false
Filtering with onlyEvens=true; 2 -> true
Filtering with onlyEvens=true; 3 -> false
Filtering with onlyEvens=true; 4 -> true
Filtering with onlyEvens=true; 5 -> false
MyFilterModel initialized, onlyEvens=false
MySortModel initialized, ascending=true
Sorting with ascending=true; 4 | 2 -> false
Sorting with ascending=true; 4 | 2 -> false
```
Output after the fix:
```
MyFilterModel initialized, onlyEvens=false
MySortModel initialized, ascending=true
Filtering with onlyEvens=false; 1 -> true
Filtering with onlyEvens=false; 2 -> true
Filtering with onlyEvens=false; 3 -> true
Filtering with onlyEvens=false; 4 -> true
Filtering with onlyEvens=false; 5 -> true
Sorting with ascending=true; 2 | 1 -> false
Sorting with ascending=true; 2 | 1 -> false
Sorting with ascending=true; 3 | 1 -> false
Sorting with ascending=true; 3 | 2 -> false
Sorting with ascending=true; 4 | 1 -> false
Sorting with ascending=true; 4 | 3 -> false
Sorting with ascending=true; 5 | 1 -> false
Sorting with ascending=true; 5 | 4 -> false
```
