### PR TITLE
live-preview: Fix layouts being shown in the wrong color when selecting something in the editor

### DIFF
--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -78,6 +78,9 @@ fn goto_node(node: &SyntaxNode) -> Option<GotoDefinitionResponse> {
     }]))
 }
 
+#[cfg(test)]
+use i_slint_compiler::parser::TextSize;
+
 #[test]
 fn test_goto_definition() {
     fn first_link(def: &GotoDefinitionResponse) -> &LocationLink {
@@ -104,8 +107,8 @@ export component Test {
     let doc = dc.get_document(&uri).unwrap().node.clone().unwrap();
 
     // Jump to the definition of Abc
-    let offset = source.find("abc := Abc").unwrap() as u32;
-    let token = crate::language::token_at_offset(&doc, offset + 8).unwrap();
+    let offset: TextSize = (source.find("abc := Abc").unwrap() as u32).into();
+    let token = crate::language::token_at_offset(&doc, offset + TextSize::new(8)).unwrap();
     assert_eq!(token.text(), "Abc");
     let def = goto_definition(&mut dc, token).unwrap();
     let link = first_link(&def);
@@ -113,8 +116,8 @@ export component Test {
     assert_eq!(link.target_range.start.line, 2);
 
     // Jump to the definition of abc
-    let offset = source.find("text: abc.hello").unwrap() as u32;
-    let token = crate::language::token_at_offset(&doc, offset + 7).unwrap();
+    let offset: TextSize = (source.find("text: abc.hello").unwrap() as u32).into();
+    let token = crate::language::token_at_offset(&doc, offset + TextSize::new(7)).unwrap();
     assert_eq!(token.text(), "abc");
     let def = goto_definition(&mut dc, token).unwrap();
     let link = first_link(&def);
@@ -122,8 +125,8 @@ export component Test {
     assert_eq!(link.target_range.start.line, 6);
 
     // Jump to the definition of hello
-    let offset = source.find("text: abc.hello").unwrap() as u32;
-    let token = crate::language::token_at_offset(&doc, offset + 12).unwrap();
+    let offset: TextSize = (source.find("text: abc.hello").unwrap() as u32).into();
+    let token = crate::language::token_at_offset(&doc, offset + TextSize::new(12)).unwrap();
     assert_eq!(token.text(), "hello");
     let def = goto_definition(&mut dc, token).unwrap();
     let link = first_link(&def);
@@ -131,7 +134,7 @@ export component Test {
     assert_eq!(link.target_range.start.line, 3);
 
     // Also jump to the definition of hello
-    let offset = source.find("hello: \"foo\"").unwrap() as u32;
+    let offset = (source.find("hello: \"foo\"").unwrap() as u32).into();
     let token = crate::language::token_at_offset(&doc, offset).unwrap();
     assert_eq!(token.text(), "hello");
     let def = goto_definition(&mut dc, token).unwrap();
@@ -140,17 +143,17 @@ export component Test {
     assert_eq!(link.target_range.start.line, 3);
 
     // Rectangle is builtin and not accessible
-    let offset = source.find("rec := ").unwrap() as u32;
-    let token = crate::language::token_at_offset(&doc, offset + 8).unwrap();
+    let offset: TextSize = (source.find("rec := ").unwrap() as u32).into();
+    let token = crate::language::token_at_offset(&doc, offset + TextSize::new(8)).unwrap();
     assert_eq!(token.text(), "Rectangle");
     assert!(goto_definition(&mut dc, token).is_none());
 
     // Button is builtin and not accessible
-    let offset = source.find("btn := ").unwrap() as u32;
-    let token = crate::language::token_at_offset(&doc, offset + 9).unwrap();
+    let offset: TextSize = (source.find("btn := ").unwrap() as u32).into();
+    let token = crate::language::token_at_offset(&doc, offset + TextSize::new(9)).unwrap();
     assert_eq!(token.text(), "Button");
     assert!(goto_definition(&mut dc, token).is_none());
-    let offset = source.find("text: abc.hello").unwrap() as u32;
+    let offset = (source.find("text: abc.hello").unwrap() as u32).into();
     let token = crate::language::token_at_offset(&doc, offset).unwrap();
     assert_eq!(token.text(), "text");
     assert!(goto_definition(&mut dc, token).is_none());
@@ -199,15 +202,15 @@ fn test_goto_definition_multi_files() {
     }
     let doc2 = dc.get_document(&url2).unwrap().node.clone().unwrap();
 
-    let offset = source2.find("h := Hello").unwrap() as u32;
-    let token = crate::language::token_at_offset(&doc2, offset + 8).unwrap();
+    let offset: TextSize = (source2.find("h := Hello").unwrap() as u32).into();
+    let token = crate::language::token_at_offset(&doc2, offset + TextSize::new(8)).unwrap();
     assert_eq!(token.text(), "Hello");
     let def = goto_definition(&mut dc, token).unwrap();
     let link = first_link(&def);
     assert_eq!(link.target_uri, url1);
     assert_eq!(link.target_range.start.line, 1);
 
-    let offset = source2.find("the_prop: 42").unwrap() as u32;
+    let offset = (source2.find("the_prop: 42").unwrap() as u32).into();
     let token = crate::language::token_at_offset(&doc2, offset).unwrap();
     assert_eq!(token.text(), "the_prop");
     let def = goto_definition(&mut dc, token).unwrap();
@@ -215,9 +218,9 @@ fn test_goto_definition_multi_files() {
     assert_eq!(link.target_uri, url1);
     assert_eq!(link.target_range.start.line, 2);
 
-    let offset = source2.find("Hello } from ").unwrap() as u32;
+    let offset = (source2.find("Hello } from ").unwrap() as u32).into();
     // check the string literal
-    let token = crate::language::token_at_offset(&doc2, offset + 20).unwrap();
+    let token = crate::language::token_at_offset(&doc2, offset + TextSize::new(20)).unwrap();
     assert_eq!(token.kind(), i_slint_compiler::parser::SyntaxKind::StringLiteral);
     let def = goto_definition(&mut dc, token).unwrap();
     let link = first_link(&def);
@@ -231,9 +234,9 @@ fn test_goto_definition_multi_files() {
     assert_eq!(link.target_uri, url1);
     assert_eq!(link.target_range.start.line, 1);
 
-    let offset = source2.find("Another as A } from ").unwrap() as u32;
+    let offset = (source2.find("Another as A } from ").unwrap() as u32).into();
     // check the string literal
-    let token = crate::language::token_at_offset(&doc2, offset + 25).unwrap();
+    let token = crate::language::token_at_offset(&doc2, offset + TextSize::new(25)).unwrap();
     assert_eq!(token.kind(), i_slint_compiler::parser::SyntaxKind::StringLiteral);
     let def = goto_definition(&mut dc, token).unwrap();
     let link = first_link(&def);

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -102,7 +102,7 @@ pub fn convert_diagnostics(diagnostics: &[slint_interpreter::Diagnostic]) -> Vec
 }
 
 fn extract_definition_location(ci: &ComponentInformation) -> (SharedString, SharedString) {
-    let Some(url) = ci.defined_at.as_ref().map(|da| &da.url) else {
+    let Some(url) = ci.defined_at.as_ref().map(|da| da.url()) else {
         return (Default::default(), Default::default());
     };
 
@@ -138,11 +138,11 @@ pub fn ui_set_known_components(
         };
 
         if let Some(position) = &ci.defined_at {
-            if let Some(library) = position.url.path().strip_prefix("/@") {
+            if let Some(library) = position.url().path().strip_prefix("/@") {
                 library_map.entry(format!("@{library}")).or_default().push(item);
             } else {
                 let path = i_slint_compiler::pathutils::clean_path(
-                    &(position.url.to_file_path().unwrap_or_default()),
+                    &(position.url().to_file_path().unwrap_or_default()),
                 );
                 if path != PathBuf::new() {
                     if longest_path_prefix == PathBuf::new() {


### PR DESCRIPTION
... in the second patch, which is pretty small.

The first one got out of hand: I wanted to change one occurance of u32 to TextSize and then ended doing that all over the place. No behavior change is intended in that first change :-)