### PR TITLE
Update to compat-1-6 instead of compat-1-2

### DIFF
--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -52,7 +52,7 @@ i-slint-backend-selector = { workspace = true, optional = true }
 i-slint-backend-testing = { workspace = true, features = ["default"], optional = true }
 i-slint-renderer-skia = {  workspace = true, features = ["default", "x11", "wayland"], optional = true }
 i-slint-core = { workspace = true, features = ["ffi"] }
-slint-interpreter = { workspace = true, features = ["ffi", "compat-1-2"], optional = true }
+slint-interpreter = { workspace = true, features = ["ffi", "compat-1-6"], optional = true }
 raw-window-handle = { version = "0.5", optional = true }
 # Enable image-rs' default features to make all image formats to C++ users
 image = { workspace = true, optional = true, features = ["default"] }

--- a/api/node/Cargo.toml
+++ b/api/node/Cargo.toml
@@ -46,7 +46,7 @@ napi-derive = "2.14.0"
 i-slint-compiler = { workspace = true, features = ["default"] }
 i-slint-core = { workspace = true, features = ["default"] }
 i-slint-backend-selector = { workspace = true }
-slint-interpreter = { workspace = true, default-features = false, features = ["display-diagnostics", "internal", "compat-1-2"] }
+slint-interpreter = { workspace = true, default-features = false, features = ["display-diagnostics", "internal", "compat-1-6"] }
 spin_on = "0.1"
 css-color-parser2 = { workspace = true }
 itertools = { workspace = true }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -27,11 +27,11 @@ default = [
   "renderer-software",
   "image-default-formats",
   "accessibility",
-  "compat-1-2",
+  "compat-1-6",
 ]
 
 ## Mandatory feature:
-## This feature is required to keep the compatibility with Slint 1.2
+## This feature is required to keep the compatibility with Slint 1.6
 ## Newer patch version may put current functionality behind a new feature
 ## that would be enabled by default only if this feature was added.
 ## [More info in this blog post](https://slint.dev/blog/rust-adding-default-cargo-feature.html)

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -195,9 +195,9 @@ See the [documentation of the `Global` trait](Global) for an example.
 
 extern crate alloc;
 
-#[cfg(not(feature = "compat-1-2"))]
+#[cfg(not(feature = "compat-1-6"))]
 compile_error!(
-    "The feature `compat-1-2` must be enabled to ensure \
+    "The feature `compat-1-6` must be enabled to ensure \
     forward compatibility with future version of this crate"
 );
 

--- a/api/rs/slint/mcu.md
+++ b/api/rs/slint/mcu.md
@@ -29,7 +29,7 @@ Start by adding a dependency to the `slint` and the `slint-build` crates to your
 Start with the `slint` crate like this:
 
 ```sh
-cargo add slint@1.5.0 --no-default-features --features "compat-1-2 unsafe-single-threaded libm"
+cargo add slint@1.5.0 --no-default-features --features "compat-1-6 unsafe-single-threaded libm"
 ```
 
 The default features of the `slint` crate are tailored towards hosted environments and includes the "std" feature. In bare metal environments,
@@ -37,7 +37,7 @@ you need to disable the default features.
 
 In the snippet above, three features are selected:
 
- * `compat-1-2`: We select this feature when disabling the default features. For a detailed explanation see our blog post ["Adding default cargo features without breaking Semantic Versioning"](https://slint.dev/blog/rust-adding-default-cargo-feature.html).
+ * `compat-1-6`: We select this feature when disabling the default features. For a detailed explanation see our blog post ["Adding default cargo features without breaking Semantic Versioning"](https://slint.dev/blog/rust-adding-default-cargo-feature.html).
  * `unsafe-single-threaded`: Slint internally uses Rust's [`thread_local!`](https://doc.rust-lang.org/std/macro.thread_local.html) macro to store global data.
    This macro is only available in the Rust Standard Library (std), but not in bare metal environments. As a fallback, the `unsafe-single-threaded`
    feature changes Slint to use unsafe static for storage. This way, you guarantee to use Slint API only from a single thread, and not from interrupt handlers.
@@ -69,7 +69,7 @@ edition = "2021"
 [dependencies.slint]
 version = "1.5.0"
 default-features = false
-features = ["compat-1-2", "unsafe-single-threaded", "libm"]
+features = ["compat-1-6", "unsafe-single-threaded", "libm"]
 [build-dependencies]
 slint-build = "1.5.0"
 ```

--- a/api/wasm-interpreter/Cargo.toml
+++ b/api/wasm-interpreter/Cargo.toml
@@ -17,7 +17,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-slint-interpreter = { workspace = true, features = ["std", "backend-winit", "renderer-femtovg", "compat-1-2", "internal"] }
+slint-interpreter = { workspace = true, features = ["std", "backend-winit", "renderer-femtovg", "compat-1-6", "internal"] }
 send_wrapper = { workspace = true }
 
 vtable = { workspace = true }

--- a/examples/carousel/rust/Cargo.toml
+++ b/examples/carousel/rust/Cargo.toml
@@ -15,7 +15,7 @@ path = "main.rs"
 name = "carousel"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-6"] }
 mcu-board-support = { path = "../../mcu-board-support", optional = true }
 
 [build-dependencies]

--- a/examples/energy-monitor/Cargo.toml
+++ b/examples/energy-monitor/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-6"] }
 mcu-board-support = { path = "../mcu-board-support", optional = true }
 chrono = { version = "0.4.34", optional = true, default-features = false, features = ["clock", "std", "wasmbind"] }
 weer_api = { version = "0.1", optional = true }

--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -23,7 +23,7 @@ esp32-s2-kaluga-1 = ["slint/unsafe-single-threaded", "esp32s2-hal", "embedded-ha
 esp32-s3-box = ["slint/unsafe-single-threaded", "esp32s3-hal", "embedded-hal", "xtensa-lx-rt/esp32s3", "esp-alloc", "esp-println/esp32s3", "esp-backtrace/esp32s3", "display-interface", "display-interface-spi", "mipidsi", "embedded-graphics-core", "slint/libm", "tt21100"]
 
 [dependencies]
-slint = { version = "=1.6.0", path = "../../api/rs/slint", default-features = false, features = ["compat-1-2", "renderer-software"] }
+slint = { version = "=1.6.0", path = "../../api/rs/slint", default-features = false, features = ["compat-1-6", "renderer-software"] }
 i-slint-core-macros = { version = "=1.6.0", path = "../../internal/core-macros" }
 
 derive_more = "0.99.5"

--- a/examples/printerdemo_mcu/Cargo.toml
+++ b/examples/printerdemo_mcu/Cargo.toml
@@ -19,7 +19,7 @@ simulator = ["slint/renderer-software", "slint/backend-winit", "slint/std"]
 default = ["simulator"]
 
 [dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-6"] }
 mcu-board-support = { path = "../mcu-board-support" }
 
 [build-dependencies]

--- a/examples/uefi-demo/Cargo.toml
+++ b/examples/uefi-demo/Cargo.toml
@@ -18,7 +18,7 @@ uefi = "0.20.0"
 uefi-services = "0.17.0"
 
 slint = { path = "../../api/rs/slint", default-features = false, features = [
-    "compat-1-2",
+    "compat-1-6",
     "renderer-software",
     "libm",
     "log",

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -80,7 +80,7 @@ cocoa = { version = "0.25.0" }
 cfg_aliases = { workspace = true }
 
 [dev-dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "backend-winit", "renderer-software", "raw-window-handle-06"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-6", "backend-winit", "renderer-software", "raw-window-handle-06"] }
 
 [package.metadata.docs.rs]
 features = ["wayland", "renderer-software"]

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -105,7 +105,7 @@ rustybuzz = { version = "0.13.0", optional = true }
 fontdue = { workspace = true, optional = true }
 
 [dev-dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-6"] }
 i-slint-backend-testing = { path="../backends/testing" }
 rustybuzz = "0.13.0"
 ttf-parser = "0.20.0"

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -20,17 +20,22 @@ path = "lib.rs"
 
 [features]
 
-default = ["backend-default", "renderer-femtovg", "accessibility", "compat-1-2"]
+default = ["backend-default", "renderer-femtovg", "accessibility", "compat-1-6"]
 
 ## Mandatory feature:
-## This feature is required to keep the compatibility with Slint 1.2
+## This feature is required to keep the compatibility with Slint 1.6
 ## Newer patch version may put current functionality behind a new feature
 ## that would be enabled by default only if this feature was added
-"compat-1-2" = []
+"compat-1-6" = []
+"compat-1-2" = ["compat-1-6", "image-default-formats"]
 "compat-1-0" = ["compat-1-2"]
 
 ## enable the [`print_diagnostics`] function to show diagnostic in the console output
 display-diagnostics = ["i-slint-compiler/display-diagnostics"]
+
+## Enable all formats from the `image` crate. To increase what is supported from [`Image::load_from_path`]
+## or in `@image-url`.
+image-default-formats = ["i-slint-core/image-default-formats"]
 
 # (internal) export C++ FFI functions
 ffi = ["spin_on", "i-slint-core/ffi"]

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -67,9 +67,9 @@ instance.run().unwrap();
 #![warn(missing_docs)]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 
-#[cfg(not(feature = "compat-1-2"))]
+#[cfg(not(feature = "compat-1-6"))]
 compile_error!(
-    "The feature `compat-1-2` must be enabled to ensure \
+    "The feature `compat-1-6` must be enabled to ensure \
     forward compatibility with future version of this crate"
 );
 

--- a/tests/driver/interpreter/Cargo.toml
+++ b/tests/driver/interpreter/Cargo.toml
@@ -18,7 +18,7 @@ path = "main.rs"
 name = "test-driver-interpreter"
 
 [dev-dependencies]
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-6"] }
 i-slint-backend-testing = { workspace = true, features = ["default"] }
 
 itertools = { workspace = true }

--- a/tests/driver/rust/Cargo.toml
+++ b/tests/driver/rust/Cargo.toml
@@ -21,9 +21,9 @@ name = "test-driver-rust"
 build-time = ["i-slint-compiler", "spin_on"]
 
 [dependencies]
-slint = { workspace = true, features = ["std", "compat-1-2"] }
+slint = { workspace = true, features = ["std", "compat-1-6"] }
 i-slint-backend-testing = { workspace = true, features = ["default"] }
-slint-interpreter = { workspace = true, features = ["std", "compat-1-2", "internal"] }
+slint-interpreter = { workspace = true, features = ["std", "compat-1-6", "internal"] }
 spin_on = "0.1"
 
 [build-dependencies]

--- a/tests/screenshots/Cargo.toml
+++ b/tests/screenshots/Cargo.toml
@@ -18,7 +18,7 @@ path = "main.rs"
 name = "test-driver-screenshot"
 
 [dependencies]
-slint = { workspace = true, features = ["std", "compat-1-2"] }
+slint = { workspace = true, features = ["std", "compat-1-6"] }
 i-slint-core = { workspace = true, features = ["default", "software-renderer", "software-renderer-rotation"] }
 i-slint-backend-testing = { workspace = true, features = ["default"] }
 image = { workspace = true }

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -91,8 +91,8 @@ dissimilar = "1.0.7"
 i-slint-backend-selector = { workspace = true, optional = true }
 i-slint-common = { workspace = true, optional = true }
 i-slint-core = { workspace = true, features = ["std"], optional = true }
-slint = { workspace = true, features = ["compat-1-2"], optional = true }
-slint-interpreter = { workspace = true, features = ["compat-1-2", "highlight", "internal"], optional = true  }
+slint = { workspace = true, features = ["compat-1-6"], optional = true }
+slint-interpreter = { workspace = true, features = ["compat-1-6", "highlight", "internal"], optional = true  }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.0", features = ["derive", "wrap_help"] }

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -53,7 +53,7 @@ default = ["backend-default", "renderer-femtovg"]
 [dependencies]
 i-slint-compiler = { workspace = true }
 i-slint-core = { workspace = true }
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-6", "internal", "accessibility"] }
 i-slint-backend-selector = { workspace = true }
 
 clap = { version = "4.0", features = ["derive", "wrap_help"] }


### PR DESCRIPTION
The upgrade of the image crate forced us to add a feature in the compat-1-2, so now use compat-1-6 everywhere