### PR TITLE
Use Color#mix for color interpolation

### DIFF
--- a/internal/core/graphics/color.rs
+++ b/internal/core/graphics/color.rs
@@ -305,7 +305,7 @@ impl Color {
 
 impl InterpolatedPropertyValue for Color {
     fn interpolate(&self, target_value: &Self, t: f32) -> Self {
-        self.mix(target_value, t)
+        target_value.mix(self, t)
     }
 }
 
@@ -410,8 +410,12 @@ fn test_brighter_darker() {
 #[test]
 fn test_transparent_transition() {
     let color = Color::from_argb_u8(0, 0, 0, 0);
+    let interpolated = color.interpolate(&Color::from_rgb_u8(211, 211, 211), 0.25);
+    assert_eq!(interpolated, Color::from_argb_u8(64, 211, 211, 211));
     let interpolated = color.interpolate(&Color::from_rgb_u8(211, 211, 211), 0.5);
     assert_eq!(interpolated, Color::from_argb_u8(128, 211, 211, 211));
+    let interpolated = color.interpolate(&Color::from_rgb_u8(211, 211, 211), 0.75);
+    assert_eq!(interpolated, Color::from_argb_u8(191, 211, 211, 211));
 }
 
 #[cfg(feature = "ffi")]

--- a/internal/core/graphics/color.rs
+++ b/internal/core/graphics/color.rs
@@ -305,12 +305,7 @@ impl Color {
 
 impl InterpolatedPropertyValue for Color {
     fn interpolate(&self, target_value: &Self, t: f32) -> Self {
-        Self {
-            red: self.red.interpolate(&target_value.red, t),
-            green: self.green.interpolate(&target_value.green, t),
-            blue: self.blue.interpolate(&target_value.blue, t),
-            alpha: self.alpha.interpolate(&target_value.alpha, t),
-        }
+        self.mix(target_value, t)
     }
 }
 
@@ -410,6 +405,13 @@ fn test_brighter_darker() {
     let blue = Color::from_rgb_u8(0, 0, 128);
     assert_eq!(blue.brighter(0.5), Color::from_rgb_u8(0, 0, 192));
     assert_eq!(blue.darker(0.5), Color::from_rgb_u8(0, 0, 85));
+}
+
+#[test]
+fn test_transparent_transition() {
+    let color = Color::from_argb_u8(0, 0, 0, 0);
+    let interpolated = color.interpolate(&Color::from_rgb_u8(211, 211, 211), 0.5);
+    assert_eq!(interpolated, Color::from_argb_u8(128, 211, 211, 211));
 }
 
 #[cfg(feature = "ffi")]


### PR DESCRIPTION
### Description
This PR changes the algorithm used for color interpolation to use `i_slint_core::graphics::color::Color#mix`. 
This would resolve the issue of color transitions having incorrect values when animating color to/from `transparent`

## Changes
Color#mix accounts for the alpha channel, so a transparent transition is not skewed by changes in transparency.
For example, with the proposed changes, a transition from `transparent` to `lightgray` changes like this .
On the left is the current algorithm, on the right is Color#mix
![image](https://github.com/slint-ui/slint/assets/19928439/02da4e3b-3ec6-4fdf-8dfa-efc5b34eb5ab)

### Motivation
Motivated by https://github.com/slint-ui/slint/issues/5055

