### PR TITLE
Fixes rust generated code when taking expression of void callback

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1993,11 +1993,11 @@ impl MemberAccess {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
                 let r = f(quote!(x));
-                quote!(let _ = #t.map(|x| #r);)
+                quote!({ let _ = #t.map(|x| #r); })
             }
             MemberAccess::OptionFn(opt, inner) => {
                 let r = f(inner);
-                quote!(let _ = #opt.as_ref().map(#r);)
+                quote!({ let _ = #opt.as_ref().map(#r); })
             }
         }
     }


### PR DESCRIPTION
code like so:
```slint
callback foo();
if true : Button {
   clicked => {
      true ? foo() : foo();
   }
}
```

the code like foo() use the `option.map()`  to get to the parent, but then it needs to still be wrapped in a `{...}` to convert that to a `()` expression

Fixes #5883