### PR TITLE
LSP: don't insert semicolon after completing a property

### DIFF
--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -69,7 +69,7 @@ pub(crate) fn completion_at(
                     c.insert_text_format = Some(InsertTextFormat::SNIPPET);
                     match c.kind {
                         Some(CompletionItemKind::PROPERTY) => {
-                            c.insert_text = Some(format!("{}: $1;", c.label))
+                            c.insert_text = Some(format!("{}: ", c.label))
                         }
                         Some(CompletionItemKind::METHOD) => {
                             c.insert_text = Some(format!("{} => {{$1}}", c.label))


### PR DESCRIPTION
Fixes https://github.com/slint-ui/slint/issues/5966

The previous behavior, as described in the issue is: (where `|` is the cursor)

```slint
Rectangle {
    back|
}
```

and autocomplete background, it will insert

```slint
Rectangle {
    background: |;
}
```

This commit changes to not add the semicolon, so the result will be

```slint
Rectangle {
    background: |
}
```