### PR TITLE
Slintpad: Fix failing typecsript build by removing unused json-schema type declaration requirement

### DIFF
--- a/tools/slintpad/src/tsconfig.json
+++ b/tools/slintpad/src/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../tsconfig.default.json",
     "compilerOptions": {
         "lib": ["dom", "es2021"],
-        "types": ["json-schema", "vscode"]
+        "types": ["vscode"]
     },
     "include": ["./*.ts", "./shared/*.ts", "../package.json", "./welcome/*.ts"],
     "references": [

--- a/tools/slintpad/src/worker/tsconfig.json
+++ b/tools/slintpad/src/worker/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.default.json",
     "compilerOptions": {
         "lib": ["webworker", "es6"],
-        "types": ["json-schema", "vscode"]
+        "types": ["vscode"]
     },
     "include": ["./*.mjs", "./*.ts"]
 }


### PR DESCRIPTION

It's not needed for the tsc build but was brought in through an implicit dependency.