### PR TITLE
Give printerdemo a clear palette

### DIFF
--- a/examples/printerdemo/ui/common.slint
+++ b/examples/printerdemo/ui/common.slint
@@ -7,34 +7,63 @@ struct ButtonColors  {
     hovered: color,
 }
 
+struct ModeColors {
+    background: color,
+    primary: color,
+    secondary: color,
+    text-primary: color,
+    text-secondary: color,
+    destructive: color,
+}
+
 export global DemoPalette  {
-    in property <bool> night-mode: false;
+    in property <bool> dark-mode: false;
+
+    property <ModeColors> light-mode-colors: {
+        background: #FFFFFF,
+        primary: #0E133F,
+        secondary: #FFBF63,
+        text-primary: #000,
+        text-secondary: #6284FF,
+        destructive: #FF3B30,
+    };
+
+    property <ModeColors> dark-mode-colors: {
+        background: #122F7B,
+        primary: #0E133F,
+        secondary: #FFBF63,
+        text-primary: #FFF,
+        text-secondary: #F1FF98,
+        destructive: #FF3B30,
+    };
+
+    out property <color> background: dark-mode ? dark-mode-colors.background : light-mode-colors.background;
+    out property <color> primary: dark-mode ? dark-mode-colors.primary : light-mode-colors.primary;
+    out property <color> secondary: dark-mode ? dark-mode-colors.secondary : light-mode-colors.secondary;
+    out property <color> text-primary: dark-mode ? dark-mode-colors.text-primary : light-mode-colors.text-primary;
+    out property <color> text-secondary: dark-mode ? dark-mode-colors.text-secondary : light-mode-colors.text-secondary;
+    out property <color> destructive: dark-mode ? dark-mode-colors.destructive : light-mode-colors.destructive;
 
     // Color of the home/settings/ink buttons on the left side bar
-    out property <color> active-page-icon-color: root.night-mode ? #6284FF : #122F7B;
+    out property <color> active-page-icon-color: root.dark-mode ? #6284FF : #122F7B;
     out property <color> inactive-page-icon-color: #BDC0D1;
-    out property <color> main-background: #0E133F;
     out property <color> neutral-box: #BDC0D1;
-    out property <color> page-background-color: root.night-mode ? #122F7B : white;
-    out property <color> text-foreground-color: root.night-mode ? #F4F6FF : black;
-    out property <color> secondary-foreground-color: root.night-mode ? #C1C3CA : #6C6E7A;
-    out property <color> printer-action-background-color: root.night-mode ? root.main-background : white;
-    out property <color> printer-queue-item-background-color: root.page-background-color;
-    out property <color> status-label-text-color: root.night-mode ? #F1FF98 : #6284FF;
+    out property <color> text-foreground-color: root.dark-mode ? #F4F6FF : black;
+    out property <color> secondary-foreground-color: root.dark-mode ? #C1C3CA : #6C6E7A;
+    out property <color> printer-queue-item-background-color: root.background; // Remove?
 
     // Color used for the border / outline of items that can be clicked on, such as the
     // "Print"/"Scan" buttons, the printer queue items (for expansion) or controls such
     // as the combo box or spin box.
-    out property <color> control-outline-color: #FFBF63;
     out property <color> control-secondary: #6284FF;
-    out property <color> control-foreground: root.night-mode ? white : #122F7B;  // FIXME: the night mode color was not part of the design
+    out property <color> control-foreground: root.dark-mode ? white : #122F7B;  // FIXME: the night mode color was not part of the design
     out property <color> primary-push-button-base: #6284FF;
     out property <ButtonColors> primary-push-button-colors: {
         base: root.primary-push-button-base,
         pressed: root.primary-push-button-base.darker(40%),
         hovered: root.primary-push-button-base.darker(20%),
     };
-    out property <color> secondary-push-button-base: #FFBF63;
+    out property <color> secondary-push-button-base: destructive;
     out property <ButtonColors> secondary-push-button-colors: {
         base: root.secondary-push-button-base,
         pressed: root.secondary-push-button-base.darker(40%),
@@ -46,6 +75,9 @@ export global DemoPalette  {
     out property <length> button-height: button-width + 30px;
     out property <length> side-bar-width: 67px;
     out property <length> side-bar-margin: 10px;
+
+    // Light and Dark mode colors
+
 }
 
 export component Page inherits Rectangle {
@@ -54,7 +86,7 @@ export component Page inherits Rectangle {
 
     callback back;
 
-    background: DemoPalette.page-background-color;
+    background: DemoPalette.background;
     // Stop accidentally getting clicks dur to animation only moving page half way offscreen
     visible: self.opacity > 0;
 
@@ -106,7 +138,7 @@ component SquareButton inherits Rectangle {
 
     border-radius: 3px;
     border-width: 2px;
-    border-color: DemoPalette.control-outline-color;
+    border-color: DemoPalette.secondary;
 
     touch := TouchArea {
         clicked => {
@@ -150,7 +182,7 @@ export component SpinBox inherits Rectangle {
         Rectangle {
             border-radius: 3px;
             border-width: 2px;
-            border-color: DemoPalette.control-outline-color;
+            border-color: DemoPalette.secondary;
 
             Text {
                 width: 100%;
@@ -182,7 +214,7 @@ export component ComboBox inherits Rectangle {
 
     border-radius: 3px;
     border-width: 2px;
-    border-color: DemoPalette.control-outline-color;
+    border-color: DemoPalette.secondary;
     height: 32px;
     min-width: label.x + label.width + i.width;
     horizontal-stretch: 1; // Work around #2284
@@ -219,10 +251,10 @@ export component ComboBox inherits Rectangle {
         width: root.width;
 
         Rectangle {
-            background: DemoPalette.page-background-color;
+            background: DemoPalette.background;
             border-radius: 3px;
             border-width: 2px;
-            border-color: DemoPalette.control-outline-color;
+            border-color: DemoPalette.secondary;
         }
 
         VerticalLayout {

--- a/examples/printerdemo/ui/common.slint
+++ b/examples/printerdemo/ui/common.slint
@@ -32,8 +32,8 @@ export global DemoPalette  {
         background: #122F7B,
         primary: #0E133F,
         secondary: #FFBF63,
-        text-primary: #FFF,
-        text-secondary: #F1FF98,
+        text-primary: #F4F6FF,
+        text-secondary: #F4F6FF,
         destructive: #FF3B30,
     };
 
@@ -44,13 +44,14 @@ export global DemoPalette  {
     out property <color> text-secondary: dark-mode ? dark-mode-colors.text-secondary : light-mode-colors.text-secondary;
     out property <color> destructive: dark-mode ? dark-mode-colors.destructive : light-mode-colors.destructive;
 
+    // Fixed (non-themeable) colors
+    out property <color> push-button-text-color: white;
+
     // Color of the home/settings/ink buttons on the left side bar
     out property <color> active-page-icon-color: root.dark-mode ? #6284FF : #122F7B;
     out property <color> inactive-page-icon-color: #BDC0D1;
     out property <color> neutral-box: #BDC0D1;
-    out property <color> text-foreground-color: root.dark-mode ? #F4F6FF : black;
     out property <color> secondary-foreground-color: root.dark-mode ? #C1C3CA : #6C6E7A;
-    out property <color> printer-queue-item-background-color: root.background; // Remove?
 
     // Color used for the border / outline of items that can be clicked on, such as the
     // "Print"/"Scan" buttons, the printer queue items (for expansion) or controls such
@@ -69,14 +70,12 @@ export global DemoPalette  {
         pressed: root.secondary-push-button-base.darker(40%),
         hovered: root.secondary-push-button-base.darker(20%),
     };
-    out property <color> push-button-text-color: white;
+    
     out property <length> base-font-size: 16px;
     out property <length> button-width: 130px;
     out property <length> button-height: button-width + 30px;
     out property <length> side-bar-width: 67px;
     out property <length> side-bar-margin: 10px;
-
-    // Light and Dark mode colors
 
 }
 
@@ -114,7 +113,7 @@ export component Page inherits Rectangle {
     h := Text {
         font-weight: 900;
         font-size: DemoPalette.base-font-size * 2;
-        color: DemoPalette.text-foreground-color;
+        color: DemoPalette.text-primary;
         y: 46px - self.font-size;
         x: root.has-back-button ? 24px + 16px : 0px;
         // Allow clicking on the title as well to get back easier when just
@@ -125,7 +124,7 @@ export component Page inherits Rectangle {
     }
 }
 export component Label inherits Text {
-    color: DemoPalette.text-foreground-color;
+    color: DemoPalette.text-primary;
     vertical-alignment: center;
     font-weight: 700;
     vertical-stretch: 0;
@@ -260,6 +259,15 @@ export component ComboBox inherits Rectangle {
         VerticalLayout {
             spacing: 6px;
             padding: 3px;
+            function textColor(hashover: bool) -> color {
+                if DemoPalette.dark-mode {
+                    return DemoPalette.text-primary;
+                }
+                // if hashover {
+                    return DemoPalette.text-primary;
+                // }
+                
+            }
 
             for value[idx] in root.choices: Rectangle {
                 border-radius: 3px;
@@ -268,7 +276,7 @@ export component ComboBox inherits Rectangle {
                 HorizontalLayout {
                     Text {
                         text: value;
-                        color: item-area.has-hover ? DemoPalette.push-button-text-color : DemoPalette.text-foreground-color;
+                        color: item-area.has-hover ? DemoPalette.push-button-text-color : DemoPalette.text-primary;
                         font-size: DemoPalette.base-font-size;
                     }
                 }

--- a/examples/printerdemo/ui/common.slint
+++ b/examples/printerdemo/ui/common.slint
@@ -1,5 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
+import { Palette } from "std-widgets.slint";
 
 struct ButtonColors  {
     base: color,
@@ -17,7 +18,7 @@ struct ModeColors {
 }
 
 export global DemoPalette  {
-    in property <bool> dark-mode: false;
+    in property <bool> dark-mode: Palette.color-scheme == ColorScheme.dark;
 
     property <ModeColors> light-mode-colors: {
         background: #FFFFFF,

--- a/examples/printerdemo/ui/home_page.slint
+++ b/examples/printerdemo/ui/home_page.slint
@@ -20,8 +20,8 @@ component ActionButton inherits Rectangle {
         Rectangle {
             border-radius: 25px;
             border-width: 5px;
-            border-color: DemoPalette.control-outline-color;
-            background: DemoPalette.printer-action-background-color;
+            border-color: DemoPalette.secondary;
+            background: DemoPalette.dark-mode ? DemoPalette.primary : DemoPalette.background;
 
             img := Image {
                 x: (parent.width / 2) - (self.width / 2);

--- a/examples/printerdemo/ui/home_page.slint
+++ b/examples/printerdemo/ui/home_page.slint
@@ -26,7 +26,7 @@ component ActionButton inherits Rectangle {
             img := Image {
                 x: (parent.width / 2) - (self.width / 2);
                 y: (parent.height / 2) - (self.height / 2);
-                colorize: DemoPalette.text-foreground-color;
+                colorize: DemoPalette.text-primary;
             }
         }
 
@@ -34,7 +34,7 @@ component ActionButton inherits Rectangle {
             font-size: DemoPalette.base-font-size * 1.375;
             font-weight: 800;
             horizontal-alignment: center;
-            color: DemoPalette.text-foreground-color;
+            color: DemoPalette.text-primary;
         }
     }
 

--- a/examples/printerdemo/ui/printer_queue.slint
+++ b/examples/printerdemo/ui/printer_queue.slint
@@ -140,7 +140,7 @@ component NarrowPrintQueueElement inherits Rectangle {
     border-color: DemoPalette.secondary;
     border-radius: 14px;
     border-width: 2px;
-    background: DemoPalette.printer-queue-item-background-color;
+    background: DemoPalette.background;
     clip: true;
     height: always-visible.min-height + layout.padding * 2;
 
@@ -195,7 +195,7 @@ component NarrowPrintQueueElement inherits Rectangle {
                 Text {
                     text: root.queue-item.title;
                     overflow: elide;
-                    color: DemoPalette.text-foreground-color;
+                    color: DemoPalette.text-primary;
                     font-weight: 800;
                     font-size: DemoPalette.base-font-size * 1.125;
                 }
@@ -282,7 +282,7 @@ component WidePrintQueueElement inherits Rectangle {
     border-color: DemoPalette.neutral-box;
     border-radius: 14px;
     border-width: 2px;
-    background: DemoPalette.printer-queue-item-background-color;
+    background: DemoPalette.background;
 
     GridLayout {
         padding: parent.border-radius;
@@ -319,7 +319,7 @@ component WidePrintQueueElement inherits Rectangle {
             col: 0;
             row: 1;
             text: root.queue-item.title;
-            color: DemoPalette.text-foreground-color;
+            color: DemoPalette.text-primary;
             overflow: elide;
             font-weight: 700;
             font-size: DemoPalette.base-font-size * 1.125;
@@ -389,7 +389,7 @@ export component PrinterQueueView inherits Rectangle {
 
         Text {
             text: @tr("Printing Queue");
-            color: DemoPalette.text-foreground-color;
+            color: DemoPalette.text-primary;
             font-size: DemoPalette.base-font-size * 1.5;
             font-weight: 700;
         }

--- a/examples/printerdemo/ui/printer_queue.slint
+++ b/examples/printerdemo/ui/printer_queue.slint
@@ -137,7 +137,7 @@ component NarrowPrintQueueElement inherits Rectangle {
 
     private property <float> expanded-opacity: 0;
 
-    border-color: DemoPalette.control-outline-color;
+    border-color: DemoPalette.secondary;
     border-radius: 14px;
     border-width: 2px;
     background: DemoPalette.printer-queue-item-background-color;
@@ -186,7 +186,7 @@ component NarrowPrintQueueElement inherits Rectangle {
                             PrinterQueue.statusString(root.queue-item.status)
                         }
                     }
-                    color: DemoPalette.status-label-text-color;
+                    color: DemoPalette.text-secondary;
                     font-size: DemoPalette.base-font-size * 0.75;
                     font-weight: 800;
                     letter-spacing: 1.56px;
@@ -299,7 +299,7 @@ component WidePrintQueueElement inherits Rectangle {
                         PrinterQueue.statusString(root.queue-item.status)
                     }
                 }
-                color: DemoPalette.status-label-text-color;
+                color: DemoPalette.text-secondary;
                 font-size: DemoPalette.base-font-size * 0.75;
                 font-weight: 700;
                 letter-spacing: 1.56px;
@@ -381,7 +381,7 @@ export component PrinterQueueView inherits Rectangle {
     callback show-job-details(int);
 
     border-radius: 27px;
-    background: DemoPalette.night-mode ? DemoPalette.printer-action-background-color : #F4F6FF;
+    background: DemoPalette.background.darker(20%);
 
     VerticalLayout {
         padding: 16px;

--- a/examples/printerdemo/ui/printerdemo.slint
+++ b/examples/printerdemo/ui/printerdemo.slint
@@ -58,7 +58,7 @@ export component MainWindow inherits Window {
     width: 772px;
     height: 504px;
     title: @tr("Slint printer demo");
-    background: DemoPalette.main-background;
+    background: DemoPalette.primary;
     default-font-family: "Noto Sans";
     default-font-size: DemoPalette.base-font-size;
 
@@ -69,7 +69,7 @@ export component MainWindow inherits Window {
         main-view := Rectangle {
             height: 100%;
             border-radius: 30px;
-            background: DemoPalette.page-background-color;
+            background: DemoPalette.background;
 
             Rectangle {
                 clip: true;
@@ -146,7 +146,7 @@ export component MainWindow inherits Window {
             x: parent.width - self.width + 1px; // workaround pixel gap
             y: sidebar.icon-y(root.active-page) - self.width / 2;
             source: @image-url("images/page_selection.svg");
-            colorize: DemoPalette.page-background-color;
+            colorize: DemoPalette.background;
             animate y { duration: 125ms; }
         }
 
@@ -169,14 +169,14 @@ export component MainWindow inherits Window {
         Rectangle {
             y: sidebar.icon-y(3) + 17px;
             x: DemoPalette.side-bar-margin + 8px;
-            background: DemoPalette.page-background-color;
+            background: DemoPalette.background;
             height: 2px;
             width: 37px;
         }
 
         SideBarIcon {
             activate => {
-                DemoPalette.night-mode = !DemoPalette.night-mode;
+                DemoPalette.dark-mode = !DemoPalette.dark-mode;
             }
 
             y: sidebar.icon-y(4);
@@ -185,8 +185,8 @@ export component MainWindow inherits Window {
             width: 30px;
 
             Image {
-                colorize: DemoPalette.night-mode ? #F1FF98 : DemoPalette.inactive-page-icon-color;
-                source: DemoPalette.night-mode ? @image-url("images/moon_full.svg") : @image-url("images/moon.svg");
+                colorize: DemoPalette.dark-mode ? #F1FF98 : DemoPalette.inactive-page-icon-color;
+                source: DemoPalette.dark-mode ? @image-url("images/moon_full.svg") : @image-url("images/moon.svg");
                 image-fit: contain;
                 width: 100%;
                 height: 100%;

--- a/examples/printerdemo_mcu/ui/printer_queue.slint
+++ b/examples/printerdemo_mcu/ui/printer_queue.slint
@@ -201,7 +201,7 @@ component NarrowPrintQueueElement inherits Rectangle {
                 Text {
                     text: root.queue-item.title;
                     overflow: elide;
-                    color: DemoPalette.text-primary;
+                    color: DemoPalette.text-foreground-color;
                     font-weight: 800;
                     font-size: DemoPalette.base-font-size * 1.125;
                 }

--- a/examples/printerdemo_mcu/ui/printer_queue.slint
+++ b/examples/printerdemo_mcu/ui/printer_queue.slint
@@ -201,7 +201,7 @@ component NarrowPrintQueueElement inherits Rectangle {
                 Text {
                     text: root.queue-item.title;
                     overflow: elide;
-                    color: DemoPalette.text-foreground-color;
+                    color: DemoPalette.text-primary;
                     font-weight: 800;
                     font-size: DemoPalette.base-font-size * 1.125;
                 }


### PR DESCRIPTION
There are many different ways this could be done.

Designers work with a limited and reusable color palette. There is no 100% standard, but pretty much of it has become common convention. 

The same colors are hardcoded or duplicated across the demo. So this pr also attempts to reuse as much of the core palette as possible.