### PR TITLE
CI: ensure that CI fails if there is a formatting error

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -68,6 +68,9 @@ jobs:
                   tool_name: xtask license_header
                   level: error
                   fail_on_error: true
+            # reviewdog should normally have errored out if there was any diff, but we've seen faillure in the past
+            - name: sanitycheck reviewdog
+              run: git diff --exit-code
             - run: sudo apt-get install reuse
             - name: Check reuse compliance
               run: cargo xtask check_reuse_compliance


### PR DESCRIPTION
reviewdog is not always failling