### PR TITLE
LSP: don't auto-complete functions or private properties for bindings

### DIFF
--- a/tools/lsp/common/component_catalog.rs
+++ b/tools/lsp/common/component_catalog.rs
@@ -230,7 +230,7 @@ pub fn file_local_components(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "preview-engine"))]
 mod tests {
     use super::*;
 

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -326,7 +326,7 @@ pub fn rename_component_from_definition(
         .ok_or("Failed to create workspace edit".into())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "preview-engine"))]
 mod tests {
     use lsp_types::Url;
 
@@ -532,7 +532,7 @@ export component Foo { }
                     r#"
 import { Foo as Bar } from "source.slint";
 
-export component UserComponent { 
+export component UserComponent {
     Bar { }
 }
 
@@ -545,7 +545,7 @@ export { Bar }
                     r#"
 import { Foo as XxxYyyZzz } from "source.slint";
 
-export component User2Component { 
+export component User2Component {
     XxxYyyZzz { }
 }
                 "#
@@ -647,7 +647,7 @@ export component Foo { }
                     r#"
 import { Foo as Bar } from "../s/source.slint";
 
-export component UserComponent { 
+export component UserComponent {
     Bar { }
 }
 
@@ -660,7 +660,7 @@ export { Bar }
                     r#"
 import { Foo as XxxYyyZzz } from "../s/source.slint";
 
-export component User2Component { 
+export component User2Component {
     XxxYyyZzz { }
 }
                 "#

--- a/tools/lsp/common/test.rs
+++ b/tools/lsp/common/test.rs
@@ -112,9 +112,9 @@ pub fn recompile_test_with_sources(
         },
     ));
 
-    i_slint_core::debug_log!("Test source diagnostics:");
+    eprintln!("Test source diagnostics:");
     for d in diagnostics.iter() {
-        i_slint_core::debug_log!("    {d}");
+        eprintln!("    {d}");
     }
     assert!(!diagnostics.has_errors());
     if !allow_warnings {


### PR DESCRIPTION
(Noticed that the LSP tried to auto-complete the `toggle-checked` function from the `Switch` while making a presentation, but that function shouldn't have been in the auto-completion list)