### PR TITLE
live-preview: Add a property editor

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -191,10 +191,10 @@ impl DocumentCache {
         &self.0.compiler_config
     }
 
-    pub fn element_at_position(
+    fn element_at_document_and_offset(
         &self,
-        text_document_uri: &Url,
-        pos: &lsp_types::Position,
+        document: &i_slint_compiler::object_tree::Document,
+        offset: u32,
     ) -> Option<ElementRcNode> {
         fn element_contains(
             element: &i_slint_compiler::object_tree::ElementRc,
@@ -205,9 +205,7 @@ impl DocumentCache {
             })
         }
 
-        let (doc, offset) = self.get_document_and_offset(text_document_uri, pos)?;
-
-        for component in &doc.inner_components {
+        for component in &document.inner_components {
             let root_element = component.root_element.clone();
             let Some(root_debug_index) = element_contains(&root_element, offset) else {
                 continue;
@@ -231,6 +229,20 @@ impl DocumentCache {
             }
         }
         None
+    }
+
+    pub fn element_at_offset(&self, text_document_uri: &Url, offset: u32) -> Option<ElementRcNode> {
+        let doc = self.get_document(text_document_uri)?;
+        self.element_at_document_and_offset(doc, offset)
+    }
+
+    pub fn element_at_position(
+        &self,
+        text_document_uri: &Url,
+        pos: &lsp_types::Position,
+    ) -> Option<ElementRcNode> {
+        let (doc, offset) = self.get_document_and_offset(text_document_uri, pos)?;
+        self.element_at_document_and_offset(doc, offset)
     }
 }
 

--- a/tools/lsp/common/properties.rs
+++ b/tools/lsp/common/properties.rs
@@ -12,7 +12,7 @@ use i_slint_compiler::parser::{syntax_nodes, Language, SyntaxKind};
 use std::collections::HashSet;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, PartialEq)]
-pub(crate) struct DefinitionInformation {
+pub struct DefinitionInformation {
     pub property_definition_range: lsp_types::Range,
     pub selection_range: lsp_types::Range,
     pub expression_range: lsp_types::Range,
@@ -20,13 +20,13 @@ pub(crate) struct DefinitionInformation {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, PartialEq)]
-pub(crate) struct DeclarationInformation {
+pub struct DeclarationInformation {
     pub uri: lsp_types::Url,
     pub start_position: lsp_types::Position,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, PartialEq)]
-pub(crate) struct PropertyInformation {
+pub struct PropertyInformation {
     pub name: String,
     pub type_name: String,
     pub declared_at: Option<DeclarationInformation>,
@@ -35,14 +35,14 @@ pub(crate) struct PropertyInformation {
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
-pub(crate) struct ElementInformation {
+pub struct ElementInformation {
     pub id: String,
     pub type_name: String,
     pub range: Option<lsp_types::Range>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
-pub(crate) struct QueryPropertyResponse {
+pub struct QueryPropertyResponse {
     pub properties: Vec<PropertyInformation>,
     pub element: Option<ElementInformation>,
     pub source_uri: String,

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -58,6 +58,54 @@ export struct DropMark {
     y2: length,
 }
 
+/// A Range in a source
+export struct Range {
+    start: int,
+    end: int,
+}
+
+/// Important Ranges in the property definition
+///
+/// The URL and version is the same as in the Element it belongs to
+export struct PropertyDefinition {
+    definition-range: Range,
+    selection-range: Range,
+    expression-range: Range,
+    expression-value: string,
+}
+
+/// The Property Declaration
+export struct PropertyDeclaration {
+    source-uri: string,
+    source-version: int,
+    range: Range,
+}
+
+/// Information on one Property
+export struct PropertyInformation {
+    name: string,
+    type-name: string,
+    declared-at: PropertyDeclaration,
+    defined-at: PropertyDefinition,
+}
+
+/// Information on one Property
+export struct PropertyGroup {
+    group-name: string,
+    properties: [PropertyInformation],
+}
+
+/// Information on an Element a Property belongs to
+export struct ElementInformation {
+    id: string,
+    type-name: string,
+    source-uri: string,
+    source-version: int,
+    range: Range,
+
+    properties: [PropertyGroup],
+}
+
 export global Api {
     // # Properties
     // ## General preview state:
@@ -85,6 +133,9 @@ export global Api {
     in property <[Selection]> selections; // Borders around things
     in-out property <DropMark> drop-mark;
     in property <component-factory> preview-area; // The actual preview
+
+    // ## Property Editor
+    in property <ElementInformation> current-element;
 
     // # Callbacks
 
@@ -121,13 +172,18 @@ export global Api {
     // ## Change Editor:    
 
     // Show a conponent in the editor
-    callback show-component(/* name */ string, /* file */ string);
+    callback show-component(/* name */ string, /* url */ string);
     // Show a position consisting of `line` and `column` in a `file` in the editor
     callback show-document(/* file */ string, /* line */ int, /* column */ int);
+    // Show a position consisting of `line` and `column` in a `file` in the editor
+    callback show-document-offset-range(/* url */ string, /* start_offset */ int, /* end_offset */ int);
 
 
     // ## Drawing Area
     // Preview some other component
     callback show-preview-for(string/* name */, string/*url*/);
 
+    // ## Property Editor
+    pure callback test-binding(/* element-url */ string, /* element-version */ int, /* element-offset */ int, /* property-name */ string, /* property-value */ string) -> bool;
+    callback set-binding(/* element-url */ string, /* element-version */ int, /* element-offset */ int, /* property-name */ string, /* property-value */ string);
 }

--- a/tools/lsp/ui/component-list.slint
+++ b/tools/lsp/ui/component-list.slint
@@ -1,13 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { Button, Palette, ScrollView, VerticalBox, GroupBox, LineEdit } from "std-widgets.slint";
+import { Button, Palette } from "std-widgets.slint";
 import { Api, ComponentListItem, ComponentItem } from "api.slint";
 import { SideBarElement } from "side-bar.slint";
 import { ListHead } from "list-head.slint";
 
 export component ComponentList inherits SideBarElement {
     name: @tr("Library");
+
     in property <[ComponentListItem]> known-components <=> Api.known-components;
 
     in property <length> preview-area-position-x;
@@ -22,17 +23,13 @@ export component ComponentList inherits SideBarElement {
         is-user-defined: false,
         is-currently-shown: false,
     };
-
-    private property <length> list-spacing: 10px;
-
     out property <bool> over-target;
 
+    private property <length> list-spacing: 10px;
     private property <bool> preview-visible: preview-area-width > 0px && preview-area-height > 0px;
 
-    VerticalLayout {
-        spacing: root.list-spacing;
-
-        for cli[index] in root.known-components: category := VerticalLayout {
+    for cli[index] in root.known-components: category := Rectangle {
+        VerticalLayout {
             spacing: root.list-spacing;
 
             private property <int> my-category-index: index;
@@ -54,7 +51,7 @@ export component ComponentList inherits SideBarElement {
                 width: 100%;
 
                 // Hack to initialize currently visible component:
-                        if ci.is_currently_shown: Rectangle {
+                if ci.is_currently_shown: Rectangle {
                     visible: false;
 
                     init() => {

--- a/tools/lsp/ui/draw-area.slint
+++ b/tools/lsp/ui/draw-area.slint
@@ -326,6 +326,7 @@ export component DrawArea {
                                     font-size: 0.8rem;
                                     horizontal-alignment: left;
                                     text: root.visible-component.pretty-location;
+                                    color: Palette.alternate-foreground;
                                 }
                                 clicked() => {
                                     Api.show-component(root.visible-component.name, root.visible-component.defined-at);

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -9,12 +9,14 @@ import { ComponentList } from "component-list.slint";
 import { DrawArea, DrawAreaMode } from "draw-area.slint";
 import { HeaderBar } from "header-bar.slint";
 import { DiagnosticsOverlay } from "diagnostics-overlay.slint";
+import { PropertyEditor } from "property-editor.slint";
+import { SideBar } from "side-bar.slint";
 
 export { Api }
 
 export component PreviewUi inherits Window {
     property <length> border: 20px;
-    property <length> side-bar-width: 200px;
+    property <length> side-bar-width: 300px;
 
     title: "Slint Live-Preview";
     icon: @image-url("assets/slint-logo-small-light.png");
@@ -97,31 +99,30 @@ export component PreviewUi inherits Window {
                 }
 
                 HorizontalLayout {
-                    left-sidebar := Rectangle {
-                        VerticalBox {
-                            component-list := ComponentList {
-                                preview-area-position-x: draw-area.preview-area-position-x;
-                                preview-area-position-y: draw-area.preview-area-position-y;
-                                preview-area-width: draw-area.preview-area-width;
-                                preview-area-height: draw-area.preview-area-height;
-                            }
-                        }
+                    left-sidebar := SideBar {
+                        default-width: root.side-bar-width;
+                        show-side-bar: pick-button.checked;
 
-                        states [
-                            visible when !pick-button.checked: {
-                                width: 0px;
-                            }
-                            hidden when pick-button.checked: {
-                                width: root.side-bar-width;
-                            }
-                        ]
+                        component-list := ComponentList {
+                            preview-area-position-x: draw-area.preview-area-position-x;
+                            preview-area-position-y: draw-area.preview-area-position-y;
+                            preview-area-width: draw-area.preview-area-width;
+                            preview-area-height: draw-area.preview-area-height;
+                        }
                     }
 
                     draw-area := DrawArea {
                         visible-component <=> component-list.visible-component;
                     }
 
-                    preferred-width: draw-area.preferred-width + root.side-bar-width/* for left-side-bar */;
+                    right-sidebar := SideBar {
+                        default-width: root.side-bar-width;
+                        show-side-bar: pick-button.checked;
+
+                        property-editor := PropertyEditor { }
+                    }
+
+                    preferred-width: draw-area.preferred-width + 2 * root.side-bar-width;
                 }
             }
 

--- a/tools/lsp/ui/property-editor.slint
+++ b/tools/lsp/ui/property-editor.slint
@@ -1,0 +1,127 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { LineEdit, Palette, VerticalBox } from "std-widgets.slint";
+
+import { Api, ElementInformation } from "api.slint";
+import { ListHead } from "list-head.slint";
+import { SideBarElement} from "side-bar.slint";
+
+component TypeHeader inherits Rectangle {
+    in property <string> type-name;
+    in property <string> id;
+
+    background: Palette.accent-background;
+    
+    VerticalBox {
+        height: self.min-height;
+
+        Text {
+            text: root.type-name;
+            color: Palette.accent-foreground;
+            font-size: 1.2rem;
+        }
+
+        Text {
+            text: root.id;
+            color: Palette.accent-foreground;
+        }
+    }
+}
+
+export component PropertyEditor inherits SideBarElement {
+    name: @tr("Properties");
+    in property <ElementInformation> current-element <=> Api.current-element;
+
+    private property <length> key-width: self.width / 2.0;
+    private property <length> splitter-width: 5px;
+
+    if root.current-element.type-name != "": Rectangle {
+        VerticalLayout {
+            alignment: start;
+
+            header := TypeHeader {
+                type-name: root.current-element.type-name;
+                id: root.current-element.id;
+            }
+
+            for group in root.current-element.properties: Rectangle {
+                VerticalBox {
+                    if group.group-name != "" && group.group-name != root.current-element.type-name: ListHead {
+                        text: group.group-name;
+                    }
+
+                    for property in group.properties: HorizontalLayout {
+                        spacing: 4px;
+                        alignment: stretch;
+                        key := Text {
+                            color: property.defined-at.expression-value == "" ? Palette.foreground.transparentize(0.5) : Palette.foreground;
+                            vertical-alignment: center;
+                            width: root.key-width - (parent.spacing / 2.0);
+                            text: property.name;
+                        }
+
+                        Rectangle {
+                            width: root.width - key.width - (parent.spacing / 2.0);
+                            LineEdit {
+                                width: 100%;
+                                height: 100%;
+                                
+                                text: property.defined-at.expression-value;
+
+                                edited(text) => {
+                                    overlay.visible = !Api.test-binding(
+                                        root.current-element.source-uri,
+                                        root.current-element.source-version,
+                                        root.current-element.range.start,
+                                        property.name,
+                                        text,
+                                    );
+                                }
+
+                                accepted(text) => {
+                                    Api.set-binding(
+                                        root.current-element.source-uri,
+                                        root.current-element.source-version,
+                                        root.current-element.range.start,
+                                        property.name,
+                                        text,
+                                    );
+                                }
+                            }
+                            overlay := Rectangle {
+                                visible: false;
+                                background: #80000040;
+
+                                width: parent.width - 8px;
+                                height: parent.height - 8px;
+                                border-radius: 3px;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        splitter := TouchArea {
+            x: root.key-width - (root.splitter-width - 1px) / 2.0;
+            y: header.height;
+            width: root.splitter-width;
+            height: root.height - header.height;
+
+            mouse-cursor: MouseCursor.col-resize;
+
+            moved() => {
+                root.key-width = Math.clamp(self.x + self.mouse-x, 0.1 * root.width, 0.9 * root.width);
+            }
+        }
+    }
+
+    if root.current-element.type-name == "": VerticalLayout {
+        Text {
+            text: "Select an Element";
+            horizontal-alignment: center;
+            vertical-alignment: center;
+        }
+    }
+}

--- a/tools/lsp/ui/side-bar.slint
+++ b/tools/lsp/ui/side-bar.slint
@@ -9,6 +9,7 @@ export component SideBarElement {
 
     VerticalLayout {
         spacing: 10px;
+
         Text {
             text: root.name;
             horizontal-alignment: center;
@@ -16,8 +17,12 @@ export component SideBarElement {
             font-weight: 800;
         }
 
-        ScrollView {
-            @children
+        scroll-area := ScrollView {
+            VerticalLayout {
+                spacing: 10px;
+
+                @children
+            }
         }
     }
 }
@@ -26,10 +31,10 @@ export component SideBar {
     in property <bool> show-side-bar;
     in property <length> default-width;
 
-    private property <length> list-spacing: 10px;
+    private property <length> side-bar-element-spacing: 10px;
 
-    VerticalBox {
-        spacing: root.list-spacing;
+    VerticalLayout {
+        spacing: root.side-bar-element-spacing;
 
         @children
     }

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -44,6 +44,17 @@ pub fn map_range(sf: &SourceFile, range: TextRange) -> lsp_types::Range {
     lsp_types::Range::new(map_position(sf, range.start()), map_position(sf, range.end()))
 }
 
+pub fn map_to_offset(sf: &SourceFile, position: lsp_types::Position) -> usize {
+    sf.offset(
+        usize::try_from(position.line).unwrap() + 1,
+        usize::try_from(position.character).unwrap() + 1,
+    )
+}
+
+pub fn map_to_offsets(sf: &SourceFile, range: lsp_types::Range) -> (usize, usize) {
+    (map_to_offset(sf, range.start), map_to_offset(sf, range.end))
+}
+
 // Find the last token that is not a Whitespace in a `SyntaxNode`. May return
 // `None` if the node contains no tokens or they are all Whitespace.
 pub fn last_non_ws_token(node: &SyntaxNode) -> Option<SyntaxToken> {


### PR DESCRIPTION
Add a really simple property editor into the design mode of the live-preview. I am not 100% happy with the looks, but it seems to work, so let's get this merged to have something to build on.

Features:

* Add/remove/change known properties
* Compile-test the edit

Missing:

* Add new properties
