### PR TITLE
Fix property access from inlined init code

### DIFF
--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -186,7 +186,9 @@ fn extract_constant_property_reference(nr: &NamedReference) -> Option<Expression
         }
 
         // There is no binding for this property, return the default value
-        return Some(Expression::default_value_for_type(&nr.ty()));
+        let ty = nr.ty();
+        debug_assert!(!matches!(ty, Type::Invalid));
+        return Some(Expression::default_value_for_type(&ty));
     };
     if !(simplify_expression(&mut expression)) {
         return None;

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -202,15 +202,8 @@ fn inline_element(
         .inlined_init_code
         .values()
         .cloned()
-        .chain(
-            inlined_component
-                .init_code
-                .borrow()
-                .constructor_code
-                .iter()
-                .cloned()
-                .map(fixup_init_expression),
-        )
+        .chain(inlined_component.init_code.borrow().constructor_code.iter().cloned())
+        .map(fixup_init_expression)
         .collect();
 
     root_component

--- a/tests/cases/issues/issue_5260_init_inlined.slint
+++ b/tests/cases/issues/issue_5260_init_inlined.slint
@@ -1,0 +1,20 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-1.2 OR LicenseRef-Slint-commercial
+
+export component DrawerLeft {
+    private property <length> logic_width;
+    rect := Rectangle {
+        init => {
+            logic_width = root.width;
+        }
+        @children
+    }
+}
+
+export component A {
+    hello := DrawerLeft { }
+}
+
+export component App inherits Window {
+    world := A { }
+}


### PR DESCRIPTION
The `fixup_init_expression` was not called for every instructions when it was inlined, causing invalid code in further passes

Fixes #5260