### PR TITLE
live preview: Move repeated/conditional elements, too

### DIFF
--- a/tools/lsp/ui/draw-area.slint
+++ b/tools/lsp/ui/draw-area.slint
@@ -84,7 +84,7 @@ component SelectionFrame {
 
     if root.interactive && selection.is-primary: Resizer {
         double-clicked(x, y, modifiers) => {
-            root.select-behind(self.absolute-position.x + x, self.absolute-position.y + y, modifiers.control, modifiers.shift);
+            root.select-behind(root.selection.geometry.x + x, root.selection.geometry.y + y, modifiers.control, modifiers.shift);
         }
 
         is-moveable: root.selection.is-moveable;


### PR DESCRIPTION
Now that we move elements with ids, lets also move conditional and repeated elements.

They have the same problem as elements with ids: They will probably break when moved into different elements.