### PR TITLE
Add support for using own properties in PopupWindow's x and y properties

### DIFF
--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -105,12 +105,14 @@ public:
         slint_windowrc_set_component(&inner, &item_tree_rc);
     }
 
-    template<typename Component, typename Parent>
-    void show_popup(const Parent *parent_component, cbindgen_private::Point p, bool close_on_click,
-                    cbindgen_private::ItemRc parent_item) const
+    template<typename Component, typename Parent, typename XGetter, typename YGetter>
+    void show_popup(const Parent *parent_component, XGetter x_getter, YGetter y_getter,
+                    bool close_on_click, cbindgen_private::ItemRc parent_item) const
     {
-        auto popup = Component::create(parent_component).into_dyn();
-        cbindgen_private::slint_windowrc_show_popup(&inner, &popup, p, close_on_click,
+        auto popup = Component::create(parent_component);
+        cbindgen_private::Point p { x_getter(popup), y_getter(popup) };
+        auto popup_dyn = popup.into_dyn();
+        cbindgen_private::slint_windowrc_show_popup(&inner, &popup_dyn, p, close_on_click,
                                                     &parent_item);
     }
 

--- a/examples/gallery/ui/pages/controls_page.slint
+++ b/examples/gallery/ui/pages/controls_page.slint
@@ -229,17 +229,12 @@ export component ControlsPage inherits Page {
     }
 
     time-picker := TimePickerPopup {
-        x: (root.width - 340px) / 2;
-        y: (root.height - 500px) / 2;
-        width: 340px;
-        height: 500px;
-        
+        x: (root.width - self.width) / 2;
+        y: (root.height - self.height) / 2;
     }
 
     date-picker := DatePickerPopup {
-        x: (root.width - 360px) / 2;
-        y: (root.height - 360px) / 2;
-        width: 360px;
-        height: 524px;       
+        x: (root.width - self.width) / 2;
+        y: (root.height - self.height) / 2;
     }
 }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -240,7 +240,7 @@ pub struct SubComponent {
     pub items: Vec<Item>,
     pub repeated: Vec<RepeatedElement>,
     pub component_containers: Vec<ComponentContainerElement>,
-    pub popup_windows: Vec<ItemTree>,
+    pub popup_windows: Vec<PopupWindow>,
     pub sub_components: Vec<SubComponentInstance>,
     /// The initial value or binding for properties.
     /// This is ordered in the order they must be set.
@@ -266,6 +266,13 @@ pub struct SubComponent {
     pub element_infos: BTreeMap<u32, String>,
 
     pub prop_analysis: HashMap<PropertyReference, PropAnalysis>,
+}
+
+#[derive(Debug)]
+pub struct PopupWindow {
+    pub item_tree: ItemTree,
+    pub x_prop: PropertyReference,
+    pub y_prop: PropertyReference,
 }
 
 #[derive(Debug, Clone)]
@@ -363,8 +370,13 @@ impl CompilationUnit {
                     Some(ParentCtx::new(&ctx, Some(idx as u32))),
                 );
             }
-            for x in &c.popup_windows {
-                visit_component(root, &x.root, visitor, Some(ParentCtx::new(&ctx, None)));
+            for popup in &c.popup_windows {
+                visit_component(
+                    root,
+                    &popup.item_tree.root,
+                    visitor,
+                    Some(ParentCtx::new(&ctx, None)),
+                );
             }
         }
         for c in &self.sub_components {

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -370,8 +370,6 @@ fn lower_show_popup(args: &[tree_Expression], ctx: &ExpressionContext) -> llr_Ex
             .enumerate()
             .find(|(_, p)| Rc::ptr_eq(&p.component, &pop_comp))
             .unwrap();
-        let x = llr_Expression::PropertyReference(ctx.map_property_reference(&popup.x));
-        let y = llr_Expression::PropertyReference(ctx.map_property_reference(&popup.y));
         let item_ref = lower_expression(
             &tree_Expression::ElementReference(Rc::downgrade(&popup.parent_element)),
             ctx,
@@ -380,8 +378,6 @@ fn lower_show_popup(args: &[tree_Expression], ctx: &ExpressionContext) -> llr_Ex
             function: BuiltinFunction::ShowPopupWindow,
             arguments: vec![
                 llr_Expression::NumberLiteral(popup_index as _),
-                x,
-                y,
                 llr_Expression::BoolLiteral(popup.close_on_click),
                 item_ref,
             ],

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -118,6 +118,18 @@ pub fn count_property_use(root: &CompilationUnit) {
             visit_property(p, ctx);
             e.visit_recursive(&mut |e| visit_expression(e, ctx));
         }
+
+        // 10. popup x/y coordinates
+        for popup in &sc.popup_windows {
+            let popup_ctx = EvaluationContext::new_sub_component(
+                root,
+                &popup.item_tree.root,
+                (),
+                Some(ParentCtx::new(&ctx, None)),
+            );
+            visit_property(&popup.x_prop, &popup_ctx);
+            visit_property(&popup.y_prop, &popup_ctx);
+        }
     });
 
     // TODO: only visit used function

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -109,7 +109,7 @@ impl<'a> PrettyPrinter<'a> {
         }
         for w in &sc.popup_windows {
             self.indent()?;
-            self.print_component(root, &w.root, Some(ParentCtx::new(&ctx, None)))?
+            self.print_component(root, &w.item_tree.root, Some(ParentCtx::new(&ctx, None)))?
         }
         self.indentation -= 1;
         self.indent()?;

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -17,18 +17,19 @@ use std::rc::Rc;
 pub fn materialize_fake_properties(component: &Rc<Component>) {
     let mut to_materialize = std::collections::HashMap::new();
 
-    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
-        visit_all_named_references_in_element(elem, |nr| {
-            let elem = nr.element();
-            let elem = elem.borrow();
-            if !to_materialize.contains_key(nr) {
-                if let Some(ty) =
-                    should_materialize(&elem.property_declarations, &elem.base_type, nr.name())
-                {
-                    to_materialize.insert(nr.clone(), ty);
-                }
+    visit_all_named_references(component, &mut |nr| {
+        let elem = nr.element();
+        let elem = elem.borrow();
+        if !to_materialize.contains_key(nr) {
+            if let Some(ty) =
+                should_materialize(&elem.property_declarations, &elem.base_type, nr.name())
+            {
+                to_materialize.insert(nr.clone(), ty);
             }
-        });
+        }
+    });
+
+    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
         for prop in elem.borrow().bindings.keys() {
             let nr = NamedReference::new(elem, prop);
             if let std::collections::hash_map::Entry::Vacant(e) = to_materialize.entry(nr) {

--- a/internal/compiler/widgets/cosmic-base/time-picker.slint
+++ b/internal/compiler/widgets/cosmic-base/time-picker.slint
@@ -18,12 +18,10 @@ export component TimePickerPopup inherits PopupWindow {
 
     callback canceled();
     callback accepted(/* current-time */ Time);
-    
-    width: 340px;
-    height: 500px;
+
     close-on-click: false;
 
-    background-layer := MenuBorder { 
+    background-layer := MenuBorder {
         width: dialog.width;
         height: dialog.height;
     }
@@ -75,7 +73,7 @@ export component TimePickerPopup inherits PopupWindow {
                 },
             };
         }
- 
+
         Button {
             icon: base.selection-mode ? Icons.keyboard : Icons.clock;
             colorize-icon: true;
@@ -86,7 +84,7 @@ export component TimePickerPopup inherits PopupWindow {
                 base.selection-mode = !base.selection-mode;
             }
         }
-        
+
         StandardButton {
             kind: cancel;
 

--- a/internal/compiler/widgets/cupertino-base/time-picker.slint
+++ b/internal/compiler/widgets/cupertino-base/time-picker.slint
@@ -17,12 +17,10 @@ export component TimePickerPopup inherits PopupWindow {
 
     callback canceled();
     callback accepted(/* current-time */ Time);
-    
-    width: 340px;
-    height: 500px;
+
     close-on-click: false;
 
-    background-layer := MenuBorder { 
+    background-layer := MenuBorder {
         width: dialog.width;
         height: dialog.height;
     }
@@ -68,9 +66,9 @@ export component TimePickerPopup inherits PopupWindow {
                     }
                 },
                 title-style: {
-                      font-size: CupertinoFontSettings.body.font-size,
-                      font-weight: CupertinoFontSettings.body.font-weight,
-                      foreground: CupertinoPalette.foreground,
+                    font-size: CupertinoFontSettings.body.font-size,
+                    font-weight: CupertinoFontSettings.body.font-weight,
+                    foreground: CupertinoPalette.foreground,
                 },
             };
         }

--- a/internal/compiler/widgets/fluent-base/time-picker.slint
+++ b/internal/compiler/widgets/fluent-base/time-picker.slint
@@ -18,18 +18,15 @@ export component TimePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(/* current-time */ Time);
 
-    width: 340px;
-    height: 500px;
     close-on-click: false;
 
-    background-layer := MenuBorder { 
+    background-layer := MenuBorder {
         width: dialog.width;
         height: dialog.height;
     }
 
     dialog := Dialog {
         padding: 8px;
-        
         base := TimePickerBase {
             title: root.title;
             style: {
@@ -74,7 +71,7 @@ export component TimePickerPopup inherits PopupWindow {
                 },
             };
         }
-        
+
         Button {
             icon: base.selection-mode ? Icons.keyboard : Icons.clock;
             colorize-icon: true;
@@ -85,7 +82,7 @@ export component TimePickerPopup inherits PopupWindow {
                 base.selection-mode = !base.selection-mode;
             }
         }
-        
+
         StandardButton {
             kind: cancel;
 

--- a/internal/compiler/widgets/material-base/time-picker.slint
+++ b/internal/compiler/widgets/material-base/time-picker.slint
@@ -17,10 +17,8 @@ export component TimePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(/* current-time */ Time);
 
-    width: 340px;
-    height: 500px;
     close-on-click: false;
-   
+
     background-layer := Rectangle {
         width: dialog.width;
         height: dialog.height;
@@ -30,7 +28,7 @@ export component TimePickerPopup inherits PopupWindow {
 
     dialog := Dialog {
         padding: 8px;
-        
+
         base := TimePickerBase {
             title: root.title;
             style: {
@@ -76,7 +74,6 @@ export component TimePickerPopup inherits PopupWindow {
             };
         }
 
-        
         IconButton {
             icon: base.selection-mode ? Icons.keyboard : Icons.clock;
             accessible-label: "Toggle input picker";
@@ -86,7 +83,7 @@ export component TimePickerPopup inherits PopupWindow {
                 base.selection-mode = !base.selection-mode;
             }
         }
-        
+
         TextButton {
             text: @tr("Cancel");
             dialog-button-role: reject;

--- a/internal/compiler/widgets/qt/time-picker.slint
+++ b/internal/compiler/widgets/qt/time-picker.slint
@@ -18,8 +18,6 @@ export component TimePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(/* current-time */ Time);
 
-    width: 340px;
-    height: 500px;
     close-on-click: false;
 
     background-layer := Rectangle {

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2234,7 +2234,7 @@ impl<'a, 'id> InstanceRef<'a, 'id> {
 /// Show the popup at the given location
 pub fn show_popup(
     popup: &object_tree::PopupWindow,
-    pos: i_slint_core::graphics::Point,
+    pos_getter: impl FnOnce(InstanceRef<'_, '_>) -> i_slint_core::graphics::Point,
     close_on_click: bool,
     parent_comp: ErasedItemTreeBoxWeak,
     parent_window_adapter: WindowAdapterRc,
@@ -2251,6 +2251,13 @@ pub fn show_popup(
         Default::default(),
     );
     inst.run_setup_code();
+
+    let pos = {
+        generativity::make_guard!(guard);
+        let compo_box = inst.unerase(guard);
+        let instance_ref = compo_box.borrow_instance();
+        pos_getter(instance_ref)
+    };
     WindowInner::from_pub(parent_window_adapter.window()).show_popup(
         &vtable::VRc::into_dyn(inst),
         pos,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -587,18 +587,6 @@ fn call_builtin_function(
                 let popup_list = parent_component.popup_windows.borrow();
                 let popup =
                     popup_list.iter().find(|p| Rc::ptr_eq(&p.component, &pop_comp)).unwrap();
-                let x = load_property_helper(
-                    local_context.component_instance,
-                    &popup.x.element(),
-                    popup.x.name(),
-                )
-                .unwrap();
-                let y = load_property_helper(
-                    local_context.component_instance,
-                    &popup.y.element(),
-                    popup.y.name(),
-                )
-                .unwrap();
 
                 generativity::make_guard!(guard);
                 let enclosing_component =
@@ -614,10 +602,17 @@ fn call_builtin_function(
 
                 crate::dynamic_item_tree::show_popup(
                     popup,
-                    i_slint_core::graphics::Point::new(
-                        x.try_into().unwrap(),
-                        y.try_into().unwrap(),
-                    ),
+                    |instance_ref| {
+                        let comp = ComponentInstance::InstanceRef(instance_ref);
+                        let x =
+                            load_property_helper(comp, &popup.x.element(), popup.x.name()).unwrap();
+                        let y =
+                            load_property_helper(comp, &popup.y.element(), popup.y.name()).unwrap();
+                        i_slint_core::graphics::Point::new(
+                            x.try_into().unwrap(),
+                            y.try_into().unwrap(),
+                        )
+                    },
                     popup.close_on_click,
                     component.self_weak().get().unwrap().clone(),
                     component.window_adapter(),

--- a/tests/cases/elements/popupwindow_context.slint
+++ b/tests/cases/elements/popupwindow_context.slint
@@ -14,10 +14,12 @@ export component TestCase {
     out property <length> last-underneath-mouse-y: ta.mouse-y;
 
     context-menu := PopupWindow {
-        x: 10px;
+        x: self.popup-center;
         y: 10px;
         width: parent.width - 20px;
         height: parent.height - 20px;
+
+        property <length> popup-center: 10px;
 
         Rectangle {
             border-width: 2px;


### PR DESCRIPTION
This allows positioning popup windows in a way that takes their width/height into account.