### PR TITLE
esp-idf: Make it possible to disable the RGB565 color swap via Kconfig

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -15,6 +15,10 @@ Files: api/cpp/docs/*/*.html api/cpp/docs/*/*.css docs/*/*.css docs/*/*.html doc
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: MIT
 
+Files: api/cpp/esp-idf/slint/Kconfig
+Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
+License: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 Files: examples/*/LC_MESSAGES/*.mo examples/*/sdkconfig*
 Copyright: Copyright © SixtyFPS GmbH <info@slint.dev>
 License: MIT

--- a/api/cpp/esp-idf/slint/Kconfig
+++ b/api/cpp/esp-idf/slint/Kconfig
@@ -5,5 +5,7 @@ menu "Slint"
         default y
         help
             Use this if your CPU is little endian but the display expects big-endian.
+            At the moment this is only supported for single-buffer rendering as well
+            as the (experimental) line-by-line rendering.
     
 endmenu

--- a/api/cpp/esp-idf/slint/Kconfig
+++ b/api/cpp/esp-idf/slint/Kconfig
@@ -1,0 +1,9 @@
+menu "Slint"
+
+    config SLINT_COLOR_16_SWAP
+        bool "Swap the 2 bytes of RGB 565 pixels before sending to the display"
+        default y
+        help
+            Use this if your CPU is little endian but the display expects big-endian.
+    
+endmenu

--- a/api/cpp/esp-idf/slint/README.md
+++ b/api/cpp/esp-idf/slint/README.md
@@ -168,6 +168,14 @@ using [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/ws
 One reason could be that you don't have enough ram for the heap or the stack.
 Make sure that the stack is big enough (~8KiB), and that all the RAM was made available for the heap allocator.
 
+# Wrong colors shown
+
+If colors look inverted on your display, it may be an incompatibility between how RGB565 colors are ordered in little-endian
+and your display expecting a different byte order. Typically, esp32 devices are little ending and display controllers often
+expect big-endian or `esp_lcd` configures them accordingly. Therefore, by default Slint converts pixels to big-endian.
+If your display controller expects little endian, uncheck the `SLINT_COLOR_16_SWAP` Kconfig option in `idf.py menuconfig`
+under `Component config --> Slint`.
+
 ## License
 
 You can use Slint under ***any*** of the following licenses, at your choice:

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -244,12 +244,14 @@ void EspPlatform::run_event_loop()
                     } else {
                         for (auto [o, s] : region.rectangles()) {
                             for (int y = o.y; y < o.y + s.height; y++) {
+#ifdef CONFIG_SLINT_COLOR_16_SWAP
                                 for (int x = o.x; x < o.x + s.width; x++) {
                                     // Swap endianess to big endian
                                     auto px = reinterpret_cast<uint16_t *>(
                                             &buffer1.value()[y * size.width + x]);
                                     *px = (*px << 8) | (*px >> 8);
                                 }
+#endif
                                 esp_lcd_panel_draw_bitmap(panel_handle, o.x, y, o.x + s.width,
                                                           y + 1,
                                                           buffer1->data() + y * size.width + o.x);

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -273,6 +273,13 @@ void EspPlatform::run_event_loop()
                         std::span<slint::platform::Rgb565Pixel> view { lb.get(),
                                                                        line_end - line_start };
                         render_fn(view);
+#    ifdef CONFIG_SLINT_COLOR_16_SWAP
+                        // Swap endianess to big endian
+                        std::for_each(view.begin(), view.end(), [](auto &rgbpix) {
+                            auto px = reinterpret_cast<uint16_t *>(&rgbpix);
+                            *px = (*px << 8) | (*px >> 8);
+                        });
+#    endif
                         esp_lcd_panel_draw_bitmap(panel_handle, line_start, line_y, line_end,
                                                   line_y + 1, lb.get());
                     });

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -413,6 +413,7 @@ lazy_static! {
         ("^editors/tree-sitter-slint/binding\\.gyp$", LicenseLocation::NoLicense), // liberal license
         ("^editors/tree-sitter-slint/test-to-corpus\\.py$", LicenseLocation::Tag(LicenseTagStyle::shell_comment_style())),
         ("^Cargo\\.lock$", LicenseLocation::NoLicense),
+        ("^api/cpp/esp-idf/slint/Kconfig$", LicenseLocation::NoLicense),
 
         // filename based matches:
         ("(^|/)CMakeLists\\.txt$", LicenseLocation::Tag(LicenseTagStyle::shell_comment_style())),


### PR DESCRIPTION
Add an option to disable the swap to big-endian at compile-time.