### PR TITLE
Fix error cursor_rect when text is empty

### DIFF
--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -616,7 +616,7 @@ pub(crate) fn layout_text_lines(
     };
     let mut y = baseline_y;
     let mut start = 0;
-    'lines: while start < string.len() && y + font_height <= max_height {
+    'lines: while start <= string.len() && y + font_height <= max_height {
         if wrap && (!elide || y + font_height * 2. <= max_height) {
             let max_line_index = string[start..].find('\n').map_or(string.len(), |i| i + 1 + start);
             let index = text_context

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -447,7 +447,9 @@ impl RendererSealed for FemtoVGRenderer {
             text_input.single_line(),
             &paint,
             |line_text, line_pos, start, metrics| {
-                if (start..=(start + line_text.len())).contains(&byte_offset) {
+                if line_text.len() == 0 {
+                    result = line_pos;
+                } else if (start..=(start + line_text.len())).contains(&byte_offset) {
                     for glyph in &metrics.glyphs {
                         if glyph.byte_index == (byte_offset - start) {
                             result = line_pos + PhysicalPoint::new(glyph.x, 0.0).to_vector();


### PR DESCRIPTION
When using femtovg, a empty textedit will get a error cursor_rect (with default value). This will result in the input box not being in the correct position when typing Chinese.

I'm trying to fix this problem.
Since I'm not familiar with the code, this change needs to be checked carefully.