### PR TITLE
core: Do not panic when popups try to find their parent

### DIFF
--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -527,7 +527,8 @@ impl ItemRc {
 
                 let subtree_index = match parent_item_tree.get(parent_item_index)? {
                     crate::item_tree::ItemTreeNode::Item { .. } => {
-                        panic!("Got an Item, expected a repeater!")
+                        // Popups can trigger this case!
+                        return None;
                     }
                     crate::item_tree::ItemTreeNode::DynamicTree { index, .. } => *index,
                 };


### PR DESCRIPTION
Popups may have normal `Item`s as parrent, while all the other
components always have a `DynamicTree` as a parent. So do not
panic when some component ends up with an `Item` as a parent.

Just return `None` instead of panicing.

We probably need to make the focus-handling more aware of
popups eventually, but this stops the panics.

Fixes: #5826, #5830