### PR TITLE
Bump Skia Rust bindings to 0.75

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -42,7 +42,7 @@ pin-weak = "1"
 scoped-tls-hkt = "0.1"
 raw-window-handle = { version = "0.5", features = ["std"] }
 
-skia-safe = { version = "0.72.0", features = ["textlayout", "gl"] }
+skia-safe = { version = "0.75.0", features = ["textlayout", "gl"] }
 glow = { version = "0.13" }
 unicode-segmentation = { version = "1.8.0" }
 
@@ -57,8 +57,8 @@ softbuffer = { workspace = true, default-features = false }
 bytemuck = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
-windows = { version = "0.54.0", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
-skia-safe = { version = "0.72.0", features = ["d3d"] }
+windows = { version = "0.56.0", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
+skia-safe = { version = "0.75.0", features = ["d3d"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = { version = "0.25.0" }
@@ -68,10 +68,10 @@ metal = { version = "0.27.0" }
 foreign-types = { version = "0.5.0" }
 objc = { version = "0.2.7" }
 core-graphics-types = { version = "0.1.1" }
-skia-safe = { version = "0.72.0", features = ["metal"] }
+skia-safe = { version = "0.75.0", features = ["metal"] }
 
 [target.'cfg(not(any(target_os = "macos", target_family = "windows")))'.dependencies]
-skia-safe = { version = "0.72.0", features = ["gl"] }
+skia-safe = { version = "0.75.0", features = ["gl"] }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -57,11 +57,11 @@ impl super::Surface for MetalSurface {
             mtl::BackendContext::new(
                 device.as_ptr() as mtl::Handle,
                 command_queue.as_ptr() as mtl::Handle,
-                std::ptr::null(),
             )
         };
 
-        let gr_context = skia_safe::gpu::DirectContext::new_metal(&backend, None).unwrap().into();
+        let gr_context =
+            skia_safe::gpu::direct_contexts::make_metal(&backend, None).unwrap().into();
 
         Ok(Self { command_queue, layer, gr_context })
     }
@@ -103,7 +103,7 @@ impl super::Surface for MetalSurface {
                 let texture_info =
                     mtl::TextureInfo::new(drawable.texture().as_ptr() as mtl::Handle);
 
-                let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_metal(
+                let backend_render_target = skia_safe::gpu::backend_render_targets::make_mtl(
                     (size.width as i32, size.height as i32),
                     &texture_info,
                 );

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -68,7 +68,7 @@ impl super::Surface for OpenGLSurface {
         })?;
 
         let mut gr_context =
-            skia_safe::gpu::DirectContext::new_gl(gl_interface, None).ok_or_else(|| {
+            skia_safe::gpu::direct_contexts::make_gl(gl_interface, None).ok_or_else(|| {
                 format!("Skia Renderer: Internal Error: Could not create Skia Direct Context from GL interface")
             })?;
 

--- a/internal/renderers/skia/textlayout.rs
+++ b/internal/renderers/skia/textlayout.rs
@@ -9,7 +9,6 @@ use i_slint_core::graphics::FontRequest;
 use i_slint_core::items::{TextHorizontalAlignment, TextVerticalAlignment};
 use i_slint_core::lengths::{LogicalLength, ScaleFactor};
 use i_slint_core::{items, Color};
-use skia_safe::FontMgr;
 
 use super::itemrenderer::to_skia_color;
 use super::{PhysicalLength, PhysicalPoint, PhysicalRect, PhysicalSize};
@@ -34,7 +33,6 @@ thread_local! {
         let font_mgr = skia_safe::FontMgr::new();
         let type_face_font_provider = skia_safe::textlayout::TypefaceFontProvider::new();
         let mut font_collection = skia_safe::textlayout::FontCollection::new();
-        font_collection.set_default_font_manager(FontMgr::new(), None);
         // FontCollection first looks up in the dynamic font manager and then the asset font manager. If the
         // family is empty, the default font manager will match against the system default. We want that behavior,
         // and only if the family is not present in the system, then we want to fall back to the assert font manager

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -134,7 +134,7 @@ impl VulkanSurface {
             )
         };
 
-        let gr_context = skia_safe::gpu::DirectContext::new_vulkan(&backend_context, None)
+        let gr_context = skia_safe::gpu::direct_contexts::make_vulkan(&backend_context, None)
             .ok_or_else(|| format!("Error creating Skia Vulkan context"))?;
 
         let previous_frame_end = RefCell::new(Some(sync::now(device.clone()).boxed()));


### PR DESCRIPTION
This updates Skia to milestone 126 and (among other things) fixes SKIA_DEBUG=1 builds.

See https://github.com/rust-skia/rust-skia/releases/tag/0.75.0 for more details.