### PR TITLE
esp-idf: Add support for using pre-built binaries

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -19,7 +19,7 @@ on:
                 description: "Release? Enable options for building binaries for a release (i.e. don't have a -nightly suffix for the extension)"
 
     schedule:
-        - cron: "0 4 * * *"
+        - cron: "0 2 * * *"
 
 env:
     # Keep in sync with features in slint_tool_binary.yaml, cpp_package.yaml, api/node/Cargo.toml, and api/python/Cargo.toml
@@ -569,6 +569,9 @@ jobs:
                 https://api.github.com/repos/slint-ui/slint-cpp-templates-stm32/actions/workflows/ci.yaml/dispatches \
                 -d '{"ref":"main"}'
 
+    nightly-tests:
+        needs: [prepare_release]
+        uses: ./.github/workflows/nightly_tests.yaml
 
     android:
         env:

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -6,9 +6,7 @@ name: Nightly tests
 
 on:
     workflow_dispatch:
-
-    schedule:
-        - cron: "0 2 * * *"
+    workflow_call:
 
 jobs:
     qa-esp-idf:
@@ -33,25 +31,25 @@ jobs:
               working-directory: examples/printerdemo_mcu/esp-idf
               run: |
                   . ${IDF_PATH}/export.sh
-                  idf.py build
+                  idf.py -D SLINT_ESP_LOCAL_EXAMPLE=OFF build
             - name: Build and Test Carousel example s3 box
               shell: bash
               working-directory: examples/carousel/esp-idf/s3-box
               run: |
                   . ${IDF_PATH}/export.sh
-                  idf.py build
+                  idf.py -D SLINT_ESP_LOCAL_EXAMPLE=OFF build
             - name: Build and Test Carousel example s3 usb otg
               shell: bash
               working-directory: examples/carousel/esp-idf/s3-usb-otg
               run: |
                   . ${IDF_PATH}/export.sh
-                  idf.py build
+                  idf.py -D SLINT_ESP_LOCAL_EXAMPLE=OFF build
             - name: Build and Test Carousel example s2 kaluga kit
               shell: bash
               working-directory: examples/carousel/esp-idf/s2-kaluga-kit
               run: |
                   . ${IDF_PATH}/export.sh
-                  idf.py build
+                  idf.py -D SLINT_ESP_LOCAL_EXAMPLE=OFF build
 
     qa-tree-sitter-latest:
         uses: ./.github/workflows/tree_sitter.yaml

--- a/.github/workflows/upgrade_version.yaml
+++ b/.github/workflows/upgrade_version.yaml
@@ -45,6 +45,7 @@ jobs:
                   # Version in esp-idf component
                   sed -i 's/^version: "[0-9]*\.[0-9]*\.[0-9]*.*"/version: "${{ github.event.inputs.new_version }}"/' api/cpp/esp-idf/slint/idf_component.yml
                   sed -i 's/GIT_TAG v[0-9]*\.[0-9]*\.[0-9]*/GIT_TAG v${{ github.event.inputs.new_version }}/' api/cpp/esp-idf/slint/CMakeLists.txt
+                  sed -i 's/find_package(Slint [0-9]*\.[0-9]*\.[0-9]*)/find_package(Slint ${{ github.event.inputs.new_version }})/' api/cpp/esp-idf/slint/CMakeLists.txt
 
                   echo "Note that the version is not updated in the documentation and README yet"
 

--- a/.github/workflows/upload_esp_idf_component.yaml
+++ b/.github/workflows/upload_esp_idf_component.yaml
@@ -18,6 +18,16 @@ jobs:
         container: espressif/idf:latest
         steps:
             - uses: actions/checkout@v4
+            - name: Remove use of nightly version
+              if: github.event.inputs.release == 'true'
+              working-directory: api/cpp/esp-idf/slint
+              run:
+                if grep -q 'set(SLINT_USE_NIGHTLY_VERSION TRUE)' CMakeLists.txt; then
+                        sed -i '/set(SLINT_USE_NIGHTLY_VERSION TRUE)/d' CMakeLists.txt
+                else
+                    echo "SLINT_USE_NIGHTLY_VERSION marker is missing in CMakeLists.txt. Did you forget to change this script?""
+                    exit 1
+                fi
             - name: Upload component
               if: github.event.inputs.release == 'true'
               uses: espressif/upload-components-ci-action@v1

--- a/api/cpp/esp-idf/slint/CMakeLists.txt
+++ b/api/cpp/esp-idf/slint/CMakeLists.txt
@@ -6,15 +6,17 @@ idf_component_register(
     INCLUDE_DIRS "include"
     REQUIRES "esp_lcd" "esp_lcd_touch")
 
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
 if (CONFIG_IDF_TARGET_ARCH_XTENSA)
-    set(Rust_CARGO_TARGET "xtensa-${IDF_TARGET}-none-elf")
+    set(rust_target "xtensa-${IDF_TARGET}-none-elf")
 elseif(CONFIG_IDF_TARGET_ARCH_RISCV)
     if (CONFIG_IDF_TARGET_ESP32C6 OR CONFIG_IDF_TARGET_ESP32C5 OR CONFIG_IDF_TARGET_ESP32H2)
-        set(Rust_CARGO_TARGET "riscv32imac-esp-espidf")
+        set(rust_target "riscv32imac-esp-espidf")
     elseif (CONFIG_IDF_TARGET_ESP32P4)
-        set(Rust_CARGO_TARGET "riscv32imafc-esp-espidf")
+        set(rust_target "riscv32imafc-esp-espidf")
     else ()
-        set(Rust_CARGO_TARGET "riscv32imc-esp-espidf")
+        set(rust_target "riscv32imc-esp-espidf")
     endif()
 else()
     message(FATAL_ERROR "Architecture currently not supported")
@@ -26,19 +28,29 @@ set(SLINT_LIBRARY_CARGO_FLAGS "-Zbuild-std=core,alloc")
 set(DEFAULT_SLINT_EMBED_RESOURCES "embed-for-software-renderer" CACHE STRING "")
 set(CMAKE_BUILD_TYPE Release)
 set(BUILD_SHARED_LIBS OFF)
-
+set(Rust_CARGO_TARGET ${rust_target})
 
 if (SLINT_ESP_LOCAL_EXAMPLE)
     add_subdirectory(../.. slint_build)
-else(SLINT_ESP_LOCAL_EXAMPLE)
-    include(FetchContent)
-    FetchContent_Declare(
-        Slint
-        GIT_REPOSITORY https://github.com/slint-ui/slint
-        GIT_TAG v1.8.0
-        SOURCE_SUBDIR api/cpp
-    )
-    FetchContent_MakeAvailable(Slint)
-endif(SLINT_ESP_LOCAL_EXAMPLE)
+else()
+    list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+    set(SLINT_USE_NIGHTLY_VERSION TRUE) # Removed by upload_esp_idf_component.yaml
+    find_package(Slint 1.8.0)
+
+    if (TARGET Slint::Slint)
+        # Imported targets are only visible in directory scope by default, but
+        # for use by the application, we need to make the target global.
+        set_target_properties(Slint::Slint PROPERTIES IMPORTED_GLOBAL TRUE)
+    else()
+        include(FetchContent)
+        FetchContent_Declare(
+            Slint
+            GIT_REPOSITORY https://github.com/slint-ui/slint
+            GIT_TAG v1.8.0
+            SOURCE_SUBDIR api/cpp
+        )
+        FetchContent_MakeAvailable(Slint)
+    endif()
+endif()
 
 target_link_libraries(${COMPONENT_LIB} PUBLIC Slint::Slint)

--- a/api/cpp/esp-idf/slint/README.md
+++ b/api/cpp/esp-idf/slint/README.md
@@ -19,8 +19,8 @@ It has been tested on ESP32-S3 devices.
 * Install the [Espressif IoT Development Framework](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/index.html) and open a terminal or command prompt with the environment set up.
 On Windows, follow the [Using the Command Prompt](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/windows-setup.html#using-the-command-prompt) instructions, on macOS and Linux, follow the
 [Set up the Environment Variables](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html#step-4-set-up-the-environment-variables) instructions.
-* Make sure that you have [Rust](https://esp-rs.github.io/book/installation/rust.html) installed.
-* Install the Rust toolchains for [Espressif SoCs with Xtensa and RISC-V targets](https://esp-rs.github.io/book/installation/riscv-and-xtensa.html).
+
+By default, Slint will use pre-compiled binaries. If for some reason there are no binaries available, the build will fall back to compiling Slint from source and you need to have [Rust installed](https://esp-rs.github.io/book/installation/rust.html installed) as well as the [Rust toolchains for Espressif SoCs with Xtensa and RISC-V targets](https://esp-rs.github.io/book/installation/riscv-and-xtensa.html).
 
 ### Hello World
 

--- a/api/cpp/esp-idf/slint/cmake/FindSlint.cmake
+++ b/api/cpp/esp-idf/slint/cmake/FindSlint.cmake
@@ -1,0 +1,87 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+#
+# FindSlint
+# ---------
+#
+# This modules attempts to locate an installation of Slint, as follows:
+#
+# 1. First `find_package(Slint ... CONFIG ...)` is called, to locate any packages in the `CMAKE_PREFIX_PATH`.
+# 2. If that failed and if `find_package` was called with a `VERSION`, then this module will attempt to download
+#    a pre-compiled binary package for the specified Slint release, extract it into `${CMAKE_BINARY_DIR}/slint-prebuilt`,
+#    and make it available.
+#
+# The following variables may be set to affect the behaviour:
+#
+# `SLINT_TARGET_ARCHITECTURE`: Set this to the desired target architecture. The format of this string is matched against
+# the `Slint-cpp-*-$SLINT_TARGET_ARCHITECTURE.tar.gz` pre-built assets on the GitHub releases. For example, if you're targeting
+# STM32 ARM architectures, you'd set this to `thumbv7em-none-eabihf`. If not set, this module will attempt to detect if compilation
+# is happening in an ESP-IDF cross-compilation environment and detect the architecture accordingly, otherwise
+# `${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}` is used.
+#
+# `SLINT_USE_NIGHTLY_VERSION`: When `find_package(Slint)` is called with a version, then this module will 
+# attempt to download a pre-compiled binary from the nightly snapshot of Slint.
+
+find_package(Slint ${Slint_FIND_VERSION} QUIET CONFIG)
+if (TARGET Slint::Slint)
+    return()
+endif()
+
+if (NOT SLINT_TARGET_ARCHITECTURE)
+    if(WIN32)
+        if(MSVC)
+            set(compiler_suffix "-MSVC")
+        elseif(MINGW)
+            set(compiler_suffix "-MinGW")
+        endif()
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            set(CPACK_SYSTEM_NAME win64)
+        else()
+            set(CPACK_SYSTEM_NAME win32)
+        endif()
+        set(SLINT_TARGET_ARCHITECTURE "${CPACK_SYSTEM_NAME}${compiler_suffix}")
+    elseif (CONFIG_IDF_TARGET_ARCH_XTENSA)
+        set(SLINT_TARGET_ARCHITECTURE "xtensa-${IDF_TARGET}-none-elf")
+    elseif(CONFIG_IDF_TARGET_ARCH_RISCV)
+        if (CONFIG_IDF_TARGET_ESP32C6 OR CONFIG_IDF_TARGET_ESP32C5 OR CONFIG_IDF_TARGET_ESP32H2)
+            set(SLINT_TARGET_ARCHITECTURE "riscv32imac-esp-espidf")
+        elseif (CONFIG_IDF_TARGET_ESP32P4)
+            set(SLINT_TARGET_ARCHITECTURE "riscv32imafc-esp-espidf")
+        else ()
+            set(SLINT_TARGET_ARCHITECTURE "riscv32imc-esp-espidf")
+        endif()
+    else()
+        set(SLINT_TARGET_ARCHITECTURE "${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
+endif()
+
+if (NOT DEFINED Slint_FIND_VERSION)
+    return()
+endif()
+
+set(slint_version "${Slint_FIND_VERSION}")
+set(github_release "${slint_version}")
+
+if (SLINT_USE_NIGHTLY_VERSION)
+    set(github_release "nightly")
+    # Set this to instruct the slint-compiler download to use the same release
+    set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")
+endif()
+
+set(prebuilt_archive_filename "Slint-cpp-${slint_version}-${SLINT_TARGET_ARCHITECTURE}.tar.gz")
+set(download_target_path "${CMAKE_BINARY_DIR}/slint-prebuilt/")
+set(download_url "https://github.com/slint-ui/slint/releases/download/${github_release}/${prebuilt_archive_filename}")
+
+file(MAKE_DIRECTORY "${download_target_path}")
+message(STATUS "Downloading pre-built Slint binary ${download_url}")
+file(DOWNLOAD "${download_url}" "${download_target_path}/${prebuilt_archive_filename}" STATUS download_status)
+list(GET download_status 0 download_code)
+if (NOT download_code EQUAL 0)
+    list(GET download_status 1 download_message)
+    message(STATUS "Download of Slint binary package failed: ${download_message}")
+    return()
+endif()
+
+file(ARCHIVE_EXTRACT INPUT "${download_target_path}/${prebuilt_archive_filename}" DESTINATION "${download_target_path}")
+list(PREPEND CMAKE_PREFIX_PATH "${download_target_path}")
+find_package(Slint CONFIG)

--- a/examples/carousel/esp-idf/s2-kaluga-kit/CMakeLists.txt
+++ b/examples/carousel/esp-idf/s2-kaluga-kit/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.14)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(SLINT_ESP_LOCAL_EXAMPLE ON)
+set(SLINT_ESP_LOCAL_EXAMPLE ON CACHE BOOL "Build example with local version of Slint")
 set(EXTRA_COMPONENT_DIRS ../../../../api/cpp/esp-idf/)
 
 add_compile_options(-fdiagnostics-color=always)

--- a/examples/carousel/esp-idf/s3-box/CMakeLists.txt
+++ b/examples/carousel/esp-idf/s3-box/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.14)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(SLINT_ESP_LOCAL_EXAMPLE ON)
+set(SLINT_ESP_LOCAL_EXAMPLE ON CACHE BOOL "Build example with local version of Slint")
 set(EXTRA_COMPONENT_DIRS ../../../../api/cpp/esp-idf/)
 
 add_compile_options(-fdiagnostics-color=always)

--- a/examples/carousel/esp-idf/s3-usb-otg/CMakeLists.txt
+++ b/examples/carousel/esp-idf/s3-usb-otg/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.14)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(SLINT_ESP_LOCAL_EXAMPLE ON)
+set(SLINT_ESP_LOCAL_EXAMPLE ON CACHE BOOL "Build example with local version of Slint")
 set(EXTRA_COMPONENT_DIRS ../../../../api/cpp/esp-idf/)
 
 add_compile_options(-fdiagnostics-color=always)

--- a/examples/printerdemo_mcu/esp-idf/CMakeLists.txt
+++ b/examples/printerdemo_mcu/esp-idf/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.14)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(SLINT_ESP_LOCAL_EXAMPLE ON)
+set(SLINT_ESP_LOCAL_EXAMPLE ON CACHE BOOL "Build example with local version of Slint")
 set(EXTRA_COMPONENT_DIRS ../../../api/cpp/esp-idf/)
 
 add_compile_options(-fdiagnostics-color=always)


### PR DESCRIPTION
Run the nightly esp-idf test against the esp-idf slint nightly binaries, after creating them. The snapshot is run earlier as well then, so that the tests don't "leak" into the morning working hours.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

cc #6057
