### PR TITLE
Winit window event filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
  - Gettext translation: clear internal gettext cache when changing translations at runtime
  - Winit backend: Fixed setting the size with set_size before showing the window (#6489)
  - Winit backend: upgraded to winit 0.30, accesskit 0.22, glutin
+ - Winit backend: added winit window event filter
  - Qt backend: fix PopupWindow exiting the application with recent Qt6
  - LinuxKMS backend: software renderer support
  - Software renderer: added API to rotate the buffer by multiple of 90 degrees.

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -295,8 +295,8 @@ impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
 
         if let Some(_winit_window) = window.winit_window() {
             if let Some(mut window_event_filter) = window.window_event_filter.take() {
-                let event_result = window_event_filter(&_winit_window, &event);
-                _winit_window.window_event_filter.set(Some(window_event_filter));
+                let event_result = window_event_filter(window.window(), &event);
+                window.window_event_filter.set(Some(window_event_filter));
 
                 match event_result {
                     WinitWindowEventResult::Accept => return,
@@ -305,7 +305,7 @@ impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
             }
 
             #[cfg(enable_accesskit)]
-            _winit_window.accesskit_adapter.borrow_mut().process_event(&_winit_window, &event);
+            window.accesskit_adapter.borrow_mut().process_event(&_winit_window, &event);
         } else {
             return;
         }

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -299,6 +299,15 @@ impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
             return;
         }
 
+        if let Some(mut window_event_filter) = window.window_event_filter.take() {
+            let should_handle_event = window_event_filter(&event);
+            window.window_event_filter.set(Some(window_event_filter));
+
+            if !should_handle_event {
+                return;
+            }
+        }
+
         let runtime_window = WindowInner::from_pub(window.window());
         match event {
             WindowEvent::RedrawRequested => {

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -299,8 +299,8 @@ impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
                 window.window_event_filter.set(Some(window_event_filter));
 
                 match event_result {
-                    WinitWindowEventResult::Accept => return,
-                    WinitWindowEventResult::Reject => (),
+                    WinitWindowEventResult::PreventDefault => return,
+                    WinitWindowEventResult::Propagate => (),
                 }
             }
 

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -391,7 +391,8 @@ pub trait WinitWindowAccessor: private::WinitWindowAccessorSealed {
     /// If this window [is not backed by winit](WinitWindowAccessor::has_winit_window), this function is a no-op.
     fn on_winit_window_event(
         &self,
-        callback: impl FnMut(&i_slint_core::api::Window, &winit::event::WindowEvent) -> WinitWindowEventResult + 'static,
+        callback: impl FnMut(&i_slint_core::api::Window, &winit::event::WindowEvent) -> WinitWindowEventResult
+            + 'static,
     );
 }
 
@@ -417,14 +418,17 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
 
     fn on_winit_window_event(
         &self,
-        mut callback: impl FnMut(&i_slint_core::api::Window, &winit::event::WindowEvent) -> WinitWindowEventResult + 'static,
+        mut callback: impl FnMut(&i_slint_core::api::Window, &winit::event::WindowEvent) -> WinitWindowEventResult
+            + 'static,
     ) {
         i_slint_core::window::WindowInner::from_pub(&self)
             .window_adapter()
             .internal(i_slint_core::InternalToken)
             .and_then(|wa| wa.as_any().downcast_ref::<WinitWindowAdapter>())
             .map(|adapter| {
-                adapter.window_event_filter.set(Some(Box::new(move |window, event| callback(window, event))));
+                adapter
+                    .window_event_filter
+                    .set(Some(Box::new(move |window, event| callback(window, event))));
             });
     }
 }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -377,7 +377,10 @@ pub trait WinitWindowAccessor: private::WinitWindowAccessorSealed {
     ///
     /// The callback is invoked in the `winit` event loop whenever a window event is received with a reference to the
     /// [`winit::event::WindowEvent`]. The return value of the callback specifies whether Slint should handle this event.
-    fn on_winit_window_event(&self, callback: impl FnMut(&winit::event::WindowEvent) -> bool + Send + 'static);
+    fn on_winit_window_event(
+        &self,
+        callback: impl FnMut(&winit::event::WindowEvent) -> bool + Send + 'static
+    );
 }
 
 impl WinitWindowAccessor for i_slint_core::api::Window {
@@ -400,7 +403,10 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
             .and_then(|adapter| adapter.winit_window().map(|w| callback(&w)))
     }
 
-    fn on_winit_window_event(&self, mut callback: impl FnMut(&winit::event::WindowEvent) -> bool + Send + 'static) {
+    fn on_winit_window_event(
+        &self,
+        mut callback: impl FnMut(&winit::event::WindowEvent) -> bool + Send + 'static
+    ) {
         i_slint_core::window::WindowInner::from_pub(&self)
             .window_adapter()
             .internal(i_slint_core::InternalToken)

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -34,10 +34,10 @@ pub struct SlintUserEvent(CustomEvent);
 /// Returned by callbacks passed to [`Window::on_winit_window_event`](WinitWindowAccessor::on_winit_window_event)
 /// to determine if winit events should propagate to the Slint event loop.
 pub enum WinitWindowEventResult {
-    /// The event was rejected by the window event filter and may propagate normally.
-    Reject,
-    /// The event was accepted by the window event filter and won't be processed further.
-    Accept,
+    /// The winit event should propagate normally.
+    Propagate,
+    /// The winit event shouldn't be processed further.
+    PreventDefault,
 }
 
 mod renderer {

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -379,7 +379,7 @@ pub trait WinitWindowAccessor: private::WinitWindowAccessorSealed {
     /// [`winit::event::WindowEvent`]. The return value of the callback specifies whether Slint should handle this event.
     fn on_winit_window_event(
         &self,
-        callback: impl FnMut(&winit::event::WindowEvent) -> bool + Send + 'static
+        callback: impl FnMut(&winit::event::WindowEvent) -> bool + Send + 'static,
     );
 }
 
@@ -405,7 +405,7 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
 
     fn on_winit_window_event(
         &self,
-        mut callback: impl FnMut(&winit::event::WindowEvent) -> bool + Send + 'static
+        mut callback: impl FnMut(&winit::event::WindowEvent) -> bool + Send + 'static,
     ) {
         i_slint_core::window::WindowInner::from_pub(&self)
             .window_adapter()

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -256,7 +256,8 @@ pub struct WinitWindowAdapter {
     #[cfg(enable_accesskit)]
     pub accesskit_adapter: RefCell<crate::accesskit::AccessKitAdapter>,
 
-    pub(crate) window_event_filter: Cell<Option<Box<dyn FnMut(&winit::event::WindowEvent) -> bool + Send>>>,
+    pub(crate) window_event_filter:
+        Cell<Option<Box<dyn FnMut(&winit::event::WindowEvent) -> bool + Send>>>,
 
     winit_window_or_none: RefCell<WinitWindowOrNone>,
 }
@@ -295,7 +296,7 @@ impl WinitWindowAdapter {
                 proxy,
             )
             .into(),
-            window_event_filter: Cell::new(None)
+            window_event_filter: Cell::new(None),
         });
 
         debug_assert!(!self_rc.renderer.is_suspended());

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -25,6 +25,7 @@ use corelib::items::{ItemRc, ItemRef};
 
 #[cfg(enable_accesskit)]
 use crate::SlintUserEvent;
+use crate::WinitWindowEventResult;
 use corelib::api::PhysicalSize;
 use corelib::layout::Orientation;
 use corelib::lengths::LogicalLength;
@@ -257,7 +258,7 @@ pub struct WinitWindowAdapter {
     pub accesskit_adapter: RefCell<crate::accesskit::AccessKitAdapter>,
 
     pub(crate) window_event_filter:
-        Cell<Option<Box<dyn FnMut(&winit::event::WindowEvent) -> bool + Send>>>,
+        Cell<Option<Box<dyn FnMut(&corelib::api::Window, &winit::event::WindowEvent) -> WinitWindowEventResult>>>,
 
     winit_window_or_none: RefCell<WinitWindowOrNone>,
 }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -256,6 +256,8 @@ pub struct WinitWindowAdapter {
     #[cfg(enable_accesskit)]
     pub accesskit_adapter: RefCell<crate::accesskit::AccessKitAdapter>,
 
+    pub(crate) window_event_filter: Cell<Option<Box<dyn FnMut(&winit::event::WindowEvent) -> bool + Send>>>,
+
     winit_window_or_none: RefCell<WinitWindowOrNone>,
 }
 
@@ -293,6 +295,7 @@ impl WinitWindowAdapter {
                 proxy,
             )
             .into(),
+            window_event_filter: Cell::new(None)
         });
 
         debug_assert!(!self_rc.renderer.is_suspended());

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -257,8 +257,16 @@ pub struct WinitWindowAdapter {
     #[cfg(enable_accesskit)]
     pub accesskit_adapter: RefCell<crate::accesskit::AccessKitAdapter>,
 
-    pub(crate) window_event_filter:
-        Cell<Option<Box<dyn FnMut(&corelib::api::Window, &winit::event::WindowEvent) -> WinitWindowEventResult>>>,
+    pub(crate) window_event_filter: Cell<
+        Option<
+            Box<
+                dyn FnMut(
+                    &corelib::api::Window,
+                    &winit::event::WindowEvent
+                ) -> WinitWindowEventResult
+            >,
+        >,
+    >,
 
     winit_window_or_none: RefCell<WinitWindowOrNone>,
 }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -262,8 +262,8 @@ pub struct WinitWindowAdapter {
             Box<
                 dyn FnMut(
                     &corelib::api::Window,
-                    &winit::event::WindowEvent
-                ) -> WinitWindowEventResult
+                    &winit::event::WindowEvent,
+                ) -> WinitWindowEventResult,
             >,
         >,
     >,


### PR DESCRIPTION
I noticed that #3066 has been a long-standing issue and fixing it would grant some functionality I want to implement in my current project (file drag-and-drop handling), so I decided to implement it.

I initially considered adding a hook element to the `Backend` but I found it very inconvenient to work with that way, mostly because I could only get it working if the closure had to be `Clone` which limits what you can do. It could still be provided this way if that's desired.

Instead, I added a method to the `WinitWindowAccessor` trait that allows you to install a filter callback. Right now, the callback only gets a `&winit::event::WindowEvent`. I've considered providing a `&winit::window::Window` or `&slint::Window` also, but I'm not sure if either would be useful. The callback can then return a bool that, if false, stops the event from propagating further.

Here's a quick and dirty example of the API in action:
```rust
{
    let main_window_weak = main_window.as_weak();
    main_window.window().on_winit_window_event(move |event| {
        match event {
            WindowEvent::Focused(active) => {
                main_window_weak.unwrap().set_active(*active);
                true
            },
            WindowEvent::DroppedFile(spc_path) => {
                main_window_weak.unwrap().invoke_open_spc(spc_path.to_str().unwrap().to_string().into());
                false
            },
            _ => true
        }
    });
}
```