### PR TITLE
Tab with modifier shouldn't change focus

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -684,14 +684,17 @@ impl WindowInner {
         }
 
         // Make Tab/Backtab handle keyboard focus
+        let extra_mod = event.modifiers.control || event.modifiers.meta || event.modifiers.alt;
         if event.text.starts_with(key_codes::Tab)
             && !event.modifiers.shift
+            && !extra_mod
             && event.event_type == KeyEventType::KeyPressed
         {
             self.focus_next_item();
         } else if (event.text.starts_with(key_codes::Backtab)
             || (event.text.starts_with(key_codes::Tab) && event.modifiers.shift))
             && event.event_type == KeyEventType::KeyPressed
+            && !extra_mod
         {
             self.focus_previous_item();
         }

--- a/tests/cases/focus/focus_change_event.slint
+++ b/tests/cases/focus/focus_change_event.slint
@@ -19,12 +19,22 @@ TestCase := Rectangle {
 
 /*
 ```rust
+use slint::platform::Key;
+
 let instance = TestCase::new().unwrap();
 assert!(!instance.get_scope_focused());
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert!(instance.get_scope_focused());
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert!(!instance.get_scope_focused());
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert!(instance.get_scope_focused());
+
+// alt-tab don't change focus
+slint_testing::send_keyboard_char(&instance, Key::Alt.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+slint_testing::send_keyboard_char(&instance, Key::Alt.into(), false);
+assert!(instance.get_scope_focused());
 ```
 
 ```cpp
@@ -35,6 +45,8 @@ slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert(instance.get_scope_focused());
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert(!instance.get_scope_focused());
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert(instance.get_scope_focused());
 ```
 
 ```js
@@ -44,5 +56,7 @@ slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
 assert(instance.scope_focused);
 slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
 assert(!instance.scope_focused);
+slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
+assert(instance.scope_focused);
 ```
 */

--- a/tests/cases/focus/keyboard_focus.slint
+++ b/tests/cases/focus/keyboard_focus.slint
@@ -138,6 +138,33 @@ assert_eq!(instance.get_result(), "B:2.1:1.789:2.0:1.456:T:");
 slint_testing::send_keyboard_string_sequence(&instance, "\u{0019}");
 slint_testing::send_keyboard_string_sequence(&instance, "X");
 assert_eq!(instance.get_result(), "B:2.1:1.789:2.0:1.456:T:B:");
+
+// With modifiers
+use slint::platform::Key;
+instance.set_result("".into());
+assert_eq!(instance.get_result(), "");
+// shift + \t = backwards
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
+slint_testing::send_keyboard_string_sequence(&instance, "X");
+assert_eq!(instance.get_result(), "2.1:");
+// alt + \t = nothing
+slint_testing::send_keyboard_char(&instance, Key::Alt.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+slint_testing::send_keyboard_char(&instance, Key::Alt.into(), false);
+slint_testing::send_keyboard_string_sequence(&instance, "X");
+assert_eq!(instance.get_result(), "2.1:2.1:");
+// ctrl + shift + \t = nothing
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), false);
+slint_testing::send_keyboard_string_sequence(&instance, "X");
+assert_eq!(instance.get_result(), "2.1:2.1:2.1:");
+
+
 ```
 
 ```cpp


### PR DESCRIPTION
(eg: alt+tab or control+tab)
Failed attempt at fixing #5823
This doesn't fixes it because the problem is that the key event are forwareded as syntetic events when we gain focus, and they are not in a order that allow to detect alt+tab