### PR TITLE
live-preview: Set a minimum size on placeholder Rectangle

### DIFF
--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -16,8 +16,8 @@ use crate::preview::ext::ElementRcNodeExt;
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
 
-fn placeholder() -> String {
-    format!(" Rectangle {{ /* {} */ }}", preview::NODE_IGNORE_COMMENT)
+pub fn placeholder() -> String {
+    format!(" Rectangle {{ min-width: 16px; min-height: 16px; /* {} */ }}", preview::NODE_IGNORE_COMMENT)
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
... so that the layout does not shrink to 0 ever. Prominent example is the hello world demo. Dragging the OK button out of its layout shrinks that to 0 height and it is impossible to put the button back.