### PR TITLE
Python: Make the timer test more robust

### DIFF
--- a/api/python/tests/test_timers.py
+++ b/api/python/tests/test_timers.py
@@ -11,8 +11,8 @@ def test_timer():
     counter = 0
     def quit_after_two_invocations():
         global counter
-        counter = counter + 1
-        if counter >= 2:
+        counter = min(counter + 1, 2)
+        if counter == 2:
             native.quit_event_loop()
 
     test_timer = native.Timer()        


### PR DESCRIPTION
It seems that with the latest winit, quit_event_loop() might take a little longer and the timer fires once more. We don't really care how long quit_event_loop() takes in this test, merely that the timer firest and that we can terminate the loop.

Fixes #5484