### PR TITLE
Python: Improve Struct mapping

### DIFF
--- a/api/python/README.md
+++ b/api/python/README.md
@@ -229,7 +229,7 @@ The types used for properties in the Slint Language each translate to specific t
 | `physical_length` | `float` | |
 | `duration` | `float` | The number of milliseconds |
 | `angle` | `float` | The angle in degrees |
-| structure | `dict` | Structures are mapped to Python dictionaries where each structure field is an item. |
+| structure | `dict`/`Struct` | When reading, structures are mapped to data classes, when writing dicts are also accepted. |
 | array | `slint.Model` | |
 
 ### Arrays and Models

--- a/api/python/lib.rs
+++ b/api/python/lib.rs
@@ -41,6 +41,7 @@ fn slint(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<brush::PyColor>()?;
     m.add_class::<brush::PyBrush>()?;
     m.add_class::<models::PyModelBase>()?;
+    m.add_class::<value::PyStruct>()?;
     m.add_function(wrap_pyfunction!(run_event_loop, m)?)?;
     m.add_function(wrap_pyfunction!(quit_event_loop, m)?)?;
 

--- a/api/python/slint/__init__.py
+++ b/api/python/slint/__init__.py
@@ -281,3 +281,4 @@ ListModel = models.ListModel
 Model = models.Model
 Timer = native.Timer
 TimerMode = native.TimerMode
+Struct = native.PyStruct

--- a/api/python/tests/test_instance.py
+++ b/api/python/tests/test_instance.py
@@ -22,6 +22,7 @@ def test_property_access():
         export struct MyStruct {
             title: string,
             finished: bool,
+            dash-prop: bool,
         }
 
         export component Test {
@@ -36,6 +37,7 @@ def test_property_access():
             in property <MyStruct> structprop: {
                 title: "builtin",
                 finished: true,
+                dash-prop: true,
             };
             in property <image> imageprop: @image-url("../../../examples/printerdemo/ui/images/cat.jpg");
 
@@ -75,11 +77,16 @@ def test_property_access():
         instance.set_property("boolprop", 0)
 
     structval = instance.get_property("structprop")
-    assert isinstance(structval, dict)
-    assert structval == {'title': 'builtin', 'finished': True}
-    instance.set_property("structprop", {'title': 'new', 'finished': False})
-    assert instance.get_property("structprop") == {
-        'title': 'new', 'finished': False}
+    assert isinstance(structval, native.PyStruct)
+    assert structval.title == "builtin"
+    assert structval.finished == True
+    assert structval.dash_prop == True
+    instance.set_property(
+        "structprop", {'title': 'new', 'finished': False, 'dash_prop': False})
+    structval = instance.get_property("structprop")
+    assert structval.title == "new"
+    assert structval.finished == False
+    assert structval.dash_prop == False
 
     imageval = instance.get_property("imageprop")
     assert imageval.width == 320

--- a/examples/memory/main.py
+++ b/examples/memory/main.py
@@ -6,6 +6,7 @@ from datetime import timedelta, datetime
 import os
 import random
 import itertools
+import copy
 import slint
 from slint import Color, ListModel, Timer, TimerMode
 
@@ -14,31 +15,32 @@ class MainWindow(slint.loader.memory.MainWindow):
     def __init__(self):
         super().__init__()
         initial_tiles = self.memory_tiles
-        tiles = ListModel(itertools.chain(initial_tiles, initial_tiles))
+        tiles = ListModel(itertools.chain(
+            map(copy.copy, initial_tiles), map(copy.copy, initial_tiles)))
         random.shuffle(tiles)
         self.memory_tiles = tiles
 
     @slint.callback
     def check_if_pair_solved(self):
-        flipped_tiles = [(index, tile) for index, tile in enumerate(
-            self.memory_tiles) if tile["image-visible"] and not tile["solved"]]
+        flipped_tiles = [(index, copy.copy(tile)) for index, tile in enumerate(
+            self.memory_tiles) if tile.image_visible and not tile.solved]
         if len(flipped_tiles) == 2:
             tile1_index, tile1 = flipped_tiles[0]
             tile2_index, tile2 = flipped_tiles[1]
-            is_pair_solved = tile1["image"].path == tile2["image"].path
+            is_pair_solved = tile1.image.path == tile2.image.path
             if is_pair_solved:
-                tile1["solved"] = True
+                tile1.solved = True
                 self.memory_tiles[tile1_index] = tile1
-                tile2["solved"] = True
+                tile2.solved = True
                 self.memory_tiles[tile2_index] = tile2
             else:
                 self.disable_tiles = True
 
                 def reenable_tiles():
                     self.disable_tiles = False
-                    tile1["image-visible"] = False
+                    tile1.image_visible = False
                     self.memory_tiles[tile1_index] = tile1
-                    tile2["image-visible"] = False
+                    tile2.image_visible = False
                     self.memory_tiles[tile2_index] = tile2
 
                 Timer.single_shot(timedelta(seconds=1), reenable_tiles)

--- a/examples/printerdemo/python/main.py
+++ b/examples/printerdemo/python/main.py
@@ -5,6 +5,7 @@ from slint import Color, ListModel, Timer, TimerMode
 import slint
 from datetime import timedelta, datetime
 import os
+import copy
 import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -48,13 +49,13 @@ class MainWindow(slint.loader.ui.printerdemo.MainWindow):
     def update_jobs(self):
         if len(self.printer_queue) <= 0:
             return
-        top_item = self.printer_queue[0]
-        top_item["progress"] += 1
-        if top_item["progress"] >= 100:
+        top_item = copy.copy(self.printer_queue[0])
+        top_item.progress += 1
+        if top_item.progress >= 100:
             del self.printer_queue[0]
             if len(self.printer_queue) == 0:
                 return
-            top_item = self.printer_queue[0]
+            top_item = copy.copy(self.printer_queue[0])
         self.printer_queue[0] = top_item
 
 


### PR DESCRIPTION
When reading, create the local equivalent of a dataclass, so that access doesn't require ["foo"] key syntax.

Also implement the copy protocol, so that we can safely make clones of the references returned by the ListModel.