### PR TITLE
C++: Fix build with nightly Rust

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -113,11 +113,11 @@ if (SLINT_BUILD_RUNTIME)
 
     if(BUILD_SHARED_LIBS)
         set(rustc_lib_type "cdylib")
-        set(slint_cpp_impl "slint-cpp-shared")
+        set(slint_cpp_impl "slint_cpp-shared")
         set(cmake_lib_type "SHARED")
     else()
         set(rustc_lib_type "staticlib")
-        set(slint_cpp_impl "slint-cpp-static")
+        set(slint_cpp_impl "slint_cpp-static")
         set(cmake_lib_type "STATIC")
     endif()
 
@@ -142,15 +142,15 @@ if (SLINT_BUILD_RUNTIME)
     # target property doesn't propagate :(
     if (APPLE AND SLINT_IS_TOPLEVEL_BUILD AND BUILD_SHARED_LIBS)
         # corrosion could provide the Cargo.toml package version as a CMake target property.
-        corrosion_add_target_local_rustflags(slint-cpp -Clink-arg=-Wl,-install_name,@rpath/libslint_cpp.dylib,-current_version,${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR},-compatibility_version,${PROJECT_VERSION_MAJOR}.0)
+        corrosion_add_target_local_rustflags(slint_cpp -Clink-arg=-Wl,-install_name,@rpath/libslint_cpp.dylib,-current_version,${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR},-compatibility_version,${PROJECT_VERSION_MAJOR}.0)
         # Set this one to false again explicitely because Corrosion will starting setting this property to true by default.
-        set_target_properties(slint-cpp-shared PROPERTIES IMPORTED_NO_SONAME 0)
-        set_target_properties(slint-cpp-shared PROPERTIES IMPORTED_SONAME libslint_cpp.dylib)
+        set_target_properties(slint_cpp-shared PROPERTIES IMPORTED_NO_SONAME 0)
+        set_target_properties(slint_cpp-shared PROPERTIES IMPORTED_SONAME libslint_cpp.dylib)
     endif()
 
     add_library(Slint INTERFACE)
     add_library(Slint::Slint ALIAS Slint)
-    target_link_libraries(Slint INTERFACE slint-cpp)
+    target_link_libraries(Slint INTERFACE slint_cpp)
     target_compile_features(Slint INTERFACE cxx_std_20)
     if (MSVC)
         target_compile_options(Slint INTERFACE /bigobj)
@@ -167,25 +167,25 @@ if (SLINT_BUILD_RUNTIME)
 
 
     set_property(
-        TARGET slint-cpp
+        TARGET slint_cpp
         APPEND
         PROPERTY CORROSION_ENVIRONMENT_VARIABLES
         "SLINT_GENERATED_INCLUDE_DIR=${CMAKE_CURRENT_BINARY_DIR}/generated_include/"
     )
 
     set_property(
-        TARGET slint-cpp
+        TARGET slint_cpp
         PROPERTY CORROSION_FEATURES
         ${features}
     )
     set_property(
-        TARGET slint-cpp
+        TARGET slint_cpp
         PROPERTY CORROSION_NO_DEFAULT_FEATURES
         ON
     )
 
     if(SLINT_LIBRARY_CARGO_FLAGS)
-        corrosion_set_cargo_flags(slint-cpp ${SLINT_LIBRARY_CARGO_FLAGS})
+        corrosion_set_cargo_flags(slint_cpp ${SLINT_LIBRARY_CARGO_FLAGS})
     endif()
 
     if(SLINT_FEATURE_BACKEND_QT)
@@ -200,14 +200,14 @@ if (SLINT_BUILD_RUNTIME)
 
     if(SLINT_FEATURE_BACKEND_QT AND TARGET Qt::qmake)
         set_property(
-            TARGET slint-cpp
+            TARGET slint_cpp
             APPEND
             PROPERTY CORROSION_ENVIRONMENT_VARIABLES
             QMAKE=$<TARGET_PROPERTY:Qt::qmake,LOCATION>
         )
     else()
         set_property(
-            TARGET slint-cpp
+            TARGET slint_cpp
             APPEND
             PROPERTY CORROSION_ENVIRONMENT_VARIABLES
             SLINT_NO_QT=1
@@ -241,7 +241,7 @@ if (SLINT_BUILD_RUNTIME)
     # to build time.
     if(DEFINED ENV{PKG_CONFIG_SYSROOT_DIR})
         set_property(
-            TARGET slint-cpp
+            TARGET slint_cpp
             APPEND
             PROPERTY CORROSION_ENVIRONMENT_VARIABLES
             "PKG_CONFIG_SYSROOT_DIR=$ENV{PKG_CONFIG_SYSROOT_DIR}"
@@ -253,7 +253,7 @@ if (SLINT_BUILD_RUNTIME)
         find_program(CLANGCXX clang++)
         if(CLANGCC AND NOT DEFINED ENV{CLANGCC})
             set_property(
-                TARGET slint-cpp
+                TARGET slint_cpp
                 APPEND
                 PROPERTY CORROSION_ENVIRONMENT_VARIABLES
                 CLANGCC=${CLANGCC}
@@ -261,7 +261,7 @@ if (SLINT_BUILD_RUNTIME)
         endif()
         if(CLANGCXX AND NOT DEFINED ENV{CLANGCXX})
             set_property(
-                TARGET slint-cpp
+                TARGET slint_cpp
                 APPEND
                 PROPERTY CORROSION_ENVIRONMENT_VARIABLES
                 CLANGCXX=${CLANGCXX}
@@ -289,13 +289,13 @@ if (SLINT_BUILD_RUNTIME)
             if(host_cc)
                 string(REPLACE "-" "_" cargo_host_target_underscore "${Rust_CARGO_HOST_TARGET}")
                 set_property(
-                    TARGET slint-cpp
+                    TARGET slint_cpp
                     APPEND
                     PROPERTY CORROSION_ENVIRONMENT_VARIABLES
                     CC_${cargo_host_target_underscore}=${host_cc}
                 )
                 set_property(
-                    TARGET slint-cpp
+                    TARGET slint_cpp
                     APPEND
                     PROPERTY CORROSION_ENVIRONMENT_VARIABLES
                     CFLAGS_${cargo_host_target_underscore}=
@@ -354,10 +354,10 @@ if (SLINT_BUILD_RUNTIME)
         include(${CMAKE_CURRENT_LIST_DIR}/cmake/SlintMacro.cmake)
     endif()
 
-    export(TARGETS Slint slint-cpp
+    export(TARGETS Slint slint_cpp
         NAMESPACE Slint:: FILE "${CMAKE_BINARY_DIR}/lib/cmake/Slint/SlintTargets.cmake")
     install(EXPORT SlintTargets NAMESPACE Slint:: DESTINATION lib/cmake/Slint)
-    install(TARGETS Slint slint-cpp
+    install(TARGETS Slint slint_cpp
         EXPORT SlintTargets LIBRARY DESTINATION lib PUBLIC_HEADER DESTINATION include/slint)
 
     install(FILES $<TARGET_FILE:${slint_cpp_impl}> TYPE LIB)

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -20,6 +20,7 @@ links = "slint_cpp"
 [lib]
 path = "lib.rs"
 crate-type = ["lib", "cdylib", "staticlib"]
+name = "slint_cpp"
 
 # Note, these features need to be kept in sync (along with their defaults) in
 # the C++ crate's CMakeLists.txt


### PR DESCRIPTION
Cargo disallows dashes in library target names (lib.name in Cargo.toml), but when not set it uses the package name. That meant that dashes snuck in and https://github.com/rust-lang/cargo/pull/12783 fixes that.

The targets Corrosion creates correspond to the library name, so after that change it's slint_cpp.

To make this work with stable cargo, explicitly switch lib.name to slint_cpp.