### PR TITLE
tree-sitter: Relicense grammar.js to MIT

### DIFF
--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+// SPDX-License-Identifier: MIT
 
 // cSpell: ignore mult prec
 

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -493,6 +493,7 @@ lazy_static! {
 
 lazy_static! {
     static ref LICENSE_FOR_FILE: Vec<(regex::Regex, &'static str)> = [
+        ("^editors/tree-sitter-slint/grammar.js$", MIT_LICENSE),
         ("^helper_crates/const-field-offset/", MIT_OR_APACHE2_LICENSE),
         ("^helper_crates/vtable/", MIT_OR_APACHE2_LICENSE),
         ("^api/cpp/esp-idf/LICENSE$", TRIPLE_LICENSE),


### PR DESCRIPTION
Code is generated from grammar.js, which gets built into a library. That library gets loaded by a text editor. So someone might argue that the GPL might infect that text editor.

We do not want that argument to come up, so let's use MIT for that code.