### PR TITLE
Fix insersion into a child `@children` when it shouldn't

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -556,10 +556,6 @@ fn duplicate_transition(
 // Some components need to be inlined to avoid increased complexity in handling them
 // in the code generators and subsequent passes.
 fn component_requires_inlining(component: &Rc<Component>) -> bool {
-    if component.child_insertion_point.borrow().is_some() {
-        return true;
-    }
-
     let root_element = &component.root_element;
     if super::flickable::is_flickable_element(root_element)
         || super::lower_layout::is_layout_element(root_element)

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -139,7 +139,7 @@ fn inline_element(
                         if Rc::ptr_eq(&cip.0, elem) {
                             *cip = (insertion_element.clone(), index + cip.1, cip_node.clone());
                         }
-                    } else {
+                    } else if Rc::ptr_eq(elem, &root_component.root_element) {
                         *cip = Some((insertion_element.clone(), *index, cip_node.clone()));
                     };
                 } else {

--- a/tests/cases/children/children_placeholder_three_levels.slint
+++ b/tests/cases/children/children_placeholder_three_levels.slint
@@ -1,0 +1,64 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+
+component Abc inherits VerticalLayout {
+    Rectangle { background: green; }
+    Rectangle { background: blue; @children }
+    Rectangle { background: pink; }
+}
+
+component Cde inherits HorizontalLayout {
+    Rectangle { background: red; }
+    Abc {}
+    Rectangle { background: orange; }
+}
+
+component Fgh inherits HorizontalLayout {
+    Abc {}
+    Rectangle { background: yellow; @children}
+    Rectangle { background: gray; }
+}
+
+component Ijk inherits Fgh {}
+
+export component TestCase inherits Window {
+    width: 600px;
+    height: 200px;
+
+    Cde {
+        // The rectangle should not be within Abc since Cde don't have a @children (despite Abc has one) )
+        r1 := Rectangle { background: black; }
+    }
+
+    Fgh {
+        // The rectangle should not be in the yellow one )
+        r2 := Rectangle { background: white; }
+    }
+
+    Ijk {
+        // Same as r2
+        r3 := Rectangle { background: brown; }
+    }
+
+    out property r1_pos <=> r1.absolute-position;
+    out property r2_pos <=> r2.absolute-position;
+    out property r3_pos <=> r2.absolute-position;
+    out property <bool> r1_ok: r1_pos.x == root.width * 3/4 && r1_pos.y == 0px;
+    out property <bool> r2_ok: r2_pos.x == root.width * 1/3 && r2_pos.y == 0px;
+    out property <bool> r3_ok: r3_pos.x == root.width * 1/3 && r3_pos.y == 0px;
+    out property <bool> test: r1_ok && r2_ok && r3_ok;
+}
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/


### PR DESCRIPTION
If a component doesn't have a @children, but inherit from a builtin element, we shouldn't take the @children from the children