### PR TITLE
lsp: Move node ignore code into the common section

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -28,6 +28,20 @@ pub type UrlVersion = Option<i32>;
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
 
+/// Use this in nodes you want the language server and preview to
+/// ignore a node for code analysis purposes.
+pub const NODE_IGNORE_COMMENT: &str = "@lsp:ignore-node";
+
+/// Check whether a node is marked to be ignored in the LSP/live preview
+/// using a comment containing `@lsp:ignore-node`
+pub fn is_element_node_ignored(node: &syntax_nodes::Element) -> bool {
+    node.children_with_tokens().any(|nt| {
+        nt.as_token()
+            .map(|t| t.kind() == SyntaxKind::Comment && t.text().contains(NODE_IGNORE_COMMENT))
+            .unwrap_or(false)
+    })
+}
+
 pub fn uri_to_file(uri: &Url) -> Option<PathBuf> {
     if uri.scheme() == "builtin" {
         Some(PathBuf::from(uri.to_string()))

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -9,7 +9,6 @@ use crate::preview::element_selection::ElementSelection;
 use crate::util;
 use i_slint_compiler::diagnostics;
 use i_slint_compiler::object_tree::ElementRc;
-use i_slint_compiler::parser::{syntax_nodes, SyntaxKind};
 use i_slint_core::component_factory::FactoryContext;
 use i_slint_core::lengths::{LogicalPoint, LogicalRect, LogicalSize};
 use i_slint_core::model::VecModel;
@@ -251,7 +250,7 @@ fn placeholder_node_text(selected: &common::ElementRcNode) -> String {
     };
 
     if parent.layout_kind() != ui::LayoutKind::None && parent.children().len() == 1 {
-        return format!("Rectangle {{ /* {} */ }}", NODE_IGNORE_COMMENT);
+        return format!("Rectangle {{ /* {} */ }}", common::NODE_IGNORE_COMMENT);
     }
 
     Default::default()
@@ -691,7 +690,8 @@ async fn reload_preview_impl(
         let (_, from_cache) = get_url_from_cache(&component.url).unwrap_or_default();
         if let Some(component_name) = &component.component {
             format!(
-                "{from_cache}\nexport component {SLINT_LIVEPREVIEW_COMPONENT} inherits {component_name} {{ /* {NODE_IGNORE_COMMENT} */ }}\n",
+                "{from_cache}\nexport component {SLINT_LIVEPREVIEW_COMPONENT} inherits {component_name} {{ /* {} */ }}\n",
+                common::NODE_IGNORE_COMMENT
             )
         } else {
             from_cache
@@ -1021,20 +1021,6 @@ pub fn lsp_to_preview_message(
             highlight(url, offset);
         }
     }
-}
-
-/// Use this in nodes you want the language server and preview to
-/// ignore a node for code analysis purposes.
-pub const NODE_IGNORE_COMMENT: &str = "@lsp:ignore-node";
-
-/// Check whether a node is marked to be ignored in the LSP/live preview
-/// using a comment containing `@lsp:ignore-node`
-pub fn is_element_node_ignored(node: &syntax_nodes::Element) -> bool {
-    node.children_with_tokens().any(|nt| {
-        nt.as_token()
-            .map(|t| t.kind() == SyntaxKind::Comment && t.text().contains(NODE_IGNORE_COMMENT))
-            .unwrap_or(false)
-    })
 }
 
 #[cfg(test)]

--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -22,7 +22,7 @@ use crate::wasm_prelude::*;
 pub fn placeholder() -> String {
     format!(
         " Rectangle {{ min-width: 16px; min-height: 16px; /* {} */ }}",
-        preview::NODE_IGNORE_COMMENT
+        common::NODE_IGNORE_COMMENT
     )
 }
 
@@ -593,7 +593,7 @@ fn drop_target_element_nodes(
             continue;
         };
 
-        if en.with_element_node(preview::is_element_node_ignored) {
+        if en.with_element_node(common::is_element_node_ignored) {
             continue;
         }
 
@@ -713,7 +713,7 @@ fn find_filtered_location(
         let children_geometries: Vec<_> = drop_target_node
             .children()
             .iter()
-            .filter(|c| !c.with_element_node(preview::is_element_node_ignored))
+            .filter(|c| !c.with_element_node(common::is_element_node_ignored))
             .filter_map(|c| c.geometry_in(component_instance, &geometry).map(|g| ((mark)(c), g)))
             .collect();
 
@@ -897,7 +897,7 @@ fn drop_ignored_elements_from_node(
         node.children()
             .filter_map(|c| {
                 let e = common::extract_element(c.clone())?;
-                if preview::is_element_node_ignored(&e) {
+                if common::is_element_node_ignored(&e) {
                     pretty_node_removal_range(&e)
                         .map(|range| util::map_range(source_file, range))
                         .map(|range| lsp_types::TextEdit::new(range, String::new()))

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -7,7 +7,7 @@ use i_slint_compiler::object_tree::{Component, ElementRc};
 use i_slint_core::lengths::LogicalPoint;
 use slint_interpreter::ComponentInstance;
 
-use crate::{common, preview};
+use crate::common;
 
 use super::{ext::ElementRcNodeExt, ui};
 
@@ -306,7 +306,7 @@ fn filter_nodes_for_selection(
 ) -> Option<common::ElementRcNode> {
     let en = selection_candidate.as_element_node()?;
 
-    if en.with_element_node(preview::is_element_node_ignored) {
+    if en.with_element_node(common::is_element_node_ignored) {
         return None;
     }
 


### PR DESCRIPTION
... it is conceptually meant to be used by the language server and the live-preview.