### PR TITLE
Fix compiler panic with init in a component inlined into a repeater

### DIFF
--- a/api/cpp/include/slint_brush.h
+++ b/api/cpp/include/slint_brush.h
@@ -157,6 +157,7 @@ private:
     using Tag = cbindgen_private::types::Brush::Tag;
     using Inner = cbindgen_private::types::Brush;
     Inner data;
+    friend class private_api::Property<Brush>;
 };
 
 Color Brush::color() const
@@ -279,4 +280,18 @@ inline Brush Brush::with_alpha(float alpha) const
     }
     return result;
 }
+
+namespace private_api {
+
+template<>
+inline void Property<slint::Brush>::set_animated_value(
+        const slint::Brush &new_value,
+        const cbindgen_private::PropertyAnimation &animation_data) const
+{
+    cbindgen_private::slint_property_set_animated_value_brush(&inner, &value, &new_value,
+                                                              &animation_data);
 }
+
+} // namespace private_api
+
+} // namespace slint

--- a/api/cpp/include/slint_brush.h
+++ b/api/cpp/include/slint_brush.h
@@ -157,7 +157,7 @@ private:
     using Tag = cbindgen_private::types::Brush::Tag;
     using Inner = cbindgen_private::types::Brush;
     Inner data;
-    friend class private_api::Property<Brush>;
+    friend struct private_api::Property<Brush>;
 };
 
 Color Brush::color() const

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -686,6 +686,7 @@ pub fn pretty_print(
         expression_tree::pretty_print(f, &repeated.model)?;
         write!(f, ":")?;
         if let ElementType::Component(base) = &e.base_type {
+            write!(f, "(base) ")?;
             if base.parent_element.upgrade().is_some() {
                 pretty_print(f, &base.root_element.borrow(), indentation)?;
                 return Ok(());

--- a/internal/compiler/passes/collect_subcomponents.rs
+++ b/internal/compiler/passes/collect_subcomponents.rs
@@ -37,6 +37,13 @@ fn collect_subcomponents_recursive(
             _ => return,
         };
         collect_subcomponents_recursive(&base_comp, result, hash);
+        if base_comp.parent_element.upgrade().is_some() {
+            // This is not a sub-component, but is a repeated component
+            return;
+        }
         result.push(base_comp);
     });
+    for popup in component.popup_windows.borrow().iter() {
+        collect_subcomponents_recursive(&popup.component, result, hash);
+    }
 }

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -219,6 +219,17 @@ pub unsafe extern "C" fn slint_property_set_animated_value_color(
     c_set_animated_value(handle, from, to, animation_data);
 }
 
+/// Internal function to set up a property animation to the specified target value for a brush property.
+#[no_mangle]
+pub unsafe extern "C" fn slint_property_set_animated_value_brush(
+    handle: &PropertyHandleOpaque,
+    from: &Brush,
+    to: &Brush,
+    animation_data: &PropertyAnimation,
+) {
+    c_set_animated_value(handle, from.clone(), to.clone(), animation_data);
+}
+
 unsafe fn c_set_animated_binding<T: InterpolatedPropertyValue + Clone>(
     handle: &PropertyHandleOpaque,
     binding: extern "C" fn(*mut c_void, *mut T),

--- a/tests/cases/callbacks/init.slint
+++ b/tests/cases/callbacks/init.slint
@@ -43,6 +43,14 @@ Container := Rectangle {
     @children
 }
 
+InsideRepeater := Rectangle {
+    property <int> index;
+    init => {
+        InitOrder.observed-order += "(i" + self.index + ")";
+    }
+    @children
+}
+
 TestCase := Rectangle {
     width: 300phx;
     height: 300phx;
@@ -74,11 +82,13 @@ TestCase := Rectangle {
         }
     }
 
-    for i in 2: Rectangle {
+    for i in 2: InsideRepeater {
+        index: i;
         init => {
             InitOrder.observed-order += "|repeater";
             InitOrder.observed-order += i;
         }
+        Rectangle {}
     }
 
     property <string> test_global_prop_value: InitOrder.observed-order;
@@ -94,7 +104,7 @@ let instance = TestCase::new().unwrap();
 
 assert!(instance.get_test());
 slint_testing::send_mouse_click(&instance, 5., 5.);
-assert_eq!(instance.global::<InitOrder<'_>>().get_observed_order(), instance.get_expected_static_order() + "|repeater0|repeater1");
+assert_eq!(instance.global::<InitOrder<'_>>().get_observed_order(), instance.get_expected_static_order() + "|repeater0(i0)|repeater1(i1)");
 ```
 
 ```cpp
@@ -102,7 +112,7 @@ auto handle = TestCase::create();
 const TestCase &instance = *handle;
 assert(instance.get_test());
 slint_testing::send_mouse_click(&instance, 5., 5.);
-assert_eq(instance.global<InitOrder>().get_observed_order(),  instance.get_expected_static_order() + "|repeater0|repeater1");
+assert_eq(instance.global<InitOrder>().get_observed_order(),  instance.get_expected_static_order() + "|repeater0(i0)|repeater1(i1)");
 ```
 
 
@@ -110,7 +120,7 @@ assert_eq(instance.global<InitOrder>().get_observed_order(),  instance.get_expec
 var instance = new slint.TestCase({});
 assert(instance.test);
 slintlib.private_api.send_mouse_click(instance, 5., 5.);
-assert.equal(instance.test_global_prop_value,  instance.expected_static_order + "|repeater0|repeater1");
+assert.equal(instance.test_global_prop_value,  instance.expected_static_order + "|repeater0(i0)|repeater1(i1)");
 ```
 
 

--- a/tests/cases/issues/issue_5146_init_animated.slint
+++ b/tests/cases/issues/issue_5146_init_animated.slint
@@ -1,0 +1,13 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.2 OR LicenseRef-Slint-commercial
+
+component MyComponent inherits Rectangle {
+    animate background { }
+    init => {
+        self.background = #000;
+    }
+}
+
+export component MyWindow inherits Window {
+    for _ in [1, 2, 3]: MyComponent { }
+}


### PR DESCRIPTION
The problem was that the code from #4322 inlined the init code in the parent Component as at that point, the per-repeater component don't exist yet.
Fix it by removing the workaround from #4322, but changing the order of the passes so that the init code are already proccessed before any inlining. This required to change the order of a bunch of passes.

Fixes #5146

As a drive-by, also add the missing C++ implementation of set_animated_value for Brush that was discovered by the test. (Code wouldn't compile)