### PR TITLE
live-preview: Remove unnecessary padding rom HeaderView

### DIFF
--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -5,6 +5,7 @@ import { HorizontalBox, Switch, Palette, ComboBox } from "std-widgets.slint";
 import { BodyText } from "../components/body-text.slint";
 import { HeaderText } from "../components/header-text.slint";
 import { Api } from "../api.slint";
+import { EditorSpaceSettings } from "../components/styling.slint";
 
 
 export component HeaderView {
@@ -24,9 +25,10 @@ export component HeaderView {
                 horizontal-stretch: 0;
             }
 
-            HorizontalBox {
+            HorizontalLayout {
                 horizontal-stretch: 1;
                 alignment: start;
+                spacing: EditorSpaceSettings.default-spacing;
                 @children
             }
 


### PR DESCRIPTION
This makes the combobox less fat and looks much nicer IMHO.


