### PR TITLE
C++: Make the system testing feature automatically enable debug info

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -65,7 +65,7 @@ function(define_cargo_dependent_feature cargo_feature description default depend
 endfunction()
 
 # Features that are mapped to features in the Rust crate. These and their
-# defaults need to be kept in sync with the Rust bit.
+# defaults need to be kept in sync with the Rust bit (cpp/Cargo.toml and cbindgen.rs)
 
 define_cargo_feature(freestanding "Enable use of freestanding environment. This is only for bare-metal systems. Most other features are incompatible with this one" OFF)
 

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -34,6 +34,7 @@ function(define_cargo_feature cargo_feature description default)
     # turn foo-bar into SLINT_FEATURE_FOO_BAR
     string(TOUPPER "${cargo_feature}" cmake_option)
     string(REPLACE "-" "_" cmake_option "${cmake_option}")
+    list(APPEND public_cmake_features ${cmake_option})
     set(cmake_option "SLINT_FEATURE_${cmake_option}")
     option("${cmake_option}" "${description}" ${default})
 
@@ -42,6 +43,7 @@ function(define_cargo_feature cargo_feature description default)
     endif()
 
     set(features "${features}" PARENT_SCOPE)
+    set(public_cmake_features "${public_cmake_features}" PARENT_SCOPE)
     add_feature_info(${cmake_option} ${cmake_option} ${description})
 endfunction()
 
@@ -49,6 +51,7 @@ function(define_cargo_dependent_feature cargo_feature description default depend
     # turn foo-bar into SLINT_FEATURE_FOO_BAR
     string(TOUPPER "${cargo_feature}" cmake_option)
     string(REPLACE "-" "_" cmake_option "${cmake_option}")
+    list(APPEND public_cmake_features ${cmake_option})
     set(cmake_option "SLINT_FEATURE_${cmake_option}")
     cmake_dependent_option("${cmake_option}" "${description}" ${default} ${depends_condition} OFF)
 
@@ -57,6 +60,7 @@ function(define_cargo_dependent_feature cargo_feature description default depend
     endif()
 
     set(features "${features}" PARENT_SCOPE)
+    set(public_cmake_features "${public_cmake_features}" PARENT_SCOPE)
     add_feature_info(${cmake_option} ${cmake_option} ${description})
 endfunction()
 
@@ -157,6 +161,19 @@ if (SLINT_BUILD_RUNTIME)
     if (MSVC)
         target_compile_options(Slint INTERFACE /bigobj)
     endif()
+
+    foreach(feature ${public_cmake_features})
+        set(cmake_option "SLINT_FEATURE_${feature}")
+        if(${cmake_option})
+            list(APPEND enabled_features ${feature})
+        else()
+            list(APPEND disabled_features ${feature})
+        endif()
+    endforeach()
+    set_property(TARGET Slint APPEND PROPERTY SLINT_ENABLED_FEATURES "${enabled_features}")
+    set_property(TARGET Slint APPEND PROPERTY SLINT_DISABLED_FEATURES "${disabled_features}")
+    set_property(TARGET Slint APPEND PROPERTY EXPORT_PROPERTIES "SLINT_ENABLED_FEATURES")
+    set_property(TARGET Slint APPEND PROPERTY EXPORT_PROPERTIES "SLINT_DISABLED_FEATURES")
 
     if (SLINT_FEATURE_FREESTANDING)
         if (ESP_PLATFORM)

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 name = "slint_cpp"
 
 # Note, these features need to be kept in sync (along with their defaults) in
-# the C++ crate's CMakeLists.txt
+# the C++ crate's CMakeLists.txt as well as cbindgen.rs
 [features]
 interpreter = ["slint-interpreter", "std"]
 # Enable some function used by the integration tests

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -961,7 +961,26 @@ macro_rules! declare_features {
     };
 }
 
-declare_features! {interpreter backend_qt freestanding renderer_software renderer_skia experimental gettext testing}
+declare_features! {
+    interpreter
+    testing
+    backend_qt
+    backend_winit
+    backend_winit_x11
+    backend_winit_wayland
+    backend_linuxkms
+    backend_linuxkms_noseat
+    renderer_femtovg
+    renderer_skia
+    renderer_skia_opengl
+    renderer_skia_vulkan
+    renderer_software
+    gettext
+    accessibility
+    system_testing
+    freestanding
+    experimental
+}
 
 /// Generate the headers.
 /// `root_dir` is the root directory of the slint git repo

--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -14,6 +14,12 @@ function(SLINT_TARGET_SOURCES target)
     # Parse the NAMESPACE argument
     cmake_parse_arguments(SLINT_TARGET_SOURCES "" "NAMESPACE" "LIBRARY_PATHS" ${ARGN})
 
+    get_target_property(enabled_features Slint::Slint SLINT_ENABLED_FEATURES)
+    if (("EXPERIMENTAL" IN_LIST enabled_features) AND ("SYSTEM_TESTING" IN_LIST enabled_features))
+        set(SLINT_COMPILER_ENV ${CMAKE_COMMAND} -E env)
+        set(SLINT_COMPILER_ENV ${SLINT_COMPILER_ENV} SLINT_EMIT_DEBUG_INFO=1)
+    endif()
+
     if (DEFINED SLINT_TARGET_SOURCES_NAMESPACE)
         # Remove the NAMESPACE argument from the list
         list(FIND ARGN "NAMESPACE" _index)
@@ -41,7 +47,7 @@ function(SLINT_TARGET_SOURCES target)
 
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
-            COMMAND Slint::slint-compiler ${_SLINT_ABSOLUTE}
+            COMMAND ${SLINT_COMPILER_ENV} $<TARGET_FILE:Slint::slint-compiler> ${_SLINT_ABSOLUTE}
                 -o ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
                 --depfile ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d
                 --style ${_SLINT_STYLE}

--- a/api/cpp/docs/cmake.md
+++ b/api/cpp/docs/cmake.md
@@ -93,6 +93,17 @@ to discover and toggle features.
 This works when compiling Slint as a package, using `cmake --build` and
 `cmake --install`, or when including Slint using `FetchContent`.
 
+If you need to check in your application's `CMakeLists.txt` whether a feature is enabled
+or disabled, read the `SLINT_ENABLED_FEATURES` and `SLINT_DISABLED_FEATURES` target
+properties from the `Slint::Slint` cmake target:
+
+```cmake
+get_target_property(slint_enabled_features Slint::Slint SLINT_ENABLED_FEATURES)
+if ("BACKEND_WINIT" IN_LIST slint_enabled_features)
+    ...
+endif()
+```
+
 ### Rust Flags
 
 Slint uses [Corrosion](https://github.com/corrosion-rs/corrosion) to build Slint, which is developed in Rust. You can utilize [Corrosion's global CMake variables](https://corrosion-rs.github.io/corrosion/usage.html#global-corrosion-options) to control certain aspects of the Rust build process.

--- a/api/cpp/docs/cmake.md
+++ b/api/cpp/docs/cmake.md
@@ -104,6 +104,17 @@ if ("BACKEND_WINIT" IN_LIST slint_enabled_features)
 endif()
 ```
 
+Similarly, if you need to check for features at compile-time, check for the existence
+of `SLINT_FEATURE_<NAME>` pre-processor macros:
+
+```
+#include <slint.h>
+
+#if defined(SLINT_FEATURE_BACKEND_WINIT)
+// ...
+#endif
+```
+
 ### Rust Flags
 
 Slint uses [Corrosion](https://github.com/corrosion-rs/corrosion) to build Slint, which is developed in Rust. You can utilize [Corrosion's global CMake variables](https://corrosion-rs.github.io/corrosion/usage.html#global-corrosion-options) to control certain aspects of the Rust build process.

--- a/xtask/src/cppdocs.rs
+++ b/xtask/src/cppdocs.rs
@@ -85,13 +85,23 @@ pub fn generate(show_warnings: bool) -> Result<(), Box<dyn std::error::Error>> {
     let generated_headers_dir = docs_build_dir.join("generated_include");
     let enabled_features = cbindgen::EnabledFeatures {
         interpreter: true,
-        backend_qt: false,
-        freestanding: false,
-        renderer_software: true,
-        renderer_skia: true,
-        experimental: false,
-        gettext: true,
         testing: true,
+        backend_qt: false,
+        backend_winit: true,
+        backend_winit_x11: false,
+        backend_winit_wayland: false,
+        backend_linuxkms: false,
+        backend_linuxkms_noseat: false,
+        renderer_femtovg: true,
+        renderer_skia: true,
+        renderer_skia_opengl: false,
+        renderer_skia_vulkan: false,
+        renderer_software: true,
+        gettext: true,
+        accessibility: true,
+        system_testing: false,
+        freestanding: false,
+        experimental: false,
     };
     cbindgen::gen_all(&root, &generated_headers_dir, enabled_features)?;
 


### PR DESCRIPTION
While we haven't settled on the debug info feature and are merely controlling it via environment variable, setting that can be very hard - especially when using Yocto.

To make life easier, let's do in C++ what we can't easily do for Rust but would like to:

When enabling system testing, automatically emit the necessary debug info, by setting the environment variable when calling the compiler.

This is done by adding SLINT_ENABLED_FEATURES and SLINT_DISABLED_FEATURES properties
on the Slint::Slint target that - as lists - export the list of features and their status.

This way we can compile Slint in once place and safely in the CMake code running in application
scope check about the available features.