### PR TITLE
Allow not inlining components that inherit from layout

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -557,9 +557,7 @@ fn duplicate_transition(
 // in the code generators and subsequent passes.
 fn component_requires_inlining(component: &Rc<Component>) -> bool {
     let root_element = &component.root_element;
-    if super::flickable::is_flickable_element(root_element)
-        || super::lower_layout::is_layout_element(root_element)
-    {
+    if super::flickable::is_flickable_element(root_element) {
         return true;
     }
 

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -133,10 +133,6 @@ fn lower_element_layout(
     }
 }
 
-pub fn is_layout_element(element: &ElementRc) -> bool {
-    matches!(&element.borrow().base_type, ElementType::Builtin(n) if n.name == "GridLayout" || n.name == "HorizontalLayout" || n.name == "VerticalLayout")
-}
-
 fn lower_grid_layout(
     component: &Rc<Component>,
     grid_layout_element: &ElementRc,


### PR DESCRIPTION
There is no longer a reason to prevent it.