### PR TITLE
Fix PopupMenu in Row

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -580,3 +580,14 @@ pub fn create_new_prop(elem: &ElementRc, tentative_name: &str, ty: Type) -> Name
         }
     }
 }
+
+/// Return true if this type is a layout that has constraints
+pub fn is_layout(base_type: &ElementType) -> bool {
+    match base_type {
+        ElementType::Builtin(b) => {
+            matches!(b.name.as_str(), "GridLayout" | "HorizontalLayout" | "VerticalLayout" | "Row")
+        }
+        ElementType::Component(c) => is_layout(&c.root_element.borrow().base_type),
+        _ => false,
+    }
+}

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -84,7 +84,7 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
                 .borrow()
                 .children
                 .iter()
-                .filter(|x| is_layout(&x.borrow().base_type))
+                .filter(|x| crate::layout::is_layout(&x.borrow().base_type))
                 // FIXME: we should ideally add runtime code to merge layout info of all elements that are repeated (#407)
                 .filter(|x| x.borrow().repeated.is_none())
                 .map(|x| Expression::PropertyReference(NamedReference::new(x, prop)))
@@ -106,7 +106,7 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
                 .borrow()
                 .children
                 .iter()
-                .filter(|x| is_layout(&x.borrow().base_type))
+                .filter(|x| crate::layout::is_layout(&x.borrow().base_type))
                 // FIXME: (#407)
                 .filter(|x| x.borrow().repeated.is_none())
                 .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-width")))
@@ -122,7 +122,7 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
                 .borrow()
                 .children
                 .iter()
-                .filter(|x| is_layout(&x.borrow().base_type))
+                .filter(|x| crate::layout::is_layout(&x.borrow().base_type))
                 // FIXME: (#407)
                 .filter(|x| x.borrow().repeated.is_none())
                 .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-height")))
@@ -132,15 +132,6 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
                 ),
         )
     });
-}
-
-/// Return true if this type is a layout that has constraints
-fn is_layout(base_type: &ElementType) -> bool {
-    if let ElementType::Builtin(be) = base_type {
-        matches!(be.name.as_str(), "GridLayout" | "HorizontalLayout" | "VerticalLayout")
-    } else {
-        false
-    }
 }
 
 /// Set the property binding on the given element to the given expression (computed lazily).

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -112,7 +112,7 @@ fn lower_element_layout(
             );
             return;
         }
-        "GridLayout" => lower_grid_layout(component, elem, diag),
+        "GridLayout" => lower_grid_layout(component, elem, diag, type_register),
         "HorizontalLayout" => lower_box_layout(elem, diag, Orientation::Horizontal),
         "VerticalLayout" => lower_box_layout(elem, diag, Orientation::Vertical),
         "Dialog" => {
@@ -146,6 +146,7 @@ fn lower_grid_layout(
     component: &Rc<Component>,
     grid_layout_element: &ElementRc,
     diag: &mut BuildDiagnostics,
+    type_register: &TypeRegister,
 ) {
     let mut grid = GridLayout {
         elems: Default::default(),
@@ -194,7 +195,13 @@ fn lower_grid_layout(
                 row += 1;
                 col = 0;
             }
-            component.optimized_elements.borrow_mut().push(layout_child);
+            if layout_child.borrow().has_popup_child {
+                // We need to keep that element otherwise the popup will malfunction
+                layout_child.borrow_mut().base_type = type_register.empty_type();
+                collected_children.push(layout_child);
+            } else {
+                component.optimized_elements.borrow_mut().push(layout_child);
+            }
         } else {
             grid.add_element(
                 &layout_child,

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -58,7 +58,15 @@ fn lower_popup_window(
             parent_component.inherits_popup_window.set(true);
             return;
         }
-        Some(parent_element) => parent_element,
+        Some(parent_element) => {
+            if crate::layout::is_layout(&parent_element.borrow().base_type) {
+                diag.push_warning(
+                    "PopupWindow shouldn't be a children of a layout".into(),
+                    &*popup_window_element.borrow(),
+                )
+            }
+            parent_element
+        }
     };
 
     if Rc::ptr_eq(&parent_component.root_element, popup_window_element) {

--- a/internal/compiler/tests/syntax/elements/popup3.slint
+++ b/internal/compiler/tests/syntax/elements/popup3.slint
@@ -1,0 +1,29 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { HorizontalBox } from "std-widgets.slint";
+
+component MyP inherits PopupWindow {}
+
+export component Component {
+
+    GridLayout {
+        p1 := PopupWindow {}
+        //    ^warning{PopupWindow shouldn't be a children of a layout}
+        Row {
+            PopupWindow {}
+        //  ^warning{PopupWindow shouldn't be a children of a layout}
+        }
+
+        Rectangle {
+            PopupWindow {} // no warnings there
+        }
+
+        HorizontalBox { PopupWindow {} }
+        //              ^warning{PopupWindow shouldn't be a children of a layout}
+        VerticalLayout { MyP {} }
+        //               ^warning{PopupWindow shouldn't be a children of a layout}
+
+    }
+
+}

--- a/tests/cases/crashes/issue5259_popup_in_row.slint
+++ b/tests/cases/crashes/issue5259_popup_in_row.slint
@@ -1,0 +1,60 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    height: 100px;
+    width: 100px;
+    out property <int> clicked;
+    GridLayout {
+        Row {
+            popup2 := PopupWindow {
+                Rectangle {
+                    background: yellow;
+                    TouchArea {
+                        clicked => { root.clicked += 1; }
+                    }
+                }
+
+                // that's 20px relative to the Row which will be a 0x0 Empty centered in the window
+                x: 20px;
+                y: 20px;
+                height: 50px;
+                width: 50px;
+            }
+
+            ta := TouchArea {
+                clicked => {
+                    popup2.show();
+                }
+            }
+        }
+     }
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 90., 90.);
+assert_eq(instance.get_clicked(), 0);
+slint_testing::send_mouse_click(&instance, 90., 90.);
+assert_eq(instance.get_clicked(), 1);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 90., 90.);
+assert_eq!(instance.get_clicked(), 0);
+slint_testing::send_mouse_click(&instance, 90., 90.);
+assert_eq!(instance.get_clicked(), 1);
+```
+
+```js
+var instance = new slint.TestCase();
+slintlib.private_api.send_mouse_click(instance, 90., 90.);
+assert.equal(instance.clicked, 0);
+slintlib.private_api.send_mouse_click(instance, 90., 90.);
+assert.equal(instance.clicked, 1);
+```
+
+*/


### PR DESCRIPTION
Don't remove the Row element. 
And add a warning when using PopupWindow in a layout

Fixes #5259