### PR TITLE
Fix C++ build breakage caused by changed in `stringify!` output in ni…

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -141,7 +141,8 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
                 )*
                 $(
                     $(writeln!(file, "    ///{}", $pri_doc)?;)*
-                    let pri_type = match stringify!($pri_type) {
+                    let pri_type = stringify!($pri_type).replace(' ', "");
+                    let pri_type = match pri_type.as_str() {
                         "usize" => "uintptr_t",
                         "crate::animations::Instant" => "uint64_t",
                         // This shouldn't be accessed by the C++ anyway, just need to have the same ABI in a struct


### PR DESCRIPTION
…ghtly Rust

The C++ build started failling with nightly rust:
https://github.com/rust-lang/rust/pull/125174 changed the output of strignify! to contins more spaces between tokens, which we relied on to perform some type substitution from Rust types to C++ types, resulting in compilation errors:

```
build/api/cpp/generated_include/slint_builtin_structs_internal.h:71:5: error: ‘Option’ does not name a type
   71 |     Option < core :: ops :: Range < i32 >> replacement_range;
      |     ^~~~~~
build/api/cpp/generated_include/slint_builtin_structs_internal.h:75:14: error: ‘core’ was not declared in this scope
   75 |     Option < core :: ops :: Range < i32 >> preedit_selection;
      |              ^~~~
```

Workaround by cleaning whitespace before matching the types.