### PR TITLE
C++: Move internal testing function to the internal namespace

### DIFF
--- a/api/cpp/include/slint-interpreter.h
+++ b/api/cpp/include/slint-interpreter.h
@@ -1051,21 +1051,7 @@ public:
 };
 }
 
-namespace slint::testing {
-
-using cbindgen_private::KeyboardModifiers;
-
-/// Send a key events to the given component instance
-inline void send_keyboard_char(const slint::interpreter::ComponentInstance *component,
-                               const slint::SharedString &str, bool pressed)
-{
-    const cbindgen_private::WindowAdapterRcOpaque *win_ptr = nullptr;
-    cbindgen_private::slint_interpreter_component_instance_window(
-            reinterpret_cast<const cbindgen_private::ErasedItemTreeBox *>(component), &win_ptr);
-    cbindgen_private::slint_send_keyboard_char(
-            &str, pressed, reinterpret_cast<const cbindgen_private::WindowAdapterRc *>(win_ptr));
-}
-
+namespace slint::private_api::testing {
 /// Send a key events to the given component instance
 inline void send_keyboard_string_sequence(const slint::interpreter::ComponentInstance *component,
                                           const slint::SharedString &str)

--- a/api/cpp/tests/interpreter.cpp
+++ b/api/cpp/tests/interpreter.cpp
@@ -504,7 +504,7 @@ SCENARIO("Send key events")
                                                "");
     REQUIRE(comp_def.has_value());
     auto instance = comp_def->create();
-    slint::testing::send_keyboard_string_sequence(&*instance, "Hello keys!");
+    slint::private_api::testing::send_keyboard_string_sequence(&*instance, "Hello keys!");
     REQUIRE(*instance->get_property("result")->to_string() == "Hello keys!");
 }
 


### PR DESCRIPTION
Remove send_keyboard_char as it doesn't appear to be used (while send_keyboard_string_sequence is used in a single test)