### PR TITLE
live-preview: Less model updates for property editor

### DIFF
--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -109,6 +109,8 @@ export struct PropertyDefinition {
 
 /// The Property Declaration
 export struct PropertyDeclaration {
+    defined-at: PropertyDefinition,
+
     source-path: string,
     source-version: int,
     range: Range,
@@ -118,8 +120,6 @@ export struct PropertyDeclaration {
 export struct PropertyInformation {
     name: string,
     type-name: string,
-    declared-at: PropertyDeclaration,
-    defined-at: PropertyDefinition,
     value: PropertyValue,
 }
 
@@ -136,8 +136,6 @@ export struct ElementInformation {
     source-uri: string,
     source-version: int,
     range: Range,
-
-    properties: [PropertyGroup],
 }
 
 export global Api {
@@ -183,7 +181,8 @@ export global Api {
     in property <bool> resize-to-preferred-size: false;
 
     // ## Property Editor
-    in property <ElementInformation> current-element;
+    in-out property <ElementInformation> current-element;
+    in-out property <[PropertyGroup]> properties;
 
     // # Callbacks
 
@@ -234,4 +233,7 @@ export global Api {
     callback set-code-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ string);
     callback set-color-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* property-value: */ color);
     callback set-string-binding(/* element-url: */ string, /* element-version: */ int, /* element-offset: */ int, /* property-name: */ string, /* value: */ string, /* is_translatable: */ bool, /* tr_context: */ string, /* tr_plural: */ string, /* tr_plural_exprression: */ string);
+
+    // Get the property declaration/definition ranges
+    callback property-declaration-ranges(/* property-name: */ string) -> PropertyDeclaration;
 }

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -3,7 +3,7 @@
 
 import { LineEdit, Palette, VerticalBox, CheckBox, ComboBox, ScrollView, Button } from "std-widgets.slint";
 
-import { Api, ElementInformation, PropertyValue, PropertyValueKind } from "../api.slint";
+import { Api, ElementInformation, PropertyDeclaration, PropertyGroup, PropertyValue, PropertyValueKind } from "../api.slint";
 import { GroupHeader } from "../components/group.slint";
 import { BodyText } from "../components/body-text.slint";
 import { EditorSizeSettings } from "../components/styling.slint";
@@ -31,6 +31,7 @@ component TypeHeader inherits Rectangle {
 
 export component PropertyView {
     in property <ElementInformation> current-element <=> Api.current-element;
+    in property <[PropertyGroup]> properties <=> Api.properties;
 
     private property <length> key-width: self.width / 2.5;
 
@@ -49,7 +50,7 @@ export component PropertyView {
 
         ScrollView {
             VerticalLayout {
-                if root.current-element.properties.length > 0: Rectangle {
+                if root.properties.length > 0: Rectangle {
                     VerticalLayout {
                         alignment: start;
 
@@ -58,7 +59,7 @@ export component PropertyView {
                             id: root.current-element.id;
                         }
 
-                        for group in root.current-element.properties: Rectangle {
+                        for group in root.properties: Rectangle {
                             VerticalBox {
                                 if group.group-name != "" && group.group-name != root.current-element.type-name: BodyText {
                                     text: group.group-name;
@@ -88,7 +89,7 @@ export component PropertyView {
                                         }
 
                                         clicked() => {
-                                            Api.show-document-offset-range(root.current-element.source-uri, property.defined-at.expression-range.start, property.defined-at.expression-range.start);
+                                            Api.show-document-offset-range(root.current-element.source-uri, Api.property-declaration-ranges(property-name).defined-at.expression-range.start, Api.property-declaration-ranges(property-name).defined-at.expression-range.start);
                                         }
                                     }
 
@@ -101,7 +102,7 @@ export component PropertyView {
                                         if property-row.property-value.kind == PropertyValueKind.code && property-row.property-value.code != "": Button {
                                             text: @tr("Code");
                                             clicked() => {
-                                                Api.show-document-offset-range(root.current-element.source-uri, property.defined-at.expression-range.start, property.defined-at.expression-range.start);
+                                                Api.show-document-offset-range(root.current-element.source-uri, Api.property-declaration-ranges(property-name).defined-at.expression-range.start, Api.property-declaration-ranges(property-name).defined-at.expression-range.start);
                                             }
                                         }
                                         if property-row.property-value.kind == PropertyValueKind.code && property-row.property-value.code == "": Text {


### PR DESCRIPTION
Move the model into an extra property and move information irrelevant for the UI behind a callback, so that changing that info will not invalidate the UI.
