### PR TITLE
compiler: perform remove return pass before const propagation

### DIFF
--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -204,6 +204,7 @@ pub async fn run_passes(
     }
 
     remove_aliases::remove_aliases(doc, diag);
+    remove_return::remove_return(doc);
 
     for component in (root_component.used_types.borrow().sub_components.iter())
         .chain(std::iter::once(root_component))
@@ -226,8 +227,6 @@ pub async fn run_passes(
 
     // collect globals once more: After optimizations we might have less globals
     collect_globals::collect_globals(doc, diag);
-
-    remove_return::remove_return(doc);
 
     embed_images::embed_images(
         root_component,

--- a/tests/cases/expr/return.slint
+++ b/tests/cases/expr/return.slint
@@ -1,15 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property <bool> toggle: { return false; }
-    property <int> value: {
+export component TestCase  {
+    in-out property <bool> toggle: { return false; }
+    in-out property <int> value: {
         if (toggle) {
             return 42;
         }
         return 100;
     }
-    property <float> value2: {
+    in-out property <float> value2: {
         return 100;
     }
 
@@ -22,8 +22,8 @@ TestCase := Rectangle {
     }
 
     callback test_signal;
-    property <bool> block_signal;
-    property <bool> signal_handled;
+    in-out property <bool> block_signal;
+    in-out property <bool> signal_handled;
     test_signal => {
         if (block_signal) {
             return;
@@ -31,7 +31,12 @@ TestCase := Rectangle {
         signal_handled = true;
     }
 
-    property<bool> test: { return value2 == value; return false; }
+    private property <bool> issue_5430_const_with_return: {
+        return true;
+    }
+    out property <string> issue_5430: issue_5430_const_with_return ? "true" : "false";
+
+    out property<bool> test: { return value2 == value && issue_5430 == "true"; return false; }
 }
 /*
 ```cpp


### PR DESCRIPTION
Otherwise we end up inlining "returns" in the wrong property

Fixes #5430