### PR TITLE
Rust generated code: handle the case if the parent is destroyed in a binding

### DIFF
--- a/tests/cases/models/delete_from_clicked.slint
+++ b/tests/cases/models/delete_from_clicked.slint
@@ -4,11 +4,15 @@
 export global Glob {
     in-out property <[string]> model: ["Hello", "World"];
     in-out property <bool> condition: true;
-    callback clicked(string);
+    // Return true if issue #3464 is NOT fixed
+    callback clicked(string) -> bool;
     clicked => {
         model = ["oops"];
+        return true; // 3464 is not fixed in the interpreter
     }
     in-out property <string> value;
+    in-out property <bool> issue-3464-not-fixed;
+    in-out property <string> value_after: "XXXXX";
 }
 
 component Button {
@@ -38,7 +42,7 @@ component Button {
 }
 
 
-component TestCase inherits Window {
+export component TestCase inherits Window {
     width: 300px;
     height: 300px;
     VerticalLayout {
@@ -49,8 +53,11 @@ component TestCase inherits Window {
                 height: 80%;
                 clicked => {
                     Glob.value = string;
-                    Glob.clicked(string);
-                    //Glob.value = string; // FIXME: this still crashes (#3464)
+                    if Glob.clicked(string) {
+                        // FIXME! issue #3464 not fixed
+                        return;
+                    }
+                    Glob.value_after = string;
                 }
             }
         }
@@ -67,9 +74,11 @@ instance.global::<Glob<'_>>().set_model(model.clone().into());
 instance.global::<Glob<'_>>().on_clicked(move |val|{
     assert_eq!(val, "world");
     model.remove(1);
+    false
 });
 slint_testing::send_mouse_click(&instance, 150., 150.);
 assert_eq!(instance.global::<Glob<'_>>().get_value(), "world");
+assert_eq!(instance.global::<Glob<'_>>().get_value_after(), "");
 ```
 
 // same thing but with the keyboard
@@ -81,6 +90,7 @@ instance.global::<Glob<'_>>().set_model(model.clone().into());
 instance.global::<Glob<'_>>().on_clicked(move |val|{
     assert_eq!(val, "world");
     model.remove(1);
+    false
 });
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
@@ -88,6 +98,7 @@ slint_testing::send_keyboard_string_sequence(&instance, " ");
 slint_testing::send_keyboard_string_sequence(&instance, " ");
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert_eq!(instance.global::<Glob<'_>>().get_value(), "world");
+assert_eq!(instance.global::<Glob<'_>>().get_value_after(), "");
 ```
 
 ```cpp
@@ -102,6 +113,7 @@ instance.global<Glob>().set_model(model);
 instance.global<Glob>().on_clicked([=](slint::SharedString val){
     assert_eq(val, "world");
     model->erase(1);
+    return true; // issue 3464 not fixed in c++ generated code
 });
 slint_testing::send_mouse_click(&instance, 150., 150.);
 assert_eq(instance.global<Glob>().get_value(), "world");
@@ -119,6 +131,7 @@ instance.global<Glob>().set_model(model);
 instance.global<Glob>().on_clicked([=](slint::SharedString val){
     assert_eq(val, "world");
     model->erase(1);
+    return true; // issue 3464 not fixed in c++ generated code
 });
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
@@ -136,6 +149,7 @@ instance.Glob.model = model;
 instance.Glob.clicked = (val) => {
     assert.equal(val, "world");
     model.remove(1, 1);
+    return true; // issue 3464 not fixed in the interpreter
 };
 slintlib.private_api.send_mouse_click(instance, 150., 150.);
 assert.equal(instance.Glob.value, "world");
@@ -148,6 +162,7 @@ instance.Glob.model = model;
 instance.Glob.clicked = (val) => {
     assert.equal(val, "world");
     model.remove(1, 1);
+    return true; // issue 3464 not fixed in the interpreter
 };
 slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
 slintlib.private_api.send_keyboard_string_sequence(instance, "\t");


### PR DESCRIPTION
This can happen if somehow the parent get destroyed while a binding is running. This is issue #3464

This is enough to fix #5698