### PR TITLE
CMake: Add support for LIBRARY_PATHS to slint_target_sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project are documented in this file.
  - Added `step-size` to `SpinBox`
  - Added `TimePicker` widget.
 
+## C++ API
+
+ - Added `LIBRARY_PATHS` multi-value argument to `slint_target_sources` that takes a list of
+   `name=path` items, to allow for the use of component libraries.
+
 ## [1.6.0] - 2024-05-13
 
 ## General

--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -12,7 +12,7 @@ set_property(CACHE DEFAULT_SLINT_EMBED_RESOURCES PROPERTY STRINGS
 
 function(SLINT_TARGET_SOURCES target)
     # Parse the NAMESPACE argument
-    cmake_parse_arguments(SLINT_TARGET_SOURCES "" "NAMESPACE" "" ${ARGN})
+    cmake_parse_arguments(SLINT_TARGET_SOURCES "" "NAMESPACE" "LIBRARY_PATHS" ${ARGN})
 
     if (DEFINED SLINT_TARGET_SOURCES_NAMESPACE)
         # Remove the NAMESPACE argument from the list
@@ -24,7 +24,13 @@ function(SLINT_TARGET_SOURCES target)
         set(_SLINT_CPP_NAMESPACE_ARG "--cpp-namespace=${SLINT_TARGET_SOURCES_NAMESPACE}")
     endif()
 
-    foreach (it IN ITEMS ${ARGN})
+    while (SLINT_TARGET_SOURCES_LIBRARY_PATHS)
+        list(POP_FRONT SLINT_TARGET_SOURCES_LIBRARY_PATHS name_and_path)
+        list(APPEND _SLINT_CPP_LIBRARY_PATHS_ARG "-L")
+        list(APPEND _SLINT_CPP_LIBRARY_PATHS_ARG "${name_and_path}")
+    endwhile()
+
+    foreach (it IN ITEMS ${SLINT_TARGET_SOURCES_UNPARSED_ARGUMENTS})
         get_filename_component(_SLINT_BASE_NAME ${it} NAME_WE)
         get_filename_component(_SLINT_ABSOLUTE ${it} REALPATH BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
         get_property(_SLINT_STYLE GLOBAL PROPERTY SLINT_STYLE)
@@ -42,6 +48,7 @@ function(SLINT_TARGET_SOURCES target)
                 --embed-resources=${embed}
                 --translation-domain="${target}"
                 ${_SLINT_CPP_NAMESPACE_ARG}
+                ${_SLINT_CPP_LIBRARY_PATHS_ARG}
             DEPENDS Slint::slint-compiler ${_SLINT_ABSOLUTE}
             COMMENT "Generating ${_SLINT_BASE_NAME}.h"
             DEPFILE ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d

--- a/api/cpp/docs/cmake_reference.md
+++ b/api/cpp/docs/cmake_reference.md
@@ -5,23 +5,30 @@
 ## `slint_target_sources`
 
 ```
-slint_target_sources(<target> <files>.... [NAMESPACE namespace])
+slint_target_sources(<target> <files>.... [NAMESPACE namespace] [LIBRARY_PATHS name1=lib1 name2=lib2 ...])
 ```
 
 Use this function to tell cmake about the .slint files of your application, similar to the builtin cmake [target_sources](https://cmake.org/cmake/help/latest/command/target_sources.html) function.
 The function takes care of running the slint-compiler to convert `.slint` files to `.h` files in the build directory,
 and extend  the include directories of your target so that the generated file is found when including it in your application.
 
-The optional NAMESPACE argument will put the generated components in the given C++ namespace.
+The optional `NAMESPACE` argument will put the generated components in the given C++ namespace.
+
+Use the `LIBRARY_PATHS` argument to specify the name and paths to [component libraries](slint-reference:src/language/syntax/modules#component-libraries),
+separated by an equals sign (`=`).
 
 Given a file called `the_window.slint`, the following example will create a file called `the_window.h` that can
 be included from your .cpp file. Assuming the `the_window.slint` contains a component `TheWindow`, the output
-C++ class will be put in the namespace `ui`, resulting to `ui::TheWindow`.
+C++ class will be put in the namespace `ui`, resulting to `ui::TheWindow`. Any import from `@mycomponentlib/` will
+be redirected to the specified path.
 
 ```cmake
 add_executable(my_application main.cpp)
 target_link_libraries(my_application PRIVATE Slint::Slint)
-slint_target_sources(my_application the_window.slint NAMESPACE ui)
+slint_target_sources(my_application the_window.slint 
+    NAMESPACE ui
+    LIBRARY_PATHS mycomponentlib=/path/to/customcomponents
+)
 ```
 
 

--- a/api/cpp/tests/CMakeLists.txt
+++ b/api/cpp/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 
 if(SLINT_FEATURE_COMPILER OR SLINT_COMPILER)
     add_subdirectory(multiple-includes)
+    add_subdirectory(libraries)
 endif()
 
 slint_test(platform_eventloop)

--- a/api/cpp/tests/libraries/CMakeLists.txt
+++ b/api/cpp/tests/libraries/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+add_executable(libraries main.cpp)
+target_link_libraries(libraries PRIVATE Slint::Slint)
+slint_target_sources(libraries appwindow.slint
+    LIBRARY_PATHS
+       helper_components=${CMAKE_CURRENT_SOURCE_DIR}/../../../../tests/helper_components/
+       helper_buttons=${CMAKE_CURRENT_SOURCE_DIR}/../../../../tests/helper_components/test_button.slint
+)
+

--- a/api/cpp/tests/libraries/README.md
+++ b/api/cpp/tests/libraries/README.md
@@ -1,0 +1,3 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0 -->
+
+This is a test making sure that slint_target_sources accepts slint component library paths.

--- a/api/cpp/tests/libraries/appwindow.slint
+++ b/api/cpp/tests/libraries/appwindow.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { TestButton } from "@helper_components/test_button.slint";
+import { ColorButton } from "@helper_buttons";
+
+
+export component App inherits Window {
+    TestButton { }
+
+    ColorButton { }
+}

--- a/api/cpp/tests/libraries/main.cpp
+++ b/api/cpp/tests/libraries/main.cpp
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#include "appwindow.h"
+
+int main(int argc, char **argv)
+{
+    auto my_ui = App::create();
+    my_ui->run();
+}


### PR DESCRIPTION
This makes it possible to use component libraries with C++.