### PR TITLE
Only generate code for the exported Window

### DIFF
--- a/api/cpp/docs/generated_code.md
+++ b/api/cpp/docs/generated_code.md
@@ -3,10 +3,10 @@
 
 The Slint compiler [called by the build system](cmake_reference.md#slint_target_sources)
 will generate a header file for the root `.slint` file.
-This header file will contain a `class` with the same name as the root
-component.
 
-This class will have the following public member functions:
+This header file will contain a `class` for every exported component from the main file that inherits from `Window` or `Dialog`.
+
+These classes have the same name as the component will have the following public member functions:
 
 * A `create` constructor function and a destructor.
 * A `show` function, which will show the component on the screen.

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -106,11 +106,10 @@ cargo generate --git https://github.com/slint-ui/slint-rust-template
 
 ## Generated components
 
-Currently, only the last component in a `.slint` source file is mapped to a Rust structure that be instantiated. We are tracking the
-resolution of this limitation in <https://github.com/slint-ui/slint/issues/784>.
+Exported component from the macro or the main file that inherit `Window` or `Dialog` is mapped to a Rust structure.
 
-The component is generated and re-exported to the location of the [`include_modules!`]  or [`slint!`] macro. It is represented
-as a struct with the same name as the component.
+The components are generated and re-exported to the location of the [`include_modules!`] or [`slint!`] macro.
+It is represented as a struct with the same name as the component.
 
 For example, if you have
 

--- a/api/rs/slint/tests/simple_macro.rs
+++ b/api/rs/slint/tests/simple_macro.rs
@@ -31,7 +31,7 @@ fn test_serialize_deserialize_struct() {
             enum: TestEnum,
             foo: int,
         }
-        export component Test { }
+        export component Test inherits Window { }
     }
     let data = TestStruct { foo: 1, r#enum: TestEnum::World };
     let serialized = serde_json::to_string(&data).unwrap();

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -104,8 +104,8 @@ pub struct CompilerConfiguration {
     /// Generate debug information for elements (ids, type names)
     pub debug_info: bool,
 
-    /// When this is true, the passes will generate component for all exported Window
-    /// and will throw a warning if a component that is not exported is a window.
+    /// When this is true, the passes will generate components for all exported Windows
+    /// and will throw a warning if an exported component is not a window.
     /// If this is false, only the last component is exported, regardless if this is a Window or not,
     /// (and it will be transformed in a Window)
     pub generate_all_exported_windows: bool,
@@ -157,7 +157,7 @@ impl CompilerConfiguration {
 
         let debug_info = std::env::var_os("SLINT_EMIT_DEBUG_INFO").is_some();
 
-        // The interpreter currently support only generating the last component
+        // The interpreter currently supports only generating the last component
         let generate_all_exported_windows = output_format != OutputFormat::Interpreter;
 
         let cpp_namespace = match output_format {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -266,6 +266,16 @@ impl Document {
         iter.chain(extra)
     }
 
+    /// This is the component that is going to be visualized by the interpreter
+    pub fn last_exported_component(&self) -> Option<Rc<Component>> {
+        self.exports
+            .iter()
+            .filter_map(|e| Some((&e.0.name_ident, e.1.as_ref().left()?)))
+            .max_by_key(|(n, _)| n.text_range().end())
+            .map(|(_, c)| c.clone())
+            .or_else(|| self.exported_roots().last())
+    }
+
     /// visit all root and used component (including globals)
     pub fn visit_all_used_components(&self, mut v: impl FnMut(&Rc<Component>)) {
         let used_types = self.used_types.borrow();
@@ -2590,6 +2600,13 @@ impl Exports {
             .binary_search_by(|(exported_name, _)| exported_name.as_str().cmp(name))
             .ok()
             .map(|index| self.components_or_types[index].1.clone())
+    }
+
+    pub fn retain(
+        &mut self,
+        func: impl FnMut(&mut (ExportedName, Either<Rc<Component>, Type>)) -> bool,
+    ) {
+        self.components_or_types.retain_mut(func)
     }
 
     pub(crate) fn snapshot(&self, snapshotter: &mut crate::typeloader::Snapshotter) -> Self {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -266,7 +266,7 @@ impl Document {
         iter.chain(extra)
     }
 
-    /// This is the component that is going to be visualized by the interpreter
+    /// This is the component that is going to be instantiated by the interpreter
     pub fn last_exported_component(&self) -> Option<Rc<Component>> {
         self.exports
             .iter()

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -54,7 +54,7 @@ use crate::expression_tree::Expression;
 use crate::namedreference::NamedReference;
 
 pub async fn run_passes(
-    doc: &crate::object_tree::Document,
+    doc: &mut crate::object_tree::Document,
     type_loader: &mut crate::typeloader::TypeLoader,
     keep_raw: bool,
     diag: &mut crate::diagnostics::BuildDiagnostics,
@@ -70,7 +70,7 @@ pub async fn run_passes(
 
     let global_type_registry = type_loader.global_type_registry.clone();
     run_import_passes(doc, type_loader, diag);
-    check_public_api::check_public_api(doc, diag);
+    check_public_api::check_public_api(doc, &type_loader.compiler_config, diag);
 
     let raw_type_loader =
         keep_raw.then(|| crate::typeloader::snapshot_with_extra_doc(type_loader, doc).unwrap());
@@ -241,7 +241,7 @@ pub async fn run_passes(
                 type_loader.compiler_config.scale_factor,
                 font_pixel_sizes,
                 characters_seen,
-                std::iter::once(doc).chain(type_loader.all_documents()),
+                std::iter::once(&*doc).chain(type_loader.all_documents()),
                 diag,
             );
         }
@@ -249,7 +249,7 @@ pub async fn run_passes(
             // Create font registration calls for custom fonts, unless we're embedding pre-rendered glyphs
             collect_custom_fonts::collect_custom_fonts(
                 doc,
-                std::iter::once(doc).chain(type_loader.all_documents()),
+                std::iter::once(&*doc).chain(type_loader.all_documents()),
                 type_loader.compiler_config.embed_resources
                     == crate::EmbedResourcesKind::EmbedAllResources,
             );

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -26,9 +26,7 @@ pub fn ensure_window(
         );
     }
 
-    if component.root_element.borrow().builtin_type().map_or(true, |b| {
-        matches!(b.name.as_str(), "Window" | "Dialog" | "WindowItem" | "PopupWindow")
-    }) {
+    if inherits_window(component) {
         return; // already a window, nothing to do
     }
 
@@ -144,4 +142,10 @@ pub fn ensure_window(
             to: Type::Brush,
         }
     });
+}
+
+pub fn inherits_window(component: &Rc<Component>) -> bool {
+    component.root_element.borrow().builtin_type().map_or(true, |b| {
+        matches!(b.name.as_str(), "Window" | "Dialog" | "WindowItem" | "PopupWindow")
+    })
 }

--- a/internal/compiler/tests/syntax/exports/export_non_window.slint
+++ b/internal/compiler/tests/syntax/exports/export_non_window.slint
@@ -1,0 +1,24 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//config:generate_all_exported_windows
+
+component Foo {}
+
+component Bar inherits Window {}
+
+export component Abc inherits Bar {}
+
+export component Cde inherits Rectangle {}
+//               ^warning{Exported component 'Cde' doesn't inherit Window. No code will be generated for it}
+
+export component Fgh inherits Foo {}
+//               ^warning{Exported component 'Fgh' doesn't inherit Window. No code will be generated for it}
+
+export component Ijk inherits Dialog { Rectangle {} }
+
+export component Xyz {}
+//               ^warning{Exported component 'Xyz' doesn't inherit Window. No code will be generated for it}
+
+export component Last {}
+//               ^warning{Exported component 'Last' doesn't inherit Window. This is deprecated}

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -192,6 +192,8 @@ fn process_file_source(
     compiler_config.embed_resources = i_slint_compiler::EmbedResourcesKind::OnlyBuiltinResources;
     compiler_config.enable_experimental = true;
     compiler_config.style = Some("fluent".into());
+    compiler_config.generate_all_exported_windows =
+        source.contains("config:generate_all_exported_windows");
     let compile_diagnostics = if !parse_diagnostics.has_error() {
         let (_, build_diags, _) = spin_on::spin_on(i_slint_compiler::compile_syntax_node(
             syntax_node.clone(),

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1063,7 +1063,7 @@ impl TypeLoader {
     ) -> (PathBuf, Option<TypeLoader>) {
         let path = crate::pathutils::clean_path(path);
         let state = RefCell::new(BorrowedTypeLoader { tl: self, diag });
-        let (path, doc) = Self::load_file_no_pass(
+        let (path, mut doc) = Self::load_file_no_pass(
             &state,
             &path,
             version,
@@ -1077,7 +1077,7 @@ impl TypeLoader {
         let mut state = state.borrow_mut();
         let state = &mut *state;
         let raw_type_loader = if !state.diag.has_error() {
-            crate::passes::run_passes(&doc, state.tl, keep_raw, state.diag).await
+            crate::passes::run_passes(&mut doc, state.tl, keep_raw, state.diag).await
         } else {
             None
         };

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -844,14 +844,7 @@ pub async fn load(
         #[allow(unused_mut)]
         let mut it = {
             let doc = loader.get_document(&path).unwrap();
-            let root_component = doc
-                .exports
-                .iter()
-                .filter_map(|e| Some((&e.0.name_ident, e.1.as_ref().left()?)))
-                .max_by_key(|(n, _)| n.text_range().end())
-                .map(|(_, c)| c.clone());
-            let Some(root_component) = root_component.or_else(|| doc.exported_roots().last())
-            else {
+            let Some(root_component) = doc.last_exported_component() else {
                 diag.push_error_with_span("No component found".into(), Default::default());
                 return (Err(()), diag);
             };

--- a/tests/cases/exports/multiple_components.slint
+++ b/tests/cases/exports/multiple_components.slint
@@ -13,13 +13,13 @@ component Shared {
     for xx in 2 : Rectangle {}
 }
 
-/// This component is both exported and Used
-export component Used {
+// This component is both exported and Used
+export component Used inherits Window {
     in-out property <int> name;
     for xx in 4 : Rectangle { }
 }
 
-export component FirstTest {
+export component FirstTest inherits Window {
 
     out property <string> global-prop: G.global-property;
     out property <string> o: shared.out.val;
@@ -33,13 +33,15 @@ export component FirstTest {
     out property <bool> test: false;
 }
 
-export component Z {
+export component Z inherits Window {
     out property <bool> test: false;
 }
 
+export component NotAWindow {}
 
 
-export component SecondTest {
+
+export component SecondTest inherits Window {
     out property <string> global-prop: G.global-property;
     out property <string> out: shared.out.val;
 
@@ -69,6 +71,12 @@ instance3.global::<G<'_>>().set_global_property("Bonjour".into());
 assert_eq!(instance1.get_o(), "Hallo Oli");
 assert_eq!(instance2.get_out(), "Hello Sim");
 assert_eq!(instance3.get_out(), "Bonjour Sim");
+
+#[allow(unused)]
+pub struct Shared;
+#[allow(unused)]
+pub struct NotAWindow;
+
 ```
 
 ```cpp
@@ -89,6 +97,7 @@ assert_eq(instance2.get_out(), "Hello Sim");
 assert_eq(instance3.get_out(), "Bonjour Sim");
 
 struct Shared {};
+struct NotAWindow {};
 ```
 
 


### PR DESCRIPTION
Have a warning when a component is exported from the main file and doesn't inherit Window.
Unless it's the last component, for compatibility with Slint 1.6

Also don't warn in the interpreter