### PR TITLE
Add support for async unit testing and element handle click events

### DIFF
--- a/api/node/src/lib.rs
+++ b/api/node/src/lib.rs
@@ -80,5 +80,5 @@ pub fn set_quit_on_last_window_closed(
 #[napi]
 pub fn init_testing() {
     #[cfg(feature = "testing")]
-    i_slint_backend_testing::init_integration_test();
+    i_slint_backend_testing::init_integration_test_with_mock_time();
 }

--- a/api/rs/slint/tests/show_strongref.rs
+++ b/api/rs/slint/tests/show_strongref.rs
@@ -5,7 +5,7 @@ use ::slint::slint;
 
 #[test]
 fn show_maintains_strong_reference() {
-    i_slint_backend_testing::init_integration_test();
+    i_slint_backend_testing::init_integration_test_with_mock_time();
 
     slint!(export component TestWindow inherits Window {
         callback root-clicked();

--- a/api/rs/slint/tests/spawn_local.rs
+++ b/api/rs/slint/tests/spawn_local.rs
@@ -39,7 +39,7 @@ mod executor {
 
 #[test]
 fn main() {
-    i_slint_backend_testing::init_integration_test();
+    i_slint_backend_testing::init_integration_test_with_mock_time();
 
     slint::invoke_from_event_loop(|| {
         let handle = slint::spawn_local(async { String::from("Hello") }).unwrap();
@@ -58,7 +58,9 @@ fn main() {
 #[test]
 fn with_context() {
     use i_slint_core::SlintContext;
-    let ctx = SlintContext::new(Box::new(i_slint_backend_testing::TestingBackend::new()));
+    let ctx = SlintContext::new(Box::new(i_slint_backend_testing::TestingBackend::new(
+        i_slint_backend_testing::TestingBackendOptions { mock_time: true, threading: true },
+    )));
     let handle = ctx.spawn_local(async { String::from("Hello") }).unwrap();
     ctx.spawn_local(async move { panic!("Aborted task") }).unwrap().abort();
     let handle2 = ctx.spawn_local(async move { handle.await + ", World" }).unwrap();

--- a/internal/backends/testing/ffi.rs
+++ b/internal/backends/testing/ffi.rs
@@ -20,7 +20,7 @@ impl super::Sealed for RootWrapper<'_> {}
 
 #[no_mangle]
 pub extern "C" fn slint_testing_init_backend() {
-    crate::init_integration_test();
+    crate::init_integration_test_with_mock_time();
 }
 
 #[no_mangle]

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -7,6 +7,7 @@ use crate::TestingWindow;
 use i_slint_core::api::ComponentHandle;
 use i_slint_core::platform::WindowEvent;
 pub use i_slint_core::tests::slint_get_mocked_time as get_mocked_time;
+pub use i_slint_core::tests::slint_mock_elapsed_time as mock_elapsed_time;
 use i_slint_core::window::WindowInner;
 use i_slint_core::SharedString;
 

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -7,7 +7,6 @@ use crate::TestingWindow;
 use i_slint_core::api::ComponentHandle;
 use i_slint_core::platform::WindowEvent;
 pub use i_slint_core::tests::slint_get_mocked_time as get_mocked_time;
-pub use i_slint_core::tests::slint_mock_elapsed_time as mock_elapsed_time;
 use i_slint_core::window::WindowInner;
 use i_slint_core::SharedString;
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -23,10 +23,13 @@ pub mod systest;
 /// an event loop such as `slint::invoke_from_event_loop` or `Timer`s won't work.
 /// Must be called before any call that would otherwise initialize the rendering backend.
 /// Calling it when the rendering backend is already initialized will panic.
+///
+/// Note that for animations and timers, the changes in the system time will be disregarded.
+/// Instead, use [`mock_elapsed_time()`] to advance the simulate (mock) time Slint uses.
 pub fn init_no_event_loop() {
-    i_slint_core::platform::set_platform(
-        Box::new(testing_backend::TestingBackend::new_no_thread()),
-    )
+    i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new(
+        testing_backend::TestingBackendOptions { mock_time: true, threading: false },
+    )))
     .expect("platform already initialized");
 }
 
@@ -35,9 +38,32 @@ pub fn init_no_event_loop() {
 /// tests with only one `#[test]` function. (Or in a doc test)
 /// Must be called before any call that would otherwise initialize the rendering backend.
 /// Calling it when the rendering backend is already initialized will panic.
-pub fn init_integration_test() {
-    i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new()))
-        .expect("platform already initialized");
+///
+/// Note that for animations and timers, the changes in the system time will be disregarded.
+/// Instead, use [`mock_elapsed_time()`] to advance the simulate (mock) time Slint uses.
+pub fn init_integration_test_with_mock_time() {
+    i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new(
+        testing_backend::TestingBackendOptions { mock_time: true, threading: true },
+    )))
+    .expect("platform already initialized");
+}
+
+/// Initialize the testing backend with support for simple event loop.
+/// This function can only be called once per process, so make sure to use integration
+/// tests with only one `#[test]` function. (Or in a doc test)
+/// Must be called before any call that would otherwise initialize the rendering backend.
+/// Calling it when the rendering backend is already initialized will panic.
+pub fn init_integration_test_with_system_time() {
+    i_slint_core::platform::set_platform(Box::new(testing_backend::TestingBackend::new(
+        testing_backend::TestingBackendOptions { mock_time: false, threading: true },
+    )))
+    .expect("platform already initialized");
+}
+
+/// Advance the simulated mock time by the specified duration. Use in combination with
+/// [`init_integration_test_with_mock_time()`] or [`init_no_event_loop()`].
+pub fn mock_elapsed_time(duration: std::time::Duration) {
+    i_slint_core::tests::slint_mock_elapsed_time(duration.as_millis() as _);
 }
 
 pub use i_slint_core::items::AccessibleRole;

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -62,6 +62,7 @@ pub fn init_integration_test_with_system_time() {
 
 /// Advance the simulated mock time by the specified duration. Use in combination with
 /// [`init_integration_test_with_mock_time()`] or [`init_no_event_loop()`].
+#[cfg(not(feature = "internal"))]
 pub fn mock_elapsed_time(duration: std::time::Duration) {
     i_slint_core::tests::slint_mock_elapsed_time(duration.as_millis() as _);
 }

--- a/internal/backends/testing/tests/click.rs
+++ b/internal/backends/testing/tests/click.rs
@@ -1,0 +1,42 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use i_slint_backend_testing::ElementHandle;
+
+#[test]
+fn test_click() {
+    i_slint_backend_testing::init_integration_test_with_system_time();
+
+    slint::spawn_local(async move {
+        slint::slint! {
+            export component App inherits Window {
+                out property <int> click-count: 0;
+                out property <int> double-click-count: 0;
+                ta := TouchArea {
+                    clicked => { root.click-count += 1; }
+                    double-clicked => { root.double-click-count += 1; }
+                }
+            }
+        }
+
+        let app = App::new().unwrap();
+
+        let mut it = ElementHandle::find_by_element_id(&app, "App::ta");
+        let elem = it.next().unwrap();
+        assert!(it.next().is_none());
+
+        assert_eq!(app.get_click_count(), 0);
+        assert_eq!(app.get_double_click_count(), 0);
+        elem.single_click().await;
+        assert_eq!(app.get_click_count(), 1);
+        assert_eq!(app.get_double_click_count(), 0);
+
+        elem.double_click().await;
+        assert_eq!(app.get_click_count(), 3);
+        assert_eq!(app.get_double_click_count(), 1);
+
+        slint::quit_event_loop().unwrap();
+    })
+    .unwrap();
+    slint::run_event_loop().unwrap();
+}

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -157,7 +157,7 @@ unsafe impl<T: Send> Send for JoinHandle<T> {}
 /// in the future passed to slint::spawn_local.
 ///
 /// ```rust
-/// # i_slint_backend_testing::init_integration_test();
+/// # i_slint_backend_testing::init_integration_test_with_mock_time();
 /// // In your main function, create a runtime that runs on the other threads
 /// let tokio_runtime = tokio::runtime::Runtime::new().unwrap();
 ///

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -690,6 +690,13 @@ impl ItemRc {
             &|item_tree, index| crate::item_focus::step_out_of_node(index, item_tree),
         )
     }
+
+    pub fn window_adapter(&self) -> Option<WindowAdapterRc> {
+        let comp_ref_pin = vtable::VRc::borrow_pin(&self.item_tree);
+        let mut result = None;
+        comp_ref_pin.as_ref().window_adapter(false, &mut result);
+        result
+    }
 }
 
 impl PartialEq for ItemRc {


### PR DESCRIPTION
This patch adds async click functions to ElementHandle and adds timer support to the testing backend's event loop.