### PR TITLE
live-preview: Add placeholder when removing the last element in a layout

### DIFF
--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1172,10 +1172,10 @@ fn prepare_scene(
         }
 
         dirty_region = (renderer.dirty_region.to_rect().cast() * factor)
-                    .round_out()
-                    .intersection(&euclid::rect(0., 0., i16::MAX as f32, i16::MAX as f32))
-                    .unwrap_or_default()
-                    .cast();
+            .round_out()
+            .intersection(&euclid::rect(0., 0., i16::MAX as f32, i16::MAX as f32))
+            .unwrap_or_default()
+            .cast();
 
         dirty_region = software_renderer.apply_dirty_region(dirty_region, size);
 


### PR DESCRIPTION
Add a placeholder Rectangle into a layout whenever the last eleemnt is removed. This makes sure we can drop into the Layout again.

Add infrastructure to find the parent element to ElementRcNode and move more code into the ElementRcNode.