### PR TITLE
Fix jitter when resizing a window on macOS

### DIFF
--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -235,7 +235,12 @@ impl AndroidWindowAdapter {
                             ),
                         )
                     };
-                    self.renderer.set_window_handle(window_handle, display_handle, size)?;
+                    self.renderer.set_window_handle(
+                        window_handle,
+                        display_handle,
+                        size,
+                        scale_factor,
+                    )?;
                     self.resize();
                 }
             }

--- a/internal/backends/winit/renderer/femtovg/glcontext.rs
+++ b/internal/backends/winit/renderer/femtovg/glcontext.rs
@@ -149,6 +149,12 @@ impl OpenGLContext {
             })?
         };
 
+        let context = not_current_gl_context.make_current(&surface)
+            .map_err(|glutin_error: glutin::error::Error| -> PlatformError {
+                format!("FemtoVG Renderer: Failed to make newly created OpenGL context current: {glutin_error}")
+            .into()
+        })?;
+
         // Align the GL layer to the top-left, so that resizing only invalidates the bottom/right
         // part of the window.
         #[cfg(target_os = "macos")]
@@ -163,12 +169,6 @@ impl OpenGLContext {
                 NSView::setLayerContentsPlacement(view_id, cocoa::appkit::NSViewLayerContentsPlacement::NSViewLayerContentsPlacementTopLeft)
             }
         }
-
-        let context = not_current_gl_context.make_current(&surface)
-            .map_err(|glutin_error: glutin::error::Error| -> PlatformError {
-                format!("FemtoVG Renderer: Failed to make newly created OpenGL context current: {glutin_error}")
-            .into()
-        })?;
 
         // Sanity check, as all this might succeed on Windows without working GL drivers, but this will fail:
         if context

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -116,6 +116,7 @@ impl super::WinitCompatibleRenderer for WinitSkiaRenderer {
             window_handle,
             display_handle,
             physical_size_to_slint(&size),
+            winit_window.scale_factor() as f32,
         )
     }
 }

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -194,8 +194,11 @@ impl SkiaRenderer {
         window_handle: raw_window_handle::WindowHandle<'_>,
         display_handle: raw_window_handle::DisplayHandle<'_>,
         size: PhysicalWindowSize,
+        scale_factor: f32,
     ) -> Result<(), PlatformError> {
-        self.set_surface((self.surface_factory)(window_handle, display_handle, size)?);
+        let surface = (self.surface_factory)(window_handle, display_handle, size)?;
+        surface.set_scale_factor(scale_factor);
+        self.set_surface(surface);
         Ok(())
     }
 
@@ -233,6 +236,8 @@ impl SkiaRenderer {
         let window_adapter = self.window_adapter()?;
         let window = window_adapter.window();
         let window_inner = WindowInner::from_pub(window);
+
+        surface.set_scale_factor(window.scale_factor());
 
         surface.render(
             surace_size,
@@ -554,6 +559,8 @@ pub trait Surface {
     fn supports_graphics_api_with_self(&self) -> bool {
         false
     }
+
+    fn set_scale_factor(&self, _scale_factor: f32) {}
 
     /// If supported, this invokes the specified callback with access to the platform graphics API.
     fn with_graphics_api(&self, _callback: &mut dyn FnMut(GraphicsAPI<'_>)) {}

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -49,6 +49,9 @@ impl super::Surface for MetalSurface {
             } as cocoa_id;
             view.setWantsLayer(YES);
             view.setLayer(layer.as_ref() as *const _ as _);
+            view.setLayerContentsPlacement(
+                cocoa::appkit::NSViewLayerContentsPlacement::NSViewLayerContentsPlacementTopLeft,
+            );
         }
 
         let command_queue = device.new_command_queue();
@@ -76,6 +79,10 @@ impl super::Surface for MetalSurface {
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         self.layer.set_drawable_size(CGSize::new(size.width as f64, size.height as f64));
         Ok(())
+    }
+
+    fn set_scale_factor(&self, scale_factor: f32) {
+        self.layer.set_contents_scale(scale_factor.into());
     }
 
     fn render(

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -304,6 +304,12 @@ impl OpenGLSurface {
                 .map_err(|e| format!("Error creating OpenGL window surface: {e}"))?
         };
 
+        let context = not_current_gl_context.make_current(&surface)
+            .map_err(|glutin_error: glutin::error::Error| -> PlatformError {
+                format!("FemtoVG Renderer: Failed to make newly created OpenGL context current: {glutin_error}")
+                .into()
+        })?;
+
         // Align the GL layer to the top-left, so that resizing only invalidates the bottom/right
         // part of the window.
         #[cfg(target_os = "macos")]
@@ -318,12 +324,6 @@ impl OpenGLSurface {
                 NSView::setLayerContentsPlacement(view_id, cocoa::appkit::NSViewLayerContentsPlacement::NSViewLayerContentsPlacementTopLeft)
             }
         }
-
-        let context = not_current_gl_context.make_current(&surface)
-            .map_err(|glutin_error: glutin::error::Error| -> PlatformError {
-                format!("FemtoVG Renderer: Failed to make newly created OpenGL context current: {glutin_error}")
-                .into()
-        })?;
 
         // Sanity check, as all this might succeed on Windows without working GL drivers, but this will fail:
         if context


### PR DESCRIPTION
Commit 1e450abc9ca3dce9958ec5c5c6e95021ecb76bf7 originally fixed this. Meanwhile, after many refactorings, this doesn't work anymore for the FemtoVG renderer. That's because the contents placement (or layer's contents gravity) is set before the hidden layer NSOpenGLContext creates is associated with the view.

For the Skia GL surface that already works, but for clarify the code is moved into the same location.

For Skia Metal rendering, apply the same on the metal layer (through the view). For this to work the contents scale also needs to be applied. To avoid further visual effects, the scale needs to be applied as early as possible, so apply it right after creating the surface and latest at rendering time.

Fixes #5258