### PR TITLE
Fix WASM Loading Issue Due to Library Name Change

### DIFF
--- a/examples/printerdemo/rust/index.html
+++ b/examples/printerdemo/rust/index.html
@@ -53,7 +53,7 @@
     </a>
   </p>
   <script type="module">
-    import init from './pkg/printerdemo.js';
+    import init from './pkg/printerdemo_lib.js';
     init().finally(() => {
       document.getElementById("spinner").remove();
     });


### PR DESCRIPTION
Following the recent changes in #4765, the library name was updated from `printerdemo` to `printerdemo_lib`. This modification has inadvertently affected the naming of the JavaScript file generated by `wasm-pack`, leading to `printerdemo.js` being renamed to `printerdemo_lib.js`. Consequently, the existing reference in the `index.html` file became outdated, causing the WASM module to fail to load correctly.

This PR addresses the issue by updating the reference in `index.html`, ensuring that the page can properly load and execute the WASM module.

Details of the changes:
- Updated the script import in `index.html` from `import init from './pkg/printerdemo.js';` to `import init from './pkg/printerdemo_lib.js';`.

With these adjustments, the resource loading error caused by the library name change is resolved, ensuring the WASM module is correctly initialized and functional.