### PR TITLE
Introduce `AccessibleRole::ListItem`

### DIFF
--- a/examples/bash/sysinfo.slint
+++ b/examples/bash/sysinfo.slint
@@ -171,6 +171,7 @@ export component SysInfo inherits Dialog {
                     for disk in root.partitions : HorizontalLayout {
                         padding: 5px;
                         spacing: 5px;
+                        accessible-role: list-item;
 
                         Text { width: t1.width; overflow: elide; text: disk.dev; }
                         Text { width: t2.width; overflow: elide; text: disk.mnt; }

--- a/examples/energy-monitor/ui/widgets/list_view.slint
+++ b/examples/energy-monitor/ui/widgets/list_view.slint
@@ -35,6 +35,7 @@ component ListViewItem {
         padding-bottom: Theme.spaces.medium;
         padding-right: Theme.spaces.medium;
         spacing: Theme.spaces.medium;
+        accessible-role: list-item;
 
         i-text := Text {
             horizontal-stretch: 1;

--- a/examples/todo-mvc/ui/widgets/selection_list_view.slint
+++ b/examples/todo-mvc/ui/widgets/selection_list_view.slint
@@ -45,6 +45,8 @@ export component SelectionListViewItemDelegate {
     }
 
     content-layer := HorizontalBox {
+        accessible-role: list-item;
+        
         check-box := CheckBox {
             horizontal-stretch: 0;
             y: (parent.height - self.height) / 2;

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -320,6 +320,7 @@ cpp! {{
                     i_slint_core::items::AccessibleRole::Tree => QAccessible_Role_Tree,
                     i_slint_core::items::AccessibleRole::TextInput => QAccessible_Role_EditableText,
                     i_slint_core::items::AccessibleRole::Switch => QAccessible_Role_CheckBox,
+                    i_slint_core::items::AccessibleRole::ListItem => QAccessible_Role_ListItem,
                     _ => QAccessible_Role_NoRole,
                 }
             });

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -96,6 +96,7 @@ enum AccessibleRole {
     ProgressIndicator = 12;
     TextInput = 13;
     Switch = 14;
+    ListItem = 15;
 }
 
 message ElementQueryInstruction {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -526,6 +526,7 @@ fn convert_to_proto_accessible_role(
         }
         i_slint_core::items::AccessibleRole::TextInput => proto::AccessibleRole::TextInput,
         i_slint_core::items::AccessibleRole::Switch => proto::AccessibleRole::Switch,
+        i_slint_core::items::AccessibleRole::ListItem => proto::AccessibleRole::ListItem,
         _ => return None,
     })
 }
@@ -551,6 +552,7 @@ fn convert_from_proto_accessible_role(
         }
         proto::AccessibleRole::TextInput => i_slint_core::items::AccessibleRole::TextInput,
         proto::AccessibleRole::Switch => i_slint_core::items::AccessibleRole::Switch,
+        proto::AccessibleRole::ListItem => i_slint_core::items::AccessibleRole::ListItem,
     })
 }
 

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -368,6 +368,7 @@ impl NodeCollection {
                         Role::ProgressIndicator
                     }
                     i_slint_core::items::AccessibleRole::Switch => Role::Switch,
+                    i_slint_core::items::AccessibleRole::ListItem => Role::ListBoxOption,
                     _ => Role::Unknown,
                 },
                 item.accessible_string_property(

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -355,7 +355,7 @@ impl NodeCollection {
                     i_slint_core::items::AccessibleRole::Button => Role::Button,
                     i_slint_core::items::AccessibleRole::Checkbox => Role::CheckBox,
                     i_slint_core::items::AccessibleRole::Combobox => Role::ComboBox,
-                    i_slint_core::items::AccessibleRole::List => Role::List,
+                    i_slint_core::items::AccessibleRole::List => Role::ListBox,
                     i_slint_core::items::AccessibleRole::Slider => Role::Slider,
                     i_slint_core::items::AccessibleRole::Spinbox => Role::SpinButton,
                     i_slint_core::items::AccessibleRole::Tab => Role::Tab,

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -369,6 +369,8 @@ macro_rules! for_each_enums {
                 TextInput,
                 /// The element is a [`Switch`](slint-reference:src/language/widgets/switch) or behaves like one.
                 Switch,
+                /// The element is an item in a [`ListView`](slint-reference:src/language/widgets/listview).
+                ListItem,
             }
 
             /// This enum represents the different values of the `sort-order` property.

--- a/internal/compiler/widgets/cosmic/components.slint
+++ b/internal/compiler/widgets/cosmic/components.slint
@@ -111,6 +111,7 @@ export component ListItem {
 
     layout := HorizontalLayout {
         padding-bottom: 8px;
+        accessible-role: list-item;
 
         StateLayerBase {
             width: 100%;

--- a/internal/compiler/widgets/cupertino/components.slint
+++ b/internal/compiler/widgets/cupertino/components.slint
@@ -73,6 +73,7 @@ export component ListItem {
     i-layout := VerticalLayout {
         padding-left: root.padding-horizontal;
         padding-right: root.padding-horizontal;
+        accessible-role: list-item;
 
         i-background := Rectangle {
             background: transparent;

--- a/internal/compiler/widgets/fluent/components.slint
+++ b/internal/compiler/widgets/fluent/components.slint
@@ -78,6 +78,7 @@ export component ListItem {
             padding-left: 16px;
             padding-right: 16px;
             spacing: 4px;
+            accessible-role: list-item;
 
             i-text := Text {
                 text: root.item.text;

--- a/internal/compiler/widgets/material/components.slint
+++ b/internal/compiler/widgets/material/components.slint
@@ -145,6 +145,7 @@ export component ListItem {
     i-layout := HorizontalLayout {
         padding-left: 12px;
         padding-right: 12px;
+        accessible-role: list-item;
 
         label := Text {
             text: root.item.text;


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Adds a new accessible role to expose list view items to assistive technologies. The standard list view is modified to take advantage of this. Some examples were also updated.

Fixes incorrect mapping of the list role for the AccessKit accessibility backend, as discussed a while back.