### PR TITLE
Python: Replace import magic with an auto-loader

### DIFF
--- a/api/python/README.md
+++ b/api/python/README.md
@@ -74,9 +74,8 @@ export component AppWindow inherits Window {
 
 ```python
 import slint
-import appwindow_slint
 
-class App(appwindow_slint.AppWindow):
+class App(slint.loader.appwindow.AppWindow):
     @slint.callback
     def request_increase_value(self):
         self.counter = self.counter + 1
@@ -93,7 +92,7 @@ app.run()
 
 The following example shows how to instantiate a Slint component in Python:
 
-**`ui.slint`**
+**`app.slint`**
 
 ```slint
 export component MainWindow inherits Window {
@@ -111,20 +110,24 @@ export component MainWindow inherits Window {
 The exported component is exposed as a Python class. To access this class, you have two
 options:
 
-1. Call `slint.load_file("ui.slint")`. The returned object is a [namespace](https://docs.python.org/3/library/types.html#types.SimpleNamespace),
+1. Call `slint.load_file("app.slint")`. The returned object is a [namespace](https://docs.python.org/3/library/types.html#types.SimpleNamespace),
    that provides the `MainWindow` class:
    ```python
    import slint
-   components = slint.load_file("ui.slint")
+   components = slint.load_file("app.slint")
    main_window = components.MainWindow()
    ```
 
-2. Import the `.slint` file as module by treating it like a Python module where the `.slint` extension is replaced with `_slint`:
+2. Use Slint's auto-loader, which lazily loads `.slint` files from `sys.path`:
    ```python
-   import slint # needs to come first
-   from ui_slint import MainWindow
-   main_window = MainWindow()
+   import slint
+   # Look for for `app.slint` in `sys.path`:
+   main_window = slint.loader.app.MainWindow()
    ```
+
+   Any attribute lookup in `slint.loader` is searched for in `sys.path`. If a directory with the name exists, it is returned as a loader object, and subsequent
+   attribute lookups follow the same logic. If the name matches a file with the `.slint` extension, it is automatically loaded with `load_file` and the
+   [namespace](https://docs.python.org/3/library/types.html#types.SimpleNamespace) is returned.
 
 ### Accessing Properties
 

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "slint"
-version = "1.6.0a5"
+version = "1.6.0a6"
 requires-python = ">= 3.10"
 authors = [
     {name = "Slint Team", email = "info@slint.dev"},

--- a/api/python/tests/test_loader.py
+++ b/api/python/tests/test_loader.py
@@ -3,25 +3,23 @@
 
 import pytest
 from slint import slint as native
+from slint import loader
 import sys
 import os
 
 
 def test_magic_import():
-    import test_load_file_slint as compiledmodule
-    instance = compiledmodule.App()
+    instance = loader.test_load_file.App()
     del instance
 
 
 def test_magic_import_path():
     oldsyspath = sys.path
-    with pytest.raises(ModuleNotFoundError, match="No module named 'printerdemo_slint'"):
-        import printerdemo_slint
+    assert loader.printerdemo == None
     try:
         sys.path.append(os.path.join(os.path.dirname(__file__),
-                        "..", "..", "..", "examples", "printerdemo", "ui"))
-        import printerdemo_slint
-        instance = printerdemo_slint.MainWindow()
+                        "..", "..", ".."))
+        instance = loader.examples.printerdemo.ui.printerdemo.MainWindow()
         del instance
     finally:
         sys.path = oldsyspath

--- a/examples/memory/main.py
+++ b/examples/memory/main.py
@@ -1,18 +1,16 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: MIT
 
-# autopep8: off
+
 from datetime import timedelta, datetime
 import os
 import random
 import itertools
 import slint
 from slint import Color, ListModel, Timer, TimerMode
-import memory_slint
-# autopep8: on
 
 
-class MainWindow(memory_slint.MainWindow):
+class MainWindow(slint.loader.memory.MainWindow):
     def __init__(self):
         super().__init__()
         initial_tiles = self.memory_tiles
@@ -22,7 +20,8 @@ class MainWindow(memory_slint.MainWindow):
 
     @slint.callback
     def check_if_pair_solved(self):
-        flipped_tiles = [(index, tile) for index, tile in enumerate(self.memory_tiles) if tile["image-visible"] and not tile["solved"]]
+        flipped_tiles = [(index, tile) for index, tile in enumerate(
+            self.memory_tiles) if tile["image-visible"] and not tile["solved"]]
         if len(flipped_tiles) == 2:
             tile1_index, tile1 = flipped_tiles[0]
             tile2_index, tile2 = flipped_tiles[1]

--- a/examples/printerdemo/python/main.py
+++ b/examples/printerdemo/python/main.py
@@ -1,18 +1,15 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: MIT
 
-# autopep8: off
+from slint import Color, ListModel, Timer, TimerMode
+import slint
 from datetime import timedelta, datetime
 import os
 import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "ui"))
-import slint
-from slint import Color, ListModel, Timer, TimerMode
-import printerdemo_slint
-# autopep8: on
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 
-class MainWindow(printerdemo_slint.MainWindow):
+class MainWindow(slint.loader.ui.printerdemo.MainWindow):
     def __init__(self):
         super().__init__()
         self.ink_levels = ListModel([


### PR DESCRIPTION
As discussed on Reddit, the magic import logic is not very tool friendly and a little too magic perhaps. Instead, this patch introduces an automatic loader (`slint.loader`), which can traverse `sys.path` and lazily load `.slint` files by attribute lookup.

Closes #4856