### PR TITLE
Spinbox: fix and test the behaviour on mousewheel

### DIFF
--- a/internal/compiler/widgets/common/spinbox-base.slint
+++ b/internal/compiler/widgets/common/spinbox-base.slint
@@ -64,12 +64,12 @@ export component SpinBoxBase {
         enabled: root.enabled;
 
         scroll-event(event) => {
-            if (event.delta-y < 0) {
+            if (event.delta-y > 0) {
                 root.increment();
                 return accept;
             }
 
-            if (event.delta-y > 0) {
+            if (event.delta-y < 0) {
                 root.decrement();
                 return accept;
             }

--- a/tests/cases/widgets/spinbox_basic.slint
+++ b/tests/cases/widgets/spinbox_basic.slint
@@ -13,19 +13,18 @@ export component TestCase inherits Window {
     forward-focus: box;
     out property <bool> spinbox-focused <=> box.has_focus;
     callback edited <=> box.edited;
+    in-out property value <=> box.value;
 }
 
 /*
 
 
 ```rust
-use slint::platform::Key;
+use slint::{LogicalPosition, platform::WindowEvent, platform::Key };
 use std::cell::RefCell;
 use std::rc::Rc;
 
 let instance = TestCase::new().unwrap();
-slint_testing::send_mouse_click(&instance, 5., 5.);
-assert!(instance.get_spinbox_focused());
 
 let edits = Rc::new(RefCell::new(Vec::new()));
 
@@ -35,11 +34,45 @@ instance.on_edited({
     edits.borrow_mut().push(val);
 }});
 
+
+assert_eq!(instance.get_value(), 0);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_spinbox_focused());
+
 slint_testing::send_keyboard_char(&instance, '4', true);
 slint_testing::send_keyboard_char(&instance, Key::Return.into(), true);
 
-assert_eq!(edits.borrow().clone(), vec![40]);
+assert_eq!(instance.get_value(), 40);
+assert_eq!(&*edits.borrow(), &[40]);
+edits.borrow_mut().clear();
+
+// This position happens to work with all styles
+let position = LogicalPosition::new(40.0, 50.0);
+
+// scroll up
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position , delta_x: 0.0, delta_y: 50.0 });
+assert_eq!(instance.get_value(), 41);
+assert_eq!(&*edits.borrow(), &[41]);
+edits.borrow_mut().clear();
+
+// scroll down
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position , delta_x: 0.0, delta_y: -10.0 });
+assert_eq!(instance.get_value(), 40);
+assert_eq!(&*edits.borrow(), &[40]);
+edits.borrow_mut().clear();
+
+
+instance.set_value(0);
+// scroll down should do nothing when the value is 0
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position , delta_x: 0.0, delta_y: -10.0 });
+assert_eq!(instance.get_value(), 0);
+assert_eq!(&*edits.borrow(), &[]);
+edits.borrow_mut().clear();
+
+
+
 
 ```
+
 
 */

--- a/tests/cases/widgets/spinbox_basic.slint
+++ b/tests/cases/widgets/spinbox_basic.slint
@@ -20,7 +20,7 @@ export component TestCase inherits Window {
 
 
 ```rust
-use slint::{LogicalPosition, platform::WindowEvent, platform::Key };
+use slint::{LogicalPosition, platform::WindowEvent, platform::Key};
 use std::cell::RefCell;
 use std::rc::Rc;
 


### PR DESCRIPTION
Scrolling up should increase the value, not decrease it.

The Qt behaviour was changed in #5010