### PR TITLE
Skia: fix mixing tiling and colorize

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -255,9 +255,11 @@ impl<'a> SkiaItemRenderer<'a> {
                             / skia_image.height() as f32,
                     ))
                     * Matrix::translate((-(tiled_offset.x as i32), -(tiled_offset.y as i32)));
-                if let Some(shader) = skia_image.make_subset(None, &src).and_then(|i| {
-                    i.to_shader((TileMode::Repeat, TileMode::Repeat), filter_mode, &matrix)
-                }) {
+                if let Some(shader) =
+                    skia_image.make_subset(self.canvas.direct_context().as_mut(), &src).and_then(
+                        |i| i.to_shader((TileMode::Repeat, TileMode::Repeat), filter_mode, &matrix),
+                    )
+                {
                     let mut paint = self.default_paint().unwrap_or_default();
                     paint.set_shader(shader);
                     self.canvas.draw_paint(&paint);


### PR DESCRIPTION
A colorized image is baked by a texture, which needs the context so that the make_subset don't return None
