### PR TITLE
Android: fix content positioning

### DIFF
--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -6,6 +6,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.WindowInsets;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.content.ClipData;
@@ -464,6 +465,16 @@ public class SlintAndroidJavaHelper {
     public Rect get_view_rect() {
         Rect rect = new Rect();
         mActivity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rect);
+        WindowInsets insets = mActivity.getWindow().getDecorView().getRootView().getRootWindowInsets();
+        if (insets != null) {
+            int dx = rect.left - insets.getSystemWindowInsetLeft();
+            int dy = rect.top - insets.getSystemWindowInsetTop();
+
+            rect.left -= dx;
+            rect.right -= dx;
+            rect.top -= dy;
+            rect.bottom -= dy;
+        }
         return rect;
     }
 


### PR DESCRIPTION
The getWindowVisibleDisplayFrame seems to return a rectangle in the screen coordinate and cut the room for the camera. The problem is that the Window is somehow already displaced. The insets seems to be a better way to get that value.

Fixes #5242