### PR TITLE
compiler: Fix bug in snapshotting

### DIFF
--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -183,7 +183,7 @@ impl NamedReferenceInner {
 
     pub(crate) fn snapshot(&self, snapshotter: &mut crate::typeloader::Snapshotter) -> Self {
         let element = if let Some(el) = self.element.upgrade() {
-            Rc::downgrade(&snapshotter.snapshot_element(&el))
+            Rc::downgrade(&snapshotter.use_element(&el))
         } else {
             std::rc::Weak::default()
         };

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2614,9 +2614,10 @@ impl Exports {
             .map(|(en, either)| {
                 let en = en.clone();
                 let either = match either {
-                    itertools::Either::Left(l) => {
-                        itertools::Either::Left(snapshotter.snapshot_component(l))
-                    }
+                    itertools::Either::Left(l) => itertools::Either::Left({
+                        Weak::upgrade(&snapshotter.use_component(l))
+                            .expect("Component should cleanly upgrade here")
+                    }),
                     itertools::Either::Right(r) => itertools::Either::Right(r.clone()),
                 };
                 (en, either)


### PR DESCRIPTION
Do not `take` an ElementRc to move it into the `Component`'s `root_element`.

@ogoffart spotted this! Thanks!