### PR TITLE
Fix broken Android build caused by missing font field

### DIFF
--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -311,7 +311,7 @@ fn get_fallback_fonts(fontdb: &sharedfontdb::FontDatabase) -> Vec<fontdue::Font>
         target_os = "macos",
         target_os = "ios",
         target_arch = "wasm32",
-	target_os = "android"
+        target_os = "android"
     )))]
     {
         fallback_families.clone_from(&fontdb.fontconfig_fallback_families);

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -310,7 +310,8 @@ fn get_fallback_fonts(fontdb: &sharedfontdb::FontDatabase) -> Vec<fontdue::Font>
         target_family = "windows",
         target_os = "macos",
         target_os = "ios",
-        target_arch = "wasm32"
+        target_arch = "wasm32",
+	target_os = "android"
     )))]
     {
         fallback_families.clone_from(&fontdb.fontconfig_fallback_families);


### PR DESCRIPTION
The code at https://github.com/slint-ui/slint/blob/bcc5327052c75b9b3e1dcb3571657b9b802c9d80/internal/common/sharedfontdb.rs#L14-L21

prevents the field `fontconfig_fallback_families` from being created on Android. But the code in `embed_glyphs.rs` attempts to access this field even on Android. This leads to a build failure.