### PR TITLE
C++: For freestanding builds, default to the fluent style

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -233,8 +233,9 @@ if (SLINT_BUILD_RUNTIME)
         )
     endif()
 
-
-    if(ANDROID)
+    if(SLINT_FEATURE_FREESTANDING)
+        set(SLINT_STYLE_DEFAULT "fluent")
+    elseif(ANDROID)
         set(SLINT_STYLE_DEFAULT "material")
     elseif(WIN32)
         set(SLINT_STYLE_DEFAULT "fluent")


### PR DESCRIPTION
Freestanding implies the lack of windowing system presence and therefore the choice of say Cupertino when building on macOS is not good.

Fluent isn't quite a great choice right now either, as it's not very touch friendly, but it's a compromise :)