### PR TITLE
Fix Weather Demo apk

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -555,8 +555,8 @@ jobs:
               run: cargo apk build -p energy-monitor --target aarch64-linux-android --lib --release
             - name: Build todo demo
               run: cargo apk build -p todo --target aarch64-linux-android --lib --release
-            - name: Build rusty-weather example
-              run: cargo apk build -p rusty-weather --target aarch64-linux-android --lib --release
+            - name: Build weather-demo example
+              run: cargo apk build -p weather-demo --target aarch64-linux-android --lib --release
             - name: "upload APK artifact"
               uses: actions/upload-artifact@v4
               with:
@@ -564,4 +564,4 @@ jobs:
                   path: |
                     target/release/apk/energy-monitor.apk
                     target/release/apk/todo_lib.apk
-                    target/release/apk/rusty_weather_lib.apk
+                    target/release/apk/weather_demo_lib.apk

--- a/examples/weather-demo/Cargo.toml
+++ b/examples/weather-demo/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 [package]
-name = "rusty-weather"
+name = "weather-demo"
 version = "1.7.1"
 authors = ["FELGO GmbH <contact@felgo.com>"]
 edition = "2021"
@@ -45,9 +45,13 @@ open_weather = ["dep:openweather_sdk", "dep:openssl"]
 
 # Android-activity / wasm support
 [lib]
-name="rusty_weather_lib"
+name="weather_demo_lib"
 crate-type = ["lib", "cdylib"]
 path = "src/lib.rs"
+
+[[bin]]
+name = "weather-demo"
+path = "src/main.rs"
 
 # Andoroid settings
 # See more: https://github.com/rust-mobile/cargo-apk?tab=readme-ov-file#manifest
@@ -57,7 +61,7 @@ resources = "android-res"
 build_targets = [ "aarch64-linux-android" ]
 
 [package.metadata.android.application]
-label = "Rusty Weather"
+label = "Weather Demo"
 icon = "@mipmap/ic_launcher"
 
 [[package.metadata.android.uses_permission]]

--- a/examples/weather-demo/Cargo.toml
+++ b/examples/weather-demo/Cargo.toml
@@ -46,7 +46,7 @@ open_weather = ["dep:openweather_sdk", "dep:openssl"]
 # Android-activity / wasm support
 [lib]
 name="rusty_weather_lib"
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 path = "src/lib.rs"
 
 # Andoroid settings
@@ -55,10 +55,6 @@ path = "src/lib.rs"
 package = "dev.slint.examples.weatherdemo"
 resources = "android-res"
 build_targets = [ "aarch64-linux-android" ]
-
-[package.metadata.android.sdk]
-min_sdk_version = 29
-target_sdk_version = 32
 
 [package.metadata.android.application]
 label = "Rusty Weather"

--- a/examples/weather-demo/README.md
+++ b/examples/weather-demo/README.md
@@ -1,8 +1,8 @@
 <!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
 
-# Rusty Weather
+# Weather Demo
 
-Rusty Weather is a weather application made by [Felgo](https://felgo.com/).
+Weather Demo is a weather application made by [Felgo](https://felgo.com/).
 
 The application retrieves weather data from the [OpenWeather](https://openweathermap.org/) API to provide:
 * Real-time weather data,
@@ -26,7 +26,7 @@ The application retrieves weather data from the [OpenWeather](https://openweathe
 </p>
 
 ## Weather data
-To enable real weather data from the [OpenWeather](https://openweathermap.org/) API, you must enable the `open_weather` feature and provide the `RUSTY_WEATHER_API_KEY` environment variable with your API key at build time. The [OpenCall API](https://openweathermap.org/price#onecall) subscription is required.
+To enable real weather data from the [OpenWeather](https://openweathermap.org/) API, you must enable the `open_weather` feature and provide the `OPEN_WEATHER_API_KEY` environment variable with your API key at build time. The [OpenCall API](https://openweathermap.org/price#onecall) subscription is required.
 
 If you do not enable the feature or provide the key, the application loads the dummy data instead.
 

--- a/examples/weather-demo/index.html
+++ b/examples/weather-demo/index.html
@@ -30,7 +30,7 @@
             <canvas id="canvas" data-slint-auto-resize-to-preferred="true" unselectable="on"></canvas>
             <script type="module">
                 // import the generated file.
-                import init from "./pkg/rusty_weather_lib.js";
+                import init from "./pkg/weather_demo_lib.js";
                 init();
             </script>
         </div>

--- a/examples/weather-demo/src/app_main.rs
+++ b/examples/weather-demo/src/app_main.rs
@@ -29,7 +29,7 @@ impl AppHandler {
 
         #[cfg(all(not(target_arch = "wasm32"), feature = "open_weather"))]
         {
-            if let Some(api_key) = std::option_env!("RUSTY_WEATHER_API_KEY") {
+            if let Some(api_key) = std::option_env!("OPEN_WEATHER_API_KEY") {
                 data_controller_opt = Some(Box::new(OpenWeatherController::new(api_key.into())));
                 support_add_city = true;
             }


### PR DESCRIPTION
I compared my `Cargo.toml` file with the working `todo` app's `Cargo.toml` file, and it seems changing `crate-type = ["cdylib"]` to `crate-type = ["lib", "cdylib"]` fixes the problem. At least on my side :wink:

I also renamed the package and internal names from rusty-weather to weather-demo. I think it's better to keep the name the same as the directory name to avoid further confusion. Sorry for the initial confusion and issues it caused!
