### PR TITLE
janitor: vtable: Fix `struct `SelfInfo` is never constructed`

### DIFF
--- a/helper_crates/vtable/macro/macro.rs
+++ b/helper_crates/vtable/macro/macro.rs
@@ -284,9 +284,6 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
             let mut self_call = None;
             let mut forward_code = None;
 
-            #[derive(Default)]
-            struct SelfInfo {}
-
             let mut has_self = false;
 
             for param in &f.inputs {


### PR DESCRIPTION
Fix a build time warning.