### PR TITLE
Add Tokio integration for the event loop when used with `[tokio::main]`

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -200,6 +200,7 @@ slint-build = { path = "../build" }
 i-slint-backend-testing = {  path = "../../../internal/backends/testing", features = ["internal"] }
 serde_json = { workspace = true }
 serde = { workspace = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"]}
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # this line is there to add the "enable" feature by default, but only on linux

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -84,6 +84,10 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 ## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation.
 raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
 
+## Enable integration between Slint's event loop and [Tokio](https://docs.rs/tokio/latest/tokio/).
+## Enable this feature if you're using `[tokio::main]` in your `main` function.
+tokio-1 = ["i-slint-core/tokio-1"]
+
 #! ### Backends
 
 #! Slint needs a backend that will act as liaison between Slint and the OS.
@@ -201,6 +205,7 @@ i-slint-backend-testing = {  path = "../../../internal/backends/testing", featur
 serde_json = { workspace = true }
 serde = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"]}
+i-slint-core = { workspace = true, features = ["tokio-1"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # this line is there to add the "enable" feature by default, but only on linux

--- a/api/rs/slint/tests/tokio.rs
+++ b/api/rs/slint/tests/tokio.rs
@@ -1,0 +1,33 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#[tokio::test]
+async fn tokio_integration() {
+    i_slint_backend_testing::init_integration_test_with_mock_time();
+
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(2);
+
+    slint::spawn_local(tokio::task::unconstrained(async move {
+        let mut count = 0;
+        loop {
+            if sender.send(count).await.is_err() {
+                break;
+            }
+            count += 1;
+        }
+    }))
+    .unwrap();
+
+    slint::spawn_local(tokio::task::unconstrained(async move {
+        loop {
+            let count = receiver.recv().await.unwrap();
+            if count > 1024 {
+                slint::quit_event_loop().unwrap();
+                break;
+            }
+        }
+    }))
+    .unwrap();
+
+    slint::run_event_loop_until_quit().unwrap();
+}

--- a/api/rs/slint/tests/tokio.rs
+++ b/api/rs/slint/tests/tokio.rs
@@ -7,7 +7,7 @@ async fn tokio_integration() {
 
     let (sender, mut receiver) = tokio::sync::mpsc::channel(2);
 
-    slint::spawn_local(tokio::task::unconstrained(async move {
+    slint::spawn_local(async move {
         let mut count = 0;
         loop {
             if sender.send(count).await.is_err() {
@@ -15,10 +15,10 @@ async fn tokio_integration() {
             }
             count += 1;
         }
-    }))
+    })
     .unwrap();
 
-    slint::spawn_local(tokio::task::unconstrained(async move {
+    slint::spawn_local(async move {
         loop {
             let count = receiver.recv().await.unwrap();
             if count > 1024 {
@@ -26,7 +26,7 @@ async fn tokio_integration() {
                 break;
             }
         }
-    }))
+    })
     .unwrap();
 
     slint::run_event_loop_until_quit().unwrap();

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -44,6 +44,8 @@ shared-fontdb = ["i-slint-common/shared-fontdb"]
 
 raw-window-handle-06 = ["dep:raw-window-handle-06"]
 
+tokio-1 = ["dep:tokio"]
+
 default = ["std", "unicode"]
 
 [dependencies]
@@ -90,6 +92,8 @@ raw-window-handle-06 = { workspace = true, optional = true }
 bitflags = { version = "2.4.2"}
 
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
+
+tokio = { version = "1", optional = true, default-features = false, features = ["rt"] }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 gettext-rs = { version = "0.7", optional = true, features = ["gettext-system"] }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -112,7 +112,7 @@ ttf-parser = { workspace = true }
 fontdb = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 tiny-skia = "0.11.0"
-tokio = { version = "1.35", features = ["rt-multi-thread"] }
+tokio = { version = "1.35", features = ["rt-multi-thread", "macros", "time"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(slint_debug_property)", "cfg(cbindgen)", "cfg(slint_int_coord)"] }

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -113,6 +113,10 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 ## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation.
 raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
 
+## Enable integration between Slint's event loop and [Tokio](https://docs.rs/tokio/latest/tokio/).
+## Enable this feature if you're using `[tokio::main]` in your `main` function.
+tokio-1 = ["i-slint-core/tokio-1"]
+
 ## Features used internally by Slint tooling that are not stable and come without
 ## any stability guarantees whatsoever.
 internal = []


### PR DESCRIPTION
Enable the tokio-1 feature to make `[tokio::main]` work.

Fixes #5733