### PR TITLE
winit: Fix setting the size with set_size before showing the window

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1846,6 +1846,8 @@ impl WindowAdapter for QtWindow {
         cpp! {unsafe [widget_ptr as "QWidget*", sz as "QSize"] {
             widget_ptr->resize(sz);
         }};
+
+        self.resize_event(sz);
     }
 
     fn size(&self) -> i_slint_core::api::PhysicalSize {


### PR DESCRIPTION
Fixes #5489

We shouldn't resize the window to the size of the WindowItem after start. This happens when set_size is called before show. The the resize event didn't yet propagate the size to the WindowItem properties.