### PR TITLE
live-preview: Only show style dropdown when using std-widgets

### DIFF
--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-#[cfg(target_arch = "wasm32")]
-use crate::wasm_prelude::*;
-
 use crate::common::{self, Result, SourceFileVersion};
 use crate::util;
 

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -113,6 +113,11 @@ fn extract_definition_location(ci: &ComponentInformation) -> (SharedString, Shar
     (url.to_string().into(), file_name.into())
 }
 
+pub fn ui_set_uses_widgets(ui: &PreviewUi, uses_widgets: bool) {
+    let api = ui.global::<Api>();
+    api.set_uses_widgets(uses_widgets);
+}
+
 pub fn ui_set_known_components(
     ui: &PreviewUi,
     known_components: &[crate::common::ComponentInformation],

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -149,6 +149,8 @@ export global Api {
     in property <bool> show-preview-ui: true;
     // Design-mode engaged!
     in-out property <bool> design-mode;
+    // std-widgets are used (=> show style dropdown)
+    in-out property <bool> uses-widgets;
 
     // ## Component Data for ComponentList:
     // All the components

--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -4,6 +4,7 @@
 import { HorizontalBox, Switch, Palette, ComboBox } from "std-widgets.slint";
 import { BodyText } from "../components/body-text.slint";
 import { HeaderText } from "../components/header-text.slint";
+import { Api } from "../api.slint";
 
 
 export component HeaderView {
@@ -30,11 +31,14 @@ export component HeaderView {
             }
 
             BodyText {
+                visible: Api.uses-widgets;
                 horizontal-stretch: 0;
+
                 text: @tr("Style");
             }
 
             style-combobox := ComboBox {
+                visible: Api.uses-widgets;
                 horizontal-stretch: 0;
 
                 selected => {


### PR DESCRIPTION
So printerdemo is without the dropdown (as it is useless there), while people working on the desktop using the standard widgets can still easily switch and check their work in different styles.