### PR TITLE
Slintpad: add an about dialog

### DIFF
--- a/tools/slintpad/src/dialogs.ts
+++ b/tools/slintpad/src/dialogs.ts
@@ -138,3 +138,27 @@ export async function export_gist_dialog(
         () => exporter(description.value, is_public.checked),
     );
 }
+
+export function about_dialog() {
+    const element = document.createElement("div");
+    element.innerHTML = `
+        <div>
+          <center>
+          <h1>Welcome to SlintPad</h1>
+
+          <a href="https://slint.dev/" target="_blank"><img src="https://slint.dev/logo/slint-logo-simple-light.svg"></a>
+          </center>
+
+          <p><a href="https://slint.dev/" target="_blank">Slint</a> is a toolkit to efficiently develop fluid graphical user interfaces for
+          any display: embedded devices and desktop applications. It comes with a custom markup language for user
+          interfaces. This language is easy to learn, to read and write, and provides a powerful way to describe
+          graphical elements. For more details, check out the <a href="https://slint.dev/docs/slint" target="_blank">Slint Language Documentation</a>.</p>
+
+          <p>Use SlintPad to quickly try out Slint code snippets, with auto-completion, code navigation, and live-preview.</p>
+          <p>The same features are also available in the <a href="https://marketplace.visualstudio.com/items?itemName=Slint.slint" target="_blank">Visual Studio Code extension</a>,
+          which runs in your local VS code installation as well as in the <a href="https://vscode.dev/" target="_blank">Visual Studio Code for the Web</a>.</p>
+
+          <p>SlintPad is licensed under the GNU GPLv3. The source code is located in our <a href="https://github.com/slint-ui/slint/tree/master/tools/slintpad" target="_blank">GitHub repository</a>.
+        </div>`;
+    modal_dialog("about_dialog", [element]);
+}

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -17,6 +17,7 @@ import {
     report_export_url_dialog,
     report_export_error_dialog,
     export_gist_dialog,
+    about_dialog,
 } from "./dialogs";
 
 import { CommandRegistry } from "@lumino/commands";
@@ -115,6 +116,14 @@ function create_project_menu(
     });
     menu.addItem({ type: "separator" });
     menu.addItem({ type: "submenu", submenu: create_settings_menu() });
+    menu.addItem({ type: "separator" });
+
+    commands.addCommand("slint:about", {
+        label: "About",
+        iconClass: "fa-info-circle",
+        execute: () => about_dialog(),
+    });
+    menu.addItem({ command: "slint:about" });
 
     return menu;
 }


### PR DESCRIPTION
Back in Slint 1.6, slintpad had a "welcome" page that explained what it is. But the welcome page was removed in commit 588ee3e4740eda68b36ff2f55323b2f2522a42b2 Now it's hard for someone who click on a link to slintpad.com to know what it is and get a link to Slint.

Add an "about" entry in the menu that shows the previous welcome page as a dialog

ChangeLog: Slintpad: add "about" entry in the menu.

![image](https://github.com/user-attachments/assets/dee90cd8-e42a-45f4-94d1-dd56ef40ef1f)
![image](https://github.com/user-attachments/assets/84998616-06d6-44a4-b39e-231cf3800dc5)
