### PR TITLE
Re-enable Node.js tests on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,8 +154,9 @@ jobs:
               working-directory: ./api/node
               run: npm test
             - name: Run test-driver-nodejs
-              if: ${{ runner.os != 'Windows' }}
-              run: cargo test --verbose --all-features -p test-driver-nodejs -p slint-node
+              # Release is only applied to the harness that drives the node.js invocations, but needed
+              # to avoid crashing on Windows with what looks like an out of stack exception.
+              run: cargo test --verbose --release --all-features -p test-driver-nodejs -p slint-node
 
     python_test:
         env:


### PR DESCRIPTION
With Rust 1.81 the test harness somehow requires a bigger stack than with earlier versions, which is a problem as threads besides the main thread default to a smaller stack on Windows. This is worked around by running the harness in release. The node.js bindings are still built as debug build, this harness merely runs nodejs as a binary.