### PR TITLE
property editor: Query property related fixes

### DIFF
--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -435,6 +435,29 @@ fn set_bool_binding(
     set_binding(element_url, element_version, element_offset, property_name, value.to_string())
 }
 
+fn set_color_binding(
+    element_url: slint::SharedString,
+    element_version: i32,
+    element_offset: i32,
+    property_name: slint::SharedString,
+    value: slint::Color,
+) {
+    // We need a CSS value which is rgba, color converts to a argb only :-/
+    let rgba: slint::RgbaColor<u8> = value.into();
+    let value: u32 = ((rgba.red as u32) << 24)
+        + ((rgba.green as u32) << 16)
+        + ((rgba.blue as u32) << 8)
+        + (rgba.alpha as u32);
+
+    set_binding(
+        element_url,
+        element_version,
+        element_offset,
+        property_name,
+        format!("#{:08x}", value),
+    )
+}
+
 fn set_enum_binding(
     element_url: slint::SharedString,
     element_version: i32,

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -362,6 +362,31 @@ fn convert_simple_string(input: slint::SharedString) -> String {
     format!("\"{}\"", str::escape_debug(&input.to_string()))
 }
 
+fn convert_string(
+    input: slint::SharedString,
+    is_translatable: bool,
+    tr_context: slint::SharedString,
+    tr_plural: slint::SharedString,
+    tr_plural_expression: slint::SharedString,
+) -> String {
+    let input = convert_simple_string(input);
+    if !is_translatable {
+        input
+    } else {
+        let context = if tr_context.is_empty() {
+            String::new()
+        } else {
+            format!("{} => ", convert_simple_string(tr_context))
+        };
+        let plural = if tr_plural.is_empty() {
+            String::new()
+        } else {
+            format!(" | {} % {}", convert_simple_string(tr_plural), tr_plural_expression)
+        };
+        format!("@tr({context}{input}{plural})")
+    }
+}
+
 // triggered from the UI, running in UI thread
 fn test_code_binding(
     element_url: slint::SharedString,
@@ -386,13 +411,17 @@ fn test_string_binding(
     element_offset: i32,
     property_name: slint::SharedString,
     value: slint::SharedString,
+    is_translatable: bool,
+    tr_context: slint::SharedString,
+    tr_plural: slint::SharedString,
+    tr_plural_expression: slint::SharedString,
 ) -> bool {
     test_binding(
         element_url,
         element_version,
         element_offset,
         property_name,
-        convert_simple_string(value),
+        convert_string(value, is_translatable, tr_context, tr_plural, tr_plural_expression),
     )
 }
 
@@ -408,7 +437,6 @@ fn test_binding(
         .is_some()
 }
 
-// triggered from the UI, running in UI thread
 fn set_code_binding(
     element_url: slint::SharedString,
     element_version: i32,
@@ -454,13 +482,17 @@ fn set_string_binding(
     element_offset: i32,
     property_name: slint::SharedString,
     value: slint::SharedString,
+    is_translatable: bool,
+    tr_context: slint::SharedString,
+    tr_plural: slint::SharedString,
+    tr_plural_expression: slint::SharedString,
 ) {
     set_binding(
         element_url,
         element_version,
         element_offset,
         property_name,
-        convert_simple_string(value),
+        convert_string(value, is_translatable, tr_context, tr_plural, tr_plural_expression),
     )
 }
 

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -396,33 +396,6 @@ fn test_string_binding(
     )
 }
 
-// // triggered from the UI, running in UI thread
-// fn test_simple_binding(
-//     element_url: slint::SharedString,
-//     element_version: i32,
-//     element_offset: i32,
-//     property_name: slint::SharedString,
-//     simple_property_value: slint::ModelRc<slint::SharedString>,
-// ) -> bool {
-//     if simple_property_value.row_count() <= 1 {
-//         return false;
-//     }
-//     if simple_property_value.row_data(0) == Some("bool".to_string().into()) {
-//         test_binding(
-//             element_url,
-//             element_version,
-//             element_offset,
-//             property_name,
-//             simple_property_value.row_data(1).unwrap(),
-//         )
-//     } else if simple_property_value.row_data(0) == Some("string".to_string().into()) {
-//         let property_value = format!("\"{}\"", simple_property_value.row_data(1).unwrap()).into();
-//         test_binding(element_url, element_version, element_offset, property_name, property_value)
-//     } else {
-//         false
-//     }
-// }
-
 // Backend function called by `test_*_binding`
 fn test_binding(
     element_url: slint::SharedString,

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -425,16 +425,6 @@ fn set_code_binding(
     )
 }
 
-fn set_bool_binding(
-    element_url: slint::SharedString,
-    element_version: i32,
-    element_offset: i32,
-    property_name: slint::SharedString,
-    value: bool,
-) {
-    set_binding(element_url, element_version, element_offset, property_name, value.to_string())
-}
-
 fn set_color_binding(
     element_url: slint::SharedString,
     element_version: i32,
@@ -455,23 +445,6 @@ fn set_color_binding(
         element_offset,
         property_name,
         format!("#{:08x}", value),
-    )
-}
-
-fn set_enum_binding(
-    element_url: slint::SharedString,
-    element_version: i32,
-    element_offset: i32,
-    property_name: slint::SharedString,
-    enum_type: slint::SharedString,
-    enum_value: slint::SharedString,
-) {
-    set_binding(
-        element_url,
-        element_version,
-        element_offset,
-        property_name,
-        format!("{}.{}", enum_type, enum_value),
     )
 }
 

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -74,6 +74,7 @@ pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, Platfor
     api.on_test_code_binding(super::test_code_binding);
     api.on_test_string_binding(super::test_string_binding);
     api.on_set_code_binding(super::set_code_binding);
+    api.on_set_color_binding(super::set_color_binding);
     api.on_set_bool_binding(super::set_bool_binding);
     api.on_set_enum_binding(super::set_enum_binding);
     api.on_set_string_binding(super::set_string_binding);

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -603,9 +603,11 @@ mod tests {
     fn property_conversion_test(contents: &str, property_line: u32) -> PropertyValue {
         let (_, pi, _, _) = properties_at_position(contents, property_line, 30).unwrap();
 
+        let test1 = pi.iter().find(|pi| pi.name == "test1").unwrap();
+
         super::simplify_value(
-            &pi[0].ty,
-            &pi[0].defined_at.as_ref().map(|da| da.code_block_or_expression.clone()),
+            &test1.ty,
+            &test1.defined_at.as_ref().map(|da| da.code_block_or_expression.clone()),
         )
     }
 

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -75,8 +75,6 @@ pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, Platfor
     api.on_test_string_binding(super::test_string_binding);
     api.on_set_code_binding(super::set_code_binding);
     api.on_set_color_binding(super::set_color_binding);
-    api.on_set_bool_binding(super::set_bool_binding);
-    api.on_set_enum_binding(super::set_enum_binding);
     api.on_set_string_binding(super::set_string_binding);
 
     Ok(ui)

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -93,6 +93,7 @@ export struct PropertyValue {
     visual-items: [string], // enum (enum members), float (units)
     tr-context: string, // string
     tr-plural: string, // string
+    tr-plural-expression: string, // string
     code: string, // ALWAYS, empty if property is not explicitly defined
 }
 
@@ -224,8 +225,8 @@ export global Api {
 
     // ## Property Editor
     pure callback test-code-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string) -> bool;
-    pure callback test-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string) -> bool;
+    pure callback test-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string, /* is_translatable: */ bool, /* tr_context: */ string, /* tr_plural: */ string, /* tr_plural_expression: */ string) -> bool;
     callback set-code-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string);
     callback set-color-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ color);
-    callback set-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string);
+    callback set-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string, /* is_translatable: */ bool, /* tr_context: */ string, /* tr_plural: */ string, /* tr_plural_exprression: */ string);
 }

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -226,6 +226,7 @@ export global Api {
     pure callback test-code-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string) -> bool;
     pure callback test-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string) -> bool;
     callback set-code-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string);
+    callback set-color-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ color);
     callback set-bool-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ bool);
     callback set-enum-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* enum_type: */ string, /* enum_value: */ string);
     callback set-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string);

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -227,7 +227,5 @@ export global Api {
     pure callback test-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string) -> bool;
     callback set-code-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string);
     callback set-color-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ color);
-    callback set-bool-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ bool);
-    callback set-enum-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* enum_type: */ string, /* enum_value: */ string);
     callback set-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string);
 }

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -134,6 +134,10 @@ export component PropertyView {
                                                     root.current-element.range.start,
                                                     property.name,
                                                     text,
+                                                    property-row.property-value.is-translatable,
+                                                    property-row.property-value.tr-context,
+                                                    property-row.property-value.tr-plural,
+                                                    property-row.property-value.tr-plural-expression,
                                                 );
                                             }
 
@@ -144,6 +148,10 @@ export component PropertyView {
                                                     root.current-element.range.start,
                                                     property.name,
                                                     text,
+                                                    property-row.property-value.is-translatable,
+                                                    property-row.property-value.tr-context,
+                                                    property-row.property-value.tr-plural,
+                                                    property-row.property-value.tr-plural-expression,
                                                 );
                                             }
                                         }

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -112,18 +112,19 @@ export component PropertyView {
                                             checked: property-row.property-value.value_bool;
 
                                             toggled() => {
-                                                Api.set-bool-binding(
+                                                Api.set-code-binding(
                                                     root.current-element.source-uri,
                                                     root.current-element.source-version,
                                                     root.current-element.range.start,
                                                     property.name,
-                                                    self.checked,
+                                                    self.checked ? "true" : "false",
                                                 );
                                             }
                                         }
                                         if property-row.property-value.kind == PropertyValueKind.string: LineEdit {
                                             width: 100%;
-                                            height: 100%; // otherwise this gets too high and covers several rows.
+                                            // otherwise this gets too high and covers several rows.
+                                            height: 100%;
                                             text: property-row.property-value.value-string;
 
                                             edited(text) => {
@@ -148,20 +149,20 @@ export component PropertyView {
                                         }
                                         if property-row.property-value.kind == PropertyValueKind.enum: ComboBox {
                                             width: 100%;
-                                            height: 100%; // otherwise this gets too high and covers several rows.
+                                            // otherwise this gets too high and covers several rows.
+                                            height: 100%;
 
                                             current-index: property-row.property-value.value-int;
 
                                             model: property-row.property-value.visual-items;
 
                                             selected(value) => {
-                                                Api.set-enum-binding(
+                                                Api.set-code-binding(
                                                     root.current-element.source-uri,
                                                     root.current-element.source-version,
                                                     root.current-element.range.start,
                                                     property.name,
-                                                    property-value.value_string,
-                                                    value,
+                                                    property-value.value_string + "." + value,
                                                 )
                                             }
                                         }


### PR DESCRIPTION
* Remove commented out code
* Add setter for color property changes
* Remove setters again that are not too helpful (where it is trivial to generate the code on the slint side). I wanted to have one setter per type, but that is getting out of hand ;-)
* Improve the test functionality to always test the same property `test1` in case there are several.
* Make @tr editable from the UI by making sure we can pass the data intact to the UI and generate correct code when we come back.