### PR TITLE
winit: Prefer X11 over Wayland when running in WSL

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -51,6 +51,16 @@ impl NotRunningEventLoop {
             {
                 use winit::platform::x11::EventLoopBuilderExtX11;
                 builder.with_any_thread(true);
+
+                // Under WSL, the compositor sometimes crashes. Since we cannot reconnect after the compositor
+                // was restarted, the application panics. This does not happen when using XWayland. Therefore,
+                // when running under WSL, try to connect to X11 instead.
+                #[cfg(feature = "wayland")]
+                if std::fs::metadata("/proc/sys/fs/binfmt_misc/WSLInterop").is_ok()
+                    || std::fs::metadata("/run/WSL").is_ok()
+                {
+                    builder.with_x11();
+                }
             }
         }
         #[cfg(target_family = "windows")]


### PR DESCRIPTION
This is a workaround for the compositor on WSL tending to crash. Unfortunately we can't just try to create an event loop with x11 first and then re-try with wayland, winit doesn't allow that. So just avoid wayland for now.

The long term solution #5667

Fixes #5657