### PR TITLE
js: show diagnostics when erroring

### DIFF
--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -23,7 +23,12 @@ test('loadFile', (t) => {
         { instanceOf: CompileError }
     );
 
-    t.is(error?.message, "Could not compile " + errorPath);
+    const formattedDiagnostics = error?.diagnostics
+    .map((d) =>
+      `[${d.fileName}:${d.lineNumber}:${d.columnNumber}] ${d.message}`
+    )
+    .join("\n");
+    t.is(error?.message, "Could not compile " + errorPath + `\nDiagnostics:\n${formattedDiagnostics}`);
     t.deepEqual(error?.diagnostics, [
         {
             columnNumber: 18,
@@ -97,7 +102,12 @@ test('loadSource', (t) => {
         { instanceOf: CompileError }
     );
 
-    t.is(error?.message, "Could not compile " + path);
+    const formattedDiagnostics = error?.diagnostics
+    .map((d) =>
+      `[${d.fileName}:${d.lineNumber}:${d.columnNumber}] ${d.message}`
+    )
+    .join("\n");
+    t.is(error?.message, "Could not compile " + path + `\nDiagnostics:\n${formattedDiagnostics}`);
     // console.log(error?.diagnostics)
     t.deepEqual(error?.diagnostics, [
         {

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -635,7 +635,13 @@ export class CompileError extends Error {
      * @param diagnostics represent a list of diagnostic items emitted while compiling .slint code.
      */
     constructor(message: string, diagnostics: napi.Diagnostic[]) {
-        super(message);
+        const formattedDiagnostics = diagnostics
+        .map((d) =>
+          `[${d.fileName}:${d.lineNumber}:${d.columnNumber}] ${d.message}`
+        )
+        .join("\n");
+  
+        super(`${message}\nDiagnostics:\n${formattedDiagnostics}`);
         this.diagnostics = diagnostics;
     }
 }

--- a/api/node/index.ts
+++ b/api/node/index.ts
@@ -636,12 +636,17 @@ export class CompileError extends Error {
      */
     constructor(message: string, diagnostics: napi.Diagnostic[]) {
         const formattedDiagnostics = diagnostics
-        .map((d) =>
-          `[${d.fileName}:${d.lineNumber}:${d.columnNumber}] ${d.message}`
-        )
-        .join("\n");
-  
-        super(`${message}\nDiagnostics:\n${formattedDiagnostics}`);
+          .map((d) =>
+            `[${d.fileName}:${d.lineNumber}:${d.columnNumber}] ${d.message}`
+          )
+          .join("\n");
+    
+        let formattedMessage = message;
+        if (diagnostics.length > 0) {
+          formattedMessage += `\nDiagnostics:\n${formattedDiagnostics}`;
+        }
+
+        super(formattedMessage);
         this.diagnostics = diagnostics;
     }
 }


### PR DESCRIPTION
before
```
error: Uncaught (in promise) Error: Could not compile ui/appwindow.slint
    at loadSlint (file:///home/mrcool/.cache/deno/npm/registry.npmjs.org/slint-ui/1.7.0/index.js:464:19)
    at Module.loadFile (file:///home/mrcool/.cache/deno/npm/registry.npmjs.org/slint-ui/1.7.0/index.js:644:12)
    at file:///home/mrcool/dev/deno/lab/memory/src/main.ts:3:23
```

after
```
error: Uncaught (in promise) Error: Could not compile ui/appwindow.slint
Diagnostics:
[ui/appwindow.slint:4:5] Unknown type MemoryTile
    at loadSlint (file:///home/mrcool/.cache/deno/npm/registry.npmjs.org/slint-ui/1.7.0/index.js:468:19)
    at Module.loadFile (file:///home/mrcool/.cache/deno/npm/registry.npmjs.org/slint-ui/1.7.0/index.js:648:12)
    at file:///home/mrcool/dev/deno/lab/memory/src/main.ts:3:23
```