### PR TITLE
Improve conversion of property info for the UI

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -866,6 +866,26 @@ impl SyntaxNode {
             .token_at_offset(offset)
             .map(|token| SyntaxToken { token, source_file: self.source_file.clone() })
     }
+    pub fn first_child(&self) -> Option<SyntaxNode> {
+        self.node
+            .first_child()
+            .map(|node| SyntaxNode { node, source_file: self.source_file.clone() })
+    }
+    pub fn first_child_or_token(&self) -> Option<NodeOrToken> {
+        self.node.first_child_or_token().map(|n_o_t| match n_o_t {
+            rowan::NodeOrToken::Node(node) => {
+                NodeOrToken::Node(SyntaxNode { node, source_file: self.source_file.clone() })
+            }
+            rowan::NodeOrToken::Token(token) => {
+                NodeOrToken::Token(SyntaxToken { token, source_file: self.source_file.clone() })
+            }
+        })
+    }
+    pub fn next_sibling(&self) -> Option<SyntaxNode> {
+        self.node
+            .next_sibling()
+            .map(|node| SyntaxNode { node, source_file: self.source_file.clone() })
+    }
 }
 
 #[derive(Debug, Clone, derive_more::From)]

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -212,17 +212,13 @@ fn find_code_block_or_expression(
     let mut selection_range = None;
     let mut code_block_or_expression = None;
     let mut property_definition_range = None;
-    let source_file = &element.source_file;
 
     if let Some(token) = element.token_at_offset(offset.into()).right_biased() {
         for ancestor in token.parent_ancestors() {
             if ancestor.kind() == SyntaxKind::BindingExpression {
                 // The BindingExpression contains leading and trailing whitespace + `;`
                 if let Some(child) = ancestor.first_child() {
-                    code_block_or_expression = CodeBlockOrExpression::new(SyntaxNode {
-                        node: child,
-                        source_file: source_file.clone(),
-                    });
+                    code_block_or_expression = CodeBlockOrExpression::new(child);
                 }
                 continue;
             }

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -33,6 +33,13 @@ impl CodeBlockOrExpression {
             _ => None,
         }
     }
+
+    pub fn expression(&self) -> Option<syntax_nodes::Expression> {
+        match self {
+            CodeBlockOrExpression::CodeBlock(_) => None,
+            CodeBlockOrExpression::Expression(expr) => Some(expr.clone()),
+        }
+    }
 }
 
 impl std::ops::Deref for CodeBlockOrExpression {
@@ -718,7 +725,7 @@ pub fn remove_binding(
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
 
     use crate::language::test::{complex_document_cache, loaded_document_cache};
@@ -730,7 +737,7 @@ mod tests {
         properties.iter().find(|p| p.name == name)
     }
 
-    fn properties_at_position_in_cache(
+    pub fn properties_at_position_in_cache(
         line: u32,
         character: u32,
         document_cache: &common::DocumentCache,

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -69,11 +69,26 @@ export struct Range {
     end: int,
 }
 
+export enum PropertyValueKind {
+    Code,
+    Boolean,
+    String,
+    Enum,
+}
+
 /// Data about the property value for use in "simple" mode
-export struct SimpleValueData {
-    widget: string,
+export struct PropertyValue {
+    value-bool: bool,
+    is-translatable: bool,
+    kind: PropertyValueKind,
+    value-float: float,
+    value-int: int,
+    default-selection: int,
+    value-string: string,
     visual-items: [string],
-    meta-data: [string],
+    tr-context: string,
+    tr-plural: string,
+    code: string,
 }
 
 /// Important Ranges in the property definition
@@ -99,7 +114,7 @@ export struct PropertyInformation {
     type-name: string,
     declared-at: PropertyDeclaration,
     defined-at: PropertyDefinition,
-    simple-value: SimpleValueData,
+    value: PropertyValue,
 }
 
 /// Information on one Property
@@ -203,8 +218,10 @@ export global Api {
     callback show-preview-for(/* name: */ string, /* url: */ string);
 
     // ## Property Editor
-    pure callback test-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string) -> bool;
-    pure callback test-simple-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* simple-property-value: */ [string]) -> bool;
-    callback set-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string);
-    callback set-simple-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* simple-property-value: */ [string]);
+    pure callback test-code-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string) -> bool;
+    pure callback test-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string) -> bool;
+    callback set-code-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string);
+    callback set-bool-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ bool);
+    callback set-enum-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* enum_type: */ string, /* enum_value: */ string);
+    callback set-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string);
 }

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { LineEdit, Palette, VerticalBox, CheckBox, ComboBox, ScrollView } from "std-widgets.slint";
+import { LineEdit, Palette, VerticalBox, CheckBox, ComboBox, ScrollView, Button } from "std-widgets.slint";
 
-import { Api, ElementInformation, SimpleValueData } from "../api.slint";
+import { Api, ElementInformation, PropertyValue, PropertyValueKind } from "../api.slint";
 import { GroupHeader } from "../components/group.slint";
 import { BodyText } from "../components/body-text.slint";
 import { EditorSizeSettings } from "../components/styling.slint";
@@ -67,13 +67,9 @@ export component PropertyView {
                                 for property in group.properties: property-row := HorizontalLayout {
                                     private property <string> property-name: property.name;
                                     private property <string> property-type: property.type-name;
-                                    private property <string> property-value: property.defined-at.expression-value;
-                                    private property <SimpleValueData> simple-value: property.simple-value;
+                                    private property <PropertyValue> property-value: property.value;
 
-                                    private property <bool> is-defined: self.property-value != "";
-                                    private property <bool> is-simple: simple-value.widget != "" && !self.force-to-complex;
-
-                                    private property <bool> force-to-complex: false;
+                                    private property <bool> is-defined: self.property-value.code != "";
 
                                     private property <brush> text-foreground: property-row.is-defined ? Palette.foreground : Palette.foreground.transparentize(0.5);
 
@@ -96,110 +92,80 @@ export component PropertyView {
                                         }
                                     }
 
-                                    complexity-icon := TouchArea {
-                                        width: complexity-icon-icon.width;
-                                        horizontal-stretch: 0;
-
-                                        complexity-icon-icon := Image {
-                                            width: self.preferred-width;
-                                            colorize: property-row.is-simple ? Palette.foreground : Palette.foreground.transparentize(0.7);
-
-                                            source: @image-url("../assets/function.svg");
-                                        }
-
-                                        clicked() => { property-row.force-to-complex = !property-row.force-to-complex; }
-                                    }
-
                                     Rectangle {
                                         min-height: 20px;
                                         horizontal-stretch: 1;
 
                                         private property <bool> have-simple-ui: false;
 
-                                        if property-row.is-simple && property-row.simple-value.widget == "bool": CheckBox {
+                                        if property-row.property-value.kind == PropertyValueKind.Code && property-row.property-value.code != "": Button {
+                                            text: @tr("Code");
+                                            clicked() => {
+                                                Api.show-document-offset-range(root.current-element.source-uri, property.defined-at.expression-range.start, property.defined-at.expression-range.start);
+                                            }
+                                        }
+                                        if property-row.property-value.kind == PropertyValueKind.Code && property-row.property-value.code == "": Text {
+                                            text: @tr("<unset>");
+                                        }
+                                        if property-row.property-value.kind == PropertyValueKind.Boolean: CheckBox {
                                             x: 0;
-                                            checked: property-row.simple-value.meta-data[0] == "true";
+                                            checked: property-row.property-value.value_bool;
 
                                             toggled() => {
-                                                Api.set-simple-binding(
+                                                Api.set-bool-binding(
                                                     root.current-element.source-uri,
                                                     root.current-element.source-version,
                                                     root.current-element.range.start,
                                                     property.name,
-                                                    ["bool", self.checked ? "true" : "false"],
+                                                    self.checked,
                                                 );
                                             }
                                         }
-                                        if property-row.is-simple && property-row.simple-value.widget == "string": LineEdit {
+                                        if property-row.property-value.kind == PropertyValueKind.String: LineEdit {
                                             width: 100%;
                                             height: 100%; // otherwise this gets too high and covers several rows.
-                                            text: property-row.simple-value.meta-data[0];
+                                            text: property-row.property-value.value-string;
 
                                             edited(text) => {
-                                                overlay.visible = !Api.test-simple-binding(
+                                                overlay.visible = !Api.test-string-binding(
                                                     root.current-element.source-uri,
                                                     root.current-element.source-version,
                                                     root.current-element.range.start,
                                                     property.name,
-                                                    ["string", text],
+                                                    text,
                                                 );
                                             }
 
                                             accepted(text) => {
-                                                Api.set-simple-binding(
+                                                Api.set-string-binding(
                                                     root.current-element.source-uri,
                                                     root.current-element.source-version,
                                                     root.current-element.range.start,
                                                     property.name,
-                                                    ["string", text],
+                                                    text,
                                                 );
                                             }
                                         }
-                                        if property-row.is-simple && property-row.simple-value.widget == "enum": ComboBox {
+                                        if property-row.property-value.kind == PropertyValueKind.Enum: ComboBox {
                                             width: 100%;
                                             height: 100%; // otherwise this gets too high and covers several rows.
 
-                                            current-index: property-row.simple-value.meta-data[2].to-float();
+                                            current-index: property-row.property-value.value-int;
 
-                                            model: property-row.simple-value.visual-items;
+                                            model: property-row.property-value.visual-items;
 
                                             selected(value) => {
-                                                Api.set-simple-binding(
+                                                Api.set-enum-binding(
                                                     root.current-element.source-uri,
                                                     root.current-element.source-version,
                                                     root.current-element.range.start,
                                                     property.name,
-                                                    ["enum", property-row.simple-value.meta-data[0], value],
+                                                    property-value.value_string,
+                                                    value,
                                                 )
                                             }
                                         }
 
-
-                                        if !property-row.is-simple: LineEdit {
-                                            width: 100%;
-                                            height: 100%; // otherwise this gets too high and covers several rows.
-                                            text: property.defined-at.expression-value;
-
-                                            edited(text) => {
-                                                overlay.visible = !Api.test-binding(
-                                                    root.current-element.source-uri,
-                                                    root.current-element.source-version,
-                                                    root.current-element.range.start,
-                                                    property.name,
-                                                    text,
-                                                );
-                                            }
-
-                                            accepted(text) => {
-                                                Api.set-binding(
-                                                    root.current-element.source-uri,
-                                                    root.current-element.source-version,
-                                                    root.current-element.range.start,
-                                                    property.name,
-                                                    text,
-                                                );
-                                            }
-                                        }
                                         overlay := Rectangle {
                                             visible: false;
                                             background: #80000040;


### PR DESCRIPTION
A big PR, but a lot of this is testing :-)

* More type-safe API (although it is still not *nice*)
* Also accept locally defined enums. This used to work only with "our" enums...
* Tests!!!

This PR also does *babysteps* towards changing the UI of the property editor, but it is 98% about the backend, and only the parts we had covered before. I still need to add in length, angle, ...  That's next.

The idea is to have something in place for Florian to play with tomorrow.