### PR TITLE
Testing: Fix duplicated accessibility element

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,7 +118,7 @@ jobs:
                   cache: true
             - name: Upgrade LLVM for Skia build on Windows
               if: runner.os == 'Windows'
-              run: choco upgrade llvm    
+              run: choco upgrade llvm
             - name: Setup headless display
               uses: pyvista/setup-headless-display-action@v1
             - uses: ./.github/actions/install-nodejs
@@ -218,6 +218,7 @@ jobs:
             CARGO_INCREMENTAL: false
             RUST_BACKTRACE: 1
             CARGO_PROFILE_DEV_DEBUG: 0
+            SLINT_EMIT_DEBUG_INFO: 1
         strategy:
             matrix:
                 os: [ubuntu-22.04, macos-12, windows-2022]

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -153,57 +153,30 @@ public:
     /// Returns the accessible-label of that element, if any.
     std::optional<SharedString> accessible_label() const
     {
-        if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            SharedString result;
-            if (item->item_tree.vtable()->accessible_string_property(
-                        item->item_tree.borrow(), item->index,
-                        cbindgen_private::AccessibleStringProperty::Label, &result)) {
-                return result;
-            }
-        }
-        return std::nullopt;
+        return get_accessible_string_property(cbindgen_private::AccessibleStringProperty::Label);
     }
 
     /// Returns the accessible-value of that element, if any.
     std::optional<SharedString> accessible_value() const
     {
-        if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            SharedString result;
-            if (item->item_tree.vtable()->accessible_string_property(
-                        item->item_tree.borrow(), item->index,
-                        cbindgen_private::AccessibleStringProperty::Value, &result)) {
-                return result;
-            }
-        }
-        return std::nullopt;
+        return get_accessible_string_property(cbindgen_private::AccessibleStringProperty::Value);
     }
 
     /// Returns the accessible-description of that element, if any.
     std::optional<SharedString> accessible_description() const
     {
-        if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            SharedString result;
-            if (item->item_tree.vtable()->accessible_string_property(
-                        item->item_tree.borrow(), item->index,
-                        cbindgen_private::AccessibleStringProperty::Description, &result)) {
-                return result;
-            }
-        }
-        return std::nullopt;
+        return get_accessible_string_property(
+                cbindgen_private::AccessibleStringProperty::Description);
     }
 
     /// Returns the accessible-value-maximum of that element, if any.
     std::optional<float> accessible_value_maximum() const
     {
-        if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            SharedString result;
-            if (item->item_tree.vtable()->accessible_string_property(
-                        item->item_tree.borrow(), item->index,
-                        cbindgen_private::AccessibleStringProperty::ValueMaximum, &result)) {
-                float value = 0.0;
-                if (cbindgen_private::slint_string_to_float(&result, &value)) {
-                    return value;
-                }
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::ValueMaximum)) {
+            float value = 0.0;
+            if (cbindgen_private::slint_string_to_float(&*result, &value)) {
+                return value;
             }
         }
         return std::nullopt;
@@ -212,15 +185,11 @@ public:
     /// Returns the accessible-value-minimum of that element, if any.
     std::optional<float> accessible_value_minimum() const
     {
-        if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            SharedString result;
-            if (item->item_tree.vtable()->accessible_string_property(
-                        item->item_tree.borrow(), item->index,
-                        cbindgen_private::AccessibleStringProperty::ValueMinimum, &result)) {
-                float value = 0.0;
-                if (cbindgen_private::slint_string_to_float(&result, &value)) {
-                    return value;
-                }
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::ValueMinimum)) {
+            float value = 0.0;
+            if (cbindgen_private::slint_string_to_float(&*result, &value)) {
+                return value;
             }
         }
         return std::nullopt;
@@ -229,15 +198,11 @@ public:
     /// Returns the accessible-value-step of that element, if any.
     std::optional<float> accessible_value_step() const
     {
-        if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            SharedString result;
-            if (item->item_tree.vtable()->accessible_string_property(
-                        item->item_tree.borrow(), item->index,
-                        cbindgen_private::AccessibleStringProperty::ValueStep, &result)) {
-                float value = 0.0;
-                if (cbindgen_private::slint_string_to_float(&result, &value)) {
-                    return value;
-                }
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::ValueStep)) {
+            float value = 0.0;
+            if (cbindgen_private::slint_string_to_float(&*result, &value)) {
+                return value;
             }
         }
         return std::nullopt;
@@ -246,16 +211,12 @@ public:
     /// Returns the accessible-checked of that element, if any.
     std::optional<bool> accessible_checked() const
     {
-        if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            SharedString result;
-            if (item->item_tree.vtable()->accessible_string_property(
-                        item->item_tree.borrow(), item->index,
-                        cbindgen_private::AccessibleStringProperty::Checked, &result)) {
-                if (result == "true")
-                    return true;
-                else if (result == "false")
-                    return false;
-            }
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::Checked)) {
+            if (*result == "true")
+                return true;
+            else if (*result == "false")
+                return false;
         }
         return std::nullopt;
     }
@@ -263,16 +224,12 @@ public:
     /// Returns the accessible-checkable of that element, if any.
     std::optional<bool> accessible_checkable() const
     {
-        if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            SharedString result;
-            if (item->item_tree.vtable()->accessible_string_property(
-                        item->item_tree.borrow(), item->index,
-                        cbindgen_private::AccessibleStringProperty::Checkable, &result)) {
-                if (result == "true")
-                    return true;
-                else if (result == "false")
-                    return false;
-            }
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::Checkable)) {
+            if (*result == "true")
+                return true;
+            else if (*result == "false")
+                return false;
         }
         return std::nullopt;
     }
@@ -282,6 +239,8 @@ public:
     /// Setting the value will invoke the `accessible-action-set-value` callback.
     void set_accessible_value(SharedString value) const
     {
+        if (inner.element_index != 0)
+            return;
         if (auto item = private_api::upgrade_item_weak(inner.item)) {
             union SetValueHelper {
                 cbindgen_private::AccessibilityAction action;
@@ -303,6 +262,8 @@ public:
     /// (`accessible-action-increment`).
     void invoke_accessible_increment_action() const
     {
+        if (inner.element_index != 0)
+            return;
         if (auto item = private_api::upgrade_item_weak(inner.item)) {
             union IncreaseActionHelper {
                 cbindgen_private::AccessibilityAction action;
@@ -322,6 +283,8 @@ public:
     /// (`accessible-action-decrement`).
     void invoke_accessible_decrement_action() const
     {
+        if (inner.element_index != 0)
+            return;
         if (auto item = private_api::upgrade_item_weak(inner.item)) {
             union DecreaseActionHelper {
                 cbindgen_private::AccessibilityAction action;
@@ -341,6 +304,8 @@ public:
     /// (`accessible-action-default`).
     void invoke_accessible_default_action() const
     {
+        if (inner.element_index != 0)
+            return;
         if (auto item = private_api::upgrade_item_weak(inner.item)) {
             union DefaultActionHelper {
                 cbindgen_private::AccessibilityAction action;
@@ -380,8 +345,23 @@ public:
         }
         return LogicalPosition({ 0, 0 });
     }
-};
 
+private:
+    std::optional<SharedString>
+    get_accessible_string_property(cbindgen_private::AccessibleStringProperty what) const
+    {
+        if (inner.element_index != 0)
+            return std::nullopt;
+        if (auto item = private_api::upgrade_item_weak(inner.item)) {
+            SharedString result;
+            if (item->item_tree.vtable()->accessible_string_property(item->item_tree.borrow(),
+                                                                     item->index, what, &result)) {
+                return result;
+            }
+        }
+        return std::nullopt;
+    }
+};
 }
 
 #    endif // SLINT_FEATURE_EXPERIMENTAL

--- a/examples/todo/cpp/CMakeLists.txt
+++ b/examples/todo/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(todo main.cpp)
 target_link_libraries(todo PRIVATE todo_lib)
 
 
-if(SLINT_BUILD_TESTING AND SLINT_FEATURE_TESTING AND SLINT_FEATURE_EXPERIMENAL)
+if(SLINT_BUILD_TESTING AND SLINT_FEATURE_TESTING AND SLINT_FEATURE_EXPERIMENTAL)
     add_executable(test_todo_basic tests/test_todo_basic.cpp)
     target_link_libraries(test_todo_basic PRIVATE Catch2::Catch2 todo_lib)
     add_test(NAME test_todo_basic COMMAND test_todo_basic)

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -304,6 +304,9 @@ impl ElementHandle {
     /// }
     /// ```
     pub fn invoke_accessible_default_action(&self) {
+        if self.element_index != 0 {
+            return;
+        }
         if let Some(item) = self.item.upgrade() {
             item.accessible_action(&AccessibilityAction::Default)
         }
@@ -311,6 +314,9 @@ impl ElementHandle {
 
     /// Returns the value of the element's `accessible-value` property, if present.
     pub fn accessible_value(&self) -> Option<SharedString> {
+        if self.element_index != 0 {
+            return None;
+        }
         self.item
             .upgrade()
             .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Value))
@@ -319,6 +325,9 @@ impl ElementHandle {
     /// Sets the value of the element's `accessible-value` property. Note that you can only set this
     /// property if it is declared in your Slint code.
     pub fn set_accessible_value(&self, value: impl Into<SharedString>) {
+        if self.element_index != 0 {
+            return;
+        }
         if let Some(item) = self.item.upgrade() {
             item.accessible_action(&AccessibilityAction::SetValue(value.into()))
         }
@@ -326,6 +335,9 @@ impl ElementHandle {
 
     /// Returns the value of the element's `accessible-value-maximum` property, if present.
     pub fn accessible_value_maximum(&self) -> Option<f32> {
+        if self.element_index != 0 {
+            return None;
+        }
         self.item.upgrade().and_then(|item| {
             item.accessible_string_property(AccessibleStringProperty::ValueMaximum)
                 .and_then(|item| item.parse().ok())
@@ -334,6 +346,9 @@ impl ElementHandle {
 
     /// Returns the value of the element's `accessible-value-minimum` property, if present.
     pub fn accessible_value_minimum(&self) -> Option<f32> {
+        if self.element_index != 0 {
+            return None;
+        }
         self.item.upgrade().and_then(|item| {
             item.accessible_string_property(AccessibleStringProperty::ValueMinimum)
                 .and_then(|item| item.parse().ok())
@@ -342,6 +357,9 @@ impl ElementHandle {
 
     /// Returns the value of the element's `accessible-value-step` property, if present.
     pub fn accessible_value_step(&self) -> Option<f32> {
+        if self.element_index != 0 {
+            return None;
+        }
         self.item.upgrade().and_then(|item| {
             item.accessible_string_property(AccessibleStringProperty::ValueStep)
                 .and_then(|item| item.parse().ok())
@@ -350,6 +368,9 @@ impl ElementHandle {
 
     /// Returns the value of the `accessible-label` property, if present.
     pub fn accessible_label(&self) -> Option<SharedString> {
+        if self.element_index != 0 {
+            return None;
+        }
         self.item
             .upgrade()
             .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Label))
@@ -357,6 +378,9 @@ impl ElementHandle {
 
     /// Returns the value of the `accessible-description` property, if present
     pub fn accessible_description(&self) -> Option<SharedString> {
+        if self.element_index != 0 {
+            return None;
+        }
         self.item
             .upgrade()
             .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Description))
@@ -364,6 +388,9 @@ impl ElementHandle {
 
     /// Returns the value of the `accessible-checked` property, if present
     pub fn accessible_checked(&self) -> Option<bool> {
+        if self.element_index != 0 {
+            return None;
+        }
         self.item
             .upgrade()
             .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Checked))
@@ -372,6 +399,9 @@ impl ElementHandle {
 
     /// Returns the value of the `accessible-checkable` property, if present
     pub fn accessible_checkable(&self) -> Option<bool> {
+        if self.element_index != 0 {
+            return None;
+        }
         self.item
             .upgrade()
             .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Checkable))
@@ -406,6 +436,9 @@ impl ElementHandle {
     /// Invokes the element's `accessible-action-increment` callback, if declared. On widgets such as spinboxes, this
     /// typically increments the value.
     pub fn invoke_accessible_increment_action(&self) {
+        if self.element_index != 0 {
+            return;
+        }
         if let Some(item) = self.item.upgrade() {
             item.accessible_action(&AccessibilityAction::Increment)
         }
@@ -414,6 +447,9 @@ impl ElementHandle {
     /// Invokes the element's `accessible-action-decrement` callback, if declared. On widgets such as spinboxes, this
     /// typically decrements the value.
     pub fn invoke_accessible_decrement_action(&self) {
+        if self.element_index != 0 {
+            return;
+        }
         if let Some(item) = self.item.upgrade() {
             item.accessible_action(&AccessibilityAction::Decrement)
         }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -731,7 +731,7 @@ pub fn pretty_print(
     if e.is_component_placeholder {
         write!(f, "/* Component Placeholder */ ")?;
     }
-    writeln!(f, "{} := {} {{", e.id, e.base_type)?;
+    writeln!(f, "{} := {} {{  /* {} */", e.id, e.base_type, e.element_infos())?;
     let mut indentation = indentation + 1;
     macro_rules! indent {
         () => {

--- a/tests/cases/testing/find_by_element_id_or_type.slint
+++ b/tests/cases/testing/find_by_element_id_or_type.slint
@@ -9,6 +9,7 @@ component Button inherits ButtonBase {
     extra-label := Text {
         accessible-label: "extra";
     }
+    inner-rect := Rectangle {}
 }
 
 export component TestCase {
@@ -47,6 +48,16 @@ assert_eq!(id_search_result[0].bases().unwrap().collect::<Vec<_>>(), ["ButtonBas
 
 let texts = slint_testing::ElementHandle::find_by_element_type_name(&instance, "Text").filter_map(|elem| elem.accessible_label()).collect::<Vec<_>>();
 assert_eq!(texts, vec!["optimized", "extra", "plain", "extra", "third", "extra"]);
+
+let inner_rects = slint_testing::ElementHandle::find_by_element_id(&instance, "Button::inner-rect").collect::<Vec<_>>();
+assert_eq!(inner_rects.len(), 3);
+for x in inner_rects {
+    assert_eq!(x.type_name().unwrap(), "Rectangle");
+    assert_eq!(x.id().unwrap(), "Button::inner-rect");
+    assert_eq!(x.bases().unwrap().next(), None);
+    assert_eq!(x.accessible_label(), None);
+    assert_eq!(x.accessible_description(), None);
+}
 ```
 
 ```cpp
@@ -72,5 +83,15 @@ assert_eq(*id_search_result[0].id(), "TestCase::second");
 assert_eq((*id_search_result[0].bases()).size(), 2);
 assert_eq((*id_search_result[0].bases())[0], "ButtonBase");
 assert_eq((*id_search_result[0].bases())[1], "Text");
+
+auto inner_rects = slint::testing::ElementHandle::find_by_element_id(handle, "Button::inner-rect");
+assert_eq(inner_rects.size(), 3);
+for (auto x : inner_rects) {
+    assert_eq(*x.type_name(), "Rectangle");
+    assert_eq(*x.id(), "Button::inner-rect");
+    assert_eq(x.bases()->size(), 0);
+    assert(!x.accessible_label());
+    assert(!x.accessible_description());
+}
 ```
 */


### PR DESCRIPTION
This fix the C++ todo test that wasn't run because of a typo

When an element is optimized in another one, only the first one should report the accessible properties. (because element with accessible properties cannot be optimized so they are always the first)