### PR TITLE
Fix `TextEdit` not invoking `edited` callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Widgets
+
+ - Fixed `TextEdit` not invoking `edited` callbacks (#5848).
+
 ## [1.7.2] - 2024-08-14
 
 ### General

--- a/internal/compiler/widgets/cosmic-base/textedit.slint
+++ b/internal/compiler/widgets/cosmic-base/textedit.slint
@@ -21,7 +21,7 @@ export component TextEdit {
     in-out property <length> viewport-width <=> base.viewport-width;
     in-out property <length> viewport-height <=> base.viewport-height;
 
-    callback edited(/* text */ string);
+    callback edited <=> base.edited;
     accessible-role: AccessibleRole.text-input;
     accessible-value <=> text;
     accessible-placeholder-text: text == "" ? placeholder-text : "";

--- a/internal/compiler/widgets/fluent-base/textedit.slint
+++ b/internal/compiler/widgets/fluent-base/textedit.slint
@@ -21,7 +21,7 @@ export component TextEdit {
     in-out property <length> viewport-width <=> base.viewport-width;
     in-out property <length> viewport-height <=> base.viewport-height;
 
-    callback edited(/* text */ string);
+    callback edited <=> base.edited;
     accessible-role: AccessibleRole.text-input;
     accessible-value <=> text;
     accessible-placeholder-text: text == "" ? placeholder-text : "";

--- a/internal/compiler/widgets/material-base/textedit.slint
+++ b/internal/compiler/widgets/material-base/textedit.slint
@@ -21,7 +21,7 @@ export component TextEdit {
     in-out property <length> viewport-width <=> base.viewport-width;
     in-out property <length> viewport-height <=> base.viewport-height;
 
-    callback edited(/* text */ string);
+    callback edited <=> base.edited;
     accessible-role: AccessibleRole.text-input;
     accessible-value <=> text;
     accessible-placeholder-text: text == "" ? placeholder-text : "";

--- a/internal/compiler/widgets/qt/textedit.slint
+++ b/internal/compiler/widgets/qt/textedit.slint
@@ -20,7 +20,7 @@ export component TextEdit {
     in-out property <length> viewport-width <=> base.viewport-width;
     in-out property <length> viewport-height <=> base.viewport-height;
 
-    callback edited(/* text */ string);
+    callback edited <=> base.edited;
     accessible-role: AccessibleRole.text-input;
     accessible-value <=> text;
     accessible-placeholder-text: text == "" ? placeholder-text : "";

--- a/tests/cases/widgets/textedit.slint
+++ b/tests/cases/widgets/textedit.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+
+import { TextEdit } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    edit := TextEdit {
+        width: 100%;
+        height: 100%;
+    }
+
+    forward-focus: edit;
+    out property <bool> textedit-focused <=> edit.has_focus;
+    callback edited <=> edit.edited;
+}
+
+/*
+
+
+```rust
+use std::cell::RefCell;
+use std::rc::Rc;
+
+let instance = TestCase::new().unwrap();
+
+let edits = Rc::new(RefCell::new(Vec::new()));
+instance.on_edited({
+    let edits = edits.clone();
+    move |val| {
+    edits.borrow_mut().push(val);
+}});
+
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_textedit_focused());
+assert!(edits.borrow().is_empty());
+
+slint_testing::send_keyboard_string_sequence(&instance, "hello");
+assert_eq!(edits.borrow().clone(), vec!["h", "he", "hel", "hell", "hello"]);
+```
+
+*/


### PR DESCRIPTION
Fixes #5848