### PR TITLE
Fix unused type warnings in i-slint-backend-linukxms build with default features

### DIFF
--- a/internal/backends/linuxkms/display.rs
+++ b/internal/backends/linuxkms/display.rs
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::cell::Cell;
-use std::rc::{Rc, Weak};
-
 use i_slint_core::api::PhysicalSize;
 use i_slint_core::platform::PlatformError;
 
@@ -101,58 +98,65 @@ impl RenderingRotation {
     }
 }
 
-struct TimerBasedAnimationDriver {
-    timer: i_slint_core::timers::Timer,
-    next_animation_frame_callback: Cell<Option<Box<dyn FnOnce()>>>,
-}
+#[cfg(any(feature = "renderer-skia-vulkan", feature = "renderer-software"))]
+pub(crate) mod timeranimations {
+    use i_slint_core::platform::PlatformError;
+    use std::cell::Cell;
+    use std::rc::{Rc, Weak};
 
-impl TimerBasedAnimationDriver {
-    fn new() -> Rc<Self> {
-        Rc::new_cyclic(|self_weak: &Weak<Self>| {
-            let self_weak = self_weak.clone();
-            let timer = i_slint_core::timers::Timer::default();
-            timer.start(
-                i_slint_core::timers::TimerMode::Repeated,
-                std::time::Duration::from_millis(16),
-                move || {
-                    let Some(this) = self_weak.upgrade() else { return };
-                    // Stop the timer and let the callback decide if we need to continue. It will set
-                    // `needs_redraw` to true of animations should continue, render() will be called,
-                    // present_with_next_frame_callback() will be called and then the timer restarted.
-                    this.timer.stop();
-                    if let Some(next_animation_frame_callback) =
-                        this.next_animation_frame_callback.take()
-                    {
-                        next_animation_frame_callback();
-                    }
-                },
-            );
-            // Activate it only when we present a frame.
-            timer.stop();
-
-            Self { timer, next_animation_frame_callback: Default::default() }
-        })
-    }
-}
-
-impl crate::display::Presenter for TimerBasedAnimationDriver {
-    fn is_ready_to_present(&self) -> bool {
-        true
+    pub(crate) struct TimerBasedAnimationDriver {
+        timer: i_slint_core::timers::Timer,
+        next_animation_frame_callback: Cell<Option<Box<dyn FnOnce()>>>,
     }
 
-    fn register_page_flip_handler(
-        &self,
-        _event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<(), PlatformError> {
-        Ok(())
+    impl TimerBasedAnimationDriver {
+        pub(crate) fn new() -> Rc<Self> {
+            Rc::new_cyclic(|self_weak: &Weak<Self>| {
+                let self_weak = self_weak.clone();
+                let timer = i_slint_core::timers::Timer::default();
+                timer.start(
+                    i_slint_core::timers::TimerMode::Repeated,
+                    std::time::Duration::from_millis(16),
+                    move || {
+                        let Some(this) = self_weak.upgrade() else { return };
+                        // Stop the timer and let the callback decide if we need to continue. It will set
+                        // `needs_redraw` to true of animations should continue, render() will be called,
+                        // present_with_next_frame_callback() will be called and then the timer restarted.
+                        this.timer.stop();
+                        if let Some(next_animation_frame_callback) =
+                            this.next_animation_frame_callback.take()
+                        {
+                            next_animation_frame_callback();
+                        }
+                    },
+                );
+                // Activate it only when we present a frame.
+                timer.stop();
+
+                Self { timer, next_animation_frame_callback: Default::default() }
+            })
+        }
     }
 
-    fn present_with_next_frame_callback(
-        &self,
-        ready_for_next_animation_frame: Box<dyn FnOnce()>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.next_animation_frame_callback.set(Some(ready_for_next_animation_frame));
-        self.timer.restart();
-        Ok(())
+    impl crate::display::Presenter for TimerBasedAnimationDriver {
+        fn is_ready_to_present(&self) -> bool {
+            true
+        }
+
+        fn register_page_flip_handler(
+            &self,
+            _event_loop_handle: crate::calloop_backend::EventLoopHandle,
+        ) -> Result<(), PlatformError> {
+            Ok(())
+        }
+
+        fn present_with_next_frame_callback(
+            &self,
+            ready_for_next_animation_frame: Box<dyn FnOnce()>,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            self.next_animation_frame_callback.set(Some(ready_for_next_animation_frame));
+            self.timer.restart();
+            Ok(())
+        }
     }
 }

--- a/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
+++ b/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
@@ -12,7 +12,7 @@ pub struct LinuxFBDisplay {
     back_buffer: RefCell<Box<[u8]>>,
     width: u32,
     height: u32,
-    presenter: Rc<crate::display::TimerBasedAnimationDriver>,
+    presenter: Rc<crate::display::timeranimations::TimerBasedAnimationDriver>,
     first_frame: Cell<bool>,
 }
 
@@ -87,7 +87,7 @@ impl LinuxFBDisplay {
             back_buffer,
             width,
             height,
-            presenter: crate::display::TimerBasedAnimationDriver::new(),
+            presenter: crate::display::timeranimations::TimerBasedAnimationDriver::new(),
             first_frame: Cell::new(true),
         }))
     }

--- a/internal/backends/linuxkms/display/vulkandisplay.rs
+++ b/internal/backends/linuxkms/display/vulkandisplay.rs
@@ -173,6 +173,6 @@ pub fn create_vulkan_display() -> Result<VulkanDisplay, PlatformError> {
         queue_family_index,
         surface: vulkan_surface,
         size,
-        presenter: crate::display::TimerBasedAnimationDriver::new(),
+        presenter: crate::display::timeranimations::TimerBasedAnimationDriver::new(),
     })
 }


### PR DESCRIPTION

When no features are enabled, the TimerBasedAnimationDriver would be unused.