### PR TITLE
live-preview: Use preferred size when requesting preview

### DIFF
--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -143,6 +143,8 @@ export global Api {
     in-out property <DropMark> drop-mark;
     in property <component-factory> preview-area; // The actual preview
 
+    in property <bool> resize-to-preferred-size: false; // set to true to resize
+    
     // ## Property Editor
     in property <ElementInformation> current-element;
 

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -215,6 +215,15 @@ export component PreviewView {
                     }
                 }
 
+                if Api.resize-to-preferred-size: Rectangle {
+                    init => {
+                        preview-area-container.width = clamp(preview-area-container.preferred-width, max(preview-area-container.min-width, 16px), max(preview-area-container.max-width, 16px));
+                        preview-area-container.height = clamp(preview-area-container.preferred-height, max(preview-area-container.min-height, 16px),  max(preview-area-container.max-height, 16px));
+
+                        Api.resize-to-preferred-size = false;
+                    }
+                }
+
                 preview-area-container := ComponentContainer {
                     property <bool> is-resizable: (self.min-width != self.max-width && self.min-height != self.max-height) && self.has-component;
 


### PR DESCRIPTION
Force the preview to preferred size when explicitly asking to preview something.