### PR TITLE
live-preview: Low-hanging fruit in the Property editor

### DIFF
--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -82,7 +82,7 @@ export component PropertyView {
                                     alignment: stretch;
 
                                     TouchArea {
-                                        width: 150px;
+                                        width: root.key-width;
                                         horizontal-stretch: 0;
 
                                         key := Text {
@@ -103,7 +103,7 @@ export component PropertyView {
 
                                         complexity-icon-icon := Image {
                                             width: self.preferred-width;
-                                            colorize: property-row.is-simple ? Palette.foreground.transparentize(0.7) : Palette.foreground;
+                                            colorize: property-row.is-simple ? Palette.foreground : Palette.foreground.transparentize(0.7);
 
                                             source: @image-url("../assets/function.svg");
                                         }


### PR DESCRIPTION
* Resizing the key field works again (using an invisible hand-crafted splitter)
* The color of the active/inactive `f(x)` icon was inversed as suggested by Daniel.