### PR TITLE
Add char-wrap functionality to text wrapping

### DIFF
--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -9,6 +9,7 @@ use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::{Renderer, RendererSealed};
 use i_slint_core::window::{InputMethodRequest, WindowAdapter, WindowAdapterInternal};
 
+use i_slint_core::items::TextWrap;
 use std::cell::{Cell, RefCell};
 use std::pin::Pin;
 use std::rc::Rc;
@@ -150,7 +151,7 @@ impl RendererSealed for TestingWindow {
         text: &str,
         _max_width: Option<LogicalLength>,
         _scale_factor: ScaleFactor,
-        _wrap_anywhere: bool,
+        _text_wrap: TextWrap,
     ) -> LogicalSize {
         LogicalSize::new(text.len() as f32 * 10., 10.)
     }

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -150,6 +150,7 @@ impl RendererSealed for TestingWindow {
         text: &str,
         _max_width: Option<LogicalLength>,
         _scale_factor: ScaleFactor,
+        _wrap_anywhere: bool,
     ) -> LogicalSize {
         LogicalSize::new(text.len() as f32 * 10., 10.)
     }

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -46,6 +46,8 @@ macro_rules! for_each_enums {
                 NoWrap,
                 /// The text will be wrapped at word boundaries.
                 WordWrap,
+                /// The text will be wrapped at any character.
+                CharWrap,
             }
 
             /// This enum describes the how the text appear if it is too wide to fit in the [`Text`](elements.md#text) width.

--- a/internal/compiler/widgets/common/textedit-base.slint
+++ b/internal/compiler/widgets/common/textedit-base.slint
@@ -61,7 +61,7 @@ export component TextEditBase inherits Rectangle {
         y: root.scroll-view-padding;
         width: parent.width - 2 * root.scroll-view-padding;
         height: parent.height - 2 * root.scroll-view-padding;
-        viewport-width: root.wrap == TextWrap.word-wrap ? self.visible-width : max(self.visible-width, text-input.preferred-width);
+        viewport-width: root.wrap == TextWrap.no-wrap ? max(self.visible-width, text-input.preferred-width) : self.visible-width;
         viewport-height: max(self.visible-height, text-input.preferred-height);
 
         text-input := TextInput {

--- a/internal/compiler/widgets/cupertino-base/textedit.slint
+++ b/internal/compiler/widgets/cupertino-base/textedit.slint
@@ -138,7 +138,7 @@ export component TextEdit {
         y: 8px;
         width: parent.width - 16px;
         height: parent.height - 16px;
-        viewport-width: root.wrap == TextWrap.word-wrap ? self.visible-width : max(self.visible-width, text-input.preferred-width);
+        viewport-width: root.wrap == TextWrap.no-wrap ? max(self.visible-width, text-input.preferred-width) : self.visible-width;
         viewport-height: max(self.visible-height, text-input.preferred-height);
 
         text-input := TextInput {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -68,13 +68,13 @@ impl Item for Text {
         window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let window_inner = WindowInner::from_pub(window_adapter.window());
-        let implicit_size = |max_width, wrap_anywhere| {
+        let implicit_size = |max_width, text_wrap| {
             window_adapter.renderer().text_size(
                 self.font_request(window_inner),
                 self.text().as_str(),
                 max_width,
                 ScaleFactor::new(window_adapter.window().scale_factor()),
-                wrap_anywhere,
+                text_wrap,
             )
         };
 
@@ -83,7 +83,7 @@ impl Item for Text {
         // letters will be cut off, apply the ceiling here.
         match orientation {
             Orientation::Horizontal => {
-                let implicit_size = implicit_size(None, false);
+                let implicit_size = implicit_size(None, TextWrap::NoWrap);
                 let min = match self.overflow() {
                     TextOverflow::Elide => implicit_size.width.min(
                         window_adapter
@@ -93,7 +93,7 @@ impl Item for Text {
                                 "…",
                                 None,
                                 ScaleFactor::new(window_inner.scale_factor()),
-                                false,
+                                TextWrap::NoWrap,
                             )
                             .width,
                     ),
@@ -110,9 +110,13 @@ impl Item for Text {
             }
             Orientation::Vertical => {
                 let h = match self.wrap() {
-                    TextWrap::NoWrap => implicit_size(None, false).height,
-                    TextWrap::WordWrap => implicit_size(Some(self.width()), false).height,
-                    TextWrap::CharWrap => implicit_size(Some(self.width()), true).height,
+                    TextWrap::NoWrap => implicit_size(None, TextWrap::NoWrap).height,
+                    TextWrap::WordWrap => {
+                        implicit_size(Some(self.width()), TextWrap::WordWrap).height
+                    }
+                    TextWrap::CharWrap => {
+                        implicit_size(Some(self.width()), TextWrap::CharWrap).height
+                    }
                 }
                 .ceil();
                 LayoutInfo { min: h, preferred: h, ..LayoutInfo::default() }
@@ -300,7 +304,7 @@ impl Item for TextInput {
         window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
         let text = self.text();
-        let implicit_size = |max_width, wrap_anywhere| {
+        let implicit_size = |max_width, text_wrap| {
             window_adapter.renderer().text_size(
                 self.font_request(window_adapter),
                 {
@@ -312,7 +316,7 @@ impl Item for TextInput {
                 },
                 max_width,
                 ScaleFactor::new(window_adapter.window().scale_factor()),
-                wrap_anywhere,
+                text_wrap,
             )
         };
 
@@ -321,7 +325,7 @@ impl Item for TextInput {
         // letters will be cut off, apply the ceiling here.
         match orientation {
             Orientation::Horizontal => {
-                let implicit_size = implicit_size(None, false);
+                let implicit_size = implicit_size(None, TextWrap::NoWrap);
                 let min = match self.wrap() {
                     TextWrap::NoWrap => implicit_size.width,
                     TextWrap::WordWrap | TextWrap::CharWrap => 0 as Coord,
@@ -334,9 +338,13 @@ impl Item for TextInput {
             }
             Orientation::Vertical => {
                 let h = match self.wrap() {
-                    TextWrap::NoWrap => implicit_size(None, false).height,
-                    TextWrap::WordWrap => implicit_size(Some(self.width()), false).height,
-                    TextWrap::CharWrap => implicit_size(Some(self.width()), true).height,
+                    TextWrap::NoWrap => implicit_size(None, TextWrap::NoWrap).height,
+                    TextWrap::WordWrap => {
+                        implicit_size(Some(self.width()), TextWrap::WordWrap).height
+                    }
+                    TextWrap::CharWrap => {
+                        implicit_size(Some(self.width()), TextWrap::CharWrap).height
+                    }
                 }
                 .ceil();
                 LayoutInfo { min: h, preferred: h, ..LayoutInfo::default() }
@@ -922,7 +930,7 @@ impl TextInput {
                 " ",
                 None,
                 ScaleFactor::new(window_adapter.window().scale_factor()),
-                false,
+                TextWrap::NoWrap,
             )
             .height;
 

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -8,6 +8,7 @@ use core::pin::Pin;
 
 use crate::api::PlatformError;
 use crate::item_tree::ItemTreeRef;
+use crate::items::TextWrap;
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
 use crate::window::WindowAdapter;
 
@@ -25,16 +26,15 @@ impl<T: RendererSealed> Renderer for T {}
 /// users to re-implement these functions.
 pub trait RendererSealed {
     /// Returns the size of the given text in logical pixels.
-    /// When set, `max_width` means that one need to wrap the text, so it does not go further than that.
-    /// When set, `wrap_anywhere` means that the text wrapping will occur at any given character, instead of
-    /// only at word boundaries.
+    /// When set, `max_width` means that one need to wrap the text, so it does not go further than that,
+    /// using the wrapping type passed by `text_wrap`.
     fn text_size(
         &self,
         font_request: crate::graphics::FontRequest,
         text: &str,
         max_width: Option<LogicalLength>,
         scale_factor: ScaleFactor,
-        wrap_anywhere: bool,
+        text_wrap: TextWrap,
     ) -> LogicalSize;
 
     /// Returns the (UTF-8) byte offset in the text property that refers to the character that contributed to

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -25,13 +25,16 @@ impl<T: RendererSealed> Renderer for T {}
 /// users to re-implement these functions.
 pub trait RendererSealed {
     /// Returns the size of the given text in logical pixels.
-    /// When set, `max_width` means that one need to wrap the text so it does not go further than that
+    /// When set, `max_width` means that one need to wrap the text, so it does not go further than that.
+    /// When set, `wrap_anywhere` means that the text wrapping will occur at any given character, instead of
+    /// only at word boundaries.
     fn text_size(
         &self,
         font_request: crate::graphics::FontRequest,
         text: &str,
         max_width: Option<LogicalLength>,
         scale_factor: ScaleFactor,
+        wrap_anywhere: bool,
     ) -> LogicalSize;
 
     /// Returns the (UTF-8) byte offset in the text property that refers to the character that contributed to

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -615,9 +615,9 @@ impl RendererSealed for SoftwareRenderer {
         text: &str,
         max_width: Option<LogicalLength>,
         scale_factor: ScaleFactor,
-        _wrap_anywhere: bool, //TODO: Add support for char-wrap
+        wrap_anywhere: bool,
     ) -> LogicalSize {
-        fonts::text_size(font_request, text, max_width, scale_factor)
+        fonts::text_size(font_request, text, max_width, scale_factor, wrap_anywhere)
     }
 
     fn text_input_byte_offset_for_position(

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -615,6 +615,7 @@ impl RendererSealed for SoftwareRenderer {
         text: &str,
         max_width: Option<LogicalLength>,
         scale_factor: ScaleFactor,
+        _wrap_anywhere: bool, //TODO: Add support for char-wrap
     ) -> LogicalSize {
         fonts::text_size(font_request, text, max_width, scale_factor)
     }

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -16,7 +16,7 @@ use crate::api::Window;
 use crate::graphics::rendering_metrics_collector::{RefreshMode, RenderingMetricsCollector};
 use crate::graphics::{BorderRadius, PixelFormat, SharedImageBuffer, SharedPixelBuffer};
 use crate::item_rendering::{CachedRenderingData, DirtyRegion, RenderBorderRectangle, RenderImage};
-use crate::items::{ItemRc, TextOverflow};
+use crate::items::{ItemRc, TextOverflow, TextWrap};
 use crate::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector,
     PhysicalPx, PointLengths, RectLengths, ScaleFactor, SizeLengths,
@@ -615,9 +615,9 @@ impl RendererSealed for SoftwareRenderer {
         text: &str,
         max_width: Option<LogicalLength>,
         scale_factor: ScaleFactor,
-        wrap_anywhere: bool,
+        text_wrap: TextWrap,
     ) -> LogicalSize {
-        fonts::text_size(font_request, text, max_width, scale_factor, wrap_anywhere)
+        fonts::text_size(font_request, text, max_width, scale_factor, text_wrap)
     }
 
     fn text_input_byte_offset_for_position(

--- a/internal/core/software_renderer/fonts.rs
+++ b/internal/core/software_renderer/fonts.rs
@@ -11,6 +11,7 @@ use crate::thread_local_ as thread_local;
 
 use super::{PhysicalLength, PhysicalSize};
 use crate::graphics::{BitmapFont, FontRequest};
+use crate::items::TextWrap;
 use crate::lengths::{LogicalLength, LogicalSize, ScaleFactor};
 use crate::textlayout::TextLayout;
 use crate::Coord;
@@ -147,7 +148,7 @@ pub fn text_size(
     text: &str,
     max_width: Option<LogicalLength>,
     scale_factor: ScaleFactor,
-    wrap_anywhere: bool,
+    text_wrap: TextWrap,
 ) -> LogicalSize {
     let font = match_font(&font_request, scale_factor);
     let (longest_line_width, height) = match font {
@@ -156,7 +157,7 @@ pub fn text_size(
             layout.text_size(
                 text,
                 max_width.map(|max_width| (max_width.cast() * scale_factor).cast()),
-                wrap_anywhere,
+                text_wrap,
             )
         }
         #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
@@ -165,7 +166,7 @@ pub fn text_size(
             layout.text_size(
                 text,
                 max_width.map(|max_width| (max_width.cast() * scale_factor).cast()),
-                wrap_anywhere,
+                text_wrap,
             )
         }
     };

--- a/internal/core/software_renderer/fonts.rs
+++ b/internal/core/software_renderer/fonts.rs
@@ -147,6 +147,7 @@ pub fn text_size(
     text: &str,
     max_width: Option<LogicalLength>,
     scale_factor: ScaleFactor,
+    wrap_anywhere: bool,
 ) -> LogicalSize {
     let font = match_font(&font_request, scale_factor);
     let (longest_line_width, height) = match font {
@@ -155,6 +156,7 @@ pub fn text_size(
             layout.text_size(
                 text,
                 max_width.map(|max_width| (max_width.cast() * scale_factor).cast()),
+                wrap_anywhere,
             )
         }
         #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
@@ -163,6 +165,7 @@ pub fn text_size(
             layout.text_size(
                 text,
                 max_width.map(|max_width| (max_width.cast() * scale_factor).cast()),
+                wrap_anywhere,
             )
         }
     };

--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -114,7 +114,7 @@ impl<'a, Font: AbstractFont> TextParagraphLayout<'a, Font> {
         ) -> core::ops::ControlFlow<R>,
         selection: Option<core::ops::Range<usize>>,
     ) -> Result<Font::Length, R> {
-        let wrap = self.wrap == TextWrap::WordWrap;
+        let wrap = self.wrap != TextWrap::NoWrap;
         let elide = self.overflow == TextOverflow::Elide;
         let elide_glyph = if elide {
             self.layout.font.glyph_for_char('…').filter(|glyph| glyph.glyph_id.is_some())

--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -62,7 +62,7 @@ impl<'a, Font: AbstractFont> TextLayout<'a, Font> {
         &self,
         text: &str,
         max_width: Option<Font::Length>,
-        wrap_anywhere: bool,
+        text_wrap: TextWrap,
     ) -> (Font::Length, Font::Length)
     where
         Font::Length: core::fmt::Debug,
@@ -71,9 +71,7 @@ impl<'a, Font: AbstractFont> TextLayout<'a, Font> {
         let mut line_count: i16 = 0;
         let shape_buffer = ShapeBuffer::new(self, text);
 
-        for line in
-            TextLineBreaker::<Font>::new(text, &shape_buffer, max_width, None, wrap_anywhere)
-        {
+        for line in TextLineBreaker::<Font>::new(text, &shape_buffer, max_width, None, text_wrap) {
             max_line_width = euclid::approxord::max(max_line_width, line.text_width);
             line_count += 1;
         }
@@ -135,7 +133,7 @@ impl<'a, Font: AbstractFont> TextParagraphLayout<'a, Font> {
                 &shape_buffer,
                 if wrap { Some(self.max_width) } else { None },
                 if elide { Some(self.layout.font.max_lines(self.max_height)) } else { None },
-                self.wrap == TextWrap::CharWrap,
+                self.wrap,
             )
         };
         let mut text_lines = None;

--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -62,6 +62,7 @@ impl<'a, Font: AbstractFont> TextLayout<'a, Font> {
         &self,
         text: &str,
         max_width: Option<Font::Length>,
+        wrap_anywhere: bool,
     ) -> (Font::Length, Font::Length)
     where
         Font::Length: core::fmt::Debug,
@@ -70,7 +71,9 @@ impl<'a, Font: AbstractFont> TextLayout<'a, Font> {
         let mut line_count: i16 = 0;
         let shape_buffer = ShapeBuffer::new(self, text);
 
-        for line in TextLineBreaker::<Font>::new(text, &shape_buffer, max_width, None) {
+        for line in
+            TextLineBreaker::<Font>::new(text, &shape_buffer, max_width, None, wrap_anywhere)
+        {
             max_line_width = euclid::approxord::max(max_line_width, line.text_width);
             line_count += 1;
         }
@@ -132,6 +135,7 @@ impl<'a, Font: AbstractFont> TextParagraphLayout<'a, Font> {
                 &shape_buffer,
                 if wrap { Some(self.max_width) } else { None },
                 if elide { Some(self.layout.font.max_lines(self.max_height)) } else { None },
+                self.wrap == TextWrap::CharWrap,
             )
         };
         let mut text_lines = None;

--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -564,7 +564,7 @@ pub(crate) fn layout_text_lines(
     paint: &femtovg::Paint,
     mut layout_line: impl FnMut(&str, PhysicalPoint, usize, &femtovg::TextMetrics),
 ) -> PhysicalLength {
-    let wrap = wrap == TextWrap::WordWrap;
+    let wrap = wrap != TextWrap::NoWrap;
     let elide = overflow == TextOverflow::Elide;
 
     let max_width = max_size.width_length();

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -365,6 +365,7 @@ impl RendererSealed for FemtoVGRenderer {
         text: &str,
         max_width: Option<LogicalLength>,
         scale_factor: ScaleFactor,
+        _wrap_anywhere: bool, //TODO: Add support for char-wrap
     ) -> LogicalSize {
         crate::fonts::text_size(&font_request, scale_factor, text, max_width)
     }

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -15,6 +15,7 @@ use i_slint_core::graphics::BorderRadius;
 use i_slint_core::graphics::FontRequest;
 use i_slint_core::graphics::{euclid, rendering_metrics_collector::RenderingMetricsCollector};
 use i_slint_core::item_rendering::ItemRenderer;
+use i_slint_core::items::TextWrap;
 use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PhysicalPx, ScaleFactor,
 };
@@ -365,7 +366,7 @@ impl RendererSealed for FemtoVGRenderer {
         text: &str,
         max_width: Option<LogicalLength>,
         scale_factor: ScaleFactor,
-        _wrap_anywhere: bool, //TODO: Add support for char-wrap
+        _text_wrap: TextWrap, //TODO: Add support for char-wrap
     ) -> LogicalSize {
         crate::fonts::text_size(&font_request, scale_factor, text, max_width)
     }

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -355,6 +355,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         text: &str,
         max_width: Option<LogicalLength>,
         scale_factor: ScaleFactor,
+        _wrap_anywhere: bool, //TODO: Add support for char-wrap
     ) -> LogicalSize {
         let (layout, _) = textlayout::create_layout(
             font_request,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -47,6 +47,7 @@ pub mod vulkan_surface;
 
 pub mod opengl_surface;
 
+use i_slint_core::items::TextWrap;
 pub use skia_safe;
 
 cfg_if::cfg_if! {
@@ -355,7 +356,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         text: &str,
         max_width: Option<LogicalLength>,
         scale_factor: ScaleFactor,
-        _wrap_anywhere: bool, //TODO: Add support for char-wrap
+        _text_wrap: TextWrap, //TODO: Add support for char-wrap
     ) -> LogicalSize {
         let (layout, _) = textlayout::create_layout(
             font_request,

--- a/internal/renderers/skia/textlayout.rs
+++ b/internal/renderers/skia/textlayout.rs
@@ -89,7 +89,7 @@ pub fn create_layout(
 
     if overflow == items::TextOverflow::Elide {
         style.set_ellipsis("…");
-        if wrap == items::TextWrap::WordWrap {
+        if wrap != items::TextWrap::NoWrap {
             let metrics = text_style.font_metrics();
             let line_height = metrics.descent - metrics.ascent + metrics.leading;
             style.set_max_lines((max_height.get() / line_height).floor() as usize);


### PR DESCRIPTION
As discussed in here https://github.com/slint-ui/slint/issues/5374, this PR adds the possibility of using character wrapping (aka wrap anywhere) with text. Prior to this, it was only possible to wrap at word boundaries.

This commit adds this functionality to both Qt and software renderer, with skia and femtovg missing it for now (falling back to word-wrap).

The trait RendererSealed  had to be changed to pass to text_size if using this new kind of wrapping.

This was based on GTK wrap mode which has the following options:
- GTK_WRAP_NONE -> Matches `no-wrap` on slint
- GTK_WRAP_CHAR -> Matches `char-wrap` with this PR (on Qt and software renderer for now)
- GTK_WRAP_WORD -> Matches `word-wrap` with Qt renderer (Qt supports WrapAtWordBoundaryOrAnywhere but would need Qt 6.3 as we use QFontMetrics to find the text size https://doc.qt.io/qt-6/qfontmetrics.html#boundingRect-2)
- GTK_WRAP_WORD_CHAR -> Matches `word-wrap` with the other renderers (Verified with software and femtovg).