### PR TITLE
Rust: Ignore dead code warning for unused enums

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -415,6 +415,7 @@ fn generate_enum(en: &std::rc::Rc<Enumeration>) -> TokenStream {
         })
     });
     quote! {
+        #[allow(dead_code)]
         #[derive(Default, Copy, Clone, PartialEq, Debug)]
         #rust_attr
         pub enum #enum_name {


### PR DESCRIPTION
Strangely I wasn't able to reproduce the problem in a test, and we already have tests that have enums which are not fully used.

Fix #5661