### PR TITLE
Fix LSP test when experimental features are enabled

### DIFF
--- a/editors/vscode/src/quick_picks.ts
+++ b/editors/vscode/src/quick_picks.ts
@@ -9,12 +9,12 @@ import * as path from "node:path";
 export async function newProject(context: vscode.ExtensionContext) {
     type Language = "Node (JavaScript/TypeScript)" | "C++" | "Rust";
 
-    const language = await vscode.window.showQuickPick(
+    const language = (await vscode.window.showQuickPick(
         ["Node (JavaScript/TypeScript)", "C++", "Rust"],
         {
             placeHolder: "What language do you want to use?",
         },
-    ) as Language;
+    )) as Language;
 
     if (!language) {
         vscode.window.showErrorMessage("Language selection is required.");

--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -95,7 +95,7 @@ function getPreviewHtml(
 ): string {
     const experimental =
         typeof process !== "undefined" &&
-        process.env.hasOwnProperty("SLINT_ENABLE_EXPERIMENTAL_FEATURES");
+        process.env.SLINT_ENABLE_EXPERIMENTAL_FEATURES === "1";
     const result = `<!DOCTYPE html>
 <html lang="en" style="height: 100%; width: 100%;">
 <head>

--- a/examples/weather-demo/build.rs
+++ b/examples/weather-demo/build.rs
@@ -4,7 +4,7 @@
 use std::env;
 
 fn main() {
-    env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "true");
+    env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1");
 
     slint_build::compile("ui/main.slint").unwrap();
 }

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -183,7 +183,8 @@ impl CompilerConfiguration {
             .filter(|f| *f > 0.)
             .unwrap_or(1.);
 
-        let enable_experimental = std::env::var_os("SLINT_ENABLE_EXPERIMENTAL_FEATURES").is_some();
+        let enable_experimental =
+            std::env::var("SLINT_ENABLE_EXPERIMENTAL_FEATURES").unwrap_or("0".into()) == "1";
 
         let debug_info = std::env::var_os("SLINT_EMIT_DEBUG_INFO").is_some();
 

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -952,8 +952,15 @@ mod tests {
 
             assert!(!res.iter().any(|ci| ci.label == "Rectangle"));
             assert!(!res.iter().any(|ci| ci.label == "Clip"));
-            assert!(!res.iter().any(|ci| ci.label == "NativeStyleMetrics"));
-            assert!(!res.iter().any(|ci| ci.label == "SlintInternal"));
+
+            if std::env::var("SLINT_ENABLE_EXPERIMENTAL_FEATURES").unwrap_or("0".into()) == "1" {
+                assert!(res.iter().any(|ci| ci.label == "NativeStyleMetrics"));
+                assert!(res.iter().any(|ci| ci.label == "SlintInternal"));
+            } else {
+                println!("Experimental features DISABLED");
+                assert!(!res.iter().any(|ci| ci.label == "NativeStyleMetrics"));
+                assert!(!res.iter().any(|ci| ci.label == "SlintInternal"));
+            }
         }
     }
 


### PR DESCRIPTION
Also enable experimental features less randomly!

With this change you need to set `SLINT_ENABLE_EXPERIMENTAL_FEATURES` to "1" to enable them.

I was just mightily confused after having experimental features enabled even though I had set the value to "0"...