### PR TITLE
Fix build for raspberry pi with cross

### DIFF
--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -7,7 +7,7 @@ FROM ghcr.io/slint-ui/cross-aarch64-base:1.0
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes libfontconfig1-dev:arm64 libxcb1-dev:arm64 libxcb-render0-dev:arm64 libxcb-shape0-dev:arm64 libxcb-xfixes0-dev:arm64 libxkbcommon-dev:arm64 libinput-dev:arm64 libgbm-dev:arm64 python3 \
+    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes libfontconfig1-dev:arm64 libxcb1-dev:arm64 libxcb-render0-dev:arm64 libxcb-shape0-dev:arm64 libxcb-xfixes0-dev:arm64 libxkbcommon-dev:arm64 libinput-dev:arm64 libgbm-dev:arm64 libssl-dev:arm64 python3 \
     libfontconfig1-dev \
     clang libstdc++-10-dev:arm64
 

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -7,7 +7,7 @@ FROM ghcr.io/slint-ui/cross-armv7-base:1.0
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes libfontconfig1-dev:armhf libxcb1-dev:armhf libxcb-render0-dev:armhf libxcb-shape0-dev:armhf libxcb-xfixes0-dev:armhf libxkbcommon-dev:armhf libinput-dev:armhf libgbm-dev:armhf python3 \
+    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes libfontconfig1-dev:armhf libxcb1-dev:armhf libxcb-render0-dev:armhf libxcb-shape0-dev:armhf libxcb-xfixes0-dev:armhf libxkbcommon-dev:armhf libinput-dev:armhf libgbm-dev:armhf libssl-dev:armhf python3 \
     libfontconfig1-dev \
     clang libstdc++-10-dev:armhf
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -42,6 +42,7 @@ For Linux a few additional packages beyond the usual build essentials are needed
 - fontconfig library (`libfontconfig-dev` on debian based distributions)
 - (optional) Qt will be used when `qmake` is found in `PATH`
 - FFMPEG library `clang` `libavcodec-dev` `libavformat-dev` `libavutil-dev` `libavfilter-dev` `libavdevice-dev` `libasound2-dev` `pkg-config`
+- openssl (`libssl-dev` on debian based distributions)
 
 `xcb` and `xcbcommon` aren't needed if you are only using `backend-winit-wayland` without `backend-winit-x11`.
 


### PR DESCRIPTION
slint needs openssl to build it.

The system library `openssl` required by crate `openssl-sys` was not found. The file `openssl.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory. PKG_CONFIG_PATH contains the following:
    - /usr/lib/arm-linux-gnueabihf/pkgconfig

HINT: you may need to install a package such as openssl, openssl-dev or openssl-devel.