### PR TITLE
Make it possible to retrieve a SharedImageBuffer for a slint::Image in Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project are documented in this file.
 
  - Added missing implementation of the `Error` for some of the errors
  - allow all clippy warnings in generated code
+ - Add `slint::Image::image_buffer()` getter to obtain pixels for a `slint::Image` if available.
 
 ### Node API
 

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -211,7 +211,8 @@ pub use i_slint_core::component_factory::ComponentFactory;
 pub use i_slint_core::graphics::{BorrowedOpenGLTextureBuilder, BorrowedOpenGLTextureOrigin};
 // keep in sync with internal/interpreter/api.rs
 pub use i_slint_core::graphics::{
-    Brush, Color, Image, LoadImageError, Rgb8Pixel, Rgba8Pixel, RgbaColor, SharedPixelBuffer,
+    Brush, Color, Image, LoadImageError, Rgb8Pixel, Rgba8Pixel, RgbaColor, SharedImageBuffer,
+    SharedPixelBuffer,
 };
 pub use i_slint_core::model::{
     FilterModel, MapModel, Model, ModelExt, ModelNotify, ModelPeer, ModelRc, ModelTracker,

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -21,7 +21,8 @@ pub use i_slint_compiler::diagnostics::{Diagnostic, DiagnosticLevel};
 pub use i_slint_core::api::*;
 // keep in sync with api/rs/slint/lib.rs
 pub use i_slint_core::graphics::{
-    Brush, Color, Image, LoadImageError, Rgb8Pixel, Rgba8Pixel, RgbaColor, SharedPixelBuffer,
+    Brush, Color, Image, LoadImageError, Rgb8Pixel, Rgba8Pixel, RgbaColor, SharedImageBuffer,
+    SharedPixelBuffer,
 };
 use i_slint_core::items::*;
 


### PR DESCRIPTION
This change exposes functionality of already existing internal API that all renderers use to obtain pixels for upload to the screen - so it's rather well tested.

This also exposes the `SharedImageBuffer` API, an enum that represents different SharedPixelBuffer encodings.