### PR TITLE
linuxkms: ignore warning when no renderer are active

### DIFF
--- a/internal/backends/linuxkms/display.rs
+++ b/internal/backends/linuxkms/display.rs
@@ -4,6 +4,7 @@
 use i_slint_core::api::PhysicalSize;
 use i_slint_core::platform::PlatformError;
 
+#[allow(unused)]
 pub trait Presenter {
     fn is_ready_to_present(&self) -> bool;
     fn register_page_flip_handler(

--- a/internal/backends/linuxkms/lib.rs
+++ b/internal/backends/linuxkms/lib.rs
@@ -38,6 +38,7 @@ mod renderer {
     pub fn try_skia_then_femtovg_then_software(
         _device_opener: &crate::DeviceOpener,
     ) -> Result<Box<dyn FullscreenRenderer>, PlatformError> {
+        #[allow(unused)]
         type FactoryFn =
             fn(&crate::DeviceOpener) -> Result<Box<(dyn FullscreenRenderer)>, PlatformError>;
 


### PR DESCRIPTION
I went with an #[allow] rather than #[cfg] because catching the exact right expression is complicated (any renderer, and none should be forgotten)