### PR TITLE
vscode: Better options on project location

### DIFF
--- a/editors/vscode/src/quick_picks.ts
+++ b/editors/vscode/src/quick_picks.ts
@@ -40,7 +40,6 @@ export async function newProject(context: vscode.ExtensionContext) {
     let workspacePath: string | undefined =
         vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
-    if (!workspacePath) {
         const folderUris = await vscode.window.showOpenDialog({
             canSelectFolders: true,
             canSelectMany: false,
@@ -55,7 +54,6 @@ export async function newProject(context: vscode.ExtensionContext) {
         }
 
         workspacePath = folderUris[0].fsPath;
-    }
 
     const projectName = await vscode.window.showInputBox({
         prompt: "Enter the name of the new project",

--- a/editors/vscode/src/quick_picks.ts
+++ b/editors/vscode/src/quick_picks.ts
@@ -30,13 +30,13 @@ export async function newProject(context: vscode.ExtensionContext) {
 
     let repoUrl: string | undefined;
     switch (language) {
-        case "Node (JavaScript/TypeScript)":
+        case node:
             repoUrl = "https://github.com/slint-ui/slint-nodejs-template";
             break;
-        case "C++":
+        case cpp:
             repoUrl = "https://github.com/slint-ui/slint-cpp-template";
             break;
-        case "Rust":
+        case rust:
             repoUrl = "https://github.com/slint-ui/slint-rust-template";
             break;
         default:

--- a/editors/vscode/src/quick_picks.ts
+++ b/editors/vscode/src/quick_picks.ts
@@ -42,22 +42,23 @@ export async function newProject(context: vscode.ExtensionContext) {
     }
 
     let workspacePath: string | undefined =
-        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
-        const folderUris = await vscode.window.showOpenDialog({
-            canSelectFolders: true,
-            canSelectMany: false,
-            openLabel: "Select Folder",
-        });
+    const folderUris = await vscode.window.showOpenDialog({
+        canSelectFolders: true,
+        canSelectMany: false,
+        openLabel: "Select Folder",
+        defaultUri: workspacePath ? vscode.Uri.file(workspacePath) : undefined
+    });
 
-        if (!folderUris || folderUris.length === 0) {
-            vscode.window.showErrorMessage(
-                "Please select a folder to place the project in.",
-            );
-            return;
-        }
+    if (!folderUris || folderUris.length === 0) {
+        vscode.window.showErrorMessage(
+            "Please select a folder to place the project in.",
+        );
+        return;
+    }
 
-        workspacePath = folderUris[0].fsPath;
+    workspacePath = folderUris[0].fsPath;
 
     const projectName = await vscode.window.showInputBox({
         prompt: "Enter the name of the new project",

--- a/editors/vscode/src/quick_picks.ts
+++ b/editors/vscode/src/quick_picks.ts
@@ -10,10 +10,11 @@ import * as path from "node:path";
 // (1) What language? (2) What directory? (3) What name? (4) Open in current window or new window?
 
 export async function newProject(context: vscode.ExtensionContext) {
-    type Language = "Node (JavaScript/TypeScript)" | "C++" | "Rust";
+    const LANGUAGES = ["Node (JavaScript/TypeScript)", "C++", "Rust"] as const;
+    type Language = typeof LANGUAGES[number];
 
     const language = await vscode.window.showQuickPick(
-        ["Node (JavaScript/TypeScript)", "C++", "Rust"],
+        LANGUAGES,
         {
             placeHolder: "What language do you want to use?",
         },

--- a/editors/vscode/src/quick_picks.ts
+++ b/editors/vscode/src/quick_picks.ts
@@ -6,6 +6,9 @@ import * as fs from "fs-extra";
 import simpleGit from "simple-git";
 import * as path from "node:path";
 
+// Flow
+// (1) What language? (2) What directory? (3) What name? (4) Open in current window or new window?
+
 export async function newProject(context: vscode.ExtensionContext) {
     type Language = "Node (JavaScript/TypeScript)" | "C++" | "Rust";
 


### PR DESCRIPTION
This always asks for the user to select a location for the project.
If VScode is already in a folder it will default to that location.

Then at the end the user is asked if they wish to open the project in a new window, the current window or current window, but new workspace.

Finally I tweaked the Typescript to be less hardcoded strings with potential errors from typos.