### PR TITLE
Fix links to widgets in AccessibleRole docs embedded in i-slint-backend-testing docs

### DIFF
--- a/docs/reference/conf.py
+++ b/docs/reference/conf.py
@@ -101,6 +101,7 @@ myst_url_schemes = {
     "slint-rust": f"https://slint.dev/releases/{version}/docs/rust/slint/{{{{path}}}}",
     "slint-build-rust": f"https://slint.dev/releases/{version}/docs/rust/slint_build/{{{{path}}}}",
     "slint-node": f"https://slint.dev/releases/{version}/docs/node/{{{{path}}}}",
+    "slint-reference": f"https://slint.dev/releases/{version}/docs/slint/{{{{path}}}}",
     'http': None, 'https': None, 'mailto': None,
 }
 

--- a/docs/resources/slint-docs-highlight.html
+++ b/docs/resources/slint-docs-highlight.html
@@ -97,5 +97,24 @@
         hljs.highlightElement(block)
       }
     }
+
+    // Fix up links that sphinx handles but for rustdoc we need to resolve manually:
+    {
+      let target_url = null;
+      if (document.location.hostname == "snapshots.slint.dev") {
+        target_url = `https://snapshots.slint.dev/master/docs/slint/`;
+      } else {
+        let version = document.querySelector("span.version");
+        if (version !== null) {
+          target_url = `https://slint.dev/releases/${version.innerText}/docs/slint/`;
+        }
+      }
+
+      if (target_url !== null) {
+        for (let link of document.querySelectorAll("a[href^='slint-reference:']")) {
+          link.href = link.href.replace("slint-reference:", target_url);
+        }
+      }
+    }
   });
 </script>

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -338,34 +338,34 @@ macro_rules! for_each_enums {
             enum AccessibleRole {
                 /// The element isn't accessible.
                 None,
-                /// The element is a [`Button`](../widgets/button.md) or behaves like one.
+                /// The element is a [`Button`](slint-reference:src/language/widgets/button) or behaves like one.
                 Button,
-                /// The element is a [`CheckBox`](../widgets/checkbox.md) or behaves like one.
+                /// The element is a [`CheckBox`](slint-reference:src/language/widgets/checkbox) or behaves like one.
                 Checkbox,
-                /// The element is a [`ComboBox`](../widgets/combobox.md) or behaves like one.
+                /// The element is a [`ComboBox`](slint-reference:src/language/widgets/combobox) or behaves like one.
                 Combobox,
-                /// The element is a [`ListView`](../widgets/listview.md) or behaves like one.
+                /// The element is a [`ListView`](slint-reference:src/language/widgets/listview) or behaves like one.
                 List,
-                /// The element is a [`Slider`](../widgets/slider.md) or behaves like one.
+                /// The element is a [`Slider`](slint-reference:src/language/widgets/slider) or behaves like one.
                 Slider,
-                /// The element is a [`SpinBox`](../widgets/spinbox.md) or behaves like one.
+                /// The element is a [`SpinBox`](slint-reference:src/language/widgets/spinbox) or behaves like one.
                 Spinbox,
-                /// The element is a [`Tab`](../widgets/tabwidget.md) or behaves like one.
+                /// The element is a [`Tab`](slint-reference:src/language/widgets/tabwidget) or behaves like one.
                 Tab,
-                /// The element is similar to the tab bar in a [`TabWidget`](../widgets/tabwidget.md).
+                /// The element is similar to the tab bar in a [`TabWidget`](slint-reference:src/language/widgets/tabwidget).
                 TabList,
-                /// The role for a [`Text`](elements.md#text) element. It's automatically applied.
+                /// The role for a [`Text`](slint-reference:src/language/builtins/elements#text) element. It's automatically applied.
                 Text,
-                /// The role for a [`TableView`](../widgets/standardtableview.md ) or behaves like one.
+                /// The role for a [`TableView`](slint-reference:src/language/widgets/standardtableview ) or behaves like one.
                 Table,
                 /// The role for a TreeView or behaves like one. (Not provided yet)
                 Tree,
-                /// The element is a [`ProgressIndicator`](../widgets/progressindicator.md) or behaves like one.
+                /// The element is a [`ProgressIndicator`](slint-reference:src/language/widgets/progressindicator) or behaves like one.
                 ProgressIndicator,
                 /// The role for widget with editable text such as a
-                /// [`LineEdit`](../widgets/lineedit.md) or a [`TextEdit`](../widgets/textedit.md)
+                /// [`LineEdit`](slint-reference:src/language/widgets/lineedit) or a [`TextEdit`](slint-reference:src/language/widgets/textedit)
                 TextInput,
-                /// The element is a [`Switch`](../widgets/switch.md) or behaves like one.
+                /// The element is a [`Switch`](slint-reference:src/language/widgets/switch) or behaves like one.
                 Switch,
             }
 


### PR DESCRIPTION
The relative links don't work, so use slint-reference: custom schemes that works with sphinx and is rewritten with JavaScript through injections.