### PR TITLE
Use f32 for float-to-string conversion

### DIFF
--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -167,7 +167,6 @@ pub fn use_24_hour_format() -> bool {
 /// internal re_exports used by the macro generated
 pub mod re_exports {
     pub use alloc::boxed::Box;
-    pub use alloc::format;
     pub use alloc::rc::{Rc, Weak};
     pub use alloc::string::String;
     pub use alloc::{vec, vec::Vec};
@@ -175,6 +174,7 @@ pub mod re_exports {
     pub use core::iter::FromIterator;
     pub use core::option::{Option, Option::*};
     pub use core::result::{Result, Result::*};
+    pub use i_slint_core::format;
     // This one is empty when Qt is not available, which triggers a warning
     #[allow(unused_imports)]
     pub use i_slint_backend_selector::native_widgets::*;

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2114,7 +2114,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                     quote!((#f as i32))
                 }
                 (from, Type::String) if from.as_unit_product().is_some() => {
-                    quote!(sp::SharedString::from(sp::format!("{}", #f).as_str()))
+                    quote!(sp::format!("{}", (#f) as f32))
                 }
                 (Type::Float32, Type::Model) | (Type::Int32, Type::Model) => {
                     quote!(sp::ModelRc::new(#f.max(::core::default::Default::default()) as usize))

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -188,7 +188,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
             match (v, to) {
                 (Value::Number(n), Type::Int32) => Value::Number(n.trunc()),
                 (Value::Number(n), Type::String) => {
-                    Value::String(i_slint_core::format!("{}", n))
+                    Value::String(i_slint_core::format!("{}", n as f32))
                 }
                 (Value::Number(n), Type::Color) => Color::from_argb_encoded(n as u32).into(),
                 (Value::Brush(brush), Type::Color) => brush.color().into(),

--- a/tests/cases/types/string.slint
+++ b/tests/cases/types/string.slint
@@ -10,10 +10,11 @@ export component TestCase  {
 
     // conversion from float
     in property<float> value: 98.7654321;
+    in property<float> increment: 0.1;
     out property <string> converted_value: round(value * 100)/100;
-    out property <bool> test: e1 && !e2 && converted_value == "98.77";
+    out property <string> ten_dot_one: 10 + increment;
+    out property <bool> test: e1 && !e2 && converted_value == "98.77" && ten_dot_one == "10.1";
 }
-
 
 /*
 


### PR DESCRIPTION
Because f64 has too much precision, so limit to f32 so that we don't have extra precision we don't need and would be wrong as all our float as in f32