### PR TITLE
Rename the weather-demo library name

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -326,7 +326,7 @@ jobs:
               with:
                   name: android-demo
                   path: android
-                 
+
             - name: Extract Version
               id: version
               run: |
@@ -353,7 +353,7 @@ jobs:
                 token: ${{ steps.app-token.outputs.token }}
 
             - name: Publish Docs and Demos
-              working-directory: ./www-releases  
+              working-directory: ./www-releases
               run: |
                 if [[ "${{ github.event.inputs.release }}" == "true" ]]; then
                   output_path="releases/${{ steps.version.outputs.VERSION }}"
@@ -426,7 +426,7 @@ jobs:
                 cp -r www-releases/releases/${{ steps.version.outputs.VERSION }}/editor www-releases/slintpad
                 for f in 404.html script.js LICENSE.md package.json; do
                   cp www-releases/releases/$f www-releases/slintpad
-                done                  
+                done
                 echo "${{ steps.version.outputs.VERSION }}" > www-releases/slintpad/versions.txt
 
             - name: Get GitHub App User ID
@@ -580,4 +580,4 @@ jobs:
                   path: |
                     target/release/apk/energy-monitor.apk
                     target/release/apk/todo_lib.apk
-                    target/release/apk/weather_demo_lib.apk
+                    target/release/apk/weather_demo.apk

--- a/examples/weather-demo/Cargo.toml
+++ b/examples/weather-demo/Cargo.toml
@@ -45,7 +45,6 @@ open_weather = ["dep:openweather_sdk", "dep:openssl"]
 
 # Android-activity / wasm support
 [lib]
-name="weather_demo_lib"
 crate-type = ["lib", "cdylib"]
 path = "src/lib.rs"
 

--- a/examples/weather-demo/index.html
+++ b/examples/weather-demo/index.html
@@ -30,7 +30,7 @@
             <canvas id="canvas" data-slint-auto-resize-to-preferred="true" unselectable="on"></canvas>
             <script type="module">
                 // import the generated file.
-                import init from "./pkg/weather_demo_lib.js";
+                import init from "./pkg/weather_demo.js";
                 init();
             </script>
         </div>


### PR DESCRIPTION
The reason why we need to have a `_lib` prefix in the printerdemo and the too example is because the binary name must be different from the library name. But in the case of the weather-demo, since there is a dash, it doesn't need the _lib suffix to be different.

Having a different name than the package name doesn't work with the `xbuild` tool: fixes #5731
(we use cargo apk for our own build which doesn't have this limitation anyway)