### PR TITLE
Fix a positive minimum causing an incorrect slider/spinbox value

### DIFF
--- a/docs/reference/src/language/widgets/slider.md
+++ b/docs/reference/src/language/widgets/slider.md
@@ -5,7 +5,7 @@
 
 -   **`enabled`**: (_in_ _bool_): Defaults to true. You can't interact with the slider if enabled is false.
 -   **`has-focus`**: (_out_ _bool_): Set to true when the slider currently has the focus
--   **`value`** (_in-out_ _float_): The value.
+-   **`value`** (_in-out_ _float_): The value. Defaults to the minimum.
 -   **`minimum`** (_in_ _float_): The minimum value (default: 0)
 -   **`maximum`** (_in_ _float_): The maximum value (default: 100)
 -   **`orientation`** (_in_ _enum [`Orientation`](../builtins/enums.md#orientation)_): If set to true the Slider is displayed vertical (default: horizontal).

--- a/docs/reference/src/language/widgets/spinbox.md
+++ b/docs/reference/src/language/widgets/spinbox.md
@@ -5,7 +5,7 @@
 
 -   **`enabled`**: (_in_ _bool_): Defaults to true. You can't interact with the spinbox if enabled is false.
 -   **`has-focus`**: (_out_ _bool_): Set to true when the spinbox currently has the focus
--   **`value`** (_in-out_ _int_): The value.
+-   **`value`** (_in-out_ _int_): The value. Defaults to the minimum.
 -   **`minimum`** (_in_ _int_): The minimum value (default: 0).
 -   **`maximum`** (_in_ _int_): The maximum value (default: 100).
 

--- a/internal/compiler/widgets/common/slider-base.slint
+++ b/internal/compiler/widgets/common/slider-base.slint
@@ -17,7 +17,7 @@ export component SliderBase {
     out property <bool> handle-has-hover: touch-area.mouse-x >= root.handle-x && touch-area.mouse-x <= root.handle-x + root.handle-width &&
         touch-area.mouse-y >= root.handle-y && touch-area.mouse-y <= root.handle-y + root.handle-height;
     out property <bool> handle-pressed;
-    in-out property <float> value: 0;
+    in-out property <float> value: minimum;
 
     callback changed(/* value */ float);
     callback released(/* value */ float);

--- a/internal/compiler/widgets/common/spinbox-base.slint
+++ b/internal/compiler/widgets/common/spinbox-base.slint
@@ -12,7 +12,7 @@ export component SpinBoxBase {
     in property <color> selection-foreground-color <=> i-text-input.selection-foreground-color;
     in property <TextHorizontalAlignment> horizontal-alignment <=> i-text-input.horizontal-alignment;
     out property <bool> has-focus <=> i-text-input.has-focus;
-    in-out property <int> value;
+    in-out property <int> value: minimum;
 
     callback edited(/* value */ int);
 

--- a/internal/compiler/widgets/qt/slider.slint
+++ b/internal/compiler/widgets/qt/slider.slint
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.2 OR LicenseRef-Slint-commercial
 
 export component Slider inherits NativeSlider {
+    value: root.minimum;
     accessible-role: slider;
     accessible-value: root.value;
     accessible-value-minimum: root.minimum;

--- a/internal/compiler/widgets/qt/spinbox.slint
+++ b/internal/compiler/widgets/qt/spinbox.slint
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.2 OR LicenseRef-Slint-commercial
 
 export component SpinBox inherits NativeSpinBox {
+    value: root.minimum;
     accessible-role: spinbox;
     accessible-value: root.value;
     accessible-value-minimum: root.minimum;

--- a/tests/cases/widgets/slider_default_value.slint
+++ b/tests/cases/widgets/slider_default_value.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.2 OR LicenseRef-Slint-commercial
+
+
+import { Slider } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    
+    slider_min_pos := Slider {
+        minimum: 10;
+        maximum: 100;
+    }
+    out property <float> pos-val <=> slider-min-pos.value;
+    
+    slider_min_default := Slider {
+        maximum: 100;
+    }
+    out property <float> default-min <=> slider-min-default.minimum;    
+    out property <float> default-val <=> slider-min-default.value;
+
+    slider_min_neg := Slider {
+        minimum: -10;
+        maximum: 100;
+    }
+    out property <float> neg-val <=> slider-min-neg.value;
+}
+
+
+/*
+
+```rust
+
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_pos_val(), 10_f32);
+assert_eq!(instance.get_default_min(), 0_f32);
+assert_eq!(instance.get_default_val(), 0_f32);
+assert_eq!(instance.get_neg_val(), -10_f32);
+
+```
+
+*/

--- a/tests/cases/widgets/spinbox_default_value.slint
+++ b/tests/cases/widgets/spinbox_default_value.slint
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.2 OR LicenseRef-Slint-commercial
+
+
+import { SpinBox } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    
+    spin_min_pos := SpinBox { minimum: 10; }
+    out property <int> pos-val <=> spin-min-pos.value;
+    
+    spin_min_default := SpinBox {}
+    out property <int> default-min <=> spin-min-default.minimum;    
+    out property <int> default-val <=> spin-min-default.value;
+
+    spin_min_neg := SpinBox {
+        minimum: -10;
+    }
+    out property <int> neg-val <=> spin-min-neg.value;
+}
+
+
+/*
+
+```rust
+
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_pos_val(), 10);
+assert_eq!(instance.get_default_min(), 0);
+assert_eq!(instance.get_default_val(), 0);
+assert_eq!(instance.get_neg_val(), -10);
+
+```
+
+*/


### PR DESCRIPTION
Currently, the default slider value is 0. This means that setting a positive minimum value causes the slider's value to be incorrect until it is moved.

This is also shown visually in most themes with the slider handle being rendered off the end of the slider body:
![incorrect_slider](https://github.com/slint-ui/slint/assets/69789934/38040cc0-46e0-4552-8e61-ae0007916a20)

And while it is visually correct with Qt, the value itself is still wrong:
![incorrect_slider_qt](https://github.com/slint-ui/slint/assets/69789934/7736c3a8-5187-45b8-8956-6ffacf70a64b)

This PR sets the default value to that of the minimum.

This is my first PR here and I'm not entirely sure if `internal/compiler/widgets/qt/slider.slint` was the correct place for this fix for Qt. Please let me know if there's a better way to implement this and thank you for your work!
