### PR TITLE
fix: disable default menu to allow custom menus

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -53,6 +53,13 @@ impl NotRunningEventLoop {
                 builder.with_any_thread(true);
             }
         }
+
+        #[cfg(target_os = "macos")]
+        {
+            use winit::platform::macos::EventLoopBuilderExtMacOS;
+            builder.with_default_menu(false);
+        }
+
         #[cfg(target_family = "windows")]
         {
             use winit::platform::windows::EventLoopBuilderExtWindows;


### PR DESCRIPTION
Slint at the moment does not support native menu bar integration. This PR aims to alleviate this issue somewhat by making slint compatible with the `muda` crate from tauri. 

Muda does not work when the default menu for the menu-bar is enabled, thus this PR disables it by default on MacOS.