### PR TITLE
Fix Yocto build after image crate update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,12 @@ cfg_aliases = { version = "0.2.0" }
 
 raw-window-handle-06 = { package = "raw-window-handle", version = "0.6", features = ["alloc"] }
 
+[patch.crates-io]
+# Patch in a special version of https://github.com/etemesi254/zune-image/pull/187 applied to zune-core 0.4.12 and zune-jpeg 0.4.11
+# to fix Linux cross-build requiring sysroot.
+zune-core = { git = "https://github.com/slint-ui/zune-image", branch = "simon/fix-rust-cross-build-04" }
+zune-jpeg = { git = "https://github.com/slint-ui/zune-image", branch = "simon/fix-rust-cross-build-04" }
+
 [profile.release]
 lto = true
 panic = "abort"


### PR DESCRIPTION
The new image create version brings in a new jpeg decoder, zune-jpeg, which specifies cdylib as crate-type. That breaks the corrosion cross-compilation of slint-cpp, as during that cdylib build, cargo also tries to create zune-jpeg's cdylib, but without the corrosion link args meant for slint-cpp.

Meanwhile, patch in a special version of https://github.com/etemesi254/zune-image/pull/187 rebased onto the version that image-rs uses.