### PR TITLE
Update the android-activity crate by adding a new feature

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -86,7 +86,7 @@ jobs:
               run: cargo doc -p slint -p slint-build -p slint-interpreter --no-deps --all-features
             - name: "Rust android-activity and i-slint-backend-winit"
               run: |
-                  cargo doc -p i-slint-backend-android-activity -p i-slint-backend-winit -p i-slint-backend-testing --no-deps --target aarch64-linux-android --features=i-slint-backend-android-activity/native-activity,i-slint-backend-winit/renderer-femtovg
+                  cargo doc -p i-slint-backend-android-activity -p i-slint-backend-winit -p i-slint-backend-testing --no-deps --target aarch64-linux-android --features=i-slint-backend-android-activity/native-activity,i-slint-backend-android-activity/aa-05,i-slint-backend-winit/renderer-femtovg
                   cp -r target/aarch64-linux-android/doc/i_slint_backend_android_activity/ target/doc/
                   cp -r target/aarch64-linux-android/doc/i_slint_backend_winit/ target/doc/
                   cp -r target/aarch64-linux-android/doc/i_slint_backend_testing/ target/doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
  - Android: Fixed support for Android 10 to 12 and Java 1.8.
  - Android: Fixed build if the locale is not UTF-8.
  - Android: Added cursor handle on TextInput and selection handle with cut/copy/paste menu.
+ - Android: added `backend-android-activity-06` feature.
  - Software renderer: Dirty regions can now be composed of multiple rectangles.
  - Added a function to mark all translations as dirty.
 

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -164,7 +164,10 @@ backend-linuxkms = ["i-slint-backend-selector/backend-linuxkms", "std"]
 backend-linuxkms-noseat = ["i-slint-backend-selector/backend-linuxkms-noseat", "std"]
 
 ## Use the backend based on the [android-activity](https://docs.rs/android-activity) crate. (Using it's native activity feature)
-backend-android-activity-05 = ["i-slint-backend-android-activity/native-activity"]
+backend-android-activity-06 = ["i-slint-backend-android-activity/native-activity", "i-slint-backend-android-activity/aa-06"]
+
+## **Deprecated** Use previous version of android-activity. This is mutually exclusive with `backend-android-activity-06`.
+backend-android-activity-05 = ["i-slint-backend-android-activity/native-activity", "i-slint-backend-android-activity/aa-05"]
 
 [dependencies]
 i-slint-core = { workspace = true }

--- a/api/rs/slint/android.rs
+++ b/api/rs/slint/android.rs
@@ -3,7 +3,7 @@
 
 //! Android backend.
 //!
-//! **Note:** This module is only available on Android with the "backend-android-activity-05" feature
+//! **Note:** This module is only available on Android with the "backend-android-activity-06" feature
 //!
 //! Slint uses the [android-activity crate](https://github.com/rust-mobile/android-activity) as a backend.
 //!
@@ -33,7 +33,7 @@
 //! }
 //! ```
 //!
-//! That function must be in a `cdylib` library, and you should enable the "backend-android-activity-05"`
+//! That function must be in a `cdylib` library, and you should enable the "backend-android-activity-06"`
 //! feature of the slint crate in your Cargo.toml:
 //!
 //! ```toml
@@ -41,7 +41,7 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies]
-//! slint = { version = "1.5", features = ["backend-android-activity-05"] }
+//! slint = { version = "1.6", features = ["backend-android-activity-06"] }
 //! ```
 //!
 //! ## Building and Deploying
@@ -63,10 +63,16 @@
 //! Note Slint does not require a specific build tool and can work with others, such as [xbuild](https://github.com/rust-mobile/xbuild).
 
 /// Re-export of the android-activity crate.
-#[cfg(all(target_os = "android", feature = "backend-android-activity-05"))]
+#[cfg(all(
+    target_os = "android",
+    any(feature = "backend-android-activity-05", feature = "backend-android-activity-06")
+))]
 pub use i_slint_backend_android_activity::android_activity;
 
-#[cfg(not(all(target_os = "android", feature = "backend-android-activity-05")))]
+#[cfg(not(all(
+    target_os = "android",
+    any(feature = "backend-android-activity-05", feature = "backend-android-activity-06")
+)))]
 /// Re-export of the [android-activity](https://docs.rs/android-activity) crate.
 pub mod android_activity {
     #[doc(hidden)]
@@ -83,7 +89,7 @@ use crate::platform::SetPlatformError;
 
 /// Initializes the Android backend.
 ///
-/// **Note:** This function is only available on Android with the "backend-android-activity-05" feature
+/// **Note:** This function is only available on Android with the "backend-android-activity-06" feature
 ///
 /// This function must be called from the `android_main` function before any call to Slint that needs a backend.
 ///
@@ -98,7 +104,7 @@ pub fn init(app: android_activity::AndroidApp) -> Result<(), SetPlatformError> {
 
 /// Similar to [`init()`], which allow to listen to android-activity's event
 ///
-/// **Note:** This function is only available on Android with the "backend-android-activity-05" feature
+/// **Note:** This function is only available on Android with the "backend-android-activity-06" feature
 ///
 /// The listener argument is a function that takes a [`android_activity::PollEvent`](https://docs.rs/android-activity/latest/android_activity/enum.PollEvent.html)
 ///

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -318,7 +318,13 @@ pub mod platform {
     }
 }
 
-#[cfg(any(doc, all(target_os = "android", feature = "backend-android-activity-05")))]
+#[cfg(any(
+    doc,
+    all(
+        target_os = "android",
+        any(feature = "backend-android-activity-05", feature = "backend-android-activity-06")
+    )
+))]
 pub mod android;
 
 /// Helper type that helps checking that the generated code is generated for the right version

--- a/examples/energy-monitor/Cargo.toml
+++ b/examples/energy-monitor/Cargo.toml
@@ -30,6 +30,6 @@ console_error_panic_hook = "0.1.5"
 slint-build = { path = "../../api/rs/build" }
 
 [features]
-default = ["slint/default", "network", "chrono", "slint/backend-android-activity-05"]
+default = ["slint/default", "network", "chrono", "slint/backend-android-activity-06"]
 simulator = ["mcu-board-support", "slint/renderer-software", "slint/backend-winit", "slint/std"]
 network = ["dep:weer_api", "tokio", "futures"]

--- a/examples/printerdemo/rust/Cargo.toml
+++ b/examples/printerdemo/rust/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["lib", "cdylib"]
 name = "printerdemo_lib"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", features = ["backend-android-activity-05"] }
+slint = { path = "../../../api/rs/slint", features = ["backend-android-activity-06"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"]}
 
 # Disable gettext on macOS due to https://github.com/Koka/gettext-rs/issues/114

--- a/examples/todo/rust/Cargo.toml
+++ b/examples/todo/rust/Cargo.toml
@@ -20,7 +20,7 @@ path = "main.rs"
 name = "todo"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", features = ["serde", "backend-android-activity-05"] }
+slint = { path = "../../../api/rs/slint", features = ["serde", "backend-android-activity-06"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/internal/backends/android-activity/Cargo.toml
+++ b/internal/backends/android-activity/Cargo.toml
@@ -16,16 +16,22 @@ version.workspace = true
 path = "lib.rs"
 
 [features]
-game-activity = ["android-activity/game-activity"]
-native-activity = ["android-activity/native-activity"]
+game-activity = ["android-activity-06?/game-activity", "android-activity-05?/game-activity"]
+native-activity = ["android-activity-06?/native-activity", "android-activity-05?/native-activity"]
+aa-06 = ["android-activity-06", "ndk-09"]
+aa-05 = ["android-activity-05", "ndk-08"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 i-slint-renderer-skia = { workspace = true }
 i-slint-core = { workspace = true, features = ["std"] }
 raw-window-handle = { version = "0.5.2" }
-android-activity = { version = "0.5" }
-ndk = { version = "0.8.0", features = ["rwh_05"] }
+android-activity-05 = { package = "android-activity", version = "0.5", optional = true }
+android-activity-06 = { package = "android-activity", version = "0.6", optional = true }
 jni = { version = "0.21", features = ["invocation"] }
+
+# We only depends on the NDK directly to enable raw-window-handle 0.5 which we need for the skia renderer
+ndk-08 = { package = "ndk", version = "0.8.0", optional = true, features = ["rwh_05"] }
+ndk-09 = { package = "ndk", version = "0.9.0", optional = true, features = ["rwh_05"], default-features = false }
 
 [package.metadata.docs.rs]
 targets = [
@@ -34,4 +40,4 @@ targets = [
     "i686-linux-android",
     "x86_64-linux-android",
 ]
-features = ["native-activity"]
+features = ["native-activity", "aa-06"]

--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -9,8 +9,13 @@
 mod androidwindowadapter;
 mod javahelper;
 
+#[cfg(all(not(feature = "aa-06"), feature = "aa-05"))]
+pub use android_activity_05 as android_activity;
+#[cfg(feature = "aa-06")]
+pub use android_activity_06 as android_activity;
+
+pub use android_activity::AndroidApp;
 use android_activity::PollEvent;
-pub use android_activity::{self, AndroidApp};
 use androidwindowadapter::AndroidWindowAdapter;
 use core::ops::ControlFlow;
 use i_slint_core::api::{EventLoopError, PlatformError};


### PR DESCRIPTION
The android-activity 0.5 no longer works with Rust 1.78 because it asserts with
> slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`