### PR TITLE
Combobox: Fix ComboBox having a too big popup when it has less than 6 items

### DIFF
--- a/internal/compiler/widgets/cosmic-base/combobox.slint
+++ b/internal/compiler/widgets/cosmic-base/combobox.slint
@@ -14,9 +14,10 @@ export component ComboBox {
     in-out property <string> current-value <=> base.current-value;
 
     callback selected <=> base.selected;
-    
+
     property <length> popup-padding: 4px;
-    property <int> visible-items: 6;
+
+    property <int> visible-items: min(6, model.length);
 
     min-width: max(160px, layout.min-height);
     min-height: max(32px, layout.min-height);
@@ -79,7 +80,7 @@ export component ComboBox {
             enabled: root.enabled;
         }
     }
-    
+
     popup := PopupWindow {
         x: 0;
         // Position the popup so that the first element is over the popup.
@@ -93,7 +94,7 @@ export component ComboBox {
                 VerticalLayout {
                     alignment: start;
                     padding: root.popup-padding;
-                    
+
                     for value[index] in root.model : ListItem {
                         item: { text: value };
                         is-selected: index == root.current-index;

--- a/internal/compiler/widgets/cupertino-base/combobox.slint
+++ b/internal/compiler/widgets/cupertino-base/combobox.slint
@@ -17,7 +17,7 @@ export component ComboBox {
 
     property <brush> background: CupertinoPalette.control-background;
     property <length> popup-padding: 4px;
-    property <int> visible-items: 6;
+    property <int> visible-items: min(6, model.length);
 
     min-width: max(160px, layout.min-width);
     min-height: max(22px, layout.min-height);

--- a/internal/compiler/widgets/fluent-base/combobox.slint
+++ b/internal/compiler/widgets/fluent-base/combobox.slint
@@ -16,7 +16,7 @@ export component ComboBox {
     callback selected <=> base.selected;
 
     property <length> popup-padding: 4px;
-    property <int> visible-items: 6;
+    property <int> visible-items: min(6, model.length);
 
     min-width: max(160px, layout.min-height);
     min-height: max(32px, layout.min-height);
@@ -104,7 +104,7 @@ export component ComboBox {
                 VerticalLayout {
                     alignment: start;
                     padding: root.popup-padding;
-                    
+
                     for value[index] in root.model : ListItem {
                         item: { text: value };
                         is-selected: index == root.current-index;

--- a/internal/compiler/widgets/material-base/combobox.slint
+++ b/internal/compiler/widgets/material-base/combobox.slint
@@ -15,8 +15,8 @@ export component ComboBox {
     in-out property <string> current-value <=> base.current-value;
 
     callback selected <=> base.selected;
-    
-    property <int> visible-items: 6;
+
+    property <int> visible-items: min(6, model.length);
 
     min-width: max(160px, layout.min-width);
     min-height: max(22px, layout.min-height);

--- a/internal/compiler/widgets/qt/combobox.slint
+++ b/internal/compiler/widgets/qt/combobox.slint
@@ -12,8 +12,6 @@ export component ComboBox {
     in-out property <string> current-value <=> base.current-value;
 
     callback selected <=> base.selected;
-    
-    property <length> popup-height: 224px;
 
     accessible-role: combobox;
     accessible-value <=> root.current-value;
@@ -31,15 +29,20 @@ export component ComboBox {
         width: 100%;
         height: 100%;
         show-popup => {
-            popup.show();
+            if model.length <= 6 {
+                small-popup.show();
+            } else {
+                big-popup.show();
+            }
         }
     }
 
-    popup := PopupWindow {
+    big-popup := PopupWindow {
         x: 0;
         y: root.height;
         width: root.width;
-        height: root.popup-height;
+        // Try to hardcode about the size of 6 items
+        height: 6 * 2rem;
 
         NativeComboBoxPopup {
             width: 100%;
@@ -49,14 +52,14 @@ export component ComboBox {
         ScrollView {
             VerticalLayout {
                 alignment: start;
-                
+
                 for value[index] in root.model: NativeStandardListViewItem {
                     item: { text: value };
                     is-selected: root.current-index == index;
-                    has-hover: ta.has-hover;
+                    has-hover: ta2.has-hover;
                     combobox: true;
 
-                    ta := TouchArea {
+                    ta2 := TouchArea {
                         clicked => {
                             base.select(index);
                         }
@@ -65,5 +68,32 @@ export component ComboBox {
             }
         }
     }
+
+    small-popup := PopupWindow {
+        x: 0;
+        y: root.height;
+        width: root.width;
+        NativeComboBoxPopup {
+            width: 100%;
+            height: 100%;
+        }
+
+        VerticalLayout {
+
+            for value[index] in root.model: NativeStandardListViewItem {
+                item: { text: value };
+                is-selected: root.current-index == index;
+                has-hover: ta.has-hover;
+                combobox: true;
+
+                ta := TouchArea {
+                    clicked => {
+                        base.select(index);
+                    }
+                }
+            }
+        }
+    }
+
 }
 


### PR DESCRIPTION
Fix #5646

Qt is a bit more involved since it always put scrollbar if there is a ScrollArea and we can't easily know the size to which make the popup. That's why it needs two popups