### PR TITLE
live-preview: Remove history navigation

### DIFF
--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -67,8 +67,6 @@ pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, Platfor
     api.on_selected_element_move(super::move_selected_element);
     api.on_selected_element_delete(super::delete_selected_element);
 
-    api.on_navigate(super::navigate);
-
     api.on_test_binding(super::test_binding);
     api.on_set_binding(super::set_binding);
     api.on_test_simple_binding(super::test_simple_binding);

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -138,10 +138,6 @@ export global Api {
     in property <[string]> known-styles; // All the known styles
     in-out property <string> current-style; // The current style
 
-    // ## History Navigation    
-    in property <bool> can-navigate-back: false;
-    in property <bool> can-navigate-forward: false;
-
     // ## Drawing Area
     in property <[Selection]> selections; // Borders around things
     in-out property <DropMark> drop-mark;
@@ -154,9 +150,6 @@ export global Api {
 
     // ## Style:
     callback style-changed();
-
-    // ## Histroy Navigation
-    callback navigate(int);
 
     // ## Component life-cycle:
 


### PR DESCRIPTION
We apparently do not want history-based navigation, so remove the code supporting that again.