### PR TITLE
 Fix live-preview not working with Skia backend

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -85,10 +85,10 @@ fn default_renderer_factory(
     window_builder: winit::window::WindowBuilder,
 ) -> Result<(Box<dyn WinitCompatibleRenderer>, Rc<winit::window::Window>), PlatformError> {
     cfg_if::cfg_if! {
-        if #[cfg(feature = "renderer-femtovg")] {
-            renderer::femtovg::GlutinFemtoVGRenderer::new(window_builder)
-        } else if #[cfg(enable_skia_renderer)] {
+        if #[cfg(enable_skia_renderer)] {
             renderer::skia::WinitSkiaRenderer::new(window_builder)
+        } else if #[cfg(feature = "renderer-femtovg")] {
+            renderer::femtovg::GlutinFemtoVGRenderer::new(window_builder)
         } else if #[cfg(feature = "renderer-software")] {
             renderer::sw::WinitSoftwareRenderer::new(window_builder)
         } else {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -173,7 +173,11 @@ impl WinitWindowAdapter {
             ),
         });
 
-        let id = self_rc.winit_window().id();
+        let winit_window = self_rc.winit_window();
+        if let Err(e) = self_rc.renderer.resumed(&winit_window) {
+            i_slint_core::debug_log!("Error initialing renderer in winit backend with window: {e}");
+        }
+        let id = winit_window.id();
         crate::event_loop::register_window(id, (self_rc.clone()) as _);
 
         let scale_factor = std::env::var("SLINT_SCALE_FACTOR")


### PR DESCRIPTION
 When the winit backend creates the Skia renderer, there is no associated surface to render into. Only the winit Resume event would cause a call to set_window_handle() and thus surface creation. This was done for the earlier Android backend, and is generally good practice.

When running for example slint-viewer with SLINT_BACKEND=winit-skia, we would create the skia renderer (no surface), then start the winit event loop, get a resume event, initialize the surface, and it all works.

With the live-preview inside the lsp, we'd create the event loop, get a resume event (but there's no window yet), and then we'd create the skia renderer without a surface... ever.

It's not ideal, but for now call resume() explicitly since we _do_ have a winit window, and we're not calling this on Android anymore.