### PR TITLE
Fix Node.js CI

### DIFF
--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -217,9 +217,9 @@ test('get/set image properties', async (t) => {
       message: "Cannot convert object to image, because the provided object does not have an u32 `height` property"
     });
     t.throws(() => {
-      instance!.setProperty("external-image", { width: 1, height: 1, data: new Uint8ClampedArray() });
+      instance!.setProperty("external-image", { width: 1, height: 1, data: new Uint8ClampedArray(1) });
     }, {
-      message: "data property does not have the correct size; expected 1 (width) * 1 (height) * 4 = 0; got 4"
+      message: "data property does not have the correct size; expected 1 (width) * 1 (height) * 4 = 1; got 4"
     });
 
     t.is(image.bitmap.width, 64);


### PR DESCRIPTION
After the Rust 1.78 release, napi-rs panics on zero-sized array buffers.

Work around it by disabling the debug assertions in the core library that trigger this.

Upstream PR: https://github.com/napi-rs/napi-rs/pull/2083