### PR TITLE
Document behaviour of globals when exporting multiple components

### DIFF
--- a/api/cpp/docs/conf.py
+++ b/api/cpp/docs/conf.py
@@ -35,7 +35,8 @@ cpp_index_common_prefix = ["slint::", "slint::interpreter::"]
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["breathe", "myst_parser", "exhale", "sphinx_markdown_tables", "sphinxcontrib.jquery"]
+extensions = ["breathe", "myst_parser", "exhale",
+              "sphinx_markdown_tables", "sphinxcontrib.jquery"]
 
 breathe_projects = {"Slint": "./docs/xml"}
 breathe_default_project = "Slint"
@@ -108,7 +109,7 @@ html_show_sourcelink = False
 html_logo = "https://slint.dev/logo/slint-logo-small-light.svg"
 
 myst_enable_extensions = [
-    "html_image",
+    "html_image", "colon_fence"
 ]
 
 # Annotate h1/h2 elements with anchors

--- a/api/cpp/docs/generated_code.md
+++ b/api/cpp/docs/generated_code.md
@@ -141,3 +141,8 @@ previous section, you can access `Logic` like this:
         return SharedString(arg);
     });
 ```
+
+:::{note}
+Global singletons are instantiated once per component. When declaring multiple components for `export` to C++,
+each instance will have their own instance of associated globals singletons.
+:::

--- a/api/node/cover.md
+++ b/api/node/cover.md
@@ -300,3 +300,6 @@ component.Logic.to_upper_case = (str) => {
     return str.toUpperCase();
 };
 ```
+
+**Note**: Global singletons are instantiated once per component. When declaring multiple components for `export` to JavaScript,
+each instance will have their own instance of associated globals singletons.

--- a/api/python/README.md
+++ b/api/python/README.md
@@ -155,6 +155,9 @@ export global PrinterJobQueue {
 print("job count:", instance.PrinterJobQueue.job_count)
 ```
 
+**Note**: Global singletons are instantiated once per component. When declaring multiple components for `export` to Python,
+each instance will have their own instance of associated globals singletons.
+
 ### Setting and Invoking Callbacks
 
 [Callbacks](src/language/syntax/callbacks) declared in `.slint` files are visible as callable properties on the component instance. Invoke them

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -184,6 +184,9 @@ For each callback
 The global can be accessed with the [`ComponentHandle::global()`] function, or with [`Global::get()`]
 
 See the [documentation of the `Global` trait](Global) for an example.
+
+**Note**: Global singletons are instantiated once per component. When declaring multiple components for `export` to Rust,
+each instance will have their own instance of associated globals singletons.
 */
 
 #![warn(missing_docs)]


### PR DESCRIPTION
Fixes #5467