### PR TITLE
Quickstart Rust Example Fix: Add x value for left Rectangle.

### DIFF
--- a/docs/quickstart/cpp/src/memory_game_logic.slint
+++ b/docs/quickstart/cpp/src/memory_game_logic.slint
@@ -27,6 +27,7 @@ component MemoryTile inherits Rectangle {
     // Left curtain
     Rectangle {
         background: #193076;
+        x: 0px;
         width: open_curtain ? 0px : (parent.width / 2);
         height: parent.height;
         animate width { duration: 250ms; easing: ease-in; }

--- a/docs/quickstart/cpp/src/memory_tiles_from_cpp.slint
+++ b/docs/quickstart/cpp/src/memory_tiles_from_cpp.slint
@@ -27,6 +27,7 @@ component MemoryTile inherits Rectangle {
     // Left curtain
     Rectangle {
         background: #193076;
+        x: 0px;
         width: open_curtain ? 0px : (parent.width / 2);
         height: parent.height;
         animate width { duration: 250ms; easing: ease-in; }

--- a/docs/quickstart/node/src/memory_game_logic.slint
+++ b/docs/quickstart/node/src/memory_game_logic.slint
@@ -27,6 +27,7 @@ component MemoryTile inherits Rectangle {
     // Left curtain
     Rectangle {
         background: #193076;
+        x: 0px;
         width: open_curtain ? 0px : (parent.width / 2);
         height: parent.height;
         animate width { duration: 250ms; easing: ease-in; }

--- a/docs/quickstart/node/src/memory_tiles_from_cpp.slint
+++ b/docs/quickstart/node/src/memory_tiles_from_cpp.slint
@@ -27,6 +27,7 @@ component MemoryTile inherits Rectangle {
     // Left curtain
     Rectangle {
         background: #193076;
+        x: 0px;
         width: open_curtain ? 0px : (parent.width / 2);
         height: parent.height;
         animate width { duration: 250ms; easing: ease-in; }

--- a/docs/quickstart/rust/src/main_game_logic_in_rust.rs
+++ b/docs/quickstart/rust/src/main_game_logic_in_rust.rs
@@ -81,6 +81,7 @@ slint::slint! {
         // Left curtain
         Rectangle {
             background: #193076;
+            x: 0px;
             width: open_curtain ? 0px : (parent.width / 2);
             height: parent.height;
             animate width { duration: 250ms; easing: ease-in; }

--- a/docs/quickstart/rust/src/main_multiple_tiles.rs
+++ b/docs/quickstart/rust/src/main_multiple_tiles.rs
@@ -37,6 +37,7 @@ component MemoryTile inherits Rectangle {
     // Left curtain
     Rectangle {
         background: #193076;
+        x: 0px;
         width: open_curtain ? 0px : (parent.width / 2);
         height: parent.height;
         animate width { duration: 250ms; easing: ease-in; }

--- a/docs/quickstart/rust/src/main_tiles_from_rust.rs
+++ b/docs/quickstart/rust/src/main_tiles_from_rust.rs
@@ -53,6 +53,7 @@ slint::slint! {
         // Left curtain
         Rectangle {
             background: #193076;
+            x: 0px;
             width: open_curtain ? 0px : (parent.width / 2);
             height: parent.height;
             animate width { duration: 250ms; easing: ease-in; }


### PR DESCRIPTION
Adds `x` value for left Rectangle. Fixes #5090 

EDIT: 
- cpp source had the same issue. Corrected and tested.
- node source had the same `.slint` source files as cpp source. These files were synced to the cpp src, but NOT tested.
