### PR TITLE
CI: don't run the nightly tests when creating a release

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -570,6 +570,7 @@ jobs:
                 -d '{"ref":"main"}'
 
     nightly-tests:
+        if: github.event.inputs.release != 'true'
         needs: [prepare_release]
         uses: ./.github/workflows/nightly_tests.yaml
 


### PR DESCRIPTION
This should be done before the release and the job that tries to download the binaries from the untagged release won't work anyway.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
