### PR TITLE
live-preview: Fix `select-behind`

### DIFF
--- a/tools/lsp/ui/draw-area.slint
+++ b/tools/lsp/ui/draw-area.slint
@@ -84,7 +84,7 @@ component SelectionFrame {
 
     if root.interactive && selection.is-primary: Resizer {
         double-clicked(x, y, modifiers) => {
-            root.select-behind(self.absolute-position.x + x, self.absolute-position.y + y, modifiers.control, modifiers.shift);
+            root.select-behind(root.selection.geometry.x + x, root.selection.geometry.y + y, modifiers.control, modifiers.shift);
         }
 
         is-moveable: root.selection.is-moveable;


### PR DESCRIPTION
Brown paper bag issue: Actually map the click to the right place :-(