### PR TITLE
Use `raw-window-metal` to do layer creation

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -60,7 +60,7 @@ bytemuck = { workspace = true }
 windows = { version = "0.56.0", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
 skia-safe = { version = "0.75.0", features = ["d3d"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 cocoa = { version = "0.25.0" }
 core-foundation = { version = "0.9.1" }
 metal = { version = "0.27.0" }
@@ -69,8 +69,9 @@ foreign-types = { version = "0.5.0" }
 objc = { version = "0.2.7" }
 core-graphics-types = { version = "0.1.1" }
 skia-safe = { version = "0.75.0", features = ["metal"] }
+raw-window-metal = "1.0"
 
-[target.'cfg(not(any(target_os = "macos", target_family = "windows")))'.dependencies]
+[target.'cfg(not(any(target_vendor = "apple", target_family = "windows")))'.dependencies]
 skia-safe = { version = "0.75.0", features = ["gl"] }
 
 [build-dependencies]


### PR DESCRIPTION
The logic for creating the `CAMetalLayer` if it doesn't exist is complex, and currently Slint is doing it wrong and prevents Winit from scheduling redraw events at the correct time. I have abstracted this away into [`raw-window-metal`](https://docs.rs/raw-window-metal/), it works by creating a layer, and inserting that as a sublayer. The bounds and scale factor are then kept in-sync with an observer, ensuring smooth resizing. This is also important for iOS support, since overwriting the layer, as currently done, isn't possible there.

See also corresponding [PR to `wgpu`](https://github.com/gfx-rs/wgpu/pull/6210), [PR to `ash`](https://github.com/ash-rs/ash/pull/939) and [PR to `vulkano`](https://github.com/vulkano-rs/vulkano/pull/2561) for more details and reasoning.

I'm pretty sure that you can remove `Surface::set_scale_factor` after this, it seems to have only been used for `MetalSurface`, but it would be a breaking change so I'm inclined to let someone else do it later.

Note also the change from setting `layerContentsPlacement` to `contentsGravity`, this _should_ be a non-functional change, since we do as [the documentation suggests](https://developer.apple.com/documentation/quartzcore/calayer/1410872-contentsgravity?language=objc), and check `contentsAreFlipped` first, but I haven't tested it enough to be certain.