### PR TITLE
C++: fix code generation of functions that don't return anything

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2184,9 +2184,10 @@ fn generate_functions<'a>(
     functions.iter().map(|f| {
         let mut ctx2 = ctx.clone();
         ctx2.argument_types = &f.args;
+        let ret = if f.ret_ty != Type::Void { "return " } else { "" };
         let body = vec![
             "[[maybe_unused]] auto self = this;".into(),
-            format!("return {};", compile_expression(&f.code, &ctx2)),
+            format!("{ret}{};", compile_expression(&f.code, &ctx2)),
         ];
         Declaration::Function(Function {
             name: ident(&format!("fn_{}", f.name)),

--- a/tests/cases/types/functions.slint
+++ b/tests/cases/types/functions.slint
@@ -12,6 +12,7 @@ TestCase := TouchArea {
     public function fn1(foo2: Foo2) -> Foo3 {
       return { b: foo2.a.member+1 };
     }
+    public function fn2() { fn1({a:{member:456}}); }
 }
 
 


### PR DESCRIPTION
and whose expression return something. Otherwise we get an error: `return-statement with a value, in function returning ‘void’`