### PR TITLE
live-preview: Simplify code setting properties

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -970,40 +970,6 @@ pub fn normalize_identifier(ident: &str) -> String {
     ident.replace('_', "-")
 }
 
-// Parse an expression into a BindingExpression. This is used by the LSP to syntax
-// check the values of properties.
-pub fn parse_expression_as_bindingexpression(
-    source: &str,
-    build_diagnostics: &mut BuildDiagnostics,
-) -> SyntaxNode {
-    let node = {
-        let mut p = DefaultParser::new(source, build_diagnostics);
-        let token = {
-            let mut p = p.start_node(SyntaxKind::BindingExpression);
-            expressions::parse_expression(&mut *p);
-            p.peek()
-        };
-        let node = rowan::SyntaxNode::new_root(p.builder.finish());
-
-        if !build_diagnostics.has_errors() && token.kind() != SyntaxKind::Eof {
-            build_diagnostics.push_error_with_span(
-                format!("Expected end of string, found \"{}\"", &token.kind()),
-                crate::diagnostics::SourceLocation {
-                    source_file: Default::default(),
-                    span: crate::diagnostics::Span {
-                        offset: token.offset,
-                        #[cfg(feature = "proc_macro_span")]
-                        span: token.span,
-                    },
-                },
-            )
-        }
-        node
-    };
-
-    SyntaxNode { node, source_file: Default::default() }
-}
-
 // Actual parser
 pub fn parse(
     source: String,

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -474,17 +474,32 @@ impl ElementRcNode {
     }
 }
 
-pub fn create_workspace_edit(uri: Url, version: UrlVersion, edits: Vec<TextEdit>) -> WorkspaceEdit {
+pub fn create_text_document_edit(
+    uri: Url,
+    version: UrlVersion,
+    edits: Vec<TextEdit>,
+) -> lsp_types::TextDocumentEdit {
     let edits = edits
         .into_iter()
         .map(lsp_types::OneOf::Left::<TextEdit, lsp_types::AnnotatedTextEdit>)
         .collect();
-    let edit = lsp_types::TextDocumentEdit {
+    lsp_types::TextDocumentEdit {
         text_document: lsp_types::OptionalVersionedTextDocumentIdentifier { uri, version },
         edits,
-    };
-    let changes = lsp_types::DocumentChanges::Edits(vec![edit]);
+    }
+}
+
+pub fn create_workspace_edit_from_text_document_edits(
+    edits: Vec<lsp_types::TextDocumentEdit>,
+) -> WorkspaceEdit {
+    let changes = lsp_types::DocumentChanges::Edits(edits);
     WorkspaceEdit { document_changes: Some(changes), ..Default::default() }
+}
+
+pub fn create_workspace_edit(uri: Url, version: UrlVersion, edits: Vec<TextEdit>) -> WorkspaceEdit {
+    create_workspace_edit_from_text_document_edits(vec![create_text_document_edit(
+        uri, version, edits,
+    )])
 }
 
 pub fn create_workspace_edit_from_source_file(

--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -1130,7 +1130,7 @@ pub fn create_move_element_workspace_edit(
         let size = element.geometries(component_instance).first().map(|g| g.size)?;
 
         if drop_info.target_element_node.layout_kind() == ui::LayoutKind::None {
-            let Ok(Some((edit, _))) =
+            let Some((edit, _)) =
                 preview::resize_selected_element_impl(LogicalRect::new(position, size))
             else {
                 return None;


### PR DESCRIPTION
Now that the properties are only used in the live preview, we can simplify the code a bit.

This gets rid of some sanity checks in the code path as well, which in turn should fix #5696.

Fixes: #5696