### PR TITLE
vscode extension: make sure the "Slint LSP" output always exist

### DIFF
--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -38,7 +38,7 @@ function startClient(
         if (m.data === "OK") {
             const cl = new LanguageClient(
                 "slint-lsp",
-                "Slint LSP",
+                "Slint",
                 clientOptions,
                 worker,
             );

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -141,6 +141,9 @@ function startClient(
 
     // Add setup common between native and wasm LSP to common.setup_client_handle!
     client.add_updater((cl) => {
+        // Just make sure that the output channel is always present.
+        cl?.outputChannel.append("");
+
         cl?.onNotification(common.serverStatus, (params: any) =>
             common.setServerStatus(params, statusBar),
         );

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -169,7 +169,7 @@ function startClient(
 
     const cl = new LanguageClient(
         "slint-lsp",
-        "Slint LSP",
+        "Slint",
         serverOptions,
         common.languageClientOptions(),
     );


### PR DESCRIPTION
It is used to show the output of `debug()`.
User don't find this output if it doesn't exist before there is any debug output. So make sure it always exist.

(Note: this is not for the browser version, since then we use console.log instead of the "Slint LSP" output from stderr)