### PR TITLE
Pick the Skia renderer over FemtoVG

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -85,10 +85,10 @@ fn default_renderer_factory(
     window_builder: winit::window::WindowBuilder,
 ) -> Result<(Box<dyn WinitCompatibleRenderer>, Rc<winit::window::Window>), PlatformError> {
     cfg_if::cfg_if! {
-        if #[cfg(feature = "renderer-femtovg")] {
-            renderer::femtovg::GlutinFemtoVGRenderer::new(window_builder)
-        } else if #[cfg(enable_skia_renderer)] {
+        if #[cfg(enable_skia_renderer)] {
             renderer::skia::WinitSkiaRenderer::new(window_builder)
+        } else if #[cfg(feature = "renderer-femtovg")] {
+            renderer::femtovg::GlutinFemtoVGRenderer::new(window_builder)
         } else if #[cfg(feature = "renderer-software")] {
             renderer::sw::WinitSoftwareRenderer::new(window_builder)
         } else {


### PR DESCRIPTION
If Skia is available, pick that over FemtoVG. We end up recommending Skia for most customers, so it should be enough to enable the feature and not require additionally setting the `SLINT_BACKEND` environment variable.

This change also means that the live-preview in the language server will default to Skia on desktop installations. On the downside, this means that Slintpad and the VS Code extension for the web will be using a different renderer (FemtoVG).