### PR TITLE
Add i-slint-backend-testing to the list of published crates

### DIFF
--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -25,7 +25,7 @@ ffi = []
 system-testing = ["quick-protobuf", "pb-rs", "generational-arena", "async-net", "futures-lite", "byteorder"]
 
 [dependencies]
-i-slint-core = { workspace = true }
+i-slint-core = { workspace = true, features = ["std"] }
 vtable = { workspace = true }
 quick-protobuf = { version = "0.8.1", optional = true }
 generational-arena = { version = "0.2.9", optional = true }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -14,6 +14,7 @@ cargo publish --manifest-path api/rs/build/Cargo.toml
 cargo publish --manifest-path internal/backends/qt/Cargo.toml
 cargo publish --manifest-path internal/backends/linuxkms/Cargo.toml
 cargo publish --manifest-path internal/backends/android-activity/Cargo.toml --features native-activity
+cargo publish --manifest-path internal/backends/testing/Cargo.toml
 cargo publish --manifest-path internal/backends/selector/Cargo.toml --features backend-winit-x11,renderer-femtovg
 cargo publish --manifest-path internal/interpreter/Cargo.toml
 cargo publish --manifest-path api/rs/slint/Cargo.toml


### PR DESCRIPTION
(also add std to the required features of core, so it compiles out of the box)