### PR TITLE
lsp: Treat GroupBox as a layout

### DIFF
--- a/tools/lsp/common/component_catalog.rs
+++ b/tools/lsp/common/component_catalog.rs
@@ -36,7 +36,7 @@ fn builtin_component_info(name: &str, fills_parent: bool) -> ComponentInformatio
 
 fn std_widgets_info(name: &str, is_global: bool) -> ComponentInformation {
     let is_layout = match name {
-        "GridBox" | "HorizontalBox" | "VerticalBox" => true,
+        "GroupBox" | "GridBox" | "HorizontalBox" | "VerticalBox" => true,
         _ => false,
     };
 


### PR DESCRIPTION
Just for completeness sake, dropping something into a GroupBox still breaks things as it does not get recognized that it contains a GridLayout. So the element will get a x/y property auto-assigned, which is not allowed in a layout.

This is not a regression though.