### PR TITLE
Add element type information and ids to the testing API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
             CARGO_PROFILE_DEV_DEBUG: 0
             CARGO_INCREMENTAL: false
             RUST_BACKTRACE: 1
+            SLINT_EMIT_DEBUG_INFO: 1
         strategy:
             matrix:
                 os: [ubuntu-22.04, macos-11, windows-2022]

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -60,6 +60,23 @@ public:
         return result;
     }
 
+    /// Find all elements matching the given type name.
+    template<typename T>
+    static SharedVector<ElementHandle>
+    find_by_element_type_name(const ComponentHandle<T> &component, std::string_view type_name)
+    {
+        cbindgen_private::Slice<uint8_t> element_type_name_view {
+            const_cast<unsigned char *>(reinterpret_cast<const unsigned char *>(type_name.data())),
+            type_name.size()
+        };
+        auto vrc = component.into_dyn();
+        SharedVector<ElementHandle> result;
+        cbindgen_private::slint_testing_element_find_by_element_type_name(
+                &vrc, &element_type_name_view,
+                reinterpret_cast<SharedVector<cbindgen_private::ElementHandle> *>(&result));
+        return result;
+    }
+
     /// Returns true if the underlying element still exists; false otherwise.
     bool is_valid() const { return private_api::upgrade_item_weak(inner.item).has_value(); }
 

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -43,6 +43,23 @@ public:
         return result;
     }
 
+    /// Find all elements matching the given element_id.
+    template<typename T>
+    static SharedVector<ElementHandle> find_by_element_id(const ComponentHandle<T> &component,
+                                                          std::string_view element_id)
+    {
+        cbindgen_private::Slice<uint8_t> element_id_view {
+            const_cast<unsigned char *>(reinterpret_cast<const unsigned char *>(element_id.data())),
+            element_id.size()
+        };
+        auto vrc = component.into_dyn();
+        SharedVector<ElementHandle> result;
+        cbindgen_private::slint_testing_element_find_by_element_id(
+                &vrc, &element_id_view,
+                reinterpret_cast<SharedVector<cbindgen_private::ItemWeak> *>(&result));
+        return result;
+    }
+
     /// Returns true if the underlying element still exists; false otherwise.
     bool is_valid() const { return private_api::upgrade_item_weak(inner).has_value(); }
 

--- a/api/cpp/tests/CMakeLists.txt
+++ b/api/cpp/tests/CMakeLists.txt
@@ -47,6 +47,10 @@ if(NOT SLINT_FEATURE_FREESTANDING)
 endif()
 slint_test(models)
 
+if(SLINT_FEATURE_EXPERIMENTAL AND SLINT_FEATURE_TESTING)
+    slint_test(testing)
+endif()
+
 if(SLINT_FEATURE_COMPILER OR SLINT_COMPILER)
     add_subdirectory(multiple-includes)
 endif()

--- a/api/cpp/tests/testing.cpp
+++ b/api/cpp/tests/testing.cpp
@@ -1,0 +1,70 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"
+
+#include <slint.h>
+#include <slint-interpreter.h>
+#include <slint-testing.h>
+
+SCENARIO("ElementHandle")
+{
+    using namespace slint::interpreter;
+    using namespace slint;
+
+    ComponentCompiler compiler;
+
+    auto result = compiler.build_from_source(
+            R"(
+        component ButtonBase {
+            @children
+        }
+        component PushButton inherits ButtonBase {
+            in property <string> text <=> label.text;
+            label := Text {}
+        }
+        export component App {
+            VerticalLayout {
+                PushButton { text: "first"; }
+                second := PushButton { text: "second"; }
+            }
+        }
+    )",
+            "");
+    for (auto &&x : compiler.diagnostics())
+        std::cerr << x.message << std::endl;
+    REQUIRE(result.has_value());
+    auto component_definition = *result;
+
+    auto instance = component_definition.create();
+
+    SECTION("Find by accessible label")
+    {
+        auto elements = slint::testing::ElementHandle::find_by_accessible_label(instance, "first");
+        REQUIRE(elements.size() == 1);
+        REQUIRE(*elements[0].accessible_label() == "first");
+        REQUIRE(*elements[0].id() == "PushButton::label");
+        REQUIRE(*elements[0].type_name() == "Text");
+        REQUIRE((*elements[0].bases()).size() == 0);
+    }
+
+    SECTION("Find by id")
+    {
+        auto elements = slint::testing::ElementHandle::find_by_element_id(instance, "App::second");
+        REQUIRE(elements.size() == 1);
+        REQUIRE(*elements[0].id() == "App::second");
+        REQUIRE(*elements[0].type_name() == "PushButton");
+        REQUIRE((*elements[0].bases()).size() == 1);
+        REQUIRE((*elements[0].bases())[0] == "ButtonBase");
+    }
+
+    SECTION("Find by type name")
+    {
+        auto elements =
+                slint::testing::ElementHandle::find_by_element_type_name(instance, "PushButton");
+        REQUIRE(elements.size() == 2);
+        REQUIRE(*elements[0].id() == "");
+        REQUIRE(*elements[1].id() == "App::second");
+    }
+}

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -374,7 +374,7 @@ pub fn compile_with_config(
     let syntax_node = syntax_node.expect("diags contained no compilation errors");
 
     // 'spin_on' is ok here because the compiler in single threaded and does not block if there is no blocking future
-    let (doc, diag, _) =
+    let (doc, diag, loader) =
         spin_on::spin_on(i_slint_compiler::compile_syntax_node(syntax_node, diag, compiler_config));
 
     if diag.has_error() {
@@ -393,7 +393,7 @@ pub fn compile_with_config(
 
     let file = std::fs::File::create(&output_file_path).map_err(CompileError::SaveError)?;
     let mut code_formatter = CodeFormatter::new(BufWriter::new(file));
-    let generated = i_slint_compiler::generator::rust::generate(&doc);
+    let generated = i_slint_compiler::generator::rust::generate(&doc, &loader.compiler_config);
 
     for x in &diag.all_loaded_files {
         if x.is_absolute() {
@@ -421,6 +421,7 @@ pub fn compile_with_config(
     println!("cargo:rerun-if-env-changed=SLINT_SCALE_FACTOR");
     println!("cargo:rerun-if-env-changed=SLINT_ASSET_SECTION");
     println!("cargo:rerun-if-env-changed=SLINT_EMBED_RESOURCES");
+    println!("cargo:rerun-if-env-changed=SLINT_EMIT_DEBUG_INFO");
 
     println!("cargo:rustc-env=SLINT_INCLUDE_GENERATED={}", output_file_path.display());
 

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -394,14 +394,14 @@ pub fn slint(stream: TokenStream) -> TokenStream {
 
     //println!("{:#?}", syntax_node);
     compiler_config.translation_domain = std::env::var("CARGO_PKG_NAME").ok();
-    let (root_component, diag, _) =
+    let (root_component, diag, loader) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
     //println!("{:#?}", tree);
     if diag.has_error() {
         return diag.report_macro_diagnostic(&tokens);
     }
 
-    let mut result = generator::rust::generate(&root_component);
+    let mut result = generator::rust::generate(&root_component, &loader.compiler_config);
 
     // Make sure to recompile if any of the external files changes
     let reload = diag

--- a/internal/backends/testing/ffi.rs
+++ b/internal/backends/testing/ffi.rs
@@ -29,9 +29,7 @@ pub extern "C" fn slint_testing_element_find_by_element_id(
     out: &mut SharedVector<crate::search_api::ElementHandle>,
 ) {
     let Ok(element_id) = core::str::from_utf8(element_id.as_slice()) else { return };
-    *out = crate::search_api::search_item(root, |elem| {
-        elem.element_type_names_and_ids().unwrap().any(|(_, eid)| eid == element_id)
-    })
+    out.extend(crate::ElementHandle::find_by_element_id_with_tree(&root, element_id));
 }
 
 #[no_mangle]
@@ -41,21 +39,44 @@ pub extern "C" fn slint_testing_element_find_by_element_type_name(
     out: &mut SharedVector<crate::search_api::ElementHandle>,
 ) {
     let Ok(type_name) = core::str::from_utf8(type_name.as_slice()) else { return };
-    *out = crate::search_api::search_item(root, |elem| {
-        elem.element_type_names_and_ids().unwrap().any(|(tid, _)| tid == type_name)
-    })
+    out.extend(crate::ElementHandle::find_by_element_type_name_with_tree(&root, type_name));
 }
 
 #[no_mangle]
-pub extern "C" fn slint_testing_element_type_names_and_ids(
+pub extern "C" fn slint_testing_element_id(
     element: &crate::search_api::ElementHandle,
-    type_names: &mut SharedVector<SharedString>,
-    ids: &mut SharedVector<SharedString>,
-) {
-    if let Some(it) = element.element_type_names_and_ids() {
-        for (type_name, id) in it {
-            type_names.push(type_name);
-            ids.push(id);
-        }
+    out: &mut SharedString,
+) -> bool {
+    if let Some(id) = element.id() {
+        *out = id;
+        true
+    } else {
+        false
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn slint_testing_element_type_name(
+    element: &crate::search_api::ElementHandle,
+    out: &mut SharedString,
+) -> bool {
+    if let Some(type_name) = element.type_name() {
+        *out = type_name;
+        true
+    } else {
+        false
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn slint_testing_element_bases(
+    element: &crate::search_api::ElementHandle,
+    out: &mut SharedVector<SharedString>,
+) -> bool {
+    if let Some(bases_it) = element.bases() {
+        out.extend(bases_it);
+        true
+    } else {
+        false
     }
 }

--- a/internal/backends/testing/ffi.rs
+++ b/internal/backends/testing/ffi.rs
@@ -35,6 +35,18 @@ pub extern "C" fn slint_testing_element_find_by_element_id(
 }
 
 #[no_mangle]
+pub extern "C" fn slint_testing_element_find_by_element_type_name(
+    root: &ItemTreeRc,
+    type_name: &Slice<u8>,
+    out: &mut SharedVector<crate::search_api::ElementHandle>,
+) {
+    let Ok(type_name) = core::str::from_utf8(type_name.as_slice()) else { return };
+    *out = crate::search_api::search_item(root, |elem| {
+        elem.element_type_names_and_ids().unwrap().any(|(tid, _)| tid == type_name)
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn slint_testing_element_type_names_and_ids(
     element: &crate::search_api::ElementHandle,
     type_names: &mut SharedVector<SharedString>,

--- a/internal/backends/testing/ffi.rs
+++ b/internal/backends/testing/ffi.rs
@@ -1,10 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use i_slint_core::accessibility::AccessibleStringProperty;
-use i_slint_core::item_tree::{ItemTreeRc, ItemWeak};
+use i_slint_core::item_tree::ItemTreeRc;
 use i_slint_core::slice::Slice;
-use i_slint_core::SharedVector;
+use i_slint_core::{SharedString, SharedVector};
 
 #[no_mangle]
 pub extern "C" fn slint_testing_init_backend() {
@@ -15,11 +14,11 @@ pub extern "C" fn slint_testing_init_backend() {
 pub extern "C" fn slint_testing_element_find_by_accessible_label(
     root: &ItemTreeRc,
     label: &Slice<u8>,
-    out: &mut SharedVector<ItemWeak>,
+    out: &mut SharedVector<crate::search_api::ElementHandle>,
 ) {
     let Ok(label) = core::str::from_utf8(label.as_slice()) else { return };
-    *out = crate::search_api::search_item(root, |item| {
-        item.accessible_string_property(AccessibleStringProperty::Label).is_some_and(|x| x == label)
+    *out = crate::search_api::search_item(root, |elem| {
+        elem.accessible_label().is_some_and(|x| x == label)
     })
 }
 
@@ -27,10 +26,24 @@ pub extern "C" fn slint_testing_element_find_by_accessible_label(
 pub extern "C" fn slint_testing_element_find_by_element_id(
     root: &ItemTreeRc,
     element_id: &Slice<u8>,
-    out: &mut SharedVector<ItemWeak>,
+    out: &mut SharedVector<crate::search_api::ElementHandle>,
 ) {
     let Ok(element_id) = core::str::from_utf8(element_id.as_slice()) else { return };
-    *out = crate::search_api::search_item(root, |item| {
-        item.element_ids().iter().any(|i| i == element_id)
+    *out = crate::search_api::search_item(root, |elem| {
+        elem.element_type_names_and_ids().unwrap().any(|(_, eid)| eid == element_id)
     })
+}
+
+#[no_mangle]
+pub extern "C" fn slint_testing_element_type_names_and_ids(
+    element: &crate::search_api::ElementHandle,
+    type_names: &mut SharedVector<SharedString>,
+    ids: &mut SharedVector<SharedString>,
+) {
+    if let Some(it) = element.element_type_names_and_ids() {
+        for (type_name, id) in it {
+            type_names.push(type_name);
+            ids.push(id);
+        }
+    }
 }

--- a/internal/backends/testing/ffi.rs
+++ b/internal/backends/testing/ffi.rs
@@ -22,3 +22,15 @@ pub extern "C" fn slint_testing_element_find_by_accessible_label(
         item.accessible_string_property(AccessibleStringProperty::Label).is_some_and(|x| x == label)
     })
 }
+
+#[no_mangle]
+pub extern "C" fn slint_testing_element_find_by_element_id(
+    root: &ItemTreeRc,
+    element_id: &Slice<u8>,
+    out: &mut SharedVector<ItemWeak>,
+) {
+    let Ok(element_id) = core::str::from_utf8(element_id.as_slice()) else { return };
+    *out = crate::search_api::search_item(root, |item| {
+        item.element_ids().iter().any(|i| i == element_id)
+    })
+}

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -66,8 +66,7 @@ impl ElementHandle {
     ) -> impl Iterator<Item = Self> {
         // dirty way to get the ItemTreeRc:
         let item_tree = WindowInner::from_pub(component.window()).component();
-        let result =
-            search_item(&item_tree, |item| item.element_ids().iter().find(|&i| *i == id).is_some());
+        let result = search_item(&item_tree, |item| item.element_ids().iter().any(|i| i == id));
         result.into_iter().map(|x| ElementHandle(x))
     }
 

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -58,6 +58,19 @@ impl ElementHandle {
         result.into_iter().map(ElementHandle)
     }
 
+    /// This function searches through the entire tree of elements of `component`, looks for
+    /// elements by their name.
+    pub fn find_by_element_id(
+        component: &impl i_slint_core::api::ComponentHandle,
+        id: &str,
+    ) -> impl Iterator<Item = Self> {
+        // dirty way to get the ItemTreeRc:
+        let item_tree = WindowInner::from_pub(component.window()).component();
+        let result =
+            search_item(&item_tree, |item| item.element_ids().iter().find(|&i| *i == id).is_some());
+        result.into_iter().map(|x| ElementHandle(x))
+    }
+
     /// Invokes the default accessible action on the element. For example a `MyButton` element might declare
     /// an accessible default action that simulates a click, as in the following example:
     ///

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -70,6 +70,20 @@ impl ElementHandle {
         result.into_iter().map(|x| ElementHandle(x))
     }
 
+    /// This function searches through the entire tree of elements of `component`, looks for
+    /// elements with given type name.
+    pub fn find_by_element_type_name(
+        component: &impl i_slint_core::api::ComponentHandle,
+        type_name: &str,
+    ) -> impl Iterator<Item = Self> {
+        // dirty way to get the ItemTreeRc:
+        let item_tree = WindowInner::from_pub(component.window()).component();
+        let result = search_item(&item_tree, |item| {
+            item.element_type_names().iter().any(|i| i == type_name)
+        });
+        result.into_iter().map(|x| ElementHandle(x))
+    }
+
     /// Invokes the default accessible action on the element. For example a `MyButton` element might declare
     /// an accessible default action that simulates a click, as in the following example:
     ///

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -16,6 +16,7 @@ use crate::expression_tree::{BindingExpression, Expression};
 use crate::langtype::ElementType;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, Document, ElementRc};
+use crate::CompilerConfiguration;
 
 #[cfg(feature = "cpp")]
 pub mod cpp;
@@ -65,6 +66,7 @@ pub fn generate(
     format: OutputFormat,
     destination: &mut impl std::io::Write,
     doc: &Document,
+    compiler_config: &CompilerConfiguration,
 ) -> std::io::Result<()> {
     #![allow(unused_variables)]
     #![allow(unreachable_code)]
@@ -77,12 +79,12 @@ pub fn generate(
     match format {
         #[cfg(feature = "cpp")]
         OutputFormat::Cpp(config) => {
-            let output = cpp::generate(doc, config);
+            let output = cpp::generate(doc, config, compiler_config);
             write!(destination, "{}", output)?;
         }
         #[cfg(feature = "rust")]
         OutputFormat::Rust => {
-            let output = rust::generate(doc);
+            let output = rust::generate(doc, compiler_config);
             write!(destination, "{}", output)?;
         }
         OutputFormat::Interpreter => {
@@ -92,7 +94,10 @@ pub fn generate(
             )); // Perhaps byte code in the future?
         }
         OutputFormat::Llr => {
-            let root = crate::llr::lower_to_item_tree::lower_to_item_tree(&doc.root_component);
+            let root = crate::llr::lower_to_item_tree::lower_to_item_tree(
+                &doc.root_component,
+                compiler_config,
+            );
             let mut output = String::new();
             crate::llr::pretty_print::pretty_print(&root, &mut output).unwrap();
             write!(destination, "{output}")?;

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1408,12 +1408,12 @@ fn generate_item_tree(
     target_struct.members.push((
         Access::Private,
         Declaration::Function(Function {
-            name: "element_ids".into(),
+            name: "element_infos".into(),
             signature:
                 "([[maybe_unused]] slint::private_api::ItemTreeRef component, uint32_t index, slint::SharedString *result) -> void"
                     .into(),
             is_static: true,
-            statements: Some(vec![format!("*result = reinterpret_cast<const {}*>(component.instance)->element_ids(index);", item_tree_class_name)]),
+            statements: Some(vec![format!("*result = reinterpret_cast<const {}*>(component.instance)->element_infos(index);", item_tree_class_name)]),
             ..Default::default()
         }),
     ));
@@ -1449,7 +1449,7 @@ fn generate_item_tree(
             "{{ visit_children, get_item_ref, get_subtree_range, get_subtree, \
                 get_item_tree, parent_node, embed_component, subtree_index, layout_info, \
                 item_geometry, accessible_role, accessible_string_property, accessibility_action, \
-                supported_accessibility_actions, element_ids, window_adapter, \
+                supported_accessibility_actions, element_infos, window_adapter, \
                 slint::private_api::drop_in_place<{}>, slint::private_api::dealloc }}",
             item_tree_class_name
         )),
@@ -2033,20 +2033,20 @@ fn generate_sub_component(
         supported_accessibility_actions_cases,
     );
 
-    let mut element_ids_cases = vec!["switch (index) {".to_string()];
-    element_ids_cases.extend(
+    let mut element_infos_cases = vec!["switch (index) {".to_string()];
+    element_infos_cases.extend(
         component
-            .element_ids
+            .element_infos
             .iter()
             .map(|(index, ids)| format!("    case {index}: return \"{}\";", ids.join(";"))),
     );
-    element_ids_cases.push("}".into());
+    element_infos_cases.push("}".into());
 
     dispatch_item_function(
-        "element_ids",
+        "element_infos",
         "(uint32_t index) const -> slint::SharedString",
         "",
-        element_ids_cases,
+        element_infos_cases,
     );
 
     if !children_visitor_cases.is_empty() {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1410,10 +1410,10 @@ fn generate_item_tree(
         Declaration::Function(Function {
             name: "element_infos".into(),
             signature:
-                "([[maybe_unused]] slint::private_api::ItemTreeRef component, uint32_t index, slint::SharedString *result) -> void"
+                "([[maybe_unused]] slint::private_api::ItemTreeRef component, uint32_t index, slint::SharedString *result) -> bool"
                     .into(),
             is_static: true,
-            statements: Some(vec![format!("*result = reinterpret_cast<const {}*>(component.instance)->element_infos(index);", item_tree_class_name)]),
+            statements: Some(vec![format!("if (auto infos = reinterpret_cast<const {}*>(component.instance)->element_infos(index)) {{ *result = *infos; return true; }};", item_tree_class_name), "return false;".into()]),
             ..Default::default()
         }),
     ));
@@ -2044,7 +2044,7 @@ fn generate_sub_component(
 
     dispatch_item_function(
         "element_infos",
-        "(uint32_t index) const -> slint::SharedString",
+        "(uint32_t index) const -> std::optional<slint::SharedString>",
         "",
         element_infos_cases,
     );

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2038,7 +2038,7 @@ fn generate_sub_component(
         component
             .element_infos
             .iter()
-            .map(|(index, ids)| format!("    case {index}: return \"{}\";", ids.join(";"))),
+            .map(|(index, ids)| format!("    case {index}: return \"{}\";", ids)),
     );
     element_infos_cases.push("}".into());
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -334,6 +334,7 @@ use crate::llr::{
 };
 use crate::object_tree::Document;
 use crate::parser::syntax_nodes;
+use crate::CompilerConfiguration;
 use cpp_ast::*;
 use itertools::{Either, Itertools};
 use std::cell::Cell;
@@ -534,7 +535,11 @@ fn handle_property_init(
 }
 
 /// Returns the text of the C++ code produced by the given root component
-pub fn generate(doc: &Document, config: Config) -> impl std::fmt::Display {
+pub fn generate(
+    doc: &Document,
+    config: Config,
+    compiler_config: &CompilerConfiguration,
+) -> impl std::fmt::Display {
     let mut file = File { namespace: config.namespace.clone(), ..Default::default() };
 
     file.includes.push("<array>".into());
@@ -764,7 +769,7 @@ pub fn generate(doc: &Document, config: Config) -> impl std::fmt::Display {
         return file;
     }
 
-    let llr = llr::lower_to_item_tree::lower_to_item_tree(&doc.root_component);
+    let llr = llr::lower_to_item_tree::lower_to_item_tree(&doc.root_component, compiler_config);
 
     // Forward-declare the root so that sub-components can access singletons, the window, etc.
     file.declarations.push(Declaration::Struct(Struct {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -20,6 +20,7 @@ use crate::llr::{
     TypeResolutionContext as _,
 };
 use crate::object_tree::Document;
+use crate::CompilerConfiguration;
 use itertools::Either;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
@@ -138,7 +139,7 @@ fn set_primitive_property_value(ty: &Type, value_expression: TokenStream) -> Tok
 }
 
 /// Generate the rust code for the given component.
-pub fn generate(doc: &Document) -> TokenStream {
+pub fn generate(doc: &Document, compiler_config: &CompilerConfiguration) -> TokenStream {
     let (structs_and_enums_ids, structs_and_enum_def): (Vec<_>, Vec<_>) = doc
         .root_component
         .used_types
@@ -162,7 +163,8 @@ pub fn generate(doc: &Document) -> TokenStream {
         return TokenStream::default();
     }
 
-    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(&doc.root_component);
+    let llr =
+        crate::llr::lower_to_item_tree::lower_to_item_tree(&doc.root_component, &compiler_config);
 
     let sub_compos = llr
         .sub_components

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -837,7 +837,7 @@ fn generate_sub_component(
     let mut item_element_infos_branch = component
         .element_infos
         .iter()
-        .map(|(item_index, ids)| quote!(#item_index => { return #ids.into(); }))
+        .map(|(item_index, ids)| quote!(#item_index => { return sp::Some(#ids.into()); }))
         .collect::<Vec<_>>();
 
     let mut user_init_code: Vec<TokenStream> = Vec::new();
@@ -1158,7 +1158,7 @@ fn generate_sub_component(
                 }
             }
 
-            fn item_element_infos(self: ::core::pin::Pin<&Self>, index: u32) -> sp::SharedString {
+            fn item_element_infos(self: ::core::pin::Pin<&Self>, index: u32) -> sp::Option<sp::SharedString> {
                 #![allow(unused)]
                 let _self = self;
                 match index {
@@ -1628,8 +1628,13 @@ fn generate_item_tree(
                 self: ::core::pin::Pin<&Self>,
                 index: u32,
                 result: &mut sp::SharedString,
-            )  {
-                *result = self.item_element_infos(index);
+            ) -> bool {
+                if let Some(infos) = self.item_element_infos(index) {
+                    *result = infos;
+                    true
+                } else {
+                    false
+                }
             }
 
             fn window_adapter(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -837,10 +837,7 @@ fn generate_sub_component(
     let mut item_element_infos_branch = component
         .element_infos
         .iter()
-        .map(|(item_index, ids)| {
-            let ids = ids.join(";");
-            quote!(#item_index => { return #ids.into(); })
-        })
+        .map(|(item_index, ids)| quote!(#item_index => { return #ids.into(); }))
         .collect::<Vec<_>>();
 
     let mut user_init_code: Vec<TokenStream> = Vec::new();

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -23,7 +23,7 @@ use crate::object_tree::Document;
 use itertools::Either;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 
@@ -832,6 +832,35 @@ fn generate_sub_component(
         })
         .collect::<Vec<_>>();
 
+    let mut sub_components_by_local_tree_index = component
+        .sub_components
+        .iter()
+        .map(|sub| {
+            let local_tree_index: u32 = sub.index_in_tree as _;
+            (local_tree_index, sub.ty.clone())
+        })
+        .collect::<HashMap<_, _>>();
+
+    let mut collect_item_element_ids_branch = component
+        .element_ids
+        .iter()
+        .map(|(item_index, ids)| {
+            let mut ids = ids.clone();
+            if let Some(sub_compo) = sub_components_by_local_tree_index.remove(&item_index) {
+                ids.extend_from_slice(&sub_compo.root_item_element_ids());
+            }
+            let ids = ids.join(";");
+            quote!(#item_index => { return #ids.into(); })
+        })
+        .collect::<Vec<_>>();
+
+    collect_item_element_ids_branch.extend(sub_components_by_local_tree_index.into_iter().map(
+        |(sub_compo_index, sc)| {
+            let compo_ids = sc.root_item_element_ids().join(";");
+            quote!(#sub_compo_index => { return #compo_ids.into(); })
+        },
+    ));
+
     let mut user_init_code: Vec<TokenStream> = Vec::new();
 
     let mut sub_component_names: Vec<Ident> = vec![];
@@ -919,6 +948,9 @@ fn generate_sub_component(
             ));
             supported_accessibility_actions_branch.push(quote!(
                 #range_begin..=#range_end => #sub_compo_field.apply_pin(_self).supported_accessibility_actions(index - #range_begin + 1),
+            ));
+            collect_item_element_ids_branch.push(quote!(
+                #range_begin..=#range_end => #sub_compo_field.apply_pin(_self).item_element_ids(index - #range_begin + 1),
             ));
         }
 
@@ -1147,6 +1179,14 @@ fn generate_sub_component(
                 }
             }
 
+            fn item_element_ids(self: ::core::pin::Pin<&Self>, index: u32) -> sp::SharedString {
+                #![allow(unused)]
+                let _self = self;
+                match index {
+                    #(#collect_item_element_ids_branch)*
+                    _ => { ::core::default::Default::default() }
+                }
+            }
 
             #(#declared_functions)*
         }
@@ -1604,6 +1644,13 @@ fn generate_item_tree(
             fn supported_accessibility_actions(self: ::core::pin::Pin<&Self>, index: u32) -> sp::SupportedAccessibilityAction {
                 self.supported_accessibility_actions(index)
             }
+
+            fn item_element_ids(
+                self: ::core::pin::Pin<&Self>,
+                index: u32,
+            ) -> sp::SharedString {
+                self.item_element_ids(index)
+        }
 
             fn window_adapter(
                 self: ::core::pin::Pin<&Self>,

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -834,8 +834,8 @@ fn generate_sub_component(
         })
         .collect::<Vec<_>>();
 
-    let mut item_element_ids_branch = component
-        .element_ids
+    let mut item_element_infos_branch = component
+        .element_infos
         .iter()
         .map(|(item_index, ids)| {
             let ids = ids.join(";");
@@ -931,8 +931,8 @@ fn generate_sub_component(
             supported_accessibility_actions_branch.push(quote!(
                 #range_begin..=#range_end => #sub_compo_field.apply_pin(_self).supported_accessibility_actions(index - #range_begin + 1),
             ));
-            item_element_ids_branch.push(quote!(
-                #range_begin..=#range_end => #sub_compo_field.apply_pin(_self).item_element_ids(index - #range_begin + 1),
+            item_element_infos_branch.push(quote!(
+                #range_begin..=#range_end => #sub_compo_field.apply_pin(_self).item_element_infos(index - #range_begin + 1),
             ));
         }
 
@@ -1161,11 +1161,11 @@ fn generate_sub_component(
                 }
             }
 
-            fn item_element_ids(self: ::core::pin::Pin<&Self>, index: u32) -> sp::SharedString {
+            fn item_element_infos(self: ::core::pin::Pin<&Self>, index: u32) -> sp::SharedString {
                 #![allow(unused)]
                 let _self = self;
                 match index {
-                    #(#item_element_ids_branch)*
+                    #(#item_element_infos_branch)*
                     _ => { ::core::default::Default::default() }
                 }
             }
@@ -1627,12 +1627,12 @@ fn generate_item_tree(
                 self.supported_accessibility_actions(index)
             }
 
-            fn item_element_ids(
+            fn item_element_infos(
                 self: ::core::pin::Pin<&Self>,
                 index: u32,
                 result: &mut sp::SharedString,
             )  {
-                *result = self.item_element_ids(index);
+                *result = self.item_element_infos(index);
             }
 
             fn window_adapter(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1648,9 +1648,10 @@ fn generate_item_tree(
             fn item_element_ids(
                 self: ::core::pin::Pin<&Self>,
                 index: u32,
-            ) -> sp::SharedString {
-                self.item_element_ids(index)
-        }
+                result: &mut sp::SharedString,
+            )  {
+                *result = self.item_element_ids(index);
+            }
 
             fn window_adapter(
                 self: ::core::pin::Pin<&Self>,

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -607,6 +607,17 @@ impl ElementType {
             _ => panic!("should be a component because of the repeater_component pass"),
         }
     }
+
+    /// Returns the Slint type name if applicable (for example `Rectangle` or `MyButton` when `component MyButton {}` is used as `MyButton` element)
+    pub fn type_name(&self) -> Option<&str> {
+        match self {
+            ElementType::Component(component) => Some(&component.id),
+            ElementType::Builtin(b) => Some(&b.name),
+            ElementType::Native(_) => None, // Too late, caller should call this function before the native class lowering
+            ElementType::Error => None,
+            ElementType::Global => None,
+        }
+    }
 }
 
 impl Display for ElementType {

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -97,6 +97,9 @@ pub struct CompilerConfiguration {
 
     /// C++ namespace
     pub cpp_namespace: Option<String>,
+
+    /// Generate debug information for elements (ids, type names)
+    pub debug_info: bool,
 }
 
 impl CompilerConfiguration {
@@ -142,6 +145,8 @@ impl CompilerConfiguration {
 
         let enable_experimental = std::env::var_os("SLINT_ENABLE_EXPERIMENTAL_FEATURES").is_some();
 
+        let debug_info = std::env::var_os("SLINT_EMIT_DEBUG_INFO").is_some();
+
         let cpp_namespace = match output_format {
             #[cfg(feature = "cpp")]
             crate::generator::OutputFormat::Cpp(config) => match config.namespace {
@@ -167,6 +172,7 @@ impl CompilerConfiguration {
             enable_experimental,
             translation_domain: None,
             cpp_namespace,
+            debug_info,
         }
     }
 }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -254,7 +254,7 @@ pub struct SubComponent {
     pub accessible_prop: BTreeMap<(u32, String), MutExpression>,
 
     /// Maps item index to a list of encoded element infos of the element  (type name, qualified ids).
-    pub element_infos: BTreeMap<u32, Vec<String>>,
+    pub element_infos: BTreeMap<u32, String>,
 
     pub prop_analysis: HashMap<PropertyReference, PropAnalysis>,
 }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -253,8 +253,8 @@ pub struct SubComponent {
     /// Maps (item_index, property) to an expression
     pub accessible_prop: BTreeMap<(u32, String), MutExpression>,
 
-    /// Maps item index to a list of qualified ids of the element.
-    pub element_ids: BTreeMap<u32, Vec<String>>,
+    /// Maps item index to a list of encoded element infos of the element  (type name, qualified ids).
+    pub element_infos: BTreeMap<u32, Vec<String>>,
 
     pub prop_analysis: HashMap<PropertyReference, PropAnalysis>,
 }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -253,6 +253,9 @@ pub struct SubComponent {
     /// Maps (item_index, property) to an expression
     pub accessible_prop: BTreeMap<(u32, String), MutExpression>,
 
+    /// Maps item index to a list of qualified ids of the element.
+    pub element_ids: BTreeMap<u32, Vec<String>>,
+
     pub prop_analysis: HashMap<PropertyReference, PropAnalysis>,
 }
 
@@ -280,6 +283,17 @@ impl SubComponent {
             count += x.ty.child_item_count();
         }
         count
+    }
+
+    pub fn root_item_element_ids(&self) -> Vec<String> {
+        let mut result = Vec::new();
+        if let Some(root_item_ids) = self.element_ids.get(&0) {
+            result.extend_from_slice(root_item_ids);
+        }
+        if let Some(sub_compo) = self.sub_components.iter().find(|c| c.index_in_tree == 0) {
+            result.extend_from_slice(&sub_compo.ty.root_item_element_ids());
+        }
+        result
     }
 }
 

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -284,17 +284,6 @@ impl SubComponent {
         }
         count
     }
-
-    pub fn root_item_element_ids(&self) -> Vec<String> {
-        let mut result = Vec::new();
-        if let Some(root_item_ids) = self.element_ids.get(&0) {
-            result.extend_from_slice(root_item_ids);
-        }
-        if let Some(sub_compo) = self.sub_components.iter().find(|c| c.index_in_tree == 0) {
-            result.extend_from_slice(&sub_compo.ty.root_item_element_ids());
-        }
-        result
-    }
 }
 
 pub struct SubComponentInstance {

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -9,10 +9,14 @@ use crate::langtype::{ElementType, Type};
 use crate::llr::item_tree::*;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, ElementRc, PropertyVisibility};
+use crate::CompilerConfiguration;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
-pub fn lower_to_item_tree(component: &Rc<Component>) -> PublicComponent {
+pub fn lower_to_item_tree(
+    component: &Rc<Component>,
+    compiler_config: &CompilerConfiguration,
+) -> PublicComponent {
     let mut state = LoweringState::default();
 
     let mut globals = Vec::new();
@@ -21,11 +25,11 @@ pub fn lower_to_item_tree(component: &Rc<Component>) -> PublicComponent {
         globals.push(lower_global(g, count, &mut state));
     }
     for c in &component.used_types.borrow().sub_components {
-        let sc = lower_sub_component(c, &state, None);
+        let sc = lower_sub_component(c, &state, None, &compiler_config);
         state.sub_components.insert(ByAddress(c.clone()), sc);
     }
 
-    let sc = lower_sub_component(component, &state, None);
+    let sc = lower_sub_component(component, &state, None, &compiler_config);
     let public_properties = public_properties(component, &sc.mapping, &state);
     let item_tree = ItemTree {
         tree: make_tree(&state, &component.root_element, &sc, &[]),
@@ -180,6 +184,7 @@ fn lower_sub_component(
     component: &Rc<Component>,
     state: &LoweringState,
     parent_context: Option<&ExpressionContext>,
+    compiler_config: &CompilerConfiguration,
 ) -> LoweredSubComponent {
     let mut sub_component = SubComponent {
         name: component_id(component),
@@ -325,9 +330,11 @@ fn lower_sub_component(
         for (prop, expr) in &elem.change_callbacks {
             change_callbacks.push((NamedReference::new(element, prop), expr.borrow().clone()));
         }
-        let element_infos = elem.element_infos();
-        if !element_infos.is_empty() {
-            sub_component.element_ids.insert(*elem.item_index.get().unwrap(), element_infos);
+        if compiler_config.debug_info {
+            let element_infos = elem.element_infos();
+            if !element_infos.is_empty() {
+                sub_component.element_ids.insert(*elem.item_index.get().unwrap(), element_infos);
+            }
         }
 
         Some(element.clone())
@@ -411,8 +418,10 @@ fn lower_sub_component(
             lower_component_container(&component_container, &sub_component, &ctx)
         })
         .collect();
-    sub_component.repeated =
-        repeated.into_iter().map(|elem| lower_repeated_component(&elem, &ctx)).collect();
+    sub_component.repeated = repeated
+        .into_iter()
+        .map(|elem| lower_repeated_component(&elem, &ctx, &compiler_config))
+        .collect();
     for s in &mut sub_component.sub_components {
         s.repeater_offset +=
             (sub_component.repeated.len() + sub_component.component_containers.len()) as u32;
@@ -422,7 +431,7 @@ fn lower_sub_component(
         .popup_windows
         .borrow()
         .iter()
-        .map(|popup| lower_popup_component(&popup.component, &ctx))
+        .map(|popup| lower_popup_component(&popup.component, &ctx, &compiler_config))
         .collect();
 
     crate::generator::for_each_const_properties(component, |elem, n| {
@@ -557,12 +566,17 @@ fn get_property_analysis(elem: &ElementRc, p: &str) -> crate::object_tree::Prope
     }
 }
 
-fn lower_repeated_component(elem: &ElementRc, ctx: &ExpressionContext) -> RepeatedElement {
+fn lower_repeated_component(
+    elem: &ElementRc,
+    ctx: &ExpressionContext,
+    compiler_config: &CompilerConfiguration,
+) -> RepeatedElement {
     let e = elem.borrow();
     let component = e.base_type.as_component().clone();
     let repeated = e.repeated.as_ref().unwrap();
 
-    let sc: LoweredSubComponent = lower_sub_component(&component, ctx.state, Some(ctx));
+    let sc: LoweredSubComponent =
+        lower_sub_component(&component, ctx.state, Some(ctx), &compiler_config);
 
     let geom = component.root_element.borrow().geometry_props.clone().unwrap();
 
@@ -612,8 +626,12 @@ fn lower_component_container(
     }
 }
 
-fn lower_popup_component(component: &Rc<Component>, ctx: &ExpressionContext) -> ItemTree {
-    let sc = lower_sub_component(component, ctx.state, Some(ctx));
+fn lower_popup_component(
+    component: &Rc<Component>,
+    ctx: &ExpressionContext,
+    compiler_config: &CompilerConfiguration,
+) -> ItemTree {
+    let sc = lower_sub_component(component, ctx.state, Some(ctx), &compiler_config);
     ItemTree {
         tree: make_tree(ctx.state, &component.root_element, &sc, &[]),
         root: Rc::try_unwrap(sc.sub_component).unwrap(),

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -206,7 +206,7 @@ fn lower_sub_component(
         layout_info_h: super::Expression::BoolLiteral(false).into(),
         layout_info_v: super::Expression::BoolLiteral(false).into(),
         accessible_prop: Default::default(),
-        element_ids: Default::default(),
+        element_infos: Default::default(),
         prop_analysis: Default::default(),
     };
     let mut mapping = LoweredSubComponentMapping::default();
@@ -330,10 +330,11 @@ fn lower_sub_component(
         for (prop, expr) in &elem.change_callbacks {
             change_callbacks.push((NamedReference::new(element, prop), expr.borrow().clone()));
         }
+
         if compiler_config.debug_info {
             let element_infos = elem.element_infos();
             if !element_infos.is_empty() {
-                sub_component.element_ids.insert(*elem.item_index.get().unwrap(), element_infos);
+                sub_component.element_infos.insert(*elem.item_index.get().unwrap(), element_infos);
             }
         }
 

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -201,6 +201,7 @@ fn lower_sub_component(
         layout_info_h: super::Expression::BoolLiteral(false).into(),
         layout_info_v: super::Expression::BoolLiteral(false).into(),
         accessible_prop: Default::default(),
+        element_ids: Default::default(),
         prop_analysis: Default::default(),
     };
     let mut mapping = LoweredSubComponentMapping::default();
@@ -323,6 +324,10 @@ fn lower_sub_component(
 
         for (prop, expr) in &elem.change_callbacks {
             change_callbacks.push((NamedReference::new(element, prop), expr.borrow().clone()));
+        }
+        let element_infos = elem.element_infos();
+        if !element_infos.is_empty() {
+            sub_component.element_ids.insert(*elem.item_index.get().unwrap(), element_infos);
         }
 
         Some(element.clone())

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -504,7 +504,7 @@ impl LookupType {
                                 .borrow()
                                 .debug
                                 .get(0)
-                                .and_then(|x| x.0.source_file())
+                                .and_then(|x| x.node.source_file())
                                 .map_or(false, |x| x.path().starts_with("builtin:")))
                         .then(|| "Palette".to_string()),
                     })

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1765,7 +1765,18 @@ impl Element {
     }
 
     pub fn element_infos(&self) -> Vec<String> {
-        self.debug.iter().flat_map(|debug_info| debug_info.qualified_id.clone()).collect()
+        let mut infos = self
+            .debug
+            .iter()
+            .flat_map(|debug_info| debug_info.qualified_id.clone())
+            .collect::<Vec<_>>();
+        let mut base = self.base_type.clone();
+        while let ElementType::Component(b) = base {
+            let elem = b.root_element.borrow();
+            base = elem.base_type.clone();
+            infos.extend(elem.debug.iter().flat_map(|debug_info| debug_info.qualified_id.clone()));
+        }
+        infos
     }
 }
 

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -247,7 +247,7 @@ fn lower_grid_layout(
     grid_layout_element.borrow_mut().layout_info_prop =
         Some((layout_info_prop_h, layout_info_prop_v));
     for d in grid_layout_element.borrow_mut().debug.iter_mut() {
-        d.1 = Some(Layout::GridLayout(grid.clone()));
+        d.layout = Some(Layout::GridLayout(grid.clone()));
     }
 }
 
@@ -437,7 +437,7 @@ fn lower_box_layout(
     );
     layout_element.borrow_mut().layout_info_prop = Some((layout_info_prop_h, layout_info_prop_v));
     for d in layout_element.borrow_mut().debug.iter_mut() {
-        d.1 = Some(Layout::BoxLayout(layout.clone()));
+        d.layout = Some(Layout::BoxLayout(layout.clone()));
     }
 }
 
@@ -650,7 +650,7 @@ fn lower_dialog_layout(
     );
     dialog_element.borrow_mut().layout_info_prop = Some((layout_info_prop_h, layout_info_prop_v));
     for d in dialog_element.borrow_mut().debug.iter_mut() {
-        d.1 = Some(Layout::GridLayout(grid.clone()));
+        d.layout = Some(Layout::GridLayout(grid.clone()));
     }
 }
 

--- a/internal/compiler/passes/optimize_useless_rectangles.rs
+++ b/internal/compiler/passes/optimize_useless_rectangles.rs
@@ -72,5 +72,5 @@ fn can_optimize(elem: &ElementRc) -> bool {
     !e.bindings.keys().chain(analysis.iter().filter(|(_, v)| v.is_set).map(|(k, _)| k)).any(|k| {
         !e.property_declarations.contains_key(k.as_str())
             && base_type.properties.contains_key(k.as_str())
-    })
+    }) && e.accessibility_props.0.is_empty()
 }

--- a/internal/compiler/passes/optimize_useless_rectangles.rs
+++ b/internal/compiler/passes/optimize_useless_rectangles.rs
@@ -22,6 +22,9 @@ pub fn optimize_useless_rectangles(root_component: &Rc<Component>) {
             }
 
             parent.children.extend(std::mem::take(&mut elem.borrow_mut().children));
+            if let Some(last) = parent.debug.last_mut() {
+                last.element_boundary = true;
+            }
             parent.debug.extend(std::mem::take(&mut elem.borrow_mut().debug));
 
             let enclosing = parent.enclosing_component.upgrade().unwrap();

--- a/internal/compiler/widgets/common/spinbox-base.slint
+++ b/internal/compiler/widgets/common/spinbox-base.slint
@@ -54,7 +54,6 @@ export component SpinBoxBase {
 
         accessible-role: AccessibleRole.text-input;
         accessible-value: self.text;
-        accessible-label: "spinbox-textinput";
 
         accepted => {
             if !self.text.is-float() {

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -14,7 +14,6 @@ use crate::lengths::{LogicalPoint, LogicalRect};
 use crate::slice::Slice;
 use crate::window::WindowAdapterRc;
 use crate::SharedString;
-use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::pin::Pin;
 use vtable::*;
@@ -369,27 +368,19 @@ impl ItemRc {
         comp_ref_pin.as_ref().supported_accessibility_actions(self.index)
     }
 
-    pub fn element_ids(&self) -> Vec<String> {
+    pub fn element_type_names_and_ids(&self) -> Vec<(SharedString, SharedString)> {
         let comp_ref_pin = vtable::VRc::borrow_pin(&self.item_tree);
         let mut result = SharedString::new();
         comp_ref_pin.as_ref().item_element_infos(self.index, &mut result);
         result
             .as_str()
             .split(";")
-            .filter_map(|encoded_elem_info| {
-                encoded_elem_info.split(',').nth(1).map(ToString::to_string)
+            .map(|encoded_elem_info| {
+                let mut decoder = encoded_elem_info.split(',');
+                let type_name = decoder.next().unwrap().into();
+                let id = decoder.next().map(Into::into).unwrap_or_default();
+                (type_name, id)
             })
-            .collect()
-    }
-
-    pub fn element_type_names(&self) -> Vec<String> {
-        let comp_ref_pin = vtable::VRc::borrow_pin(&self.item_tree);
-        let mut result = SharedString::new();
-        comp_ref_pin.as_ref().item_element_infos(self.index, &mut result);
-        result
-            .as_str()
-            .split(";")
-            .map(|encoded_elem_info| encoded_elem_info.split(',').next().unwrap().to_string())
             .collect()
     }
 

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -368,12 +368,25 @@ impl ItemRc {
         comp_ref_pin.as_ref().supported_accessibility_actions(self.index)
     }
 
-    pub fn element_type_names_and_ids(&self) -> Vec<(SharedString, SharedString)> {
+    pub fn element_count(&self) -> usize {
+        let comp_ref_pin = vtable::VRc::borrow_pin(&self.item_tree);
+        let mut result = SharedString::new();
+        comp_ref_pin.as_ref().item_element_infos(self.index, &mut result);
+        result.as_str().split("/").count()
+    }
+
+    pub fn element_type_names_and_ids(
+        &self,
+        element_index: usize,
+    ) -> Vec<(SharedString, SharedString)> {
         let comp_ref_pin = vtable::VRc::borrow_pin(&self.item_tree);
         let mut result = SharedString::new();
         comp_ref_pin.as_ref().item_element_infos(self.index, &mut result);
         result
             .as_str()
+            .split("/")
+            .nth(element_index)
+            .unwrap()
             .split(";")
             .map(|encoded_elem_info| {
                 let mut decoder = encoded_elem_info.split(',');

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -131,8 +131,11 @@ pub struct ItemTreeVTable {
     ) -> SupportedAccessibilityAction,
 
     /// Add the `ElementName::id` entries of the given item
-    pub item_element_ids:
-        extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, item_index: u32) -> SharedString,
+    pub item_element_ids: extern "C" fn(
+        core::pin::Pin<VRef<ItemTreeVTable>>,
+        item_index: u32,
+        result: &mut SharedString,
+    ),
 
     /// Returns a Window, creating a fresh one if `do_create` is true.
     pub window_adapter: extern "C" fn(
@@ -368,13 +371,9 @@ impl ItemRc {
 
     pub fn element_ids(&self) -> Vec<String> {
         let comp_ref_pin = vtable::VRc::borrow_pin(&self.item_tree);
-        comp_ref_pin
-            .as_ref()
-            .item_element_ids(self.index)
-            .as_str()
-            .split(";")
-            .map(ToString::to_string)
-            .collect()
+        let mut result = SharedString::new();
+        comp_ref_pin.as_ref().item_element_ids(self.index, &mut result);
+        return result.as_str().split(";").map(ToString::to_string).collect();
     }
 
     pub fn geometry(&self) -> LogicalRect {
@@ -1169,9 +1168,7 @@ mod tests {
             false
         }
 
-        fn item_element_ids(self: Pin<&Self>, _: u32) -> SharedString {
-            Default::default()
-        }
+        fn item_element_ids(self: Pin<&Self>, _: u32, _: &mut SharedString) {}
 
         fn window_adapter(
             self: Pin<&Self>,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -256,8 +256,8 @@ impl ItemTree for ErasedItemTreeBox {
         self.borrow().as_ref().supported_accessibility_actions(index)
     }
 
-    fn item_element_ids(self: core::pin::Pin<&Self>, index: u32) -> SharedString {
-        self.borrow().as_ref().item_element_ids(index)
+    fn item_element_ids(self: core::pin::Pin<&Self>, index: u32, result: &mut SharedString) {
+        self.borrow().as_ref().item_element_ids(index, result)
     }
 }
 
@@ -2014,15 +2014,18 @@ extern "C" fn supported_accessibility_actions(
     val
 }
 
-extern "C" fn item_element_ids(component: ItemTreeRefPin, item_index: u32) -> SharedString {
+extern "C" fn item_element_ids(
+    component: ItemTreeRefPin,
+    item_index: u32,
+    result: &mut SharedString,
+) {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
-    let val = instance_ref.description.original_elements[item_index as usize]
+    *result = instance_ref.description.original_elements[item_index as usize]
         .borrow()
         .element_infos()
         .join(";")
         .into();
-    val
 }
 
 extern "C" fn window_adapter(

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -256,7 +256,11 @@ impl ItemTree for ErasedItemTreeBox {
         self.borrow().as_ref().supported_accessibility_actions(index)
     }
 
-    fn item_element_infos(self: core::pin::Pin<&Self>, index: u32, result: &mut SharedString) {
+    fn item_element_infos(
+        self: core::pin::Pin<&Self>,
+        index: u32,
+        result: &mut SharedString,
+    ) -> bool {
         self.borrow().as_ref().item_element_infos(index, result)
     }
 }
@@ -2018,13 +2022,14 @@ extern "C" fn item_element_infos(
     component: ItemTreeRefPin,
     item_index: u32,
     result: &mut SharedString,
-) {
+) -> bool {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     *result = instance_ref.description.original_elements[item_index as usize]
         .borrow()
         .element_infos()
         .into();
+    true
 }
 
 extern "C" fn window_adapter(

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -255,6 +255,10 @@ impl ItemTree for ErasedItemTreeBox {
     ) -> SupportedAccessibilityAction {
         self.borrow().as_ref().supported_accessibility_actions(index)
     }
+
+    fn item_element_ids(self: core::pin::Pin<&Self>, index: u32) -> SharedString {
+        self.borrow().as_ref().item_element_ids(index)
+    }
 }
 
 i_slint_core::ItemTreeVTable_static!(static COMPONENT_BOX_VT for ErasedItemTreeBox);
@@ -1193,6 +1197,7 @@ pub(crate) fn generate_item_tree<'id>(
         accessible_string_property,
         accessibility_action,
         supported_accessibility_actions,
+        item_element_ids,
         window_adapter,
         drop_in_place,
         dealloc,
@@ -2006,6 +2011,17 @@ extern "C" fn supported_accessibility_actions(
             .unwrap_or_else(|| panic!("Not an accessible action: {value:?}"))
                 | acc
         });
+    val
+}
+
+extern "C" fn item_element_ids(component: ItemTreeRefPin, item_index: u32) -> SharedString {
+    generativity::make_guard!(guard);
+    let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
+    let val = instance_ref.description.original_elements[item_index as usize]
+        .borrow()
+        .element_infos()
+        .join(";")
+        .into();
     val
 }
 

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2024,7 +2024,6 @@ extern "C" fn item_element_infos(
     *result = instance_ref.description.original_elements[item_index as usize]
         .borrow()
         .element_infos()
-        .join(";")
         .into();
 }
 

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -256,8 +256,8 @@ impl ItemTree for ErasedItemTreeBox {
         self.borrow().as_ref().supported_accessibility_actions(index)
     }
 
-    fn item_element_ids(self: core::pin::Pin<&Self>, index: u32, result: &mut SharedString) {
-        self.borrow().as_ref().item_element_ids(index, result)
+    fn item_element_infos(self: core::pin::Pin<&Self>, index: u32, result: &mut SharedString) {
+        self.borrow().as_ref().item_element_infos(index, result)
     }
 }
 
@@ -1197,7 +1197,7 @@ pub(crate) fn generate_item_tree<'id>(
         accessible_string_property,
         accessibility_action,
         supported_accessibility_actions,
-        item_element_ids,
+        item_element_infos,
         window_adapter,
         drop_in_place,
         dealloc,
@@ -2014,7 +2014,7 @@ extern "C" fn supported_accessibility_actions(
     val
 }
 
-extern "C" fn item_element_ids(
+extern "C" fn item_element_infos(
     component: ItemTreeRefPin,
     item_index: u32,
     result: &mut SharedString,

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -154,7 +154,7 @@ fn find_element_node_at_source_code_position(
                 .debug
                 .iter()
                 .enumerate()
-                .filter_map(|(i, n)| n.0.QualifiedName().map(|n| (i, n)))
+                .filter_map(|(i, n)| n.node.QualifiedName().map(|n| (i, n)))
             {
                 if node.source_file.path() == path && node.text_range().contains(offset.into()) {
                     result.push((elem.clone(), index));

--- a/tests/cases/accessibility/materialized.slint
+++ b/tests/cases/accessibility/materialized.slint
@@ -24,6 +24,15 @@ Cb := Rectangle {
     accessible-checked: true;
 }
 
+component ComboBox inherits Rectangle {
+    accessible-role: combobox;
+    accessible-label: "mycombo";
+    Rectangle {
+        accessible-role: text;
+        accessible-label: "innerlabel";
+    }
+}
+
 TestCase := Rectangle {
     width: 300phx;
     height: 300phx;
@@ -43,6 +52,8 @@ TestCase := Rectangle {
         }
 
         cb := Cb { text: "hello"; }
+
+        ComboBox {}
     }
 
     for t in ["abc"] : Text { text: t; accessible-description: t;  }
@@ -74,6 +85,9 @@ assert(instance.get_test());
 ```rust
 let instance = TestCase::new().unwrap();
 assert!(instance.get_test());
+
+assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "mycombo").collect::<Vec<_>>().len(), 1);
+assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "innerlabel").collect::<Vec<_>>().len(), 1);
 ```
 
 ```js

--- a/tests/cases/testing/find_by_element_id.slint
+++ b/tests/cases/testing/find_by_element_id.slint
@@ -1,0 +1,42 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component ButtonBase inherits Text { }
+
+component Button inherits ButtonBase {
+    accessible-role: button;
+    accessible-label: "optimized";
+    extra-label := Text { }
+}
+
+export component TestCase {
+    first := Button { }
+
+    second := Button {
+        accessible-label: "plain";
+    }
+
+    // third
+    Button {
+        accessible-label: "third";
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+let mut button_search = slint_testing::ElementHandle::find_by_element_id(&instance, "Button::root");
+let mut button = button_search.next().unwrap();
+assert!(button.is_valid());
+assert_eq!(button.accessible_label().unwrap(), "optimized");
+button = button_search.next().unwrap();
+assert!(button.is_valid());
+assert_eq!(button.accessible_label().unwrap(), "plain");
+button = button_search.next().unwrap();
+assert!(button.is_valid());
+assert_eq!(button.accessible_label().unwrap(), "third");
+assert!(button_search.next().is_none());
+
+assert_eq!(slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::second").count(), 1);
+```
+*/

--- a/tests/cases/testing/find_by_element_id.slint
+++ b/tests/cases/testing/find_by_element_id.slint
@@ -39,4 +39,23 @@ assert!(button_search.next().is_none());
 
 assert_eq!(slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::second").count(), 1);
 ```
+
+```cpp
+auto handle = TestCase::create();
+//const TestCase &instance = *handle;
+
+auto button_search = slint::testing::ElementHandle::find_by_element_id(handle, "Button::root");
+assert_eq(button_search.size(), 3);
+auto button = button_search[0];
+assert(button.is_valid());
+assert_eq(button.accessible_label().value(), "optimized");
+button = button_search[1];
+assert(button.is_valid());
+assert_eq(button.accessible_label().value(), "plain");
+button = button_search[2];
+assert(button.is_valid());
+assert_eq(button.accessible_label().value(), "third");
+
+assert_eq(slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::second").size(), 1);
+```
 */

--- a/tests/cases/testing/find_by_element_id_or_type.slint
+++ b/tests/cases/testing/find_by_element_id_or_type.slint
@@ -39,12 +39,11 @@ assert!(button.is_valid());
 assert_eq!(button.accessible_label().unwrap(), "third");
 assert!(button_search.next().is_none());
 
-assert_eq!(slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::second").flat_map(|elem| elem.element_type_names_and_ids().unwrap()).collect::<Vec<_>>(),
-           vec![
-                ("Button".into(), "TestCase::second".into()),
-                ("ButtonBase".into(), "Button::root".into()),
-                ("Text".into(), "ButtonBase::root".into()),
-           ]);
+let id_search_result = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::second").collect::<Vec<_>>();
+assert_eq!(id_search_result.len(), 1);
+assert_eq!(id_search_result[0].type_name().unwrap(), "Button");
+assert_eq!(id_search_result[0].id().unwrap(), "TestCase::second");
+assert_eq!(id_search_result[0].bases().unwrap().collect::<Vec<_>>(), ["ButtonBase", "Text"]);
 
 let texts = slint_testing::ElementHandle::find_by_element_type_name(&instance, "Text").filter_map(|elem| elem.accessible_label()).collect::<Vec<_>>();
 assert_eq!(texts, vec!["optimized", "extra", "plain", "extra", "third", "extra"]);
@@ -68,13 +67,10 @@ assert_eq(button.accessible_label().value(), "third");
 
 auto id_search_result = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::second");
 assert_eq(id_search_result.size(), 1);
-auto type_names_and_ids = id_search_result[0].element_type_names_and_ids();
-assert_eq(type_names_and_ids.size(), 3);
-assert_eq(type_names_and_ids[0].type_name, "Button");
-assert_eq(type_names_and_ids[0].id, "TestCase::second");
-assert_eq(type_names_and_ids[1].type_name, "ButtonBase");
-assert_eq(type_names_and_ids[1].id, "Button::root");
-assert_eq(type_names_and_ids[2].type_name, "Text");
-assert_eq(type_names_and_ids[2].id, "ButtonBase::root");
+assert_eq(*id_search_result[0].type_name(), "Button");
+assert_eq(*id_search_result[0].id(), "TestCase::second");
+assert_eq((*id_search_result[0].bases()).size(), 2);
+assert_eq((*id_search_result[0].bases())[0], "ButtonBase");
+assert_eq((*id_search_result[0].bases())[1], "Text");
 ```
 */

--- a/tests/cases/testing/find_by_element_id_or_type.slint
+++ b/tests/cases/testing/find_by_element_id_or_type.slint
@@ -39,7 +39,12 @@ assert!(button.is_valid());
 assert_eq!(button.accessible_label().unwrap(), "third");
 assert!(button_search.next().is_none());
 
-assert_eq!(slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::second").count(), 1);
+assert_eq!(slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::second").flat_map(|elem| elem.element_type_names_and_ids().unwrap()).collect::<Vec<_>>(),
+           vec![
+                ("Button".into(), "TestCase::second".into()),
+                ("ButtonBase".into(), "Button::root".into()),
+                ("Text".into(), "ButtonBase::root".into()),
+           ]);
 
 let texts = slint_testing::ElementHandle::find_by_element_type_name(&instance, "Text").filter_map(|elem| elem.accessible_label()).collect::<Vec<_>>();
 assert_eq!(texts, vec!["optimized", "extra", "plain", "extra", "third", "extra"]);
@@ -61,6 +66,15 @@ button = button_search[2];
 assert(button.is_valid());
 assert_eq(button.accessible_label().value(), "third");
 
-assert_eq(slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::second").size(), 1);
+auto id_search_result = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::second");
+assert_eq(id_search_result.size(), 1);
+auto type_names_and_ids = id_search_result[0].element_type_names_and_ids();
+assert_eq(type_names_and_ids.size(), 3);
+assert_eq(type_names_and_ids[0].type_name, "Button");
+assert_eq(type_names_and_ids[0].id, "TestCase::second");
+assert_eq(type_names_and_ids[1].type_name, "ButtonBase");
+assert_eq(type_names_and_ids[1].id, "Button::root");
+assert_eq(type_names_and_ids[2].type_name, "Text");
+assert_eq(type_names_and_ids[2].id, "ButtonBase::root");
 ```
 */

--- a/tests/cases/testing/find_by_element_id_or_type.slint
+++ b/tests/cases/testing/find_by_element_id_or_type.slint
@@ -6,7 +6,9 @@ component ButtonBase inherits Text { }
 component Button inherits ButtonBase {
     accessible-role: button;
     accessible-label: "optimized";
-    extra-label := Text { }
+    extra-label := Text {
+        accessible-label: "extra";
+    }
 }
 
 export component TestCase {
@@ -38,6 +40,9 @@ assert_eq!(button.accessible_label().unwrap(), "third");
 assert!(button_search.next().is_none());
 
 assert_eq!(slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::second").count(), 1);
+
+let texts = slint_testing::ElementHandle::find_by_element_type_name(&instance, "Text").filter_map(|elem| elem.accessible_label()).collect::<Vec<_>>();
+assert_eq!(texts, vec!["optimized", "extra", "plain", "extra", "third", "extra"]);
 ```
 
 ```cpp

--- a/tests/cases/widgets/button.slint
+++ b/tests/cases/widgets/button.slint
@@ -19,7 +19,7 @@ export component TestCase inherits Window {
             clicked => {clicked += "a"; }
         }
 
-        Button {
+        b := Button {
             text: "Bbb";
             accessible-description: "Normal Button";
             clicked => {clicked += "b"; }
@@ -46,7 +46,7 @@ slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key:
 assert_eq!(instance.get_clicked(), SharedString::from(""));
 assert_eq!(instance.get_a_checked(), false);
 
-let mut result = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Aaa").collect::<Vec<_>>();
+let mut result = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::a").collect::<Vec<_>>();
 assert_eq!(result.len(), 1);
 let aaa = result.pop().unwrap();
 assert_eq!(aaa.accessible_label().unwrap(), "Aaa");
@@ -79,7 +79,7 @@ assert_eq!(instance.get_a_checked(), true, "button aaa was not toggled on enter"
 assert_eq!(aaa.accessible_checked(), Some(true));
 assert_eq!(instance.get_a_focused(), true);
 
-let mut result = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Bbb").collect::<Vec<_>>();
+let mut result = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::b").collect::<Vec<_>>();
 assert_eq!(result.len(), 1);
 let bbb = result.pop().unwrap();
 assert_eq!(bbb.accessible_label().unwrap(), "Bbb");
@@ -103,7 +103,7 @@ assert_eq!(instance.get_a_focused(), true);
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
 
-auto label_search = slint::testing::ElementHandle::find_by_accessible_label(handle, "Aaa");
+auto label_search = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::a");
 assert(label_search.size() == 1);
 auto aaa = label_search[0];
 assert_eq(aaa.accessible_label().value(), "Aaa");
@@ -131,7 +131,7 @@ assert_eq(instance.get_clicked(), "aa");
 assert_eq(aaa.accessible_checked().value(), true);
 assert_eq(instance.get_a_focused(), true);
 
-label_search = slint::testing::ElementHandle::find_by_accessible_label(handle, "Bbb");
+label_search = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::b");
 assert(label_search.size() == 1);
 auto bbb = label_search[0];
 assert_eq(bbb.accessible_label().value(), "Bbb");

--- a/tests/cases/widgets/spinbox_basic.slint
+++ b/tests/cases/widgets/spinbox_basic.slint
@@ -9,7 +9,8 @@ import { SpinBox } from "std-widgets.slint";
 export component TestCase inherits Window {
     width: 100px;
     height: 100px;
-    box := SpinBox {}
+    box := SpinBox { }
+
     forward-focus: box;
     out property <bool> spinbox-focused <=> box.has_focus;
     callback edited <=> box.edited;
@@ -87,7 +88,7 @@ edits.borrow_mut().clear();
 instance.set_value(30);
 mock_elapsed_time(500);
 
-let mut text_input_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "spinbox-textinput");
+let mut text_input_search = slint_testing::ElementHandle::find_by_element_id(&instance, "SpinBoxBase::text-input");
 let text_input = text_input_search.next().unwrap();
 assert_eq!(text_input.accessible_value().unwrap(), "30");
 edits.borrow_mut().clear();

--- a/tests/cases/widgets/spinbox_default_value.slint
+++ b/tests/cases/widgets/spinbox_default_value.slint
@@ -6,23 +6,23 @@ import { SpinBox } from "std-widgets.slint";
 export component TestCase inherits Window {
     width: 100px;
     height: 100px;
-    
     spin_min_pos := SpinBox {
-       accessible-label: "spinbox";
-       minimum: 10;
+        accessible-label: "spinbox";
+        minimum: 10;
     }
+
     out property <int> pos-val <=> spin-min-pos.value;
-    
-    spin_min_default := SpinBox {}
-    out property <int> default-min <=> spin-min-default.minimum;    
+    spin_min_default := SpinBox { }
+
+    out property <int> default-min <=> spin-min-default.minimum;
     out property <int> default-val <=> spin-min-default.value;
 
     spin_min_neg := SpinBox {
         minimum: -10;
     }
+
     out property <int> neg-val <=> spin-min-neg.value;
 }
-
 
 /*
 
@@ -34,7 +34,7 @@ assert_eq!(instance.get_default_min(), 0);
 assert_eq!(instance.get_default_val(), 0);
 assert_eq!(instance.get_neg_val(), -10);
 
-let mut label_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "spinbox").collect::<Vec<_>>();
+let mut label_search = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::spin-min-pos").collect::<Vec<_>>();
 assert_eq!(label_search.len(), 1);
 let spinbox = label_search.pop().unwrap();
 assert_eq!(spinbox.accessible_value_maximum(), Some(100f32));
@@ -53,7 +53,7 @@ assert_eq!(spinbox.accessible_value().unwrap(), "10");
 ```cpp
 auto handle = TestCase::create();
 
-auto label_search = slint::testing::ElementHandle::find_by_accessible_label(handle, "spinbox");
+auto label_search = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::spin-min-pos");
 assert(label_search.size() == 1);
 auto spinbox = label_search[0];
 assert_eq(spinbox.accessible_value_maximum().value(), 100);

--- a/tests/driver/cpp/cppdriver.rs
+++ b/tests/driver/cpp/cppdriver.rs
@@ -27,7 +27,8 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
     compiler_config.include_paths = include_paths;
     compiler_config.library_paths = library_paths;
     compiler_config.style = testcase.requested_style.map(str::to_string);
-    let (root_component, diag, _) =
+    compiler_config.debug_info = true;
+    let (root_component, diag, loader) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
 
     if diag.has_error() {
@@ -37,7 +38,12 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
 
     let mut generated_cpp: Vec<u8> = Vec::new();
 
-    generator::generate(output_format, &mut generated_cpp, &root_component)?;
+    generator::generate(
+        output_format,
+        &mut generated_cpp,
+        &root_component,
+        &loader.compiler_config,
+    )?;
 
     if diag.has_error() {
         let vec = diag.to_string_vec();

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -57,6 +57,7 @@ fn main() -> std::io::Result<()> {
     //Make sure to use a consistent style
     println!("cargo:rustc-env=SLINT_STYLE=fluent");
     println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+    println!("cargo:rustc-env=SLINT_EMIT_DEBUG_INFO=1");
     Ok(())
 }
 
@@ -140,7 +141,8 @@ fn generate_source(
     compiler_config.include_paths = include_paths;
     compiler_config.library_paths = library_paths;
     compiler_config.style = Some(testcase.requested_style.unwrap_or("fluent").to_string());
-    let (root_component, diag, _) =
+    compiler_config.debug_info = true;
+    let (root_component, diag, loader) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
 
     if diag.has_error() {
@@ -153,6 +155,11 @@ fn generate_source(
         diag.print();
     }
 
-    generator::generate(generator::OutputFormat::Rust, output, &root_component)?;
+    generator::generate(
+        generator::OutputFormat::Rust,
+        output,
+        &root_component,
+        &loader.compiler_config,
+    )?;
     Ok(())
 }

--- a/tests/screenshots/build.rs
+++ b/tests/screenshots/build.rs
@@ -163,7 +163,7 @@ fn generate_source(
     compiler_config.enable_experimental = true;
     compiler_config.style = Some("fluent".to_string());
     compiler_config.scale_factor = scale_factor.into();
-    let (root_component, diag, _) =
+    let (root_component, diag, loader) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
 
     if diag.has_error() {
@@ -176,6 +176,11 @@ fn generate_source(
         diag.print();
     }
 
-    generator::generate(generator::OutputFormat::Rust, output, &root_component)?;
+    generator::generate(
+        generator::OutputFormat::Rust,
+        output,
+        &root_component,
+        &loader.compiler_config,
+    )?;
     Ok(())
 }

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -112,17 +112,19 @@ fn main() -> std::io::Result<()> {
         compiler_config.style = Some(style);
     }
     let syntax_node = syntax_node.expect("diags contained no compilation errors");
-    let (doc, diag, _) = spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
+    let (doc, diag, loader) =
+        spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
 
     let diag = diag.check_and_exit_on_error();
 
     if args.output == std::path::Path::new("-") {
-        generator::generate(format, &mut std::io::stdout(), &doc)?;
+        generator::generate(format, &mut std::io::stdout(), &doc, &loader.compiler_config)?;
     } else {
         generator::generate(
             format,
             &mut BufWriter::new(std::fs::File::create(&args.output)?),
             &doc,
+            &loader.compiler_config,
         )?;
     }
 

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -90,8 +90,8 @@ impl ElementRcNode {
     }
 
     pub fn find_in(element: ElementRc, path: &std::path::Path, offset: u32) -> Option<Self> {
-        let debug_index = element.borrow().debug.iter().position(|(n, _)| {
-            u32::from(n.text_range().start()) == offset && n.source_file.path() == path
+        let debug_index = element.borrow().debug.iter().position(|d| {
+            u32::from(d.node.text_range().start()) == offset && d.node.source_file.path() == path
         })?;
 
         Some(Self { element, debug_index })
@@ -102,8 +102,8 @@ impl ElementRcNode {
         path: &std::path::Path,
         offset: u32,
     ) -> Option<Self> {
-        let debug_index = element.borrow().debug.iter().position(|(n, _)| {
-            u32::from(n.text_range().start()) == offset && n.source_file.path() == path
+        let debug_index = element.borrow().debug.iter().position(|d| {
+            u32::from(d.node.text_range().start()) == offset && d.node.source_file.path() == path
         });
         if let Some(debug_index) = debug_index {
             Some(Self { element, debug_index })
@@ -127,8 +127,8 @@ impl ElementRcNode {
         ) -> R,
     ) -> R {
         let elem = self.element.borrow();
-        let (n, l) = &elem.debug.get(self.debug_index).unwrap();
-        func(n, l)
+        let d = &elem.debug.get(self.debug_index).unwrap();
+        func(&d.node, &d.layout)
     }
 
     /// Run with the `Element` node
@@ -137,7 +137,7 @@ impl ElementRcNode {
         func: impl Fn(&i_slint_compiler::parser::syntax_nodes::Element) -> R,
     ) -> R {
         let elem = self.element.borrow();
-        func(&elem.debug.get(self.debug_index).unwrap().0)
+        func(&elem.debug.get(self.debug_index).unwrap().node)
     }
 
     /// Run with the SyntaxNode incl. any id, condition, etc.

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -143,7 +143,7 @@ impl ElementRcNode {
     /// Run with the SyntaxNode incl. any id, condition, etc.
     pub fn with_decorated_node<R>(&self, func: impl Fn(SyntaxNode) -> R) -> R {
         let elem = self.element.borrow();
-        func(find_element_with_decoration(&elem.debug.get(self.debug_index).unwrap().0))
+        func(find_element_with_decoration(&elem.debug.get(self.debug_index).unwrap().node))
     }
 
     pub fn path_and_offset(&self) -> (PathBuf, u32) {

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -769,7 +769,7 @@ fn element_contains(
         .borrow()
         .debug
         .iter()
-        .position(|n| n.0.parent().map_or(false, |n| n.text_range().contains(offset.into())))
+        .position(|n| n.node.parent().map_or(false, |n| n.text_range().contains(offset.into())))
 }
 
 fn element_node_contains(element: &common::ElementRcNode, offset: u32) -> bool {
@@ -1127,7 +1127,7 @@ fn get_document_symbols(
         .iter()
         .filter_map(|c| {
             let root_element = c.root_element.borrow();
-            let element_node = &root_element.debug.first()?.0;
+            let element_node = &root_element.debug.first()?.node;
             let component_node = syntax_nodes::Component::new(element_node.parent()?)?;
             let selection_range = util::map_node(&component_node.DeclaredIdentifier())?;
             if c.id.is_empty() {
@@ -1179,7 +1179,7 @@ fn get_document_symbols(
             .iter()
             .filter_map(|child| {
                 let e = child.borrow();
-                let element_node = &e.debug.first()?.0;
+                let element_node = &e.debug.first()?.node;
                 let sub_element_node = element_node.parent()?;
                 debug_assert_eq!(sub_element_node.kind(), SyntaxKind::SubElement);
                 Some(DocumentSymbol {
@@ -1216,7 +1216,7 @@ fn get_code_lenses(
         // Handle preview lens
         r.extend(inner_components.iter().filter(|c| !c.is_global()).filter_map(|c| {
             Some(CodeLens {
-                range: util::map_node(&c.root_element.borrow().debug.first()?.0)?,
+                range: util::map_node(&c.root_element.borrow().debug.first()?.node)?,
                 command: Some(create_show_preview_command(true, &text_document.uri, c.id.as_str())),
                 data: None,
             })

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -37,7 +37,7 @@ pub fn goto_definition(
                     let doc = document_cache.documents.get_document(node.source_file.path())?;
                     match doc.local_registry.lookup_element(&qual.to_string()) {
                         Ok(ElementType::Component(c)) => {
-                            goto_node(&c.root_element.borrow().debug.first()?.0)
+                            goto_node(&c.root_element.borrow().debug.first()?.node)
                         }
                         _ => None,
                     }
@@ -68,7 +68,7 @@ pub fn goto_definition(
                         LookupResult::Expression {
                             expression: Expression::ElementReference(e),
                             ..
-                        } => e.upgrade()?.borrow().debug.first()?.0.clone().into(),
+                        } => e.upgrade()?.borrow().debug.first()?.node.clone().into(),
                         LookupResult::Expression {
                             expression:
                                 Expression::CallbackReference(nr, _)
@@ -108,7 +108,7 @@ pub fn goto_definition(
             let imp_name = i_slint_compiler::typeloader::ImportedName::from_node(n);
             return match doc.local_registry.lookup_element(&imp_name.internal_name) {
                 Ok(ElementType::Component(c)) => {
-                    goto_node(&c.root_element.borrow().debug.first()?.0)
+                    goto_node(&c.root_element.borrow().debug.first()?.node)
                 }
                 _ => None,
             };

--- a/tools/lsp/preview/debug.rs
+++ b/tools/lsp/preview/debug.rs
@@ -167,7 +167,7 @@ fn recurse_into_element(state: &mut State, element: &ElementRc) -> (usize, Vec<S
 
 fn add_element_node(state: &mut State, element: &ElementRc, node_number: usize) {
     let e = element.borrow();
-    let layout = if e.debug.iter().any(|d| d.1.is_some()) { ",shape = box" } else { "" };
+    let layout = if e.debug.iter().any(|d| d.layout.is_some()) { ",shape = box" } else { "" };
     let repeated = if e.repeated.is_some() { ",color = blue" } else { "" };
     let component = if matches!(e.base_type, i_slint_compiler::langtype::ElementType::Component(_))
     {

--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -511,7 +511,7 @@ fn find_drop_location(
         .borrow()
         .debug
         .first()
-        .map(|(n, _)| n.source_file.path().to_owned());
+        .map(|info| info.node.source_file.path().to_owned());
     let filter = Box::new(move |e: &common::ElementRcNode| {
         e.with_element_node(|n| Some(n.source_file.path()) != root_node_path.as_deref())
     });

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -32,9 +32,9 @@ impl ElementSelection {
 
         let debug_index = {
             let e = element.borrow();
-            e.debug.iter().position(|(n, _)| {
-                n.source_file.path() == self.path
-                    && u32::from(n.text_range().start()) == self.offset
+            e.debug.iter().position(|d| {
+                d.node.source_file.path() == self.path
+                    && u32::from(d.node.text_range().start()) == self.offset
             })
         };
 

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -171,7 +171,7 @@ pub fn with_property_lookup_ctx<R>(
         loop {
             scope.push(it.clone());
             if let Some(c) = it.clone().borrow().children.iter().find(|c| {
-                c.borrow().debug.first().map_or(false, |n| n.0.text_range().contains(offset))
+                c.borrow().debug.first().map_or(false, |n| n.node.text_range().contains(offset))
             }) {
                 it = c.clone();
             } else {

--- a/tools/updater/main.rs
+++ b/tools/updater/main.rs
@@ -222,7 +222,7 @@ fn visit_node(
                     .borrow()
                     .children
                     .iter()
-                    .find(|c| c.borrow().debug.first().map_or(false, |n| n.0.node == node.node))
+                    .find(|c| c.borrow().debug.first().map_or(false, |n| n.node.node == node.node))
                     .cloned()
             } else if let Some(parent_co) = &state.current_component {
                 if node.parent().map_or(false, |n| n.kind() == SyntaxKind::Component) {


### PR DESCRIPTION
This requires additional debug information to be generated, which is disabled by default in Rust and in C++ for release builds.