### PR TITLE
Implement the Error trait for our errors

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -324,6 +324,22 @@ pub enum SetRenderingNotifierError {
     AlreadySet,
 }
 
+impl core::fmt::Display for SetRenderingNotifierError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Unsupported => {
+                f.write_str("The rendering backend does not support rendering notifiers.")
+            }
+            Self::AlreadySet => f.write_str(
+                "There is already a rendering notifier set, multiple notifiers are not supported.",
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SetRenderingNotifierError {}
+
 /// This struct represents a persistent handle to a window and implements the
 /// [`raw_window_handle_06::HasWindowHandle`] and [`raw_window_handle_06::HasDisplayHandle`]
 /// traits for accessing exposing raw window and display handles.
@@ -910,6 +926,9 @@ impl core::fmt::Display for EventLoopError {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for EventLoopError {}
 
 /// The platform encountered a fatal error.
 ///

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -188,9 +188,20 @@ pub(crate) fn event_loop_proxy() -> Option<&'static dyn EventLoopProxy> {
 #[repr(C)]
 #[non_exhaustive]
 pub enum SetPlatformError {
-    /// The platform has been initialized in an earlier call to [`set_platform`].
+    /// The platform has already been initialized in an earlier call to [`set_platform`].
     AlreadySet,
 }
+
+impl core::fmt::Display for SetPlatformError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SetPlatformError::AlreadySet => f.write_str("The platform has already been initialized."),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SetPlatformError {}
 
 /// Set the Slint platform abstraction.
 ///

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -195,7 +195,9 @@ pub enum SetPlatformError {
 impl core::fmt::Display for SetPlatformError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            SetPlatformError::AlreadySet => f.write_str("The platform has already been initialized."),
+            SetPlatformError::AlreadySet => {
+                f.write_str("The platform has already been initialized.")
+            }
         }
     }
 }


### PR DESCRIPTION
Some error already had it, so just add the missing ones

(Found this while trying to use `?` in an example