### PR TITLE
live-preview: Take note that the UI was opened

### DIFF
--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -150,6 +150,10 @@ pub(super) fn open_ui_impl(preview_state: &mut PreviewState) -> Result<(), slint
         Some(ui) => ui,
         None => {
             let ui = super::ui::create_ui(default_style, experimental)?;
+
+            let mut cache = super::CONTENT_CACHE.get_or_init(Default::default).lock().unwrap();
+            cache.ui_is_visible = true;
+
             preview_state.ui.insert(ui)
         }
     };


### PR DESCRIPTION
This makes the entire thing so much more responsive as most events are just ignored when the window is closed.