### PR TITLE
CI: cancel earlier CI runs when a new version for a PR is pushed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ on:
         branches: [master, "feature/*"]
     workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+      
 env:
     MACOSX_DEPLOYMENT_TARGET: "11.0"
 


### PR DESCRIPTION
Place all CI runs into groups (ideally one per PR), and cancel in-progress runs if a new one is triggered.