### PR TITLE
Set accessible min/max values on progress indicator widgets

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -459,21 +459,21 @@ impl AccessKitAdapter {
             builder.add_action(Action::Focus);
         }
 
-        if let Some(Ok(min)) = item
+        if let Some(min) = item
             .accessible_string_property(AccessibleStringProperty::ValueMinimum)
-            .map(|min| min.parse())
+            .and_then(|min| min.parse().ok())
         {
             builder.set_min_numeric_value(min);
         }
-        if let Some(Ok(max)) = item
+        if let Some(max) = item
             .accessible_string_property(AccessibleStringProperty::ValueMaximum)
-            .map(|max| max.parse())
+            .and_then(|max| max.parse().ok())
         {
             builder.set_max_numeric_value(max);
         }
-        if let Some(Ok(step)) = item
+        if let Some(step) = item
             .accessible_string_property(AccessibleStringProperty::ValueStep)
-            .map(|step| step.parse())
+            .and_then(|step| step.parse().ok())
         {
             builder.set_numeric_value_step(step);
         }

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -459,22 +459,23 @@ impl AccessKitAdapter {
             builder.add_action(Action::Focus);
         }
 
-        let min = item
+        if let Some(Ok(min)) = item
             .accessible_string_property(AccessibleStringProperty::ValueMinimum)
-            .unwrap_or_default();
-        let max = item
+            .map(|min| min.parse())
+        {
+            builder.set_min_numeric_value(min);
+        }
+        if let Some(Ok(max)) = item
             .accessible_string_property(AccessibleStringProperty::ValueMaximum)
-            .unwrap_or_default();
-        let step = item
+            .map(|max| max.parse())
+        {
+            builder.set_max_numeric_value(max);
+        }
+        if let Some(Ok(step)) = item
             .accessible_string_property(AccessibleStringProperty::ValueStep)
-            .unwrap_or_default();
-        match (min.parse(), max.parse(), step.parse()) {
-            (Ok(min), Ok(max), Ok(step)) => {
-                builder.set_min_numeric_value(min);
-                builder.set_max_numeric_value(max);
-                builder.set_numeric_value_step(step);
-            }
-            _ => {}
+            .map(|step| step.parse())
+        {
+            builder.set_numeric_value_step(step);
         }
 
         if let Some(value) = item.accessible_string_property(AccessibleStringProperty::Value) {

--- a/internal/compiler/widgets/cosmic-base/progressindicator.slint
+++ b/internal/compiler/widgets/cosmic-base/progressindicator.slint
@@ -11,7 +11,9 @@ export component ProgressIndicator {
     horizontal-stretch: 1;
     vertical-stretch: 0;
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 
     Rectangle {
         clip: true;

--- a/internal/compiler/widgets/cosmic-base/spinner.slint
+++ b/internal/compiler/widgets/cosmic-base/spinner.slint
@@ -13,7 +13,9 @@ export component Spinner {
     horizontal-stretch: 0;
     vertical-stretch: 0;
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 
     base := SpinnerBase {
         width: 100%;

--- a/internal/compiler/widgets/cupertino-base/progressindicator.slint
+++ b/internal/compiler/widgets/cupertino-base/progressindicator.slint
@@ -11,7 +11,9 @@ export component ProgressIndicator {
     horizontal-stretch: 1;
     vertical-stretch: 0;
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 
     Rectangle {
         clip: true;

--- a/internal/compiler/widgets/cupertino-base/spinner.slint
+++ b/internal/compiler/widgets/cupertino-base/spinner.slint
@@ -13,7 +13,9 @@ export component Spinner {
     horizontal-stretch: 0;
     vertical-stretch: 0;
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 
     base := SpinnerBase {
         width: 100%;

--- a/internal/compiler/widgets/fluent-base/progressindicator.slint
+++ b/internal/compiler/widgets/fluent-base/progressindicator.slint
@@ -11,7 +11,9 @@ export component ProgressIndicator {
     horizontal-stretch: 1;
     vertical-stretch: 0;
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 
     Rectangle {
         clip: true;

--- a/internal/compiler/widgets/fluent-base/spinner.slint
+++ b/internal/compiler/widgets/fluent-base/spinner.slint
@@ -13,7 +13,9 @@ export component Spinner {
     horizontal-stretch: 0;
     vertical-stretch: 0;
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 
     base := SpinnerBase {
         width: 100%;

--- a/internal/compiler/widgets/material-base/progressindicator.slint
+++ b/internal/compiler/widgets/material-base/progressindicator.slint
@@ -11,7 +11,9 @@ export component ProgressIndicator {
     horizontal-stretch: 1;
     vertical-stretch: 0;
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 
     i-background := Rectangle {
         background: MaterialPalette.control-background-variant;

--- a/internal/compiler/widgets/material-base/spinner.slint
+++ b/internal/compiler/widgets/material-base/spinner.slint
@@ -13,7 +13,9 @@ export component Spinner {
     horizontal-stretch: 0;
     vertical-stretch: 0;
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 
     base := SpinnerBase {
         width: 100%;

--- a/internal/compiler/widgets/qt/progressindicator.slint
+++ b/internal/compiler/widgets/qt/progressindicator.slint
@@ -3,5 +3,7 @@
 
 export component ProgressIndicator inherits NativeProgressIndicator {
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 }

--- a/internal/compiler/widgets/qt/spinner.slint
+++ b/internal/compiler/widgets/qt/spinner.slint
@@ -12,7 +12,9 @@ export component Spinner {
     horizontal-stretch: 0;
     vertical-stretch: 0;
     accessible-role: progress-indicator;
-    accessible-value: root.progress;
+    accessible-value: !root.indeterminate ? root.progress : "";
+    accessible-value-minimum: 0.0;
+    accessible-value-maximum: 1.0;
 
     for i in count : Path {
         property <angle> angle: -90deg + i*1turn / count;


### PR DESCRIPTION
The default values for minimum and maximum values are 0 and 100. Since Slint's value for progress indicators range from 0 to 1, this needs to be communicated to assistive technologies so they can calculate the correct percentage.

Passing an empty string when the progress is indeterminate feels like a hack, let me know if there is a way to conditionally set a property.

I had to refactor the way minimum, maximum and step properties are set on nodes because having them tied together is not really a great idea. In the case of progress indicators, step doesn't really make sense.

Not directly related to this PR: the numeric value shouldn't be set on a node just because `accessible-value` can be parsed to an f64. If a text entry contains `"42"`, the `value` property should be set, not `numeric_value`.