### PR TITLE
Use command instead of control for the status text when running on macOS

### DIFF
--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -107,6 +107,7 @@ image = { workspace = true, optional = true, features = ["default"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.5"
 js-sys = { version = "0.3.57" }
+web-sys = { version = "0.3", features=[ "Navigator" ] }
 send_wrapper = { workspace = true }
 serde-wasm-bindgen = "0.6.0"
 wasm-bindgen = "0.2.80"

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -78,6 +78,17 @@ pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, Platfor
     api.on_set_color_binding(super::set_color_binding);
     api.on_set_string_binding(super::set_string_binding);
 
+    #[cfg(target_vendor = "apple")]
+    api.set_control_key_name("command".into());
+
+    #[cfg(target_family = "wasm")]
+    if web_sys::window()
+        .and_then(|window| window.navigator().platform().ok())
+        .map_or(false, |platform| platform.to_ascii_lowercase().contains("mac"))
+    {
+        api.set_control_key_name("command".into());
+    }
+
     Ok(ui)
 }
 

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -169,6 +169,8 @@ export global Api {
     in property <[string]> known-styles;
     // The current style
     in-out property <string> current-style;
+    in-out property <string> control-key-name: "control";
+    // control, but command on macOS
 
     // ## Drawing Area
     // Borders around things

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -73,7 +73,7 @@ component SelectionFrame {
 
         changed has-hover => {
             if self.has-hover {
-                StatusLineApi.help-text = @tr("<double-click> select behind element, <shift double-click> select before element, <ctrl> ignores component boundaries");
+                StatusLineApi.help-text = @tr("<double-click> select behind element, <shift double-click> select before element, <{}> ignores component boundaries", Api.control-key-name);
             } else {
                 StatusLineApi.help-text = "";
             }
@@ -293,7 +293,7 @@ export component PreviewView {
 
                     changed has-hover => {
                         if self.has-hover && self.enabled {
-                            StatusLineApi.help-text = @tr("<click> select element in current component, <ctrl-click> to select an element in any component");
+                            StatusLineApi.help-text = @tr("<click> select element in current component, <{}-click> to select an element in any component", Api.control-key-name);
                         } else {
                             StatusLineApi.help-text = "";
                         }


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
