### PR TITLE
live-preview: Show properties for `Empty`

### DIFF
--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -49,7 +49,7 @@ export component PropertyView {
 
         ScrollView {
             VerticalLayout {
-                  if root.current-element.type-name != "": Rectangle {
+                if root.current-element.properties.length > 0: Rectangle {
                     VerticalLayout {
                         alignment: start;
 


### PR DESCRIPTION
For beauty-reasons we no longer report `Empty` though and replace that with `""`. This prevents the property editor from showing a UI: The `type-name` field being empty was abused to indicate that no data is available -- we do not have options in Slint :-/

Replace that test with the length of the model holding the properties.

We assume we got no data when that model is empty... which is probably a safer bet for "no property data availabel" than the `type-name` field.