### PR TITLE
Add `is_finished` to JoinHandle

### DIFF
--- a/api/rs/slint/tests/spawn_local.rs
+++ b/api/rs/slint/tests/spawn_local.rs
@@ -67,18 +67,18 @@ fn main() {
 
     // test_is_finished
     slint::invoke_from_event_loop(|| {
-        let handle_one = slint::spawn_local(async {
-            "Hello, World!"
-        }).unwrap();
+        let handle_one = slint::spawn_local(async { "Hello, World!" }).unwrap();
         assert!(!handle_one.is_finished());
         let handle_two = slint::spawn_local(async move {
             assert!(handle_one.is_finished());
-        }).unwrap();
+        })
+        .unwrap();
         std::thread::spawn(move || {
             let _ = executor::block_on(handle_two);
         });
         slint::quit_event_loop().unwrap();
-    }).unwrap();
+    })
+    .unwrap();
     slint::run_event_loop().unwrap();
 }
 

--- a/api/rs/slint/tests/spawn_local.rs
+++ b/api/rs/slint/tests/spawn_local.rs
@@ -61,10 +61,24 @@ fn main() {
         std::thread::spawn(move || {
             let x = executor::block_on(handle2);
             assert_eq!(x, "Hello, World");
-            slint::quit_event_loop().unwrap();
         });
     })
     .unwrap();
+
+    // test_is_finished
+    slint::invoke_from_event_loop(|| {
+        let handle_one = slint::spawn_local(async {
+            "Hello, World!"
+        }).unwrap();
+        assert!(!handle_one.is_finished());
+        let handle_two = slint::spawn_local(async move {
+            assert!(handle_one.is_finished());
+        }).unwrap();
+        std::thread::spawn(move || {
+            let _ = executor::block_on(handle_two);
+        });
+        slint::quit_event_loop().unwrap();
+    }).unwrap();
     slint::run_event_loop().unwrap();
 }
 

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -24,16 +24,6 @@ enum FutureState<T> {
     Finished(Option<T>),
 }
 
-impl<T> PartialEq for FutureState<T> {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (FutureState::Running(_), FutureState::Running(_)) => true,
-            (FutureState::Finished(_), FutureState::Finished(_)) => true,
-            _ => false
-        }
-    }
-}
-
 struct FutureRunnerInner<T> {
     fut: FutureState<T>,
     wakers: Vec<core::task::Waker>,
@@ -132,7 +122,8 @@ impl<T> JoinHandle<T> {
         self.0.aborted.store(true, atomic::Ordering::Relaxed);
     }
     /// Checks if the task associated with this `JoinHandle` has finished.
-    pub fn is_finished(&self) -> bool { self.0.inner.lock().expect("Failed to acquire mutex on FutureInner").fut == FutureState::Finished(None)  }
+    pub fn is_finished(&self) -> bool {
+        matches!(self.0.inner.lock().expect("Failed to acquire mutex on FutureInner").fut, FutureState::Finished(_)) }
 
 }
 

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -24,6 +24,16 @@ enum FutureState<T> {
     Finished(Option<T>),
 }
 
+impl<T> PartialEq for FutureState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (FutureState::Running(_), FutureState::Running(_)) => true,
+            (FutureState::Finished(_), FutureState::Finished(_)) => true,
+            _ => false
+        }
+    }
+}
+
 struct FutureRunnerInner<T> {
     fut: FutureState<T>,
     wakers: Vec<core::task::Waker>,
@@ -121,6 +131,9 @@ impl<T> JoinHandle<T> {
     pub fn abort(self) {
         self.0.aborted.store(true, atomic::Ordering::Relaxed);
     }
+    /// Checks if the task associated with this `JoinHandle` has finished.
+    pub fn is_finished(&self) -> bool { self.0.inner.lock().expect("Failed to acquire mutex on FutureInner").fut == FutureState::Finished(None)  }
+
 }
 
 #[cfg(feature = "std")]

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -123,8 +123,8 @@ impl<T> JoinHandle<T> {
     }
     /// Checks if the task associated with this `JoinHandle` has finished.
     pub fn is_finished(&self) -> bool {
-        matches!(self.0.inner().fut, FutureState::Finished(_)) }
-
+        matches!(self.0.inner().fut, FutureState::Finished(_))
+    }
 }
 
 #[cfg(feature = "std")]

--- a/internal/core/future.rs
+++ b/internal/core/future.rs
@@ -123,7 +123,7 @@ impl<T> JoinHandle<T> {
     }
     /// Checks if the task associated with this `JoinHandle` has finished.
     pub fn is_finished(&self) -> bool {
-        matches!(self.0.inner.lock().expect("Failed to acquire mutex on FutureInner").fut, FutureState::Finished(_)) }
+        matches!(self.0.inner().fut, FutureState::Finished(_)) }
 
 }
 


### PR DESCRIPTION
Adds `is_finished` method to JoinHandle, the same functionality as here: https://docs.tvix.dev/rust/tokio/task/struct.JoinHandle.html#method.is_finished