### PR TITLE
compiler: Add `ConditionalElement` as a possible child of `Element`

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -332,8 +332,8 @@ declare_syntax! {
         /// `id := Element { ... }`
         SubElement -> [ Element ],
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
-                     *CallbackDeclaration, *Function, *SubElement, *RepeatedElement,
-                     *PropertyAnimation, *PropertyChangedCallback,
+                     *CallbackDeclaration, *ConditionalElement, *Function, *SubElement,
+                     *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
                      *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
         RepeatedIndex -> [],

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -13,6 +13,7 @@ use super::statements::parse_statement;
 /// ```test,Element
 /// Item { }
 /// Item { property: value; SubElement { } }
+/// Item { if true: Rectangle {} }
 /// ```
 pub fn parse_element(p: &mut impl Parser) -> bool {
     let mut p = p.start_node(SyntaxKind::Element);


### PR DESCRIPTION
It's not critical, but nice to have this option documnted (and the code to find all `ConditionalElement`s generated).