### PR TITLE
live-preview: Send Telemetry messages

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -514,6 +514,8 @@ pub enum PreviewToLspMessage {
     SendWorkspaceEdit { label: Option<String>, edit: lsp_types::WorkspaceEdit },
     /// Pass a `ShowMessage` notification on to the editor
     SendShowMessage { message: lsp_types::ShowMessageParams },
+    /// Report telemetry
+    SendTelemetry { message: String },
 }
 
 /// Information on the Element types available
@@ -574,6 +576,13 @@ pub mod lsp_to_editor {
                 },
             )
             .unwrap_or_else(|e| eprintln!("Error sending notification: {:?}", e));
+    }
+
+    pub fn send_telemetry(sender: crate::ServerNotifier, message: String) {
+        eprintln!("Sending telemetry: \"{message}\"");
+        let _ = sender.send_notification::<lsp_types::notification::TelemetryEvent>(
+            lsp_types::OneOf::Right(vec![serde_json::Value::String(message)]),
+        );
     }
 
     pub fn notify_lsp_diagnostics(

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -544,6 +544,9 @@ async fn handle_preview_to_lsp_message(
             ctx.server_notifier
                 .send_notification::<lsp_types::notification::ShowMessage>(message)?;
         }
+        M::SendTelemetry { message } => {
+            common::lsp_to_editor::send_telemetry(ctx.server_notifier.clone(), message);
+        }
     }
     Ok(())
 }

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1018,6 +1018,8 @@ pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior)
                 preview_component.style.clone()
             };
 
+            send_telemetry(format!("Loading preview with style {style}"));
+
             match reload_preview_impl(preview_component, behavior, style, config).await {
                 Ok(()) => {}
                 Err(e) => {

--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use super::PreviewState;
-use crate::common::{PreviewToLspMessage, SourceFileVersion};
+use crate::common::{self, PreviewToLspMessage, SourceFileVersion};
 use crate::lsp_ext::Health;
 use crate::ServerNotifier;
 use once_cell::sync::Lazy;
@@ -242,6 +242,13 @@ pub fn ask_editor_to_show_document(file: &str, selection: lsp_types::Range) {
     let Ok(url) = lsp_types::Url::from_file_path(file) else { return };
     let fut = crate::common::lsp_to_editor::send_show_document_to_editor(sender, url, selection);
     slint_interpreter::spawn_local(fut).unwrap(); // Fire and forget.
+}
+
+pub fn send_telemetry(message: String) {
+    let Some(sender) = SERVER_NOTIFIER.lock().unwrap().clone() else {
+        return;
+    };
+    common::lsp_to_editor::send_telemetry(sender, message);
 }
 
 pub fn send_message_to_lsp(message: PreviewToLspMessage) {

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -307,6 +307,9 @@ impl SlintServer {
                     .server_notifier
                     .send_notification::<lsp_types::notification::ShowMessage>(message);
             }
+            M::SendTelementry { message } => {
+                common::send_telemetry(&self.ctx.server_notifier, message)
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
This is the LSP side... it seems to send the messages on to VSCode, but I have not tracked further than that.