### PR TITLE
Fix declaring callback alias that override a property

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1049,22 +1049,6 @@ impl Element {
                 sig_decl.child_token(SyntaxKind::Identifier).map_or(false, |t| t.text() == "pure"),
             );
 
-            if let Some(csn) = sig_decl.TwoWayBinding() {
-                r.bindings
-                    .insert(name.clone(), BindingExpression::new_uncompiled(csn.into()).into());
-                r.property_declarations.insert(
-                    name,
-                    PropertyDeclaration {
-                        property_type: Type::InferredCallback,
-                        node: Some(sig_decl.into()),
-                        visibility: PropertyVisibility::InOut,
-                        pure,
-                        ..Default::default()
-                    },
-                );
-                continue;
-            }
-
             let PropertyLookupResult {
                 resolved_name: existing_name,
                 property_type: maybe_existing_prop_type,
@@ -1092,6 +1076,22 @@ impl Element {
                         &sig_decl.DeclaredIdentifier(),
                     );
                 }
+                continue;
+            }
+
+            if let Some(csn) = sig_decl.TwoWayBinding() {
+                r.bindings
+                    .insert(name.clone(), BindingExpression::new_uncompiled(csn.into()).into());
+                r.property_declarations.insert(
+                    name,
+                    PropertyDeclaration {
+                        property_type: Type::InferredCallback,
+                        node: Some(sig_decl.into()),
+                        visibility: PropertyVisibility::InOut,
+                        pure,
+                        ..Default::default()
+                    },
+                );
                 continue;
             }
 

--- a/internal/compiler/tests/syntax/basic/signal.slint
+++ b/internal/compiler/tests/syntax/basic/signal.slint
@@ -52,4 +52,7 @@ export SubElements := Rectangle {
 
     callback init;
 //           ^error{Cannot override callback 'init'}
+
+    callback width;
+//           ^error{Cannot declare callback 'width' when a property with the same name exists}
 }

--- a/internal/compiler/tests/syntax/lookup/callback_alias3.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias3.slint
@@ -30,5 +30,8 @@ export Xxx := Rectangle {
             return "hello";
 //          ^error{Cannot convert string to int}
         }
+
+        callback x <=> compute_alias;
+//               ^error{Cannot declare callback 'x' when a property with the same name exists}
     }
 }


### PR DESCRIPTION
Do the check for existing property before handling of callback aliases

Fixes #5205