### PR TITLE
rerun-if-env-changed=SLINT_GENERATED_INCLUDE_DIR

### DIFF
--- a/api/cpp/build.rs
+++ b/api/cpp/build.rs
@@ -14,6 +14,7 @@ fn main() -> Result<(), anyhow::Error> {
         manifest_dir.to_string_lossy()
     ));
 
+    println!("cargo:rerun-if-env-changed=SLINT_GENERATED_INCLUDE_DIR");
     let output_dir = std::env::var_os("SLINT_GENERATED_INCLUDE_DIR").unwrap_or_else(|| {
         Path::new(&std::env::var_os("OUT_DIR").unwrap()).join("generated_include").into()
     });


### PR DESCRIPTION
cargo currently doesn't know that we read this env var, which can lead to caching issues
