### PR TITLE
live-preview: Fix size being displayed wrongly

### DIFF
--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -214,6 +214,10 @@ export component PreviewView {
             }
 
             main-resizer := Resizer {
+                private property <component-factory> component-factory <=> preview-area-container.component-factory;
+                private property <length> target-width;
+                private property <length> target-height;
+
                 color: root.design-mode ? Colors.black : Colors.transparent;
                 fill-color: root.design-mode ? Colors.white : Colors.transparent;
 
@@ -236,26 +240,20 @@ export component PreviewView {
                 // is called every time the condition is dirty, to make sure that the size
                 // is within the bounds.
                 // Query the preview-area to make sure this is evaluated when it changes
-                if preview-area-container.has-component && root.preview-area == preview-area-container.component-factory: Rectangle {
-                    init => {
-                        preview-area-container.width = clamp(preview-area-container.width, max(preview-area-container.min-width, 16px), max(preview-area-container.max-width, 16px));
-                        preview-area-container.height = clamp(preview-area-container.height, max(preview-area-container.min-height, 16px),  max(preview-area-container.max-height, 16px));
-                    }
-                }
-
-                if Api.resize-to-preferred-size: Rectangle {
-                    private property <length> target-width: 0px;
-                    private property <length> target-height: 0px;
-
-                    init => {
+                changed component-factory => {
+                    if Api.resize-to-preferred-size {
                         self.target-width = preview-area-container.preferred-width.abs() < 0.5px ? drawing-rect.width - scroll-view.border : preview-area-container.preferred-width;
                         self.target-height = preview-area-container.preferred-height.abs() < 0.5px ? drawing-rect.height - scroll-view.border : preview-area-container.preferred-height;
 
                         preview-area-container.width = clamp(self.target-width, max(preview-area-container.min-width, 16px), max(preview-area-container.max-width, 16px));
                         preview-area-container.height = clamp(self.target-height, max(preview-area-container.min-height, 16px), max(preview-area-container.max-height, 16px));
 
-                        Api.resize-to-preferred-size = false;
+                    } else {
+                        preview-area-container.width = clamp(preview-area-container.width, max(preview-area-container.min-width, 16px), max(preview-area-container.max-width, 16px));
+                        preview-area-container.height = clamp(preview-area-container.height, max(preview-area-container.min-height, 16px),  max(preview-area-container.max-height, 16px));
                     }
+
+                    Api.resize-to-preferred-size = false;
                 }
 
                 Rectangle {


### PR DESCRIPTION
Stop abusing the init callback, abuse the changed callback instead ;-)

Also merge the initial size calculation into one place. This fixes the preview showing the wrong sizes. It does introduce a bit of flicker though as the UI is rendered in the wrong state once and then immediently corrects itself.

That is annoying, but strictly better than staying in the wrong state till the user does something.

Closes: #5954
