### PR TITLE
lsp: set offset_encoding to utf-16

### DIFF
--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -192,7 +192,7 @@ pub fn server_initialize_result(client_cap: &ClientCapabilities) -> InitializeRe
             name: env!("CARGO_PKG_NAME").to_string(),
             version: Some(env!("CARGO_PKG_VERSION").to_string()),
         }),
-        offset_encoding: Some("utf-8".to_string()),
+        offset_encoding: Some("utf-16".to_string()),
     }
 }
 


### PR DESCRIPTION
Please see Issue #5669

UTF-16 seems to be the standard in the LSP specification to maintain backwards compatibility.
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments

## Tests
- Built and test the LSP in Neovim and confirmed that the warnings no longer show up.