### PR TITLE
docs: translation is not supported on Windows

### DIFF
--- a/docs/reference/src/language/concepts/translations.md
+++ b/docs/reference/src/language/concepts/translations.md
@@ -27,6 +27,12 @@ Complete the following steps to translate your application:
 
 At this point, all strings marked for translation are automatically rendered in the target language.
 
+:::{note}
+
+Support for translations via gettext is currently not supported on Windows, see [Add support for translations on Windows #3307](https://github.com/slint-ui/slint/issues/3307).
+
+:::
+
 ## Annotating Translatable Strings
 
 Use the `@tr` macro in `.slint` files to mark that a string for translation. This macro


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
While support for translations via gettext is currently not supported on Windows #3307 , it should be mentioned in the document.
Respect for [the comment](https://github.com/slint-ui/slint/issues/3307#issuecomment-2282195298)