### PR TITLE
LSP: Report error through the LSP when the preview can't open 

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -673,6 +673,8 @@ pub enum PreviewToLspMessage {
     RequestState { unused: bool },
     /// Pass a `WorkspaceEdit` on to the editor
     SendWorkspaceEdit { label: Option<String>, edit: lsp_types::WorkspaceEdit },
+    /// Pass a `ShowMessage` notification on to the editor
+    SendShowMessage { message: lsp_types::ShowMessageParams },
 }
 
 /// Information on the Element types available

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -179,8 +179,9 @@ fn invoke_from_event_loop_wrapped_in_promise(
 
 pub fn run_in_ui_thread<F: Future<Output = ()> + 'static>(
     create_future: impl Send + FnOnce() -> F + 'static,
-) {
-    i_slint_core::future::spawn_local(create_future()).unwrap();
+) -> Result<(), String> {
+    i_slint_core::future::spawn_local(create_future()).map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 pub fn resource_url_mapper(

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -302,6 +302,12 @@ impl SlintServer {
             M::SendWorkspaceEdit { label, edit } => {
                 send_workspace_edit(self.ctx.server_notifier.clone(), label, Ok(edit));
             }
+            M::SendShowMessage { message } => {
+                let _ = self
+                    .ctx
+                    .server_notifier
+                    .send_notification::<lsp_types::notification::ShowMessage>(message);
+            }
         }
         Ok(())
     }

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -17,7 +17,6 @@ use i_slint_compiler::CompilerConfiguration;
 use js_sys::Function;
 pub use language::{Context, RequestHandler};
 use lsp_types::Url;
-use serde::Serialize;
 use std::cell::RefCell;
 use std::future::Future;
 use std::io::ErrorKind;
@@ -95,7 +94,7 @@ impl RequestHandler {
         if let Some(f) = self.0.get(&method.as_str()) {
             let param = serde_wasm_bindgen::from_value(params)
                 .map_err(|x| format!("invalid param to handle_request: {x:?}"))?;
-            let r = f(param, ctx).await?;
+            let r = f(param, ctx).await.map_err(|e| e.message)?;
             to_value(&r).map_err(|e| e.to_string().into())
         } else {
             Err("Cannot handle request".into())


### PR DESCRIPTION
Instead of panicking the whole server

Fixes https://github.com/slint-ui/slint/issues/204
(Note that this issue is also talking about fallback to the wasm UI in this case, but we don't do that in this patch yet)


The two commit are independent. At first i thought i'd need the first commit, but it turns out it is difficult to send the error back to the LSP thread before answering the request, so I made it with a notification instead.