### PR TITLE
janitor: Ignore direnv config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ docs/reference/src/language/builtins/structs.md
 *.d.ts
 
 .env
+.envrc
 __pycache__


### PR DESCRIPTION
It's handy to have those, but not in git :-)