### PR TITLE
Android: workaround PollEvent::Wake not being received

### DIFF
--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -194,16 +194,14 @@ impl AndroidWindowAdapter {
     }
 
     pub fn process_event(&self, event: &PollEvent<'_>) -> Result<ControlFlow<()>, PlatformError> {
-        match event {
-            PollEvent::Wake => {
-                let queue = std::mem::take(&mut *self.event_queue.lock().unwrap());
-                for e in queue {
-                    match e {
-                        Event::Quit => return Ok(ControlFlow::Break(())),
-                        Event::Other(o) => o(),
-                    }
-                }
+        let queue = std::mem::take(&mut *self.event_queue.lock().unwrap());
+        for e in queue {
+            match e {
+                Event::Quit => return Ok(ControlFlow::Break(())),
+                Event::Other(o) => o(),
             }
+        }
+        match event {
             PollEvent::Main(MainEvent::InputAvailable) => {
                 self.process_inputs().map_err(|e| PlatformError::Other(e.to_string()))?
             }


### PR DESCRIPTION
We observe, in issue #5699 that the call to `AndroidAppWaker::wake` doesn't always result in a `PollEvent::Wake` event. So to work around that, always process event from any event we receive so that any timeout or input event would make sure event gets processed.

Closes #5699

Note: I have no idea why we don't receive the event. the bug is not fixed as there may not be any other event for a long time, but it makes it less likely to cause problems.