### PR TITLE
Update a bunch of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,14 +137,15 @@ clru = { version = "0.6.0" }
 css-color-parser2 = { version = "1.0.1" }
 derive_more = { version = "0.99.17" }
 euclid = { version = "0.22.1", default-features = false }
-fontdb = { version = "0.16.0", default-features = false }
-fontdue = { version = "0.8.0" }
+fontdb = { version = "0.18.0", default-features = false }
+fontdue = { version = "0.9.0" }
 glutin = { version = "0.32.0", default-features = false }
 image = { version = "0.24", default-features = false, features = [ "png", "jpeg" ] }
-itertools = { version = "0.12" }
+itertools = { version = "0.13" }
 log = { version = "0.4.17" }
-resvg = { version= "0.41.0", default-features = false, features = ["text"] }
+resvg = { version= "0.42.0", default-features = false, features = ["text"] }
 rowan = { version = "0.15" }
+rustybuzz = { version = "0.14.0" }
 send_wrapper = { version = "0.6.0" }
 serde = { version = "1.0.163", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.96" }
@@ -152,6 +153,7 @@ softbuffer = { version = "0.4.4", default-features = false }
 spin_on = { version = "0.1" }
 strum = { version = "0.26.1", default-features = false, features = ["derive"] }
 toml_edit = { version = "0.22.7" }
+ttf-parser = { version = "0.21" }
 
 raw-window-handle-06 = { package = "raw-window-handle", version = "0.6", features = ["alloc"] }
 

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -110,7 +110,7 @@ fn embed_glyphs_with_fontdb<'a>(
     for doc in all_docs {
         for (font_path, import_token) in doc.custom_fonts.iter() {
             let face_count = fontdb.faces().count();
-            if let Err(e) = fontdb.load_font_file(font_path) {
+            if let Err(e) = fontdb.make_mut().load_font_file(font_path) {
                 diag.push_error(format!("Error loading font: {}", e), import_token);
             } else {
                 custom_fonts.extend(fontdb.faces().skip(face_count).map(|info| info.id))

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -363,14 +363,14 @@ fn load_image(
     if file.canon_path.extension() == Some(OsStr::new("svg"))
         || file.canon_path.extension() == Some(OsStr::new("svgz"))
     {
-        let options = usvg::Options::default();
-        let tree = i_slint_common::sharedfontdb::FONT_DB.with(|db| {
+        let tree = i_slint_common::sharedfontdb::FONT_DB.with_borrow(|db| {
+            let mut options = usvg::Options::default();
+            options.fontdb = (*db).clone();
             match file.builtin_contents {
-                Some(data) => usvg::Tree::from_data(data, &options, &db.borrow()),
+                Some(data) => usvg::Tree::from_data(data, &options),
                 None => usvg::Tree::from_data(
                     std::fs::read(&file.canon_path).map_err(image::ImageError::IoError)?.as_slice(),
                     &options,
-                    &db.borrow(),
                 ),
             }
             .map_err(|e| {

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -102,14 +102,14 @@ web-sys = { version = "0.3", features = [ "HtmlImageElement" ] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { workspace = true, optional = true, default-features = true }
-rustybuzz = { version = "0.13.0", optional = true }
+rustybuzz = { workspace = true, optional = true }
 fontdue = { workspace = true, optional = true }
 
 [dev-dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }
 i-slint-backend-testing = { path="../backends/testing" }
-rustybuzz = "0.13.0"
-ttf-parser = "0.20.0"
+rustybuzz = { workspace = true }
+ttf-parser = { workspace = true }
 fontdb = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 tiny-skia = "0.11.0"

--- a/internal/core/graphics/image/svg.rs
+++ b/internal/core/graphics/image/svg.rs
@@ -83,16 +83,19 @@ pub fn load_from_path(
 ) -> Result<ParsedSVG, std::io::Error> {
     let svg_data = std::fs::read(std::path::Path::new(&path.as_str()))?;
 
-    i_slint_common::sharedfontdb::FONT_DB.with(|db| {
-        usvg::Tree::from_data(&svg_data, &Default::default(), &db.borrow())
+    i_slint_common::sharedfontdb::FONT_DB.with_borrow(|db| {
+        let mut option = usvg::Options::default();
+        option.fontdb = (*db).clone();
+        usvg::Tree::from_data(&svg_data, &option)
             .map(|svg| ParsedSVG { svg_tree: svg, cache_key })
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
     })
 }
 
 pub fn load_from_data(slice: &[u8], cache_key: ImageCacheKey) -> Result<ParsedSVG, usvg::Error> {
-    i_slint_common::sharedfontdb::FONT_DB.with(|db| {
-        usvg::Tree::from_data(slice, &Default::default(), &db.borrow())
-            .map(|svg| ParsedSVG { svg_tree: svg, cache_key })
+    i_slint_common::sharedfontdb::FONT_DB.with_borrow(|db| {
+        let mut option = usvg::Options::default();
+        option.fontdb = (*db).clone();
+        usvg::Tree::from_data(slice, &option).map(|svg| ParsedSVG { svg_tree: svg, cache_key })
     })
 }

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -32,7 +32,7 @@ once_cell = "1.5"
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
 femtovg = { version = "0.9.0" }
-ttf-parser = { version = "0.20.0" } # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
+ttf-parser = { workspace = true }
 unicode-script = { version = "0.5.4" } # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
 imgref = { version = "1.6.1" }
 rgb = { version = "0.8.27" }

--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -193,9 +193,7 @@ impl FontCache {
 
         //let now = std::time::Instant::now();
 
-        let fontdb_face_id = sharedfontdb::FONT_DB.with(|db| {
-            let db = db.borrow();
-
+        let fontdb_face_id = sharedfontdb::FONT_DB.with_borrow(|db| {
             db.query_with_family(query, family.map(|s| s.as_str()))
                 .or_else(|| {
                     // If the requested family could not be found, fall back to *some* family that must exist
@@ -213,14 +211,13 @@ impl FontCache {
         // on Unixy platforms and on Windows the default file flags prevent the deletion.
         #[cfg(not(target_arch = "wasm32"))]
         let (shared_data, face_index) = unsafe {
-            sharedfontdb::FONT_DB.with(|db| {
-                db.borrow_mut().make_shared_face_data(fontdb_face_id).expect("unable to mmap font")
+            sharedfontdb::FONT_DB.with_borrow_mut(|db| {
+                db.make_mut().make_shared_face_data(fontdb_face_id).expect("unable to mmap font")
             })
         };
         #[cfg(target_arch = "wasm32")]
-        let (shared_data, face_index) = crate::sharedfontdb::FONT_DB.with(|db| {
-            db.borrow()
-                .face_source(fontdb_face_id)
+        let (shared_data, face_index) = crate::sharedfontdb::FONT_DB.with_borrow(|db| {
+            db.face_source(fontdb_face_id)
                 .map(|(source, face_index)| {
                     (
                         match source {


### PR DESCRIPTION
Bigger change is cause by resvg/usvg which now takes the font database in a Arc, so we must store it in a Arc ourself to cheaply lend it to usvg