### PR TITLE
janitor: Remove unused variable warning in winit

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -123,7 +123,7 @@ fn try_create_window_with_fallback_renderer(
         Some(WinitWindowAdapter::new(
             renderer,
             winit_window,
-            #[cfg(not(target_family = "wasm"))]
+            #[cfg(enable_accesskit)]
             _proxy.clone(),
         ))
     })
@@ -273,7 +273,7 @@ impl i_slint_core::platform::Platform for Backend {
                 WinitWindowAdapter::new(
                     renderer,
                     window,
-                    #[cfg(not(target_family = "wasm"))]
+                    #[cfg(enable_accesskit)]
                     self.proxy.clone(),
                 )
             })

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -26,7 +26,7 @@ use corelib::items::{ColorScheme, MouseCursor};
 #[cfg(enable_accesskit)]
 use corelib::items::{ItemRc, ItemRef};
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(enable_accesskit)]
 use crate::SlintUserEvent;
 use corelib::api::PhysicalSize;
 use corelib::layout::Orientation;
@@ -37,7 +37,7 @@ use corelib::Property;
 use corelib::{graphics::*, Coord};
 use i_slint_core as corelib;
 use once_cell::unsync::OnceCell;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(enable_accesskit)]
 use winit::event_loop::EventLoopProxy;
 use winit::window::WindowAttributes;
 
@@ -165,7 +165,7 @@ impl WinitWindowAdapter {
     pub(crate) fn new(
         renderer: Box<dyn WinitCompatibleRenderer>,
         winit_window: Rc<winit::window::Window>,
-        #[cfg(not(target_family = "wasm"))] proxy: EventLoopProxy<SlintUserEvent>,
+        #[cfg(enable_accesskit)] proxy: EventLoopProxy<SlintUserEvent>,
     ) -> Rc<Self> {
         let self_rc = Rc::new_cyclic(|self_weak| Self {
             window: OnceCell::with_value(corelib::api::Window::new(self_weak.clone() as _)),


### PR DESCRIPTION
I am trying to get all the warnings out of my build again:-)

I think this is safe: enable_accesskit is `not(wasm)` and `accessibility` ...