### PR TITLE
Fix rust generated code with struct of `percent` value

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -341,6 +341,7 @@ impl Type {
         match self {
             Type::UnitProduct(u) => Some(u.clone()),
             Type::Float32 | Type::Int32 => Some(Vec::new()),
+            Type::Percent => Some(Vec::new()),
             _ => self.default_unit().map(|u| vec![(u, 1)]),
         }
     }

--- a/tests/cases/issues/issue_5887_struct_f64-f32.slint
+++ b/tests/cases/issues/issue_5887_struct_f64-f32.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { VerticalBox } from "std-widgets.slint";
+
+export component AppWindow inherits Window {
+    function default-height-width()->{height:percent,width:percent} {
+        {height: 0%, width: 100%}
+    }
+    VerticalBox {
+        height: default-height-width().height;
+        width: default-height-width().width;
+    }
+}


### PR DESCRIPTION
We wouldn't detect percent as a unit product in
https://github.com/slint-ui/slint/blob/43c7f57b0ff0ee10e7275cd635dc5e6aa0ef4be1/internal/compiler/generator/rust.rs#L2418-L2422

Percent is not strictly of percent unit because that unit doesn't combine with other unit (as per the comment in `default_unit`) But since it converts to number, it is then an unitless value. (scalar)

Fixes #5887