### PR TITLE
live-preview: List more components in the components list

### DIFF
--- a/tools/lsp/common/component_catalog.rs
+++ b/tools/lsp/common/component_catalog.rs
@@ -163,9 +163,6 @@ pub fn all_exported_components(
             result.push(to_push);
         }
     }
-
-    result.sort_by(|a, b| a.name.cmp(&b.name));
-    result.dedup_by(|a, b| a.name == b.name);
 }
 
 #[cfg(feature = "preview-engine")]

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -128,6 +128,7 @@ pub fn ui_set_known_components(
             pretty_location,
             is_user_defined: !(ci.is_builtin || ci.is_std_widget),
             is_currently_shown: idx == current_component_index,
+            is_exported: ci.is_exported,
         };
 
         if let Some(position) = &ci.defined_at {

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -8,6 +8,7 @@ export struct ComponentItem {
     pretty-location: string,
     is-user-defined: bool,
     is-currently-shown: bool,
+    is-exported: bool,
 }
 
 /// A `category` with a lost of `ComponentItem`s that belong into it.


### PR DESCRIPTION
* Show all file-local components (check is-exported)
* Parse all known files before generating the file list

Keep the document_cache with all the extra documents loaded around.

This keeps the list in the live-preview much more static.

There seems to be a bug somewhere though that eats components re-exported from a file when one of those re-exports gets previewed. I'll need to look into that, but this is a big step forward, so I want this in soon:-)