### PR TITLE
Remove unnecesary esp-idf component dependency

### DIFF
--- a/examples/printerdemo_mcu/esp-idf/main/CMakeLists.txt
+++ b/examples/printerdemo_mcu/esp-idf/main/CMakeLists.txt
@@ -5,7 +5,7 @@
 idf_component_register(
     SRCS "main.cpp"
     INCLUDE_DIRS "."
-    REQUIRES slint esp-box-3
+    REQUIRES slint
 )
 
 slint_target_sources(${COMPONENT_LIB} ../../ui/printerdemo.slint)


### PR DESCRIPTION
Depending on just the bsp in the yaml file is sufficient for linkage. (we use the same in the other esp-idf projects)