### PR TITLE
UX enhance the Printerdemo primary screen

### DIFF
--- a/examples/printerdemo/ui/common.slint
+++ b/examples/printerdemo/ui/common.slint
@@ -42,6 +42,10 @@ export global DemoPalette  {
     };
     out property <color> push-button-text-color: white;
     out property <length> base-font-size: 16px;
+    out property <length> button-width: 130px;
+    out property <length> button-height: button-width + 30px;
+    out property <length> side-bar-width: 67px;
+    out property <length> side-bar-margin: 10px;
 }
 
 export component Page inherits Rectangle {

--- a/examples/printerdemo/ui/common.slint
+++ b/examples/printerdemo/ui/common.slint
@@ -7,7 +7,7 @@ struct ButtonColors  {
     hovered: color,
 }
 
-export global DemoPalette {
+export global DemoPalette  {
     in property <bool> night-mode: false;
 
     // Color of the home/settings/ink buttons on the left side bar
@@ -27,8 +27,7 @@ export global DemoPalette {
     // as the combo box or spin box.
     out property <color> control-outline-color: #FFBF63;
     out property <color> control-secondary: #6284FF;
-    out property <color> control-foreground: root.night-mode ? white : #122F7B;
-    // FIXME: the night mode color was not part of the design
+    out property <color> control-foreground: root.night-mode ? white : #122F7B;  // FIXME: the night mode color was not part of the design
     out property <color> primary-push-button-base: #6284FF;
     out property <ButtonColors> primary-push-button-colors: {
         base: root.primary-push-button-base,
@@ -43,11 +42,6 @@ export global DemoPalette {
     };
     out property <color> push-button-text-color: white;
     out property <length> base-font-size: 16px;
-
-    out property <length> button-width: 130px;
-    out property <length> button-height: button-width + 30px;
-    out property <length> side-bar-width: 67px;
-    out property <length> side-bar-margin: 10px;
 }
 
 export component Page inherits Rectangle {
@@ -58,12 +52,10 @@ export component Page inherits Rectangle {
 
     background: DemoPalette.page-background-color;
 
-    TouchArea { }
+    TouchArea {} // protect underneath controls
 
-    // protect underneath controls
-
-    if (root.has-back-button): Image {
-        x: 0;
+    if (root.has-back-button) : Image {
+        x:0;
         source: @image-url("images/back.svg");
         image-fit: contain;
         colorize: DemoPalette.control-secondary;
@@ -72,11 +64,9 @@ export component Page inherits Rectangle {
         height: 24px;
 
         TouchArea {
-            clicked => {
-                root.back()
-            }
+            clicked => { root.back() }
 
-            x: 0;
+            x:0;
             width: 150%;
         }
     }
@@ -89,14 +79,11 @@ export component Page inherits Rectangle {
         x: root.has-back-button ? 24px + 16px : 0px;
         // Allow clicking on the title as well to get back easier when just
         // using fingers on a small screen.
-        if (root.has-back-button): TouchArea {
-            clicked => {
-                root.back()
-            }
+        if (root.has-back-button) : TouchArea {
+            clicked => { root.back() }
         }
     }
 }
-
 export component Label inherits Text {
     color: DemoPalette.text-foreground-color;
     vertical-alignment: center;
@@ -122,8 +109,8 @@ component SquareButton inherits Rectangle {
     Image {
         height: 40%;
         width: 40%;
-        x: (parent.width - self.width) / 2;
-        y: (parent.height - self.height) / 2;
+        x: (parent.width - self.width)/2;
+        y: (parent.height - self.height)/2;
         source <=> root.img;
         image-fit: contain;
         colorize: DemoPalette.control-secondary;
@@ -190,8 +177,7 @@ export component ComboBox inherits Rectangle {
     border-color: DemoPalette.control-outline-color;
     height: 32px;
     min-width: label.x + label.width + i.width;
-    horizontal-stretch: 1;
-    // Work around #2284
+    horizontal-stretch: 1; // Work around #2284
 
     label := Text {
         vertical-alignment: center;
@@ -209,20 +195,18 @@ export component ComboBox inherits Rectangle {
         width: self.height;
         image-fit: contain;
         x: parent.width - self.width - self.y;
-        y: (parent.height - self.height) / 2;
+        y: (parent.height - self.height)/2;
     }
 
     TouchArea {
-        clicked => {
-            popup.show();
-        }
+        clicked => { popup.show(); }
 
         width: 100%;
         height: 100%;
     }
 
     popup := PopupWindow {
-        x: 0;
+        x:0;
         y: root.height;
         width: root.width;
 
@@ -270,9 +254,7 @@ export component CheckBox inherits Rectangle {
         spacing: 12px;
         padding: 0;
         SquareButton {
-            clicked => {
-                root.checked = !root.checked;
-            }
+            clicked => { root.checked = !root.checked; }
 
             width: root.height - parent.padding * 2;
             img: root.checked ? @image-url("images/check.svg") : @image-url("");
@@ -306,8 +288,7 @@ export component PushButton inherits Rectangle {
     border-radius: 13.5px;
     background: root.pressed ? root.colors.pressed : (touch-area.has-hover ? root.colors.hovered : root.colors.base);
 
-    height: 27px;
-    // line-height in the design
+    height: 27px; // line-height in the design
     horizontal-stretch: 1;
 
     HorizontalLayout {
@@ -332,9 +313,5 @@ export component PushButton inherits Rectangle {
         }
     }
 
-    touch-area := TouchArea {
-        clicked => {
-            root.clicked()
-        }
-    }
+    touch-area := TouchArea { clicked => { root.clicked() } }
 }

--- a/examples/printerdemo/ui/common.slint
+++ b/examples/printerdemo/ui/common.slint
@@ -55,8 +55,12 @@ export component Page inherits Rectangle {
     callback back;
 
     background: DemoPalette.page-background-color;
+    // Stop accidentally getting clicks dur to animation only moving page half way offscreen
+    visible: self.opacity > 0;
 
-    TouchArea {} // protect underneath controls
+    TouchArea { } // protect underneath controls
+
+    
 
     if (root.has-back-button) : Image {
         x:0;

--- a/examples/printerdemo/ui/common.slint
+++ b/examples/printerdemo/ui/common.slint
@@ -7,7 +7,7 @@ struct ButtonColors  {
     hovered: color,
 }
 
-export global DemoPalette  {
+export global DemoPalette {
     in property <bool> night-mode: false;
 
     // Color of the home/settings/ink buttons on the left side bar
@@ -27,7 +27,8 @@ export global DemoPalette  {
     // as the combo box or spin box.
     out property <color> control-outline-color: #FFBF63;
     out property <color> control-secondary: #6284FF;
-    out property <color> control-foreground: root.night-mode ? white : #122F7B;  // FIXME: the night mode color was not part of the design
+    out property <color> control-foreground: root.night-mode ? white : #122F7B;
+    // FIXME: the night mode color was not part of the design
     out property <color> primary-push-button-base: #6284FF;
     out property <ButtonColors> primary-push-button-colors: {
         base: root.primary-push-button-base,
@@ -42,6 +43,11 @@ export global DemoPalette  {
     };
     out property <color> push-button-text-color: white;
     out property <length> base-font-size: 16px;
+
+    out property <length> button-width: 130px;
+    out property <length> button-height: button-width + 30px;
+    out property <length> side-bar-width: 67px;
+    out property <length> side-bar-margin: 10px;
 }
 
 export component Page inherits Rectangle {
@@ -52,10 +58,12 @@ export component Page inherits Rectangle {
 
     background: DemoPalette.page-background-color;
 
-    TouchArea {} // protect underneath controls
+    TouchArea { }
 
-    if (root.has-back-button) : Image {
-        x:0;
+    // protect underneath controls
+
+    if (root.has-back-button): Image {
+        x: 0;
         source: @image-url("images/back.svg");
         image-fit: contain;
         colorize: DemoPalette.control-secondary;
@@ -64,9 +72,11 @@ export component Page inherits Rectangle {
         height: 24px;
 
         TouchArea {
-            clicked => { root.back() }
+            clicked => {
+                root.back()
+            }
 
-            x:0;
+            x: 0;
             width: 150%;
         }
     }
@@ -79,11 +89,14 @@ export component Page inherits Rectangle {
         x: root.has-back-button ? 24px + 16px : 0px;
         // Allow clicking on the title as well to get back easier when just
         // using fingers on a small screen.
-        if (root.has-back-button) : TouchArea {
-            clicked => { root.back() }
+        if (root.has-back-button): TouchArea {
+            clicked => {
+                root.back()
+            }
         }
     }
 }
+
 export component Label inherits Text {
     color: DemoPalette.text-foreground-color;
     vertical-alignment: center;
@@ -109,8 +122,8 @@ component SquareButton inherits Rectangle {
     Image {
         height: 40%;
         width: 40%;
-        x: (parent.width - self.width)/2;
-        y: (parent.height - self.height)/2;
+        x: (parent.width - self.width) / 2;
+        y: (parent.height - self.height) / 2;
         source <=> root.img;
         image-fit: contain;
         colorize: DemoPalette.control-secondary;
@@ -177,7 +190,8 @@ export component ComboBox inherits Rectangle {
     border-color: DemoPalette.control-outline-color;
     height: 32px;
     min-width: label.x + label.width + i.width;
-    horizontal-stretch: 1; // Work around #2284
+    horizontal-stretch: 1;
+    // Work around #2284
 
     label := Text {
         vertical-alignment: center;
@@ -195,18 +209,20 @@ export component ComboBox inherits Rectangle {
         width: self.height;
         image-fit: contain;
         x: parent.width - self.width - self.y;
-        y: (parent.height - self.height)/2;
+        y: (parent.height - self.height) / 2;
     }
 
     TouchArea {
-        clicked => { popup.show(); }
+        clicked => {
+            popup.show();
+        }
 
         width: 100%;
         height: 100%;
     }
 
     popup := PopupWindow {
-        x:0;
+        x: 0;
         y: root.height;
         width: root.width;
 
@@ -254,7 +270,9 @@ export component CheckBox inherits Rectangle {
         spacing: 12px;
         padding: 0;
         SquareButton {
-            clicked => { root.checked = !root.checked; }
+            clicked => {
+                root.checked = !root.checked;
+            }
 
             width: root.height - parent.padding * 2;
             img: root.checked ? @image-url("images/check.svg") : @image-url("");
@@ -288,7 +306,8 @@ export component PushButton inherits Rectangle {
     border-radius: 13.5px;
     background: root.pressed ? root.colors.pressed : (touch-area.has-hover ? root.colors.hovered : root.colors.base);
 
-    height: 27px; // line-height in the design
+    height: 27px;
+    // line-height in the design
     horizontal-stretch: 1;
 
     HorizontalLayout {
@@ -313,5 +332,9 @@ export component PushButton inherits Rectangle {
         }
     }
 
-    touch-area := TouchArea { clicked => { root.clicked() } }
+    touch-area := TouchArea {
+        clicked => {
+            root.clicked()
+        }
+    }
 }

--- a/examples/printerdemo/ui/images/page_selection.svg
+++ b/examples/printerdemo/ui/images/page_selection.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="49" height="86" fill="none"><path d="M33 16h-7C11.465 16 0 28.707 0 43.5S11.465 68 26 68h7c9.071 0 16 8.768 16 18V0c0 9.232-6.929 16-16 16z" fill="#fff"/></svg>
+<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" viewBox="0 0 49 86" xmlns="http://www.w3.org/2000/svg"><path d="m33 16h-7c-12.869 0-25.851 12.165-25.851 26.958s12.894 27.005 25.851 27.042h7c9.071 0 16 6.768 16 16v-86c0 9.232-6.929 16-16 16z" fill="#fff" fill-rule="nonzero"/></svg>

--- a/examples/printerdemo/ui/printerdemo.slint
+++ b/examples/printerdemo/ui/printerdemo.slint
@@ -15,12 +15,23 @@ import "./fonts/NotoSans-Bold.ttf";
 
 component SideBarIcon inherits Rectangle {
     in-out property <bool> active;
+    in-out property <image> icon <=> i.source;
 
     callback activate;
+    width: DemoPalette.side-bar-width;
+    height: 72px;
 
-    GridLayout {
-        padding: 0px;
-        @children
+    Rectangle {
+        x: DemoPalette.side-bar-margin;
+        GridLayout {
+            padding: 0px;
+            @children
+        }
+
+        i := Image {
+            colorize: root.active ? DemoPalette.active-page-icon-color : DemoPalette.inactive-page-icon-color;
+            animate colorize { duration: 125ms; }
+        }
     }
 
     TouchArea {
@@ -67,21 +78,57 @@ export component MainWindow inherits Window {
                 width: main-view.width - main-view.border-radius;
                 height: main-view.height - main-view.border-radius;
 
+                function calcPageY(pageNumber: int) -> length {
+                    if (root.active-page == pageNumber) {
+                        return 0;
+                    }
+                    return root.active-page < pageNumber ? - self.height / 2 : parent.height / 2;
+                }
+
+                property <duration> page-animation-duration: 250ms;
+
                 home-page := HomePage {
-                    y: root.active-page == 0 ? 0 : root.active-page < 0 ? - self.height - 1px : parent.height + 1px;
-                    animate y { duration: 125ms; easing: ease; }
+                    property <int> pageNumber: 0;
+                    y: calcPageY(0);
+                    opacity: root.active-page == 0 ? 1 : 0;
+                    animate y {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
+                    animate opacity {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
                 }
 
                 SettingsPage {
-                    y: root.active-page == 1 ? 0 : root.active-page < 1 ? - self.height - 1px : parent.height + 1px;
-                    animate y { duration: 125ms; easing: ease; }
+                    property <int> pageNumber: 1;
+                    y: calcPageY(1);
+                    opacity: root.active-page == pageNumber ? 1 : 0;
+                    animate y {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
+                    animate opacity {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
                 }
 
                 InkPage {
-                    y: root.active-page == 2 ? 0 : root.active-page < 2 ? - self.height - 1px : parent.height + 1px;
+                    property <int> pageNumber: 2;
+                    y: calcPageY(pageNumber);
+                    opacity: root.active-page == pageNumber ? 1 : 0;
                     ink-levels <=> root.ink-levels;
-                    page-visible: root.active-page == 2;
-                    animate y { duration: 125ms; easing: ease; }
+                    page-visible: root.active-page == pageNumber;
+                    animate y {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
+                    animate opacity {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
                 }
             }
         }
@@ -92,53 +139,37 @@ export component MainWindow inherits Window {
             return 100px // top padding
                 + index * 72px;
         }
-
-        width: 57px;
-        x: 10px;
-
+        x: 0px;
+        width: DemoPalette.side-bar-width;
 
         Image {
-            x:0;
-            source: @image-url("images/page_selection.svg");
+            x: DemoPalette.side-bar-margin + 8px;
             y: sidebar.icon-y(root.active-page) - self.width / 2;
-            width: main-view.x - sidebar.x + 1px;
-            height: 1.75 * self.width;
+            source: @image-url("images/page_selection.svg");
             colorize: DemoPalette.page-background-color;
-            animate y {
-                duration: 125ms;
-            }
+            animate y { duration: 125ms; }
         }
 
-        for page-icon[idx] in [
-            @image-url("images/home.svg"),
-            @image-url("images/settings.svg"),
-            @image-url("images/ink.svg"),
-        ] : SideBarIcon {
-            activate => {
-                root.active-page = idx;
-            }
+        VerticalLayout {
+            y: 82px;
 
-            y: sidebar.icon-y(idx);
-            x: 16px;
-            height: 35px;
-            width: 30px;
-
-            icon := Image {
-                colorize: (root.active-page == idx) ? DemoPalette.active-page-icon-color : DemoPalette.inactive-page-icon-color;
-                animate colorize {
-                    duration: 125ms;
+            for page-icon[idx] in [
+                @image-url("images/home.svg"),
+                @image-url("images/settings.svg"),
+                @image-url("images/ink.svg"),
+            ]: SideBarIcon {
+                activate => {
+                    root.active-page = idx;
                 }
-                source: page-icon;
-                image-fit: contain;
-                width: 100%;
-                height: 100%;
+                icon: page-icon;
+                active: root.active-page == idx;
             }
         }
 
         Rectangle {
             y: sidebar.icon-y(3) + 17px;
-            x: 12px;
-            background: #6284FF;
+            x: DemoPalette.side-bar-margin + 8px;
+            background: DemoPalette.page-background-color;
             height: 2px;
             width: 37px;
         }

--- a/examples/printerdemo/ui/printerdemo.slint
+++ b/examples/printerdemo/ui/printerdemo.slint
@@ -143,7 +143,7 @@ export component MainWindow inherits Window {
         width: DemoPalette.side-bar-width;
 
         Image {
-            x: DemoPalette.side-bar-margin + 8px;
+            x: parent.width - self.width;
             y: sidebar.icon-y(root.active-page) - self.width / 2;
             source: @image-url("images/page_selection.svg");
             colorize: DemoPalette.page-background-color;

--- a/examples/printerdemo/ui/printerdemo.slint
+++ b/examples/printerdemo/ui/printerdemo.slint
@@ -15,29 +15,16 @@ import "./fonts/NotoSans-Bold.ttf";
 
 component SideBarIcon inherits Rectangle {
     in-out property <bool> active;
-    in-out property <image> icon <=> i.source;
 
     callback activate;
-    width: DemoPalette.side-bar-width;
-    height: 72px;
 
-    Rectangle {
-        x: DemoPalette.side-bar-margin;
-        GridLayout {
-            padding: 0px;
-            @children
-        }
-
-        i := Image {
-            colorize: root.active ? DemoPalette.active-page-icon-color : DemoPalette.inactive-page-icon-color;
-            animate colorize { duration: 125ms; }
-        }
+    GridLayout {
+        padding: 0px;
+        @children
     }
 
     TouchArea {
-        clicked => {
-            root.activate();
-        }
+        clicked => { root.activate(); }
     }
 }
 
@@ -45,10 +32,10 @@ export component MainWindow inherits Window {
     /// Note that this property is overwritten in the .cpp and .rs code.
     /// The data is only in this file so it looks good in the viewer
     in property <[InkLevel]> ink-levels: [
-        { color: #0ff, level: 60% },
-        { color: #ff0, level: 80% },
-        { color: #f0f, level: 70% },
-        { color: #000, level: 30% },
+        {color: #0ff, level: 60%},
+        {color: #ff0, level: 80%},
+        {color: #f0f, level: 70%},
+        {color: #000, level: 30%},
     ];
     out property <int> active-page: 0;
 
@@ -74,62 +61,27 @@ export component MainWindow inherits Window {
             background: DemoPalette.page-background-color;
 
             Rectangle {
-                function calcPageY(pageNumber: int) -> length {
-                    if (root.active-page == pageNumber) {
-                        return 0;
-                    }
-                    return root.active-page < pageNumber ? - self.height / 2 : parent.height / 2;
-                }
                 clip: true;
                 x: main-view.border-radius / 2;
                 y: main-view.border-radius / 2;
                 width: main-view.width - main-view.border-radius;
                 height: main-view.height - main-view.border-radius;
 
-                property <duration> page-animation-duration: 250ms;
-
                 home-page := HomePage {
-                    property <int> pageNumber: 0;
-                    y: calcPageY(0);
-                    opacity: root.active-page == 0 ? 1 : 0;
-                    animate y {
-                        duration: page-animation-duration;
-                        easing: ease-out-quad;
-                    }
-                    animate opacity {
-                        duration: page-animation-duration;
-                        easing: ease-out-quad;
-                    }
+                    y: root.active-page == 0 ? 0 : root.active-page < 0 ? - self.height - 1px : parent.height + 1px;
+                    animate y { duration: 125ms; easing: ease; }
                 }
 
                 SettingsPage {
-                    property <int> pageNumber: 1;
-                    y: calcPageY(1);
-                    opacity: root.active-page == pageNumber ? 1 : 0;
-                    animate y {
-                        duration: page-animation-duration;
-                        easing: ease-out-quad;
-                    }
-                    animate opacity {
-                        duration: page-animation-duration;
-                        easing: ease-out-quad;
-                    }
+                    y: root.active-page == 1 ? 0 : root.active-page < 1 ? - self.height - 1px : parent.height + 1px;
+                    animate y { duration: 125ms; easing: ease; }
                 }
 
                 InkPage {
-                    property <int> pageNumber: 2;
-                    y: calcPageY(pageNumber);
-                    opacity: root.active-page == pageNumber ? 1 : 0;
+                    y: root.active-page == 2 ? 0 : root.active-page < 2 ? - self.height - 1px : parent.height + 1px;
                     ink-levels <=> root.ink-levels;
-                    page-visible: root.active-page == pageNumber;
-                    animate y {
-                        duration: page-animation-duration;
-                        easing: ease-out-quad;
-                    }
-                    animate opacity {
-                        duration: page-animation-duration;
-                        easing: ease-out-quad;
-                    }
+                    page-visible: root.active-page == 2;
+                    animate y { duration: 125ms; easing: ease; }
                 }
             }
         }
@@ -137,40 +89,56 @@ export component MainWindow inherits Window {
 
     sidebar := Rectangle {
         function icon-y(index: int) -> length {
-            return 100px// top padding
+            return 100px // top padding
                 + index * 72px;
         }
-        x: 0px;
-        width: DemoPalette.side-bar-width;
+
+        width: 57px;
+        x: 10px;
+
 
         Image {
-            x: DemoPalette.side-bar-margin + 8px;
+            x:0;
             source: @image-url("images/page_selection.svg");
             y: sidebar.icon-y(root.active-page) - self.width / 2;
+            width: main-view.x - sidebar.x + 1px;
+            height: 1.75 * self.width;
             colorize: DemoPalette.page-background-color;
-            animate y { duration: 125ms; }
+            animate y {
+                duration: 125ms;
+            }
         }
 
-        VerticalLayout {
-            y: 82px;
+        for page-icon[idx] in [
+            @image-url("images/home.svg"),
+            @image-url("images/settings.svg"),
+            @image-url("images/ink.svg"),
+        ] : SideBarIcon {
+            activate => {
+                root.active-page = idx;
+            }
 
-            for page-icon[idx] in [
-                @image-url("images/home.svg"),
-                @image-url("images/settings.svg"),
-                @image-url("images/ink.svg"),
-            ]: SideBarIcon {
-                activate => {
-                    root.active-page = idx;
+            y: sidebar.icon-y(idx);
+            x: 16px;
+            height: 35px;
+            width: 30px;
+
+            icon := Image {
+                colorize: (root.active-page == idx) ? DemoPalette.active-page-icon-color : DemoPalette.inactive-page-icon-color;
+                animate colorize {
+                    duration: 125ms;
                 }
-                icon: page-icon;
-                active: root.active-page == idx;
+                source: page-icon;
+                image-fit: contain;
+                width: 100%;
+                height: 100%;
             }
         }
 
         Rectangle {
             y: sidebar.icon-y(3) + 17px;
-            x: DemoPalette.side-bar-margin + 8px;
-            background: DemoPalette.page-background-color;
+            x: 12px;
+            background: #6284FF;
             height: 2px;
             width: 37px;
         }

--- a/examples/printerdemo/ui/printerdemo.slint
+++ b/examples/printerdemo/ui/printerdemo.slint
@@ -15,16 +15,29 @@ import "./fonts/NotoSans-Bold.ttf";
 
 component SideBarIcon inherits Rectangle {
     in-out property <bool> active;
+    in-out property <image> icon <=> i.source;
 
     callback activate;
+    width: DemoPalette.side-bar-width;
+    height: 72px;
 
-    GridLayout {
-        padding: 0px;
-        @children
+    Rectangle {
+        x: DemoPalette.side-bar-margin;
+        GridLayout {
+            padding: 0px;
+            @children
+        }
+
+        i := Image {
+            colorize: root.active ? DemoPalette.active-page-icon-color : DemoPalette.inactive-page-icon-color;
+            animate colorize { duration: 125ms; }
+        }
     }
 
     TouchArea {
-        clicked => { root.activate(); }
+        clicked => {
+            root.activate();
+        }
     }
 }
 
@@ -32,10 +45,10 @@ export component MainWindow inherits Window {
     /// Note that this property is overwritten in the .cpp and .rs code.
     /// The data is only in this file so it looks good in the viewer
     in property <[InkLevel]> ink-levels: [
-        {color: #0ff, level: 60%},
-        {color: #ff0, level: 80%},
-        {color: #f0f, level: 70%},
-        {color: #000, level: 30%},
+        { color: #0ff, level: 60% },
+        { color: #ff0, level: 80% },
+        { color: #f0f, level: 70% },
+        { color: #000, level: 30% },
     ];
     out property <int> active-page: 0;
 
@@ -61,27 +74,62 @@ export component MainWindow inherits Window {
             background: DemoPalette.page-background-color;
 
             Rectangle {
+                function calcPageY(pageNumber: int) -> length {
+                    if (root.active-page == pageNumber) {
+                        return 0;
+                    }
+                    return root.active-page < pageNumber ? - self.height / 2 : parent.height / 2;
+                }
                 clip: true;
                 x: main-view.border-radius / 2;
                 y: main-view.border-radius / 2;
                 width: main-view.width - main-view.border-radius;
                 height: main-view.height - main-view.border-radius;
 
+                property <duration> page-animation-duration: 250ms;
+
                 home-page := HomePage {
-                    y: root.active-page == 0 ? 0 : root.active-page < 0 ? - self.height - 1px : parent.height + 1px;
-                    animate y { duration: 125ms; easing: ease; }
+                    property <int> pageNumber: 0;
+                    y: calcPageY(0);
+                    opacity: root.active-page == 0 ? 1 : 0;
+                    animate y {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
+                    animate opacity {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
                 }
 
                 SettingsPage {
-                    y: root.active-page == 1 ? 0 : root.active-page < 1 ? - self.height - 1px : parent.height + 1px;
-                    animate y { duration: 125ms; easing: ease; }
+                    property <int> pageNumber: 1;
+                    y: calcPageY(1);
+                    opacity: root.active-page == pageNumber ? 1 : 0;
+                    animate y {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
+                    animate opacity {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
                 }
 
                 InkPage {
-                    y: root.active-page == 2 ? 0 : root.active-page < 2 ? - self.height - 1px : parent.height + 1px;
+                    property <int> pageNumber: 2;
+                    y: calcPageY(pageNumber);
+                    opacity: root.active-page == pageNumber ? 1 : 0;
                     ink-levels <=> root.ink-levels;
-                    page-visible: root.active-page == 2;
-                    animate y { duration: 125ms; easing: ease; }
+                    page-visible: root.active-page == pageNumber;
+                    animate y {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
+                    animate opacity {
+                        duration: page-animation-duration;
+                        easing: ease-out-quad;
+                    }
                 }
             }
         }
@@ -89,56 +137,40 @@ export component MainWindow inherits Window {
 
     sidebar := Rectangle {
         function icon-y(index: int) -> length {
-            return 100px // top padding
+            return 100px// top padding
                 + index * 72px;
         }
-
-        width: 57px;
-        x: 10px;
-
+        x: 0px;
+        width: DemoPalette.side-bar-width;
 
         Image {
-            x:0;
+            x: DemoPalette.side-bar-margin + 8px;
             source: @image-url("images/page_selection.svg");
             y: sidebar.icon-y(root.active-page) - self.width / 2;
-            width: main-view.x - sidebar.x + 1px;
-            height: 1.75 * self.width;
             colorize: DemoPalette.page-background-color;
-            animate y {
-                duration: 125ms;
-            }
+            animate y { duration: 125ms; }
         }
 
-        for page-icon[idx] in [
-            @image-url("images/home.svg"),
-            @image-url("images/settings.svg"),
-            @image-url("images/ink.svg"),
-        ] : SideBarIcon {
-            activate => {
-                root.active-page = idx;
-            }
+        VerticalLayout {
+            y: 82px;
 
-            y: sidebar.icon-y(idx);
-            x: 16px;
-            height: 35px;
-            width: 30px;
-
-            icon := Image {
-                colorize: (root.active-page == idx) ? DemoPalette.active-page-icon-color : DemoPalette.inactive-page-icon-color;
-                animate colorize {
-                    duration: 125ms;
+            for page-icon[idx] in [
+                @image-url("images/home.svg"),
+                @image-url("images/settings.svg"),
+                @image-url("images/ink.svg"),
+            ]: SideBarIcon {
+                activate => {
+                    root.active-page = idx;
                 }
-                source: page-icon;
-                image-fit: contain;
-                width: 100%;
-                height: 100%;
+                icon: page-icon;
+                active: root.active-page == idx;
             }
         }
 
         Rectangle {
             y: sidebar.icon-y(3) + 17px;
-            x: 12px;
-            background: #6284FF;
+            x: DemoPalette.side-bar-margin + 8px;
+            background: DemoPalette.page-background-color;
             height: 2px;
             width: 37px;
         }

--- a/examples/printerdemo/ui/printerdemo.slint
+++ b/examples/printerdemo/ui/printerdemo.slint
@@ -143,7 +143,7 @@ export component MainWindow inherits Window {
         width: DemoPalette.side-bar-width;
 
         Image {
-            x: parent.width - self.width;
+            x: parent.width - self.width + 1px; // workaround pixel gap
             y: sidebar.icon-y(root.active-page) - self.width / 2;
             source: @image-url("images/page_selection.svg");
             colorize: DemoPalette.page-background-color;


### PR DESCRIPTION
- The general page change animation is more subtle. It's now a combo of fade in and move. As opposed to a full page slide.
- Fixes the position of the sidebar selection SVG to remove a broken curve.
- The SVG also has been tweaked to make it symmetrical and remove the lopsided bulge it had. 
- The sidebar buttons touch area covers the whole space they represent, as opposed to just being the same size as the icon.
- The code has been simplified a bit. Layout values are moved to DemoPalette and animation values are based on reusable variables to make changing the timings easier.