### PR TITLE
API review (esp-idf): Replace the use of std::optional<esp_lcd_touch_handle_t> with esp_lcd_touch_handle_t directly

### DIFF
--- a/api/cpp/esp-idf/slint/README.md
+++ b/api/cpp/esp-idf/slint/README.md
@@ -86,8 +86,8 @@ extern "C" void app_main(void)
     /* Initialize Slint's ESP platform support*/
     slint_esp_init(SlintPlatformConfiguration {
             .size = slint::PhysicalSize({ BSP_LCD_H_RES, BSP_LCD_V_RES }),
-            .panel = panel_handle,
-            .touch = touch_handle,
+            .panel_handle = panel_handle,
+            .touch_handle = touch_handle,
             .buffer1 = buffer,
             .color_swap_16 = true });
 

--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -37,10 +37,11 @@ struct SlintPlatformConfiguration
     /// The size of the screen in pixels.
     slint::PhysicalSize size;
     /// The handle to the display as previously initialized by `bsp_display_new` or
-    /// `esp_lcd_panel_init`.
-    esp_lcd_panel_handle_t panel = nullptr;
-    /// The touch screen handle, if the device is equipped with a touch screen.
-    esp_lcd_touch_handle_t touch = nullptr;
+    /// `esp_lcd_panel_init`. Must be set to a valid, non-null esp_lcd_panel_handle_t.
+    esp_lcd_panel_handle_t panel_handle = nullptr;
+    /// The touch screen handle, if the device is equipped with a touch screen. Set to nullptr
+    /// otherwise;
+    esp_lcd_touch_handle_t touch_handle = nullptr;
     /// The buffer Slint will render into. It must have have the size of at least one frame. Slint
     /// calls esp_lcd_panel_draw_bitmap to flush the buffer to the screen.
     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer1 = {};

--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -38,9 +38,9 @@ struct SlintPlatformConfiguration
     slint::PhysicalSize size;
     /// The handle to the display as previously initialized by `bsp_display_new` or
     /// `esp_lcd_panel_init`.
-    esp_lcd_panel_handle_t panel;
+    esp_lcd_panel_handle_t panel = nullptr;
     /// The touch screen handle, if the device is equipped with a touch screen.
-    std::optional<esp_lcd_touch_handle_t> touch;
+    esp_lcd_touch_handle_t touch = nullptr;
     /// The buffer Slint will render into. It must have have the size of at least one frame. Slint
     /// calls esp_lcd_panel_draw_bitmap to flush the buffer to the screen.
     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer1 = {};

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -48,7 +48,7 @@ struct EspPlatform : public slint::platform::Platform
 private:
     slint::PhysicalSize size;
     esp_lcd_panel_handle_t panel_handle;
-    std::optional<esp_lcd_touch_handle_t> touch_handle;
+    esp_lcd_touch_handle_t touch_handle;
     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer1;
     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2;
     bool color_swap_16;
@@ -127,7 +127,7 @@ void EspPlatform::run_event_loop()
 
     if (touch_handle) {
         if (esp_lcd_touch_register_interrupt_callback(
-                    *touch_handle, [](auto) { vTaskNotifyGiveFromISR(task, nullptr); })
+                    touch_handle, [](auto) { vTaskNotifyGiveFromISR(task, nullptr); })
             != ESP_OK) {
 
             // No touch interrupt assigned or supported? Fall back to polling like esp_lvgl_port.
@@ -179,11 +179,11 @@ void EspPlatform::run_event_loop()
                 uint8_t touchpad_cnt = 0;
 
                 /* Read touch controller data */
-                esp_lcd_touch_read_data(*touch_handle);
+                esp_lcd_touch_read_data(touch_handle);
 
                 /* Get coordinates */
                 bool touchpad_pressed = esp_lcd_touch_get_coordinates(
-                        *touch_handle, touchpad_x, touchpad_y, NULL, &touchpad_cnt, 1);
+                        touch_handle, touchpad_x, touchpad_y, NULL, &touchpad_cnt, 1);
 
                 if (touchpad_pressed && touchpad_cnt > 0) {
                     // ESP_LOGI(TAG, "x: %i, y: %i", touchpad_x[0], touchpad_y[0]);
@@ -328,7 +328,7 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
     SlintPlatformConfiguration config {
         .size = size,
         .panel = panel,
-        .touch = touch,
+        .touch = touch ? *touch : nullptr,
         .buffer1 = buffer1,
         .buffer2 = buffer2,
         // For compatibility with earlier versions of Slint, we compute the value of
@@ -345,7 +345,7 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
 {
     SlintPlatformConfiguration config { .size = size,
                                         .panel = panel,
-                                        .touch = touch,
+                                        .touch = touch ? *touch : nullptr,
                                         .buffer1 = std::nullopt,
                                         .buffer2 = std::nullopt,
                                         .rotation = rotation,

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -22,8 +22,8 @@ struct EspPlatform : public slint::platform::Platform
 {
     EspPlatform(const SlintPlatformConfiguration &config)
         : size(config.size),
-          panel_handle(config.panel),
-          touch_handle(config.touch),
+          panel_handle(config.panel_handle),
+          touch_handle(config.touch_handle),
           buffer1(config.buffer1),
           buffer2(config.buffer2),
           color_swap_16(config.color_swap_16),
@@ -327,8 +327,8 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
 
     SlintPlatformConfiguration config {
         .size = size,
-        .panel = panel,
-        .touch = touch ? *touch : nullptr,
+        .panel_handle = panel,
+        .touch_handle = touch ? *touch : nullptr,
         .buffer1 = buffer1,
         .buffer2 = buffer2,
         // For compatibility with earlier versions of Slint, we compute the value of
@@ -344,8 +344,8 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     slint::platform::SoftwareRenderer::RenderingRotation rotation)
 {
     SlintPlatformConfiguration config { .size = size,
-                                        .panel = panel,
-                                        .touch = touch ? *touch : nullptr,
+                                        .panel_handle = panel,
+                                        .touch_handle = touch ? *touch : nullptr,
                                         .buffer1 = std::nullopt,
                                         .buffer2 = std::nullopt,
                                         .rotation = rotation,

--- a/examples/carousel/esp-idf/main.cpp
+++ b/examples/carousel/esp-idf/main.cpp
@@ -51,8 +51,8 @@ extern "C" void app_main(void)
 
     slint_esp_init(SlintPlatformConfiguration {
             .size = slint::PhysicalSize({ BSP_LCD_H_RES, BSP_LCD_V_RES }),
-            .panel = panel_handle,
-            .touch = touch_handle,
+            .panel_handle = panel_handle,
+            .touch_handle = touch_handle,
             .buffer1 = buffer,
             .color_swap_16 = true });
 

--- a/examples/printerdemo_mcu/esp-idf/main/main.cpp
+++ b/examples/printerdemo_mcu/esp-idf/main/main.cpp
@@ -53,8 +53,8 @@ extern "C" void app_main(void)
 
     slint_esp_init(SlintPlatformConfiguration {
             .size = slint::PhysicalSize({ BSP_LCD_H_RES, BSP_LCD_V_RES }),
-            .panel = panel_handle,
-            .touch = touch_handle,
+            .panel_handle = panel_handle,
+            .touch_handle = touch_handle,
             .buffer1 = buffer,
             .color_swap_16 = true });
 


### PR DESCRIPTION
esp_lcd_touch_handle_t is a pointer, so might as well treat it like one.

Also default initialize the panel pointer.