### PR TITLE
ESP32: Fix flashing examples such as printerdemo_mcu with espflash

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,7 +7,7 @@ Files: */slint-icon-*.svg */slint-icon-*.png */slint-icon-*.pdf */slint-logo-*.s
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: CC-BY-ND-4.0
 
-Files: .gitattributes .gitignore */.gitignore .dockerignore .prettierignore .pre-commit-config.yaml .vscode/* cspell.json rustfmt.toml .mailmap */.eslintrc.yml Cargo.lock */.npmignore
+Files: .gitattributes .gitignore */.gitignore .dockerignore .prettierignore .pre-commit-config.yaml .vscode/* cspell.json rustfmt.toml .mailmap */.eslintrc.yml Cargo.lock */.npmignore espflash.toml
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.2 OR LicenseRef-Slint-commercial
 
@@ -84,7 +84,7 @@ Files: examples/carousel/fonts/*.ttf
 Copyright: Roboto <https://fonts.google.com/specimen/Roboto/about>
 License: Apache-2.0
 
-Files: examples/*/esp-idf/*/partitions.csv examples/*/esp-idf/partitions.csv
+Files: examples/*/esp-idf/*/partitions.csv examples/*/esp-idf/partitions.csv examples/mcu-board-support/partitions.csv
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: MIT
 

--- a/espflash.toml
+++ b/espflash.toml
@@ -1,0 +1,1 @@
+partition_table = "examples/mcu-board-support/partitions.csv"

--- a/examples/mcu-board-support/partitions.csv
+++ b/examples/mcu-board-support/partitions.csv
@@ -1,0 +1,5 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+# Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
+nvs,      data, nvs,     0x9000,  0x6000,
+phy_init, data, phy,     ,        0x1000,
+factory,  app,  factory, ,        4096k,


### PR DESCRIPTION
These tend to grow now beyond the 1MB default, so use the same partitions.csv that we use for esp-idf, which provisions a 4MB partition.

Fixes #5252