### PR TITLE
Fix crash on app shutdown on Wayland

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -185,8 +185,12 @@ impl Backend {
     pub fn new_with_renderer_by_name(renderer_name: Option<&str>) -> Result<Self, PlatformError> {
         // Initialize the winit event loop and propagate errors if for example `DISPLAY` or `WAYLAND_DISPLAY` isn't set.
 
-        let (proxy, clipboard) = crate::event_loop::with_not_running_event_loop(|nre| {
-            Ok((nre.instance.create_proxy(), Rc::downgrade(&nre.clipboard)))
+        let proxy =
+            crate::event_loop::with_not_running_event_loop(|nre| Ok(nre.instance.create_proxy()))?;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let clipboard = crate::event_loop::with_not_running_event_loop(|nre| {
+            Ok(Rc::downgrade(&nre.clipboard))
         })?;
 
         let renderer_factory_fn = match renderer_name {


### PR DESCRIPTION
Valgrind would report invalid reads on the wayland clipboard shutdown code, suggesting that the wayland display has already been destroyed.

Since the display handle isn't refcounted, we must make sure that the wayland clipboard is around as long as the wayland display handle, provided by the winit event loop.