### PR TITLE
Fix generated setter and getter of public property alias in globals

### DIFF
--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -709,6 +709,9 @@ fn lower_global(
     let mut functions = vec![];
 
     for (p, x) in &global.root_element.borrow().property_declarations {
+        if x.is_alias.is_some() {
+            continue;
+        }
         let property_index = properties.len();
         let nr = NamedReference::new(&global.root_element, p);
 

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -68,6 +68,10 @@ impl<'a> PrettyPrinter<'a> {
                 DisplayExpression(&f.code, &ctx)
             )?;
         }
+        for (p1, p2) in &sc.two_way_bindings {
+            self.indent()?;
+            writeln!(self.writer, "{} <=> {};", DisplayPropertyRef(p1, &ctx), DisplayPropertyRef(p2, &ctx))?
+        }
         for (p, init) in &sc.property_init {
             self.indent()?;
             writeln!(

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -70,7 +70,12 @@ impl<'a> PrettyPrinter<'a> {
         }
         for (p1, p2) in &sc.two_way_bindings {
             self.indent()?;
-            writeln!(self.writer, "{} <=> {};", DisplayPropertyRef(p1, &ctx), DisplayPropertyRef(p2, &ctx))?
+            writeln!(
+                self.writer,
+                "{} <=> {};",
+                DisplayPropertyRef(p1, &ctx),
+                DisplayPropertyRef(p2, &ctx)
+            )?
         }
         for (p, init) in &sc.property_init {
             self.indent()?;

--- a/tests/cases/bindings/two_way_global.slint
+++ b/tests/cases/bindings/two_way_global.slint
@@ -1,0 +1,81 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export global G1 {
+    in-out property <int> data: 42;
+}
+
+export global G2 {
+    in-out property <int> data <=> G1.data;
+}
+
+export component TestCase inherits Window {
+
+    out property <int> d1: G1.data;
+    out property <int> d2: G2.data;
+    out property <bool> test: G2.data == 42;
+}
+
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+assert_eq!(G1::get(&instance).get_data(), 42);
+assert_eq!(G2::get(&instance).get_data(), 42);
+assert_eq!(instance.get_d1(), 42);
+assert_eq!(instance.get_d2(), 42);
+instance.global::<G1<'_>>().set_data(100);
+assert_eq!(G1::get(&instance).get_data(), 100);
+assert_eq!(G2::get(&instance).get_data(), 100);
+assert_eq!(instance.get_d1(), 100);
+assert_eq!(instance.get_d2(), 100);
+instance.global::<G2<'_>>().set_data(-1);
+assert_eq!(G1::get(&instance).get_data(), -1);
+assert_eq!(G2::get(&instance).get_data(), -1);
+assert_eq!(instance.get_d1(), -1);
+assert_eq!(instance.get_d2(), -1);
+
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+assert_eq(instance.global<G1>().get_data(), 42);
+assert_eq(instance.global<G2>().get_data(), 42);
+assert_eq(instance.get_d1(), 42);
+assert_eq(instance.get_d2(), 42);
+instance.global<G1>().set_data(100);
+assert_eq(instance.global<G1>().get_data(), 100);
+assert_eq(instance.global<G2>().get_data(), 100);
+assert_eq(instance.get_d1(), 100);
+assert_eq(instance.get_d2(), 100);
+instance.global<G2>().set_data(-1);
+assert_eq(instance.global<G1>().get_data(), -1);
+assert_eq(instance.global<G2>().get_data(), -1);
+assert_eq(instance.get_d1(), -1);
+assert_eq(instance.get_d2(), -1);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test);
+assert.equal(instance.G1.data, 42);
+assert.equal(instance.G2.data, 42);
+assert.equal(instance.d1, 42);
+assert.equal(instance.d2, 42);
+instance.G1.data = 100;
+assert.equal(instance.G1.data, 100);
+assert.equal(instance.G2.data, 100);
+assert.equal(instance.d1, 100);
+assert.equal(instance.d2, 100);
+instance.G2.data = -1;
+assert.equal(instance.G1.data, -1);
+assert.equal(instance.G2.data, -1);
+assert.equal(instance.d1, -1);
+assert.equal(instance.d2, -1);
+```
+
+*/


### PR DESCRIPTION
We need to skip the generation of the local property so it directly forward to the alias in the public property

Fixes #5855
ChangeLog: Fixed generated getter and setter of alias properties in globals

