### PR TITLE
live-preview: Navigate to property

### DIFF
--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -178,7 +178,6 @@ export global Api {
     // Show a position consisting of `line` and `column` in a `file` in the editor
     callback show-document-offset-range(/* url */ string, /* start_offset */ int, /* end_offset */ int);
 
-
     // ## Drawing Area
     // Preview some other component
     callback show-preview-for(string/* name */, string/*url*/);

--- a/tools/lsp/ui/property-editor.slint
+++ b/tools/lsp/ui/property-editor.slint
@@ -54,11 +54,18 @@ export component PropertyEditor inherits SideBarElement {
                     for property in group.properties: HorizontalLayout {
                         spacing: 4px;
                         alignment: stretch;
-                        key := Text {
-                            color: property.defined-at.expression-value == "" ? Palette.foreground.transparentize(0.5) : Palette.foreground;
-                            vertical-alignment: center;
+                        TouchArea {
                             width: root.key-width - (parent.spacing / 2.0);
-                            text: property.name;
+
+                            key := Text {
+                                width: 100%;
+                                color: property.defined-at.expression-value == "" ? Palette.foreground.transparentize(0.5) : Palette.foreground;
+                                vertical-alignment: center;
+                                text: property.name;
+                            }
+                            clicked() => {
+                                Api.show-document-offset-range(root.current-element.source-uri, property.defined-at.expression-range.start, property.defined-at.expression-range.start);
+                            }
                         }
 
                         Rectangle {


### PR DESCRIPTION
Clicking on an existing property in the PropertyEditor will ask the editor to navigate to the right place.