### PR TITLE
live-preview: Always unselect when clicking onto background

### DIFF
--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -187,8 +187,7 @@ export component PreviewView {
                     Api.unselect();
                     root.select-mode = false;
                 }
-                mouse-cursor: crosshair;
-                enabled: root.mode == DrawAreaMode.designing || root.mode == DrawAreaMode.selecting;
+                mouse-cursor: root.mode == DrawAreaMode.designing || root.mode == DrawAreaMode.selecting ? MouseCursor.crosshair : MouseCursor.default;
 
                 changed has-hover => {
                     StatusLineApi.help-text = "<click> unselect";


### PR DESCRIPTION
Always unselect the currently selected item when clicking onto the background around the previewed UI.
