### PR TITLE
live-preview: Disable switching between Components

### DIFF
--- a/tools/lsp/ui/components/expandable-listview.slint
+++ b/tools/lsp/ui/components/expandable-listview.slint
@@ -155,12 +155,6 @@ export component ExpandableListView inherits ScrollView {
                     offset: header-item.offset;
                     height: self.min-height;
 
-                    clicked => {
-                        if ci.is_user_defined && !ci.is_currently_shown {
-                            root.show-preview-for(self.data.name, self.data.defined_at)
-                        }
-                    }
-
                     pointer-event(event) => {
                         if self.can-drop-here && event.kind == PointerEventKind.up && event.button == PointerEventButton.left {
                             root.drop(self.data.name, drop-x, drop-y);


### PR DESCRIPTION
Disable switching components by clicking on the component name in the library.