### PR TITLE
Fix GBM rendering on mali EGL drivers

### DIFF
--- a/internal/backends/linuxkms/renderer/femtovg.rs
+++ b/internal/backends/linuxkms/renderer/femtovg.rs
@@ -49,12 +49,13 @@ impl GlContextWrapper {
             .map_err(|e| format!("Error creating EGL display: {e}"))?
         };
 
-        let config_template = glutin::config::ConfigTemplateBuilder::new().build();
+        let config_template = gbm_display.config_template_builder().build();
 
         let config = unsafe {
             gl_display
                 .find_configs(config_template)
                 .map_err(|e| format!("Error locating EGL configs: {e}"))?
+                .filter(|config| gbm_display.filter_gl_config(config))
                 .reduce(|accum, config| {
                     let transparency_check = config.supports_transparency().unwrap_or(false)
                         & !accum.supports_transparency().unwrap_or(false);

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -53,16 +53,17 @@ impl SkiaRendererAdapter {
         let drm_output = DrmOutput::new(device_opener)?;
         let display = Rc::new(crate::display::gbmdisplay::GbmDisplay::new(drm_output)?);
 
-        use i_slint_renderer_skia::Surface;
-
         let (width, height) = display.drm_output.size();
         let size = i_slint_core::api::PhysicalSize::new(width, height);
 
-        let skia_gl_surface = i_slint_renderer_skia::opengl_surface::OpenGLSurface::new(
-            display.clone(),
-            display.clone(),
-            size,
-        )?;
+        let skia_gl_surface =
+            i_slint_renderer_skia::opengl_surface::OpenGLSurface::new_with_config(
+                display.clone(),
+                display.clone(),
+                size,
+                display.config_template_builder(),
+                Some(&|config| display.filter_gl_config(config)),
+            )?;
 
         let renderer = Box::new(Self {
             renderer: i_slint_renderer_skia::SkiaRenderer::new_with_surface(Box::new(

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -30,81 +30,13 @@ impl super::Surface for OpenGLSurface {
         display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
     ) -> Result<Self, PlatformError> {
-        let width: std::num::NonZeroU32 = size.width.try_into().map_err(|_| {
-            format!("Attempting to create window surface with an invalid width: {}", size.width)
-        })?;
-        let height: std::num::NonZeroU32 = size.height.try_into().map_err(|_| {
-            format!("Attempting to create window surface with an invalid height: {}", size.height)
-        })?;
-
-        let window_handle = window_handle
-            .window_handle()
-            .map_err(|e| format!("error obtaining window handle for skia opengl renderer: {e}"))?;
-        let display_handle = display_handle
-            .display_handle()
-            .map_err(|e| format!("error obtaining display handle for skia opengl renderer: {e}"))?;
-
-        let (current_glutin_context, glutin_surface) =
-            Self::init_glutin(window_handle, display_handle, width, height)?;
-
-        glutin_surface.resize(&current_glutin_context, width, height);
-
-        let fb_info = {
-            use glow::HasContext;
-
-            let gl = unsafe {
-                glow::Context::from_loader_function_cstr(|name| {
-                    current_glutin_context.display().get_proc_address(name) as *const _
-                })
-            };
-            let fboid = unsafe { gl.get_parameter_i32(glow::FRAMEBUFFER_BINDING) };
-
-            skia_safe::gpu::gl::FramebufferInfo {
-                fboid: fboid.try_into().map_err(|_| {
-                    format!("Skia Renderer: Internal error, framebuffer binding returned signed id")
-                })?,
-                format: skia_safe::gpu::gl::Format::RGBA8.into(),
-                ..Default::default()
-            }
-        };
-
-        let gl_interface = skia_safe::gpu::gl::Interface::new_load_with_cstr(|name| {
-            current_glutin_context.display().get_proc_address(name) as *const _
-        })
-        .ok_or_else(|| {
-            format!("Skia Renderer: Internal Error: Could not create OpenGL Interface")
-        })?;
-
-        let mut gr_context =
-            skia_safe::gpu::direct_contexts::make_gl(gl_interface, None).ok_or_else(|| {
-                format!("Skia Renderer: Internal Error: Could not create Skia Direct Context from GL interface")
-            })?;
-
-        let width: i32 = size.width.try_into().map_err(|e| {
-                format!("Attempting to create window surface with width that doesn't fit into non-zero i32: {e}")
-            })?;
-        let height: i32 = size.height.try_into().map_err(|e| {
-                format!(
-                    "Attempting to create window surface with height that doesn't fit into non-zero i32: {e}"
-                )
-            })?;
-
-        let surface = Self::create_internal_surface(
-            fb_info,
-            &current_glutin_context,
-            &mut gr_context,
-            width,
-            height,
-        )?
-        .into();
-
-        Ok(Self {
-            fb_info,
-            surface,
-            gr_context: RefCell::new(gr_context),
-            glutin_context: current_glutin_context,
-            glutin_surface,
-        })
+        Self::new_with_config(
+            window_handle,
+            display_handle,
+            size,
+            glutin::config::ConfigTemplateBuilder::new(),
+            None,
+        )
     }
 
     fn name(&self) -> &'static str {
@@ -206,11 +138,103 @@ impl super::Surface for OpenGLSurface {
 }
 
 impl OpenGLSurface {
+    pub fn new_with_config(
+        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        size: PhysicalWindowSize,
+        config_builder: glutin::config::ConfigTemplateBuilder,
+        config_filter: Option<&dyn Fn(&glutin::config::Config) -> bool>,
+    ) -> Result<Self, PlatformError> {
+        let width: std::num::NonZeroU32 = size.width.try_into().map_err(|_| {
+            format!("Attempting to create window surface with an invalid width: {}", size.width)
+        })?;
+        let height: std::num::NonZeroU32 = size.height.try_into().map_err(|_| {
+            format!("Attempting to create window surface with an invalid height: {}", size.height)
+        })?;
+
+        let window_handle = window_handle
+            .window_handle()
+            .map_err(|e| format!("error obtaining window handle for skia opengl renderer: {e}"))?;
+        let display_handle = display_handle
+            .display_handle()
+            .map_err(|e| format!("error obtaining display handle for skia opengl renderer: {e}"))?;
+
+        let (current_glutin_context, glutin_surface) = Self::init_glutin(
+            window_handle,
+            display_handle,
+            width,
+            height,
+            config_builder,
+            config_filter,
+        )?;
+
+        glutin_surface.resize(&current_glutin_context, width, height);
+
+        let fb_info = {
+            use glow::HasContext;
+
+            let gl = unsafe {
+                glow::Context::from_loader_function_cstr(|name| {
+                    current_glutin_context.display().get_proc_address(name) as *const _
+                })
+            };
+            let fboid = unsafe { gl.get_parameter_i32(glow::FRAMEBUFFER_BINDING) };
+
+            skia_safe::gpu::gl::FramebufferInfo {
+                fboid: fboid.try_into().map_err(|_| {
+                    format!("Skia Renderer: Internal error, framebuffer binding returned signed id")
+                })?,
+                format: skia_safe::gpu::gl::Format::RGBA8.into(),
+                ..Default::default()
+            }
+        };
+
+        let gl_interface = skia_safe::gpu::gl::Interface::new_load_with_cstr(|name| {
+            current_glutin_context.display().get_proc_address(name) as *const _
+        })
+        .ok_or_else(|| {
+            format!("Skia Renderer: Internal Error: Could not create OpenGL Interface")
+        })?;
+
+        let mut gr_context =
+            skia_safe::gpu::direct_contexts::make_gl(gl_interface, None).ok_or_else(|| {
+                format!("Skia Renderer: Internal Error: Could not create Skia Direct Context from GL interface")
+            })?;
+
+        let width: i32 = size.width.try_into().map_err(|e| {
+                format!("Attempting to create window surface with width that doesn't fit into non-zero i32: {e}")
+            })?;
+        let height: i32 = size.height.try_into().map_err(|e| {
+                format!(
+                    "Attempting to create window surface with height that doesn't fit into non-zero i32: {e}"
+                )
+            })?;
+
+        let surface = Self::create_internal_surface(
+            fb_info,
+            &current_glutin_context,
+            &mut gr_context,
+            width,
+            height,
+        )?
+        .into();
+
+        Ok(Self {
+            fb_info,
+            surface,
+            gr_context: RefCell::new(gr_context),
+            glutin_context: current_glutin_context,
+            glutin_surface,
+        })
+    }
+
     fn init_glutin(
         _window_handle: raw_window_handle::WindowHandle<'_>,
         _display_handle: raw_window_handle::DisplayHandle<'_>,
         width: NonZeroU32,
         height: NonZeroU32,
+        config_template_builder: glutin::config::ConfigTemplateBuilder,
+        config_filter: Option<&dyn Fn(&glutin::config::Config) -> bool>,
     ) -> Result<
         (
             glutin::context::PossiblyCurrentContext,
@@ -239,8 +263,6 @@ impl OpenGLSurface {
                 })?
         };
 
-        let config_template_builder = glutin::config::ConfigTemplateBuilder::new();
-
         // On macOS, there's only one GL config and that's initialized based on the values in the config template
         // builder. So if that one has transparency enabled, it'll show up in the config, and will be set on the
         // context later. So we must enable it here, there's no way of enabling it later.
@@ -262,6 +284,7 @@ impl OpenGLSurface {
             gl_display
                 .find_configs(config_template)
                 .map_err(|e| format!("Could not find valid OpenGL display configurations: {e}"))?
+                .filter(|config| config_filter.as_ref().map_or(true, |filter_fn| filter_fn(config)))
                 .reduce(|accum, config| {
                     let transparency_check = config.supports_transparency().unwrap_or(false)
                         & !accum.supports_transparency().unwrap_or(false);


### PR DESCRIPTION
Combining an EGL config with EGL_ALPHA_SIZE == 8 with an Xrgb8888 surface yields a bad match on eglCreateWindowSurface. That's fair, and we should accomodate for that by avoiding such EGL configs.