### PR TITLE
live-preview: Pass a element node to ui when converting property info

### DIFF
--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -465,6 +465,7 @@ fn map_properties_to_ui(
 pub fn ui_set_properties(
     ui: &PreviewUi,
     document_cache: &common::DocumentCache,
+    _element_node: &common::ElementRcNode,
     properties: Option<properties::QueryPropertyResponse>,
 ) {
     let element = map_properties_to_ui(document_cache, properties).unwrap_or(ElementInformation {


### PR DESCRIPTION
We need an ElementRcNode (based on the AST from the document cache!), so that we can look up types in the Document's local type registry (LATER!)