### PR TITLE
slint-esp: Remove rotation parameter from older slint_esp_init overload

### DIFF
--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -67,7 +67,6 @@ struct SlintPlatformConfiguration
  *    will be drawn. Slint will take care to flush it to the screen
  * - `buffer2`, if specified, is a second buffer to be used with double buffering,
  *    both buffer1 and buffer2 should then be obtained with `esp_lcd_rgb_panel_get_frame_buffer`
- * - `rotation` applies a transformation while rendering in the buffer
  *
  * Note: For compatibility, this function overload selects RGB16 byte swapping if single-buffering
  * is selected as rendering method.
@@ -75,10 +74,7 @@ struct SlintPlatformConfiguration
 void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     std::optional<esp_lcd_touch_handle_t> touch,
                     std::span<slint::platform::Rgb565Pixel> buffer1,
-                    std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2 = {},
-                    slint::platform::SoftwareRenderer::RenderingRotation rotation = {}
-
-);
+                    std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2 = {});
 
 #ifdef SLINT_FEATURE_EXPERIMENTAL
 /**

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -322,8 +322,7 @@ TaskHandle_t EspPlatform::task = {};
 void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     std::optional<esp_lcd_touch_handle_t> touch,
                     std::span<slint::platform::Rgb565Pixel> buffer1,
-                    std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2,
-                    slint::platform::SoftwareRenderer::RenderingRotation rotation)
+                    std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2)
 {
 
     SlintPlatformConfiguration config {
@@ -332,7 +331,6 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
         .touch = touch,
         .buffer1 = buffer1,
         .buffer2 = buffer2,
-        .rotation = rotation,
         // For compatibility with earlier versions of Slint, we compute the value of
         // color_swap_16 the way it was implemented in Slint (slint-esp) <= 1.6.0:
         .color_swap_16 = buffer2.has_value()


### PR DESCRIPTION
Commit 88e1a366a305626c5151c5727aa4e29aae71d338 stabilized the rotation support and commit 1378d6e3bc16b4f9ee78d01861fd90190accc79a adds new API to select rotation in the esp-idf integration.

The previous rotation parameter was behind the experimental flag. Now that we have a "cleaner" API, we might as well remove the old experiment in favor of the newer API.