### PR TITLE
Rework the version handling inside the LSP to not need infrastructure in the compiler

### DIFF
--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -62,8 +62,6 @@ pub trait Spanned {
     }
 }
 
-pub type SourceFileVersion = Option<i32>;
-
 #[derive(Default)]
 pub struct SourceFileInner {
     path: PathBuf,
@@ -73,21 +71,17 @@ pub struct SourceFileInner {
 
     /// The offset of each linebreak
     line_offsets: once_cell::unsync::OnceCell<Vec<usize>>,
-
-    /// The version of the source file. `None` means "as seen on disk"
-    version: SourceFileVersion,
 }
 
 impl std::fmt::Debug for SourceFileInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let v = if let Some(v) = self.version { format!("@{v}") } else { String::new() };
-        write!(f, "{:?}{v}", self.path)
+        write!(f, "{:?}", self.path)
     }
 }
 
 impl SourceFileInner {
-    pub fn new(path: PathBuf, source: String, version: SourceFileVersion) -> Self {
-        Self { path, source: Some(source), line_offsets: Default::default(), version }
+    pub fn new(path: PathBuf, source: String) -> Self {
+        Self { path, source: Some(source), line_offsets: Default::default() }
     }
 
     pub fn path(&self) -> &Path {
@@ -153,10 +147,6 @@ impl SourceFileInner {
 
     pub fn source(&self) -> Option<&str> {
         self.source.as_deref()
-    }
-
-    pub fn version(&self) -> SourceFileVersion {
-        self.version
     }
 }
 
@@ -590,7 +580,7 @@ component MainWindow inherits Window {
 
 
     "#.to_string();
-        let sf = SourceFileInner::new(PathBuf::from("foo.slint"), content.clone(), None);
+        let sf = SourceFileInner::new(PathBuf::from("foo.slint"), content.clone());
 
         let mut line = 1;
         let mut column = 1;

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -312,7 +312,6 @@ pub async fn compile_syntax_node(
 /// a set of `BuildDiagnostics` and a `TypeLoader` with all compilation passes applied.
 pub async fn load_root_file(
     path: &Path,
-    version: diagnostics::SourceFileVersion,
     source_path: &Path,
     source_code: String,
     mut diagnostics: diagnostics::BuildDiagnostics,
@@ -320,9 +319,8 @@ pub async fn load_root_file(
 ) -> (std::path::PathBuf, diagnostics::BuildDiagnostics, typeloader::TypeLoader) {
     let mut loader = prepare_for_compile(&mut diagnostics, compiler_config);
 
-    let (path, _) = loader
-        .load_root_file(path, version, source_path, source_code, false, &mut diagnostics)
-        .await;
+    let (path, _) =
+        loader.load_root_file(path, source_path, source_code, false, &mut diagnostics).await;
 
     (path, diagnostics, loader)
 }
@@ -335,7 +333,6 @@ pub async fn load_root_file(
 /// applied and another `TypeLoader` with a minimal set of passes applied to it.
 pub async fn load_root_file_with_raw_type_loader(
     path: &Path,
-    version: diagnostics::SourceFileVersion,
     source_path: &Path,
     source_code: String,
     mut diagnostics: diagnostics::BuildDiagnostics,
@@ -348,9 +345,8 @@ pub async fn load_root_file_with_raw_type_loader(
 ) {
     let mut loader = prepare_for_compile(&mut diagnostics, compiler_config);
 
-    let (path, raw_type_loader) = loader
-        .load_root_file(path, version, source_path, source_code, true, &mut diagnostics)
-        .await;
+    let (path, raw_type_loader) =
+        loader.load_root_file(path, source_path, source_code, true, &mut diagnostics).await;
 
     (path, diagnostics, loader, raw_type_loader)
 }

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -22,7 +22,7 @@ use crate::typeregister::TypeRegister;
 /// At this point, it really should already contain the basic Types (string, int, ...)
 pub(crate) fn load_builtins(register: &mut TypeRegister) {
     let mut diag = crate::diagnostics::BuildDiagnostics::default();
-    let node = crate::parser::parse(include_str!("builtins.slint").into(), None, None, &mut diag);
+    let node = crate::parser::parse(include_str!("builtins.slint").into(), None, &mut diag);
     if !diag.is_empty() {
         let vec = diag.to_string_vec();
         #[cfg(feature = "display-diagnostics")]

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -12,7 +12,7 @@ This module has different sub modules with the actual parser functions
 
 */
 
-use crate::diagnostics::{BuildDiagnostics, SourceFile, SourceFileVersion, Spanned};
+use crate::diagnostics::{BuildDiagnostics, SourceFile, Spanned};
 pub use smol_str::SmolStr;
 use std::fmt::Display;
 
@@ -976,14 +976,12 @@ pub fn normalize_identifier(ident: &str) -> String {
 pub fn parse(
     source: String,
     path: Option<&std::path::Path>,
-    version: SourceFileVersion,
     build_diagnostics: &mut BuildDiagnostics,
 ) -> SyntaxNode {
     let mut p = DefaultParser::new(&source, build_diagnostics);
     p.source_file = std::rc::Rc::new(crate::diagnostics::SourceFileInner::new(
         path.map(crate::pathutils::clean_path).unwrap_or_default(),
         source,
-        version,
     ));
     document::parse_document(&mut p);
     SyntaxNode {
@@ -1000,7 +998,7 @@ pub fn parse_file<P: AsRef<std::path::Path>>(
     let source = crate::diagnostics::load_from_path(&path)
         .map_err(|d| build_diagnostics.push_internal_error(d))
         .ok()?;
-    Some(parse(source, Some(path.as_ref()), None, build_diagnostics))
+    Some(parse(source, Some(path.as_ref()), build_diagnostics))
 }
 
 pub fn parse_tokens(

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -217,7 +217,6 @@ export component Foo {
 "#
         .into(),
         Some(std::path::Path::new("HELLO")),
-        None,
         &mut test_diags,
     );
     let (doc, diag, _) =

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -480,7 +480,6 @@ fn test_no_property_for_100pc() {
 "#
         .into(),
         Some(std::path::Path::new("HELLO")),
-        None,
         &mut test_diags,
     );
     let (doc, diag, _) =

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -184,7 +184,7 @@ fn process_file_source(
 ) -> std::io::Result<bool> {
     let mut parse_diagnostics = i_slint_compiler::diagnostics::BuildDiagnostics::default();
     let syntax_node =
-        i_slint_compiler::parser::parse(source.clone(), Some(path), None, &mut parse_diagnostics);
+        i_slint_compiler::parser::parse(source.clone(), Some(path), &mut parse_diagnostics);
 
     let has_parse_error = parse_diagnostics.has_errors();
     let mut compiler_config = i_slint_compiler::CompilerConfiguration::new(

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -618,8 +618,7 @@ impl ComponentCompiler {
             }
         };
 
-        let r =
-            crate::dynamic_item_tree::load(source, path.into(), None, self.config.clone()).await;
+        let r = crate::dynamic_item_tree::load(source, path.into(), self.config.clone()).await;
         self.diagnostics = r.diagnostics.into_iter().collect();
         r.components.into_values().next()
     }
@@ -645,7 +644,7 @@ impl ComponentCompiler {
         source_code: String,
         path: PathBuf,
     ) -> Option<ComponentDefinition> {
-        let r = crate::dynamic_item_tree::load(source_code, path, None, self.config.clone()).await;
+        let r = crate::dynamic_item_tree::load(source_code, path, self.config.clone()).await;
         self.diagnostics = r.diagnostics.into_iter().collect();
         r.components.into_values().next()
     }
@@ -783,7 +782,7 @@ impl Compiler {
             }
         };
 
-        crate::dynamic_item_tree::load(source, path.into(), None, self.config.clone()).await
+        crate::dynamic_item_tree::load(source, path.into(), self.config.clone()).await
     }
 
     /// Compile some .slint code
@@ -799,7 +798,7 @@ impl Compiler {
     /// If that is not used, then it is fine to use a very simple executor, such as the one
     /// provided by the `spin_on` crate
     pub async fn build_from_source(&self, source_code: String, path: PathBuf) -> CompilationResult {
-        crate::dynamic_item_tree::load(source_code, path, None, self.config.clone()).await
+        crate::dynamic_item_tree::load(source_code, path, self.config.clone()).await
     }
 }
 

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -6,7 +6,6 @@ use crate::global_component::CompiledGlobalCollection;
 use crate::{dynamic_type, eval};
 use core::ptr::NonNull;
 use dynamic_type::{Instance, InstanceBox};
-use i_slint_compiler::diagnostics::SourceFileVersion;
 use i_slint_compiler::expression_tree::{Expression, NamedReference};
 use i_slint_compiler::langtype::Type;
 use i_slint_compiler::object_tree::ElementRc;
@@ -813,7 +812,6 @@ fn rtti_for<T: 'static + Default + rtti::BuiltinItem + vtable::HasStaticVTable<I
 pub async fn load(
     source: String,
     path: std::path::PathBuf,
-    version: SourceFileVersion,
     mut compiler_config: CompilerConfiguration,
 ) -> CompilationResult {
     // If the native style should be Qt, resolve it here as we know that we have it
@@ -833,7 +831,6 @@ pub async fn load(
     let (path, mut diag, loader, raw_type_loader) =
         i_slint_compiler::load_root_file_with_raw_type_loader(
             &path,
-            version,
             &path,
             source,
             diag,
@@ -842,8 +839,7 @@ pub async fn load(
         .await;
     #[cfg(not(feature = "highlight"))]
     let (path, mut diag, loader) =
-        i_slint_compiler::load_root_file(&path, version, &path, source, diag, compiler_config)
-            .await;
+        i_slint_compiler::load_root_file(&path, &path, source, diag, compiler_config).await;
     if diag.has_errors() {
         return CompilationResult {
             components: HashMap::new(),

--- a/tests/driver/cpp/cppdriver.rs
+++ b/tests/driver/cpp/cppdriver.rs
@@ -19,7 +19,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
     let cpp_namespace = test_driver_lib::extract_cpp_namespace(&source);
 
     let mut diag = BuildDiagnostics::default();
-    let syntax_node = parser::parse(source.clone(), Some(&testcase.absolute_path), None, &mut diag);
+    let syntax_node = parser::parse(source.clone(), Some(&testcase.absolute_path), &mut diag);
     let output_format = generator::OutputFormat::Cpp(generator::cpp::Config {
         namespace: cpp_namespace,
         ..Default::default()

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -134,8 +134,7 @@ fn generate_source(
         .collect::<std::collections::HashMap<_, _>>();
 
     let mut diag = BuildDiagnostics::default();
-    let syntax_node =
-        parser::parse(source.to_owned(), Some(&testcase.absolute_path), None, &mut diag);
+    let syntax_node = parser::parse(source.to_owned(), Some(&testcase.absolute_path), &mut diag);
     let mut compiler_config = CompilerConfiguration::new(generator::OutputFormat::Rust);
     compiler_config.enable_experimental = true;
     compiler_config.include_paths = include_paths;

--- a/tests/screenshots/build.rs
+++ b/tests/screenshots/build.rs
@@ -159,8 +159,7 @@ fn generate_source(
         .collect::<Vec<_>>();
 
     let mut diag = BuildDiagnostics::default();
-    let syntax_node =
-        parser::parse(source.to_owned(), Some(&testcase.absolute_path), None, &mut diag);
+    let syntax_node = parser::parse(source.to_owned(), Some(&testcase.absolute_path), &mut diag);
     let mut compiler_config = CompilerConfiguration::new(generator::OutputFormat::Rust);
     compiler_config.include_paths = include_paths;
     compiler_config.embed_resources = EmbedResourcesKind::EmbedTextures;

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -3,18 +3,17 @@
 
 //! Data structures common between LSP and previewer
 
-use i_slint_compiler::diagnostics::{BuildDiagnostics, SourceFile};
-use i_slint_compiler::object_tree::{Document, ElementRc};
+use i_slint_compiler::diagnostics::SourceFile;
+use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{syntax_nodes, SyntaxKind, SyntaxNode};
-use i_slint_compiler::typeloader::TypeLoader;
-use i_slint_compiler::typeregister::TypeRegister;
-use i_slint_compiler::CompilerConfiguration;
 use lsp_types::{TextEdit, Url, WorkspaceEdit};
 
 use std::path::Path;
 use std::{collections::HashMap, path::PathBuf};
 
 pub mod component_catalog;
+pub mod document_cache;
+pub use document_cache::{DocumentCache, SourceFileVersion};
 pub mod rename_component;
 #[cfg(test)]
 pub mod test;
@@ -25,8 +24,6 @@ pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
-
-pub type SourceFileVersion = Option<i32>;
 
 /// Use this in nodes you want the language server and preview to
 /// ignore a node for code analysis purposes.
@@ -57,193 +54,6 @@ pub fn file_to_uri(path: &Path) -> Option<Url> {
         Url::parse(path.to_str()?).ok()
     } else {
         Url::from_file_path(path).ok()
-    }
-}
-
-/// A cache of loaded documents
-pub struct DocumentCache(TypeLoader);
-
-impl DocumentCache {
-    pub fn new(config: CompilerConfiguration) -> Self {
-        Self(TypeLoader::new(
-            i_slint_compiler::typeregister::TypeRegister::builtin(),
-            config,
-            &mut BuildDiagnostics::default(),
-        ))
-    }
-
-    pub fn new_from_type_loader(type_loader: TypeLoader) -> Self {
-        Self(type_loader)
-    }
-
-    pub fn snapshot(&self) -> Option<Self> {
-        i_slint_compiler::typeloader::snapshot(&self.0).map(Self::new_from_type_loader)
-    }
-
-    pub fn resolve_import_path(
-        &self,
-        import_token: Option<&i_slint_compiler::parser::NodeOrToken>,
-        maybe_relative_path_or_url: &str,
-    ) -> Option<(PathBuf, Option<&'static [u8]>)> {
-        self.0.resolve_import_path(import_token, maybe_relative_path_or_url)
-    }
-
-    pub fn document_version(&self, target_uri: &Url) -> SourceFileVersion {
-        self.document_version_by_path(&uri_to_file(target_uri).unwrap_or_default())
-    }
-
-    pub fn document_version_by_path(&self, path: &Path) -> SourceFileVersion {
-        self.0.get_document(&path).and_then(|doc| doc.node.as_ref()?.source_file.version())
-    }
-
-    pub fn get_document<'a>(&'a self, url: &'_ Url) -> Option<&'a Document> {
-        let path = uri_to_file(url)?;
-        self.0.get_document(&path)
-    }
-
-    pub fn get_document_by_path<'a>(&'a self, path: &'_ Path) -> Option<&'a Document> {
-        self.0.get_document(path)
-    }
-
-    pub fn get_document_for_source_file<'a>(
-        &'a self,
-        source_file: &'_ SourceFile,
-    ) -> Option<&'a Document> {
-        self.0.get_document(source_file.path())
-    }
-
-    pub fn get_document_and_offset<'a>(
-        &'a self,
-        text_document_uri: &'_ Url,
-        pos: &'_ lsp_types::Position,
-    ) -> Option<(&'a i_slint_compiler::object_tree::Document, u32)> {
-        let doc = self.get_document(text_document_uri)?;
-        let o = doc
-            .node
-            .as_ref()?
-            .source_file
-            .offset(pos.line as usize + 1, pos.character as usize + 1) as u32;
-        doc.node.as_ref()?.text_range().contains_inclusive(o.into()).then_some((doc, o))
-    }
-
-    pub fn all_url_documents(&self) -> impl Iterator<Item = (Url, &Document)> + '_ {
-        self.0.all_file_documents().filter_map(|(p, d)| Some((file_to_uri(p)?, d)))
-    }
-
-    pub fn all_urls(&self) -> impl Iterator<Item = Url> + '_ {
-        self.0.all_files().filter_map(|p| file_to_uri(p))
-    }
-
-    pub fn global_type_registry(&self) -> std::cell::Ref<TypeRegister> {
-        self.0.global_type_registry.borrow()
-    }
-
-    pub async fn reconfigure(
-        &mut self,
-        style: Option<String>,
-        include_paths: Option<Vec<PathBuf>>,
-        library_paths: Option<HashMap<String, PathBuf>>,
-    ) -> Result<CompilerConfiguration> {
-        if style.is_none() && include_paths.is_none() && library_paths.is_none() {
-            return Ok(self.0.compiler_config.clone());
-        }
-
-        if let Some(s) = style {
-            if s.is_empty() {
-                self.0.compiler_config.style = None;
-            } else {
-                self.0.compiler_config.style = Some(s);
-            }
-        }
-
-        if let Some(ip) = include_paths {
-            self.0.compiler_config.include_paths = ip;
-        }
-
-        if let Some(lp) = library_paths {
-            self.0.compiler_config.library_paths = lp;
-        }
-
-        self.preload_builtins().await;
-
-        Ok(self.0.compiler_config.clone())
-    }
-
-    pub async fn preload_builtins(&mut self) {
-        // Always load the widgets so we can auto-complete them
-        let mut diag = BuildDiagnostics::default();
-        self.0.import_component("std-widgets.slint", "StyleMetrics", &mut diag).await;
-        assert!(!diag.has_errors());
-    }
-
-    pub async fn load_url(
-        &mut self,
-        url: &Url,
-        version: SourceFileVersion,
-        content: String,
-        diag: &mut BuildDiagnostics,
-    ) -> Result<()> {
-        let path = uri_to_file(url).ok_or("Failed to convert path")?;
-        self.0.load_file(&path, version, &path, content, false, diag).await;
-        Ok(())
-    }
-
-    pub fn compiler_configuration(&self) -> &CompilerConfiguration {
-        &self.0.compiler_config
-    }
-
-    fn element_at_document_and_offset(
-        &self,
-        document: &i_slint_compiler::object_tree::Document,
-        offset: u32,
-    ) -> Option<ElementRcNode> {
-        fn element_contains(
-            element: &i_slint_compiler::object_tree::ElementRc,
-            offset: u32,
-        ) -> Option<usize> {
-            element.borrow().debug.iter().position(|n| {
-                n.node.parent().map_or(false, |n| n.text_range().contains(offset.into()))
-            })
-        }
-
-        for component in &document.inner_components {
-            let root_element = component.root_element.clone();
-            let Some(root_debug_index) = element_contains(&root_element, offset) else {
-                continue;
-            };
-
-            let mut element =
-                ElementRcNode { element: root_element, debug_index: root_debug_index };
-            while element.contains_offset(offset) {
-                if let Some((c, i)) = element
-                    .element
-                    .clone()
-                    .borrow()
-                    .children
-                    .iter()
-                    .find_map(|c| element_contains(c, offset).map(|i| (c, i)))
-                {
-                    element = ElementRcNode { element: c.clone(), debug_index: i };
-                } else {
-                    return Some(element);
-                }
-            }
-        }
-        None
-    }
-
-    pub fn element_at_offset(&self, text_document_uri: &Url, offset: u32) -> Option<ElementRcNode> {
-        let doc = self.get_document(text_document_uri)?;
-        self.element_at_document_and_offset(doc, offset)
-    }
-
-    pub fn element_at_position(
-        &self,
-        text_document_uri: &Url,
-        pos: &lsp_types::Position,
-    ) -> Option<ElementRcNode> {
-        let (doc, offset) = self.get_document_and_offset(text_document_uri, pos)?;
-        self.element_at_document_and_offset(doc, offset)
     }
 }
 
@@ -804,8 +614,6 @@ pub mod lsp_to_editor {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::complex_document_cache;
-
     use super::*;
 
     #[test]
@@ -834,71 +642,5 @@ mod tests {
         assert_eq!(back_conversion1, back_conversion3);
 
         assert_eq!(back_conversion1, builtin_path1);
-    }
-
-    fn id_at_position(dc: &DocumentCache, url: &Url, line: u32, character: u32) -> Option<String> {
-        let result = dc.element_at_position(url, &lsp_types::Position { line, character })?;
-        let element = result.element.borrow();
-        Some(element.id.clone())
-    }
-
-    fn base_type_at_position(
-        dc: &DocumentCache,
-        url: &Url,
-        line: u32,
-        character: u32,
-    ) -> Option<String> {
-        let result = dc.element_at_position(url, &lsp_types::Position { line, character })?;
-        let element = result.element.borrow();
-        Some(format!("{}", &element.base_type))
-    }
-
-    #[test]
-    fn test_element_at_position_no_element() {
-        let (dc, url, _) = complex_document_cache();
-        assert_eq!(id_at_position(&dc, &url, 0, 10), None);
-        // TODO: This is past the end of the line and should thus return None
-        assert_eq!(id_at_position(&dc, &url, 42, 90), Some(String::new()));
-        assert_eq!(id_at_position(&dc, &url, 1, 0), None);
-        assert_eq!(id_at_position(&dc, &url, 55, 1), None);
-        assert_eq!(id_at_position(&dc, &url, 56, 5), None);
-    }
-
-    #[test]
-    fn test_element_at_position_no_such_document() {
-        let (dc, _, _) = complex_document_cache();
-        assert_eq!(id_at_position(&dc, &Url::parse("https://foo.bar/baz").unwrap(), 5, 0), None);
-    }
-
-    #[test]
-    fn test_element_at_position_root() {
-        let (dc, url, _) = complex_document_cache();
-
-        assert_eq!(id_at_position(&dc, &url, 2, 30), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 2, 32), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 2, 42), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 3, 0), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 3, 53), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 4, 19), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 5, 0), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 6, 8), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 6, 15), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 6, 23), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 8, 15), Some("root".to_string()));
-        assert_eq!(id_at_position(&dc, &url, 12, 3), Some("root".to_string())); // right before child // TODO: Seems wrong!
-        assert_eq!(id_at_position(&dc, &url, 51, 5), Some("root".to_string())); // right after child // TODO: Why does this not work?
-        assert_eq!(id_at_position(&dc, &url, 52, 0), Some("root".to_string()));
-    }
-
-    #[test]
-    fn test_element_at_position_child() {
-        let (dc, url, _) = complex_document_cache();
-
-        assert_eq!(base_type_at_position(&dc, &url, 12, 4), Some("VerticalBox".to_string()));
-        assert_eq!(base_type_at_position(&dc, &url, 14, 22), Some("HorizontalBox".to_string()));
-        assert_eq!(base_type_at_position(&dc, &url, 15, 33), Some("Text".to_string()));
-        assert_eq!(base_type_at_position(&dc, &url, 27, 4), Some("VerticalBox".to_string()));
-        assert_eq!(base_type_at_position(&dc, &url, 28, 8), Some("Text".to_string()));
-        assert_eq!(base_type_at_position(&dc, &url, 51, 4), Some("VerticalBox".to_string()));
     }
 }

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -3,7 +3,7 @@
 
 //! Data structures common between LSP and previewer
 
-use i_slint_compiler::diagnostics::{BuildDiagnostics, SourceFile, SourceFileVersion};
+use i_slint_compiler::diagnostics::{BuildDiagnostics, SourceFile};
 use i_slint_compiler::object_tree::{Document, ElementRc};
 use i_slint_compiler::parser::{syntax_nodes, SyntaxKind, SyntaxNode};
 use i_slint_compiler::typeloader::TypeLoader;
@@ -25,6 +25,8 @@ pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
+
+pub type SourceFileVersion = Option<i32>;
 
 /// Use this in nodes you want the language server and preview to
 /// ignore a node for code analysis purposes.

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -1,0 +1,278 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Data structures common between LSP and previewer
+
+use i_slint_compiler::diagnostics::{BuildDiagnostics, SourceFile};
+use i_slint_compiler::object_tree::Document;
+use i_slint_compiler::typeloader::TypeLoader;
+use i_slint_compiler::typeregister::TypeRegister;
+use i_slint_compiler::CompilerConfiguration;
+use lsp_types::Url;
+
+use std::path::Path;
+use std::{collections::HashMap, path::PathBuf};
+
+pub type SourceFileVersion = Option<i32>;
+
+use crate::common::{file_to_uri, uri_to_file, ElementRcNode, Result};
+
+/// A cache of loaded documents
+pub struct DocumentCache(TypeLoader);
+
+impl DocumentCache {
+    pub fn new(config: CompilerConfiguration) -> Self {
+        Self(TypeLoader::new(
+            i_slint_compiler::typeregister::TypeRegister::builtin(),
+            config,
+            &mut BuildDiagnostics::default(),
+        ))
+    }
+
+    pub fn new_from_type_loader(type_loader: TypeLoader) -> Self {
+        Self(type_loader)
+    }
+
+    pub fn snapshot(&self) -> Option<Self> {
+        i_slint_compiler::typeloader::snapshot(&self.0).map(Self::new_from_type_loader)
+    }
+
+    pub fn resolve_import_path(
+        &self,
+        import_token: Option<&i_slint_compiler::parser::NodeOrToken>,
+        maybe_relative_path_or_url: &str,
+    ) -> Option<(PathBuf, Option<&'static [u8]>)> {
+        self.0.resolve_import_path(import_token, maybe_relative_path_or_url)
+    }
+
+    pub fn document_version(&self, target_uri: &Url) -> SourceFileVersion {
+        self.document_version_by_path(&uri_to_file(target_uri).unwrap_or_default())
+    }
+
+    pub fn document_version_by_path(&self, path: &Path) -> SourceFileVersion {
+        self.0.get_document(&path).and_then(|doc| doc.node.as_ref()?.source_file.version())
+    }
+
+    pub fn get_document<'a>(&'a self, url: &'_ Url) -> Option<&'a Document> {
+        let path = uri_to_file(url)?;
+        self.0.get_document(&path)
+    }
+
+    pub fn get_document_by_path<'a>(&'a self, path: &'_ Path) -> Option<&'a Document> {
+        self.0.get_document(path)
+    }
+
+    pub fn get_document_for_source_file<'a>(
+        &'a self,
+        source_file: &'_ SourceFile,
+    ) -> Option<&'a Document> {
+        self.0.get_document(source_file.path())
+    }
+
+    pub fn get_document_and_offset<'a>(
+        &'a self,
+        text_document_uri: &'_ Url,
+        pos: &'_ lsp_types::Position,
+    ) -> Option<(&'a i_slint_compiler::object_tree::Document, u32)> {
+        let doc = self.get_document(text_document_uri)?;
+        let o = doc
+            .node
+            .as_ref()?
+            .source_file
+            .offset(pos.line as usize + 1, pos.character as usize + 1) as u32;
+        doc.node.as_ref()?.text_range().contains_inclusive(o.into()).then_some((doc, o))
+    }
+
+    pub fn all_url_documents(&self) -> impl Iterator<Item = (Url, &Document)> + '_ {
+        self.0.all_file_documents().filter_map(|(p, d)| Some((file_to_uri(p)?, d)))
+    }
+
+    pub fn all_urls(&self) -> impl Iterator<Item = Url> + '_ {
+        self.0.all_files().filter_map(|p| file_to_uri(p))
+    }
+
+    pub fn global_type_registry(&self) -> std::cell::Ref<TypeRegister> {
+        self.0.global_type_registry.borrow()
+    }
+
+    pub async fn reconfigure(
+        &mut self,
+        style: Option<String>,
+        include_paths: Option<Vec<PathBuf>>,
+        library_paths: Option<HashMap<String, PathBuf>>,
+    ) -> Result<CompilerConfiguration> {
+        if style.is_none() && include_paths.is_none() && library_paths.is_none() {
+            return Ok(self.0.compiler_config.clone());
+        }
+
+        if let Some(s) = style {
+            if s.is_empty() {
+                self.0.compiler_config.style = None;
+            } else {
+                self.0.compiler_config.style = Some(s);
+            }
+        }
+
+        if let Some(ip) = include_paths {
+            self.0.compiler_config.include_paths = ip;
+        }
+
+        if let Some(lp) = library_paths {
+            self.0.compiler_config.library_paths = lp;
+        }
+
+        self.preload_builtins().await;
+
+        Ok(self.0.compiler_config.clone())
+    }
+
+    pub async fn preload_builtins(&mut self) {
+        // Always load the widgets so we can auto-complete them
+        let mut diag = BuildDiagnostics::default();
+        self.0.import_component("std-widgets.slint", "StyleMetrics", &mut diag).await;
+        assert!(!diag.has_errors());
+    }
+
+    pub async fn load_url(
+        &mut self,
+        url: &Url,
+        version: SourceFileVersion,
+        content: String,
+        diag: &mut BuildDiagnostics,
+    ) -> Result<()> {
+        let path = uri_to_file(url).ok_or("Failed to convert path")?;
+        self.0.load_file(&path, version, &path, content, false, diag).await;
+        Ok(())
+    }
+
+    pub fn compiler_configuration(&self) -> &CompilerConfiguration {
+        &self.0.compiler_config
+    }
+
+    fn element_at_document_and_offset(
+        &self,
+        document: &i_slint_compiler::object_tree::Document,
+        offset: u32,
+    ) -> Option<ElementRcNode> {
+        fn element_contains(
+            element: &i_slint_compiler::object_tree::ElementRc,
+            offset: u32,
+        ) -> Option<usize> {
+            element.borrow().debug.iter().position(|n| {
+                n.node.parent().map_or(false, |n| n.text_range().contains(offset.into()))
+            })
+        }
+
+        for component in &document.inner_components {
+            let root_element = component.root_element.clone();
+            let Some(root_debug_index) = element_contains(&root_element, offset) else {
+                continue;
+            };
+
+            let mut element =
+                ElementRcNode { element: root_element, debug_index: root_debug_index };
+            while element.contains_offset(offset) {
+                if let Some((c, i)) = element
+                    .element
+                    .clone()
+                    .borrow()
+                    .children
+                    .iter()
+                    .find_map(|c| element_contains(c, offset).map(|i| (c, i)))
+                {
+                    element = ElementRcNode { element: c.clone(), debug_index: i };
+                } else {
+                    return Some(element);
+                }
+            }
+        }
+        None
+    }
+
+    pub fn element_at_offset(&self, text_document_uri: &Url, offset: u32) -> Option<ElementRcNode> {
+        let doc = self.get_document(text_document_uri)?;
+        self.element_at_document_and_offset(doc, offset)
+    }
+
+    pub fn element_at_position(
+        &self,
+        text_document_uri: &Url,
+        pos: &lsp_types::Position,
+    ) -> Option<ElementRcNode> {
+        let (doc, offset) = self.get_document_and_offset(text_document_uri, pos)?;
+        self.element_at_document_and_offset(doc, offset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::complex_document_cache;
+
+    use super::*;
+
+    fn id_at_position(dc: &DocumentCache, url: &Url, line: u32, character: u32) -> Option<String> {
+        let result = dc.element_at_position(url, &lsp_types::Position { line, character })?;
+        let element = result.element.borrow();
+        Some(element.id.clone())
+    }
+
+    fn base_type_at_position(
+        dc: &DocumentCache,
+        url: &Url,
+        line: u32,
+        character: u32,
+    ) -> Option<String> {
+        let result = dc.element_at_position(url, &lsp_types::Position { line, character })?;
+        let element = result.element.borrow();
+        Some(format!("{}", &element.base_type))
+    }
+
+    #[test]
+    fn test_element_at_position_no_element() {
+        let (dc, url, _) = complex_document_cache();
+        assert_eq!(id_at_position(&dc, &url, 0, 10), None);
+        // TODO: This is past the end of the line and should thus return None
+        assert_eq!(id_at_position(&dc, &url, 42, 90), Some(String::new()));
+        assert_eq!(id_at_position(&dc, &url, 1, 0), None);
+        assert_eq!(id_at_position(&dc, &url, 55, 1), None);
+        assert_eq!(id_at_position(&dc, &url, 56, 5), None);
+    }
+
+    #[test]
+    fn test_element_at_position_no_such_document() {
+        let (dc, _, _) = complex_document_cache();
+        assert_eq!(id_at_position(&dc, &Url::parse("https://foo.bar/baz").unwrap(), 5, 0), None);
+    }
+
+    #[test]
+    fn test_element_at_position_root() {
+        let (dc, url, _) = complex_document_cache();
+
+        assert_eq!(id_at_position(&dc, &url, 2, 30), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 2, 32), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 2, 42), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 3, 0), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 3, 53), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 4, 19), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 5, 0), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 6, 8), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 6, 15), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 6, 23), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 8, 15), Some("root".to_string()));
+        assert_eq!(id_at_position(&dc, &url, 12, 3), Some("root".to_string())); // right before child // TODO: Seems wrong!
+        assert_eq!(id_at_position(&dc, &url, 51, 5), Some("root".to_string())); // right after child // TODO: Why does this not work?
+        assert_eq!(id_at_position(&dc, &url, 52, 0), Some("root".to_string()));
+    }
+
+    #[test]
+    fn test_element_at_position_child() {
+        let (dc, url, _) = complex_document_cache();
+
+        assert_eq!(base_type_at_position(&dc, &url, 12, 4), Some("VerticalBox".to_string()));
+        assert_eq!(base_type_at_position(&dc, &url, 14, 22), Some("HorizontalBox".to_string()));
+        assert_eq!(base_type_at_position(&dc, &url, 15, 33), Some("Text".to_string()));
+        assert_eq!(base_type_at_position(&dc, &url, 27, 4), Some("VerticalBox".to_string()));
+        assert_eq!(base_type_at_position(&dc, &url, 28, 8), Some("Text".to_string()));
+        assert_eq!(base_type_at_position(&dc, &url, 51, 4), Some("VerticalBox".to_string()));
+    }
+}

--- a/tools/lsp/common/test.rs
+++ b/tools/lsp/common/test.rs
@@ -22,7 +22,7 @@ async fn parse_source(
         ) -> core::pin::Pin<
             Box<
                 dyn core::future::Future<
-                    Output = Option<std::io::Result<(String, common::SourceFileVersion)>>,
+                    Output = Option<std::io::Result<(common::SourceFileVersion, String)>>,
                 >,
             >,
         > + 'static,
@@ -34,7 +34,10 @@ async fn parse_source(
         }
         tmp.include_paths = include_paths;
         tmp.library_paths = library_paths;
-        tmp.open_import_fallback = Some(Rc::new(move |path| file_loader_fallback(&path)));
+        tmp.open_import_fallback = Some(Rc::new(move |path| {
+            let path = PathBuf::from(&path);
+            file_loader_fallback(&path)
+        }));
         #[cfg(target_arch = "wasm32")]
         {
             tmp.resource_url_mapper = resource_url_mapper();
@@ -102,7 +105,7 @@ pub fn recompile_test_with_sources(
                             "path not found",
                         )));
                     };
-                    Some(Ok((source.clone(), Some(23))))
+                    Some(Ok((Some(23), source.clone())))
                 } else {
                     Some(Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,

--- a/tools/lsp/common/text_edit.rs
+++ b/tools/lsp/common/text_edit.rs
@@ -791,7 +791,6 @@ fn test_texteditor_edit_out_of_range() {
     let source_file = std::rc::Rc::new(SourceFileInner::new(
         std::path::PathBuf::from("/tmp/foo.slint"),
         r#""#.to_string(),
-        Some(42),
     ));
 
     let mut editor = TextEditor::new(source_file.clone()).unwrap();
@@ -816,7 +815,6 @@ fn test_texteditor_delete_everything() {
 def
 geh"#
             .to_string(),
-        Some(42),
     ));
 
     let mut editor = TextEditor::new(source_file.clone()).unwrap();
@@ -847,7 +845,6 @@ fn test_texteditor_replace() {
 def
 geh"#
             .to_string(),
-        Some(42),
     ));
 
     let mut editor = TextEditor::new(source_file.clone()).unwrap();
@@ -883,7 +880,6 @@ fn test_texteditor_2step_replace_all() {
 def
 geh"#
             .to_string(),
-        Some(42),
     ));
 
     let mut editor = TextEditor::new(source_file.clone()).unwrap();

--- a/tools/lsp/common/text_edit.rs
+++ b/tools/lsp/common/text_edit.rs
@@ -215,7 +215,7 @@ impl TextEditor {
     pub fn apply_versioned(
         &mut self,
         text_edit: &lsp_types::TextEdit,
-        document_version: i_slint_compiler::diagnostics::SourceFileVersion,
+        document_version: common::SourceFileVersion,
     ) -> crate::Result<()> {
         if let Some(expected) = document_version {
             if let Some(actual) = self.source_file.version() {

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -1291,7 +1291,6 @@ mod tests {
         let syntax_node = i_slint_compiler::parser::parse(
             String::from(unformatted),
             None,
-            None,
             &mut BuildDiagnostics::default(),
         );
         // Turn the syntax node into a document

--- a/tools/lsp/fmt/tool.rs
+++ b/tools/lsp/fmt/tool.rs
@@ -45,7 +45,7 @@ fn process_rust_file(source: String, mut file: impl Write) -> std::io::Result<()
         let code = &source[range];
 
         let mut diag = BuildDiagnostics::default();
-        let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, None, &mut diag);
+        let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, &mut diag);
         let len = syntax_node.text_range().end().into();
         visit_node(syntax_node, &mut file)?;
         if diag.has_errors() {
@@ -75,7 +75,7 @@ fn process_markdown_file(source: String, mut file: impl Write) -> std::io::Resul
         source_slice = &source_slice[code_end..];
 
         let mut diag = BuildDiagnostics::default();
-        let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, None, &mut diag);
+        let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, &mut diag);
         let len = syntax_node.text_range().end().into();
         visit_node(syntax_node, &mut file)?;
         if diag.has_errors() {
@@ -92,7 +92,7 @@ fn process_slint_file(
     mut file: impl Write,
 ) -> std::io::Result<()> {
     let mut diag = BuildDiagnostics::default();
-    let syntax_node = i_slint_compiler::parser::parse(source.clone(), Some(&path), None, &mut diag);
+    let syntax_node = i_slint_compiler::parser::parse(source.clone(), Some(&path), &mut diag);
     let len = syntax_node.node.text_range().end().into();
     visit_node(syntax_node, &mut file)?;
     if diag.has_errors() {

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -543,8 +543,10 @@ pub async fn reload_document(
         reload_document_impl(Some(ctx), content, url.clone(), version, document_cache).await;
 
     for (uri, diagnostics) in lsp_diags {
+        let version = document_cache.document_version(&uri);
+
         ctx.server_notifier.send_notification::<lsp_types::notification::PublishDiagnostics>(
-            PublishDiagnosticsParams { uri, diagnostics, version: None },
+            PublishDiagnosticsParams { uri, diagnostics, version },
         )?;
     }
 

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -11,9 +11,7 @@ use crate::language::{reload_document_impl, DocumentCache};
 
 /// Create an empty `DocumentCache`
 pub fn empty_document_cache() -> DocumentCache {
-    let mut config = i_slint_compiler::CompilerConfiguration::new(
-        i_slint_compiler::generator::OutputFormat::Interpreter,
-    );
+    let mut config = crate::common::document_cache::CompilerConfiguration::default();
     config.style = Some("fluent".to_string());
     DocumentCache::new(config)
 }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -313,7 +313,7 @@ fn main_loop(connection: Connection, init_param: InitializeParams, cli_args: Cli
                     )
                 }
             }
-            Some(contents.map(|c| (c, None)))
+            Some(contents.map(|c| (None, c)))
         })
     }));
 

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -18,7 +18,6 @@ pub mod util;
 use common::Result;
 use language::*;
 
-use i_slint_compiler::CompilerConfiguration;
 use lsp_types::notification::{
     DidChangeConfiguration, DidChangeTextDocument, DidOpenTextDocument, Notification,
 };
@@ -34,6 +33,8 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::{atomic, Arc, Mutex};
 use std::task::{Poll, Waker};
+
+use crate::common::document_cache::CompilerConfiguration;
 
 #[derive(Clone, clap::Parser)]
 #[command(author, version, about, long_about = None)]
@@ -287,8 +288,7 @@ fn main_loop(connection: Connection, init_param: InitializeParams, cli_args: Cli
     #[cfg(feature = "preview-builtin")]
     preview::set_server_notifier(server_notifier.clone());
 
-    let mut compiler_config =
-        CompilerConfiguration::new(i_slint_compiler::generator::OutputFormat::Interpreter);
+    let mut compiler_config = CompilerConfiguration::default();
 
     compiler_config.style =
         Some(if cli_args.style.is_empty() { "native".into() } else { cli_args.style });
@@ -313,7 +313,7 @@ fn main_loop(connection: Connection, init_param: InitializeParams, cli_args: Cli
                     )
                 }
             }
-            Some(contents)
+            Some(contents.map(|c| (c, None)))
         })
     }));
 

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -490,10 +490,11 @@ async fn handle_preview_to_lsp_message(
                 health,
             );
         }
-        M::Diagnostics { uri, diagnostics } => {
+        M::Diagnostics { uri, version, diagnostics } => {
             crate::common::lsp_to_editor::notify_lsp_diagnostics(
                 &ctx.server_notifier,
                 uri,
+                version,
                 diagnostics,
             );
         }

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -208,7 +208,9 @@ fn add_new_component() {
         return;
     };
 
-    if let Some((edit, drop_data)) = drop_location::add_new_component(&component_name, document) {
+    if let Some((edit, drop_data)) =
+        drop_location::add_new_component(&document_cache, &component_name, document)
+    {
         element_selection::select_element_at_source_code_position(
             drop_data.path,
             drop_data.selection_offset,

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -3,12 +3,12 @@
 
 use crate::common::{
     self, component_catalog, rename_component, ComponentInformation, ElementRcNode,
-    PreviewComponent, PreviewConfig, PreviewToLspMessage,
+    PreviewComponent, PreviewConfig, PreviewToLspMessage, SourceFileVersion,
 };
 use crate::lsp_ext::Health;
 use crate::preview::element_selection::ElementSelection;
 use crate::util;
-use i_slint_compiler::diagnostics::{self, SourceFileVersion};
+use i_slint_compiler::diagnostics;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::syntax_nodes;
 use i_slint_core::component_factory::FactoryContext;

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1177,16 +1177,22 @@ pub fn get_component_info(component_type: &str) -> Option<ComponentInformation> 
 
 fn convert_diagnostics(
     diagnostics: &[slint_interpreter::Diagnostic],
-) -> HashMap<Url, Vec<lsp_types::Diagnostic>> {
-    let mut result: HashMap<Url, Vec<lsp_types::Diagnostic>> = Default::default();
+) -> HashMap<Url, (SourceFileVersion, Vec<lsp_types::Diagnostic>)> {
+    let mut result: HashMap<Url, (SourceFileVersion, Vec<lsp_types::Diagnostic>)> =
+        Default::default();
+    let Some(document_cache) = document_cache() else {
+        return result;
+    };
+
     for d in diagnostics {
         if d.source_file().map_or(true, |f| !i_slint_compiler::pathutils::is_absolute(f)) {
             continue;
         }
-        let uri = Url::from_file_path(d.source_file().unwrap())
-            .ok()
-            .unwrap_or_else(|| Url::parse("file:/unknown").unwrap());
-        result.entry(uri).or_default().push(crate::util::to_lsp_diag(d));
+        let path = d.source_file().unwrap();
+        let uri =
+            Url::from_file_path(path).ok().unwrap_or_else(|| Url::parse("file:/unknown").unwrap());
+        let version = document_cache.document_version_by_path(path);
+        result.entry(uri).or_insert((version, Vec::new())).1.push(crate::util::to_lsp_diag(d));
     }
     result
 }

--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use super::PreviewState;
-use crate::common::PreviewToLspMessage;
+use crate::common::{PreviewToLspMessage, SourceFileVersion};
 use crate::lsp_ext::Health;
 use crate::ServerNotifier;
 use once_cell::sync::Lazy;
@@ -204,10 +204,7 @@ pub fn set_server_notifier(sender: ServerNotifier) {
 }
 
 pub fn notify_diagnostics(
-    diagnostics: HashMap<
-        lsp_types::Url,
-        (i_slint_compiler::diagnostics::SourceFileVersion, Vec<lsp_types::Diagnostic>),
-    >,
+    diagnostics: HashMap<lsp_types::Url, (SourceFileVersion, Vec<lsp_types::Diagnostic>)>,
 ) -> Option<()> {
     let Some(sender) = SERVER_NOTIFIER.lock().unwrap().clone() else {
         return Some(());

--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -210,8 +210,8 @@ pub fn notify_diagnostics(diagnostics: &[slint_interpreter::Diagnostic]) -> Opti
 
     let lsp_diags = crate::preview::convert_diagnostics(diagnostics);
 
-    for (url, diagnostics) in lsp_diags {
-        crate::common::lsp_to_editor::notify_lsp_diagnostics(&sender, url, diagnostics)?;
+    for (url, (version, diagnostics)) in lsp_diags {
+        crate::common::lsp_to_editor::notify_lsp_diagnostics(&sender, url, version, diagnostics)?;
     }
     Some(())
 }

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -1,10 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use crate::common::{self, Result};
+use crate::common::{self, Result, SourceFileVersion};
 use crate::util;
 
-use i_slint_compiler::diagnostics::{SourceFileVersion, Spanned};
+use i_slint_compiler::diagnostics::Spanned;
 use i_slint_compiler::langtype::{ElementType, Type};
 use i_slint_compiler::object_tree::{Element, PropertyDeclaration, PropertyVisibility};
 use i_slint_compiler::parser::{syntax_nodes, Language, SyntaxKind};

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -224,7 +224,8 @@ fn map_property_declaration(
 
     let doc = document_cache.get_document(&da.uri)?;
     let doc_node = doc.node.as_ref()?;
-    let source_version = doc_node.source_file.version().unwrap_or(-1);
+    let source_version =
+        document_cache.document_version_by_path(doc_node.source_file.path()).unwrap_or(-1);
 
     let pos = util::map_to_offset(&doc_node.source_file, da.start_position);
 

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use crate::common::SourceFileVersion;
 use crate::lsp_ext::Health;
 use crate::wasm_prelude::*;
 use slint_interpreter::ComponentHandle;
@@ -219,10 +220,7 @@ pub fn send_status(message: &str, health: Health) {
 }
 
 pub fn notify_diagnostics(
-    diagnostics: HashMap<
-        lsp_types::Url,
-        (i_slint_compiler::diagnostics::SourceFileVersion, Vec<lsp_types::Diagnostic>),
-    >,
+    diagnostics: HashMap<lsp_types::Url, (SourceFileVersion, Vec<lsp_types::Diagnostic>)>,
 ) -> Option<()> {
     for (uri, (version, diagnostics)) in diagnostics {
         send_message_to_lsp(crate::common::PreviewToLspMessage::Diagnostics {

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -4,6 +4,8 @@
 //! This wasm library can be loaded from JS to load and display the content of .slint files
 #![cfg(target_arch = "wasm32")]
 
+use std::collections::HashMap;
+
 use crate::lsp_ext::Health;
 use crate::wasm_prelude::*;
 use slint_interpreter::ComponentHandle;
@@ -216,11 +218,13 @@ pub fn send_status(message: &str, health: Health) {
     });
 }
 
-pub fn notify_diagnostics(diagnostics: &[slint_interpreter::Diagnostic]) -> Option<()> {
-    super::set_diagnostics(diagnostics);
-    let diags = crate::preview::convert_diagnostics(diagnostics);
-
-    for (uri, (version, diagnostics)) in diags {
+pub fn notify_diagnostics(
+    diagnostics: HashMap<
+        lsp_types::Url,
+        (i_slint_compiler::diagnostics::SourceFileVersion, Vec<lsp_types::Diagnostic>),
+    >,
+) -> Option<()> {
+    for (uri, (version, diagnostics)) in diagnostics {
         send_message_to_lsp(crate::common::PreviewToLspMessage::Diagnostics {
             uri,
             version,

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -220,8 +220,12 @@ pub fn notify_diagnostics(diagnostics: &[slint_interpreter::Diagnostic]) -> Opti
     super::set_diagnostics(diagnostics);
     let diags = crate::preview::convert_diagnostics(diagnostics);
 
-    for (uri, diagnostics) in diags {
-        send_message_to_lsp(crate::common::PreviewToLspMessage::Diagnostics { uri, diagnostics });
+    for (uri, (version, diagnostics)) in diags {
+        send_message_to_lsp(crate::common::PreviewToLspMessage::Diagnostics {
+            uri,
+            version,
+            diagnostics,
+        });
     }
     Some(())
 }

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -279,10 +279,11 @@ impl SlintServer {
                     health,
                 );
             }
-            M::Diagnostics { diagnostics, uri } => {
+            M::Diagnostics { diagnostics, version, uri } => {
                 crate::common::lsp_to_editor::notify_lsp_diagnostics(
                     &self.ctx.server_notifier,
                     uri,
+                    version,
                     diagnostics,
                 );
             }

--- a/tools/tr-extractor/main.rs
+++ b/tools/tr-extractor/main.rs
@@ -284,7 +284,6 @@ fn extract_messages() {
     let syntax_node = i_slint_compiler::parser::parse(
         source.into(),
         Some(std::path::Path::new("test.slint")),
-        None,
         &mut diag,
     );
 

--- a/tools/updater/main.rs
+++ b/tools/updater/main.rs
@@ -67,7 +67,7 @@ fn process_rust_file(source: String, mut file: impl Write, args: &Cli) -> std::i
         let code = &source[range];
 
         let mut diag = BuildDiagnostics::default();
-        let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, None, &mut diag);
+        let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, &mut diag);
         let len = syntax_node.text_range().end().into();
         let mut state = init_state(&syntax_node, &mut diag);
         visit_node(syntax_node, &mut file, &mut state, args)?;
@@ -99,7 +99,7 @@ fn process_markdown_file(source: String, mut file: impl Write, args: &Cli) -> st
         source_slice = &source_slice[code_end..];
 
         let mut diag = BuildDiagnostics::default();
-        let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, None, &mut diag);
+        let syntax_node = i_slint_compiler::parser::parse(code.to_owned(), None, &mut diag);
         let len = syntax_node.text_range().end().into();
         let mut state = init_state(&syntax_node, &mut diag);
         visit_node(syntax_node, &mut file, &mut state, args)?;
@@ -124,7 +124,7 @@ fn process_file(
     }
 
     let mut diag = BuildDiagnostics::default();
-    let syntax_node = i_slint_compiler::parser::parse(source.clone(), Some(path), None, &mut diag);
+    let syntax_node = i_slint_compiler::parser::parse(source.clone(), Some(path), &mut diag);
     let len = syntax_node.node.text_range().end().into();
     let mut state = init_state(&syntax_node, &mut diag);
     visit_node(syntax_node, &mut file, &mut state, args)?;


### PR DESCRIPTION
Change the handling of source file version information to be all inside the LSP and remove the support infrastructure from the slint compiler again.

This removes some internal API while at it :-)

This PR replaces #5820 (which tried to extend the infrastructure the PR removes).