### PR TITLE
Spinner: simplify the arc path

### DIFF
--- a/internal/compiler/widgets/common/spinner-base.slint
+++ b/internal/compiler/widgets/common/spinner-base.slint
@@ -11,13 +11,11 @@ export component SpinnerBase {
         private property <float> radius: min(self.viewbox-width, self.viewbox-height) / 2;
         private property <float> start-x: self.viewbox-width / 2;
         private property <float> start-y: self.viewbox-height / 2;
-        private property <float> thickness: 2;
-        private property <float> inner-radius: self.radius - self.thickness;
         private property <float> start : !indeterminate ? 0 :
             1 * mod(animation-tick(), 3s) / 3s;
-        // min is a workaground to get filled circle by 1.0
-        private property <float> progress: !root.indeterminate ? min(0.999, root.progress) :
-            min(0.99, max(0.25, 1 * abs(sin(360deg * animation-tick() / 1.5s))));
+        // min is a workaround to get filled circle by 1.0
+        private property <float> progress: !root.indeterminate ? min(0.9999, root.progress) :
+            min(0.9999, max(0.20, 1 * abs(sin(360deg * animation-tick() / 1.5s))));
 
         viewbox-width: 100;
         viewbox-height: 100;
@@ -29,37 +27,13 @@ export component SpinnerBase {
             y: start-y - radius * cos(-path.start * 360deg);
         }
 
-        LineTo {
-            x: start-x - path.inner-radius * sin(-path.start * 360deg);
-            y: start-y - path.inner-radius * cos(-path.start * 360deg);
-        }
-
         ArcTo {
-            radius-x: path.inner-radius;
-            radius-y: path.inner-radius;
-            x: start-x - path.inner-radius * sin(-(path.start + path.progress) * 360deg);
-            y: start-y - path.inner-radius * cos(-(path.start + path.progress) * 360deg);
+            radius-x: path.radius;
+            radius-y: path.radius;
+            x: start-x - path.radius * sin(-(path.start + path.progress) * 360deg);
+            y: start-y - path.radius * cos(-(path.start + path.progress) * 360deg);
             sweep: path.progress > 0;
             large-arc: path.progress > 0.5;
-        }
-
-        LineTo {
-            x: start-x - radius * sin(-(path.start + path.progress) * 360deg);
-            y: start-y - radius * cos(-(path.start + path.progress) * 360deg);
-        }
-
-        ArcTo {
-            radius-x: radius;
-            radius-y: radius;
-            x: start-x - radius * sin(-path.start * 360deg);
-            y: start-y - radius * cos(-path.start * 360deg);
-            sweep: path.progress < 0;
-            large-arc: path.progress > 0.5;
-        }
-
-        LineTo {
-            x: start-x - radius * sin(-path.start * 360deg);
-            y: start-y - radius * cos(-path.start * 360deg);
         }
     }
 }

--- a/internal/compiler/widgets/common/spinner-base.slint
+++ b/internal/compiler/widgets/common/spinner-base.slint
@@ -23,6 +23,12 @@ export component SpinnerBase {
         height: 100%;
 
         MoveTo {
+            x: start-x - radius * sin(-(path.start - 0.001) * 360deg);
+            y: start-y - radius * cos(-(path.start - 0.001) * 360deg);
+        }
+
+        // Workaround for femtovg not filling complete circle
+        LineTo {
             x: start-x - radius * sin(-path.start * 360deg);
             y: start-y - radius * cos(-path.start * 360deg);
         }

--- a/internal/compiler/widgets/cosmic-base/spinner.slint
+++ b/internal/compiler/widgets/cosmic-base/spinner.slint
@@ -20,7 +20,7 @@ export component Spinner {
     base := SpinnerBase {
         width: 100%;
         height: 100%;
-        stroke-width: 2px;
+        stroke-width: 3px;
         stroke: CosmicPalette.accent-background;
     }
 }

--- a/internal/compiler/widgets/cupertino-base/spinner.slint
+++ b/internal/compiler/widgets/cupertino-base/spinner.slint
@@ -20,7 +20,7 @@ export component Spinner {
     base := SpinnerBase {
         width: 100%;
         height: 100%;
-        stroke-width: 2px;
+        stroke-width: 3px;
         stroke: CupertinoPalette.accent-background;
     }
 }

--- a/internal/compiler/widgets/fluent-base/spinner.slint
+++ b/internal/compiler/widgets/fluent-base/spinner.slint
@@ -20,7 +20,7 @@ export component Spinner {
     base := SpinnerBase {
         width: 100%;
         height: 100%;
-        stroke-width: 2px;
+        stroke-width: 3px;
         stroke: FluentPalette.accent-background;
     }
 }

--- a/internal/compiler/widgets/material-base/spinner.slint
+++ b/internal/compiler/widgets/material-base/spinner.slint
@@ -20,7 +20,7 @@ export component Spinner {
     base := SpinnerBase {
         width: 100%;
         height: 100%;
-        stroke-width: 2px;
+        stroke-width: 3px;
         stroke: MaterialPalette.accent-background;
     }
 }


### PR DESCRIPTION
Since we use the stroke and stroke with, then a single arc is enough instead of two connected by lines