### PR TITLE
backout of commit 402f7ea64913514712c1b71be67e3e2e12982f19

### DIFF
--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -67,7 +67,7 @@ once_cell = { version = "1.5", default-features = false, features = ["critical-s
 pin-project = "1"
 pin-weak = { version = "1.1", default-features = false }
 # Note: the rgb version is extracted in ci.yaml for rustdoc builds
-rgb = "0.8.42"
+rgb = "0.8.27"
 scoped-tls-hkt = { version = "0.1", optional = true }
 scopeguard =  { version = "1.1.0", default-features = false }
 slab = { version = "0.4.3", default-features = false }

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -91,7 +91,7 @@ impl<Pixel: Clone> SharedPixelBuffer<Pixel> {
 
 impl<Pixel: Clone + rgb::Pod> SharedPixelBuffer<Pixel>
 where
-    [Pixel]: rgb::ComponentBytes<Pixel>,
+    [Pixel]: rgb::ComponentBytes<u8>,
 {
     /// Returns the pixels interpreted as raw bytes.
     pub fn as_bytes(&self) -> &[u8] {


### PR DESCRIPTION
rgb crate has eben fixed upstream, remove the temporary work-around again.