### PR TITLE
Fix web vscode extension

### DIFF
--- a/editors/vscode/src/browser-lsp-worker.ts
+++ b/editors/vscode/src/browser-lsp-worker.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import slint_init, * as slint_lsp from "../out/slint_lsp_wasm.js";
+import slint_wasm_data from "../out/slint_lsp_wasm_bg.wasm";
 import { InitializeParams, InitializeResult } from "vscode-languageserver";
 import {
     createConnection,
@@ -9,7 +10,7 @@ import {
     BrowserMessageWriter,
 } from "vscode-languageserver/browser";
 
-slint_init().then((_) => {
+slint_init(slint_wasm_data).then((_) => {
     const reader = new BrowserMessageReader(self);
     const writer = new BrowserMessageWriter(self);
 


### PR DESCRIPTION
We need to load slint_lsp_wasm_bg.wasm for it to load the LSP webassembly
This was removed by mistake in commit 1639274486e5540b394c7bdb1c76ab3a99045ce6