### PR TITLE
Dependabot should ignore @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
     schedule:
       interval: "weekly"
       time: "04:00"
+    ignore:
+      - dependency-name: "@types/node"
     groups:
       vscode_major:
         patterns:


### PR DESCRIPTION
The latest node types will always be a future beta or version that is not under LTS. According to this [issue](https://github.com/dependabot/dependabot-core/issues/2247) there is no solution. So the simplest one is to ignore it and just manually update the types as and when needed.