### PR TITLE
janitor: Use more workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,18 +128,26 @@ vtable = { version = "0.2", path = "helper_crates/vtable", default-features = fa
 
 bytemuck = { version = "1.13.1" }
 cbindgen = { version = "0.26", default-features = false }
+cfg_aliases = { version = "0.2.0" }
+clap = { version = "4.0", features = ["derive", "wrap_help"] }
 css-color-parser2 = { version = "1.0.1" }
+derive_more = { version = "0.99.17" }
+euclid = { version = "0.22.1", default-features = false }
 fontdb = { version = "0.16.0", default-features = false }
 fontdue = { version = "0.8.0" }
 glutin = { version = "0.31.1", default-features = false }
 image = { version = "0.24", default-features = false, features = [ "png", "jpeg" ] }
 itertools = { version = "0.12" }
+log = { version = "0.4.17" }
 resvg = { version= "0.41.0", default-features = false, features = ["text"] }
+rowan = { version = "0.15" }
 send_wrapper = { version = "0.6.0" }
+serde = { version = "1.0.163", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.96" }
 softbuffer = { version = "0.3.3", default-features = false }
+spin_on = { version = "0.1" }
 strum = { version = "0.26.1", default-features = false, features = ["derive"] }
 toml_edit = { version = "0.22.7" }
-cfg_aliases = { version = "0.2.0" }
 
 raw-window-handle-06 = { package = "raw-window-handle", version = "0.6", features = ["alloc"] }
 

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -65,5 +65,5 @@ esp-println = { version = "0.9.0", default-features = false, features = ["uart"]
 [build-dependencies]
 anyhow = "1.0"
 cbindgen = { workspace = true }
-proc-macro2 = "1.0.11"
 i-slint-common = { workspace = true, features = ["default"] }
+proc-macro2 = "1.0.11"

--- a/api/node/Cargo.toml
+++ b/api/node/Cargo.toml
@@ -47,7 +47,7 @@ i-slint-compiler = { workspace = true, features = ["default"] }
 i-slint-core = { workspace = true, features = ["default"] }
 i-slint-backend-selector = { workspace = true }
 slint-interpreter = { workspace = true, default-features = false, features = ["display-diagnostics", "internal", "compat-1-2"] }
-spin_on = "0.1"
+spin_on = { workspace = true }
 css-color-parser2 = { workspace = true }
 itertools = { workspace = true }
 send_wrapper = { workspace = true }

--- a/api/python/Cargo.toml
+++ b/api/python/Cargo.toml
@@ -24,7 +24,7 @@ slint-interpreter = { workspace = true, features = ["default", "display-diagnost
 pyo3 = { version = "0.21.0", features = ["extension-module", "indexmap", "chrono", "abi3-py310"] }
 indexmap = { version = "2.1.0" }
 chrono = "0.4"
-spin_on = "0.1"
+spin_on = { workspace = true }
 css-color-parser2 = { workspace = true }
 
 [package.metadata.maturin]

--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -23,6 +23,6 @@ default = []
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "rust", "display-diagnostics", "software-renderer"] }
 
-spin_on = "0.1"
+spin_on = { workspace = true }
 thiserror = "1"
 toml_edit = { workspace = true }

--- a/api/rs/macros/Cargo.toml
+++ b/api/rs/macros/Cargo.toml
@@ -26,4 +26,4 @@ i-slint-compiler = { workspace = true, features = ["default", "proc_macro_span",
 
 proc-macro2 = "1.0.17"
 quote = "1.0"
-spin_on = "0.1"
+spin_on = { workspace = true }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -182,7 +182,7 @@ once_cell = { version = "1.5", default-features = false, features = ["alloc"] }
 pin-weak = { version = "1.1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 
-log = { version = "0.4.17", optional = true }
+log = { workspace = true, optional = true }
 
 raw-window-handle-06 = { workspace = true, optional = true }
 
@@ -196,9 +196,10 @@ i-slint-backend-android-activity = { workspace = true, optional = true }
 
 [dev-dependencies]
 slint-build = { path = "../build" }
-i-slint-backend-testing = { path = "../../../internal/backends/testing", features = ["internal"] }
-serde_json = "1.0.96"
-serde = { version = "1.0.163", features = ["derive"] }
+# The next can not be a workspace dependency because it may not have a version
+i-slint-backend-testing = {  path = "../../../internal/backends/testing", features = ["internal"] }
+serde_json = { workspace = true }
+serde = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # this line is there to add the "enable" feature by default, but only on linux

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -38,7 +38,7 @@ i-slint-common = { workspace = true, features = ["default"] }
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
 
 cfg-if = "1"
-derive_more = "0.99.5"
+derive_more = { workspace = true }
 lyon_path = "1.0"
 once_cell = "1.5"
 pin-weak = "1"

--- a/internal/common/Cargo.toml
+++ b/internal/common/Cargo.toml
@@ -22,7 +22,7 @@ shared-fontdb = ["dep:fontdb", "dep:libloading", "derive_more", "cfg-if"]
 
 [dependencies]
 fontdb = { workspace = true, optional = true }
-derive_more = { version = "0.99.5", optional = true }
+derive_more = { workspace = true, optional = true }
 cfg-if = { version = "1", optional = true }
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32", target_os = "android")))'.dependencies]

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -37,9 +37,9 @@ i-slint-common = { workspace = true, features = ["default"] }
 
 num_enum = "0.7"
 strum = { workspace = true }
-rowan = "0.15.5"
+rowan = { workspace = true }
 smol_str = "0.2.0"
-derive_more = "0.99.5"
+derive_more = { workspace = true }
 codemap-diagnostic = { version = "0.1.1", optional = true }
 codemap = { version = "0.1", optional = true }
 quote = { version = "1.0", optional = true }
@@ -64,5 +64,5 @@ fontdue = { workspace = true, optional = true }
 i-slint-parser-test-macro = { path = "./parser-test-macro" }
 
 regex = "1.3.7"
-spin_on = "0.1"
+spin_on = { workspace = true }
 rayon = "1.5.3"

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -59,8 +59,8 @@ vtable = { workspace = true }
 portable-atomic = { version = "1", features = ["critical-section"] }
 auto_enums = "0.8.0"
 cfg-if = "1"
-derive_more = "0.99.5"
-euclid = { version = "0.22.1", default-features = false }
+derive_more = { workspace = true }
+euclid = { workspace = true }
 lyon_algorithms = { version = "1.0", optional = true }
 lyon_geom = { version = "1.0", optional = true  }
 lyon_path = { version = "1.0", optional = true }
@@ -87,7 +87,7 @@ clru = { version = "0.6.0", optional = true }
 
 resvg = { workspace = true, optional = true }
 fontdb = { workspace = true, optional = true }
-serde = { version = "1.0.163", features = ["derive"], optional = true }
+serde = { workspace = true, optional = true }
 
 raw-window-handle-06 = { workspace = true, optional = true }
 bitflags = { version = "2.4.2" }
@@ -111,6 +111,6 @@ i-slint-backend-testing = { path="../backends/testing" }
 rustybuzz = "0.13.0"
 ttf-parser = "0.20.0"
 fontdb = { workspace = true, default-features = true }
-serde_json = "1.0.96"
+serde_json = { workspace = true }
 tiny-skia = "0.11.0"
 tokio = { version = "1.35", features = ["rt-multi-thread"] }

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -125,13 +125,13 @@ i-slint-backend-selector = { workspace = true, features = ["rtti"] }
 
 vtable = { workspace = true }
 
-derive_more = "0.99.5"
+derive_more = { workspace = true }
 generativity = "1"
 lyon_path = { version = "1.0" }
 once_cell = "1.5"
 thiserror = "1"
 document-features = { version = "0.2.0", optional = true }
-spin_on = { version = "0.1", optional = true }
+spin_on = { workspace = true, optional = true }
 raw-window-handle-06 = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -141,10 +141,9 @@ i-slint-backend-winit = { workspace = true }
 # this line is there to add the "enable" feature by default, but only on linux
 i-slint-backend-qt = { workspace = true, features = [ "enable" ], optional = true }
 
-
 [dev-dependencies]
 i-slint-backend-testing = { path = "../../internal/backends/testing" }
-spin_on = "0.1"
+spin_on = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["display-diagnostics", "document-features", "raw-window-handle-06"]

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -26,7 +26,7 @@ i-slint-common = { workspace = true, features = ["default"] }
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
 
 cfg-if = "1"
-derive_more = "0.99.5"
+derive_more = { workspace = true }
 lyon_path = "1.0"
 once_cell = "1.5"
 pin-weak = "1"

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -35,7 +35,7 @@ const-field-offset = { version = "0.1", path = "../../../helper_crates/const-fie
 vtable = { workspace = true }
 
 cfg-if = "1"
-derive_more = "0.99.5"
+derive_more = { workspace = true }
 lyon_path = "1.0"
 once_cell = "1.5"
 pin-weak = "1"

--- a/tests/doctests/Cargo.toml
+++ b/tests/doctests/Cargo.toml
@@ -21,4 +21,4 @@ walkdir = "2"
 
 [dev-dependencies]
 slint-interpreter = { workspace = true, features = ["default", "display-diagnostics"] }
-spin_on = "0.1"
+spin_on = { workspace = true }

--- a/tests/driver/cpp/Cargo.toml
+++ b/tests/driver/cpp/Cargo.toml
@@ -25,7 +25,7 @@ i-slint-compiler = { workspace = true, features = ["default", "cpp", "display-di
 
 cc = "1.0.54"
 scopeguard = "1.1.0"
-spin_on = "0.1"
+spin_on = { workspace = true }
 tempfile = "3"
 test_driver_lib = { path = "../driverlib" }
 

--- a/tests/driver/interpreter/Cargo.toml
+++ b/tests/driver/interpreter/Cargo.toml
@@ -23,7 +23,7 @@ i-slint-backend-testing = { workspace = true }
 
 itertools = { workspace = true }
 lazy_static = "1.4.0"
-spin_on = "0.1"
+spin_on = { version = "0.1" }
 test_driver_lib = { path = "../driverlib" }
 
 [build-dependencies]

--- a/tests/driver/rust/Cargo.toml
+++ b/tests/driver/rust/Cargo.toml
@@ -24,10 +24,10 @@ build-time = ["i-slint-compiler", "spin_on"]
 slint = { workspace = true, features = ["std", "compat-1-2"] }
 i-slint-backend-testing = { workspace = true, features = ["internal"] }
 slint-interpreter = { workspace = true, features = ["std", "compat-1-2", "internal"] }
-spin_on = "0.1"
+spin_on = { workspace = true }
 
 [build-dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "rust", "display-diagnostics"], optional = true }
 
-spin_on = { version = "0.1", optional = true}
+spin_on = { workspace = true, optional = true }
 test_driver_lib = { path = "../driverlib" }

--- a/tests/screenshots/Cargo.toml
+++ b/tests/screenshots/Cargo.toml
@@ -27,5 +27,5 @@ crossterm = "0.27"
 [build-dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "rust", "display-diagnostics", "software-renderer"] }
 walkdir = "2.3"
-spin_on = { version = "0.1" }
+spin_on = { workspace = true }
 test_driver_lib = { path = "../driver/driverlib" }

--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -25,7 +25,7 @@ default = ["software-renderer"]
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "display-diagnostics", "cpp", "rust"]}
 
-clap = { version = "4.0", features = ["derive", "wrap_help"] }
+clap = { workspace = true }
 proc-macro2 = "1.0.11"
-spin_on = "0.1"
+spin_on = { workspace = true }
 itertools = { workspace = true }

--- a/tools/figma_import/Cargo.toml
+++ b/tools/figma_import/Cargo.toml
@@ -21,11 +21,11 @@ path = "src/main.rs"
 
 [dependencies]
 float-cmp = "0.9.0"
-clap = { version = "4.0", features = ["derive", "wrap_help"] }
+clap = { workspace = true }
 reqwest = { version = "0.11", features = ["json", "stream"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-serde = { version = "1.0.123", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 smart-default = "0.7"
-derive_more = "0.99"
+derive_more = { workspace = true }

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -79,13 +79,13 @@ default = ["backend-default", "renderer-femtovg", "preview"]
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["display-diagnostics"] }
 
-euclid = "0.22"
+dissimilar = "1.0.7"
+euclid = { workspace = true }
 itertools = { workspace = true }
 lsp-types = { version = "0.95.0", features = ["proposed"] }
-rowan = "0.15.5"
-serde = "1.0.118"
-serde_json = "1.0.60"
-dissimilar = "1.0.7"
+rowan = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # for the preview-engine feature
 i-slint-backend-selector = { workspace = true, optional = true }
@@ -95,7 +95,7 @@ slint = { workspace = true, features = ["compat-1-2"], optional = true }
 slint-interpreter = { workspace = true, features = ["compat-1-2", "highlight", "internal"], optional = true  }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-clap = { version = "4.0", features = ["derive", "wrap_help"] }
+clap = { workspace = true }
 crossbeam-channel = "0.5"  # must match the version used by lsp-server
 lsp-server = "0.7"
 once_cell = "1.9.0"

--- a/tools/tr-extractor/Cargo.toml
+++ b/tools/tr-extractor/Cargo.toml
@@ -17,7 +17,7 @@ categories = [ "gui", "command-line-utilities", "development-tools" ]
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "display-diagnostics"] }
 chrono = {version = "0.4.24", default-features = false, features = ["clock"] }
-clap = { version = "4.0", features = ["derive", "wrap_help"] }
+clap = { workspace = true }
 polib = "0.2"
 
 [dev-dependencies]

--- a/tools/updater/Cargo.toml
+++ b/tools/updater/Cargo.toml
@@ -19,10 +19,10 @@ categories = ["gui", "development-tools", "command-line-utilities"]
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "display-diagnostics"] }
 
-clap = { version = "4.0", features = ["derive", "wrap_help"] }
+clap = { workspace = true }
 codemap = "0.1"
 codemap-diagnostic = "0.1.1"
-spin_on = "0.1"
+spin_on = { workspace = true }
 by_address = "1.0.4"
 
 [[bin]]

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -56,13 +56,13 @@ i-slint-core = { workspace = true }
 slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility"] }
 i-slint-backend-selector = { workspace = true }
 
-clap = { version = "4.0", features = ["derive", "wrap_help"] }
+clap = { workspace = true }
 codemap = "0.1"
 codemap-diagnostic = "0.1.1"
 notify = { version = "6.0.0", default-features = false, features = ["macos_kqueue"] }
-serde_json = "1"
+serde_json = { workspace = true }
 shlex = "1"
-spin_on = "0.1"
+spin_on = { workspace = true }
 env_logger = "0.11.0"
 itertools = { workspace = true }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,15 +14,15 @@ version.workspace = true
 publish = false
 
 [dependencies]
-const_format = "0.2"
-clap = { version = "4.0", features = ["derive", "wrap_help"] }
 anyhow = "1.0"
-lazy_static = "1.4.0"
-regex = "1.4"
-toml_edit = { workspace = true }
-xshell = "0.2.1"
-serde_json = "1.0"
 cbindgen = { workspace = true }
-proc-macro2 = "1.0.11"
-which = "6.0"
+clap = { workspace = true }
+const_format = "0.2"
 i-slint-common = { workspace = true, features = ["default"] }
+lazy_static = "1.4.0"
+proc-macro2 = "1.0.11"
+regex = "1.4"
+serde_json = { workspace = true }
+toml_edit = { workspace = true }
+which = "6.0"
+xshell = "0.2.1"


### PR DESCRIPTION
Move more dependencies into the workspace to avoid having to duplicate the versions all over the place.

I also sorted some lists where I noticed duplicates and removed those.

The examples are unchanged: Those should to be stand alone so users can just copy them over to get started.