### PR TITLE
compiler: Version numbers in SourceFiles

### DIFF
--- a/editors/vscode/src/browser-lsp-worker.ts
+++ b/editors/vscode/src/browser-lsp-worker.ts
@@ -26,7 +26,7 @@ slint_init().then((_) => {
         return await connection.sendRequest(method, params);
     }
 
-    async function load_file(path: string): Promise<string> {
+    async function load_file(path: string): Promise<[string, null | number]> {
         return await connection.sendRequest("slint/load_file", path);
     }
 

--- a/editors/vscode/src/browser-lsp-worker.ts
+++ b/editors/vscode/src/browser-lsp-worker.ts
@@ -9,6 +9,8 @@ import {
     BrowserMessageWriter,
 } from "vscode-languageserver/browser";
 
+export type VersionedFileContents = slint_lsp.VersionedFileContents;
+
 slint_init().then((_) => {
     const reader = new BrowserMessageReader(self);
     const writer = new BrowserMessageWriter(self);
@@ -26,7 +28,7 @@ slint_init().then((_) => {
         return await connection.sendRequest(method, params);
     }
 
-    async function load_file(path: string): Promise<[string, null | number]> {
+    async function load_file(path: string): Promise<VersionedFileContents> {
         return await connection.sendRequest("slint/load_file", path);
     }
 

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -102,7 +102,17 @@ pub struct CompilerConfiguration {
     /// The callback should open the file specified by the given file name and
     /// return an future that provides the text content of the file as output.
     pub open_import_fallback: Option<
-        Rc<dyn Fn(String) -> Pin<Box<dyn Future<Output = Option<std::io::Result<String>>>>>>,
+        Rc<
+            dyn Fn(
+                String,
+            ) -> Pin<
+                Box<
+                    dyn Future<
+                        Output = Option<std::io::Result<(String, diagnostics::SourceFileVersion)>>,
+                    >,
+                >,
+            >,
+        >,
     >,
     /// Callback to map URLs for resources
     ///

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use i_slint_compiler::diagnostics::SourceFileVersion;
 use i_slint_compiler::langtype::Type as LangType;
 use i_slint_core::component_factory::ComponentFactory;
 #[cfg(feature = "internal")]
@@ -800,6 +801,30 @@ impl Compiler {
     /// provided by the `spin_on` crate
     pub async fn build_from_source(&self, source_code: String, path: PathBuf) -> CompilationResult {
         crate::dynamic_item_tree::load(source_code, path, None, self.config.clone()).await
+    }
+
+    /// Compile some .slint code
+    ///
+    /// The `path` argument will be used for diagnostics and to compute relative
+    /// paths while importing.
+    ///
+    /// Any diagnostics produced during the compilation, such as warnings or errors, can be retrieved
+    /// after the call using [`CompilationResult::diagnostics()`].
+    ///
+    /// This function is `async` but in practice, this is only asynchronous if
+    /// [`Self::set_file_loader`] is set and its future is actually asynchronous.
+    /// If that is not used, then it is fine to use a very simple executor, such as the one
+    /// provided by the `spin_on` crate
+    #[doc(hidden)]
+    #[cfg(feature = "internal")]
+    pub async fn build_from_versioned_source(
+        &self,
+        source_code: String,
+        path: PathBuf,
+        version: SourceFileVersion,
+        _: i_slint_core::InternalToken,
+    ) -> CompilationResult {
+        crate::dynamic_item_tree::load(source_code, path, version, self.config.clone()).await
     }
 }
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -579,8 +579,18 @@ impl ComponentCompiler {
                 Box<dyn core::future::Future<Output = Option<std::io::Result<String>>>>,
             > + 'static,
     ) {
-        self.config.open_import_fallback =
-            Some(Rc::new(move |path| file_loader_fallback(Path::new(path.as_str()))));
+        let open_import_fallback = move |file_name: String| -> core::pin::Pin<
+            Box<
+                dyn core::future::Future<
+                    Output = Option<std::io::Result<(String, SourceFileVersion)>>,
+                >,
+            >,
+        > {
+            let flfb = file_loader_fallback(&Path::new(file_name.as_str()));
+            Box::pin(async move { flfb.await.map(|r| r.map(|c| (c, None))) })
+        };
+
+        self.config.open_import_fallback = Some(Rc::new(open_import_fallback));
     }
 
     /// Returns the diagnostics that were produced in the last call to [`Self::build_from_path`] or [`Self::build_from_source`].
@@ -744,8 +754,18 @@ impl Compiler {
                 Box<dyn core::future::Future<Output = Option<std::io::Result<String>>>>,
             > + 'static,
     ) {
-        self.config.open_import_fallback =
-            Some(Rc::new(move |path| file_loader_fallback(Path::new(path.as_str()))));
+        let open_import_fallback = move |file_name: String| -> core::pin::Pin<
+            Box<
+                dyn core::future::Future<
+                    Output = Option<std::io::Result<(String, SourceFileVersion)>>,
+                >,
+            >,
+        > {
+            let flfb = file_loader_fallback(&Path::new(file_name.as_str()));
+            Box::pin(async move { flfb.await.map(|r| r.map(|c| (c, None))) })
+        };
+
+        self.config.open_import_fallback = Some(Rc::new(open_import_fallback));
     }
 
     /// Compile a .slint file

--- a/tools/lsp/common/test.rs
+++ b/tools/lsp/common/test.rs
@@ -20,7 +20,7 @@ async fn parse_source(
     file_loader_fallback: impl Fn(
             &Path,
         ) -> core::pin::Pin<
-            Box<dyn core::future::Future<Output = Option<std::io::Result<String>>>>,
+            Box<dyn core::future::Future<Output = Option<std::io::Result<(String, Option<i32>)>>>>,
         > + 'static,
 ) -> (BuildDiagnostics, common::DocumentCache) {
     let config = {
@@ -101,7 +101,7 @@ pub fn recompile_test_with_sources(
                             "path not found",
                         )));
                     };
-                    Some(Ok(source.clone()))
+                    Some(Ok((source.clone(), Some(23))))
                 } else {
                     Some(Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -490,10 +490,11 @@ async fn handle_preview_to_lsp_message(
                 health,
             );
         }
-        M::Diagnostics { uri, diagnostics } => {
+        M::Diagnostics { uri, version, diagnostics } => {
             crate::common::lsp_to_editor::notify_lsp_diagnostics(
                 &ctx.server_notifier,
                 uri,
+                version,
                 diagnostics,
             );
         }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -313,7 +313,7 @@ fn main_loop(connection: Connection, init_param: InitializeParams, cli_args: Cli
                     )
                 }
             }
-            Some(contents)
+            Some(contents.map(|c| (c, None)))
         })
     }));
 

--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -210,8 +210,8 @@ pub fn notify_diagnostics(diagnostics: &[slint_interpreter::Diagnostic]) -> Opti
 
     let lsp_diags = crate::preview::convert_diagnostics(diagnostics);
 
-    for (url, diagnostics) in lsp_diags {
-        crate::common::lsp_to_editor::notify_lsp_diagnostics(&sender, url, diagnostics)?;
+    for (url, (version, diagnostics)) in lsp_diags {
+        crate::common::lsp_to_editor::notify_lsp_diagnostics(&sender, url, version, diagnostics)?;
     }
     Some(())
 }

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -220,8 +220,12 @@ pub fn notify_diagnostics(diagnostics: &[slint_interpreter::Diagnostic]) -> Opti
     super::set_diagnostics(diagnostics);
     let diags = crate::preview::convert_diagnostics(diagnostics);
 
-    for (uri, diagnostics) in diags {
-        send_message_to_lsp(crate::common::PreviewToLspMessage::Diagnostics { uri, diagnostics });
+    for (uri, (version, diagnostics)) in diags {
+        send_message_to_lsp(crate::common::PreviewToLspMessage::Diagnostics {
+            uri,
+            version,
+            diagnostics,
+        });
     }
     Some(())
 }

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -282,10 +282,11 @@ impl SlintServer {
                     health,
                 );
             }
-            M::Diagnostics { diagnostics, uri } => {
+            M::Diagnostics { diagnostics, version, uri } => {
                 crate::common::lsp_to_editor::notify_lsp_diagnostics(
                     &self.ctx.server_notifier,
                     uri,
+                    version,
                     diagnostics,
                 );
             }

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -149,7 +149,9 @@ impl Drop for ReentryGuardLock {
 
 #[wasm_bindgen(typescript_custom_section)]
 const IMPORT_CALLBACK_FUNCTION_SECTION: &'static str = r#"
-type ImportCallbackFunction = (url: string) => Promise<[string, null | number]>;
+type Version = number | null;
+type VersionedFileContents = [string, Version];
+type ImportCallbackFunction = (url: string) => Promise<VersionedFileContents>;
 type SendRequestFunction = (method: string, r: any) => Promise<any>;
 type HighlightInPreviewFunction = (file: string, offset: number) => void;
 "#;

--- a/tools/slintpad/src/editor_widget.ts
+++ b/tools/slintpad/src/editor_widget.ts
@@ -12,7 +12,7 @@ import {
     editor_position_to_lsp_position,
     lsp_range_to_editor_range,
 } from "./lsp_integration";
-import { Lsp } from "./lsp";
+import { Lsp, Version, VersionedFileContents } from "./lsp";
 import { PositionChangeCallback, VersionedDocumentAndPosition } from "./text";
 import * as github from "./github";
 
@@ -551,7 +551,7 @@ class EditorPaneWidget extends Widget {
     protected async handle_lsp_url_request(
         era: number,
         url: string,
-    ): Promise<[string, null | number]> {
+    ): Promise<VersionedFileContents> {
         if (this.#url_mapper === null) {
             return Promise.reject("Error: Can not resolve URL.");
         }
@@ -579,7 +579,7 @@ class EditorPaneWidget extends Widget {
         uri: monaco.Uri,
         internal_uri: monaco.Uri,
         raise_alert: boolean,
-    ): Promise<[monaco.Uri | null, string, null | number]> {
+    ): Promise<[monaco.Uri | null, string, Version]> {
         let model = monaco.editor.getModel(internal_uri);
         if (model != null) {
             return [model.uri, model.getValue(), model.getVersionId()];
@@ -628,7 +628,7 @@ class EditorPaneWidget extends Widget {
 
     async open_tab_from_url(
         input_url: monaco.Uri,
-    ): Promise<[monaco.Uri | null, string, null | number]> {
+    ): Promise<[monaco.Uri | null, string, Version]> {
         const [url, file_name, mapper] = await github.open_url(
             this.#internal_uuid,
             input_url.toString(),

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -56,7 +56,9 @@ function createLanguageClient(
     return client;
 }
 
-export type FileReader = (_url: string) => Promise<[string, null | number]>;
+export type Version = slint_preview.Version;
+export type VersionedFileContents = slint_preview.VersionedFileContents;
+export type FileReader = (_url: string) => Promise<VersionedFileContents>;
 
 export class LspWaiter {
     #previewer_promise: Promise<slint_preview.InitOutput> | null;
@@ -219,7 +221,7 @@ export class Lsp {
         this.#show_document_callback = cb;
     }
 
-    private read_url(url: string): Promise<[string, null | number]> {
+    private read_url(url: string): Promise<VersionedFileContents> {
         try {
             return this.#file_reader?.(url) ?? Promise.reject();
         } catch (e) {

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -56,7 +56,7 @@ function createLanguageClient(
     return client;
 }
 
-export type FileReader = (_url: string) => Promise<string>;
+export type FileReader = (_url: string) => Promise<[string, null | number]>;
 
 export class LspWaiter {
     #previewer_promise: Promise<slint_preview.InitOutput> | null;
@@ -147,11 +147,11 @@ export class Lsp {
                     const url = (request.params as string[])[0];
 
                     this.read_url(url)
-                        .then((text_contents) => {
+                        .then((contents) => {
                             writer.write({
                                 jsonrpc: request.jsonrpc,
                                 id: request.id,
-                                result: text_contents,
+                                result: contents,
                                 error: undefined,
                             } as ResponseMessage);
                         })
@@ -219,7 +219,7 @@ export class Lsp {
         this.#show_document_callback = cb;
     }
 
-    private read_url(url: string): Promise<string> {
+    private read_url(url: string): Promise<[string, null | number]> {
         try {
             return this.#file_reader?.(url) ?? Promise.reject();
         } catch (e) {

--- a/tools/slintpad/src/worker/lsp_worker.ts
+++ b/tools/slintpad/src/worker/lsp_worker.ts
@@ -29,7 +29,7 @@ slint_init().then(() => {
         return await connection.sendRequest(method, params);
     }
 
-    async function load_file(path: string): Promise<[string, null | number]> {
+    async function load_file(path: string): Promise<slint_lsp.VersionedFileContents> {
         return await connection.sendRequest("slint/load_file", path);
     }
 

--- a/tools/slintpad/src/worker/lsp_worker.ts
+++ b/tools/slintpad/src/worker/lsp_worker.ts
@@ -29,7 +29,7 @@ slint_init().then(() => {
         return await connection.sendRequest(method, params);
     }
 
-    async function load_file(path: string): Promise<string> {
+    async function load_file(path: string): Promise<[string, null | number]> {
         return await connection.sendRequest("slint/load_file", path);
     }
 


### PR DESCRIPTION
We do have version numbers in the `SourceFile`s we generate and pass around for a while now.

Unfortunately those were almost consistently `None`. This PR fixes that.

It is mostly about being able to pass a version number when triggering a compile and about changing the fallback function we have to open files in such a way that it returns the file contents as well as the version.

In all typical cases that version will be `None` (== as on disk), but in the live-preview we can set it to what is in the editor.

An extra patch makes the diagnostics we return contain the version number they refer to. This should (eventually) stop us from showing stale diagnostics.