### PR TITLE
live-preview: Deduplicate component list

### DIFF
--- a/tools/lsp/language/component_catalog.rs
+++ b/tools/lsp/language/component_catalog.rs
@@ -173,6 +173,9 @@ pub fn all_exported_components(
             result.push(to_push);
         }
     }
+
+    result.sort_by(|a, b| a.name.cmp(&b.name));
+    result.dedup_by(|a, b| a.name == b.name);
 }
 
 pub fn file_local_components(


### PR DESCRIPTION
We end up with components added several times due to re-exports.

Fixes: #5126