### PR TITLE
CI: Bump macos-11 to macos-12 images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,18 +25,18 @@ jobs:
             SLINT_EMIT_DEBUG_INFO: 1
         strategy:
             matrix:
-                os: [ubuntu-22.04, macos-11, windows-2022]
+                os: [ubuntu-22.04, macos-12, windows-2022]
                 rust_version: [stable, "1.73"]
                 include:
                     - os: windows-2022
                       extra_args: "--exclude ffmpeg --exclude gstreamer-player"
-                    - os: macos-11
+                    - os: macos-12
                       extra_args: "--exclude ffmpeg --exclude gstreamer-player"
                     - os: windows-2022
                       rust_version: "beta"
                       extra_args: "--exclude ffmpeg --exclude gstreamer-player"
                 exclude:
-                    - os: macos-11
+                    - os: macos-12
                       rust_version: "1.73"
 
         runs-on: ${{ matrix.os }}
@@ -102,7 +102,7 @@ jobs:
             RUST_BACKTRACE: 1
         strategy:
             matrix:
-                os: [ubuntu-22.04, macos-11, windows-2022]
+                os: [ubuntu-22.04, macos-12, windows-2022]
 
         runs-on: ${{ matrix.os }}
 
@@ -148,7 +148,7 @@ jobs:
             RUST_BACKTRACE: full
         strategy:
             matrix:
-                os: [ubuntu-22.04, macos-11, windows-2022]
+                os: [ubuntu-22.04, macos-12, windows-2022]
 
         runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -157,7 +157,7 @@ jobs:
 
     build_vscode_lsp_macos_bundle:
         needs: [build_vscode_lsp_macos_x86_64, build_vscode_lsp_macos_aarch64]
-        runs-on: macos-11
+        runs-on: macos-12
         steps:
             - uses: actions/checkout@v4
               with:
@@ -227,7 +227,7 @@ jobs:
                 build_vscode_cross_linux_lsp,
                 check-for-secrets,
             ]
-        runs-on: macos-11
+        runs-on: macos-12
         if: ${{ needs.check-for-secrets.outputs.has-openvsx-pat == 'yes' && needs.check-for-secrets.outputs.has-vscode-marketplace-pat == 'yes' }}
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
macos-11 will be removed end of June as per https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/