### PR TITLE
live-preview: Make component selection more robust

### DIFF
--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -124,6 +124,7 @@ pub fn ui_set_known_components(
         let (url, pretty_location) = extract_definition_location(ci);
         let item = ComponentItem {
             name: ci.name.clone().into(),
+            index: idx.try_into().unwrap(),
             defined_at: url.clone(),
             pretty_location,
             is_user_defined: !(ci.is_builtin || ci.is_std_widget),

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -4,6 +4,7 @@
 /// Basic information on a known component
 export struct ComponentItem {
     name: string,
+    index: int,
     defined-at: string,
     pretty-location: string,
     is-user-defined: bool,
@@ -163,8 +164,8 @@ export global Api {
     callback add-new-component();
 
     // Add an existing component
-    pure callback can-drop(/* component-type */ string, /* x */ length, /* y */ length, /* on-drop-area */ bool) -> bool;
-    callback drop(/* component-type */ string, /* x */ length, /* y */ length);
+    pure callback can-drop(/* component-index */ int, /* x */ length, /* y */ length, /* on-drop-area */ bool) -> bool;
+    callback drop(/* component-index */ int, /* x */ length, /* y */ length);
     
     callback rename-component(string/* old-name */, string/* defined-at */, string/* new-name */);
 

--- a/tools/lsp/ui/components/expandable-listview.slint
+++ b/tools/lsp/ui/components/expandable-listview.slint
@@ -124,8 +124,8 @@ export component ExpandableListView inherits ScrollView {
         is-currently-shown: false,
     };
 
-    pure callback can-drop(/* name */ string, /* x */ length, /* y */ length, /* on-drop-area */ bool) -> bool;
-    callback drop(/* name */ string, /* x */ length, /* y */ length);
+    pure callback can-drop(/* index */ int, /* x */ length, /* y */ length, /* on-drop-area */ bool) -> bool;
+    callback drop(/* index */ int, /* x */ length, /* y */ length);
     callback show-preview-for(/* name */ string, /* defined-at */ string);
 
     property <bool> preview-visible: preview-area-width > 0px && preview-area-height > 0px;
@@ -147,7 +147,7 @@ export component ExpandableListView inherits ScrollView {
                             drop-x >= 0 && drop-x <= root.preview-area-width && drop-y >= 0 && drop-y <= root.preview-area-height;
                     property <ComponentItem> data: ci;
 
-                    can-drop-here: !self.data.is-currently-shown && root.can-drop(self.data.name, drop-x, drop-y, on-drop-area);
+                    can-drop-here: !self.data.is-currently-shown && root.can-drop(self.data.index, drop-x, drop-y, on-drop-area);
                     enabled: root.preview-visible;
                     text: ci.name;
                     offset: header-item.offset;
@@ -155,7 +155,7 @@ export component ExpandableListView inherits ScrollView {
 
                     pointer-event(event) => {
                         if self.can-drop-here && event.kind == PointerEventKind.up && event.button == PointerEventButton.left {
-                            root.drop(self.data.name, drop-x, drop-y);
+                            root.drop(self.data.index, drop-x, drop-y);
                         }
                     }
 

--- a/tools/lsp/ui/components/state-layer.slint
+++ b/tools/lsp/ui/components/state-layer.slint
@@ -13,7 +13,6 @@ export component StateLayer {
     in property <bool> has-hover;
     in property <bool> has-focus;
     in property <length> focus-padding: 2px;
-    
     focus-border := Rectangle {
         x: (root.width - self.width) / 2;
         y: (root.height - self.height) / 2;
@@ -25,27 +24,23 @@ export component StateLayer {
         opacity: 0;
 
         states [
-            focused when root.has-focus : {
+            focused when root.has-focus: {
                 opacity: 1;
             }
         ]
 
-        animate opacity {
-            duration: EditorAnimationSettings.color-duration;
-        }
+        animate opacity { duration: EditorAnimationSettings.color-duration; }
     }
-    
+
     state-layer := Rectangle {
         width: 100%;
         height: 100%;
 
-        animate background {
-            duration: EditorAnimationSettings.color-duration;
-        }
+        animate background { duration: EditorAnimationSettings.color-duration; }
     }
 
     states [
-        pressed when root.pressed : {
+        pressed when root.pressed: {
             state-layer.background: EditorPalette.state-pressed;
         }
         hoverd when root.has-hover: {

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -64,7 +64,7 @@ export component PreviewUi inherits Window {
                 HorizontalLayout {
                     spacing: EditorSpaceSettings.default-spacing;
 
-                    if Api.design-mode : LibraryView {
+                    if Api.design-mode: LibraryView {
                         known-components: Api.known-components;
                         preview-area-position-x: preview.preview-area-position-x;
                         preview-area-position-y: preview.preview-area-position-y;
@@ -72,12 +72,12 @@ export component PreviewUi inherits Window {
                         preview-area-height: preview.preview-area-height;
                         visible-component <=> root.visible-component;
 
-                        can-drop(name, x, y, on-drop-area) => {
-                            Api.can-drop(name, x, y, on-drop-area);
+                        can-drop(index, x, y, on-drop-area) => {
+                            Api.can-drop(index, x, y, on-drop-area);
                         }
 
-                        drop(name, x, y) => {
-                            Api.drop(name, x, y);
+                        drop(index, x, y) => {
+                            Api.drop(index, x, y);
                         }
 
                         show-preview-for(name, defined-at) => {
@@ -89,7 +89,7 @@ export component PreviewUi inherits Window {
                         visible-component <=> root.visible-component;
                     }
 
-                    if Api.design-mode : PropertyView {}
+                    if Api.design-mode: PropertyView { }
                 }
             }
 

--- a/tools/lsp/ui/views/library-view.slint
+++ b/tools/lsp/ui/views/library-view.slint
@@ -22,14 +22,14 @@ export component LibraryView {
     width: EditorSizeSettings.side-bar-width;
     min-height: side-bar.min-height;
 
-    side-bar := Group {   
+    side-bar := Group {
         width: 100%;
-        height: 100%;  
+        height: 100%;
 
         GroupHeader {
             title: @tr("Library");
         }
-        
+
         component-list-view := ExpandableListView {
             vertical-stretch: 1;
         }

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -26,7 +26,7 @@ component SelectionFrame {
     in property <Selection> selection;
     in property <bool> interactive: true;
 
-    function pick-selection-color(layout-kind: LayoutKind,is-primary: bool) -> color {
+    function pick-selection-color(layout-kind: LayoutKind, is-primary: bool) -> color {
         if layout-kind == LayoutKind.None {
             if is-primary {
                 return #2379f4ff;
@@ -327,5 +327,4 @@ export component PreviewView {
             root.mode: DrawAreaMode.viewing;
         }
     ]
-
 }


### PR DESCRIPTION
... by not relying on the component name, which could be used in several files.

A bit bigger than I would want at this point of the release process, but it is way more robust than before.