### PR TITLE
Add `export { ... } from "....slint";` syntax.

### DIFF
--- a/docs/reference/src/language/syntax/modules.md
+++ b/docs/reference/src/language/syntax/modules.md
@@ -104,8 +104,11 @@ export component MyButton inherits Rectangle { /* ... */ }
 
 // Export lists
 component MySwitch inherits Rectangle { /* ... */ }
-export { MySwitch };
-export { MySwitch as Alias1, MyButton as Alias2 };
+export { MySwitch }
+export { MySwitch as Alias1, MyButton as Alias2 }
+
+// Re-export types from other module
+export { MyCheckBox, MyButton as OtherButton } from "other_module.slint";
 
 // Re-export all types from other module (only possible once per file)
 export * from "other_module.slint";

--- a/examples/gallery/ui/pages/pages.slint
+++ b/examples/gallery/ui/pages/pages.slint
@@ -1,11 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-import { AboutPage } from "about_page.slint";
-import { ControlsPage } from "controls_page.slint";
-import { EasingsPage } from "easings_page.slint";
-import { ListViewPage } from "list_view_page.slint";
-import { TableViewPage, TableViewPageAdapter } from "table_view_page.slint";
-import { TextEditPage } from "text_edit_page.slint";
-
-export { AboutPage, ControlsPage, EasingsPage, ListViewPage, TextEditPage, TableViewPage, TableViewPageAdapter }
+export { AboutPage } from "about_page.slint";
+export { ControlsPage } from "controls_page.slint";
+export { EasingsPage } from "easings_page.slint";
+export { ListViewPage } from "list_view_page.slint";
+export { TableViewPage, TableViewPageAdapter } from "table_view_page.slint";
+export { TextEditPage } from "text_edit_page.slint";

--- a/examples/memory/main.rs
+++ b/examples/memory/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use wasm_bindgen::prelude::*;
 
 slint::slint! {
-    import { MainWindow } from "memory.slint";
+    export { MainWindow } from "memory.slint";
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2426,7 +2426,7 @@ impl ExportedName {
             .unwrap_or_else(|| self.name.clone())
     }
 
-    pub fn from_export_scpecifier(
+    pub fn from_export_specifier(
         export_specifier: &syntax_nodes::ExportSpecifier,
     ) -> (String, ExportedName) {
         let internal_name = parser::identifier_text(&export_specifier.ExportIdentifier())
@@ -2496,7 +2496,7 @@ impl Exports {
                 .flat_map(|exports| exports.ExportSpecifier())
                 .filter_map(|export_specifier| {
                     let (internal_name, exported_name) =
-                        ExportedName::from_export_scpecifier(&export_specifier);
+                        ExportedName::from_export_specifier(&export_specifier);
                     Some((
                         exported_name,
                         resolve_export_to_inner_component_or_import(

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -411,13 +411,13 @@ declare_syntax! {
         /// There is an identifier "in" or "out", the DeclaredIdentifier is the state name
         Transition -> [?DeclaredIdentifier, *PropertyAnimation],
         /// Export a set of declared components by name
-        ExportsList -> [ *ExportSpecifier, ?Component, *StructDeclaration, *ExportModule, *EnumDeclaration ],
+        ExportsList -> [ *ExportSpecifier, ?Component, *StructDeclaration, ?ExportModule, *EnumDeclaration ],
         /// Declare the first identifier to be exported, either under its name or instead
         /// under the name of the second identifier.
         ExportSpecifier -> [ ExportIdentifier, ?ExportName ],
         ExportIdentifier -> [],
         ExportName -> [],
-        /// `export * from "foo"`. The import uri is stored as string literal.
+        /// `export ... from "foo"`. The import uri is stored as string literal.
         ExportModule -> [],
         /// import { foo, bar, baz } from "blah"; The import uri is stored as string literal.
         ImportSpecifier -> [ ?ImportIdentifierList ],

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -180,12 +180,14 @@ pub fn parse_qualified_name(p: &mut impl Parser) -> bool {
 #[cfg_attr(test, parser_test)]
 /// ```test,ExportsList
 /// export { Type }
-/// export { Type, AnotherType }
+/// export { Type, AnotherType, }
 /// export { Type as Foo, AnotherType }
 /// export Foo := Item { }
 /// export struct Foo := { foo: bar }
 /// export enum Foo { bar }
 /// export * from "foo";
+/// export { Abc } from "foo";
+/// export { Abc, Efg } from "foo";
 /// ```
 fn parse_export<P: Parser>(p: &mut P, checkpoint: Option<P::Checkpoint>) -> bool {
     debug_assert_eq!(p.peek().as_str(), "export");
@@ -194,11 +196,14 @@ fn parse_export<P: Parser>(p: &mut P, checkpoint: Option<P::Checkpoint>) -> bool
     p.expect(SyntaxKind::Identifier); // "export"
     if p.test(SyntaxKind::LBrace) {
         loop {
+            if p.test(SyntaxKind::RBrace) {
+                break;
+            }
             parse_export_specifier(&mut *p);
             match p.nth(0).kind() {
                 SyntaxKind::RBrace => {
                     p.consume();
-                    return true;
+                    break;
                 }
                 SyntaxKind::Eof => {
                     p.error("Expected comma");
@@ -209,10 +214,18 @@ fn parse_export<P: Parser>(p: &mut P, checkpoint: Option<P::Checkpoint>) -> bool
                 }
                 _ => {
                     p.consume();
-                    p.error("Expected comma")
+                    p.error("Expected comma");
+                    return false;
                 }
             }
         }
+        if p.peek().as_str() == "from" {
+            let mut p = p.start_node(SyntaxKind::ExportModule);
+            p.consume(); // "from"
+            p.expect(SyntaxKind::StringLiteral);
+            p.expect(SyntaxKind::Semicolon);
+        }
+        true
     } else if p.peek().as_str() == "struct" {
         parse_struct_declaration(&mut *p, checkpoint)
     } else if p.peek().as_str() == "enum" {

--- a/internal/compiler/tests/syntax/exports/reexport2.slint
+++ b/internal/compiler/tests/syntax/exports/reexport2.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export { SomeRect, Invalid } from "../../typeloader/incpath/local_helper_type.slint";
-//                 ^error{No exported type called 'Invalid' found in ".*/local_helper_type.slint"}
+//                 ^error{No exported type called 'Invalid' found in ".*local_helper_type.slint"}
 //       ^^warning{'SomeRect' is already exported in this file; it will not be re-exported}
 
   export {} from "../../typeloader/incpath/dependency_from_incpath.slint";

--- a/internal/compiler/tests/syntax/exports/reexport2.slint
+++ b/internal/compiler/tests/syntax/exports/reexport2.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export { SomeRect, Invalid } from "../../typeloader/incpath/local_helper_type.slint";
+//                 ^error{No exported type called 'Invalid' found in ".*/local_helper_type.slint"}
+//       ^^warning{'SomeRect' is already exported in this file; it will not be re-exported}
+
+  export {} from "../../typeloader/incpath/dependency_from_incpath.slint";
+//^error{Import names are missing. Please specify which types you would like to re-export}
+
+
+export component SomeRect {}

--- a/internal/compiler/tests/syntax/exports/reexport_duplicate.slint
+++ b/internal/compiler/tests/syntax/exports/reexport_duplicate.slint
@@ -1,8 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export * from "../../typeloader/incpath/local_helper_type.slint";
-//     ^warning{'SomeRect' is already exported in this file; it will not be re-exported}
+  export * from "../../typeloader/incpath/local_helper_type.slint";
+//^warning{'SomeRect' is already exported in this file; it will not be re-exported}
 
 export * from "../../typeloader/incpath/dependency_from_incpath.slint";
 //     ^error{re-exporting modules is only allowed once per file}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -837,7 +837,7 @@ impl TypeLoader {
                                     .ExportSpecifier()
                                     .filter_map(|e| {
                                         let (imported_name, exported_name) =
-                                            ExportedName::from_export_scpecifier(&e);
+                                            ExportedName::from_export_specifier(&e);
                                         let Some(r) = doc.exports.find(&imported_name) else {
                                             state.diag.push_error(format!("No exported type called '{imported_name}' found in {doc_path:?}"), &e);
                                             return None;

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -740,12 +740,14 @@ impl TypeLoader {
         .await
     }
 
-    async fn load_dependencies_recursively_impl<'a: 'b, 'b>(
+    // This function could be async when MSRV >= 1.77, but until then, we need to return a Box
+    fn load_dependencies_recursively_impl<'a: 'b, 'b>(
         state: &'a RefCell<BorrowedTypeLoader<'a>>,
         doc: &'b syntax_nodes::Document,
         registry_to_populate: &'b Rc<RefCell<TypeRegister>>,
         import_stack: &'b HashSet<PathBuf>,
-    ) -> (Vec<ImportedTypes>, Exports) {
+    ) -> core::pin::Pin<Box<dyn std::future::Future<Output = (Vec<ImportedTypes>, Exports)> + 'b>>
+    {
         let mut foreign_imports = vec![];
         let mut dependencies_futures = vec![];
         for mut import in Self::collect_dependencies(state, doc) {
@@ -779,83 +781,84 @@ impl TypeLoader {
             }));
         }
 
-        let mut reexports = None;
-        let mut has_star_reexport = false;
-        std::future::poll_fn(|cx| {
-            dependencies_futures.retain_mut(|fut| {
-                let core::task::Poll::Ready((import, doc_path)) = fut.as_mut().poll(cx) else {
-                    return true;
-                };
-                let Some(doc_path) = doc_path else { return false };
-                let mut state = state.borrow_mut();
-                let state = &mut *state;
-                let doc = state.tl.all_documents.docs.get(&doc_path).unwrap();
-                match &import.import_kind {
-                    ImportKind::ImportList(imported_types) => {
-                        let mut imported_types =
-                            ImportedName::extract_imported_names(imported_types).peekable();
-                        if imported_types.peek().is_some() {
-                            Self::register_imported_types(
-                                doc,
-                                &import,
-                                imported_types,
-                                registry_to_populate,
-                                state.diag,
-                            );
-                        } else {
-                            state.diag.push_error("Import names are missing. Please specify which types you would like to import".into(), &import.import_uri_token.parent());
-                        }
-                    }
-                    ImportKind::ModuleReexport(export_module_syntax_node) => {
-                        let exports = reexports.get_or_insert_with(|| Exports::default());
-                        if let Some(star_reexport) = export_module_syntax_node
-                            .ExportModule()
-                            .and_then(|x| x.child_token(SyntaxKind::Star))
-                        {
-                            if has_star_reexport {
-                                state.diag.push_error("re-exporting modules is only allowed once per file".into(), &star_reexport);
-                                return false;
+        Box::pin(async move {
+            let mut reexports = None;
+            let mut has_star_reexport = false;
+            std::future::poll_fn(|cx| {
+                dependencies_futures.retain_mut(|fut| {
+                    let core::task::Poll::Ready((import, doc_path)) = fut.as_mut().poll(cx) else {
+                        return true;
+                    };
+                    let Some(doc_path) = doc_path else { return false };
+                    let mut state = state.borrow_mut();
+                    let state = &mut *state;
+                    let doc = state.tl.all_documents.docs.get(&doc_path).unwrap();
+                    match &import.import_kind {
+                        ImportKind::ImportList(imported_types) => {
+                            let mut imported_types =
+                                ImportedName::extract_imported_names(imported_types).peekable();
+                            if imported_types.peek().is_some() {
+                                Self::register_imported_types(
+                                    doc,
+                                    &import,
+                                    imported_types,
+                                    registry_to_populate,
+                                    state.diag,
+                                );
+                            } else {
+                                state.diag.push_error("Import names are missing. Please specify which types you would like to import".into(), &import.import_uri_token.parent());
                             }
-                            has_star_reexport = true;
-                            exports.add_reexports(
-                                doc.exports.iter().map(|(exported_name, compo_or_type)| {
-                                    let exported_name = ExportedName {
-                                        name: exported_name.name.clone(),
-                                        name_ident: (**export_module_syntax_node).clone(),
-                                    };
-                                    (exported_name, compo_or_type.clone())
-                                }),
-                                state.diag,
-                            );
-                        } else if export_module_syntax_node.ExportSpecifier().next().is_none() {
-                            state.diag.push_error("Import names are missing. Please specify which types you would like to re-export".into(), export_module_syntax_node);
-                        } else {
-                            let e = export_module_syntax_node
-                                .ExportSpecifier()
-                                .filter_map(|e| {
-                                    let (imported_name, exported_name) =
-                                        ExportedName::from_export_scpecifier(&e);
-                                    let Some(r) = doc.exports.find(&imported_name) else {
-                                        state.diag.push_error(format!("No exported type called '{imported_name}' found in {doc_path:?}"), &e);
-                                        return None;
-                                    };
-                                    Some((exported_name, r))
-                                })
-                                .collect::<Vec<_>>();
-                            exports.add_reexports(e, state.diag);
+                        }
+                        ImportKind::ModuleReexport(export_module_syntax_node) => {
+                            let exports = reexports.get_or_insert_with(|| Exports::default());
+                            if let Some(star_reexport) = export_module_syntax_node
+                                .ExportModule()
+                                .and_then(|x| x.child_token(SyntaxKind::Star))
+                            {
+                                if has_star_reexport {
+                                    state.diag.push_error("re-exporting modules is only allowed once per file".into(), &star_reexport);
+                                    return false;
+                                }
+                                has_star_reexport = true;
+                                exports.add_reexports(
+                                    doc.exports.iter().map(|(exported_name, compo_or_type)| {
+                                        let exported_name = ExportedName {
+                                            name: exported_name.name.clone(),
+                                            name_ident: (**export_module_syntax_node).clone(),
+                                        };
+                                        (exported_name, compo_or_type.clone())
+                                    }),
+                                    state.diag,
+                                );
+                            } else if export_module_syntax_node.ExportSpecifier().next().is_none() {
+                                state.diag.push_error("Import names are missing. Please specify which types you would like to re-export".into(), export_module_syntax_node);
+                            } else {
+                                let e = export_module_syntax_node
+                                    .ExportSpecifier()
+                                    .filter_map(|e| {
+                                        let (imported_name, exported_name) =
+                                            ExportedName::from_export_scpecifier(&e);
+                                        let Some(r) = doc.exports.find(&imported_name) else {
+                                            state.diag.push_error(format!("No exported type called '{imported_name}' found in {doc_path:?}"), &e);
+                                            return None;
+                                        };
+                                        Some((exported_name, r))
+                                    })
+                                    .collect::<Vec<_>>();
+                                exports.add_reexports(e, state.diag);
+                            }
                         }
                     }
+                    false
+                });
+                if dependencies_futures.is_empty() {
+                    core::task::Poll::Ready(())
+                } else {
+                    core::task::Poll::Pending
                 }
-                false
-            });
-            if dependencies_futures.is_empty() {
-                core::task::Poll::Ready(())
-            } else {
-                core::task::Poll::Pending
-            }
+            }).await;
+            (foreign_imports, reexports.unwrap_or_default())
         })
-        .await;
-        (foreign_imports, reexports.unwrap_or_default())
     }
 
     pub async fn import_component(

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -29,7 +29,8 @@ struct LoadedDocuments {
 
 pub enum ImportKind {
     ImportList(syntax_nodes::ImportSpecifier),
-    ModuleReexport(syntax_nodes::ExportModule), // re-export all types, as per export * from "foo".
+    /// re-export types, as per `export ... from "foo"``.
+    ModuleReexport(syntax_nodes::ExportsList),
 }
 
 pub struct ImportedTypes {
@@ -739,98 +740,122 @@ impl TypeLoader {
         .await
     }
 
-    fn load_dependencies_recursively_impl<'a: 'b, 'b>(
+    async fn load_dependencies_recursively_impl<'a: 'b, 'b>(
         state: &'a RefCell<BorrowedTypeLoader<'a>>,
         doc: &'b syntax_nodes::Document,
         registry_to_populate: &'b Rc<RefCell<TypeRegister>>,
         import_stack: &'b HashSet<PathBuf>,
-    ) -> core::pin::Pin<Box<dyn std::future::Future<Output = (Vec<ImportedTypes>, Exports)> + 'b>>
-    {
+    ) -> (Vec<ImportedTypes>, Exports) {
         let mut foreign_imports = vec![];
-        let mut dependencies = Self::collect_dependencies(state, doc)
-            .filter_map(|mut import| {
-                let resolved_import = if let Some((path, _)) = state.borrow().tl.resolve_import_path(Some(&import.import_uri_token.clone().into()), &import.file) {
-                    path.to_string_lossy().to_string()
-                } else {
-                    import.file.clone()
-                };
-                if resolved_import.ends_with(".slint") || resolved_import.ends_with(".60") || import.file.starts_with('@') {
-                    Some(Box::pin(async move {
-                        let file = import.file.as_str();
-                        let doc_path = Self::ensure_document_loaded(
-                            state,
-                            file,
-                            Some(import.import_uri_token.clone().into()),
-                            import_stack.clone()
-                        )
-                        .await?;
-                        let mut state = state.borrow_mut();
-                        let state = &mut *state;
-                        let doc = state.tl.all_documents.docs.get(&doc_path).unwrap();
-                        match &import.import_kind {
-                            ImportKind::ImportList(imported_types) => {
-                                let mut imported_types =
-                                    ImportedName::extract_imported_names(imported_types).peekable();
-                                if imported_types.peek().is_some() {
-                                    Self::register_imported_types(doc, &import, imported_types, registry_to_populate, state.diag);
-                                } else {
-                                    state.diag.push_error("Import names are missing. Please specify which types you would like to import".into(), &import.import_uri_token.parent());
-                                }
-                                None
-                            }
-                            ImportKind::ModuleReexport(export_module_syntax_node) => {
-                                let mut exports = Exports::default();
-                                exports.add_reexports(
-                                    doc.exports.iter().map(|(exported_name, compo_or_type)| {
-                                        (
-                                            ExportedName {
-                                                name: exported_name.name.clone(),
-                                                name_ident: (**export_module_syntax_node).clone(),
-                                            },
-                                            compo_or_type.clone(),
-                                        )
-                                    }),
-                                    state.diag,
-                                );
-                                Some((exports, export_module_syntax_node.clone()))
-                            }
-                        }
-                    }))
-                } else {
-                    import.file = resolved_import;
-                    foreign_imports.push(import);
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+        let mut dependencies_futures = vec![];
+        for mut import in Self::collect_dependencies(state, doc) {
+            let resolved_import = if let Some((path, _)) = state
+                .borrow()
+                .tl
+                .resolve_import_path(Some(&import.import_uri_token.clone().into()), &import.file)
+            {
+                path.to_string_lossy().to_string()
+            } else {
+                import.file.clone()
+            };
+            if !(resolved_import.ends_with(".slint")
+                || resolved_import.ends_with(".60")
+                || import.file.starts_with('@'))
+            {
+                import.file = resolved_import;
+                foreign_imports.push(import);
+                continue;
+            }
+            dependencies_futures.push(Box::pin(async move {
+                let file = import.file.as_str();
+                let doc_path = Self::ensure_document_loaded(
+                    state,
+                    file,
+                    Some(import.import_uri_token.clone().into()),
+                    import_stack.clone(),
+                )
+                .await;
+                (import, doc_path)
+            }));
+        }
 
-        Box::pin(async move {
-            let mut reexports = None;
-            std::future::poll_fn(|cx| {
-                dependencies.retain_mut(|fut| {
-                    let core::task::Poll::Ready(export) = fut.as_mut().poll(cx) else {
-                        return true;
-                    };
-                    let Some((exports, node)) = export else { return false };
-                    if reexports.is_none() {
-                        reexports = Some(exports);
-                    } else {
-                        state.borrow_mut().diag.push_error(
-                            "re-exporting modules is only allowed once per file".into(),
-                            &node,
-                        );
-                    };
-                    false
-                });
-                if dependencies.is_empty() {
-                    core::task::Poll::Ready(())
-                } else {
-                    core::task::Poll::Pending
+        let mut reexports = None;
+        let mut has_star_reexport = false;
+        std::future::poll_fn(|cx| {
+            dependencies_futures.retain_mut(|fut| {
+                let core::task::Poll::Ready((import, doc_path)) = fut.as_mut().poll(cx) else {
+                    return true;
+                };
+                let Some(doc_path) = doc_path else { return false };
+                let mut state = state.borrow_mut();
+                let state = &mut *state;
+                let doc = state.tl.all_documents.docs.get(&doc_path).unwrap();
+                match &import.import_kind {
+                    ImportKind::ImportList(imported_types) => {
+                        let mut imported_types =
+                            ImportedName::extract_imported_names(imported_types).peekable();
+                        if imported_types.peek().is_some() {
+                            Self::register_imported_types(
+                                doc,
+                                &import,
+                                imported_types,
+                                registry_to_populate,
+                                state.diag,
+                            );
+                        } else {
+                            state.diag.push_error("Import names are missing. Please specify which types you would like to import".into(), &import.import_uri_token.parent());
+                        }
+                    }
+                    ImportKind::ModuleReexport(export_module_syntax_node) => {
+                        let exports = reexports.get_or_insert_with(|| Exports::default());
+                        if let Some(star_reexport) = export_module_syntax_node
+                            .ExportModule()
+                            .and_then(|x| x.child_token(SyntaxKind::Star))
+                        {
+                            if has_star_reexport {
+                                state.diag.push_error("re-exporting modules is only allowed once per file".into(), &star_reexport);
+                                return false;
+                            }
+                            has_star_reexport = true;
+                            exports.add_reexports(
+                                doc.exports.iter().map(|(exported_name, compo_or_type)| {
+                                    let exported_name = ExportedName {
+                                        name: exported_name.name.clone(),
+                                        name_ident: (**export_module_syntax_node).clone(),
+                                    };
+                                    (exported_name, compo_or_type.clone())
+                                }),
+                                state.diag,
+                            );
+                        } else if export_module_syntax_node.ExportSpecifier().next().is_none() {
+                            state.diag.push_error("Import names are missing. Please specify which types you would like to re-export".into(), export_module_syntax_node);
+                        } else {
+                            let e = export_module_syntax_node
+                                .ExportSpecifier()
+                                .filter_map(|e| {
+                                    let (imported_name, exported_name) =
+                                        ExportedName::from_export_scpecifier(&e);
+                                    let Some(r) = doc.exports.find(&imported_name) else {
+                                        state.diag.push_error(format!("No exported type called '{imported_name}' found in {doc_path:?}"), &e);
+                                        return None;
+                                    };
+                                    Some((exported_name, r))
+                                })
+                                .collect::<Vec<_>>();
+                            exports.add_reexports(e, state.diag);
+                        }
+                    }
                 }
-            })
-            .await;
-            (foreign_imports, reexports.unwrap_or_default())
+                false
+            });
+            if dependencies_futures.is_empty() {
+                core::task::Poll::Ready(())
+            } else {
+                core::task::Poll::Pending
+            }
         })
+        .await;
+        (foreign_imports, reexports.unwrap_or_default())
     }
 
     pub async fn import_component(
@@ -1264,10 +1289,12 @@ impl TypeLoader {
                 (maybe_import_uri, ImportKind::ImportList(import))
             })
             .chain(
-                // process `export * from "foo"`
-                doc.ExportsList().flat_map(|exports| exports.ExportModule()).map(|reexport| {
-                    let maybe_import_uri = reexport.child_token(SyntaxKind::StringLiteral);
-                    (maybe_import_uri, ImportKind::ModuleReexport(reexport))
+                // process `export ... from "foo"`
+                doc.ExportsList().filter_map(|exports| {
+                    exports.ExportModule().map(|reexport| {
+                        let maybe_import_uri = reexport.child_token(SyntaxKind::StringLiteral);
+                        (maybe_import_uri, ImportKind::ModuleReexport(exports))
+                    })
                 }),
             )
             .filter_map(|(maybe_import_uri, type_specifier)| {

--- a/internal/compiler/widgets/cosmic-base/std-widgets-base.slint
+++ b/internal/compiler/widgets/cosmic-base/std-widgets-base.slint
@@ -3,55 +3,24 @@
 
 // cSpell: ignore standardbutton
 
-import { AboutSlint } from "../common/common.slint";
-import { StandardButton } from "../common/standardbutton.slint";
-import { StyleMetrics, ScrollView, Button, Palette } from "std-widgets-impl.slint";
+export { AboutSlint } from "../common/common.slint";
+export { StandardButton } from "../common/standardbutton.slint";
+export { StyleMetrics, ScrollView, Button, Palette } from "std-widgets-impl.slint";
 
-import { CheckBox } from "checkbox.slint";
-export { CheckBox }
-
-import { ComboBox } from "combobox.slint";
-export { ComboBox }
-
-import { GroupBox } from "groupbox.slint";
-export { GroupBox }
-
-import { LineEdit } from "lineedit.slint";
-export { LineEdit }
-
-import { ListView, StandardListView } from "../common/listview.slint";
-export { ListView, StandardListView }
-
-import { ProgressIndicator } from "progressindicator.slint";
-export { ProgressIndicator }
-
-import { Slider } from "slider.slint";
-export { Slider }
-
-import { SpinBox } from "spinbox.slint";
-export { SpinBox }
-
-import { Spinner } from "spinner.slint";
-export { Spinner }
-
-import { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget } from "tabwidget.slint";
-export { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget }
-
-import { VerticalBox, HorizontalBox, GridBox } from "layouts.slint";
-export { VerticalBox, HorizontalBox, GridBox }
-
-import { Switch } from "switch.slint";
-export { Switch }
-
-import { TextEdit } from "textedit.slint";
-export { TextEdit }
-
-import { TimePicker, Time } from "time-picker.slint";
-export { TimePicker, Time }
-
-import { DatePicker, Date } from "datepicker.slint";
-export { DatePicker, Date }
-
-export { StyleMetrics, ScrollView, Button, StandardButton, AboutSlint, Palette }
+export { CheckBox } from "checkbox.slint";
+export { ComboBox } from "combobox.slint";
+export { GroupBox } from "groupbox.slint";
+export { LineEdit } from "lineedit.slint";
+export { ListView, StandardListView } from "../common/listview.slint";
+export { ProgressIndicator } from "progressindicator.slint";
+export { Slider } from "slider.slint";
+export { SpinBox } from "spinbox.slint";
+export { Spinner } from "spinner.slint";
+export { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget } from "tabwidget.slint";
+export { VerticalBox, HorizontalBox, GridBox } from "layouts.slint";
+export { Switch } from "switch.slint";
+export { TextEdit } from "textedit.slint";
+export { TimePicker, Time } from "time-picker.slint";
+export { DatePicker, Date } from "datepicker.slint";
 
 export * from "tableview.slint";

--- a/internal/compiler/widgets/cosmic-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic-base/std-widgets-impl.slint
@@ -1,21 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { ColorSchemeSelector } from "color-scheme.slint";
 
-import { Button } from "button.slint";
-export { Button }
+export { Button } from "button.slint";
+export { ScrollView } from "scrollview.slint";
+export { ListItem } from "components.slint";
+export { LineEdit } from "lineedit.slint";
 
-import { ScrollView } from "scrollview.slint";
-export { ScrollView }
-
-import { ListItem } from "components.slint";
-export { ListItem }
-
-import { LineEdit } from "lineedit.slint";
-export { LineEdit }
-
-import { CosmicPalette, CosmicFontSettings } from "styling.slint";
+import { CosmicPalette } from "styling.slint";
 
 export global StyleMetrics  {
     out property <length> layout-spacing: 8px;

--- a/internal/compiler/widgets/cosmic-dark/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic-dark/std-widgets-impl.slint
@@ -1,5 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cosmic-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette }
+export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cosmic-base/std-widgets-impl.slint";

--- a/internal/compiler/widgets/cosmic-light/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic-light/std-widgets-impl.slint
@@ -1,5 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cosmic-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette }
+export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cosmic-base/std-widgets-impl.slint";

--- a/internal/compiler/widgets/cosmic/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic/std-widgets-impl.slint
@@ -1,5 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cosmic-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette }
+export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cosmic-base/std-widgets-impl.slint";

--- a/internal/compiler/widgets/cupertino-base/std-widgets-base.slint
+++ b/internal/compiler/widgets/cupertino-base/std-widgets-base.slint
@@ -3,55 +3,23 @@
 
 // cSpell: ignore standardbutton
 
-import { AboutSlint } from "../common/common.slint";
-import { StandardButton } from "../common/standardbutton.slint";
-import { StyleMetrics, ScrollView, Button, Palette } from "std-widgets-impl.slint";
+export { AboutSlint } from "../common/common.slint";
+export { StandardButton } from "../common/standardbutton.slint";
+export { StyleMetrics, ScrollView, Button, Palette } from "std-widgets-impl.slint";
 
-import { CheckBox } from "checkbox.slint";
-export { CheckBox }
-
-import { ComboBox } from "combobox.slint";
-export { ComboBox }
-
-import { GroupBox } from "groupbox.slint";
-export { GroupBox }
-
-import { LineEdit } from "lineedit.slint";
-export { LineEdit }
-
-import { ListView, StandardListView } from "../common/listview.slint";
-export { ListView, StandardListView }
-
-import { ProgressIndicator } from "progressindicator.slint";
-export { ProgressIndicator }
-
-import { Slider } from "slider.slint";
-export { Slider }
-
-import { SpinBox } from "spinbox.slint";
-export { SpinBox }
-
-import { Spinner } from "spinner.slint";
-export { Spinner }
-
-import { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget } from "tabwidget.slint";
-export { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget }
-
-import { VerticalBox, HorizontalBox, GridBox } from "layouts.slint";
-export { VerticalBox, HorizontalBox, GridBox }
-
-import { Switch } from "switch.slint";
-export { Switch }
-
-import { TextEdit } from "textedit.slint";
-export { TextEdit }
-
-import { TimePicker, Time } from "time-picker.slint";
-export { TimePicker, Time }
-
-import { DatePicker, Date } from "./datepicker.slint";
-export { DatePicker, Date }
-
-export { StyleMetrics, ScrollView, Button, StandardButton, AboutSlint, Palette }
-
+export { CheckBox } from "checkbox.slint";
+export { ComboBox } from "combobox.slint";
+export { GroupBox } from "groupbox.slint";
+export { LineEdit } from "lineedit.slint";
+export { ListView, StandardListView } from "../common/listview.slint";
+export { ProgressIndicator } from "progressindicator.slint";
+export { Slider } from "slider.slint";
+export { SpinBox } from "spinbox.slint";
+export { Spinner } from "spinner.slint";
+export { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget } from "tabwidget.slint";
+export { VerticalBox, HorizontalBox, GridBox } from "layouts.slint";
+export { Switch } from "switch.slint";
+export { TextEdit } from "textedit.slint";
+export { TimePicker, Time } from "time-picker.slint";
+export { DatePicker, Date } from "./datepicker.slint";
 export * from "tableview.slint";

--- a/internal/compiler/widgets/cupertino-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino-base/std-widgets-impl.slint
@@ -1,21 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { ColorSchemeSelector } from "color-scheme.slint";
-
-import { Button } from "button.slint";
-export { Button }
-
-import { ScrollView } from "scrollview.slint";
-export { ScrollView }
-
-import { ListItem } from "components.slint";
-export { ListItem }
-
-import { LineEdit } from "lineedit.slint";
-export { LineEdit }
-
-import { CupertinoPalette, CupertinoFontSettings } from "styling.slint";
+export { Button } from "button.slint";
+export { ScrollView } from "scrollview.slint";
+export { ListItem } from "components.slint";
+export { LineEdit } from "lineedit.slint";
+import { CupertinoPalette } from "styling.slint";
 
 export global StyleMetrics  {
     out property <length> layout-spacing: 10px;

--- a/internal/compiler/widgets/cupertino-dark/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino-dark/std-widgets-impl.slint
@@ -1,5 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cupertino-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette }
+export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cupertino-base/std-widgets-impl.slint";

--- a/internal/compiler/widgets/cupertino-light/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino-light/std-widgets-impl.slint
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cupertino-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette }
+export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cupertino-base/std-widgets-impl.slint";
+

--- a/internal/compiler/widgets/cupertino/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino/std-widgets-impl.slint
@@ -1,5 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cupertino-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette }
+export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../cupertino-base/std-widgets-impl.slint";

--- a/internal/compiler/widgets/fluent-base/std-widgets-base.slint
+++ b/internal/compiler/widgets/fluent-base/std-widgets-base.slint
@@ -3,55 +3,23 @@
 
 // cSpell: ignore standardbutton
 
-import { AboutSlint } from "../common/common.slint";
-import { StandardButton } from "../common/standardbutton.slint";
-import { StyleMetrics, ScrollView, Button, Palette } from "std-widgets-impl.slint";
+export { AboutSlint } from "../common/common.slint";
+export { StandardButton } from "../common/standardbutton.slint";
+export { StyleMetrics, ScrollView, Button, Palette } from "std-widgets-impl.slint";
 
-import { CheckBox } from "checkbox.slint";
-export { CheckBox }
-
-import { ComboBox } from "combobox.slint";
-export { ComboBox }
-
-import { GroupBox } from "groupbox.slint";
-export { GroupBox }
-
-import { LineEdit } from "lineedit.slint";
-export { LineEdit }
-
-import { ListView, StandardListView } from "../common/listview.slint";
-export { ListView, StandardListView }
-
-import { ProgressIndicator } from "progressindicator.slint";
-export { ProgressIndicator }
-
-import { Slider } from "slider.slint";
-export { Slider }
-
-import { SpinBox } from "spinbox.slint";
-export { SpinBox }
-
-import { Spinner } from "spinner.slint";
-export { Spinner }
-
-import { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget } from "tabwidget.slint";
-export { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget }
-
-import { VerticalBox, HorizontalBox, GridBox } from "layouts.slint";
-export { VerticalBox, HorizontalBox, GridBox }
-
-import { Switch } from "switch.slint";
-export { Switch }
-
-import { TextEdit } from "textedit.slint";
-export { TextEdit }
-
-import { TimePicker, Time } from "time-picker.slint";
-export { TimePicker, Time }
-
-import { DatePicker, Date } from "datepicker.slint";
-export { DatePicker, Date }
-
-export { StyleMetrics, ScrollView, Button, StandardButton, AboutSlint, Palette }
-
+export { CheckBox } from "checkbox.slint";
+export { ComboBox } from "combobox.slint";
+export { GroupBox } from "groupbox.slint";
+export { LineEdit } from "lineedit.slint";
+export { ListView, StandardListView } from "../common/listview.slint";
+export { ProgressIndicator } from "progressindicator.slint";
+export { Slider } from "slider.slint";
+export { SpinBox } from "spinbox.slint";
+export { Spinner } from "spinner.slint";
+export { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget } from "tabwidget.slint";
+export { VerticalBox, HorizontalBox, GridBox } from "layouts.slint";
+export { Switch } from "switch.slint";
+export { TextEdit } from "textedit.slint";
+export { TimePicker, Time } from "time-picker.slint";
+export { DatePicker, Date } from "datepicker.slint";
 export * from "tableview.slint";

--- a/internal/compiler/widgets/fluent-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent-base/std-widgets-impl.slint
@@ -1,21 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { ColorSchemeSelector } from "color-scheme.slint";
-
-import { Button } from "button.slint";
-export { Button }
-
-import { ScrollView } from "scrollview.slint";
-export { ScrollView }
-
-import { ListItem } from "components.slint";
-export { ListItem }
-
-import { LineEdit } from "lineedit.slint";
-export { LineEdit }
-
-import { FluentPalette, FluentFontSettings } from "styling.slint";
+export { Button } from "button.slint";
+export { ScrollView } from "scrollview.slint";
+export { ListItem } from "components.slint";
+export { LineEdit } from "lineedit.slint";
+import { FluentPalette } from "styling.slint";
 
 export global StyleMetrics  {
     out property <length> layout-spacing: 8px;

--- a/internal/compiler/widgets/fluent-dark/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent-dark/std-widgets-impl.slint
@@ -1,5 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, LineEdit, Button, ListItem, Palette } from "../fluent-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, LineEdit, Button, ListItem, Palette }
+export { StyleMetrics, ScrollView, LineEdit, Button, ListItem, Palette } from "../fluent-base/std-widgets-impl.slint";

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -1,5 +1,4 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, LineEdit, Button, ListItem, Palette } from "../fluent-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, LineEdit, Button, ListItem, Palette }
+export { StyleMetrics, ScrollView, LineEdit, Button, ListItem, Palette } from "../fluent-base/std-widgets-impl.slint";

--- a/internal/compiler/widgets/material-base/std-widgets-base.slint
+++ b/internal/compiler/widgets/material-base/std-widgets-base.slint
@@ -3,33 +3,21 @@
 
 // cSpell: ignore standardbutton
 
-import { AboutSlint } from "../common/common.slint";
-import { StandardButton } from "../common/standardbutton.slint";
-import { StyleMetrics, ScrollView, Button, CheckBox, Palette  } from "std-widgets-impl.slint";
-import { LineEdit } from "lineedit.slint";
-import { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget } from "tabwidget.slint";
-import { GroupBox } from "groupbox.slint";
-import { VerticalBox, HorizontalBox, GridBox } from "layouts.slint";
-import { Slider } from "slider.slint";
-import { ComboBox } from "combobox.slint";
-import { ListView, StandardListView } from "../common/listview.slint";
-import { SpinBox } from "spinbox.slint";
-import { StandardTableView } from "tableview.slint";
-import { ProgressIndicator } from "progressindicator.slint";
-import { Switch } from "switch.slint";
-
-export { StyleMetrics, ScrollView, Button, ComboBox, CheckBox, GroupBox, StandardButton, TabWidgetImpl,
-    TabImpl, TabBarImpl, TabWidget, LineEdit, AboutSlint, VerticalBox, HorizontalBox,
-    GridBox, Slider, ListView, StandardListView, StandardTableView, SpinBox, ProgressIndicator, Switch, Palette }
-
-import { Spinner } from "spinner.slint";
-export { Spinner }
-
-import { TextEdit } from "textedit.slint";
-export { TextEdit }
-
-import { TimePicker, Time } from "time-picker.slint";
-export { TimePicker, Time }
-
-import { DatePicker, Date } from "./datepicker.slint";
-export { DatePicker, Date }
+export { AboutSlint } from "../common/common.slint";
+export { StandardButton } from "../common/standardbutton.slint";
+export { StyleMetrics, ScrollView, Button, CheckBox, Palette  } from "std-widgets-impl.slint";
+export { LineEdit } from "lineedit.slint";
+export { TabWidgetImpl, TabImpl, TabBarImpl, TabWidget } from "tabwidget.slint";
+export { GroupBox } from "groupbox.slint";
+export { VerticalBox, HorizontalBox, GridBox } from "layouts.slint";
+export { Slider } from "slider.slint";
+export { ComboBox } from "combobox.slint";
+export { ListView, StandardListView } from "../common/listview.slint";
+export { SpinBox } from "spinbox.slint";
+export { StandardTableView } from "tableview.slint";
+export { ProgressIndicator } from "progressindicator.slint";
+export { Switch } from "switch.slint";
+export { Spinner } from "spinner.slint";
+export { TextEdit } from "textedit.slint";
+export { TimePicker, Time } from "time-picker.slint";
+export { DatePicker, Date } from "./datepicker.slint";

--- a/internal/compiler/widgets/material-base/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material-base/std-widgets-impl.slint
@@ -2,19 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // widget imports
-import { Button } from "button.slint";
-import { CheckBox } from "checkbox.slint";
-import { ScrollView } from "scrollview.slint";
+export { Button } from "button.slint";
+export { CheckBox } from "checkbox.slint";
+export { ScrollView } from "scrollview.slint";
 import { MaterialPalette } from "styling.slint";
-import { Switch } from "switch.slint";
+export { Switch } from "switch.slint";
+export { ListItem } from "components.slint";
+export { LineEdit } from "lineedit.slint";
 
-export { Button, CheckBox, ScrollView, Switch }
-
-import { ListItem } from "components.slint";
-export { ListItem }
-
-import { LineEdit } from "lineedit.slint";
-export { LineEdit }
 
 export global StyleMetrics  {
     out property <length> layout-spacing: 16px;

--- a/internal/compiler/widgets/material-dark/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material-dark/std-widgets-impl.slint
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../material-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette }
+export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../material-base/std-widgets-impl.slint";
+

--- a/internal/compiler/widgets/material-light/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material-light/std-widgets-impl.slint
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../material-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette }
+export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../material-base/std-widgets-impl.slint";
+

--- a/internal/compiler/widgets/material/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material/std-widgets-impl.slint
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, ScrollView, Button, LineEdit, Switch, ListItem, Palette } from "../material-base/std-widgets-impl.slint";
-export { StyleMetrics, ScrollView, Button, LineEdit, Switch, ListItem, Palette }
+export { StyleMetrics, ScrollView, Button, LineEdit, Switch, ListItem, Palette } from "../material-base/std-widgets-impl.slint";
+

--- a/internal/compiler/widgets/qt/std-widgets-impl.slint
+++ b/internal/compiler/widgets/qt/std-widgets-impl.slint
@@ -4,10 +4,7 @@
 export { NativeStyleMetrics as StyleMetrics }
 export { NativePalette as Palette }
 
-import { ScrollView } from "scrollview.slint";
-export { ScrollView }
-
-import { LineEdit } from "lineedit.slint";
-export { LineEdit }
+export { ScrollView } from "scrollview.slint";
+export { LineEdit } from "lineedit.slint";
 
 export component ListItem inherits NativeStandardListViewItem {}

--- a/internal/compiler/widgets/qt/std-widgets.slint
+++ b/internal/compiler/widgets/qt/std-widgets.slint
@@ -1,55 +1,22 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { AboutSlint } from "../common/common.slint";
-import { StyleMetrics, ScrollView, Palette } from "std-widgets-impl.slint";
-import { StandardTableView } from "tableview.slint";
-export { StyleMetrics, ScrollView, AboutSlint, StandardTableView, Palette }
-
-import { Button, StandardButton } from "button.slint";
-export { Button, StandardButton }
-
-import { CheckBox } from "checkbox.slint";
-export { CheckBox }
-
-import { SpinBox } from "spinbox.slint";
-export { SpinBox }
-
-import { Slider } from "slider.slint";
-export { Slider }
-
-import { Switch } from "switch.slint";
-export { Switch }
-
-import { GroupBox } from "groupbox.slint";
-export { GroupBox }
-
-import { LineEdit } from "lineedit.slint";
-export { LineEdit }
-
-import { ComboBox } from "combobox.slint";
-export { ComboBox }
-
-import { TabWidget, TabWidgetImpl, TabImpl, TabBarImpl } from "tabwidget.slint";
-export { TabWidget, TabWidgetImpl, TabImpl, TabBarImpl }
-
-import { HorizontalBox, VerticalBox, GridBox } from "layouts.slint";
-export { HorizontalBox, VerticalBox, GridBox }
-
-import { ProgressIndicator } from "progressindicator.slint";
-export { ProgressIndicator }
-
-import { Spinner } from "spinner.slint";
-export { Spinner }
-
-import { TimePicker, Time } from "time-picker.slint";
-export { TimePicker, Time }
-
-import { StandardListView, ListView } from "../common/listview.slint";
-export { StandardListView, ListView }
-
-import { TextEdit } from "textedit.slint";
-export { TextEdit }
-
-import { DatePicker, Date } from "./datepicker.slint";
-export { DatePicker, Date }
+export { AboutSlint } from "../common/common.slint";
+export { StyleMetrics, ScrollView, Palette } from "std-widgets-impl.slint";
+export { StandardTableView } from "tableview.slint";
+export { Button, StandardButton } from "button.slint";
+export { CheckBox } from "checkbox.slint";
+export { SpinBox } from "spinbox.slint";
+export { Slider } from "slider.slint";
+export { Switch } from "switch.slint";
+export { GroupBox } from "groupbox.slint";
+export { LineEdit } from "lineedit.slint";
+export { ComboBox } from "combobox.slint";
+export { TabWidget, TabWidgetImpl, TabImpl, TabBarImpl } from "tabwidget.slint";
+export { HorizontalBox, VerticalBox, GridBox } from "layouts.slint";
+export { ProgressIndicator } from "progressindicator.slint";
+export { Spinner } from "spinner.slint";
+export { TimePicker, Time } from "time-picker.slint";
+export { StandardListView, ListView } from "../common/listview.slint";
+export { TextEdit } from "textedit.slint";
+export { DatePicker, Date } from "./datepicker.slint";

--- a/tests/cases/imports/reexport2.slint
+++ b/tests/cases/imports/reexport2.slint
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//include_path: ../../helper_components
+import { TestButton, TheWindow } from "re_export2.slint";
+export component TestCase inherits TheWindow {
+    TestButton {}
+}

--- a/tests/helper_components/main_window.slint
+++ b/tests/helper_components/main_window.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export MainWindow := Window {
+export component MainWindow inherits Window {
     property <int> some_prop: 42;
 }
 

--- a/tests/helper_components/main_window.slint
+++ b/tests/helper_components/main_window.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component MainWindow inherits Window {
-    property <int> some_prop: 42;
+    in-out property <int> some_prop: 42;
 }
 
 export { MainWindow as Main-Window }

--- a/tests/helper_components/re_export2.slint
+++ b/tests/helper_components/re_export2.slint
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export { StyleMetrics, ScrollView, Button, LineEdit, ListItem, Palette } from "../fluent-base/std-widgets-impl.slint";
-
+export { TestButton } from "./test_button.slint";
+export { Main-Window as TheWindow } from "./main_window.slint";

--- a/tests/helper_components/test_button.slint
+++ b/tests/helper_components/test_button.slint
@@ -1,8 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestButtonImpl := Rectangle {
-    property<string> button_text;
+component TestButtonImpl inherits  Rectangle {
+    in-out property<string> button_text;
     Text {
         x: 10phx;
         y: 10phx;
@@ -11,6 +11,6 @@ TestButtonImpl := Rectangle {
 }
 export { TestButtonImpl as TestButton }
 
-export ColorButton := TestButtonImpl {
-    property<color> button_color;
+export component ColorButton inherits TestButtonImpl {
+    in-out property<color> button_color;
 }


### PR DESCRIPTION
This simplifies the styles a bit.

But the reason is that i want to deprecate that
```rs
slint!{ import { MainWindow } from "main.slint"; }
```
In favor of an `export` statement.