### PR TITLE
Fix panic in slint::Timer due to double mutable borrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project are documented in this file.
  - Added missing implementation of the `Error` for some of the errors
  - allow all clippy warnings in generated code
  - Add `slint::Image::image_buffer()` getter to obtain pixels for a `slint::Image` if available.
+ - Fix panic in `slint::Timer` when a new timer is started while stopping another.
 
 ### Node API
 

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -183,6 +183,7 @@ impl Drop for Timer {
         if let Some(id) = self.id() {
             let _ = CURRENT_TIMERS.try_with(|timers| {
                 let callback = timers.borrow_mut().remove_timer(id);
+                // drop the callback without having CURRENT_TIMERS borrowed
                 drop(callback);
             });
         }


### PR DESCRIPTION
When stopping a timer, the removal from the timer list requires a mutable borrow. If during that borrow the timer's closure is dropped and a `Drop` impl starts another time, then the attempt of acquiring a mutable borrow for the timers list to insert the new timer fails.