### PR TITLE
Simplify task creation controller interface

### DIFF
--- a/examples/todo-mvc/rust/src/lib.rs
+++ b/examples/todo-mvc/rust/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-use mvc::{CreateTaskController, TaskListController};
+use mvc::TaskListController;
 use slint::ComponentHandle;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -26,9 +26,7 @@ fn init() -> ui::MainWindow {
 
     ui::task_list_adapter::initialize_adapter(&view_handle, task_list_controller.clone());
 
-    let create_task_controller = CreateTaskController::new(
-        ui::create_task_adapter::create_controller_callbacks(&view_handle),
-    );
+    let create_task_controller = ui::create_task_adapter::new_create_task_controller(&view_handle);
 
     ui::create_task_adapter::initialize_adapter(
         &view_handle,

--- a/examples/todo-mvc/rust/src/mvc/controllers/create_task_controller.rs
+++ b/examples/todo-mvc/rust/src/mvc/controllers/create_task_controller.rs
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 pub trait CreateTaskController {
-    fn refresh(&self);
+    fn initialize(&self);
     fn back(&self);
 }

--- a/examples/todo-mvc/rust/src/mvc/controllers/create_task_controller.rs
+++ b/examples/todo-mvc/rust/src/mvc/controllers/create_task_controller.rs
@@ -1,53 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-use std::rc::Rc;
-
-pub struct CreateTaskControllerCallbacks {
-    pub on_refresh: Box<dyn Fn()>,
-    pub on_back: Box<dyn Fn()>,
-}
-
-pub struct CreateTaskController {
-    callbacks: CreateTaskControllerCallbacks,
-}
-
-impl CreateTaskController {
-    pub fn new(callbacks: CreateTaskControllerCallbacks) -> Rc<Self> {
-        Rc::new(Self { callbacks })
-    }
-
-    pub fn refresh(&self) {
-        (self.callbacks.on_refresh)();
-    }
-
-    pub fn back(&self) {
-        (self.callbacks.on_back)();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::cell::Cell;
-
-    #[test]
-    fn test_back() {
-        let callback_invoked = Rc::new(Cell::new(false));
-
-        let controller = CreateTaskController::new(CreateTaskControllerCallbacks {
-            on_refresh: Box::new(|| {}),
-            on_back: Box::new({
-                let callback_invoked = callback_invoked.clone();
-
-                move || {
-                    callback_invoked.set(true);
-                }
-            }),
-        });
-
-        controller.back();
-
-        assert!(callback_invoked.get());
-    }
+pub trait CreateTaskController {
+    fn refresh(&self);
+    fn back(&self);
 }

--- a/examples/todo-mvc/rust/src/ui/create_task_adapter.rs
+++ b/examples/todo-mvc/rust/src/ui/create_task_adapter.rs
@@ -19,7 +19,7 @@ struct CreateTaskControllerAdapter {
 }
 
 impl CreateTaskController for CreateTaskControllerAdapter {
-    fn refresh(&self) {
+    fn initialize(&self) {
         let Some(view) = self.view_handle.upgrade() else {
             return;
         };
@@ -63,11 +63,11 @@ pub fn initialize_adapter(
 ) {
     let adapter = ui::CreateTaskAdapter::get(&view_handle);
 
-    adapter.on_refresh({
+    adapter.on_initialize({
         let create_task_controller = create_task_controller.clone();
 
         move || {
-            create_task_controller.refresh();
+            create_task_controller.initialize();
         }
     });
 

--- a/examples/todo-mvc/ui/views/create_task_view.slint
+++ b/examples/todo-mvc/ui/views/create_task_view.slint
@@ -11,7 +11,7 @@ export global CreateTaskAdapter {
     in-out property <Date> due-date: { year: 2024, month: 12, day: 24 };
     in-out property <Time> due-time: { hour: 12, minute: 45, second: 0 };
 
-    callback refresh();
+    callback initialize();
     callback create(/* title */ string, /* due-date */ Date, /* due-time */ Time);
     callback back();
     pure callback date-string(Date) -> string;
@@ -42,7 +42,7 @@ export component CreateTaskView {
             }
 
             // spacer
-            Rectangle {}
+            Rectangle { }
 
             Button {
                 text: @tr("Create");
@@ -94,7 +94,6 @@ export component CreateTaskView {
                 }
             }
 
-
             TextButton {
                 text: CreateTaskAdapter.time-string(CreateTaskAdapter.due-time);
                 horizontal-stretch: 0;
@@ -105,10 +104,10 @@ export component CreateTaskView {
             }
         }
 
-        Rectangle {}
+        Rectangle { }
     }
 
-     date-picker := DatePickerPopup {
+    date-picker := DatePickerPopup {
         x: (root.width - self.width) / 2;
         y: (root.height - self.height) / 2;
 
@@ -132,6 +131,6 @@ export component CreateTaskView {
     }
 
     init => {
-        CreateTaskAdapter.refresh();
+        CreateTaskAdapter.initialize();
     }
 }


### PR DESCRIPTION
Replace CreateTaskControllerCallbacks and Rc<CreateTaskController>, the latter just forwarding to the former, with a single trait.

The two callbacks are always supplied together, so they might as well share the underlying data (Weak on the UI) and life-time.