### PR TITLE
Avid reporting further error when an element is misspelled

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -541,7 +541,7 @@ impl ElementType {
 
         tr.lookup_element(name).and_then(|t| {
             if !tr.expose_internal_types && matches!(&t, Self::Builtin(e) if e.is_internal) {
-                Err(format!("Unknown type {}. (The type exist as an internal type, but cannot be accessed in this scope)", name))
+                Err(format!("Unknown element '{}'. (The type exist as an internal type, but cannot be accessed in this scope)", name))
             } else {
                 Ok(t)
             }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1267,10 +1267,12 @@ impl Element {
             } else if property_type == Type::InferredCallback {
                 // argument matching will happen later
             } else {
-                diag.push_error(
-                    format!("'{}' is not a callback in {}", unresolved_name, r.base_type),
-                    &con_node.child_token(SyntaxKind::Identifier).unwrap(),
-                );
+                if r.base_type != ElementType::Error {
+                    diag.push_error(
+                        format!("'{}' is not a callback in {}", unresolved_name, r.base_type),
+                        &con_node.child_token(SyntaxKind::Identifier).unwrap(),
+                    );
+                }
                 continue;
             }
             match r.bindings.entry(resolved_name.into_owned()) {
@@ -1294,6 +1296,9 @@ impl Element {
             for prop_name_token in anim.QualifiedName() {
                 match QualifiedTypeName::from_node(prop_name_token.clone()).members.as_slice() {
                     [unresolved_prop_name] => {
+                        if r.base_type == ElementType::Error {
+                            continue;
+                        };
                         let lookup_result = r.lookup_property(unresolved_prop_name);
                         let valid_assign = lookup_result.is_valid_for_assignment();
                         if let Some(anim_element) = animation_element_from_node(
@@ -1358,10 +1363,12 @@ impl Element {
             let Some(prop) = parser::identifier_text(&ch.DeclaredIdentifier()) else { continue };
             let lookup_result = r.lookup_property(&prop);
             if !lookup_result.is_valid() {
-                diag.push_error(
-                    format!("Property '{prop}' does not exist"),
-                    &ch.DeclaredIdentifier(),
-                );
+                if r.base_type != ElementType::Error {
+                    diag.push_error(
+                        format!("Property '{prop}' does not exist"),
+                        &ch.DeclaredIdentifier(),
+                    );
+                }
             } else if !lookup_result.property_type.is_property_type() {
                 let what = match lookup_result.property_type {
                     Type::Function { .. } => "a function",

--- a/internal/compiler/tests/syntax/basic/unknown_item.slint
+++ b/internal/compiler/tests/syntax/basic/unknown_item.slint
@@ -5,14 +5,17 @@ struct Struct := { def: int, }
 
 export SuperSimple := Rectangle {
     DoesNotExist {
-//  ^error{Unknown type DoesNotExist}
+//  ^error{Unknown element 'DoesNotExist'}
     }
 
     dd := DoesNotExist2 {
-//        ^error{Unknown type DoesNotExist2}
+//        ^error{Unknown element 'DoesNotExist2'}
         abc: 42;
+        cb => {}
+        animate abcd { duration: 3ms; }
+        changed efgh => { self.foo(); }
         Hallo {}
-//      ^error{Unknown type Hallo}
+//      ^error{Unknown element 'Hallo'}
         Rectangle {
             background: blue;
             foo_bar: blue;
@@ -24,8 +27,9 @@ export SuperSimple := Rectangle {
     float {
 //  ^error{'float' cannot be used as an element}
         abc: 42;
+        cb => {}
         Hallo {}
-//      ^error{Unknown type Hallo}
+//      ^error{Unknown element 'Hallo'}
 
     }
 
@@ -34,7 +38,7 @@ export SuperSimple := Rectangle {
         def: "42";
         xyz: "42";
         Hallo {}
-//      ^error{Unknown type Hallo}
+//      ^error{Unknown element 'Hallo'}
     }
 
     Rectangle {
@@ -44,9 +48,9 @@ export SuperSimple := Rectangle {
     }
 
     NativeLineEdit { }
-//  ^error{Unknown type NativeLineEdit. \(The type exist as an internal type, but cannot be accessed in this scope\)}
+//  ^error{Unknown element 'NativeLineEdit'. \(The type exist as an internal type, but cannot be accessed in this scope\)}
 
     Opacity { }
-//  ^error{Unknown type Opacity. \(The type exist as an internal type, but cannot be accessed in this scope\)}
+//  ^error{Unknown element 'Opacity'. \(The type exist as an internal type, but cannot be accessed in this scope\)}
 
 }

--- a/internal/compiler/tests/syntax/elements/tabwidget3.slint
+++ b/internal/compiler/tests/syntax/elements/tabwidget3.slint
@@ -3,9 +3,9 @@
 
 export Test3 := Rectangle {
     TabWidget {
-//  ^error{Unknown type TabWidget. \(The type exist as an internal type, but cannot be accessed in this scope\)}
+//  ^error{Unknown element 'TabWidget'. \(The type exist as an internal type, but cannot be accessed in this scope\)}
     }
 }
 
 export Foo := TabWidget { }
-//            ^error{Unknown type TabWidget. \(The type exist as an internal type, but cannot be accessed in this scope\)}
+//            ^error{Unknown element 'TabWidget'. \(The type exist as an internal type, but cannot be accessed in this scope\)}

--- a/internal/compiler/tests/syntax/imports/bug_2719.slint
+++ b/internal/compiler/tests/syntax/imports/bug_2719.slint
@@ -11,5 +11,5 @@ export component X {
     Qq {  }
     SomeRect {  }
     Yy {  }
-//  ^error{Unknown type Yy}
+//  ^error{Unknown element 'Yy'}
 }

--- a/internal/compiler/tests/syntax/imports/cyclic_import.slint
+++ b/internal/compiler/tests/syntax/imports/cyclic_import.slint
@@ -4,6 +4,6 @@
 import { Rec12 } from "../../typeloader/recursive_import1.slint";
 //                    ^error{No exported type called 'Rec12' found in ".*recursive_import1.slint"}
 export Blah := Rec12 {
-//             ^error{Unknown type Rec12}
+//             ^error{Unknown element 'Rec12'}
     width: 100px;
 }

--- a/internal/compiler/tests/syntax/imports/invalid_export.slint
+++ b/internal/compiler/tests/syntax/imports/invalid_export.slint
@@ -11,5 +11,5 @@ export { string as Boob }
 //       ^error{Cannot export 'string' because it is not a component}
 
 export Hello := Plop {
-//              ^error{Unknown type Plop}
+//              ^error{Unknown element 'Plop'}
 }

--- a/internal/compiler/tests/typeloader/incpath/should_fail.slint
+++ b/internal/compiler/tests/typeloader/incpath/should_fail.slint
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export X := SomeRect {
-//          ^error{Unknown type SomeRect}
+//          ^error{Unknown element 'SomeRect'}
     foo: 42;
 }

--- a/internal/compiler/tests/typeloader/incpath/should_fail2.slint
+++ b/internal/compiler/tests/typeloader/incpath/should_fail2.slint
@@ -3,7 +3,7 @@
 
 export X := Rectangle {
     eh := Invalid {
-//        ^error{Unknown type Invalid}
+//        ^error{Unknown element 'Invalid'}
         foo: 42;
     }
     width: eh.bhal;

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -454,7 +454,7 @@ impl TypeRegister {
             } else if let Some(ty) = self.types.get(name) {
                 format!("'{}' cannot be used as an element", ty)
             } else {
-                format!("Unknown type {}", name)
+                format!("Unknown element '{}'", name)
             }
         })
     }


### PR DESCRIPTION
eg, don't report an error for each callback or animation or changed event that the the property doesn't exist or such.

Also reword the message when an element doesn't exist. Use "element" rather than "type" as it is more accurate.