### PR TITLE
live-preview on macOS: Fix ever bouncing icon and re-add a quit item

### DIFF
--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -68,7 +68,7 @@ preview-lense = []
 ## to provide an implementation of the external preview API when building for WASM)
 preview-api = ["preview-external"]
 ## Build in the actual code to act as a preview for slint files.
-preview-engine = ["dep:slint", "dep:slint-interpreter", "dep:i-slint-core", "dep:i-slint-backend-selector", "dep:image", "dep:slint-build", "dep:i-slint-common", "dep:i-slint-backend-winit", "dep:muda"]
+preview-engine = ["dep:slint", "dep:slint-interpreter", "dep:i-slint-core", "dep:i-slint-backend-selector", "dep:image", "dep:slint-build", "dep:i-slint-common", "dep:i-slint-backend-winit", "dep:muda", "dep:objc2-foundation"]
 ## Build in the actual code to act as a preview for slint files. Does nothing in WASM!
 preview-builtin = ["preview-engine"]
 ## Support the external preview optionally used by e.g. the VSCode plugin
@@ -115,6 +115,7 @@ wasm-bindgen-futures = "0.4.30"
 [target.'cfg(target_vendor = "apple")'.dependencies]
 i-slint-backend-winit = { workspace = true, optional = true }
 muda = { version = "0.14.1", optional = true }
+objc2-foundation = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 i-slint-backend-testing = { path = "../../internal/backends/testing" }

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -204,38 +204,6 @@ fn main() {
     let args: Cli = Cli::parse();
     if !args.backend.is_empty() {
         std::env::set_var("SLINT_BACKEND", &args.backend);
-    } else {
-        #[cfg(target_vendor = "apple")]
-        {
-            use i_slint_backend_winit::winit;
-            use muda::{Menu, PredefinedMenuItem, Submenu};
-            use winit::platform::macos::EventLoopBuilderExtMacOS;
-            let mut builder = winit::event_loop::EventLoop::with_user_event();
-            builder.with_default_menu(false);
-            slint::platform::set_platform(Box::new(
-                i_slint_backend_winit::Backend::new_with_renderer_by_name_and_event_loop_builder(
-                    None, builder,
-                )
-                .unwrap(),
-            ))
-            .unwrap();
-
-            let menu_bar = Menu::new();
-            menu_bar.init_for_nsapp();
-            let app_m = Submenu::new("App", true);
-            menu_bar.append(&app_m).unwrap();
-            app_m
-                .append_items(&[
-                    &PredefinedMenuItem::about(None, None),
-                    &PredefinedMenuItem::separator(),
-                    &PredefinedMenuItem::services(None),
-                    &PredefinedMenuItem::separator(),
-                    &PredefinedMenuItem::hide(None),
-                    &PredefinedMenuItem::hide_others(None),
-                    &PredefinedMenuItem::show_all(None),
-                ])
-                .unwrap();
-        }
     }
 
     if let Some(Commands::Format(args)) = args.command {


### PR DESCRIPTION
We need to do the platform init only when we intend to soon thereafter show a window.

Re-added a Quit item that merely hides the UI, so CMD+Q kind of works for convenience.