### PR TITLE
Support dithering gradients in the skia renderer

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -65,24 +65,29 @@ impl<'a> SkiaItemRenderer<'a> {
         width: PhysicalLength,
         height: PhysicalLength,
     ) -> Option<skia_safe::Paint> {
-        Self::brush_to_shader(brush, width, height).map(|shader| {
-            let mut paint = skia_safe::Paint::default();
+        Self::brush_to_shader(brush, width, height, |mut paint, shader| {
             paint.set_shader(shader);
             paint.set_alpha_f(paint.alpha_f() * self.current_state.alpha);
+
             paint
         })
     }
 
-    fn brush_to_shader(
+    fn brush_to_shader<T>(
         brush: Brush,
         width: PhysicalLength,
         height: PhysicalLength,
-    ) -> Option<skia_safe::shader::Shader> {
+        func: impl FnOnce(skia_safe::Paint, Option<skia_safe::Shader>) -> T,
+    ) -> Option<T> {
         if brush.is_transparent() {
             return None;
         }
+
+        let mut paint = skia_safe::Paint::default();
+
         match brush {
             Brush::SolidColor(color) => Some(skia_safe::shaders::color(to_skia_color(&color))),
+
             Brush::LinearGradient(g) => {
                 let (start, end) = i_slint_core::graphics::line_for_angle(
                     g.angle(),
@@ -90,6 +95,9 @@ impl<'a> SkiaItemRenderer<'a> {
                 );
                 let (colors, pos): (Vec<_>, Vec<_>) =
                     g.stops().map(|s| (to_skia_color(&s.color), s.position)).unzip();
+
+                paint.set_dither(true);
+
                 skia_safe::gradient_shader::linear(
                     (skia_safe::Point::new(start.x, start.y), skia_safe::Point::new(end.x, end.y)),
                     skia_safe::gradient_shader::GradientShaderColors::Colors(&colors),
@@ -103,6 +111,9 @@ impl<'a> SkiaItemRenderer<'a> {
                 let (colors, pos): (Vec<_>, Vec<_>) =
                     g.stops().map(|s| (to_skia_color(&s.color), s.position)).unzip();
                 let circle_scale = width.max(height) / 2.;
+
+                paint.set_dither(true);
+
                 skia_safe::gradient_shader::radial(
                     skia_safe::Point::new(0., 0.),
                     1.,
@@ -117,6 +128,7 @@ impl<'a> SkiaItemRenderer<'a> {
             }
             _ => None,
         }
+        .and_then(|shader| Some(func(paint, Some(shader))))
     }
 
     fn colorize_image(
@@ -131,25 +143,27 @@ impl<'a> SkiaItemRenderer<'a> {
             None,
         );
 
-        let mut surface = self.canvas.new_surface(&image_info, None)?;
-        let canvas = surface.canvas();
-        canvas.clear(skia_safe::Color::TRANSPARENT);
-
-        let colorize_shader = Self::brush_to_shader(
+        Self::brush_to_shader(
             colorize_brush,
             PhysicalLength::new(image.width() as f32),
             PhysicalLength::new(image.height() as f32),
-        )?;
+            |mut paint, colorize_shader| -> Option<skia_safe::Image> {
+                let colorize_shader = colorize_shader?;
+                let mut surface = self.canvas.new_surface(&image_info, None)?;
+                let canvas = surface.canvas();
+                canvas.clear(skia_safe::Color::TRANSPARENT);
 
-        let mut paint = skia_safe::Paint::default();
-        paint.set_image_filter(skia_safe::image_filters::blend(
-            skia_safe::BlendMode::SrcIn,
-            skia_safe::image_filters::image(image, None, None, None),
-            skia_safe::image_filters::shader(colorize_shader, None),
-            None,
-        ));
-        canvas.draw_paint(&paint);
-        Some(surface.image_snapshot())
+                paint.set_image_filter(skia_safe::image_filters::blend(
+                    skia_safe::BlendMode::SrcIn,
+                    skia_safe::image_filters::image(image, None, None, None),
+                    skia_safe::image_filters::shader(colorize_shader, None),
+                    None,
+                ));
+                canvas.draw_paint(&paint);
+
+                Some(surface.image_snapshot())
+            },
+        )?
     }
 
     fn draw_image_impl(

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -66,7 +66,7 @@ impl<'a> SkiaItemRenderer<'a> {
         height: PhysicalLength,
     ) -> Option<skia_safe::Paint> {
         let (mut paint, shader) = Self::brush_to_shader(brush, width, height)?;
-        paint.set_shader(shader);
+        paint.set_shader(Some(shader));
         paint.set_alpha_f(paint.alpha_f() * self.current_state.alpha);
 
         Some(paint)
@@ -76,7 +76,7 @@ impl<'a> SkiaItemRenderer<'a> {
         brush: Brush,
         width: PhysicalLength,
         height: PhysicalLength,
-    ) -> Option<(skia_safe::Paint, Option<skia_safe::Shader>)> {
+    ) -> Option<(skia_safe::Paint, skia_safe::Shader)> {
         if brush.is_transparent() {
             return None;
         }
@@ -126,7 +126,7 @@ impl<'a> SkiaItemRenderer<'a> {
             }
             _ => None,
         }
-        .map(|shader| (paint, Some(shader)))
+        .map(|shader| (paint, shader))
     }
 
     fn colorize_image(
@@ -147,8 +147,6 @@ impl<'a> SkiaItemRenderer<'a> {
             PhysicalLength::new(image.height() as f32),
         )
         .map(|(mut paint, colorize_shader)| {
-            let colorize_shader = colorize_shader?;
-
             let mut surface = self.canvas.new_surface(&image_info, None)?;
             let canvas = surface.canvas();
             canvas.clear(skia_safe::Color::TRANSPARENT);


### PR DESCRIPTION
**Notes**

This overcomplicates `brush_to_shader()` a bit more than necessary to avoid duplicating two lines of code, but it made sense to me to pair shader-specific paint settings with shader-instantiation. One consideration is that `brush_to_paint()` already exists and has several callers in the renderer, but produces a `Paint` object that isn't compatible with `colorize_image()`. `brush_to_shader()` only has these two callers(one being `brush_to_paint()`, the other being `colorize_image()` so the complexity is mostly tucked away from the rest of the module.

Also, when trying this out with the energy monitor example, it seems to have traded _banding_ in the background radial gradient for _jitter_ in the background radial gradient. This doesn't make sense to me because [dithering in skia is deterministic](https://github.com/google/skia/blob/3c7298922f69d361f122e7c9e0c3d3d3feeef657/src/opts/SkRasterPipeline_opts.h#L1281), but still seems like an improvement to me, and doesn't seem to affect linear gradients. Unsure if that's something idiosyncratic to the energy monitor, or to radial gradients.