### PR TITLE
live-preview: Unbreak layout detection

### DIFF
--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -955,13 +955,13 @@ pub fn drop_at(
                         {
                             element_base_type_is_layout(&child_insertion_parent)
                         } else {
-                            false
+                            is_layout
                         }
                     }
                     _ => is_layout,
                 }
             } else {
-                false
+                is_layout
             }
         };
 


### PR DESCRIPTION
Return the element's "layoutness" when no child insertion point was found in the element. This fixes droping elements into normal layouts.