### PR TITLE
live-preview: Hide resize elements in interactive mode

### DIFF
--- a/tools/lsp/ui/components/resizer.slint
+++ b/tools/lsp/ui/components/resizer.slint
@@ -55,6 +55,7 @@ export component Resizer {
     in property <bool> is-resizable: true;
     in property <bool> is-moveable: false;
     in property <color> color: Colors.black;
+    in property <color> fill-color: Colors.white;
     out property <bool> resizing: n.resizing || ne.resizing || e.resizing || se.resizing || s.resizing || sw.resizing || w.resizing || nw.resizing;
     out property <bool> moving: resize-area.moving;
     out property <length> handle-size: ResizeState.handle-size;
@@ -140,6 +141,7 @@ export component Resizer {
 
         ne := ResizeHandle {
             my-color: root.color;
+            background: root.fill-color;
             resize(x-offset, y-offset, done) => {
                 self.new-width = Math.max(0px, x-offset + root.width);
                 self.new-height = Math.max(0px, y-offset * -1.0 + root.height);
@@ -169,6 +171,7 @@ export component Resizer {
 
         se := ResizeHandle {
             my-color: root.color;
+            background: root.fill-color;
             resize(x-offset, y-offset, done) => {
                 self.new-width = Math.max(0px, x-offset + root.width);
                 self.new-height = Math.max(0px, y-offset + root.height);
@@ -198,6 +201,7 @@ export component Resizer {
 
         sw := ResizeHandle {
             my-color: root.color;
+            background: root.fill-color;
             resize(x-offset, y-offset, done) => {
                 self.new-width = Math.max(0px, x-offset * -1.0 + root.width);
                 self.new-height = Math.max(0px, y-offset + root.height);
@@ -227,6 +231,7 @@ export component Resizer {
 
         nw := ResizeHandle {
             my-color: root.color;
+            background: root.fill-color;
             resize(x-offset, y-offset, done) => {
                 self.new-width = Math.max(0px, x-offset * -1.0 + root.width);
                 self.new-height = Math.max(0px, y-offset * -1.0 + root.height);

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -189,6 +189,9 @@ export component PreviewView {
             }
 
             main-resizer := Resizer {
+                color: root.design-mode ? Colors.black : Colors.transparent;
+                fill-color: root.design-mode ? Colors.white : Colors.transparent;
+
                 is-moveable: false;
                 is-resizable <=> preview-area-container.is-resizable;
 


### PR DESCRIPTION
... by rendering the elements as transparent. They are still there and work, so you can still resize, but you still get a better view of your UI.

We still draw a border around the UI, just to show where it ends and the background begins, but that is purely decorative :-)

I am not totally happy with this: It still sets mouse cursors in the area that should actually be controlled by the UI and overlays its own touchareas around the border of the UI, stealing a few pixels from the interactive area of the UI.
