### PR TITLE
Reduce size of VS code extension production builds

### DIFF
--- a/editors/vscode/esbuild.js
+++ b/editors/vscode/esbuild.js
@@ -1,6 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+const production = process.argv.includes('--production');
+
+const commonBuildOptions = {
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+};
+
 let wasmPlugin = {
     name: "wasm",
     setup(build) {
@@ -42,6 +50,7 @@ esbuild
         outfile: "out/browser.js",
         format: "cjs",
         platform: "browser",
+        ...commonBuildOptions
     })
     .catch(() => process.exit(1));
 
@@ -53,6 +62,7 @@ esbuild
         format: "iife",
         platform: "browser",
         plugins: [wasmPlugin],
+        ...commonBuildOptions
     })
     .catch(() => process.exit(1));
 
@@ -64,5 +74,6 @@ esbuild
         outfile: "out/extension.js",
         platform: "node",
         format: "cjs",
+        ...commonBuildOptions
     })
     .catch(() => process.exit(1));

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -197,12 +197,13 @@
     "bin/slint-lsp-*"
   ],
   "scripts": {
-    "vscode:prepublish": "npm run build:wasm_lsp-release && npm run compile && shx echo \"GPL-3.0-only OR LicenseRef-Slint-Software-3.0\" > LICENSE.txt",
+    "vscode:prepublish": "npm run build:wasm_lsp-release && npm run compile-production && shx echo \"GPL-3.0-only OR LicenseRef-Slint-Software-3.0\" > LICENSE.txt",
     "build:lsp": "cargo build -p slint-lsp",
     "build:lsp-release": "cargo build --release -p slint-lsp",
     "build:wasm_lsp": "env-var wasm-pack build --dev     --target web --no-pack ../../tools/lsp --out-dir {{npm_config_local_prefix}}/out -- --no-default-features --features backend-winit,renderer-femtovg,preview",
     "build:wasm_lsp-release": "env-var wasm-pack build --release --target web --no-pack ../../tools/lsp --out-dir {{npm_config_local_prefix}}/out -- --no-default-features --features backend-winit,renderer-femtovg,preview",
     "compile": "node ./esbuild.js",
+    "compile-production": "node ./esbuild.js --production",
     "local-package": "shx mkdir -p bin && shx cp ../../target/debug/slint-lsp* bin/ && npx vsce package",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run check",


### PR DESCRIPTION
Follow basically the steps of https://code.visualstudio.com/api/working-with-extensions/bundling-extension#using-esbuild to minify the JS and omit source maps.