### PR TITLE
Update language-specific docs to document that public functions can be called from the backend code

### DIFF
--- a/api/cpp/docs/generated_code.md
+++ b/api/cpp/docs/generated_code.md
@@ -26,6 +26,8 @@ These classes have the same name as the component will have the following public
   * `invoke_<callback_name>` function which takes the callback argument as parameter and call the callback.
   * `on_<callback_name>` function which takes a functor as an argument and sets the callback handler
      for this callback. the functor must accept the type parameter of the callback
+* For each public function declared in the root component, an `invoke_<function_name>` function which
+  takes the function arguments as parameters and calls the function.
 * A `global` function to access exported global singletons.
 
 The `create` function creates a new instance of the component, which is wrapped
@@ -48,10 +50,13 @@ Let's assume we've this code in our `.slint` file:
 ```slint,no-preview
 export component SampleComponent inherits Window {
     in-out property<int> counter;
+    // note that dashes will be replaced by underscores in the generated code
     in-out property<string> user_name;
     callback hello;
+    public function do-something(d: duration) -> bool { return true; } 
     // ... maybe more elements here
 }
+
 ```
 
 This generates a header with the following contents (edited for documentation purpose)
@@ -93,6 +98,9 @@ public:
     inline void invoke_hello () const;
     /// Sets the callback handler for the `hello` callback.
     template<typename Functor> inline void on_hello (Functor && callback_handler) const;
+
+    /// Call this function to call the `do-something` function.
+    inline bool invoke_do_something (std::int64_t d) const;
 
     /// Returns a reference to a global singleton that's exported.
     ///

--- a/api/cpp/docs/generated_code.md
+++ b/api/cpp/docs/generated_code.md
@@ -26,8 +26,7 @@ These classes have the same name as the component will have the following public
   * `invoke_<callback_name>` function which takes the callback argument as parameter and call the callback.
   * `on_<callback_name>` function which takes a functor as an argument and sets the callback handler
      for this callback. the functor must accept the type parameter of the callback
-* For each public function declared in the root component, an `invoke_<function_name>` function which
-  takes the function arguments as parameters and calls the function.
+* For each public function declared in the root component, an `invoke_<function_name>` function to call the function.
 * A `global` function to access exported global singletons.
 
 The `create` function creates a new instance of the component, which is wrapped

--- a/api/cpp/docs/generated_code.md
+++ b/api/cpp/docs/generated_code.md
@@ -53,7 +53,7 @@ export component SampleComponent inherits Window {
     // note that dashes will be replaced by underscores in the generated code
     in-out property<string> user_name;
     callback hello;
-    public function do-something(d: duration) -> bool { return true; } 
+    public function do-something(x: int) -> bool { return x > 0; } 
     // ... maybe more elements here
 }
 
@@ -100,7 +100,7 @@ public:
     template<typename Functor> inline void on_hello (Functor && callback_handler) const;
 
     /// Call this function to call the `do-something` function.
-    inline bool invoke_do_something (std::int64_t d) const;
+    inline bool invoke_do_something (int x) const;
 
     /// Returns a reference to a global singleton that's exported.
     ///

--- a/api/node/README.md
+++ b/api/node/README.md
@@ -144,6 +144,37 @@ component.clicked = function() { console.log("hello"); };
 component.clicked();
 ```
 
+### Functions
+
+Functions in Slint can be defined using the `function` keyword.
+
+**`ui/my-component.slint`**
+
+```slint
+export component MyComponent inherits Window {
+    width: 400px;
+    height: 200px;
+
+    public function my-function() -> int {
+        return 42;
+    }
+}
+```
+
+If the function is marked `public`, it can also be called from JavaScript.
+
+**`main.js`**
+
+```js
+import * as slint from "slint-ui";
+
+let ui = slint.loadFile("ui/my-component.slint");
+let component = new ui.MyComponent();
+
+// call a public function
+let result = component.my_function();
+```
+
 ### Type Mappings
 
 The types used for properties in .slint design markup each translate to specific types in JavaScript. The follow table summarizes the entire mapping:

--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -25,7 +25,7 @@ pub mod generated_code {
     /// what functions you can call and how you can pass data in and out.
     ///
     /// This is the source code:
-    /// 
+    ///
     /// ```slint,no-preview
     /// export component SampleComponent inherits Window {
     ///     in-out property<int> counter;

--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -23,7 +23,7 @@ pub mod generated_code {
 
     /// This an example of the API that is generated for a component in `.slint` design markup. This may help you understand
     /// what functions you can call and how you can pass data in and out.
-    /// 
+    ///
     /// This is the source code:
     /// 
     /// ```slint,no-preview

--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -32,7 +32,7 @@ pub mod generated_code {
     ///     // note that dashes will be replaced by underscores in the generated code
     ///     in-out property<string> user-name;
     ///     callback hello;
-    ///     public function do-something(d: duration) -> bool { return true; } 
+    ///     public function do-something(x: int) -> bool { return x > 0; }
     ///     // ... maybe more elements here
     /// }
     /// ```
@@ -84,7 +84,7 @@ pub mod generated_code {
         /// For each public function declared at the root of the component, a function to call
         /// that function is generated. This is the function that calls the `do-something` function
         /// declared in the `.slint` design markup.
-        pub fn invoke_do_something(&self, d: i64) -> bool {
+        pub fn invoke_do_something(&self, d: i32) -> bool {
             unimplemented!()
         }
     }

--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -23,13 +23,16 @@ pub mod generated_code {
 
     /// This an example of the API that is generated for a component in `.slint` design markup. This may help you understand
     /// what functions you can call and how you can pass data in and out.
+    /// 
     /// This is the source code:
+    /// 
     /// ```slint,no-preview
     /// export component SampleComponent inherits Window {
     ///     in-out property<int> counter;
     ///     // note that dashes will be replaced by underscores in the generated code
     ///     in-out property<string> user-name;
-    ///     callback hello();
+    ///     callback hello;
+    ///     public function do-something(d: duration) -> bool { return true; } 
     ///     // ... maybe more elements here
     /// }
     /// ```
@@ -77,6 +80,13 @@ pub mod generated_code {
         ///     });
         /// ```
         pub fn on_hello(&self, f: impl Fn() + 'static) {}
+
+        /// For each public function declared at the root of the component, a function to call
+        /// that function is generated. This is the function that calls the `do-something` function
+        /// declared in the `.slint` design markup.
+        pub fn invoke_do_something(&self, d: i64) -> bool {
+            unimplemented!()
+        }
     }
 
     impl ComponentHandle for SampleComponent {

--- a/tests/cases/examples/sample_component.slint
+++ b/tests/cases/examples/sample_component.slint
@@ -6,6 +6,6 @@ export component SampleComponent inherits Window {
     // note that dashes will be replaced by underscores in the generated code
     in-out property<string> user_name;
     callback hello;
-    public function do-something(d: duration) -> bool { return true; } 
+    public function do-something(x: int) -> bool { return x > 0; }
     // ... maybe more elements here
 }

--- a/tests/cases/examples/sample_component.slint
+++ b/tests/cases/examples/sample_component.slint
@@ -1,14 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export struct MyStruct := {
-    foo: int,
-    bar: string,
-}
-
-SampleComponent := Window {
-    property<int> counter;
-    property<string> user_name;
+export component SampleComponent inherits Window {
+    in-out property<int> counter;
+    // note that dashes will be replaced by underscores in the generated code
+    in-out property<string> user_name;
     callback hello;
+    public function do-something(d: duration) -> bool { return true; } 
     // ... maybe more elements here
 }


### PR DESCRIPTION
Tested for Rust and C++, wasn't able to test JS but it should work.

I found a `sample_component.slint` file that seems to be intended to be the same code as the SampleComponent in Rust and C++ docs, so I updated it to be in sync with the code in those language docs. Let me know if that is not what it's supposed to be.