### PR TITLE
vscode web extension: Fix loading of images

### DIFF
--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -202,7 +202,7 @@ function map_url(webview: vscode.Webview, url_: string) {
 
     try {
         const url = Uri.parse(url_, false);
-        if (vscode.workspace.getWorkspaceFolder(url) && url.scheme === "file") {
+        if (vscode.workspace.getWorkspaceFolder(url)) {
             result = previewPanel?.webview.asWebviewUri(url)?.toString();
         }
     } catch (_) {


### PR DESCRIPTION
Prospective fix for loading of image when using the vscode extension from the web (eg, via https://github.dev)

URL is different in a local web extension and in a online web extension. In a local web extension, it still use file:// for urls, but online, it uses vscode-vfs:// url. And we wouldn't map it because it doesn't start with file://

I couldn't find a reason looking at the git history why we check for file://, I assumed this might have been because of builtin:/, but I checked and these still work both with the wasm in the native extension, and as a web extension