### PR TITLE
live preview: Add a drop marker

### DIFF
--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -182,8 +182,7 @@ impl SelectionCandidate {
     }
 
     pub fn as_element_node(&self) -> Option<ElementRcNode> {
-        let (sf, range) = self.text_range.as_ref()?;
-        ElementRcNode::find_in(self.element.clone(), sf.path(), u32::from(range.start()))
+        ElementRcNode::new(self.element.clone(), self.debug_index)
     }
 }
 
@@ -368,11 +367,11 @@ fn filter_nodes_for_selection(
         return None;
     }
 
-    if !enter_component && !is_same_file_as_root_node(&component_instance, &en) {
+    if !enter_component && !is_same_file_as_root_node(component_instance, &en) {
         return None;
     }
 
-    if is_root_element_node(&component_instance, &en) {
+    if is_root_element_node(component_instance, &en) {
         return None;
     }
 
@@ -387,9 +386,9 @@ pub fn select_element_behind_impl(
     enter_component: bool,
     reverse: bool,
 ) -> Option<ElementRcNode> {
-    let elements = collect_all_element_nodes_covering(x, y, &component_instance);
+    let elements = collect_all_element_nodes_covering(x, y, component_instance);
     let current_selection_position =
-        elements.iter().position(|sc| sc.is_selected_element_node(&selected_element_node))?;
+        elements.iter().position(|sc| sc.is_selected_element_node(selected_element_node))?;
 
     let (start_position, iterations) = if reverse {
         let start_position = current_selection_position.saturating_sub(1);

--- a/tools/lsp/ui/component-list.slint
+++ b/tools/lsp/ui/component-list.slint
@@ -16,7 +16,9 @@ export component ComponentList {
     in property <length> preview-area-width;
     in property <length> preview-area-height;
 
-    pure callback can-drop(string/* component_type */, length/* x */, length/* y */) -> bool;
+    out property <bool> over-target;
+
+    pure callback can-drop(string/* component_type */, length/* x */, length/* y */, bool/* on-drop-area */) -> bool;
     callback drop(string/* component_type */, length/* x */, length/* y */);
 
     private property <bool> preview-visible: preview-area-width > 0px && preview-area-height > 0px;
@@ -47,7 +49,8 @@ export component ComponentList {
                         private property <length> drop-y: self.absolute-position.y + self.mouse-y - root.preview-area-position-y;
                         private property <bool> on-drop-area:
                             drop-x >= 0 && drop-x <= root.preview-area-width && drop-y >= 0 && drop-y <= root.preview-area-height;
-                        private property <bool> can-drop-here: on-drop-area && root.can-drop(ci, drop-x, drop-y);
+                        private property <bool> can-drop-here: root.can-drop(ci, drop-x, drop-y, on-drop-area);
+
                         enabled: root.preview-visible;
                         height: name.preferred-height + 10px;
                         width: 100%;

--- a/tools/lsp/ui/draw-area.slint
+++ b/tools/lsp/ui/draw-area.slint
@@ -35,6 +35,13 @@ export struct Selection {
     is-resizable: bool,
 }
 
+export struct DropMark {
+    x1: length,
+    y1: length,
+    x2: length,
+    y2: length,
+}
+
 component SelectionFrame {
     in property <Selection> selection;
     in property <bool> interactive: true;
@@ -136,6 +143,7 @@ export enum DrawAreaMode {
 export component DrawArea {
     in property <[Diagnostics]> diagnostics;
     in property <[Selection]> selections;
+    in property <DropMark> drop-mark;
     in property <component-factory> preview-area;
     in property <bool> design-mode;
 
@@ -280,6 +288,15 @@ export component DrawArea {
                         }
                     }
                 }
+
+                if drop-mark.x1 >= 0.0 || drop-mark.y1 >= 0.0 || drop-mark.x2 >= 0.0 || drop-mark.y2 >= 0.0: Rectangle {
+                    x: drop-mark.x1;
+                    y: drop-mark.y1;
+                    width: drop-mark.x2 - drop-mark.x1;
+                    height: drop-mark.y2 - drop-mark.y1;
+
+                    background: #00ff00;
+                }
             }
         }
     }
@@ -288,7 +305,7 @@ export component DrawArea {
     diagnostics := DiagnosticsOverlay {
         width: 100%;
         height: 100%;
-        diagnostics <=> root.diagnostics;
+       diagnostics <=> root.diagnostics;
         show-document(url, line, column) => {
             root.show-document(url, line, column);
         }

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -5,16 +5,17 @@
 
 import { Button, ComboBox, ListView, ScrollView, VerticalBox } from "std-widgets.slint";
 import { ComponentList, ComponentListItem } from "component-list.slint";
-import { DrawArea, DrawAreaMode, LayoutKind, Selection } from "draw-area.slint";
+import { DrawArea, DrawAreaMode, DropMark, LayoutKind, Selection } from "draw-area.slint";
 import { HeaderBar } from "header-bar.slint";
 import { Diagnostics, DiagnosticsOverlay } from "diagnostics-overlay.slint";
 
-export { Diagnostics, LayoutKind }
+export { Diagnostics, DropMark, LayoutKind }
 
 export component PreviewUi inherits Window {
     in property <[ComponentListItem]> known-components;
     in property <[Diagnostics]> diagnostics;
     in property <[Selection]> selections;
+    in-out property <DropMark> drop-mark;
     in property <[string]> known-styles;
     in property <bool> experimental: false;
     in property <bool> show-preview-ui: true;
@@ -23,7 +24,7 @@ export component PreviewUi inherits Window {
     in-out property <string> current-style;
     out property <bool> design-mode;
 
-    pure callback can-drop(/* component_type */ string, /* x */ length, /* y */ length) -> bool;
+    pure callback can-drop(/* component_type */ string, /* x */ length, /* y */ length, /* on-drop-area */ bool) -> bool;
     callback drop(/* component_type */ string, /* x */ length, /* y */ length);
     callback selected-element-update-geometry(/* x */ length, /* y */ length, /* width */ length, /* height */ length);
     callback selected-element-delete();
@@ -103,8 +104,8 @@ export component PreviewUi inherits Window {
                                 preview-area-width: draw-area.preview-area-width;
                                 preview-area-height: draw-area.preview-area-height;
 
-                                can-drop(c, x, y) => {
-                                    return root.can-drop(c, x, y);
+                                can-drop(c, x, y, oda) => {
+                                    return root.can-drop(c, x, y, oda);
                                 }
                                 drop(c, x, y) => {
                                     root.drop(c, x, y);
@@ -127,6 +128,7 @@ export component PreviewUi inherits Window {
                         diagnostics <=> root.diagnostics;
                         preview-area <=> root.preview-area;
                         selections <=> root.selections;
+                        drop-mark <=> root.drop-mark;
 
                         select-at(x, y, enter_component) => {
                             root.select-at(x, y, enter_component);


### PR DESCRIPTION
Add a drop mark into DropInformation to visualize where an item will get added.

This is the UI side of things and some more preparational work.