### PR TITLE
macOS: When quitting the preview via the system menubar's menu, reall…

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -189,6 +189,12 @@ function startClient(
                     });
             }
         });
+
+        cl?.onRequest("slint/request_restart", async () => {
+            await client.stop();
+            await cl.stop();
+            await cl.start();
+        });
     });
 
     const cl = new LanguageClient(


### PR DESCRIPTION
…y quit

Instead of just hiding the window, restart the lsp entirely, to start with a clean state.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
