### PR TITLE
Add support for slint syntax highlighting in markcode code fences

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -57,6 +57,16 @@
         "embeddedLanguages": {
           "source.slint": "slint"
         }
+      },
+      {
+        "scopeName": "markdown.slint.codeblock",
+        "path": "./slint.markdown-injection.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.slint": "slint"
+        }
       }
     ],
     "commands": [

--- a/editors/vscode/slint.markdown-injection.json
+++ b/editors/vscode/slint.markdown-injection.json
@@ -1,0 +1,45 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#slint-code-block"
+        }
+    ],
+    "repository": {
+        "slint-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(slint)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced_code.block.language.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes.markdown"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.slint",
+                    "patterns": [
+                        {
+                            "include": "source.slint"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.slint.codeblock"
+}


### PR DESCRIPTION
Use an injection grammar to achieve this.