### PR TITLE
Rust: Don't get the default font size through the root component

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -533,6 +533,7 @@ fn gen_corelib(
             "slint_windowrc_set_logical_size",
             "slint_windowrc_set_physical_size",
             "slint_windowrc_color_scheme",
+            "slint_windowrc_default_font_size",
             "slint_windowrc_dispatch_pointer_event",
             "slint_windowrc_dispatch_key_event",
             "slint_windowrc_dispatch_event",

--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -221,6 +221,11 @@ public:
         cbindgen_private::slint_register_bitmap_font(&inner, &font);
     }
 
+    inline float default_font_size() const
+    {
+        return cbindgen_private::slint_windowrc_default_font_size(&inner);
+    }
+
     /// \private
     const cbindgen_private::WindowAdapterRcOpaque &handle() const { return inner; }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2528,7 +2528,6 @@ fn access_window_field(ctx: &EvaluationContext) -> String {
 /// let access = access_member(...);
 /// format!("{access}(...)")
 /// ```
-
 fn access_member(reference: &llr::PropertyReference, ctx: &EvaluationContext) -> String {
     fn in_native_item(
         ctx: &EvaluationContext,
@@ -3076,15 +3075,10 @@ fn compile_builtin_function_call(
 
     match function {
         BuiltinFunction::GetWindowScaleFactor => {
-            let window = access_window_field(ctx);
-            format!("{}.scale_factor()", window)
+            format!("{}.scale_factor()", access_window_field(ctx))
         }
         BuiltinFunction::GetWindowDefaultFontSize => {
-            let window_item_name = ident(&ctx.public_component.item_tree.root.items[0].name);
-            format!(
-                "{}->{}.default_font_size.get()",
-                ctx.generator_state.root_access, window_item_name
-            )
+            format!("{}.default_font_size()", access_window_field(ctx))
         }
         BuiltinFunction::AnimationTick => "slint::cbindgen_private::slint_animation_tick()".into(),
         BuiltinFunction::Debug => {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2582,11 +2582,8 @@ fn compile_builtin_function_call(
             quote!(sp::WindowInner::from_pub(#window_adapter_tokens.window()).scale_factor())
         }
         BuiltinFunction::GetWindowDefaultFontSize => {
-            let window_item_name = ident(&ctx.public_component.item_tree.root.items[0].name);
-            let root_access = &ctx.generator_state;
-            let root_component_id = inner_component_id(&ctx.public_component.item_tree.root);
-            let item_field = access_component_field_offset(&root_component_id, &window_item_name);
-            quote!((#item_field + sp::WindowItem::FIELD_OFFSETS.default_font_size).apply_pin(#root_access.as_pin_ref()).get().get())
+            let window_adapter_tokens = access_window_adapter_field(ctx);
+            quote!(sp::WindowInner::from_pub(#window_adapter_tokens.window()).window_item().unwrap().as_pin_ref().default_font_size().get())
         }
         BuiltinFunction::AnimationTick => {
             quote!(sp::animation_tick())

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1473,6 +1473,15 @@ pub mod ffi {
             .map_or(ColorScheme::Unknown, |x| x.color_scheme())
     }
 
+    /// Return the default-font-size property of the WindowItem
+    #[no_mangle]
+    pub unsafe extern "C" fn slint_windowrc_default_font_size(
+        handle: *const WindowAdapterRcOpaque,
+    ) -> f32 {
+        let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
+        window_adapter.window().0.window_item().unwrap().as_pin_ref().default_font_size().get()
+    }
+
     /// Dispatch a key pressed or release event
     #[no_mangle]
     pub unsafe extern "C" fn slint_windowrc_dispatch_key_event(


### PR DESCRIPTION
Planning for multi-component support