### PR TITLE
testing api: Avoid bogus warnings about missing debug info

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1437,10 +1437,18 @@ fn generate_item_tree(
         Declaration::Function(Function {
             name: "element_infos".into(),
             signature:
-                "([[maybe_unused]] slint::private_api::ItemTreeRef component, uint32_t index, slint::SharedString *result) -> bool"
+                "([[maybe_unused]] slint::private_api::ItemTreeRef component, [[maybe_unused]] uint32_t index, [[maybe_unused]] slint::SharedString *result) -> bool"
                     .into(),
             is_static: true,
-            statements: Some(vec![format!("if (auto infos = reinterpret_cast<const {}*>(component.instance)->element_infos(index)) {{ *result = *infos; return true; }};", item_tree_class_name), "return false;".into()]),
+            statements: Some(if root.has_debug_info {
+                vec![
+                    format!("if (auto infos = reinterpret_cast<const {}*>(component.instance)->element_infos(index)) {{ *result = *infos; }};",
+                    item_tree_class_name),
+                    "return true;".into()
+                ]
+            } else {
+                vec!["return false;".into()]
+            }),
             ..Default::default()
         }),
     ));

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1463,6 +1463,15 @@ fn generate_item_tree(
     let item_tree_array_len = item_tree_array.len();
     let item_array_len = item_array.len();
 
+    let element_info_body = if root.has_debug_info {
+        quote!(
+            *_result = self.item_element_infos(_index).unwrap_or_default();
+            true
+        )
+    } else {
+        quote!(false)
+    };
+
     quote!(
         #sub_comp
 
@@ -1597,15 +1606,10 @@ fn generate_item_tree(
 
             fn item_element_infos(
                 self: ::core::pin::Pin<&Self>,
-                index: u32,
-                result: &mut sp::SharedString,
+                _index: u32,
+                _result: &mut sp::SharedString,
             ) -> bool {
-                if let Some(infos) = self.item_element_infos(index) {
-                    *result = infos;
-                    true
-                } else {
-                    false
-                }
+                #element_info_body
             }
 
             fn window_adapter(

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -330,6 +330,7 @@ pub struct CompilationUnit {
     pub public_components: Vec<PublicComponent>,
     pub sub_components: Vec<Rc<SubComponent>>,
     pub globals: Vec<GlobalComponent>,
+    pub has_debug_info: bool,
 }
 
 impl CompilationUnit {

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -62,6 +62,7 @@ pub fn lower_to_item_tree(
                 state.sub_components[&ByAddress(tree_sub_compo.clone())].sub_component.clone()
             })
             .collect(),
+        has_debug_info: compiler_config.debug_info,
     };
     super::optim_passes::run_passes(&root);
     root


### PR DESCRIPTION
A `Rectangle { clip: true; }` will generate an intermediate `Clip` rectangle, which certainly has no debug info.

The check whether debug info is present or not should not be done on a per-element level but it can be done on the level of the compilation unit.