### PR TITLE
slintpad/vscode: Get rid of the shared files

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -195,6 +195,7 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
+    "syntax_check": "tsc --build --force",
     "test": "node ./out/test/runTest.js",
     "clean": "shx rm -rf out bin LICENSE.txt slint-*.vsix"
   },

--- a/editors/vscode/src/browser-lsp-worker.ts
+++ b/editors/vscode/src/browser-lsp-worker.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import slint_init, * as slint_lsp from "../out/slint_lsp_wasm.js";
-import slint_wasm_data from "../out/slint_lsp_wasm_bg.wasm";
 import { InitializeParams, InitializeResult } from "vscode-languageserver";
 import {
     createConnection,
@@ -10,7 +9,7 @@ import {
     BrowserMessageWriter,
 } from "vscode-languageserver/browser";
 
-slint_init(slint_wasm_data).then((_) => {
+slint_init().then((_) => {
     const reader = new BrowserMessageReader(self);
     const writer = new BrowserMessageWriter(self);
 

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -8,7 +8,7 @@
 import * as vscode from "vscode";
 
 import * as wasm_preview from "./wasm_preview";
-import * as lsp_commands from "../../../tools/slintpad/src/shared/lsp_commands";
+import * as lsp_commands from "./lsp_commands";
 import * as snippets from "./snippets";
 
 import {

--- a/editors/vscode/src/lsp_commands.ts
+++ b/editors/vscode/src/lsp_commands.ts
@@ -1,16 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import {
-    OptionalVersionedTextDocumentIdentifier,
-    Range as LspRange,
-    URI as LspURI,
-    WorkspaceEdit,
-} from "vscode-languageserver-types";
-
+import { URI as LspURI } from "vscode-languageserver-types";
 import * as vscode from "vscode";
-
-export type WorkspaceEditor = (_we: WorkspaceEdit) => boolean;
 
 // Use the auto-registered VSCode command for the custom executables offered
 // by our language server.
@@ -31,17 +23,4 @@ export async function showPreview(
     component: string,
 ): Promise<unknown> {
     return vscode.commands.executeCommand("slint/showPreview", url, component);
-}
-
-export async function removeBinding(
-    doc: OptionalVersionedTextDocumentIdentifier,
-    element_range: LspRange,
-    property_name: string,
-): Promise<boolean> {
-    return vscode.commands.executeCommand(
-        "slint/removeBinding",
-        doc,
-        element_range,
-        property_name,
-    );
 }

--- a/editors/vscode/src/tsconfig.json
+++ b/editors/vscode/src/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../tsconfig.default.json",
+    "compilerOptions": {
+        "lib": ["es2021", "webworker"],
+        "types": ["vscode"]
+    },
+    "include": ["./*.ts"],
+}

--- a/editors/vscode/tsconfig.default.json
+++ b/editors/vscode/tsconfig.default.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "resolveJsonModule": true,
+        "baseUrl": "./node_modules",
+        "composite": true,
+        "declaration": true,
+        "declarationMap": true,
+        "lib": ["es2021"],
+        "module": "esnext",
+        "moduleResolution": "node",
+        "outDir": "./out",
+        "rootDir": ".",
+        "skipLibCheck": true,
+        "strict": true,
+        "target": "es6",
+        "typeRoots": ["./node_modules/@types"]
+    }
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,17 +1,8 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es2020",
-        "outDir": "out",
-        "lib": ["es2021", "WebWorker", "dom"],
-        "sourceMap": true,
-        "rootDir": ".",
-        "strict": true /* enable all strict type-checking options */
-        /* Additional Checks */
-        // "noImplicitReturns": true, /* Report error when not all code paths in function return a
-        // value. */ "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in
-        // switch statement. */ "noUnusedParameters": true,  /* Report errors on unused parameters.
-        // */
-    },
-    "exclude": ["node_modules", ".vscode-test"]
+    "files": [],
+    "references": [
+        {
+            "path": "src"
+        }
+    ]
 }

--- a/tools/slintpad/src/tsconfig.json
+++ b/tools/slintpad/src/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": ["dom", "es2021"],
         "types": ["vscode"]
     },
-    "include": ["./*.ts", "./shared/*.ts", "../package.json", "./welcome/*.ts"],
+    "include": ["./*.ts", "../package.json", "./welcome/*.ts"],
     "references": [
         {
             "path": "worker"


### PR DESCRIPTION
Theyre are no more shared files, so move the files into vscode and set up a syntax check over there.

That was not possible before as the typescript
compiler would error out on the shared files being outside its root directory.

Fix the errors and warnings the typescript compiler noticed while at it.