### PR TITLE
Only mark builtin StyleMetrics as deprectated.

### DIFF
--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -499,8 +499,14 @@ impl LookupType {
                     Some(LookupResult::Expression {
                         expression: Expression::ElementReference(Rc::downgrade(&c.root_element)),
                         deprecated: (name == "StyleMetrics"
-                            && !ctx.type_register.expose_internal_types)
-                            .then(|| "Palette".to_string()),
+                            && !ctx.type_register.expose_internal_types
+                            && c.root_element
+                                .borrow()
+                                .debug
+                                .get(0)
+                                .and_then(|x| x.0.source_file())
+                                .map_or(false, |x| x.path().starts_with("builtin:")))
+                        .then(|| "Palette".to_string()),
                     })
                 }
             }

--- a/internal/compiler/tests/syntax/lookup/global.slint
+++ b/internal/compiler/tests/syntax/lookup/global.slint
@@ -16,6 +16,10 @@ global my_lowercase := {
 }
 
 
+global StyleMetrics {
+    out property <length> padding: 3px;
+}
+
 export X := Rectangle {
     x: MyGlobal.custom_prop;
     background: MyGlobal.blue;
@@ -28,6 +32,8 @@ export X := Rectangle {
         //    ^error{Cannot access id 'NativeStyleMetrics'}
         visible: SlintInternal.color-scheme;
         //       ^error{Cannot access id 'SlintInternal'}
+
+        height: StyleMetrics.padding;
     }
 
     property <int> my_lowercase: 45;


### PR DESCRIPTION
User defined component or global named StyleMetrics shouldn't be deprecated