### PR TITLE
API review: clean up Time/Date struct docs

### DIFF
--- a/docs/reference/src/language/widgets/datepicker.md
+++ b/docs/reference/src/language/widgets/datepicker.md
@@ -1,15 +1,5 @@
 <!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 
-## struct `Date`
-
-Defines a date with day, month, and year
-
-### Fields
-
--   **`day`(int)**: The day value (range from 1 to 31).
--   **`month`(int)**: The month value (range from 1 to 12).
--   **`year`(int)**: The year value.
-
 ## `DatePickerPopup`
 
 Use a date picker to let the user select a date.
@@ -17,7 +7,7 @@ Use a date picker to let the user select a date.
 ### Properties
 
 -   **`title`** (_in_ _string_): The text that is displayed at the top of the picker.
--   **`date`**: (_in_ _Date_): Set the initial displayed date.
+-   **`date`**: (_in_ _struct [`Date`](#struct-date)_): Set the initial displayed date.
 
 ### Callbacks
 
@@ -51,3 +41,13 @@ export component Example inherits Window {
     }
 }
 ```
+
+### Struct `Date`
+
+Defines a date with day, month, and year.
+
+#### Fields
+
+-   **`day`(int)**: The day value (range from 1 to 31).
+-   **`month`(int)**: The month value (range from 1 to 12).
+-   **`year`(int)**: The year value.

--- a/docs/reference/src/language/widgets/timepicker.md
+++ b/docs/reference/src/language/widgets/timepicker.md
@@ -1,15 +1,5 @@
 <!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 
-## struct `Time`
-
-Defines a time with hours, minutes, and seconds.
-
-### Fields
-
--   **`hour`(int)**: The hour value (range from 0 to 23).
--   **`minute`(int)**: The minute value (range from 1 to 59).
--   **`second`(int)**: The second value (range form 1 to 59).
-
 ## `TimePickerPopup`
 
 Use the timer picker to select the time, in either 24-hour or 12-hour mode (AM/PM). 
@@ -18,7 +8,7 @@ Use the timer picker to select the time, in either 24-hour or 12-hour mode (AM/P
 
 -   **`use-24-hour-format`**: (_in_ _bool_): If set to `true` 24 hours are displayed otherwise it is displayed in AM/PM mode. (default: system default, if cannot be determined then `true`) 
 -   **`title`** (_in_ _string_): The text that is displayed at the top of the picker.
--   **`time`**: (_in_ _Time_): Set the initial displayed time.
+-   **`time`**: (_in_ struct _[`Time`](#struct-time)_): Set the initial displayed time.
 
 ### Callbacks
 
@@ -53,3 +43,13 @@ export component Example inherits Window {
     }
 }
 ```
+
+### Struct `Time`
+
+Defines a time with hours, minutes, and seconds.
+
+#### Fields
+
+-   **`hour`(int)**: The hour value (range from 0 to 23).
+-   **`minute`(int)**: The minute value (range from 1 to 59).
+-   **`second`(int)**: The second value (range form 1 to 59).


### PR DESCRIPTION
- Remove `struct Date` and `struct Time` from the widgets side bar
- Move it to the bottom of each page
- Link to it from the respective properties