### PR TITLE
live-preview: Use TextRange and TextSize in property information

### DIFF
--- a/tools/lsp/common/component_catalog.rs
+++ b/tools/lsp/common/component_catalog.rs
@@ -12,10 +12,7 @@ use i_slint_compiler::langtype::{DefaultSizeBinding, ElementType};
 
 #[cfg(feature = "preview-engine")]
 fn builtin_component_info(name: &str, fills_parent: bool) -> ComponentInformation {
-    let is_layout = match name {
-        "GridLayout" | "HorizontalLayout" | "VerticalLayout" => true,
-        _ => false,
-    };
+    let is_layout = matches!(name, "GridLayout" | "HorizontalLayout" | "VerticalLayout");
 
     let default_properties = match name {
         "Text" | "TextInput" => vec![PropertyChange::new("text", format!("\"{name}\""))],
@@ -38,10 +35,7 @@ fn builtin_component_info(name: &str, fills_parent: bool) -> ComponentInformatio
 }
 
 fn std_widgets_info(name: &str, is_global: bool) -> ComponentInformation {
-    let is_layout = match name {
-        "GridBox" | "HorizontalBox" | "VerticalBox" => true,
-        _ => false,
-    };
+    let is_layout = matches!(name, "GridBox" | "HorizontalBox" | "VerticalBox");
 
     let default_properties = match name {
         "Button" | "CheckBox" | "LineEdit" | "Switch" | "TextEdit" => {

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -64,9 +64,7 @@ impl Default for CompilerConfiguration {
 }
 
 impl CompilerConfiguration {
-    fn to_compiler_configuration(
-        mut self,
-    ) -> (i_slint_compiler::CompilerConfiguration, OpenImportFallback) {
+    fn build(mut self) -> (i_slint_compiler::CompilerConfiguration, OpenImportFallback) {
         let mut result = default_cc();
         result.include_paths = std::mem::take(&mut self.include_paths);
         result.library_paths = std::mem::take(&mut self.library_paths);
@@ -131,7 +129,7 @@ impl DocumentCache {
     }
 
     pub fn new(config: CompilerConfiguration) -> Self {
-        let (mut compiler_config, open_import_fallback) = config.to_compiler_configuration();
+        let (mut compiler_config, open_import_fallback) = config.build();
 
         let (open_import_fallback, source_file_versions) = Self::wire_up_import_fallback(
             &mut compiler_config,

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -73,7 +73,7 @@ fn replace_element_types(
                     document_cache,
                     element.source_file.path(),
                     lsp_types::TextEdit {
-                        range: util::map_node(&name).expect("Just had a source_file"),
+                        range: util::node_to_lsp_range(&name),
                         new_text: new_type.to_string(),
                     },
                 )
@@ -183,7 +183,7 @@ fn fix_import_in_document(
                     document_cache,
                     source_file.path(),
                     lsp_types::TextEdit {
-                        range: util::map_node(&external).expect("Just had a source file"),
+                        range: util::node_to_lsp_range(&external),
                         new_text: new_type.to_string(),
                     },
                 )
@@ -195,9 +195,9 @@ fn fix_import_in_document(
                 if internal_name == new_type {
                     // remove " as Foo" part, no need to change anything else though!
                     let start_position =
-                        util::map_position(source_file, external.text_range().end());
+                        util::text_size_to_lsp_position(source_file, external.text_range().end());
                     let end_position =
-                        util::map_position(source_file, identifier.text_range().end());
+                        util::text_size_to_lsp_position(source_file, identifier.text_range().end());
                     edits.push(
                         common::SingleTextEdit::from_path(
                             document_cache,
@@ -259,8 +259,7 @@ fn fix_exports(
                         document_cache,
                         source_file.path(),
                         lsp_types::TextEdit {
-                            range: util::map_node(&identifier)
-                                .expect("This needs to have a source file"),
+                            range: util::node_to_lsp_range(&identifier),
                             new_text: new_type.to_string(),
                         },
                     )
@@ -270,10 +269,14 @@ fn fix_exports(
                 let update_imports = if let Some(export_name) = specifier.ExportName() {
                     // Remove "as Foo"
                     if export_name.text().to_string().trim() == new_type {
-                        let start_position =
-                            util::map_position(source_file, identifier.text_range().end());
-                        let end_position =
-                            util::map_position(source_file, export_name.text_range().end());
+                        let start_position = util::text_size_to_lsp_position(
+                            source_file,
+                            identifier.text_range().end(),
+                        );
+                        let end_position = util::text_size_to_lsp_position(
+                            source_file,
+                            export_name.text_range().end(),
+                        );
                         edits.push(
                             common::SingleTextEdit::from_path(
                                 document_cache,
@@ -340,7 +343,7 @@ pub fn rename_component_from_definition(
             document_cache,
             source_file.path(),
             lsp_types::TextEdit {
-                range: util::map_node(identifier).expect("This has a source_file"),
+                range: util::node_to_lsp_range(identifier),
                 new_text: new_name.to_string(),
             },
         )

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -717,7 +717,7 @@ fn get_code_actions(
                 kind: Some(lsp_types::CodeActionKind::REFACTOR),
                 edit: common::create_workspace_edit_from_path(
                     document_cache,
-                    &token.source_file.path(),
+                    token.source_file.path(),
                     edits,
                 ),
                 ..Default::default()
@@ -785,7 +785,7 @@ fn get_code_actions(
                     kind: Some(lsp_types::CodeActionKind::REFACTOR),
                     edit: common::create_workspace_edit_from_path(
                         document_cache,
-                        &token.source_file.path(),
+                        token.source_file.path(),
                         edits,
                     ),
                     ..Default::default()
@@ -812,7 +812,7 @@ fn get_code_actions(
                     kind: Some(lsp_types::CodeActionKind::REFACTOR),
                     edit: common::create_workspace_edit_from_path(
                         document_cache,
-                        &token.source_file.path(),
+                        token.source_file.path(),
                         edits,
                     ),
                     ..Default::default()
@@ -827,7 +827,7 @@ fn get_code_actions(
                     kind: Some(lsp_types::CodeActionKind::REFACTOR),
                     edit: common::create_workspace_edit_from_path(
                         document_cache,
-                        &token.source_file.path(),
+                        token.source_file.path(),
                         edits,
                     ),
                     ..Default::default()
@@ -925,14 +925,12 @@ fn get_document_symbols(
             kind: lsp_types::SymbolKind::STRUCT,
             ..ds.clone()
         }),
-        Type::Enumeration(enumeration) => enumeration.node.as_ref().and_then(|node| {
-            Some(DocumentSymbol {
-                range: util::node_to_lsp_range(node),
-                selection_range: util::node_to_lsp_range(&node.DeclaredIdentifier()),
-                name: enumeration.name.clone(),
-                kind: lsp_types::SymbolKind::ENUM,
-                ..ds.clone()
-            })
+        Type::Enumeration(enumeration) => enumeration.node.as_ref().map(|node| DocumentSymbol {
+            range: util::node_to_lsp_range(node),
+            selection_range: util::node_to_lsp_range(&node.DeclaredIdentifier()),
+            name: enumeration.name.clone(),
+            kind: lsp_types::SymbolKind::ENUM,
+            ..ds.clone()
         }),
         _ => None,
     }));

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -5,7 +5,7 @@
 
 use crate::common::component_catalog::all_exported_components;
 use crate::common::{self, DocumentCache};
-use crate::util::{lookup_current_element_type, map_position, with_lookup_ctx};
+use crate::util::{lookup_current_element_type, text_size_to_lsp_position, with_lookup_ctx};
 
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_prelude::*;
@@ -729,7 +729,7 @@ fn find_import_locations(
             let node = list.ImportIdentifier().last()?;
             let id = crate::util::last_non_ws_token(&node).or_else(|| node.first_token())?;
             Some((
-                map_position(id.source_file()?, id.text_range().end()),
+                text_size_to_lsp_position(id.source_file()?, id.text_range().end()),
                 import.child_token(SyntaxKind::StringLiteral)?,
             ))
         }) {
@@ -772,9 +772,9 @@ fn find_import_locations(
                 }
             }
         }
-        map_position(&document.source_file, offset.unwrap_or_default())
+        text_size_to_lsp_position(&document.source_file, offset.unwrap_or_default())
     } else {
-        Position::new(map_position(&document.source_file, last.into()).line + 1, 0)
+        Position::new(text_size_to_lsp_position(&document.source_file, last.into()).line + 1, 0)
     };
 
     (new_import_position, import_locations)

--- a/tools/lsp/language/formatting.rs
+++ b/tools/lsp/language/formatting.rs
@@ -3,11 +3,10 @@
 
 use crate::common::DocumentCache;
 use crate::fmt::{fmt, writer};
-use crate::util::map_range;
+use crate::util::text_range_to_lsp_range;
 use dissimilar::Chunk;
-use i_slint_compiler::parser::SyntaxToken;
+use i_slint_compiler::parser::{SyntaxToken, TextRange, TextSize};
 use lsp_types::{DocumentFormattingParams, TextEdit};
-use rowan::{TextRange, TextSize};
 
 struct StringWriter {
     text: String,
@@ -56,7 +55,8 @@ pub fn format_document(
             }
             Chunk::Delete(text) => {
                 let len = TextSize::of(text);
-                let deleted_range = map_range(&doc.source_file, TextRange::at(pos, len));
+                let deleted_range =
+                    text_range_to_lsp_range(&doc.source_file, TextRange::at(pos, len));
                 edits.push(TextEdit { range: deleted_range, new_text: String::new() });
                 last_was_deleted = true;
                 pos += len;
@@ -70,7 +70,7 @@ pub fn format_document(
                 }
 
                 let range = TextRange::empty(pos);
-                let range = map_range(&doc.source_file, range);
+                let range = text_range_to_lsp_range(&doc.source_file, range);
                 edits.push(TextEdit { range, new_text: text.into() });
             }
         }

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use super::DocumentCache;
-use crate::util::{lookup_current_element_type, map_node_and_url, with_lookup_ctx};
+use crate::util::{lookup_current_element_type, node_to_url_and_lsp_range, with_lookup_ctx};
 
 use i_slint_compiler::diagnostics::Spanned;
 use i_slint_compiler::expression_tree::Expression;
@@ -216,7 +216,7 @@ fn goto_type(ty: &Type) -> Option<GotoDefinitionResponse> {
 }
 
 fn goto_node(node: &SyntaxNode) -> Option<GotoDefinitionResponse> {
-    let (target_uri, range) = map_node_and_url(node)?;
+    let (target_uri, range) = node_to_url_and_lsp_range(node)?;
     let range = Range::new(range.start, range.start); // Shrink range to a position:-)
     Some(GotoDefinitionResponse::Link(vec![LocationLink {
         origin_selection_range: None,

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -743,7 +743,7 @@ fn test_workspace_edit(edit: &lsp_types::WorkspaceEdit, test_edit: bool) -> bool
         let Some(document_cache) = document_cache() else {
             return false;
         };
-        drop_location::workspace_edit_compiles(&document_cache, &edit)
+        drop_location::workspace_edit_compiles(&document_cache, edit)
     } else {
         true
     }
@@ -812,12 +812,7 @@ fn finish_parsing(ok: bool) {
         for (url, (version, contents)) in &source_code {
             let mut diag = diagnostics::BuildDiagnostics::default();
             if document_cache.get_document(url).is_none() {
-                poll_once(document_cache.load_url(
-                    url,
-                    version.clone(),
-                    contents.clone(),
-                    &mut diag,
-                ));
+                poll_once(document_cache.load_url(url, *version, contents.clone(), &mut diag));
             }
         }
 
@@ -1104,7 +1099,7 @@ async fn reload_preview_impl(
             let path = path.to_owned();
             Box::pin(async move {
                 let path = PathBuf::from(&path);
-                get_path_from_cache(&path).map(|r| Result::Ok(r))
+                get_path_from_cache(&path).map(Result::Ok)
             })
         },
     )

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -475,7 +475,8 @@ fn show_component(name: slint::SharedString, url: slint::SharedString) {
         return;
     };
 
-    let start = util::map_position(&identifier.source_file, identifier.text_range().start());
+    let start =
+        util::text_size_to_lsp_position(&identifier.source_file, identifier.text_range().start());
     ask_editor_to_show_document(&file.to_string_lossy(), lsp_types::Range::new(start, start))
 }
 
@@ -496,8 +497,8 @@ fn show_document_offset_range(url: slint::SharedString, start: i32, end: i32) {
         let document = document_cache.get_document(&url)?;
         let document = document.node.as_ref()?;
 
-        let start = util::map_position(&document.source_file, start.into());
-        let end = util::map_position(&document.source_file, end.into());
+        let start = util::text_size_to_lsp_position(&document.source_file, start.into());
+        let end = util::text_size_to_lsp_position(&document.source_file, end.into());
 
         Some((file, start, end))
     }
@@ -593,9 +594,7 @@ fn delete_selected_element() {
         return;
     };
 
-    let Some(range) = selected_node.with_decorated_node(|n| util::map_node(&n)) else {
-        return;
-    };
+    let range = selected_node.with_decorated_node(|n| util::node_to_lsp_range(&n));
 
     // Insert a placeholder node into layouts if those end up empty:
     let new_text = placeholder_node_text(&selected_node);
@@ -1004,7 +1003,10 @@ pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior)
                         };
                         let (path, pos) = element_node.with_element_node(|node| {
                             let sf = &node.source_file;
-                            (sf.path().to_owned(), util::map_position(sf, se.offset.into()))
+                            (
+                                sf.path().to_owned(),
+                                util::text_size_to_lsp_position(sf, se.offset.into()),
+                            )
                         });
                         ask_editor_to_show_document(
                             &path.to_string_lossy(),

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -224,16 +224,11 @@ fn map_property_declaration(
     declared_at: &Option<properties::DeclarationInformation>,
 ) -> Option<PropertyDeclaration> {
     let da = declared_at.as_ref()?;
-
-    let doc = document_cache.get_document(&da.uri)?;
-    let doc_node = doc.node.as_ref()?;
-    let source_version =
-        document_cache.document_version_by_path(doc_node.source_file.path()).unwrap_or(-1);
-
+    let source_version = document_cache.document_version_by_path(&da.path).unwrap_or(-1);
     let pos = TextRange::new(da.start_position, da.start_position);
 
     Some(PropertyDeclaration {
-        source_uri: da.uri.to_string().into(),
+        source_path: da.path.to_string_lossy().to_string().into(),
         source_version,
         range: to_ui_range(pos)?,
     })
@@ -414,7 +409,7 @@ fn map_properties_to_ui(
     for pi in &properties.properties {
         let declared_at = map_property_declaration(document_cache, &pi.declared_at).unwrap_or(
             PropertyDeclaration {
-                source_uri: String::new().into(),
+                source_path: String::new().into(),
                 source_version: -1,
                 range: Range { start: 0, end: 0 },
             },

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -134,7 +134,7 @@ pub fn ui_set_known_components(
 
         if let Some(position) = &ci.defined_at {
             if let Some(library) = position.url.path().strip_prefix("/@") {
-                library_map.entry(format!("@{library}")).or_insert(Vec::new()).push(item);
+                library_map.entry(format!("@{library}")).or_default().push(item);
             } else {
                 let path = i_slint_compiler::pathutils::clean_path(
                     &(position.url.to_file_path().unwrap_or_default()),

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -62,8 +62,6 @@ impl PreviewConnector {
     ) -> Result<PreviewConnectorPromise, JsValue> {
         console_error_panic_hook::set_once();
 
-        i_slint_core::debug_log!("PreviewConnector: Enable experimental? {experimental}");
-
         WASM_CALLBACKS.set(Some(WasmCallbacks { lsp_notifier, resource_url_mapper }));
 
         Ok(JsValue::from(js_sys::Promise::new(&mut move |resolve, reject| {

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -88,7 +88,7 @@ export struct PropertyDefinition {
 
 /// The Property Declaration
 export struct PropertyDeclaration {
-    source-uri: string,
+    source-path: string,
     source-version: int,
     range: Range,
 }


### PR DESCRIPTION
The Properties are no longer sent out straight to the editor, so we do not need to convert our internal `TextRange` and `TextSize` to `lsp_types::Range` and `lsp_types::Position`.

We are noweadys turning that straight back into offsets -- which is just another name for `TextSize` (or pairs of offsets).