### PR TITLE
live-preview: Use a checkerboard as the background

### DIFF
--- a/tools/lsp/ui/assets/background.svg
+++ b/tools/lsp/ui/assets/background.svg
@@ -1,0 +1,5 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0 -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+  <rect x="0" y="0" width="10" height="10" fill="black"/>
+  <rect x="10" y="10" width="10" height="10" fill="black"/>
+</svg>

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -3,7 +3,7 @@
 
 // cSpell: ignore Heade
 
-import { Button, ComboBox, ListView, ScrollView, VerticalBox } from "std-widgets.slint";
+import { Button, ComboBox, ListView, ScrollView, VerticalBox, Palette } from "std-widgets.slint";
 import { Api, ComponentItem } from "api.slint";
 
 import { DiagnosticsOverlay } from "./components/diagnostics-overlay.slint";
@@ -73,7 +73,7 @@ export component PreviewUi inherits Window {
                         checkable: true;
                         checked <=> preview.select-mode;
                         enabled: !preview.design-mode;
-                        visible: !preview.design-mode; 
+                        visible: !preview.design-mode;
                     }
                 }
 

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -167,8 +167,9 @@ export component PreviewView {
     out property <length> preview-area-width: preview-visible ? preview-area-container.width : 0px;
     out property <length> preview-area-height: preview-visible ? preview-area-container.height : 0px;
 
-    preferred-height: max(preview-area-container.preferred-height, preview-area-container.min-height) + 2 * scroll-view.border;
-    preferred-width: max(preview-area-container.preferred-width, preview-area-container.min-width) + 2 * scroll-view.border;
+    preferred-height: max(max(preview-area-container.preferred-height, preview-area-container.min-height) + 2 * scroll-view.border, 10 * scroll-view.border);
+    preferred-width: max(max(preview-area-container.preferred-width, preview-area-container.min-width) + 2 * scroll-view.border, 10 * scroll-view.border);
+
 
     scroll-view := ScrollView {
         out property <length> border: 30px;
@@ -181,6 +182,15 @@ export component PreviewView {
         drawing-rect := Rectangle {
             width: max(scroll-view.visible-width, main-resizer.width + scroll-view.border);
             height: max(scroll-view.visible-height, main-resizer.height + scroll-view.border);
+            background: Palette.background;
+            Image {
+                width: 100%;
+                height: 100%;
+                source: @image-url("../assets/background.svg");
+                vertical-tiling: repeat;
+                horizontal-tiling: repeat;
+                colorize: Palette.alternate-background;
+            }
 
             unselect-area := TouchArea {
                 clicked => {
@@ -236,7 +246,7 @@ export component PreviewView {
                 if Api.resize-to-preferred-size: Rectangle {
                     private property <length> target-width: 0px;
                     private property <length> target-height: 0px;
-                    
+
                     init => {
                         self.target-width = preview-area-container.preferred-width.abs() < 0.5px ? drawing-rect.width - scroll-view.border : preview-area-container.preferred-width;
                         self.target-height = preview-area-container.preferred-height.abs() < 0.5px ? drawing-rect.height - scroll-view.border : preview-area-container.preferred-height;


### PR DESCRIPTION
Also have a slightly bigger preferred size by default when the previewed component is very small

![image](https://github.com/user-attachments/assets/e380cf09-83e5-43ef-bb92-6ccad523fe32)

What do you think?
