### PR TITLE
janitor: Fix some clippy warnings pre-release

### DIFF
--- a/helper_crates/vtable/macro/macro.rs
+++ b/helper_crates/vtable/macro/macro.rs
@@ -396,7 +396,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     return Error::new(a.span(), "invalid ABI").to_compile_error().into();
                 }
             } else {
-                f.abi = sig_extern.abi.clone();
+                f.abi.clone_from(&sig_extern.abi);
             }
 
             let mut wrap_trait_call = None;

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -55,7 +55,7 @@ impl ElementHandle {
             item.accessible_string_property(AccessibleStringProperty::Label)
                 .is_some_and(|x| x == label)
         });
-        result.into_iter().map(|x| ElementHandle(x))
+        result.into_iter().map(ElementHandle)
     }
 
     /// Invokes the default accessible action on the element. For example a `MyButton` element might declare

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -239,17 +239,8 @@ fn hsv_macro(
         );
         return Expression::Invalid;
     }
-    let mut arguments: Vec<_> = args
-        .into_iter()
-        .enumerate()
-        .map(|(i, (expr, n))| {
-            if i < 3 {
-                expr.maybe_convert_to(Type::Float32, &n, diag)
-            } else {
-                expr.maybe_convert_to(Type::Float32, &n, diag)
-            }
-        })
-        .collect();
+    let mut arguments: Vec<_> =
+        args.into_iter().map(|(expr, n)| expr.maybe_convert_to(Type::Float32, &n, diag)).collect();
     if arguments.len() < 4 {
         arguments.push(Expression::NumberLiteral(1., Unit::None))
     }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1487,7 +1487,7 @@ impl BindingExpression {
     /// Returns true if the other expression was taken
     pub fn merge_with(&mut self, other: &Self) -> bool {
         if self.animation.is_none() {
-            self.animation = other.animation.clone();
+            self.animation.clone_from(&other.animation);
         }
         let has_binding = self.has_binding();
         self.two_way_bindings.extend_from_slice(&other.two_way_bindings);

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -322,7 +322,7 @@ fn lower_sub_component(
         }
 
         for (prop, expr) in &elem.change_callbacks {
-            change_callbacks.push((NamedReference::new(&element, prop), expr.borrow().clone()));
+            change_callbacks.push((NamedReference::new(element, prop), expr.borrow().clone()));
         }
 
         Some(element.clone())

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -197,7 +197,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
             .collect();
         if let Some(builtin_name) = exports.get(&id) {
             if !matches!(&base, Base::Global) {
-                builtin.name = builtin_name.clone();
+                builtin.name.clone_from(&builtin_name);
                 register.add_builtin(Rc::new(builtin));
             } else {
                 let glob = Rc::new(Component {

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -496,12 +496,12 @@ impl LookupType {
                 {
                     None
                 } else {
-                    return Some(LookupResult::Expression {
+                    Some(LookupResult::Expression {
                         expression: Expression::ElementReference(Rc::downgrade(&c.root_element)),
                         deprecated: (name == "StyleMetrics"
                             && !ctx.type_register.expose_internal_types)
                             .then(|| "Palette".to_string()),
-                    });
+                    })
                 }
             }
             _ => None,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1412,7 +1412,7 @@ impl Element {
             };
             for trs in state.Transition() {
                 let mut t = Transition::from_node(trs, &r, tr, diag);
-                t.state_id = s.id.clone();
+                t.state_id.clone_from(&s.id);
                 r.borrow_mut().transitions.push(t);
             }
             r.borrow_mut().states.push(s);
@@ -2621,7 +2621,7 @@ pub fn adjust_geometry_for_injected_parent(injected_parent: &ElementRc, old_elem
     );
     let mut old_elem_mut = old_elem.borrow_mut();
     injected_parent_mut.default_fill_parent = std::mem::take(&mut old_elem_mut.default_fill_parent);
-    injected_parent_mut.geometry_props = old_elem_mut.geometry_props.clone();
+    injected_parent_mut.geometry_props.clone_from(&old_elem_mut.geometry_props);
     drop(injected_parent_mut);
     old_elem_mut.geometry_props.as_mut().unwrap().x = NamedReference::new(injected_parent, "dummy");
     old_elem_mut.geometry_props.as_mut().unwrap().y = NamedReference::new(injected_parent, "dummy");

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -557,7 +557,7 @@ mod parser_trait {
             let mut brackets = 0;
             loop {
                 match self.nth(0).kind() {
-                    k @ _ if k == kind && parens == 0 && braces == 0 && brackets == 0 => break,
+                    k if k == kind && parens == 0 && braces == 0 && brackets == 0 => break,
                     SyntaxKind::Eof => break,
                     SyntaxKind::LParent => parens += 1,
                     SyntaxKind::LBrace => braces += 1,

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -312,7 +312,7 @@ fn get_fallback_fonts(fontdb: &sharedfontdb::FontDatabase) -> Vec<fontdue::Font>
         target_arch = "wasm32"
     )))]
     {
-        fallback_families = fontdb.fontconfig_fallback_families.clone();
+        fallback_families.clone_from(&fontdb.fontconfig_fallback_families);
     }
 
     let fallback_fonts = fallback_families

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -96,7 +96,7 @@ fn resolve_alias(
         let same_element = Rc::ptr_eq(&element, elem);
         if same_element && nr.name() == prop {
             diag.push_error(
-                format!("Cannot alias to itself"),
+                "Cannot alias to itself".to_string(),
                 &elem.borrow().property_declarations[prop].type_node(),
             );
             return;

--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -163,7 +163,7 @@ pub fn lower_shadow_properties(
                     }
                 };
 
-                shadow_elem.geometry_props = child.borrow().geometry_props.clone();
+                shadow_elem.geometry_props.clone_from(&child.borrow().geometry_props);
                 elem.borrow_mut().children.push(ElementRc::new(shadow_elem.into()));
             }
             elem.borrow_mut().children.push(child);

--- a/internal/compiler/passes/resolve_native_classes.rs
+++ b/internal/compiler/passes/resolve_native_classes.rs
@@ -71,7 +71,7 @@ fn select_minimal_class_based_on_property_usage<'a>(
         minimal_class = class;
     }
     let (_min_distance, minimal_class) = properties_used.fold(
-        (std::usize::MAX, minimal_class),
+        (usize::MAX, minimal_class),
         |(current_distance, current_class), prop_name| {
             let (prop_distance, prop_class) = lookup_property_distance(class.clone(), prop_name);
 

--- a/internal/compiler/passes/unique_id.rs
+++ b/internal/compiler/passes/unique_id.rs
@@ -40,7 +40,7 @@ fn rename_globals(component: &Rc<Component>, mut count: u32) {
         let mut root = g.root_element.borrow_mut();
         if matches!(&root.base_type, ElementType::Builtin(_)) {
             // builtin global keeps its name
-            root.id = g.id.clone();
+            root.id.clone_from(&g.id);
         } else if let Some(s) = g.exported_global_names.borrow().first() {
             root.id = s.to_string();
         } else {

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -12,7 +12,7 @@ use alloc::rc::Rc;
 
 thread_local! {
     pub(crate) static GLOBAL_CONTEXT : once_cell::unsync::OnceCell<SlintContext>
-        = once_cell::unsync::OnceCell::new()
+        = const { once_cell::unsync::OnceCell::new() }
 }
 
 pub(crate) struct SlintContextInner {

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -485,7 +485,7 @@ impl DirtyRegion {
             if r.contains_box(&b) {
                 // the rectangle is already in the union
                 return;
-            } else if b.contains_box(&r) {
+            } else if b.contains_box(r) {
                 self.rectangles.swap(i, self.count - 1);
                 self.count -= 1;
                 continue;

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -974,7 +974,7 @@ pub(crate) fn generate_item_tree<'id>(
             );
             for (prop, expr) in &item.change_callbacks {
                 self.change_callbacks.push((
-                    NamedReference::new(&rc_item, prop),
+                    NamedReference::new(rc_item, prop),
                     Expression::CodeBlock(expr.borrow().clone()),
                 ));
             }
@@ -1813,7 +1813,7 @@ extern "C" fn subtree_index(component: ItemTreeRefPin) -> usize {
     if let Ok(value) = instance_ref.description.get_property(component, SPECIAL_PROPERTY_INDEX) {
         value.try_into().unwrap()
     } else {
-        core::usize::MAX
+        usize::MAX
     }
 }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -936,10 +936,10 @@ fn call_builtin_function(
             let g: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
             let b: i32 = eval_expression(&arguments[2], local_context).try_into().unwrap();
             let a: f32 = eval_expression(&arguments[3], local_context).try_into().unwrap();
-            let r: u8 = r.max(0).min(255) as u8;
-            let g: u8 = g.max(0).min(255) as u8;
-            let b: u8 = b.max(0).min(255) as u8;
-            let a: u8 = (255. * a).max(0.).min(255.) as u8;
+            let r: u8 = r.clamp(0, 255) as u8;
+            let g: u8 = g.clamp(0, 255) as u8;
+            let b: u8 = b.clamp(0, 255) as u8;
+            let a: u8 = (255. * a).clamp(0., 255.) as u8;
             Value::Brush(Brush::SolidColor(Color::from_argb_u8(a, r, g, b)))
         }
         BuiltinFunction::Hsv => {
@@ -947,7 +947,7 @@ fn call_builtin_function(
             let s: f32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
             let v: f32 = eval_expression(&arguments[2], local_context).try_into().unwrap();
             let a: f32 = eval_expression(&arguments[3], local_context).try_into().unwrap();
-            let a = (1. * a).max(0.).min(1.);
+            let a = (1. * a).clamp(0., 1.);
             Value::Brush(Brush::SolidColor(Color::from_hsva(h, s, v, a)))
         }
         BuiltinFunction::ColorScheme => match local_context.component_instance {

--- a/tests/screenshots/testing.rs
+++ b/tests/screenshots/testing.rs
@@ -72,7 +72,7 @@ pub fn screenshot(
     window.request_redraw();
     window.draw_if_needed(|renderer| {
         renderer.mark_dirty_region(
-            LogicalRect::from_size(euclid::size2(width as f32, height as f32).into()).into(),
+            LogicalRect::from_size(euclid::size2(width as f32, height as f32)).into(),
         );
         renderer.set_rendering_rotation(rotated);
         renderer.render(buffer.make_mut_slice(), width as usize);

--- a/tools/figma_import/src/main.rs
+++ b/tools/figma_import/src/main.rs
@@ -3,6 +3,7 @@
 
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
+#![allow(clippy::upper_case_acronyms)]
 
 use clap::Parser;
 use futures::prelude::*;

--- a/tools/lsp/preview/debug.rs
+++ b/tools/lsp/preview/debug.rs
@@ -117,8 +117,7 @@ impl State {
 /// to generate a PDF file out of it.
 #[allow(unused)]
 pub fn as_dot(element: &ElementRc, mark_up: Option<ElementRc>) -> ElementMap {
-    let mut state = State::default();
-    state.mark_up = mark_up;
+    let mut state = State { mark_up, ..State::default() };
     state.register_component(
         &Weak::upgrade(&element.borrow().enclosing_component).unwrap(),
         "root".to_string(),

--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -17,7 +17,10 @@ use crate::preview::ext::ElementRcNodeExt;
 use crate::wasm_prelude::*;
 
 pub fn placeholder() -> String {
-    format!(" Rectangle {{ min-width: 16px; min-height: 16px; /* {} */ }}", preview::NODE_IGNORE_COMMENT)
+    format!(
+        " Rectangle {{ min-width: 16px; min-height: 16px; /* {} */ }}",
+        preview::NODE_IGNORE_COMMENT
+    )
 }
 
 #[derive(Clone, Debug)]
@@ -821,7 +824,7 @@ fn extract_text_of_element(
         let start = usize::from(dr.start()) - offset;
         let end = usize::from(dr.end()) - offset;
 
-        offset = offset + (end - start);
+        offset += end - start;
 
         text.drain(start..end);
     }

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -185,7 +185,7 @@ fn init_compiler(
     if let Some(watcher) = fswatcher {
         watch_with_retry(&args.path, &watcher);
         if let Some(data_path) = &args.load_data {
-            watch_with_retry(&data_path, &watcher);
+            watch_with_retry(data_path, &watcher);
         }
         compiler.set_file_loader(move |path| {
             watch_with_retry(&path.into(), &watcher);
@@ -198,7 +198,7 @@ fn init_compiler(
 fn watch_with_retry(path: &PathBuf, watcher: &Arc<Mutex<notify::RecommendedWatcher>>) {
     notify::Watcher::watch(
         &mut *watcher.lock().unwrap(),
-        &path,
+        path,
         notify::RecursiveMode::NonRecursive,
     )
     .unwrap_or_else(|err| match err.kind {


### PR DESCRIPTION
Nothing that should be controversial, but the
`internal/compiler/builtin_macros.rs` could point to a thinko in the original commit.