### PR TITLE
Text strokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 
 ## Slint Language
 
+ - Text: Added `stroke`, `stroke-width`, and `stroke-style` properties.
  - Added `Colors.hsv()` method to create colors in the HSV color space.
  - Added `to-hsv()` function to color.
  - Throw an error when `rgb()` or `argb()` have too many arguments.

--- a/docs/reference/src/advanced/backends_and_renderers.md
+++ b/docs/reference/src/advanced/backends_and_renderers.md
@@ -67,6 +67,7 @@ The Qt renderer comes with the [Qt backend](backend_qt.md) and renders using QPa
   * No support for `drop-shadow-*` properties.
   * No support for `border-radius` in combination with `clip: true`.
   * No circular gradients.
+  * No text stroking/outlining.
 - Text rendering currently limited to western scripts.
 - Available in the [Winit backend](backend_winit.md).
 - Public [Rust](slint-rust:platform/software_renderer/) and [C++](slint-cpp:api/classslint_1_1platform_1_1SoftwareRenderer) API.

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -710,7 +710,8 @@ export component Example inherits Window {
 ## `Text`
 
 The `Text` element is responsible for rendering text. Besides the `text` property, that specifies which text to render,
-it also allows configuring different visual aspects through the `font-family`, `font-size`, `font-weight` and `color` properties.
+it also allows configuring different visual aspects through the `font-family`, `font-size`, `font-weight`, `color`, and
+`stroke` properties.
 
 The `Text` element can break long text into multiple lines of text. A line feed character (`\n`) in the string of the `text`
 property will trigger a manual line break. For automatic line breaking you need to set the `wrap` property to a value other than
@@ -731,6 +732,9 @@ and the text itself.
 -   **`text`** (_in_ _[string](../syntax/types.md#strings)_): The text rendered.
 -   **`vertical-alignment`** (_in_ _enum [`TextVerticalAlignment`](enums.md#textverticalalignment)_): The vertical alignment of the text.
 -   **`wrap`** (_in_ _enum [`TextWrap`](enums.md#textwrap)_): The way the text wraps (default value: `no-wrap`).
+-   **`stroke`** (_in_ _brush_): The brush used for the text outline (default value: `transparent`).
+-   **`stroke-width`** (_in_ _length_): The width of the text outline. If the width is zero, then a hairline stroke (1 physical pixel) will be rendered.
+-   **`stroke-style`** (_in_ _enum [`TextStrokeStyle`](enums.md#textstrokestyle)_): The style/alignment of the text outline (default value: `outside`).
 
 ### Example
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -777,6 +777,14 @@ impl ItemRenderer for QtItemRenderer<'_> {
                 
                 QPen stroke_pen(stroke_brush, stroke_width, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
                 stroke_pen.setMiterLimit(10.0);
+                if (stroke_width == 0.0) {
+                    // Hairline stroke
+                    if (stroke_outside)
+                        stroke_pen.setWidthF(2.0);
+                    else
+                        stroke_pen.setWidthF(1.0);
+                    stroke_pen.setCosmetic(true);
+                }
 
                 QTextCursor cursor(&document);
                 cursor.select(QTextCursor::Document);

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -678,13 +678,14 @@ impl ItemRenderer for QtItemRenderer<'_> {
         };
         let wrap = text.wrap() == TextWrap::WordWrap;
         let elide = text.overflow() == TextOverflow::Elide;
+        let stroke_visible = !text.stroke().is_transparent();
         let stroke_outside = text.stroke_style() == TextStrokeStyle::Outside;
         let stroke_width = match text.stroke_style() {
             TextStrokeStyle::Outside => text.stroke_width().get() * 2.0,
             TextStrokeStyle::Center => text.stroke_width().get(),
         };
         let painter: &mut QPainterPtr = &mut self.painter;
-        cpp! { unsafe [painter as "QPainterPtr*", rect as "QRectF", fill_brush as "QBrush", stroke_brush as "QBrush", mut string as "QString", font as "QFont", elide as "bool", alignment as "Qt::Alignment", wrap as "bool", stroke_outside as "bool", stroke_width as "float"] {
+        cpp! { unsafe [painter as "QPainterPtr*", rect as "QRectF", fill_brush as "QBrush", stroke_brush as "QBrush", mut string as "QString", font as "QFont", elide as "bool", alignment as "Qt::Alignment", wrap as "bool", stroke_visible as "bool", stroke_outside as "bool", stroke_width as "float"] {
             QString elided;
             if (!elide) {
                 elided = string;
@@ -736,7 +737,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
                 }
             }
 
-            if (stroke_width == 0) {
+            if (!stroke_visible) {
                 int flags = alignment;
                 if (wrap)
                     flags |= Qt::TextWordWrap;

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -741,7 +741,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
                 int flags = alignment;
                 if (wrap)
                     flags |= Qt::TextWordWrap;
-                
+
                 (*painter)->setFont(font);
                 (*painter)->setBrush(Qt::NoBrush);
                 (*painter)->setPen(QPen(fill_brush, 0));
@@ -774,7 +774,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
 
                 QTextCharFormat format;
                 format.setFont(font);
-                
+
                 QPen stroke_pen(stroke_brush, stroke_width, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
                 stroke_pen.setMiterLimit(10.0);
                 if (stroke_width == 0.0) {

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -56,6 +56,14 @@ macro_rules! for_each_enums {
                 Elide,
             }
 
+            /// This enum describes the positioning of a text stroke relative to the border of the glyphs in a [`Text`](elements.md#text).
+            enum TextStrokeStyle {
+                /// The inside edge of the stroke is at the outer edge of the text.
+                Outside,
+                /// The center line of the stroke is at the outer edge of the text, like in Adobe Illustrator.
+                Center,
+            }
+
             /// This enum describes whether an event was rejected or accepted by an event handler.
             enum EventResult {
                 /// The event is rejected by this event handler and may then be handled by the parent item

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -102,6 +102,9 @@ export component Text inherits Empty {
     in property <TextOverflow> overflow;
     in property <TextWrap> wrap;
     in property <length> letter-spacing;
+    in property <brush> stroke;
+    in property <length> stroke-width;
+    in property <TextStrokeStyle> stroke-style;
     //-default_size_binding:implicit_size
 }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -10,7 +10,7 @@ Lookup the [`crate::items`] module documentation.
 use super::{
     InputType, Item, ItemConsts, ItemRc, KeyEventResult, KeyEventType, PointArg,
     PointerEventButton, RenderingResult, TextHorizontalAlignment, TextOverflow,
-    TextVerticalAlignment, TextWrap, VoidArg,
+    TextStrokeStyle, TextVerticalAlignment, TextWrap, VoidArg,
 };
 use crate::graphics::{Brush, Color, FontRequest};
 use crate::input::{
@@ -51,6 +51,9 @@ pub struct Text {
     pub wrap: Property<TextWrap>,
     pub overflow: Property<TextOverflow>,
     pub letter_spacing: Property<LogicalLength>,
+    pub stroke: Property<Brush>,
+    pub stroke_width: Property<LogicalLength>,
+    pub stroke_style: Property<TextStrokeStyle>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
     pub cached_rendering_data: CachedRenderingData,

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -9,8 +9,8 @@ Lookup the [`crate::items`] module documentation.
 */
 use super::{
     InputType, Item, ItemConsts, ItemRc, KeyEventResult, KeyEventType, PointArg,
-    PointerEventButton, RenderingResult, TextHorizontalAlignment, TextOverflow,
-    TextStrokeStyle, TextVerticalAlignment, TextWrap, VoidArg,
+    PointerEventButton, RenderingResult, TextHorizontalAlignment, TextOverflow, TextStrokeStyle,
+    TextVerticalAlignment, TextWrap, VoidArg,
 };
 use crate::graphics::{Brush, Color, FontRequest};
 use crate::input::{

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -16,7 +16,7 @@ use i_slint_core::item_rendering::{
 };
 use i_slint_core::items::{
     self, Clip, FillRule, ImageRendering, ItemRc, Layer, Opacity, RenderingResult,
-    TextHorizontalAlignment, TextStrokeStyle
+    TextHorizontalAlignment, TextStrokeStyle,
 };
 use i_slint_core::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector,
@@ -341,7 +341,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
                     paint.set_line_width(stroke_width);
                     Some(font.init_paint(text.letter_spacing() * self.scale_factor, paint))
                 }
-            },
+            }
             None => None,
         };
 
@@ -360,14 +360,14 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
                     (TextStrokeStyle::Outside, Some(stroke_paint)) => {
                         canvas.stroke_text(pos.x, pos.y, to_draw.trim_end(), stroke_paint).unwrap();
                         canvas.fill_text(pos.x, pos.y, to_draw.trim_end(), &paint).unwrap();
-                    },
+                    }
                     (TextStrokeStyle::Center, Some(stroke_paint)) => {
                         canvas.fill_text(pos.x, pos.y, to_draw.trim_end(), &paint).unwrap();
                         canvas.stroke_text(pos.x, pos.y, to_draw.trim_end(), stroke_paint).unwrap();
-                    },
+                    }
                     _ => {
                         canvas.fill_text(pos.x, pos.y, to_draw.trim_end(), &paint).unwrap();
-                    },
+                    }
                 };
             },
         );

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -332,7 +332,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
             .brush_to_paint(text.stroke(), &rect_to_path((size * self.scale_factor).into()))
         {
             Some(mut paint) => {
-                if stroke_width == 0.0 {
+                if text.stroke().is_transparent() {
                     None
                 } else {
                     paint.set_line_width(stroke_width);

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -316,21 +316,24 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
             )
         });
 
-        let paint = match self
-            .brush_to_paint(text.color(), &rect_to_path((size * self.scale_factor).into()))
-        {
+        let text_path = rect_to_path((size * self.scale_factor).into());
+        let paint = match self.brush_to_paint(text.color(), &text_path) {
             Some(paint) => font.init_paint(text.letter_spacing() * self.scale_factor, paint),
             None => return,
         };
 
         let stroke_style = text.stroke_style();
-        let stroke_width = match stroke_style {
-            TextStrokeStyle::Outside => (text.stroke_width() * self.scale_factor).get() * 2.0,
-            TextStrokeStyle::Center => (text.stroke_width() * self.scale_factor).get(),
+        let stroke_width = if text.stroke_width().get() != 0.0 {
+            (text.stroke_width() * self.scale_factor).get()
+        } else {
+            // Hairline stroke
+            1.0
         };
-        let stroke_paint = match self
-            .brush_to_paint(text.stroke(), &rect_to_path((size * self.scale_factor).into()))
-        {
+        let stroke_width = match stroke_style {
+            TextStrokeStyle::Outside => stroke_width * 2.0,
+            TextStrokeStyle::Center => stroke_width,
+        };
+        let stroke_paint = match self.brush_to_paint(text.stroke(), &text_path) {
             Some(mut paint) => {
                 if text.stroke().is_transparent() {
                     None

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -465,7 +465,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
         let mut text_stroke_style = skia_safe::textlayout::TextStyle::new();
         let stroke_layout = match self.brush_to_paint(text.stroke(), max_width, max_height) {
             Some(mut stroke_paint) => {
-                if stroke_width == 0.0 {
+                if text.stroke().is_transparent() {
                     None
                 } else {
                     stroke_paint.set_style(skia_safe::PaintStyle::Stroke);

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -457,9 +457,15 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
         text_style.set_foreground_paint(&paint);
 
         let stroke_style = text.stroke_style();
+        let stroke_width = if text.stroke_width().get() != 0.0 {
+            (text.stroke_width() * self.scale_factor).get()
+        } else {
+            // Hairline stroke
+            1.0
+        };
         let stroke_width = match stroke_style {
-            TextStrokeStyle::Outside => (text.stroke_width() * self.scale_factor).get() * 2.0,
-            TextStrokeStyle::Center => (text.stroke_width() * self.scale_factor).get(),
+            TextStrokeStyle::Outside => stroke_width * 2.0,
+            TextStrokeStyle::Center => stroke_width,
         };
 
         let mut text_stroke_style = skia_safe::textlayout::TextStyle::new();

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -10,7 +10,9 @@ use i_slint_core::graphics::boxshadowcache::BoxShadowCache;
 use i_slint_core::graphics::euclid::num::Zero;
 use i_slint_core::graphics::euclid::{self, Vector2D};
 use i_slint_core::item_rendering::{CachedRenderingData, ItemCache, ItemRenderer, RenderImage};
-use i_slint_core::items::{ImageFit, ImageRendering, ItemRc, Layer, Opacity, RenderingResult, TextStrokeStyle};
+use i_slint_core::items::{
+    ImageFit, ImageRendering, ItemRc, Layer, Opacity, RenderingResult, TextStrokeStyle,
+};
 use i_slint_core::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalPx, LogicalRect, LogicalSize,
     LogicalVector, PhysicalPx, RectLengths, ScaleFactor, SizeLengths,
@@ -492,10 +494,10 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
                         text.vertical_alignment(),
                         text.wrap(),
                         text.overflow(),
-                        None
+                        None,
                     ))
                 }
-            },
+            }
             None => None,
         };
 
@@ -517,11 +519,11 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
             (TextStrokeStyle::Outside, Some((stroke_layout, stroke_layout_top_left))) => {
                 stroke_layout.paint(&mut self.canvas, to_skia_point(stroke_layout_top_left));
                 layout.paint(&mut self.canvas, to_skia_point(layout_top_left));
-            },
+            }
             (TextStrokeStyle::Center, Some((stroke_layout, stroke_layout_top_left))) => {
                 layout.paint(&mut self.canvas, to_skia_point(layout_top_left));
                 stroke_layout.paint(&mut self.canvas, to_skia_point(stroke_layout_top_left));
-            },
+            }
             _ => {
                 layout.paint(&mut self.canvas, to_skia_point(layout_top_left));
             }


### PR DESCRIPTION
Closes #4981.

Contains implementations for FemtoVG, Skia, and Qt.

Notes:
- While working on this, I stumbled upon a bug in FemtoVG (femtovg/femtovg#205) which causes outlines to sometimes render incorrectly.
- Using text strokes on Qt causes a noticeable performance dip on my machine. I did my best to optimize it but there may be further room for improvement.