### PR TITLE
Change `mod()` to always return positive number

### DIFF
--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -217,6 +217,7 @@ pub mod re_exports {
     pub use i_slint_core::SharedString;
     pub use i_slint_core::SharedVector;
     pub use num_traits::float::Float;
+    pub use num_traits::ops::euclid::Euclid;
     pub use once_cell::race::OnceBox;
     pub use once_cell::unsync::OnceCell;
     pub use pin_weak::rc::PinWeak;

--- a/docs/reference/src/language/builtins/namespaces.md
+++ b/docs/reference/src/language/builtins/namespaces.md
@@ -90,6 +90,8 @@ against the constants below.
 
 These functions are available both in the global scope and in the `Math` namespace.
 
+They can also be called directly as member function of numeric types. (For example `angle.sin()` or `foo.mod(10)`).
+
 ### `abs(T) -> T`
 
 Return the absolute value, where T is a numeric type.
@@ -119,6 +121,8 @@ Return the arguments with the minimum (or maximum) value. All arguments must be 
 ### `mod(T, T) -> T`
 
 Perform a modulo operation, where T is some numeric type.
+Returns the remainder of the euclidean division of the arguments.
+This always returns a positive number between 0 and the absolute value of the second value.
 
 ### `round(float) -> int`
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3297,7 +3297,7 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::Mod => {
             ctx.generator_state.conditional_includes.cmath.set(true);
-            format!("std::fmod({}, {})", a.next().unwrap(), a.next().unwrap())
+            format!("([](float a, float b) {{ return a >= 0 ? std::fmod(a, b) : std::fmod(a, b) + std::abs(b); }})({},{})", a.next().unwrap(), a.next().unwrap())
         }
         BuiltinFunction::Round => {
             ctx.generator_state.conditional_includes.cmath.set(true);

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2715,7 +2715,7 @@ fn compile_builtin_function_call(
         BuiltinFunction::Debug => quote!(slint::private_unstable_api::debug(#(#a)*)),
         BuiltinFunction::Mod => {
             let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
-            quote!((#a1 as f64).rem_euclid(#a2 as f64))
+            quote!(sp::Euclid::rem_euclid(&(#a1 as f64), &(#a2 as f64)))
         }
         BuiltinFunction::Round => quote!((#(#a)* as f64).round()),
         BuiltinFunction::Ceil => quote!((#(#a)* as f64).ceil()),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2713,7 +2713,10 @@ fn compile_builtin_function_call(
             quote!(sp::animation_tick())
         }
         BuiltinFunction::Debug => quote!(slint::private_unstable_api::debug(#(#a)*)),
-        BuiltinFunction::Mod => quote!((#(#a as f64)%*)),
+        BuiltinFunction::Mod => {
+            let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
+            quote!((#a1 as f64).rem_euclid(#a2 as f64))
+        }
         BuiltinFunction::Round => quote!((#(#a)* as f64).round()),
         BuiltinFunction::Ceil => quote!((#(#a)* as f64).ceil()),
         BuiltinFunction::Floor => quote!((#(#a)* as f64).floor()),

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -433,7 +433,7 @@ fn call_builtin_function(
         }
         BuiltinFunction::Mod => {
             let mut to_num = |e| -> f64 { eval_expression(e, local_context).try_into().unwrap() };
-            Value::Number(to_num(&arguments[0]) % to_num(&arguments[1]))
+            Value::Number(to_num(&arguments[0]).rem_euclid(to_num(&arguments[1])))
         }
         BuiltinFunction::Round => {
             let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();

--- a/tests/cases/expr/mod.slint
+++ b/tests/cases/expr/mod.slint
@@ -43,8 +43,9 @@ assert.equal(instance.t1, 0);
 assert.equal(instance.t2, 8.5);
 assert.equal(instance.t3, 3);
 assert.equal(instance.t4, 432);
-assert.equal(instance.t5, 1.8);
+assert.equal(Math.round(instance.t5 * 1000), 1800);
 assert.equal(instance.t6, 2.);
 assert.equal(instance.t7, 3.5);
+assert(instance.test);
 ```
 */

--- a/tests/cases/expr/mod.slint
+++ b/tests/cases/expr/mod.slint
@@ -1,13 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
- TestCase := Rectangle {
-    property<int> t1: mod(42, 2);
-    property<float> t2: mod(18.5, 10);
-    property<int> t3: mod(153, 10);
-    property <duration> t4: mod(5432ms, 1s);
+ export component TestCase inherits Window {
+    out property<int> t1: mod(42, 2);
+    out property<float> t2: mod(18.5, 10);
+    out property<int> t3: mod(153, 10);
+    out property <duration> t4: mod(5432ms, 1s);
+    out property <length> t5: (-28.2px).mod(10px);
+    out property <float> t6: (42).mod(-10);
+    out property <float> t7: (-420).mod(-5.5);
 
-    property <bool> test: t1 == 0 && t2 == 8.5 && t3 == 3 && t4 == 432ms;
+    out property <bool> test: t1 == 0 && t2 == 8.5 && t3 == 3 && t4 == 432ms && t5 == 1.8px && t6 == 2 && t7 == 3.5;
 }
 /*
 ```cpp
@@ -17,6 +20,9 @@ assert_eq(instance.get_t1(), 0);
 assert_eq(instance.get_t2(), 8.5);
 assert_eq(instance.get_t3(),3);
 assert_eq(instance.get_t4(),432);
+assert_eq(instance.get_t5(), 1.8);
+assert_eq(instance.get_t6(), 2.);
+assert_eq(instance.get_t7(), 3.5);
 ```
 
 
@@ -26,6 +32,9 @@ assert_eq!(instance.get_t1(), 0);
 assert_eq!(instance.get_t2(), 8.5);
 assert_eq!(instance.get_t3(), 3);
 assert_eq!(instance.get_t4(),432);
+assert_eq!(instance.get_t5(), 1.8);
+assert_eq!(instance.get_t6(), 2.);
+assert_eq!(instance.get_t7(), 3.5);
 ```
 
 ```js
@@ -34,6 +43,8 @@ assert.equal(instance.t1, 0);
 assert.equal(instance.t2, 8.5);
 assert.equal(instance.t3, 3);
 assert.equal(instance.t4, 432);
-
+assert.equal(instance.t5, 1.8);
+assert.equal(instance.t6, 2.);
+assert.equal(instance.t7, 3.5);
 ```
 */


### PR DESCRIPTION
Closes #6178

ChangeLog: The mod function was changed to always return a positive value (#6178)
