### PR TITLE
live-preview: Never report "Empty" as a base type of an element

### DIFF
--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -55,7 +55,7 @@ export component PropertyView {
                         alignment: start;
 
                         header := TypeHeader {
-                            type-name: root.current-element.type-name;
+                            type-name: root.current-element.type-name == "Empty" ? "" : root.current-element.type-name;
                             id: root.current-element.id;
                         }
 


### PR DESCRIPTION
... in the properties view.