### PR TITLE
Lint and build the VScode extension as a CI check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -325,7 +325,11 @@ jobs:
             - uses: ./.github/actions/install-linux-dependencies            
             - uses: actions/setup-node@v4
               with:
-                  node-version: 18            
+                  node-version: 18
+            - name: Install wasm-pack
+              run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+            - name: Build lap
+              run: cargo build -p slint-lsp
             - name: Run npm install
               working-directory: ./editors/vscode
               run: npm clean-install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -332,6 +332,9 @@ jobs:
             - name: Lint vscode project
               working-directory: ./editors/vscode
               run: npm run lint
+            - name: vscode prebuild
+              working-directory: ./editors/vscode
+              run: npm run vscode:prepublish
             - name: Build VS Code extension
               working-directory: ./editors/vscode
               run: npm run local-package

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -331,7 +331,7 @@ jobs:
                   node-version: 18
             - name: Install wasm-pack
               run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-            - name: Build lap
+            - name: Build lsp
               run: cargo build -p slint-lsp
             - name: Run npm install
               working-directory: ./editors/vscode

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,6 +312,25 @@ jobs:
                   cmakeAppendedArgs: "-DCMAKE_BUILD_TYPE=Release -DSLINT_FEATURE_INTERPRETER=1 -DSLINT_FEATURE_BACKEND_QT=1"
                   buildDirectory: ${{ runner.workspace }}/examples/build
                   buildWithCMakeArgs: "--config Release"
+    
+    vsce_build_test:
+        strategy:
+            matrix:
+                os: [ubuntu-22.04]
+
+        runs-on: ${{ matrix.os }}
+
+        steps:
+            - uses: actions/checkout@v4
+            - name: Run npm install
+              working-directory: ./editors/vscode
+              run: npm clean-install
+            - name: Lint vscode project
+              working-directory: ./editors/vscode
+              run: npm run lint
+            - name: Build VS Code extension
+              working-directory: ./editors/vscode
+              run: npm run local-package
 
     # test to compile the mcu backend for the arm target (no_std)
     mcu:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,6 +322,10 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+            - uses: ./.github/actions/install-linux-dependencies            
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18            
             - name: Run npm install
               working-directory: ./editors/vscode
               run: npm clean-install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,6 +322,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+            - uses: Swatinem/rust-cache@v2
+              with:
+                key: "vsce_1" # increment this to bust the cache if needed
             - uses: ./.github/actions/install-linux-dependencies            
             - uses: actions/setup-node@v4
               with:


### PR DESCRIPTION
Also synergises with Dependabot so any PR's the bot creates will be tested by this. Currently the PR will look okay even if it breaks the project.