### PR TITLE
live-preview: round the x and y properties when dropping

### DIFF
--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -963,11 +963,11 @@ pub fn drop_at(
             {
                 props.push(common::PropertyChange::new(
                     "x",
-                    format!("{}px", position.x - area.origin.x),
+                    format!("{}px", (position.x - area.origin.x).round()),
                 ));
                 props.push(common::PropertyChange::new(
                     "y",
-                    format!("{}px", position.y - area.origin.y),
+                    format!("{}px", (position.y - area.origin.y).round()),
                 ));
             }
         }


### PR DESCRIPTION
Otherwise we end up with values such as

```slint
    SpinBox {
        minimum: 0;
        value: 42;
        maximum: 100;
        x: 94.44821px;
        y: 108.07013px;
    }
```

Which doesn't make much sense
