### PR TITLE
Accessibility: Remove the replace-select-text from the slint api

### DIFF
--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -621,7 +621,7 @@ cpp! {{
         void *interface_cast(QAccessible::InterfaceType t) override {
             if (t == QAccessible::ValueInterface && !item_string_property(m_data, QAccessible::Value).isEmpty()) {
                 return static_cast<QAccessibleValueInterface*>(this);
-            } else if (t == QAccessible::ActionInterface && !item_string_property(m_data, QAccessible::Value).isEmpty()) {
+            } else if (t == QAccessible::ActionInterface) {
                 return static_cast<QAccessibleActionInterface*>(this);
             }
             return QAccessibleInterface::interface_cast(t);
@@ -633,8 +633,11 @@ cpp! {{
         }
 
         void setCurrentValue(const QVariant &value) override {
-            // FIXME: Implement this?
-            Q_UNUSED(value);
+            QString value_string = value.toString();
+            rust!(Slint_accessible_setCurrentValue [m_data: Pin<&SlintAccessibleItemData> as "void*", value_string: qttypes::QString as "QString"] {
+                let Some(item) = m_data.item.upgrade() else {return};
+                item.accessible_action(&AccessibilityAction::SetValue(i_slint_core::format!("{value_string}")));
+            });
         }
 
         QVariant maximumValue() const override {

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -136,14 +136,15 @@ impl AccessKitAdapter {
                 let Some(accesskit::ActionData::Value(v)) = request.data else { return };
                 AccessibilityAction::ReplaceSelectedText(SharedString::from(&*v))
             }
-            Action::SetValue => {
-                match request.data.unwrap() {
-                    // FIXME: what to do when there is a string value?
-                    accesskit::ActionData::Value(_) => return,
-                    accesskit::ActionData::NumericValue(v) => AccessibilityAction::SetValue(v),
-                    _ => return,
+            Action::SetValue => match request.data.unwrap() {
+                accesskit::ActionData::Value(v) => {
+                    AccessibilityAction::SetValue(SharedString::from(&*v))
                 }
-            }
+                accesskit::ActionData::NumericValue(v) => {
+                    AccessibilityAction::SetValue(i_slint_core::format!("{v}"))
+                }
+                _ => return,
+            },
             _ => return,
         };
         if let Some(item) = self.item_rc_for_node_id(request.target) {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -115,10 +115,6 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-action-decrement", Type::Callback { return_type: None, args: vec![] }),
         (
             "accessible-action-set-value",
-            Type::Callback { return_type: None, args: vec![Type::Float32] },
-        ),
-        (
-            "accessible-action-replace-selected-text",
             Type::Callback { return_type: None, args: vec![Type::String] },
         ),
     ]

--- a/internal/compiler/widgets/cosmic-base/spinbox.slint
+++ b/internal/compiler/widgets/cosmic-base/spinbox.slint
@@ -56,7 +56,7 @@ export component SpinBox {
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
-    accessible-action-set-value(v) => { base.update-value(v); }
+    accessible-action-set-value(v) => { if v.is-float() { base.update-value(v.to-float()); } }
     accessible-action-increment => { base.increment(); }
     accessible-action-decrement => { base.decrement(); }
 

--- a/internal/compiler/widgets/cupertino-base/spinbox.slint
+++ b/internal/compiler/widgets/cupertino-base/spinbox.slint
@@ -101,7 +101,7 @@ export component SpinBox {
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
-    accessible-action-set-value(v) => { i-base.update-value(v); }
+    accessible-action-set-value(v) => { if v.is-float() { i-base.update-value(v.to-float()); } }
     accessible-action-increment => { i-base.increment(); }
     accessible-action-decrement => { i-base.decrement(); }
 

--- a/internal/compiler/widgets/fluent-base/spinbox.slint
+++ b/internal/compiler/widgets/fluent-base/spinbox.slint
@@ -53,7 +53,7 @@ export component SpinBox {
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
-    accessible-action-set-value(v) => { i-base.update-value(v); }
+    accessible-action-set-value(v) => { if v.is-float() { i-base.update-value(v.to-float()); } }
     accessible-action-increment => { i-base.increment(); }
     accessible-action-decrement => { i-base.decrement(); }
 

--- a/internal/compiler/widgets/material-base/spinbox.slint
+++ b/internal/compiler/widgets/material-base/spinbox.slint
@@ -79,7 +79,7 @@ export component SpinBox {
     accessible-value-minimum: root.minimum;
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
-    accessible-action-set-value(v) => { i-base.update-value(v); }
+    accessible-action-set-value(v) => { if v.is-float() { i-base.update-value(v.to-float()); } }
     accessible-action-increment => { i-base.increment(); }
     accessible-action-decrement => { i-base.decrement(); }
 

--- a/internal/compiler/widgets/qt/spinbox.slint
+++ b/internal/compiler/widgets/qt/spinbox.slint
@@ -8,7 +8,7 @@ export component SpinBox inherits NativeSpinBox {
     accessible-value-maximum: root.maximum;
     accessible-value-step: (root.maximum - root.minimum) / 100;
 
-    accessible-action-set-value(v) => { update-value(v); }
+    accessible-action-set-value(v) => { if v.is-float() {update-value(v.to-float());} }
     accessible-action-increment => { update-value(root.value + 1); }
     accessible-action-decrement => { update-value(root.value - 1); }
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -33,8 +33,9 @@ pub enum AccessibilityAction {
     Default,
     Decrement,
     Increment,
+    /// This is currently unused
     ReplaceSelectedText(SharedString),
-    SetValue(f64),
+    SetValue(SharedString),
 }
 
 bitflags! {


### PR DESCRIPTION
Because we don't support it in Qt and in our widgets yet.

Also accessible-action-set-value now takes a string because value is a string (for the line edit)