### PR TITLE
Expose toggle buttons as such to AccessKit

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -348,12 +348,18 @@ impl AccessKitAdapter {
     }
 
     fn build_node_without_children(&self, item: &ItemRc, scale_factor: ScaleFactor) -> NodeBuilder {
+        let is_checkable =
+            item.accessible_string_property(AccessibleStringProperty::Checkable) == "true";
+
         let (role, label) = if let Some(window_item) = item.downcast::<WindowItem>() {
             (Role::Window, window_item.as_pin_ref().title().to_string())
         } else {
             (
                 match item.accessible_role() {
                     i_slint_core::items::AccessibleRole::None => Role::Unknown,
+                    i_slint_core::items::AccessibleRole::Button if is_checkable => {
+                        Role::ToggleButton
+                    }
                     i_slint_core::items::AccessibleRole::Button => Role::Button,
                     i_slint_core::items::AccessibleRole::Checkbox => Role::CheckBox,
                     i_slint_core::items::AccessibleRole::Combobox => Role::ComboBox,
@@ -393,7 +399,7 @@ impl AccessKitAdapter {
             y1: physical_origin.y + physical_size.height,
         });
 
-        if item.accessible_string_property(AccessibleStringProperty::Checkable) == "true" {
+        if is_checkable {
             builder.set_checked(
                 if item.accessible_string_property(AccessibleStringProperty::Checked) == "true" {
                     Checked::True

--- a/internal/compiler/widgets/cosmic-base/button.slint
+++ b/internal/compiler/widgets/cosmic-base/button.slint
@@ -23,6 +23,8 @@ export component Button {
     min-height: max(32px, layout.min-height);
     horizontal-stretch: 0;
     vertical-stretch: 0;
+    accessible-checkable: root.checkable;
+    accessible-checked <=> root.checked;
     accessible-label: text;
     accessible-role: button;
     forward-focus: state-layer;

--- a/internal/compiler/widgets/cupertino-base/button.slint
+++ b/internal/compiler/widgets/cupertino-base/button.slint
@@ -24,6 +24,8 @@ export component Button {
     min-height: max(20px, i-layout.min-height);
     horizontal-stretch: 0;
     vertical-stretch: 0;
+    accessible-checkable: root.checkable;
+    accessible-checked <=> root.checked;
     accessible-label: text;
     accessible-role: button;
     forward-focus: i-focus-scope;

--- a/internal/compiler/widgets/fluent-base/button.slint
+++ b/internal/compiler/widgets/fluent-base/button.slint
@@ -23,6 +23,8 @@ export component Button {
     min-height: max(32px, i-layout.min-height);
     horizontal-stretch: 0;
     vertical-stretch: 0;
+    accessible-checkable: root.checkable;
+    accessible-checked <=> root.checked;
     accessible-label: text;
     accessible-role: button;
     forward-focus: i-focus-scope;

--- a/internal/compiler/widgets/material-base/button.slint
+++ b/internal/compiler/widgets/material-base/button.slint
@@ -23,6 +23,8 @@ export component Button {
 
     min-height: max(40px, i-layout.min-height);
     min-width: max(40px, i-layout.min-width);
+    accessible-checkable: root.checkable;
+    accessible-checked <=> root.checked;
     accessible-label: text;
     accessible-role: button;
     forward-focus: i-state-layer;


### PR DESCRIPTION
If a button is checkable then it becomes a toggle button. It is probably not necessary to expose this accessible role directly, it can be figured out by looking if `accessible-checkable` is set on the widget.

Since the Qt button already had `accessible-checkable` and `accessible-checked`, I assume the behavior has been validated, I haven't done it myself.

Tested by playing with the OFF/ON toggle button in the gallery example, below the Dark mode switch.