### PR TITLE
Fix component that inherits from PopupWindow

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -337,7 +337,7 @@ pub struct Component {
     pub used_types: RefCell<UsedSubTypes>,
     pub popup_windows: RefCell<Vec<PopupWindow>>,
 
-    /// This component actually inherits PopupWindow (although that has been changed to a Waindow by the lower_popups pass)
+    /// This component actually inherits PopupWindow (although that has been changed to a Window by the lower_popups pass)
     pub inherits_popup_window: Cell<bool>,
 
     /// The names under which this component should be accessible

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -337,6 +337,9 @@ pub struct Component {
     pub used_types: RefCell<UsedSubTypes>,
     pub popup_windows: RefCell<Vec<PopupWindow>>,
 
+    /// This component actually inherits PopupWindow (although that has been changed to a Waindow by the lower_popups pass)
+    pub inherits_popup_window: Cell<bool>,
+
     /// The names under which this component should be accessible
     /// if it is a global singleton and exported.
     pub exported_global_names: RefCell<Vec<ExportedName>>,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -78,6 +78,7 @@ pub async fn run_passes(
 
     let global_type_registry = type_loader.global_type_registry.clone();
     let root_component = &doc.root_component;
+    root_component.is_root_component.set(true);
     run_import_passes(doc, type_loader, diag);
     check_public_api::check_public_api(doc, diag);
 
@@ -271,8 +272,6 @@ pub async fn run_passes(
             );
         }
     }
-
-    root_component.is_root_component.set(true);
 }
 
 /// Run the passes on imported documents

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -331,6 +331,7 @@ fn duplicate_sub_component(
         exported_global_names: component_to_duplicate.exported_global_names.clone(),
         is_root_component: Default::default(),
         private_properties: Default::default(),
+        inherits_popup_window: core::cell::Cell::new(false),
     };
 
     let new_component = Rc::new(new_component);

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -103,6 +103,9 @@ fn should_materialize(
         let ty = crate::typeregister::reserved_property(prop).property_type;
         if ty != Type::Invalid {
             return Some(ty);
+        } else if prop == "close-on-click" {
+            // PopupWindow::close-on-click
+            return Some(Type::Bool);
         }
     }
     None

--- a/internal/compiler/tests/syntax/elements/popup2.slint
+++ b/internal/compiler/tests/syntax/elements/popup2.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.2 OR LicenseRef-Slint-commercial
+
+component MyPopup inherits PopupWindow {}
+
+component MyPopup2 inherits MyPopup {}
+
+export component TopLevel inherits MyPopup2 {
+//                                 ^error{PopupWindow cannot be the top level}
+    if true : MyPopup2 {}
+//            ^error{PopupWindow cannot be directly repeated or conditional}
+}

--- a/tests/cases/elements/popupwindow.slint
+++ b/tests/cases/elements/popupwindow.slint
@@ -4,6 +4,8 @@
 // The presence of this component shouldn't break anything
 component Window {}
 
+component InheritsPopup inherits PopupWindow {}
+
 Combo := Rectangle {
     property <color> inner_color;
     my_popup := PopupWindow {
@@ -46,4 +48,5 @@ TypeConversionTestCase := Rectangle {
     TouchArea {
         clicked => { popup.show() }
     }
+    InheritsPopup {}
 }

--- a/tests/cases/elements/popupwindow_inherits.slint
+++ b/tests/cases/elements/popupwindow_inherits.slint
@@ -1,0 +1,109 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.2 OR LicenseRef-Slint-commercial
+
+
+component MyPopup inherits PopupWindow {
+    callback clicked;
+    in property <bool> do-close: false;
+    width: 20px;
+    height: 20px;
+    TouchArea {
+        clicked => {
+            clicked();
+            if do-close {
+                root.close();
+            }
+        }
+    }
+}
+
+component MyPopup2 inherits MyPopup {
+    close-on-click: false;
+}
+
+export component TestCase {
+    width: 300px;
+    height: 300px;
+
+    property<int>p1_clicked;
+    property<int>p2_clicked;
+    property<int>p3_clicked;
+
+    p1 := MyPopup {
+        x: 10px;
+        y: 10px;
+        clicked => {p1_clicked+=1;}
+    }
+
+    p2 := MyPopup2 {
+        x: 30px;
+        y: 10px;
+        clicked => {p2_clicked+=1;}
+    }
+
+    p3 := MyPopup2 {
+        x: 60px;
+        y: 10px;
+        do-close: true;
+        clicked => {p3_clicked+=1;}
+    }
+
+    public function show_popup(p: int) {
+        if p == 1 {
+            p1.show();
+        } else if p == 2 {
+            p2.show();
+        } else if p == 3 {
+            p3.show();
+        }
+    }
+    public function hide_2() {
+        p2.close();
+    }
+
+    out property <string> value: @tr("p1={} p2={} p3={}", p1_clicked, p2_clicked, p3_clicked);
+
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 15., 15.);
+slint_testing::send_mouse_click(&instance, 35., 15.);
+slint_testing::send_mouse_click(&instance, 65., 15.);
+assert_eq!(instance.get_value(), "p1=0 p2=0 p3=0");
+
+instance.invoke_show_popup(1);
+slint_testing::send_mouse_click(&instance, 15., 15.);
+
+slint_testing::send_mouse_click(&instance, 15., 15.);
+slint_testing::send_mouse_click(&instance, 35., 15.);
+slint_testing::send_mouse_click(&instance, 65., 15.);
+assert_eq!(instance.get_value(), "p1=1 p2=0 p3=0");
+
+
+instance.invoke_show_popup(2);
+slint_testing::send_mouse_click(&instance, 35., 15.);
+slint_testing::send_mouse_click(&instance, 35., 15.);
+slint_testing::send_mouse_click(&instance, 15., 15.);
+slint_testing::send_mouse_click(&instance, 35., 15.);
+slint_testing::send_mouse_click(&instance, 65., 15.);
+assert_eq!(instance.get_value(), "p1=1 p2=3 p3=0");
+
+instance.invoke_hide_2();
+slint_testing::send_mouse_click(&instance, 35., 15.);
+slint_testing::send_mouse_click(&instance, 35., 15.);
+assert_eq!(instance.get_value(), "p1=1 p2=3 p3=0");
+
+instance.invoke_show_popup(3);
+slint_testing::send_mouse_click(&instance, 65., 15.);
+slint_testing::send_mouse_click(&instance, 65., 15.);
+slint_testing::send_mouse_click(&instance, 15., 15.);
+slint_testing::send_mouse_click(&instance, 35., 15.);
+slint_testing::send_mouse_click(&instance, 65., 15.);
+assert_eq!(instance.get_value(), "p1=1 p2=3 p3=1");
+```
+
+
+*/


### PR DESCRIPTION
This regressed in commit 12d904a71ca31f947bfe983e7dbfe745b2439b74 which changed the order of the pass to get the lower_popup pass before the first inlining pass.
If by chance (which is likely if one have children), the component that inherits from PopupWindow was inlined in that pass, it would be as if it was not a component, and it would be removed from its parent. But since it is no longer inlined, we need to support that case and delay the removal when processing the component that holds that popup.