### PR TITLE
Use less precision when comparing vaue in slint language

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,9 +35,8 @@ jobs:
                     - os: windows-2022
                       rust_version: "beta"
                       extra_args: "--exclude ffmpeg --exclude gstreamer-player"
-# Disable nightly until https://github.com/rust-lang/rust/issues/128386 is resolved                      
-#                    - os: ubuntu-22.04
-#                      rust_version: "nightly"
+                    - os: ubuntu-22.04
+                      rust_version: "nightly"
                 exclude:
                     - os: macos-12
                       rust_version: "1.73"

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2184,7 +2184,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                             | Type::Rem
                     ) =>
                 {
-                    (Some(quote!(as f64)), Some(quote!(as f64)))
+                    (Some(quote!(as f32)), Some(quote!(as f32)))
                 }
                 _ => (None, None),
             };

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -6,6 +6,7 @@ use i_slint_compiler::langtype::Type as LangType;
 use i_slint_core::component_factory::ComponentFactory;
 #[cfg(feature = "internal")]
 use i_slint_core::component_factory::FactoryContext;
+use i_slint_core::graphics::euclid::approxeq::ApproxEq as _;
 use i_slint_core::model::{Model, ModelRc};
 #[cfg(feature = "internal")]
 use i_slint_core::window::WindowInner;
@@ -151,7 +152,7 @@ impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
         match self {
             Value::Void => matches!(other, Value::Void),
-            Value::Number(lhs) => matches!(other, Value::Number(rhs) if lhs == rhs),
+            Value::Number(lhs) => matches!(other, Value::Number(rhs) if lhs.approx_eq(rhs)),
             Value::String(lhs) => matches!(other, Value::String(rhs) if lhs == rhs),
             Value::Bool(lhs) => matches!(other, Value::Bool(rhs) if lhs == rhs),
             Value::Image(lhs) => matches!(other, Value::Image(rhs) if lhs == rhs),


### PR DESCRIPTION
In rust, use f32 instead of f64 for arithmetic comparison. In the interpreter, use approx_eq

The test is failling in nightly because of precision change in `log`. By using f32, it actually should work

Also Revert "Disable builds with nightly Rust temporarily" This reverts commit 4afc3a2e84d422ced978368cb2654d7fc19b1615.

Fixes #5722