### PR TITLE
Fix Vscode publish failing due to PNPM

### DIFF
--- a/editors/vscode/.npmrc
+++ b/editors/vscode/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/editors/vscode/.npmrc
+++ b/editors/vscode/.npmrc
@@ -1,1 +1,4 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
 node-linker=hoisted


### PR DESCRIPTION
PNPM symlinks the node_modules and this is probably what confuses VSIX. This fixes the issue by letting PNPM install the npm dependencies by copying the files.

I will look a bit deeper as a separate task as the error message suggests all the dev dependencies are being packaged into the VSCode extension and probably contribute a non significant amount to the package size?