### PR TITLE
C++: move globals in a different struct

### DIFF
--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -99,11 +99,10 @@ public:
         cbindgen_private::slint_windowrc_set_focus_item(&inner, &item_rc, set_focus);
     }
 
-    template<typename Component>
-    void set_component(const Component &c) const
+    void set_component(const cbindgen_private::ItemTreeWeak &weak) const
     {
-        auto self_rc = (*c.self_weak.lock()).into_dyn();
-        slint_windowrc_set_component(&inner, &self_rc);
+        auto item_tree_rc = (*weak.lock()).into_dyn();
+        slint_windowrc_set_component(&inner, &item_tree_rc);
     }
 
     template<typename Component, typename Parent>


### PR DESCRIPTION
So that subcomponent don't depend on the root component name which will hallow to have several root components