### PR TITLE
Timer: fix timer when two timers have the same id

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -183,6 +183,8 @@ fn inline_element(
             .map(|p| duplicate_popup(p, &mut mapping, priority_delta)),
     );
 
+    root_component.timers.borrow_mut().extend(inlined_component.timers.borrow().iter().cloned());
+
     let mut moved_into_popup = HashSet::new();
     if let Some(children) = move_children_into_popup {
         let child_insertion_point = inlined_component.child_insertion_point.borrow();
@@ -409,6 +411,9 @@ fn duplicate_sub_component(
     recurse_elem(&new_component.root_element, &(), &mut |e, _| {
         e.borrow_mut().enclosing_component = weak.clone()
     });
+    for o in new_component.optimized_elements.borrow().iter() {
+        o.borrow_mut().enclosing_component = weak.clone()
+    }
     *new_component.popup_windows.borrow_mut() = component_to_duplicate
         .popup_windows
         .borrow()

--- a/internal/compiler/passes/unique_id.rs
+++ b/internal/compiler/passes/unique_id.rs
@@ -32,6 +32,15 @@ fn assign_unique_id_in_component(component: &Rc<Component>, count: &mut u32) {
             elem_mut.base_type.to_string().to_ascii_lowercase()
         };
         elem_mut.id = format!("{}-{}", old_id, count);
+
+        let enclosing = elem_mut.enclosing_component.upgrade().unwrap();
+        if Rc::ptr_eq(&elem, &enclosing.root_element) {
+            for o in enclosing.optimized_elements.borrow().iter() {
+                *count += 1;
+                let mut elem_mut = o.borrow_mut();
+                elem_mut.id = format!("optimized-{}-{}", elem_mut.id, count);
+            }
+        }
     });
 }
 

--- a/tests/cases/elements/timer.slint
+++ b/tests/cases/elements/timer.slint
@@ -1,14 +1,37 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-/*component FizBuzz {
-    out property <string> result;
+component SubCompo {
 
-}*/
+    out property <string> r;
+
+    HorizontalLayout {
+        Rectangle {}
+        Timer {
+            interval: 1s;
+            triggered => { r += "A"; }
+        }
+        Timer {
+            interval: 1.502s;
+            triggered => { r += "B"; }
+        }
+        for l in ["c", "d"] : Rectangle {
+            Timer {
+                interval: 3.0003s;
+                triggered => { r += l; }
+            }
+        }
+    }
+    init => {
+        // instentiate the repeater
+        debug(root.preferred-height);
+    }
+}
 
 export component TestCase inherits Window {
 
     out property <string> result;
+    out property <string> second_result: s.r;
 
     in property <int> tm2duration;
     in property <bool> tm2running <=> tm2.running;
@@ -36,6 +59,7 @@ export component TestCase inherits Window {
             interval: -5ms;
             triggered => { result += "oops"; }
         }
+        s := SubCompo {  }
     }
 
 
@@ -76,6 +100,11 @@ slint_testing::mock_elapsed_time(2);
 assert_eq!(instance.get_result(), "1212222");
 slint_testing::mock_elapsed_time(19);
 assert_eq!(instance.get_result(), "12122222");
+
+for _ in 0..20 {
+    slint_testing::mock_elapsed_time(500);
+}
+assert_eq!(instance.get_second_result(), "ABAcdABAABAcdABAAcdBAABAcd");
 ```
 
 ```cpp
@@ -113,6 +142,11 @@ slint_testing::mock_elapsed_time(2);
 assert_eq(instance.get_result(), "1212222");
 slint_testing::mock_elapsed_time(19);
 assert_eq(instance.get_result(), "12122222");
+
+for (int i = 0; i < 20; ++i) {
+    slint_testing::mock_elapsed_time(500);
+}
+assert_eq(instance.get_second_result(), "ABAcdABAABAcdABAAcdBAABAcd");
 ```
 
 ```js
@@ -149,5 +183,10 @@ slintlib.private_api.mock_elapsed_time(2);
 assert.equal(instance.result, "1212222");
 slintlib.private_api.mock_elapsed_time(19);
 assert.equal(instance.result, "12122222");
+
+for (var i = 0; i < 20; ++i) {
+    slintlib.private_api.mock_elapsed_time(500);
+}
+assert.equal(instance.second_result, "ABAcdABAABAcdABAAcdBAABAcd");
 ```
 */


### PR DESCRIPTION
We need to give unique name to optimized item as well, otherwise the properties ends up the same.

Also fix the optimized element and timer when inlining

Fixes #5977
Fixes #5976