### PR TITLE
vscode: selection in wasm preview should show the text document on a …

### DIFF
--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -17,6 +17,10 @@ function use_wasm_preview(): boolean {
         .get("preview.providedByEditor", false);
 }
 
+export function panel(): vscode.WebviewPanel | null {
+    return previewPanel;
+}
+
 export function update_configuration() {
     if (language_client) {
         send_to_lsp({


### PR DESCRIPTION
…different side

highjack the code to show the text document when we detect it comes from the preview panel, in order to not show the code in the active panel, but to the left of it (or to the right when the preview is already to the left)