### PR TITLE
Run Node.js tests with the testing backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
               working-directory: ./api/node
               run: npm install --ignore-scripts
             - name: Build node plugin in debug
-              run: npm run build:debug
+              run: npm run build:testing
               working-directory: ./api/node
             - name: Run node tests
               working-directory: ./api/node

--- a/api/node/Cargo.toml
+++ b/api/node/Cargo.toml
@@ -37,6 +37,9 @@ renderer-skia-vulkan = ["slint-interpreter/renderer-skia-vulkan"]
 renderer-software = ["slint-interpreter/renderer-software"]
 accessibility = ["slint-interpreter/accessibility"]
 
+# Removed by node_package xtask
+testing = ["dep:i-slint-backend-testing"]
+
 [dependencies]
 napi = { version = "2.14.0", default-features = false, features = ["napi8"] }
 napi-derive = "2.14.0"
@@ -48,6 +51,8 @@ spin_on = "0.1"
 css-color-parser2 = { workspace = true }
 itertools = { workspace = true }
 send_wrapper = { workspace = true }
+# Removed by node_package xtask
+i-slint-backend-testing = { workspace = true, optional = true }
 
 [build-dependencies]
 napi-build = "2.1.0"

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -1039,4 +1039,6 @@ export namespace private_api {
     ) {
         component.component_instance.sendKeyboardStringSequence(s);
     }
+
+    export import initTesting = napi.initTesting;
 }

--- a/api/node/package.json
+++ b/api/node/package.json
@@ -37,6 +37,7 @@
     "compile": "tsc",
     "build": "napi build --platform --release --js rust-module.cjs --dts rust-module.d.ts -c binaries.json",
     "build:debug": "napi build --platform --js rust-module.cjs --dts rust-module.d.ts -c binaries.json && npm run compile",
+    "build:testing": "napi build --platform --js rust-module.cjs --dts rust-module.d.ts -c binaries.json --features testing && npm run compile",
     "install": "node build-on-demand.mjs",
     "docs": "npm run build && typedoc --hideGenerator --treatWarningsAsErrors --readme cover.md index.ts",
     "test": "ava"

--- a/api/node/src/lib.rs
+++ b/api/node/src/lib.rs
@@ -76,3 +76,10 @@ pub fn set_quit_on_last_window_closed(
     }
     env.get_undefined()
 }
+
+#[napi]
+pub fn init_testing()
+{
+    #[cfg(feature = "testing")]
+    i_slint_backend_testing::init_with_event_loop();
+}

--- a/tests/driver/nodejs/nodejs.rs
+++ b/tests/driver/nodejs/nodejs.rs
@@ -40,7 +40,7 @@ lazy_static::lazy_static! {
         // builds the slint node package in debug
         let o = std::process::Command::new(npm.clone())
                 .arg("run")
-                .arg("build:debug")
+                .arg("build:testing")
                 .current_dir(node_dir.clone())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
@@ -64,6 +64,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
         r#"
                 const assert = require('assert').strict;
                 let slintlib = require(String.raw`{slintpath}`);
+                slintlib.private_api.initTesting();
                 let slint = slintlib.loadFile(String.raw`{path}`);
         "#,
         slintpath = slintpath.to_string_lossy(),

--- a/xtask/src/nodepackage.rs
+++ b/xtask/src/nodepackage.rs
@@ -101,6 +101,11 @@ pub fn generate(sha1: Option<String>) -> Result<(), Box<dyn std::error::Error>> 
         toml["package"][&key_to_replace] = data;
     }
 
+    // Remove testing feature as we also remove the i-slint-backend-testing dependency below
+    if let Some(features_table) = toml["features"].as_table_mut() {
+        features_table.remove("testing");
+    }
+
     // Remove all `path = ` entries from dependencies and subsitute workspace = true
     for dep_key in ["dependencies", "build-dependencies"].iter() {
         let dep_table = match toml[dep_key].as_table_mut() {
@@ -108,6 +113,10 @@ pub fn generate(sha1: Option<String>) -> Result<(), Box<dyn std::error::Error>> 
             _ => continue,
         };
         let deps: Vec<_> = dep_table.iter().map(|(name, _)| name.to_string()).collect();
+
+        // Remove testing backend as it's not published
+        dep_table.remove("i-slint-backend-testing");
+
         deps.iter().for_each(|name| {
             if let Some(dep_config) = dep_table[name].as_inline_table_mut() {
                 if name.contains("slint") {


### PR DESCRIPTION
Add the ability to depend on the testing backend and opt into it when running tests/cases, like we do for the other drivers.

The testing backend dependency is removed in the packaging step, as we don't publish i-slint-backend-testing.