### PR TITLE
Clarify that generated <kind>_clicked callbacks are aliases

### DIFF
--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -108,6 +108,7 @@ There can't be several `StandardButton`s of the same kind.
 A callback `<kind>_clicked` is automatically added for each `StandardButton` which doesn't have an explicit
 callback handler, so it can be handled from the native code: For example if there is a button of kind `cancel`,
 a `cancel_clicked` callback will be added.
+Each of these automatically-generated callbacks is an alias for the `clicked` callback of the associated `StandardButton`.
 
 ### Properties
 


### PR DESCRIPTION
My assumption from reading the docs was that the `StandardButton`s delegated to the root and that the generated callbacks in the root were to facilitate that behavior.