### PR TITLE
API review: Remove accidental public strum dependency

### DIFF
--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -40,4 +40,4 @@ pb-rs = { version = "0.10.0", optional = true, default-features = false }
 [dev-dependencies]
 slint = { workspace = true, default-features = false, features = ["std", "compat-1-2"] }
 i-slint-core-macros = { workspace = true }
-strum = { workspace = true }
+i-slint-common = { workspace = true }

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -427,8 +427,19 @@ fn convert_pointer_event_button(
 
 #[test]
 fn test_accessibility_role_mapping_complete() {
-    use strum::IntoEnumIterator;
-    for role in i_slint_core::items::AccessibleRole::iter() {
-        assert!(convert_accessible_role(role).is_some());
+    macro_rules! test_accessiblity_enum_mapping_inner {
+        (AccessibleRole, $($Value:ident,)*) => {
+            $(assert!(convert_accessible_role(i_slint_core::items::AccessibleRole::$Value).is_some());)*
+        };
+        ($_:ident, $($Value:ident,)*) => {};
     }
+
+    macro_rules! test_accessiblity_enum_mapping {
+        ($( $(#[doc = $enum_doc:literal])* $(#[non_exhaustive])? enum $Name:ident { $( $(#[doc = $value_doc:literal])* $Value:ident,)* })*) => {
+            $(
+                test_accessiblity_enum_mapping_inner!($Name, $($Value,)*);
+            )*
+        };
+    }
+    i_slint_common::for_each_enums!(test_accessiblity_enum_mapping);
 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1471,7 +1471,7 @@ declare_item_vtable! {
 macro_rules! declare_enums {
     ($( $(#[$enum_doc:meta])* enum $Name:ident { $( $(#[$value_doc:meta])* $Value:ident,)* })*) => {
         $(
-            #[derive(Copy, Clone, Debug, PartialEq, Eq, strum::EnumString, strum::Display, strum::EnumIter, Hash)]
+            #[derive(Copy, Clone, Debug, PartialEq, Eq, strum::EnumString, strum::Display, Hash)]
             #[repr(u32)]
             #[strum(serialize_all = "kebab-case")]
             $(#[$enum_doc])*


### PR DESCRIPTION
Deriving strum::EnumIter on a publicly exposed enum (like PointerEventButton) implies visibility into types that strum declares. This was added just for testing in systest and can be solved differently.

Amends a1857e6154c8a8aae569564e7c5f5151aa8c08dc