### PR TITLE
live-preview: Fix dropmark ending up in the wrong place

### DIFF
--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -180,6 +180,7 @@ impl<'a> Iterator for DropZoneIterator<'a> {
             if is_selected {
                 if let Some((_, (next_is_selected, (next_start, next_end)))) = self.input.next() {
                     assert!(!next_is_selected); // We can not handle the same element twice in the same layout:-)
+                    self.state = DropZoneIteratorState::InProgress;
 
                     let next_mid = next_start + (next_end - next_start) / 2.0;
 


### PR DESCRIPTION
when trying to move the first element to after the following element. In that case the iterator state stayed at NotStarted, putting the DropMark into the wrong place.