### PR TITLE
Fix slint::Window::hide() on Wayland with winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     'tests/driver/nodejs',
     'tests/driver/rust',
     'tests/screenshots',
+    'tests/manual/windowattributes',
     'tools/compiler',
     'tools/figma_import',
     'tools/lsp',

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -224,7 +224,9 @@ impl NodeCollection {
     fn focus_node(&self, window_adapter_weak: &Weak<WinitWindowAdapter>) -> NodeId {
         window_adapter_weak
             .upgrade()
-            .filter(|window_adapter| window_adapter.winit_window().has_focus())
+            .filter(|window_adapter| {
+                window_adapter.winit_window().map_or(false, |winit_window| winit_window.has_focus())
+            })
             .and_then(|window_adapter| {
                 let window_inner = WindowInner::from_pub(window_adapter.window());
                 window_inner

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -17,7 +17,6 @@ pub struct WinitSoftwareRenderer {
     renderer: SoftwareRenderer,
     _context: softbuffer::Context<Rc<winit::window::Window>>,
     surface: RefCell<softbuffer::Surface<Rc<winit::window::Window>, Rc<winit::window::Window>>>,
-    winit_window: Rc<winit::window::Window>,
 }
 
 #[repr(transparent)]
@@ -89,7 +88,6 @@ impl WinitSoftwareRenderer {
                 renderer: SoftwareRenderer::new(),
                 _context: context,
                 surface: RefCell::new(surface),
-                winit_window: winit_window.clone(),
             }),
             winit_window,
         ))
@@ -107,6 +105,8 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
         };
 
         let mut surface = self.surface.borrow_mut();
+
+        let winit_window = surface.window().clone();
 
         surface
             .resize(width, height)
@@ -157,7 +157,7 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
             })
         };
 
-        self.winit_window.pre_present_notify();
+        winit_window.pre_present_notify();
 
         let size = region.bounding_box_size();
         if let Some((w, h)) = Option::zip(NonZeroU32::new(size.width), NonZeroU32::new(size.height))

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -475,6 +475,7 @@ impl WinitWindowAdapter {
             }
             WinitWindowOrNone::None(attributes) => {
                 attributes.borrow_mut().inner_size = Some(size);
+                self.resize_event(size.to_physical(self.window().scale_factor() as _))?;
                 Ok(true)
             }
         }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -263,9 +263,10 @@ impl WinitWindowAdapter {
     /// Creates a new reference-counted instance.
     pub(crate) fn new(
         renderer: Box<dyn WinitCompatibleRenderer>,
-        winit_window: Rc<winit::window::Window>,
+        window_attributes: winit::window::WindowAttributes,
         #[cfg(enable_accesskit)] proxy: EventLoopProxy<SlintUserEvent>,
-    ) -> Rc<Self> {
+    ) -> Result<Rc<Self>, PlatformError> {
+        let winit_window = renderer.resume(window_attributes)?;
         let self_rc = Rc::new_cyclic(|self_weak| Self {
             window: OnceCell::with_value(corelib::api::Window::new(self_weak.clone() as _)),
             self_weak: self_weak.clone(),
@@ -306,7 +307,7 @@ impl WinitWindowAdapter {
             .unwrap_or_else(|| winit_window.scale_factor() as f32);
         self_rc.window().dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor });
 
-        self_rc
+        Ok(self_rc)
     }
 
     fn renderer(&self) -> &dyn WinitCompatibleRenderer {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -676,10 +676,15 @@ impl WindowAdapter for WinitWindowAdapter {
                         winit::dpi::Position::Physical(phys_pos) => {
                             Some(corelib::api::PhysicalPosition::new(phys_pos.x, phys_pos.y))
                         }
-                        winit::dpi::Position::Logical(_) => {
-                            // User requested a logical position before the window was known, and the window hasn't been created yet. We don't really
-                            // have a scale factor to convert this to a proper physical position :()
-                            None
+                        winit::dpi::Position::Logical(logical_pos) => {
+                            // Best effort: Use the last known scale factor
+                            Some(
+                                corelib::api::LogicalPosition::new(
+                                    logical_pos.x as _,
+                                    logical_pos.y as _,
+                                )
+                                .to_physical(self.window().scale_factor()),
+                            )
                         }
                     }
                 })

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -256,7 +256,7 @@ pub struct WinitWindowAdapter {
     #[cfg(enable_accesskit)]
     pub accesskit_adapter: RefCell<crate::accesskit::AccessKitAdapter>,
 
-    winit_window_or_none: RefCell<WinitWindowOrNone>, // Last field so that any previously provided window handles are still valid in the drop impl of the renderers, etc.
+    winit_window_or_none: RefCell<WinitWindowOrNone>,
 }
 
 impl WinitWindowAdapter {

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -173,6 +173,11 @@ impl<T: Clone> ItemCache<T> {
             sub.remove(&item_rc.index());
         }
     }
+
+    /// Returns true if there are no entries in the cache; false otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.map.borrow().is_empty()
+    }
 }
 
 /// Return true if the item might be a clipping item

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -153,6 +153,24 @@ pub trait WindowAdapter {
     ) -> Result<raw_window_handle_06::DisplayHandle<'_>, raw_window_handle_06::HandleError> {
         Err(raw_window_handle_06::HandleError::NotSupported)
     }
+
+    /// Re-implement this to support exposing raw window handles (version 0.6).
+    #[cfg(feature = "raw-window-handle-06")]
+    fn window_handle_06_rc(
+        &self,
+    ) -> Result<Rc<dyn raw_window_handle_06::HasWindowHandle>, raw_window_handle_06::HandleError>
+    {
+        Err(raw_window_handle_06::HandleError::NotSupported)
+    }
+
+    /// Re-implement this to support exposing raw display handles (version 0.6).
+    #[cfg(feature = "raw-window-handle-06")]
+    fn display_handle_06_rc(
+        &self,
+    ) -> Result<Rc<dyn raw_window_handle_06::HasDisplayHandle>, raw_window_handle_06::HandleError>
+    {
+        Err(raw_window_handle_06::HandleError::NotSupported)
+    }
 }
 
 /// Implementation details behind [`WindowAdapter`], but since this

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -140,60 +140,14 @@ impl FemtoVGRenderer {
         #[cfg(not(target_arch = "wasm32"))] opengl_context: impl OpenGLInterface + 'static,
         #[cfg(target_arch = "wasm32")] html_canvas: web_sys::HtmlCanvasElement,
     ) -> Result<Self, PlatformError> {
-        #[cfg(target_arch = "wasm32")]
-        let opengl_context = WebGLNeedsNoCurrentContext {};
-
-        let opengl_context = Box::new(opengl_context);
-        #[cfg(not(target_arch = "wasm32"))]
-        let gl_renderer = unsafe {
-            femtovg::renderer::OpenGl::new_from_function_cstr(|name| {
-                opengl_context.get_proc_address(name)
-            })
-            .unwrap()
-        };
-
-        #[cfg(target_arch = "wasm32")]
-        let gl_renderer = match femtovg::renderer::OpenGl::new_from_html_canvas(&html_canvas) {
-            Ok(gl_renderer) => gl_renderer,
-            Err(_) => {
-                use wasm_bindgen::JsCast;
-
-                // I don't believe that there's a way of disabling the 2D canvas.
-                let context_2d = html_canvas
-                    .get_context("2d")
-                    .unwrap()
-                    .unwrap()
-                    .dyn_into::<web_sys::CanvasRenderingContext2d>()
-                    .unwrap();
-                context_2d.set_font("20px serif");
-                // We don't know if we're rendering on dark or white background, so choose a "color" in the middle for the text.
-                context_2d.set_fill_style(&wasm_bindgen::JsValue::from_str("red"));
-                context_2d
-                    .fill_text("Slint requires WebGL to be enabled in your browser", 0., 30.)
-                    .unwrap();
-                panic!("Cannot proceed without WebGL - aborting")
-            }
-        };
-
-        let femtovg_canvas = femtovg::Canvas::new_with_text_context(
-            gl_renderer,
-            self::fonts::FONT_CACHE.with(|cache| cache.borrow().text_context.clone()),
-        )
-        .unwrap();
-        let canvas = Rc::new(RefCell::new(femtovg_canvas));
-
-        Ok(Self {
-            maybe_window_adapter: Default::default(),
-            rendering_notifier: Default::default(),
-            canvas: RefCell::new(Some(canvas)),
-            graphics_cache: Default::default(),
-            texture_cache: Default::default(),
-            rendering_metrics_collector: Default::default(),
-            rendering_first_time: Cell::new(true),
-            opengl_context: RefCell::new(opengl_context),
+        let this = Self::new_suspended();
+        this.resume(
+            #[cfg(not(target_arch = "wasm32"))]
+            opengl_context,
             #[cfg(target_arch = "wasm32")]
-            canvas_id: RefCell::new(html_canvas.id()),
-        })
+            html_canvas,
+        )?;
+        Ok(this)
     }
 
     /// Creates a new renderer in suspended state. Any attempts at rendering, etc. will produce an error,

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -108,7 +108,7 @@ unsafe impl OpenGLInterface for SuspendedRenderer {
         _: NonZeroU32,
         _: NonZeroU32,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        Err(format!("resize called on suspended renderer").into())
+        Ok(())
     }
 
     fn get_proc_address(&self, _: &std::ffi::CStr) -> *const std::ffi::c_void {

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -92,21 +92,45 @@ unsafe impl OpenGLInterface for WebGLNeedsNoCurrentContext {
     }
 }
 
+struct SuspendedRenderer {}
+
+unsafe impl OpenGLInterface for SuspendedRenderer {
+    fn ensure_current(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Err(format!("ensure current called on suspended renderer").into())
+    }
+
+    fn swap_buffers(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Err(format!("swap_buffers called on suspended renderer").into())
+    }
+
+    fn resize(
+        &self,
+        _: NonZeroU32,
+        _: NonZeroU32,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Err(format!("resize called on suspended renderer").into())
+    }
+
+    fn get_proc_address(&self, _: &std::ffi::CStr) -> *const std::ffi::c_void {
+        panic!("get_proc_address called on suspended renderer")
+    }
+}
+
 /// Use the FemtoVG renderer when implementing a custom Slint platform where you deliver events to
 /// Slint and want the scene to be rendered using OpenGL. The rendering is done using the [FemtoVG](https://github.com/femtovg/femtovg)
 /// library.
 pub struct FemtoVGRenderer {
     maybe_window_adapter: RefCell<Option<Weak<dyn WindowAdapter>>>,
     rendering_notifier: RefCell<Option<Box<dyn RenderingNotifier>>>,
-    canvas: CanvasRc,
+    canvas: RefCell<Option<CanvasRc>>,
     graphics_cache: itemrenderer::ItemGraphicsCache,
     texture_cache: RefCell<images::TextureCache>,
     rendering_metrics_collector: RefCell<Option<Rc<RenderingMetricsCollector>>>,
     rendering_first_time: Cell<bool>,
     // Last field, so that it's dropped last and context exists and is current when destroying the FemtoVG canvas
-    opengl_context: Box<dyn OpenGLInterface>,
+    opengl_context: RefCell<Box<dyn OpenGLInterface>>,
     #[cfg(target_arch = "wasm32")]
-    canvas_id: String,
+    canvas_id: RefCell<String>,
 }
 
 impl FemtoVGRenderer {
@@ -161,15 +185,102 @@ impl FemtoVGRenderer {
         Ok(Self {
             maybe_window_adapter: Default::default(),
             rendering_notifier: Default::default(),
-            canvas,
+            canvas: RefCell::new(Some(canvas)),
             graphics_cache: Default::default(),
             texture_cache: Default::default(),
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Cell::new(true),
-            opengl_context,
+            opengl_context: RefCell::new(opengl_context),
             #[cfg(target_arch = "wasm32")]
-            canvas_id: html_canvas.id(),
+            canvas_id: RefCell::new(html_canvas.id()),
         })
+    }
+
+    /// Creates a new renderer in suspended state. Any attempts at rendering, etc. will produce an error,
+    /// until [`Self::resume()`] was called successfully.
+    pub fn new_suspended() -> Self {
+        let opengl_context = Box::new(SuspendedRenderer {});
+
+        Self {
+            maybe_window_adapter: Default::default(),
+            rendering_notifier: Default::default(),
+            canvas: RefCell::new(None),
+            graphics_cache: Default::default(),
+            texture_cache: Default::default(),
+            rendering_metrics_collector: Default::default(),
+            rendering_first_time: Cell::new(true),
+            opengl_context: RefCell::new(opengl_context),
+            #[cfg(target_arch = "wasm32")]
+            canvas_id: Default::default(),
+        }
+    }
+
+    /// Suspends the renderer by deleting all OpenGL sources moving into a suspended state.
+    /// All subsequence attempt at rendering will produce an error, until [`Self::resume()`]
+    /// is called successfully.
+    ///
+    /// Use this to transfer a renderer between different window surfaces.
+    pub fn suspend(&self) -> Result<(), i_slint_core::platform::PlatformError> {
+        if self.opengl_context.borrow().ensure_current().is_ok() {
+            self.graphics_cache.clear_all();
+            self.texture_cache.borrow_mut().clear();
+        }
+        drop(self.canvas.borrow_mut().take());
+        *self.opengl_context.borrow_mut() = Box::new(SuspendedRenderer {});
+        Ok(())
+    }
+
+    /// Resumes a previously suspended renderer.
+    pub fn resume(
+        &self,
+        #[cfg(not(target_arch = "wasm32"))] opengl_context: impl OpenGLInterface + 'static,
+        #[cfg(target_arch = "wasm32")] html_canvas: web_sys::HtmlCanvasElement,
+    ) -> Result<(), i_slint_core::platform::PlatformError> {
+        #[cfg(target_arch = "wasm32")]
+        let opengl_context = WebGLNeedsNoCurrentContext {};
+
+        let opengl_context = Box::new(opengl_context);
+        #[cfg(not(target_arch = "wasm32"))]
+        let gl_renderer = unsafe {
+            femtovg::renderer::OpenGl::new_from_function_cstr(|name| {
+                opengl_context.get_proc_address(name)
+            })
+            .unwrap()
+        };
+
+        #[cfg(target_arch = "wasm32")]
+        let gl_renderer = match femtovg::renderer::OpenGl::new_from_html_canvas(&html_canvas) {
+            Ok(gl_renderer) => gl_renderer,
+            Err(_) => {
+                use wasm_bindgen::JsCast;
+
+                // I don't believe that there's a way of disabling the 2D canvas.
+                let context_2d = html_canvas
+                    .get_context("2d")
+                    .unwrap()
+                    .unwrap()
+                    .dyn_into::<web_sys::CanvasRenderingContext2d>()
+                    .unwrap();
+                context_2d.set_font("20px serif");
+                // We don't know if we're rendering on dark or white background, so choose a "color" in the middle for the text.
+                context_2d.set_fill_style(&wasm_bindgen::JsValue::from_str("red"));
+                context_2d
+                    .fill_text("Slint requires WebGL to be enabled in your browser", 0., 30.)
+                    .unwrap();
+                panic!("Cannot proceed without WebGL - aborting")
+            }
+        };
+
+        let femtovg_canvas = femtovg::Canvas::new_with_text_context(
+            gl_renderer,
+            self::fonts::FONT_CACHE.with(|cache| cache.borrow().text_context.clone()),
+        )
+        .unwrap();
+        let canvas = Rc::new(RefCell::new(femtovg_canvas));
+
+        *self.canvas.borrow_mut() = canvas.into();
+        *self.opengl_context.borrow_mut() = opengl_context;
+        Ok(())
     }
 
     /// Render the scene using OpenGL.
@@ -189,7 +300,7 @@ impl FemtoVGRenderer {
         surface_size: i_slint_core::api::PhysicalSize,
         post_render_cb: Option<&dyn Fn(&mut dyn ItemRenderer)>,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
-        self.opengl_context.ensure_current()?;
+        self.opengl_context.borrow().ensure_current()?;
 
         if self.rendering_first_time.take() {
             *self.rendering_metrics_collector.borrow_mut() =
@@ -213,16 +324,24 @@ impl FemtoVGRenderer {
             return Ok(());
         };
 
+        if self.canvas.borrow().is_none() {
+            // Nothing to render
+            return Ok(());
+        }
+
         let window_inner = WindowInner::from_pub(window);
         let scale = window_inner.scale_factor().ceil();
 
         window_inner
             .draw_contents(|components| -> Result<(), PlatformError> {
+                // self.canvas is checked for being Some(...) at the beginning of this function
+                let canvas = self.canvas.borrow().as_ref().unwrap().clone();
+
                 let window_background_brush =
                     window_inner.window_item().map(|w| w.as_pin_ref().background());
 
                 {
-                    let mut femtovg_canvas = self.canvas.borrow_mut();
+                    let mut femtovg_canvas = canvas.borrow_mut();
                     // We pass an integer that is greater than or equal to the scale factor as
                     // dpi / device pixel ratio as the anti-alias of femtovg needs that to draw text clearly.
                     // We need to care about that `ceil()` when calculating metrics.
@@ -241,14 +360,14 @@ impl FemtoVGRenderer {
                 }
 
                 {
-                    let mut femtovg_canvas = self.canvas.borrow_mut();
+                    let mut femtovg_canvas = canvas.borrow_mut();
                     femtovg_canvas.reset();
                     femtovg_canvas.rotate(rotation_angle_degrees.to_radians());
                     femtovg_canvas.translate(translation.0, translation.1);
                 }
 
                 if let Some(notifier_fn) = self.rendering_notifier.borrow_mut().as_mut() {
-                    let mut femtovg_canvas = self.canvas.borrow_mut();
+                    let mut femtovg_canvas = canvas.borrow_mut();
                     // For the BeforeRendering rendering notifier callback it's important that this happens *after* clearing
                     // the back buffer, in order to allow the callback to provide its own rendering of the background.
                     // femtovg's clear_rect() will merely schedule a clear call, so flush right away to make it immediate.
@@ -266,7 +385,7 @@ impl FemtoVGRenderer {
                 self.graphics_cache.clear_cache_if_scale_factor_changed(window);
 
                 let mut item_renderer = self::itemrenderer::GLItemRenderer::new(
-                    &self.canvas,
+                    &canvas,
                     &self.graphics_cache,
                     &self.texture_cache,
                     window,
@@ -303,7 +422,7 @@ impl FemtoVGRenderer {
                     collector.measure_frame_rendered(&mut item_renderer);
                 }
 
-                self.canvas.borrow_mut().flush();
+                canvas.borrow_mut().flush();
 
                 // Delete any images and layer images (and their FBOs) before making the context not current anymore, to
                 // avoid GPU memory leaks.
@@ -317,7 +436,7 @@ impl FemtoVGRenderer {
             self.with_graphics_api(|api| callback.notify(RenderingState::AfterRendering, &api))?;
         }
 
-        self.opengl_context.swap_buffers()?;
+        self.opengl_context.borrow().swap_buffers()?;
         Ok(())
     }
 
@@ -328,9 +447,9 @@ impl FemtoVGRenderer {
     ) -> Result<(), PlatformError> {
         use i_slint_core::api::GraphicsAPI;
 
-        self.opengl_context.ensure_current()?;
+        self.opengl_context.borrow().ensure_current()?;
         let api = GraphicsAPI::NativeOpenGL {
-            get_proc_address: &|name| self.opengl_context.get_proc_address(name),
+            get_proc_address: &|name| self.opengl_context.borrow().get_proc_address(name),
         };
         callback(api);
         Ok(())
@@ -343,10 +462,10 @@ impl FemtoVGRenderer {
     ) -> Result<(), PlatformError> {
         use i_slint_core::api::GraphicsAPI;
 
-        let api = GraphicsAPI::WebGL {
-            canvas_element_id: self.canvas_id.as_str(),
-            context_type: "webgl",
-        };
+        let canvas_id = self.canvas_id.borrow();
+
+        let api =
+            GraphicsAPI::WebGL { canvas_element_id: canvas_id.as_str(), context_type: "webgl" };
         callback(api);
         Ok(())
     }
@@ -520,14 +639,16 @@ impl RendererSealed for FemtoVGRenderer {
         component: i_slint_core::item_tree::ItemTreeRef,
         _items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'_>>>,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
-        self.opengl_context.ensure_current()?;
-        self.graphics_cache.component_destroyed(component);
+        if !self.graphics_cache.is_empty() {
+            self.opengl_context.borrow().ensure_current()?;
+            self.graphics_cache.component_destroyed(component);
+        }
         Ok(())
     }
 
     fn set_window_adapter(&self, window_adapter: &Rc<dyn WindowAdapter>) {
         *self.maybe_window_adapter.borrow_mut() = Some(Rc::downgrade(window_adapter));
-        if self.opengl_context.ensure_current().is_ok() {
+        if self.opengl_context.borrow().ensure_current().is_ok() {
             self.graphics_cache.clear_all();
             self.texture_cache.borrow_mut().clear();
         }
@@ -535,16 +656,18 @@ impl RendererSealed for FemtoVGRenderer {
 
     fn resize(&self, size: i_slint_core::api::PhysicalSize) -> Result<(), PlatformError> {
         if let Some((width, height)) = size.width.try_into().ok().zip(size.height.try_into().ok()) {
-            self.opengl_context.resize(width, height)?;
+            self.opengl_context.borrow().resize(width, height)?;
         };
         Ok(())
     }
 
     /// Returns an image buffer of what was rendered last by reading the previous front buffer (using glReadPixels).
     fn screenshot(&self) -> Result<SharedImageBuffer, PlatformError> {
-        self.opengl_context.ensure_current()?;
-        let screenshot = self
-            .canvas
+        self.opengl_context.borrow().ensure_current()?;
+        let Some(canvas) = self.canvas.borrow().as_ref().cloned() else {
+            return Err("FemtoVG renderer cannot take screenshot without a window".into());
+        };
+        let screenshot = canvas
             .borrow_mut()
             .screenshot()
             .map_err(|e| format!("FemtoVG error reading current back buffer: {e}"))?;
@@ -561,7 +684,7 @@ impl RendererSealed for FemtoVGRenderer {
 impl Drop for FemtoVGRenderer {
     fn drop(&mut self) {
         // Ensure the context is current before the renderer is destroyed
-        if self.opengl_context.ensure_current().is_ok() {
+        if self.opengl_context.borrow().ensure_current().is_ok() {
             drop(self.rendering_metrics_collector.borrow_mut().take());
 
             if let Some(callback) = self.rendering_notifier.borrow_mut().as_mut() {
@@ -576,8 +699,10 @@ impl Drop for FemtoVGRenderer {
         self.graphics_cache.clear_all();
         self.texture_cache.borrow_mut().clear();
 
-        if Rc::strong_count(&self.canvas) != 1 {
-            i_slint_core::debug_log!("internal warning: there are canvas references left when destroying the window. OpenGL resources will be leaked.")
+        if let Some(canvas) = self.canvas.borrow_mut().take() {
+            if Rc::strong_count(&canvas) != 1 {
+                i_slint_core::debug_log!("internal warning: there are canvas references left when destroying the window. OpenGL resources will be leaked.")
+            }
         }
     }
 }

--- a/tests/manual/windowattributes/Cargo.toml
+++ b/tests/manual/windowattributes/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+[package]
+name = "windowattributes"
+description.workspace = true
+authors.workspace = true
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[[bin]]
+name = "windowattributes"
+path = "main.rs"
+
+[dependencies]
+slint = { version = "=1.7.0", path = "../../../api/rs/slint" }

--- a/tests/manual/windowattributes/main.rs
+++ b/tests/manual/windowattributes/main.rs
@@ -1,0 +1,92 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+slint::slint! {
+
+import { VerticalBox, CheckBox, LineEdit } from "std-widgets.slint";
+
+export component MainWindow inherits Window {
+    callback toggle-visibility(bool);
+    callback toggle-minimized(bool);
+    callback toggle-maximized(bool);
+    callback set-title(string);
+
+    VerticalBox {
+        CheckBox {
+            text: "visible";
+            checked: true;
+            toggled => { root.toggle-visibility(self.checked); }
+        }
+        CheckBox {
+            text: "minimized";
+            checked: false;
+            toggled => { root.toggle-minimized(self.checked); }
+        }
+        CheckBox {
+            text: "maximized";
+            checked: false;
+            toggled => { root.toggle-maximized(self.checked); }
+        }
+        Text {
+            text: "title:";
+        }
+        LineEdit {
+            accepted => { root.set-title(self.text); }
+        }
+    }
+}
+
+export component TestWindow inherits Window {
+    in property<string> window-title <=> self.title;
+    Text {
+        text: "Go ahead and use the\nother window to control aspects\nof this window.";
+    }
+}
+
+}
+
+fn main() -> Result<(), slint::PlatformError> {
+    let main_window = MainWindow::new()?;
+    main_window.show()?;
+
+    let test_window = TestWindow::new()?;
+    test_window.show()?;
+
+    main_window.on_toggle_visibility({
+        let test_window_weak = test_window.as_weak();
+        move |visible| {
+            let Some(test_window) = test_window_weak.upgrade() else { return };
+            if visible {
+                test_window.show().unwrap();
+            } else {
+                test_window.hide().unwrap()
+            }
+        }
+    });
+
+    main_window.on_toggle_minimized({
+        let test_window_weak = test_window.as_weak();
+        move |minimized| {
+            let Some(test_window) = test_window_weak.upgrade() else { return };
+            test_window.window().set_minimized(minimized);
+        }
+    });
+
+    main_window.on_toggle_maximized({
+        let test_window_weak = test_window.as_weak();
+        move |maximized| {
+            let Some(test_window) = test_window_weak.upgrade() else { return };
+            test_window.window().set_maximized(maximized);
+        }
+    });
+
+    main_window.on_set_title({
+        let test_window_weak = test_window.as_weak();
+        move |title| {
+            let Some(test_window) = test_window_weak.upgrade() else { return };
+            test_window.set_window_title(title);
+        }
+    });
+
+    slint::run_event_loop()
+}


### PR DESCRIPTION
On Wayland hiding a window requires destroying the surface, which
means destroying the winit window as well as the underlying graphics
surface. The latter is tricky as we have to keep the renderer around,
as our WindowAdapter trait's `renderer()` function returns a `&dyn
Renderer` and that also has to work without a window (to obtain text
metrics).

Fixes [#4225](https://github.com/slint-ui/slint/issues/4225)
