### PR TITLE
Remove some `cargo:rustc-check-cfg` output:

### DIFF
--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -4,10 +4,6 @@
 use cfg_aliases::cfg_aliases;
 
 fn main() {
-    // Remove when cfg_aliases supports this
-    println!("cargo:rustc-check-cfg=cfg(enable_skia_renderer)");
-    println!("cargo:rustc-check-cfg=cfg(enable_accesskit)");
-
     // Setup cfg aliases
     cfg_aliases! {
        enable_skia_renderer: { any(feature = "renderer-skia", feature = "renderer-skia-opengl", feature = "renderer-skia-vulkan")},

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -14,7 +14,6 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 categories = ["gui", "development-tools", "no-std"]
-build = "build.rs"
 
 [lib]
 path = "lib.rs"
@@ -114,3 +113,6 @@ fontdb = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 tiny-skia = "0.11.0"
 tokio = { version = "1.35", features = ["rt-multi-thread"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(slint_debug_property)", "cfg(cbindgen)", "cfg(slint_int_coord)"] }

--- a/internal/core/build.rs
+++ b/internal/core/build.rs
@@ -1,8 +1,0 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
-
-fn main() {
-    println!("cargo:rustc-check-cfg=cfg(slint_debug_property)");
-    println!("cargo:rustc-check-cfg=cfg(cbindgen)");
-    println!("cargo:rustc-check-cfg=cfg(slint_int_coord)");
-}

--- a/internal/renderers/skia/build.rs
+++ b/internal/renderers/skia/build.rs
@@ -4,13 +4,6 @@
 use cfg_aliases::cfg_aliases;
 
 fn main() {
-    // Remove when cfg_aliases supports this
-    println!("cargo:rustc-check-cfg=cfg(skia_backend_opengl)");
-    println!("cargo:rustc-check-cfg=cfg(skia_backend_metal)");
-    println!("cargo:rustc-check-cfg=cfg(skia_backend_d3d)");
-    println!("cargo:rustc-check-cfg=cfg(skia_backend_vulkan)");
-    println!("cargo:rustc-check-cfg=cfg(skia_backend_software)");
-
     // Setup cfg aliases
     cfg_aliases! {
        skia_backend_opengl: { any(feature = "opengl", not(any(target_os = "macos", target_family = "windows", target_arch = "wasm32"))) },


### PR DESCRIPTION
 - The cfg_aliases crate does it out of the box already
 - Don't create a build.rs for this only purpose when it can be added in Cargo.toml lints group. (This wasn't possible when the warning was first introduced in nightly)