### PR TITLE
Update Skia to 0.78

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -42,7 +42,7 @@ pin-weak = "1"
 scoped-tls-hkt = "0.1"
 raw-window-handle = { version = "0.6", features = ["std"] }
 
-skia-safe = { version = "0.75.0", features = ["textlayout", "gl"] }
+skia-safe = { version = "0.78.0", features = ["textlayout", "gl"] }
 glow = { version = "0.13" }
 unicode-segmentation = { version = "1.8.0" }
 
@@ -57,8 +57,8 @@ softbuffer = { workspace = true, default-features = false }
 bytemuck = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
-windows = { version = "0.56.0", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
-skia-safe = { version = "0.75.0", features = ["d3d"] }
+windows = { version = "0.58.0", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
+skia-safe = { version = "0.78.0", features = ["d3d"] }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 cocoa = { version = "0.25.0" }
@@ -68,11 +68,11 @@ metal = { version = "0.27.0" }
 foreign-types = { version = "0.5.0" }
 objc = { version = "0.2.7" }
 core-graphics-types = { version = "0.1.1" }
-skia-safe = { version = "0.75.0", features = ["metal"] }
+skia-safe = { version = "0.78.0", features = ["metal"] }
 raw-window-metal = "1.0"
 
 [target.'cfg(not(any(target_vendor = "apple", target_family = "windows")))'.dependencies]
-skia-safe = { version = "0.75.0", features = ["gl"] }
+skia-safe = { version = "0.78.0", features = ["gl"] }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }


### PR DESCRIPTION
This updates Skia to Milestone 129. See
https://github.com/rust-skia/rust-skia/releases/tag/0.78.0 for additional details.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
