### PR TITLE
Speed up vsce CI step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -327,8 +327,10 @@ jobs:
                   node-version: 18
             - name: Install wasm-pack
               run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-            - name: Build lsp
-              run: cargo build -p slint-lsp
+            - name: Fake slint-lsp build
+              run: |
+                  mkdir -p target/debug
+                  echo 1 > target/debug/slint-lsp
             - name: Run npm install
               working-directory: ./editors/vscode
               run: npm clean-install


### PR DESCRIPTION
Don't build slint-lsp.

(there's still the wasm build though)