### PR TITLE
Default to ignoring package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ Pipfile.lock
 docs/reference/src/language/builtins/enums.md
 docs/reference/src/language/builtins/structs.md
 
+# Ignore all package-lock.json files
+**/package-lock.json
+# But keep these specific ones
+!editors/vscode/package-lock.json
+
 *.node
 *.d.ts
 


### PR DESCRIPTION
An earlier PR stopped all the package-lock.json files being ignored. This was meant just for the VSCode extension to ensure more deterministic builds. An unintended side effect was multiple other package-lock.json files now accidentally wanting to be committed after trying out Node demos and other such changes.

This PR defaults to git ignoring all package-lock.json files. Then any exceptions can be added manually. 