### PR TITLE
Revert "Remove extra vertical spacing between the header view and the…

### DIFF
--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -3,7 +3,7 @@
 
 // cSpell: ignore Heade
 
-import { Button, ComboBox, ListView, ScrollView, VerticalBox } from "std-widgets.slint";
+import { Button, ComboBox, ListView, ScrollView, VerticalBox, Palette } from "std-widgets.slint";
 import { Api, ComponentItem } from "api.slint";
 import { PreviewView, DrawAreaMode } from "./views/preview-view.slint";
 import { DiagnosticsOverlay } from "./components/diagnostics-overlay.slint";
@@ -46,7 +46,11 @@ export component PreviewUi inherits Window {
             }
         }
         if Api.show-preview-ui: Rectangle {           
+            background: Palette.alternate-background;
+
             VerticalLayout {
+                spacing: EditorSpaceSettings.default-spacing;
+
                 header-view := HeaderView {
                     edit-mode <=> Api.design-mode;
                     current-style <=> Api.current-style;


### PR DESCRIPTION
… library/preview/property."

This reverts commit a4ce75de6926bf4372984b759e8c0e03622730db, maintains the margin, but fixes the background color to patch the header.