### PR TITLE
Permit rotation properties on Text elements without children

### DIFF
--- a/internal/compiler/passes/check_rotation.rs
+++ b/internal/compiler/passes/check_rotation.rs
@@ -6,7 +6,7 @@ use crate::diagnostics::Spanned;
 use crate::langtype::ElementType;
 use crate::object_tree::Element;
 
-/// Check that the rotation is only on Image
+/// Check that the rotation is only on Image and Text
 pub fn check_rotation(doc: &crate::object_tree::Document, diag: &mut BuildDiagnostics) {
     for cmp in &doc.inner_components {
         crate::object_tree::recurse_elem_including_sub_components(cmp, &(), &mut |elem, _| {
@@ -15,7 +15,8 @@ pub fn check_rotation(doc: &crate::object_tree::Document, diag: &mut BuildDiagno
                 .iter()
                 .any(|(property_name, _)| is_property_set(&e, property_name))
             {
-                if matches!(e.native_class(), Some(native) if native.class_name != "ClippedImage") {
+                if matches!(e.native_class(), Some(native) if native.class_name != "ClippedImage" && native.class_name != "Text")
+                {
                     let span = e
                         .bindings
                         .get("rotation-angle")
@@ -23,7 +24,8 @@ pub fn check_rotation(doc: &crate::object_tree::Document, diag: &mut BuildDiagno
                         .unwrap_or_else(|| e.to_source_location());
 
                     diag.push_error_with_span(
-                        "rotation properties can only be applied to the Image element".into(),
+                        "rotation properties can only be applied to the Image or Text element"
+                            .into(),
                         span,
                     );
                 } else if has_any_children(&e) {

--- a/internal/compiler/tests/syntax/basic/rotation.slint
+++ b/internal/compiler/tests/syntax/basic/rotation.slint
@@ -5,13 +5,17 @@ export Ex1 := Rectangle {
     Rectangle {
         rotation-origin-x: width / 2;
         rotation-angle: 45deg;
-//                      ^error{rotation properties can only be applied to the Image element}
+//                      ^error{rotation properties can only be applied to the Image or Text element}
         rotation-origin-y: width / 2;
     }
     Rectangle {
-//  ^error{rotation properties can only be applied to the Image element}
+//  ^error{rotation properties can only be applied to the Image or Text element}
         rotation-origin-x: width / 2;
         rotation-origin-y: width / 2;
+    }
+
+    Text {
+        rotation-angle: 90deg;
     }
 }
 
@@ -53,7 +57,7 @@ export Ex3 := Rectangle {
         Rectangle {}
     }
     i2 := Rectangle {}
-//        ^error{rotation properties can only be applied to the Image element}
+//        ^error{rotation properties can only be applied to the Image or Text element}
 
     TouchArea {
         clicked => {
@@ -67,5 +71,5 @@ export component Ex4  {
     in property rot <=> rect . rotation-angle;
 
     rect := Rectangle {}
-//          ^error{rotation properties can only be applied to the Image element}
+//          ^error{rotation properties can only be applied to the Image or Text element}
 }

--- a/tests/cases/examples/rotate.slint
+++ b/tests/cases/examples/rotate.slint
@@ -55,4 +55,11 @@ TestCase := Window {
             source: @image-url("../../../logo/slint-logo-square-light-128x128.png");
         }
     }
+
+    Text {
+        x: 150px;
+        y: 200px;
+        text: "Hello World";
+        rotation-angle: 360deg * animation-tick() / 3s;
+    }
 }


### PR DESCRIPTION
This works with Skia, Qt, and FemtoVG.

cc #1481