### PR TITLE
Properly expose `Switch` as such in the accessibility tree

### DIFF
--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -317,6 +317,7 @@ cpp! {{
                     i_slint_core::items::AccessibleRole::Table => QAccessible_Role_Table,
                     i_slint_core::items::AccessibleRole::Tree => QAccessible_Role_Tree,
                     i_slint_core::items::AccessibleRole::TextInput => QAccessible_Role_EditableText,
+                    i_slint_core::items::AccessibleRole::Switch => QAccessible_Role_CheckBox,
                 }
             });
         }

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -369,6 +369,7 @@ impl AccessKitAdapter {
                     i_slint_core::items::AccessibleRole::ProgressIndicator => {
                         Role::ProgressIndicator
                     }
+                    i_slint_core::items::AccessibleRole::Switch => Role::Switch,
                 },
                 item.accessible_string_property(
                     i_slint_core::accessibility::AccessibleStringProperty::Label,

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -356,6 +356,8 @@ macro_rules! for_each_enums {
                 /// The role for widget with editable text such as a
                 /// [`LineEdit`](../widgets/lineedit.md) or a [`TextEdit`](../widgets/textedit.md)
                 TextInput,
+                /// The element is a [`Switch`](../widgets/switch.md) or behaves like one.
+                Switch,
             }
 
             /// This enum represents the different values of the `sort-order` property.

--- a/internal/compiler/widgets/cosmic-base/switch.slint
+++ b/internal/compiler/widgets/cosmic-base/switch.slint
@@ -30,7 +30,7 @@ export component Switch {
     accessible-label: root.text;
     accessible-checkable: true;
     accessible-checked <=> root.checked;
-    accessible-role: checkbox;
+    accessible-role: switch;
     forward-focus: state-layer;
 
     states [

--- a/internal/compiler/widgets/cupertino-base/switch.slint
+++ b/internal/compiler/widgets/cupertino-base/switch.slint
@@ -31,7 +31,7 @@ export component Switch {
     accessible-label: root.text;
     accessible-checkable: true;
     accessible-checked <=> root.checked;
-    accessible-role: checkbox;
+    accessible-role: switch;
     forward-focus: i-focus-scope;
 
     states [

--- a/internal/compiler/widgets/fluent-base/switch.slint
+++ b/internal/compiler/widgets/fluent-base/switch.slint
@@ -30,7 +30,7 @@ export component Switch {
     accessible-label: root.text;
     accessible-checkable: true;
     accessible-checked <=> root.checked;
-    accessible-role: checkbox;
+    accessible-role: switch;
     forward-focus: i-focus-scope;
 
     states [

--- a/internal/compiler/widgets/material-base/switch.slint
+++ b/internal/compiler/widgets/material-base/switch.slint
@@ -27,7 +27,7 @@ export component Switch {
     accessible-label <=> i-label.text;
     accessible-checkable: true;
     accessible-checked <=> root.checked;
-    accessible-role: checkbox;
+    accessible-role: switch;
 
     states [
         disabled-selected when !root.enabled && root.checked  : {

--- a/internal/compiler/widgets/qt/switch.slint
+++ b/internal/compiler/widgets/qt/switch.slint
@@ -5,5 +5,5 @@ export component Switch inherits NativeCheckBox {
     accessible-checkable: true;
     accessible-checked <=> root.checked;
     accessible-label <=> root.text;
-    accessible-role: checkbox;
+    accessible-role: switch;
 }


### PR DESCRIPTION
`Switch` widgets are currently exposed as check boxes in the accessibility tree. Since AccessKit has the `Switch` role, let's use that to better carry the meaning.

Tested by running the gallery example app which contain many.