### PR TITLE
Improve documented workaround for Tokio integration

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -200,6 +200,8 @@ slint-build = { path = "../build" }
 i-slint-backend-testing = {  path = "../../../internal/backends/testing", features = ["internal"] }
 serde_json = { workspace = true }
 serde = { workspace = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "io-util"]}
+async-compat = { version = "0.2.4" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # this line is there to add the "enable" feature by default, but only on linux

--- a/api/rs/slint/tests/tokio.rs
+++ b/api/rs/slint/tests/tokio.rs
@@ -1,0 +1,34 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#[test]
+fn tokio_poll_with_compat() {
+    i_slint_backend_testing::init_integration_test_with_mock_time();
+    use std::io::Write;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let local_addr = listener.local_addr().unwrap();
+    let server = std::thread::spawn(move || {
+        let mut stream = listener.incoming().next().unwrap().unwrap();
+        stream.write("Hello World".as_bytes()).unwrap();
+    });
+
+    let slint_future = async move {
+        for _ in 0..1000 {
+            tokio::task::consume_budget().await;
+        }
+
+        use tokio::io::AsyncReadExt;
+        let mut stream = tokio::net::TcpStream::connect(local_addr).await.unwrap();
+        let mut data = Vec::new();
+        stream.read_to_end(&mut data).await.unwrap();
+        assert_eq!(data, "Hello World".as_bytes());
+        slint::quit_event_loop().unwrap();
+    };
+
+    slint::spawn_local(async_compat::Compat::new(slint_future)).unwrap();
+
+    slint::run_event_loop_until_quit().unwrap();
+
+    server.join().unwrap();
+}

--- a/api/rs/slint/tests/tokio_block_in_place.rs
+++ b/api/rs/slint/tests/tokio_block_in_place.rs
@@ -1,0 +1,34 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn tokio_poll_with_block_in_place() {
+    i_slint_backend_testing::init_integration_test_with_mock_time();
+    use std::io::Write;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let local_addr = listener.local_addr().unwrap();
+    let server = std::thread::spawn(move || {
+        let mut stream = listener.incoming().next().unwrap().unwrap();
+        stream.write("Hello World".as_bytes()).unwrap();
+    });
+
+    let slint_future = async move {
+        for _ in 0..1000 {
+            tokio::task::consume_budget().await;
+        }
+
+        use tokio::io::AsyncReadExt;
+        let mut stream = tokio::net::TcpStream::connect(local_addr).await.unwrap();
+        let mut data = Vec::new();
+        stream.read_to_end(&mut data).await.unwrap();
+        assert_eq!(data, "Hello World".as_bytes());
+        slint::quit_event_loop().unwrap();
+    };
+
+    slint::spawn_local(slint_future).unwrap();
+
+    tokio::task::block_in_place(slint::run_event_loop_until_quit).unwrap();
+
+    server.join().unwrap();
+}

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -112,7 +112,8 @@ ttf-parser = { workspace = true }
 fontdb = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 tiny-skia = "0.11.0"
-tokio = { version = "1.35", features = ["rt-multi-thread"] }
+tokio = { version = "1.35", features = ["rt-multi-thread", "macros", "time", "net", "io-util"] }
+async-compat = { version = "0.2.4" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(slint_debug_property)", "cfg(cbindgen)", "cfg(slint_int_coord)"] }

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -202,37 +202,12 @@ unsafe impl<T: Send> Send for JoinHandle<T> {}
 /// ```
 ///
 /// The use of `#[tokio::main]` is **not recommended**. If it's necessary to use though, wrap the call to enter the Slint
-/// event loop in a call to [`tokio::task::block_in_place`](https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html):
+/// event loop  in a call to [`tokio::task::block_in_place`](https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html):
 ///
 /// ```rust, no_run
-/// // A dummy TCP server that once reports "Hello World"
-/// #[tokio::main]
-/// async fn main() {
-///     # i_slint_backend_testing::init_integration_test_with_mock_time();
-///     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-///     let local_addr = listener.local_addr().unwrap();
-///     let server = std::thread::spawn(move || {
-///         use std::io::Write;
-///         let mut stream = listener.incoming().next().unwrap().unwrap();
-///         stream.write("Hello World".as_bytes()).unwrap();
-///     });
-///
-///     let slint_future = async move {
-///         use tokio::io::AsyncReadExt;
-///         let mut stream = tokio::net::TcpStream::connect(local_addr).await.unwrap();
-///         let mut data = Vec::new();
-///         stream.read_to_end(&mut data).await.unwrap();        
-///         assert_eq!(data, "Hello World".as_bytes());
-///         slint::quit_event_loop().unwrap();
-///     };
-///
-///     slint::spawn_local(slint_future).unwrap();
-///
-///     // Wrap the call to run_event_loop to ensure presence of a Tokio run-time.
-///     tokio::task::block_in_place(slint::run_event_loop_until_quit).unwrap();
-///
-///     server.join().unwrap();
-/// }
+/// ...   
+/// // Wrap the call to run_event_loop to ensure presence of a Tokio run-time.
+/// tokio::task::block_in_place(slint::run_event_loop).unwrap();
 /// ```
 pub fn spawn_local<F: Future + 'static>(fut: F) -> Result<JoinHandle<F::Output>, EventLoopError> {
     // ensure we are in the backend's thread

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -205,7 +205,6 @@ unsafe impl<T: Send> Send for JoinHandle<T> {}
 /// event loop  in a call to [`tokio::task::block_in_place`](https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html):
 ///
 /// ```rust, no_run
-/// ...   
 /// // Wrap the call to run_event_loop to ensure presence of a Tokio run-time.
 /// tokio::task::block_in_place(slint::run_event_loop).unwrap();
 /// ```

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -200,8 +200,8 @@ unsafe impl<T: Send> Send for JoinHandle<T> {}
 ///
 /// server.join().unwrap();
 /// ```
-///  
-/// Alternatively, if your application uses `#[tokio::main]` to create a Tokio run-time, wrap the call to enter the Slint
+///
+/// The use of `#[tokio::main]` is **not recommended**. If it's necessary to use though, wrap the call to enter the Slint
 /// event loop in a call to [`tokio::task::block_in_place`](https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html):
 ///
 /// ```rust, no_run

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -128,7 +128,7 @@ impl<T> JoinHandle<T> {
 // Safety: JoinHandle doesn't access the future, only the
 unsafe impl<T: Send> Send for JoinHandle<T> {}
 
-/// Spawns a future to execute in the Slint event loop.
+/// Spawns a [`Future`] to execute in the Slint event loop.
 ///
 /// This function is intended to be invoked only from the main Slint thread that runs the event loop.
 /// The event loop must be initialized prior to calling this function.

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -171,7 +171,7 @@ unsafe impl<T: Send> Send for JoinHandle<T> {}
 /// The following little example demonstrates the use of Tokio's [`TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html) to
 /// read from a network socket. The entire future passed to `spawn_local()` is wrapped in `Compat::new()` to make it run:
 ///
-/// ```rust,no_runt
+/// ```rust,no_run
 /// // A dummy TCP server that once reports "Hello World"
 /// # i_slint_backend_testing::init_integration_test_with_mock_time();
 /// use std::io::Write;


### PR DESCRIPTION
Improve documented workaround for Tokio integration

Document the two constraints of using Tokio futures in Slint, and how to work around them.

Fixes #5733