### PR TITLE
LSP: refactor send_notification to use the Notification trait

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -628,6 +628,11 @@ pub enum LspToPreviewMessage {
     HighlightFromEditor { url: Option<Url>, offset: u32 },
 }
 
+impl lsp_types::notification::Notification for LspToPreviewMessage {
+    type Params = Self;
+    const METHOD: &'static str = "slint/lsp_to_preview";
+}
+
 #[allow(unused)]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Diagnostic {
@@ -714,16 +719,13 @@ impl ComponentInformation {
 
 #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
 pub mod lsp_to_editor {
-    use lsp_types::notification::Notification;
-
     pub fn send_status_notification(
         sender: &crate::ServerNotifier,
         message: &str,
         health: crate::lsp_ext::Health,
     ) {
         sender
-            .send_notification(
-                crate::lsp_ext::ServerStatusNotification::METHOD.into(),
+            .send_notification::<crate::lsp_ext::ServerStatusNotification>(
                 crate::lsp_ext::ServerStatusParams {
                     health,
                     quiescent: false,
@@ -739,8 +741,7 @@ pub mod lsp_to_editor {
         diagnostics: Vec<lsp_types::Diagnostic>,
     ) -> Option<()> {
         sender
-            .send_notification(
-                "textDocument/publishDiagnostics".into(),
+            .send_notification::<lsp_types::notification::PublishDiagnostics>(
                 lsp_types::PublishDiagnosticsParams { uri, diagnostics, version: None },
             )
             .ok()

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -692,8 +692,7 @@ pub async fn reload_document(
         reload_document_impl(Some(ctx), content, url.clone(), version, document_cache).await;
 
     for (uri, diagnostics) in lsp_diags {
-        ctx.server_notifier.send_notification(
-            "textDocument/publishDiagnostics".into(),
+        ctx.server_notifier.send_notification::<lsp_types::notification::PublishDiagnostics>(
             PublishDiagnosticsParams { uri, diagnostics, version: None },
         )?;
     }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -113,8 +113,11 @@ impl ServerNotifier {
 }
 
 impl ServerNotifier {
-    pub fn send_notification(&self, method: String, params: impl serde::Serialize) -> Result<()> {
-        self.sender.send(Message::Notification(lsp_server::Notification::new(method, params)))?;
+    pub fn send_notification<N: Notification>(&self, params: N::Params) -> Result<()> {
+        self.sender.send(Message::Notification(lsp_server::Notification::new(
+            N::METHOD.to_string(),
+            params,
+        )))?;
         Ok(())
     }
 
@@ -152,7 +155,7 @@ impl ServerNotifier {
 
     pub fn send_message_to_preview(&self, message: common::LspToPreviewMessage) {
         if self.use_external_preview() {
-            let _ = self.send_notification("slint/lsp_to_preview".to_string(), message);
+            let _ = self.send_notification::<common::LspToPreviewMessage>(message);
         } else {
             #[cfg(feature = "preview-builtin")]
             preview::lsp_to_preview_message(message, self);

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -54,9 +54,12 @@ pub struct ServerNotifier {
 }
 
 impl ServerNotifier {
-    pub fn send_notification(&self, method: String, params: impl Serialize) -> Result<()> {
+    pub fn send_notification<N: lsp_types::notification::Notification>(
+        &self,
+        params: N::Params,
+    ) -> Result<()> {
         self.send_notification
-            .call2(&JsValue::UNDEFINED, &method.into(), &to_value(&params)?)
+            .call2(&JsValue::UNDEFINED, &N::METHOD.into(), &to_value(&params)?)
             .map_err(|x| format!("Error calling send_notification: {x:?}"))?;
         Ok(())
     }
@@ -78,7 +81,7 @@ impl ServerNotifier {
     }
 
     pub fn send_message_to_preview(&self, message: LspToPreviewMessage) {
-        let _ = self.send_notification("slint/lsp_to_preview".to_string(), message);
+        let _ = self.send_notification::<LspToPreviewMessage>(message);
     }
 }
 


### PR DESCRIPTION
This ensure there is no typo in the method name