### PR TITLE
janitor: Fix several cargo warnings about deprecated `default_features`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ i-slint-renderer-skia = { version = "=1.6.0", path = "internal/renderers/skia", 
 slint = { version = "=1.6.0", path = "api/rs/slint", default-features = false }
 slint-build = { version = "=1.6.0", path = "api/rs/build", default-features = false }
 slint-cpp = { version = "=1.6.0", path = "api/cpp", default-features = false }
-slint-interpreter = { version = "=1.6.0", path = "internal/interpreter", default_features = false }
+slint-interpreter = { version = "=1.6.0", path = "internal/interpreter", default-features = false }
 slint-macros = { version = "=1.6.0", path = "api/rs/macros", default-features = false }
 
 vtable = { version = "0.2", path = "helper_crates/vtable", default-features = false }


### PR DESCRIPTION
... by updating the one occurance in the `workspace.dependencies`.