### PR TITLE
Python: Expose Slint structs

### DIFF
--- a/api/python/Cargo.toml
+++ b/api/python/Cargo.toml
@@ -40,6 +40,7 @@ accessibility = ["slint-interpreter/accessibility"]
 i-slint-backend-selector = { workspace = true }
 i-slint-core = { workspace = true }
 slint-interpreter = { workspace = true, features = ["default", "display-diagnostics", "internal"] }
+i-slint-compiler = { workspace = true }
 pyo3 = { version = "0.21.0", features = ["extension-module", "indexmap", "chrono", "abi3-py310"] }
 indexmap = { version = "2.1.0" }
 chrono = "0.4"

--- a/api/python/README.md
+++ b/api/python/README.md
@@ -266,3 +266,34 @@ When sub-classing `slint.Model`, provide the following methods:
 When adding/inserting rows, call `notify_row_added(row, count)` on the super class. Similarly, removal
 requires notifying Slint by calling `notify_row_removed(row, count)`.
 
+### Structs
+
+Structs declared in Slint and exposed to Python via `export` are accessible in the namespace returned
+when [instantiating a component](#instantiating-a-component).
+
+**`app.slint`**
+
+```slint
+export struct MyData {
+    name: string,
+    age: int
+}
+
+export component MainWindow inherits Window {
+    in-out property <MyData> data;
+}
+```
+
+**`main.py`**
+
+The exported `MyData` struct can be constructed
+
+```python
+import slint
+# Look for for `app.slint` in `sys.path`:
+main_window = slint.loader.app.MainWindow()
+
+data = slint.loader.app.MyData(name = "Simon")
+data.age = 10
+main_window.data = data
+```

--- a/api/python/interpreter.rs
+++ b/api/python/interpreter.rs
@@ -179,6 +179,11 @@ impl CompilationResult {
             .into_iter()
             .collect::<HashMap<String, PyObject>>()
     }
+
+    #[getter]
+    fn named_exports(&self) -> Vec<(String, String)> {
+        self.result.named_exports(i_slint_core::InternalToken {}).cloned().collect::<Vec<_>>()
+    }
 }
 
 #[pyclass(unsendable)]

--- a/api/python/slint/__init__.py
+++ b/api/python/slint/__init__.py
@@ -242,8 +242,14 @@ def load_file(path, quiet=False, style=None, include_paths=None, library_paths=N
         setattr(module, comp_name, wrapper_class)
 
     for name, struct_or_enum_prototype in result.structs_and_enums.items():
+        name = _normalize_prop(name)
         struct_wrapper = _build_struct(name, struct_or_enum_prototype)
         setattr(module, name, struct_wrapper)
+
+    for orig_name, new_name in result.named_exports:
+        orig_name = _normalize_prop(orig_name)
+        new_name = _normalize_prop(new_name)
+        setattr(module, new_name, getattr(module, orig_name))
 
     return module
 

--- a/api/python/tests/test_load_file.py
+++ b/api/python/tests/test_load_file.py
@@ -12,13 +12,21 @@ def test_load_file(caplog):
 
     assert "The property 'color' has been deprecated. Please use 'background' instead" in caplog.text
 
-    assert len(list(module.__dict__.keys())) == 2
+    assert len(list(module.__dict__.keys())) == 3
     assert "App" in module.__dict__
     assert "Diag" in module.__dict__
+    assert "MyData" in module.__dict__
     instance = module.App()
     del instance
     instance = module.Diag()
     del instance
+
+    struct_instance = module.MyData()
+    struct_instance.name = "Test"
+    struct_instance.age = 42
+
+    struct_instance = module.MyData(name="testing")
+    assert struct_instance.name == "testing"
 
 
 def test_load_file_fail():

--- a/api/python/tests/test_load_file.py
+++ b/api/python/tests/test_load_file.py
@@ -12,13 +12,16 @@ def test_load_file(caplog):
 
     assert "The property 'color' has been deprecated. Please use 'background' instead" in caplog.text
 
-    assert len(list(module.__dict__.keys())) == 3
+    assert len(list(module.__dict__.keys())) == 6
     assert "App" in module.__dict__
     assert "Diag" in module.__dict__
+    assert "MyDiag" in module.__dict__
     assert "MyData" in module.__dict__
+    assert "Secret_Struct" in module.__dict__
+    assert "Public_Struct" in module.__dict__
     instance = module.App()
     del instance
-    instance = module.Diag()
+    instance = module.MyDiag()
     del instance
 
     struct_instance = module.MyData()
@@ -27,6 +30,9 @@ def test_load_file(caplog):
 
     struct_instance = module.MyData(name="testing")
     assert struct_instance.name == "testing"
+
+    assert module.Public_Struct is module.Secret_Struct
+    assert module.MyDiag is module.Diag
 
 
 def test_load_file_fail():

--- a/api/python/tests/test_load_file.slint
+++ b/api/python/tests/test_load_file.slint
@@ -13,6 +13,11 @@ export global SecondGlobal {
     out property <string> second: "second";
 }
 
+export struct MyData {
+    name: string,
+    age: int
+}
+
 export component App inherits Window {
     in-out property <string> hello: "World";
     callback say-hello(string) -> string;

--- a/api/python/tests/test_load_file.slint
+++ b/api/python/tests/test_load_file.slint
@@ -15,8 +15,14 @@ export global SecondGlobal {
 
 export struct MyData {
     name: string,
-    age: int
+    age: int,
 }
+
+struct Secret-Struct {
+    balance: int,
+}
+
+export { Secret-Struct as Public-Struct }
 
 export component App inherits Window {
     in-out property <string> hello: "World";
@@ -47,4 +53,6 @@ export component App inherits Window {
     }
 }
 
-export component Diag inherits Window { }
+component Diag inherits Window { }
+
+export { Diag as MyDiag }

--- a/api/python/value.rs
+++ b/api/python/value.rs
@@ -165,6 +165,12 @@ impl PyStruct {
     }
 }
 
+impl From<slint_interpreter::Struct> for PyStruct {
+    fn from(data: slint_interpreter::Struct) -> Self {
+        Self { data }
+    }
+}
+
 #[pyclass(unsendable)]
 struct PyStructFieldIterator {
     inner: std::collections::hash_map::IntoIter<String, slint_interpreter::Value>,

--- a/examples/printerdemo/python/main.py
+++ b/examples/printerdemo/python/main.py
@@ -9,6 +9,8 @@ import copy
 import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
+PrinterQueueItem = slint.loader.ui.printerdemo.PrinterQueueItem
+
 
 class MainWindow(slint.loader.ui.printerdemo.MainWindow):
     def __init__(self):
@@ -32,15 +34,15 @@ class MainWindow(slint.loader.ui.printerdemo.MainWindow):
 
     @slint.callback(global_name="PrinterQueue", name="start_job")
     def push_job(self, title):
-        self.printer_queue.append({
-            "status": "waiting",
-            "progress": 0,
-            "title": title,
-            "owner": "Me",
-            "pages": 1,
-            "size": "100kB",
-            "submission_date": str(datetime.now()),
-        })
+        self.printer_queue.append(PrinterQueueItem(
+            status="waiting",
+            progress=0,
+            title=title,
+            owner="Me",
+            pages=1,
+            size="100kB",
+            submission_date=str(datetime.now()),
+        ))
 
     @slint.callback(global_name="PrinterQueue")
     def cancel_job(self, index):

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -243,6 +243,10 @@ impl Document {
         self.exports.iter().filter_map(|e| e.1.as_ref().left()).filter(|c| !c.is_global()).cloned()
     }
 
+    pub fn exposed_structs_and_enums(&self) -> Vec<Type> {
+        self.used_types.borrow().structs_and_enums.clone()
+    }
+
     /// This is the component that is going to be instantiated by the interpreter
     pub fn last_exported_component(&self) -> Option<Rc<Component>> {
         self.exports

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -243,10 +243,6 @@ impl Document {
         self.exports.iter().filter_map(|e| e.1.as_ref().left()).filter(|c| !c.is_global()).cloned()
     }
 
-    pub fn exposed_structs_and_enums(&self) -> Vec<Type> {
-        self.used_types.borrow().structs_and_enums.clone()
-    }
-
     /// This is the component that is going to be instantiated by the interpreter
     pub fn last_exported_component(&self) -> Option<Rc<Component>> {
         self.exports

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -133,6 +133,7 @@ thiserror = "1"
 document-features = { version = "0.2.0", optional = true }
 spin_on = { workspace = true, optional = true }
 raw-window-handle-06 = { workspace = true, optional = true }
+itertools = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 i-slint-backend-winit = { workspace = true }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -814,6 +814,7 @@ impl Compiler {
                 return CompilationResult {
                     components: HashMap::new(),
                     diagnostics: diagnostics.into_iter().collect(),
+                    #[cfg(feature = "internal")]
                     structs_and_enums: Vec::new(),
                 };
             }
@@ -849,6 +850,7 @@ impl Compiler {
 pub struct CompilationResult {
     pub(crate) components: HashMap<String, ComponentDefinition>,
     pub(crate) diagnostics: Vec<Diagnostic>,
+    #[cfg(feature = "internal")]
     pub(crate) structs_and_enums: Vec<LangType>,
 }
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -816,6 +816,8 @@ impl Compiler {
                     diagnostics: diagnostics.into_iter().collect(),
                     #[cfg(feature = "internal")]
                     structs_and_enums: Vec::new(),
+                    #[cfg(feature = "internal")]
+                    named_exports: Vec::new(),
                 };
             }
         };
@@ -852,6 +854,9 @@ pub struct CompilationResult {
     pub(crate) diagnostics: Vec<Diagnostic>,
     #[cfg(feature = "internal")]
     pub(crate) structs_and_enums: Vec<LangType>,
+    /// For `export { Foo as Bar }` this vec contains tuples of (`Foo`, `Bar`)
+    #[cfg(feature = "internal")]
+    pub(crate) named_exports: Vec<(String, String)>,
 }
 
 impl core::fmt::Debug for CompilationResult {
@@ -911,6 +916,17 @@ impl CompilationResult {
         _: i_slint_core::InternalToken,
     ) -> impl Iterator<Item = &LangType> {
         self.structs_and_enums.iter()
+    }
+
+    /// This is an internal function without API stability guarantees.
+    /// Returns the list of named export aliases as tuples (`export { Foo as Bar}` is (`Foo`, `Bar` tuple)).
+    #[doc(hidden)]
+    #[cfg(feature = "internal")]
+    pub fn named_exports(
+        &self,
+        _: i_slint_core::InternalToken,
+    ) -> impl Iterator<Item = &(String, String)> {
+        self.named_exports.iter()
     }
 }
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -814,6 +814,7 @@ impl Compiler {
                 return CompilationResult {
                     components: HashMap::new(),
                     diagnostics: diagnostics.into_iter().collect(),
+                    structs_and_enums: Vec::new(),
                 };
             }
         };
@@ -848,6 +849,7 @@ impl Compiler {
 pub struct CompilationResult {
     pub(crate) components: HashMap<String, ComponentDefinition>,
     pub(crate) diagnostics: Vec<Diagnostic>,
+    pub(crate) structs_and_enums: Vec<LangType>,
 }
 
 impl core::fmt::Debug for CompilationResult {
@@ -897,6 +899,16 @@ impl CompilationResult {
     /// If the component does not exist, then `None` is returned.
     pub fn component(&self, name: &str) -> Option<ComponentDefinition> {
         self.components.get(name).cloned()
+    }
+
+    /// This is an internal function without and ABI or API stability guarantees.
+    #[doc(hidden)]
+    #[cfg(feature = "internal")]
+    pub fn structs_and_enums(
+        &self,
+        _: i_slint_core::InternalToken,
+    ) -> impl Iterator<Item = &LangType> {
+        self.structs_and_enums.iter()
     }
 }
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -903,7 +903,7 @@ impl CompilationResult {
         self.components.get(name).cloned()
     }
 
-    /// This is an internal function without and ABI or API stability guarantees.
+    /// This is an internal function without API stability guarantees.
     #[doc(hidden)]
     #[cfg(feature = "internal")]
     pub fn structs_and_enums(

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -875,11 +875,14 @@ pub async fn load(
         diag.push_error_with_span("No component found".into(), Default::default());
     };
 
+    #[cfg(feature = "internal")]
+    let structs_and_enums = doc.used_types.borrow().structs_and_enums.clone();
+
     CompilationResult {
         diagnostics: diag.into_iter().collect(),
         components,
         #[cfg(feature = "internal")]
-        structs_and_enums: doc.exposed_structs_and_enums(),
+        structs_and_enums,
     }
 }
 

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -844,6 +844,7 @@ pub async fn load(
         return CompilationResult {
             components: HashMap::new(),
             diagnostics: diag.into_iter().collect(),
+            structs_and_enums: Vec::new(),
         };
     }
 
@@ -873,7 +874,11 @@ pub async fn load(
         diag.push_error_with_span("No component found".into(), Default::default());
     };
 
-    CompilationResult { diagnostics: diag.into_iter().collect(), components }
+    CompilationResult {
+        diagnostics: diag.into_iter().collect(),
+        components,
+        structs_and_enums: doc.exposed_structs_and_enums(),
+    }
 }
 
 pub(crate) fn generate_item_tree<'id>(

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -844,6 +844,7 @@ pub async fn load(
         return CompilationResult {
             components: HashMap::new(),
             diagnostics: diag.into_iter().collect(),
+            #[cfg(feature = "internal")]
             structs_and_enums: Vec::new(),
         };
     }
@@ -877,6 +878,7 @@ pub async fn load(
     CompilationResult {
         diagnostics: diag.into_iter().collect(),
         components,
+        #[cfg(feature = "internal")]
         structs_and_enums: doc.exposed_structs_and_enums(),
     }
 }


### PR DESCRIPTION
Structs declared and exported in Slint are now available in the module namespace with a constructor.

Fixes #5708