### PR TITLE
Revert "Add a "image-default-formats" feature" and "Janitor: Update the image crate"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ css-color-parser2 = { version = "1.0.1" }
 fontdb = { version = "0.16.0", default-features = false }
 fontdue = { version = "0.8.0" }
 glutin = { version = "0.31.1", default-features = false }
-image = { version = "0.25", default-features = false, features = [ "png", "jpeg" ] }
+image = { version = "0.24", default-features = false, features = [ "png", "jpeg" ] }
 itertools = { version = "0.12" }
 resvg = { version= "0.40.0", default-features = false, features = ["text"] }
 send_wrapper = { version = "0.6.0" }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -25,7 +25,6 @@ default = [
   "backend-default",
   "renderer-femtovg",
   "renderer-software",
-  "image-default-formats",
   "accessibility",
   "compat-1-2",
 ]
@@ -35,8 +34,7 @@ default = [
 ## Newer patch version may put current functionality behind a new feature
 ## that would be enabled by default only if this feature was added.
 ## [More info in this blog post](https://slint.dev/blog/rust-adding-default-cargo-feature.html)
-"compat-1-6" = []
-"compat-1-2" = ["compat-1-6", "image-default-formats"]
+"compat-1-2" = []
 "compat-1-0" = ["compat-1-2", "renderer-software"]
 
 ## Enable use of the Rust standard library.
@@ -85,10 +83,6 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 ## [HasWindowHandle](raw_window_handle_06::HasWindowHandle) and
 ## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation.
 raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
-
-## Enable all formats from the `image` crate. To increase what is supported from [`Image::load_from_path`]
-## or in `@image-url`.
-image-default-formats = ["i-slint-core/image-default-formats"]
 
 #! ### Backends
 

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -38,7 +38,6 @@ software-renderer = ["bytemuck"]
 software-renderer-rotation = []
 
 image-decoders = ["dep:image", "dep:clru"]
-image-default-formats = ["image?/default-formats"]
 svg = ["dep:resvg", "shared-fontdb"]
 
 box-shadow-cache = []


### PR DESCRIPTION
This reverts commit a159562ea7724909f201491427d581e06ca0f60c and just the version part of commit 1d2201a7ce48b4a61e66cdde6d7eed1a38ab8be0 to downgrade image to 0.24 again.

This is not a straight revert, the workspace unification remains, just the version is down to 0.24.

The update to the new image crate version causes two issues

- With the Xtensa Rust toolchain, a release build of the image crate takes excessively long (cargo +esp build --release in image-rs)
- The image crate version updates to zune-jpeg for JPEG decoding, which uses "cdylib" in crate-type, which in turn breaks the cross-compilation with Corrosion against a Linux sysroot, because the (unnecessary) zune-jpeg cdylib creation doesn't see corrosion's link args that provide the sysroot. (upstream PR at https://github.com/etemesi254/zune-image/pull/187 )

By reverting, this also closes #5068.