### PR TITLE
live-preview: Move already placed elements

### DIFF
--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -8,7 +8,7 @@ use crate::util;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{syntax_nodes, SyntaxKind};
 use i_slint_core::component_factory::FactoryContext;
-use i_slint_core::lengths::{LogicalLength, LogicalPoint};
+use i_slint_core::lengths::{LogicalPoint, LogicalRect, LogicalSize};
 use i_slint_core::model::VecModel;
 use lsp_types::Url;
 use slint_interpreter::{ComponentDefinition, ComponentHandle, ComponentInstance};
@@ -120,27 +120,16 @@ fn can_drop_component(
         return false;
     }
 
+    let position = LogicalPoint::new(x, y);
     let component_type = component_type.to_string();
 
-    PREVIEW_STATE.with(move |preview_state| {
-        let preview_state = preview_state.borrow();
-
-        let component_index = &preview_state
-            .known_components
-            .binary_search_by_key(&component_type.as_str(), |ci| ci.name.as_str())
-            .unwrap_or(usize::MAX);
-
-        let Some(component) = preview_state.known_components.get(*component_index) else {
-            return false;
-        };
-
-        drop_location::can_drop_at(x, y, component)
-    })
+    drop_location::can_drop_at(position, &component_type)
 }
 
 // triggered from the UI, running in UI thread
 fn drop_component(component_type: slint::SharedString, x: f32, y: f32) {
     let component_type = component_type.to_string();
+    let position = LogicalPoint::new(x, y);
 
     let drop_result = PREVIEW_STATE.with(|preview_state| {
         let preview_state = preview_state.borrow();
@@ -150,7 +139,7 @@ fn drop_component(component_type: slint::SharedString, x: f32, y: f32) {
             .binary_search_by_key(&component_type.as_str(), |ci| ci.name.as_str())
             .unwrap_or(usize::MAX);
 
-        drop_location::drop_at(x, y, preview_state.known_components.get(*component_index)?)
+        drop_location::drop_at(position, preview_state.known_components.get(*component_index)?)
     });
 
     if let Some((edit, drop_data)) = drop_result {
@@ -227,7 +216,14 @@ fn delete_selected_element() {
 }
 
 // triggered from the UI, running in UI thread
-fn change_geometry_of_selected_element(x: f32, y: f32, width: f32, height: f32) {
+fn resize_selected_element(x: f32, y: f32, width: f32, height: f32) {
+    resize_selected_element_impl(LogicalRect::new(
+        LogicalPoint::new(x, y),
+        LogicalSize::new(width, height),
+    ))
+}
+
+fn resize_selected_element_impl(rect: LogicalRect) {
     let Some(selected) = selected_element() else {
         return;
     };
@@ -244,43 +240,48 @@ fn change_geometry_of_selected_element(x: f32, y: f32, width: f32, height: f32) 
         return;
     };
 
-    let click_position = LogicalPoint::from_lengths(LogicalLength::new(x), LogicalLength::new(y));
+    let position = rect.origin;
     let root_element = element_selection::root_element(&component_instance);
 
-    let (parent_x, parent_y) =
-        search_for_parent_element(&root_element, &selected_element_node.element)
-            .and_then(|parent_element| {
-                component_instance
-                    .element_positions(&parent_element)
-                    .iter()
-                    .find(|g| g.contains(click_position))
-                    .map(|g| (g.origin.x, g.origin.y))
-            })
-            .unwrap_or_default();
+    let parent = search_for_parent_element(&root_element, &selected_element_node.element)
+        .and_then(|parent_element| {
+            component_instance
+                .element_positions(&parent_element)
+                .iter()
+                .find(|g| g.contains(position))
+                .map(|g| g.origin)
+        })
+        .unwrap_or_default();
 
     let (properties, op) = {
         let mut p = Vec::with_capacity(4);
         let mut op = "";
-        if geometry.origin.x != x && x.is_finite() {
+        if geometry.origin.x != position.x && position.x.is_finite() {
             p.push(crate::common::PropertyChange::new(
                 "x",
-                format!("{}px", (x - parent_x).round()),
+                format!("{}px", (position.x - parent.x).round()),
             ));
             op = "Moving";
         }
-        if geometry.origin.y != y && y.is_finite() {
+        if geometry.origin.y != position.y && position.y.is_finite() {
             p.push(crate::common::PropertyChange::new(
                 "y",
-                format!("{}px", (y - parent_y).round()),
+                format!("{}px", (position.y - parent.y).round()),
             ));
             op = "Moving";
         }
-        if geometry.size.width != width && width.is_finite() {
-            p.push(crate::common::PropertyChange::new("width", format!("{}px", width.round())));
+        if geometry.size.width != rect.size.width && rect.size.width.is_finite() {
+            p.push(crate::common::PropertyChange::new(
+                "width",
+                format!("{}px", rect.size.width.round()),
+            ));
             op = "Resizing";
         }
-        if geometry.size.height != height && height.is_finite() {
-            p.push(crate::common::PropertyChange::new("height", format!("{}px", height.round())));
+        if geometry.size.height != rect.size.height && rect.size.height.is_finite() {
+            p.push(crate::common::PropertyChange::new(
+                "height",
+                format!("{}px", rect.size.height.round()),
+            ));
             op = "Resizing";
         }
         (p, op)
@@ -303,6 +304,47 @@ fn change_geometry_of_selected_element(x: f32, y: f32, width: f32, height: f32) 
                 selected.offset,
             ),
             properties,
+        });
+    }
+}
+
+// triggered from the UI, running in UI thread
+fn can_move_selected_element(_x: f32, _y: f32, mouse_x: f32, mouse_y: f32) -> bool {
+    let Some(selected) = selected_element() else {
+        return false;
+    };
+    let Some(selected_element_node) = selected.as_element_node() else {
+        return false;
+    };
+
+    let mouse_position = LogicalPoint::new(mouse_x, mouse_y);
+    drop_location::can_move_to(mouse_position, selected_element_node)
+}
+
+// triggered from the UI, running in UI thread
+fn move_selected_element(x: f32, y: f32, mouse_x: f32, mouse_y: f32) {
+    let position = LogicalPoint::new(x, y);
+    let mouse_position = LogicalPoint::new(mouse_x, mouse_y);
+    let Some(selected) = selected_element() else {
+        return;
+    };
+    let Some(selected_element_node) = selected.as_element_node() else {
+        return;
+    };
+
+    if let Some((edit, drop_data)) =
+        drop_location::move_element_to(selected_element_node, position, mouse_position)
+    {
+        element_selection::select_element_at_source_code_position(
+            drop_data.path,
+            drop_data.selection_offset,
+            None,
+            true,
+        );
+
+        send_message_to_lsp(crate::common::PreviewToLspMessage::SendWorkspaceEdit {
+            label: Some("Move element".to_string()),
+            edit,
         });
     }
 }
@@ -616,6 +658,17 @@ pub fn known_components(
     });
 }
 
+pub fn get_component_info(component_type: &str) -> Option<ComponentInformation> {
+    PREVIEW_STATE.with(|preview_state| {
+        let preview_state = preview_state.borrow();
+        let index = preview_state
+            .known_components
+            .binary_search_by(|ci| ci.name.as_str().cmp(component_type))
+            .ok()?;
+        preview_state.known_components.get(index).cloned()
+    })
+}
+
 fn convert_diagnostics(
     diagnostics: &[slint_interpreter::Diagnostic],
 ) -> HashMap<lsp_types::Url, Vec<lsp_types::Diagnostic>> {
@@ -711,7 +764,7 @@ fn set_selected_element(
             preview_state.ui.as_ref(),
             selection.as_ref().map(|s| s.instance_index).unwrap_or_default(),
             layout_kind,
-            !is_in_layout && !is_layout,
+            !is_layout,
             !is_in_layout && !is_layout,
             positions,
         );

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -46,7 +46,9 @@ pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, Platfor
     ui.on_select_behind(super::element_selection::select_element_behind);
     ui.on_can_drop(super::can_drop_component);
     ui.on_drop(super::drop_component);
-    ui.on_selected_element_update_geometry(super::change_geometry_of_selected_element);
+    ui.on_selected_element_resize(super::resize_selected_element);
+    ui.on_selected_element_can_move_to(super::can_move_selected_element);
+    ui.on_selected_element_move(super::move_selected_element);
     ui.on_selected_element_delete(super::delete_selected_element);
 
     Ok(ui)

--- a/tools/lsp/ui/draw-area.slint
+++ b/tools/lsp/ui/draw-area.slint
@@ -46,12 +46,12 @@ component SelectionFrame {
     in property <Selection> selection;
     in property <bool> interactive: true;
 
-    function pick-selection-color(layout-kind: LayoutKind, is-primary: bool) -> color {
+    function pick-selection-color(layout-kind: LayoutKind,is-primary: bool) -> color {
         if layout-kind == LayoutKind.None {
             if is-primary {
                 return #2379f4ff;
             } else {
-                return #2379f480;  
+                return #2379f480;
             }
         } else {
             if is-primary {
@@ -69,7 +69,9 @@ component SelectionFrame {
     width: root.selection.geometry.width;
     height: root.selection.geometry.height;
 
-    callback update-geometry(/* x */ length, /* y */ length, /* width */ length, /* height */ length);
+    callback resize(/* x */ length, /* y */ length, /* width */ length, /* height */ length);
+    callback can-move-to(/* x */ length, /* y */ length, /* mouse-x */ length, /* mouse-y */ length) -> bool;
+    callback move-to(/* x */ length, /* y */ length, /* mouse-x */ length, /* mouse-y */ length);
     callback select-behind(/* x */ length, /* y */ length, /* enter component? */ bool, /* same file? */ bool);
     callback selected-element-delete();
 
@@ -97,14 +99,26 @@ component SelectionFrame {
         width: root.width;
         height: root.height;
 
-        update-geometry(x, y, w, h, done) => {
+        resize(x, y, w, h, done) => {
             root.x = x;
             root.y = y;
             root.width = w;
             root.height = h;
             if done {
-                root.update-geometry(x, y, w, h);
+                root.resize(x, y, w, h);
             }
+        }
+
+        can-move-to(x, y, mx, my) => {
+            root.x = x;
+            root.y = y;
+            return root.can-move-to(x, y, mx, my);
+        }
+
+        move-to(x, y, mx, my) => {
+            root.x = x;
+            root.y = y;
+            root.move-to(x, y, mx, my);
         }
 
         inner := Rectangle {
@@ -127,7 +141,7 @@ component SelectionFrame {
             height: label-text.height * 1.2;
             label-text := Text {
                 color: Colors.white;
-                text: Math.round(root.width/1px) + "x" + Math.round(root.height/1px);
+                text: Math.round(root.width / 1px) + "x" + Math.round(root.height / 1px);
             }
         }
     }
@@ -161,7 +175,9 @@ export component DrawArea {
     callback reselect();
     // Reselect element e.g. after changing the window size (which may move the element)
     callback unselect();
-    callback selected-element-update-geometry(/* x */ length, /* y */ length, /* width */ length, /* height */ length);
+    callback selected-element-resize(/* x */ length, /* y */ length, /* width */ length, /* height */ length);
+    callback selected-element-can-move-to(/* x */ length, /* y */ length, /* mouse-x */ length, /* mouse-y */ length) -> bool;
+    callback selected-element-move(/* x */ length, /* y */ length, /* mouse-x */ length, /* mouse-y */ length);
     callback selected-element-delete();
 
     preferred-height: max(preview-area-container.preferred-height, preview-area-container.min-height) + 2 * scroll-view.border;
@@ -203,7 +219,7 @@ export component DrawArea {
                 x-position: parent.x;
                 y-position: parent.y;
 
-                update-geometry(_, _, w, h) => {
+                resize(_, _, w, h) => {
                     preview-area-container.width = clamp(w, preview-area-container.min-width, preview-area-container.max-width);
                     preview-area-container.height = clamp(h, preview-area-container.min-height, preview-area-container.max-height);
                     reselect();
@@ -275,8 +291,16 @@ export component DrawArea {
                     for s in root.selections: SelectionFrame {
                         interactive: root.mode == DrawAreaMode.designing;
                         selection: s;
-                        update-geometry(x, y, w, h) => {
-                            root.selected-element-update-geometry(x, y, w, h);
+                        resize(x, y, w, h) => {
+                            root.selected-element-resize(x, y, w, h);
+                        }
+
+                        can-move-to(x, y, mx, my) => {
+                            root.selected-element-can-move-to(x, y, mx, my);
+                        }
+
+                        move-to(x, y, mx, my) => {
+                            root.selected-element-move(x, y, mx, my);
                         }
 
                         selected-element-delete() => {
@@ -295,7 +319,8 @@ export component DrawArea {
                     width: drop-mark.x2 - drop-mark.x1;
                     height: drop-mark.y2 - drop-mark.y1;
 
-                    background: #00ff00;
+                    border-color: #00ff00;
+                    background: #00ff0080;
                 }
             }
         }
@@ -305,7 +330,7 @@ export component DrawArea {
     diagnostics := DiagnosticsOverlay {
         width: 100%;
         height: 100%;
-       diagnostics <=> root.diagnostics;
+        diagnostics <=> root.diagnostics;
         show-document(url, line, column) => {
             root.show-document(url, line, column);
         }

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -26,7 +26,9 @@ export component PreviewUi inherits Window {
 
     pure callback can-drop(/* component_type */ string, /* x */ length, /* y */ length, /* on-drop-area */ bool) -> bool;
     callback drop(/* component_type */ string, /* x */ length, /* y */ length);
-    callback selected-element-update-geometry(/* x */ length, /* y */ length, /* width */ length, /* height */ length);
+    callback selected-element-resize(/* x */ length, /* y */ length, /* width */ length, /* height */ length);
+    callback selected-element-can-move-to(/* x */ length, /* y */ length, /* mouse-x */ length, /* mouse-y */ length) -> bool;
+    callback selected-element-move(/* x */ length, /* y */ length, /* mouse-x */ length, /* mouse-y */ length);
     callback selected-element-delete();
     callback select-at(/* x */ length, /* y */ length, /* enter_component? */ bool);
     callback select-behind(/* x */ length, /* y */ length, /* enter_component* */ bool, /* reverse */ bool);
@@ -114,7 +116,7 @@ export component PreviewUi inherits Window {
                         }
 
                         states [
-                        visible when !pick-button.checked: {
+                            visible when !pick-button.checked: {
                                 width: 0px;
                             }
                             hidden when pick-button.checked: {
@@ -133,8 +135,14 @@ export component PreviewUi inherits Window {
                         select-at(x, y, enter_component) => {
                             root.select-at(x, y, enter_component);
                         }
-                        selected-element-update-geometry(x, y, w, h) => {
-                            root.selected-element-update-geometry(x, y, w, h);
+                        selected-element-resize(x, y, w, h) => {
+                            root.selected-element-resize(x, y, w, h);
+                        }
+                        selected-element-can-move-to(x, y, mx, my) => {
+                            root.selected-element-can-move-to(x, y, mx, my);
+                        }
+                        selected-element-move(x, y, mx, my) => {
+                            root.selected-element-move(x, y, mx, my);
                         }
                         selected-element-delete() => {
                             root.selected-element-delete();

--- a/tools/lsp/ui/resizer.slint
+++ b/tools/lsp/ui/resizer.slint
@@ -59,7 +59,9 @@ export component Resizer {
     out property <bool> moving: resize-area.moving;
     out property <length> handle-size: ResizeState.handle-size;
 
-    callback update-geometry(/* x */ length, /* y */ length, /* width */ length, /* height */ length, /* done */ bool);
+    callback resize(/* x */ length, /* y */ length, /* width */ length, /* height */ length, /* done */ bool);
+    callback can-move-to(/* x */ length, /* y */ length, /* mouse_x */ length, /* mouse_y */ length) -> bool;
+    callback move-to(/* x */ length, /* y */ length, /* mouse_x */ length, /* mouse_y */ length);
     callback double-clicked(/* x */ length, /* y */ length, /* modifiers */ KeyboardModifiers);
 
     // Private!
@@ -81,6 +83,7 @@ export component Resizer {
             private property <length> y-offset: self.mouse-y - self.pressed-y;
             private property <KeyboardModifiers> modifiers;
             private property <bool> has-moved;
+            private property <bool> can-move-to;
 
             mouse-cursor: MouseCursor.move;
 
@@ -89,7 +92,7 @@ export component Resizer {
             }
 
             moved() => {
-                root.update-geometry(root.x-position + x-offset, root.y-position + y-offset, root.width, root.height, false);
+                self.can-move-to = root.can-move-to(root.x-position + x-offset, root.y-position + y-offset, root.x-position + self.mouse-x, root.y-position + self.mouse-y);
                 self.has-moved = true;
             }
 
@@ -97,10 +100,22 @@ export component Resizer {
                 resize-area.moving = self.pressed;
                 self.modifiers = event.modifiers;
                 if self.has-moved && event.button == PointerEventButton.left && event.kind == PointerEventKind.up {
-                    root.update-geometry(root.x-position + x-offset, root.y-position + y-offset, root.width, root.height, true);
+                    root.move-to(root.x-position + x-offset, root.y-position + y-offset, root.x-position + self.mouse-x, root.y-position + self.mouse-y);
                     self.has-moved = false;
                 }
             }
+
+            states [
+                dragging-no-drop when self.has-moved && !self.can-move-to: {
+                    mouse-cursor: MouseCursor.no-drop;
+                }
+                dragging-can-drop when self.has-moved && self.can-move-to: {
+                    mouse-cursor: MouseCursor.copy;
+                }
+                normal when !self.has-moved: {
+                    mouse-cursor: MouseCursor.default;
+                }
+            ]
         }
     }
 
@@ -114,7 +129,7 @@ export component Resizer {
                 self.new-height = Math.max(0px, y-offset * -1.0 + root.height);
                 self.new-x = root.left;
                 self.new-y = root.bottom - self.new-height;
-                root.update-geometry(self.new-x, self.new-y, self.new-width, self.new-height, done);
+                root.resize(self.new-x, self.new-y, self.new-width, self.new-height, done);
             }
 
             mouse-cursor: MouseCursor.n-resize;
@@ -130,7 +145,7 @@ export component Resizer {
                 self.new-height = Math.max(0px, y-offset * -1.0 + root.height);
                 self.new-x = root.left;
                 self.new-y = root.bottom - self.new-height;
-                root.update-geometry(self.new-x, self.new-y, self.new-width, self.new-height, done);
+                root.resize(self.new-x, self.new-y, self.new-width, self.new-height, done);
             }
             mouse-cursor: MouseCursor.ne-resize;
             x: root.width - (root.handle-size / 2.0);
@@ -144,7 +159,7 @@ export component Resizer {
                 self.new-height = root.height;
                 self.new-x = root.left;
                 self.new-y = root.top;
-                root.update-geometry(self.new-x, self.new-y, self.new-width, self.new-height, done);
+                root.resize(self.new-x, self.new-y, self.new-width, self.new-height, done);
             }
             mouse-cursor: MouseCursor.e-resize;
             x: root.width - (root.handle-size / 2.0);
@@ -159,7 +174,7 @@ export component Resizer {
                 self.new-height = Math.max(0px, y-offset + root.height);
                 self.new-x = root.left;
                 self.new-y = root.top;
-                root.update-geometry(self.new-x, self.new-y, self.new-width, self.new-height, done);
+                root.resize(self.new-x, self.new-y, self.new-width, self.new-height, done);
             }
             mouse-cursor: MouseCursor.se-resize;
             x: root.width - (root.handle-size / 2.0);
@@ -173,7 +188,7 @@ export component Resizer {
                 self.new-height = Math.max(0px, y-offset + root.height);
                 self.new-x = root.left;
                 self.new-y = root.top;
-                root.update-geometry(self.new-x, self.new-y, self.new-width, self.new-height, done);
+                root.resize(self.new-x, self.new-y, self.new-width, self.new-height, done);
             }
             mouse-cursor: MouseCursor.s-resize;
             x: root.handle-size / 2.0;
@@ -188,7 +203,7 @@ export component Resizer {
                 self.new-height = Math.max(0px, y-offset + root.height);
                 self.new-x = root.right - self.new-width;
                 self.new-y = root.top;
-                root.update-geometry(self.new-x, self.new-y, self.new-width, self.new-height, done);
+                root.resize(self.new-x, self.new-y, self.new-width, self.new-height, done);
             }
             mouse-cursor: MouseCursor.sw-resize;
             x: -(root.handle-size / 2.0);
@@ -202,7 +217,7 @@ export component Resizer {
                 self.new-height = root.height;
                 self.new-x = root.right - self.new-width;
                 self.new-y = root.top;
-                root.update-geometry(self.new-x, self.new-y, self.new-width, self.new-height, done);
+                root.resize(self.new-x, self.new-y, self.new-width, self.new-height, done);
             }
             mouse-cursor: MouseCursor.w-resize;
             x: -(root.handle-size / 2.0);
@@ -217,7 +232,7 @@ export component Resizer {
                 self.new-height = Math.max(0px, y-offset * -1.0 + root.height);
                 self.new-x = root.right - self.new-width;
                 self.new-y = root.bottom - self.new-height;
-                root.update-geometry(self.new-x, self.new-y, self.new-width, self.new-height, done);
+                root.resize(self.new-x, self.new-y, self.new-width, self.new-height, done);
             }
             mouse-cursor: MouseCursor.nw-resize;
             x: -(root.handle-size / 2.0);

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -59,7 +59,7 @@ pub fn last_non_ws_token(node: &SyntaxNode) -> Option<SyntaxToken> {
 }
 
 // Find the indentation of the element node itself as well as the indentation of properties inside the
-// element. Returns the element indent followed by the block indent
+// element. Returns the element indent.
 pub fn find_element_indent(element: &common::ElementRcNode) -> Option<String> {
     let mut token = element.with_element_node(|node| node.first_token()?.prev_token());
     while let Some(t) = token {


### PR DESCRIPTION
Allow to move already placed elements in Design Mode of the live preview.

Todo: GridLayout is not supported yet.