### PR TITLE
live-preview: Work on the property editor

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -517,7 +517,7 @@ pub enum PreviewToLspMessage {
     /// Report diagnostics to editor.
     Diagnostics { uri: Url, version: SourceFileVersion, diagnostics: Vec<lsp_types::Diagnostic> },
     /// Show a document in the editor.
-    ShowDocument { file: Url, selection: lsp_types::Range },
+    ShowDocument { file: Url, selection: lsp_types::Range, take_focus: bool },
     /// Switch between native and WASM preview (if supported)
     PreviewTypeChanged { is_external: bool },
     /// Request all documents and configuration to be sent from the LSP to the
@@ -603,6 +603,7 @@ pub mod lsp_to_editor {
     fn show_document_request_from_element_callback(
         uri: lsp_types::Url,
         range: lsp_types::Range,
+        take_focus: bool,
     ) -> Option<lsp_types::ShowDocumentParams> {
         if range.start.character == 0 || range.end.character == 0 {
             return None;
@@ -611,7 +612,7 @@ pub mod lsp_to_editor {
         Some(lsp_types::ShowDocumentParams {
             uri,
             external: Some(false),
-            take_focus: Some(false),
+            take_focus: Some(take_focus),
             selection: Some(range),
         })
     }
@@ -620,8 +621,10 @@ pub mod lsp_to_editor {
         sender: crate::ServerNotifier,
         file: lsp_types::Url,
         range: lsp_types::Range,
+        take_focus: bool,
     ) {
-        let Some(params) = show_document_request_from_element_callback(file, range) else {
+        let Some(params) = show_document_request_from_element_callback(file, range, take_focus)
+        else {
             return;
         };
         let Ok(fut) = sender.send_request::<lsp_types::request::ShowDocument>(params) else {

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -523,11 +523,12 @@ async fn handle_preview_to_lsp_message(
                 diagnostics,
             );
         }
-        M::ShowDocument { file, selection } => {
+        M::ShowDocument { file, selection, take_focus } => {
             crate::common::lsp_to_editor::send_show_document_to_editor(
                 ctx.server_notifier.clone(),
                 file,
                 selection,
+                take_focus,
             )
             .await;
         }

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -555,11 +555,11 @@ fn show_component(name: slint::SharedString, url: slint::SharedString) {
 
     let start =
         util::text_size_to_lsp_position(&identifier.source_file, identifier.text_range().start());
-    ask_editor_to_show_document(&file.to_string_lossy(), lsp_types::Range::new(start, start))
+    ask_editor_to_show_document(&file.to_string_lossy(), lsp_types::Range::new(start, start), false)
 }
 
 // triggered from the UI, running in UI thread
-fn show_document_offset_range(url: slint::SharedString, start: i32, end: i32) {
+fn show_document_offset_range(url: slint::SharedString, start: i32, end: i32, take_focus: bool) {
     fn internal(
         url: slint::SharedString,
         start: i32,
@@ -582,7 +582,7 @@ fn show_document_offset_range(url: slint::SharedString, start: i32, end: i32) {
     }
 
     if let Some((f, s, e)) = internal(url, start, end) {
-        ask_editor_to_show_document(&f.to_string_lossy(), lsp_types::Range::new(s, e));
+        ask_editor_to_show_document(&f.to_string_lossy(), lsp_types::Range::new(s, e), take_focus);
     }
 }
 
@@ -1136,6 +1136,7 @@ pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior)
                         ask_editor_to_show_document(
                             &path.to_string_lossy(),
                             lsp_types::Range::new(pos, pos),
+                            false,
                         );
                     }
                 }

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -142,7 +142,7 @@ fn select_element_node(
     );
 
     if let Some(document_position) = lsp_element_node_position(selected_element) {
-        super::ask_editor_to_show_document(&document_position.0, document_position.1);
+        super::ask_editor_to_show_document(&document_position.0, document_position.1, false);
     }
 }
 

--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -233,12 +233,14 @@ pub fn send_status(message: &str, health: Health) {
     crate::common::lsp_to_editor::send_status_notification(&sender, message, health)
 }
 
-pub fn ask_editor_to_show_document(file: &str, selection: lsp_types::Range) {
+pub fn ask_editor_to_show_document(file: &str, selection: lsp_types::Range, take_focus: bool) {
     let Some(sender) = SERVER_NOTIFIER.lock().unwrap().clone() else {
         return;
     };
     let Ok(url) = lsp_types::Url::from_file_path(file) else { return };
-    let fut = crate::common::lsp_to_editor::send_show_document_to_editor(sender, url, selection);
+    let fut = crate::common::lsp_to_editor::send_show_document_to_editor(
+        sender, url, selection, take_focus,
+    );
     slint_interpreter::spawn_local(fut).unwrap(); // Fire and forget.
 }
 

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -411,6 +411,8 @@ fn get_properties(element: &common::ElementRcNode) -> Vec<PropertyInformation> {
         break;
     }
 
+    result.sort_by_key(|i| i.group.clone());
+
     insert_property_definitions(element, result)
 }
 

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -58,7 +58,7 @@ pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, Platfor
     api.on_show_document(|file, line, column| {
         use lsp_types::{Position, Range};
         let pos = Position::new((line as u32).saturating_sub(1), (column as u32).saturating_sub(1));
-        super::ask_editor_to_show_document(&file, Range::new(pos, pos))
+        super::ask_editor_to_show_document(&file, Range::new(pos, pos), false)
     });
     api.on_show_document_offset_range(super::show_document_offset_range);
     api.on_show_preview_for(super::show_preview_for);

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -361,10 +361,19 @@ fn extract_color(
         if let Some(color) = literals::parse_color_literal(&text) {
             value.kind = kind;
             value.value_brush = slint::Brush::SolidColor(slint::Color::from_argb_encoded(color));
+            value.value_string = text.into();
             return true;
         }
     }
     false
+}
+
+fn set_default_brush(kind: PropertyValueKind, value: &mut PropertyValue) {
+    let text = "#00000000";
+    let color = literals::parse_color_literal(&text).unwrap();
+    value.kind = kind;
+    value.value_string = text.into();
+    value.value_brush = slint::Brush::SolidColor(slint::Color::from_argb_encoded(color));
 }
 
 fn simplify_value(
@@ -419,7 +428,7 @@ fn simplify_value(
                 // This makes no sense right now, as we have no way to get any
                 // information on the palettes.
             } else if value.code.is_empty() {
-                value.kind = PropertyValueKind::Color;
+                set_default_brush(PropertyValueKind::Color, &mut value);
             }
         }
         Type::Brush => {
@@ -427,7 +436,7 @@ fn simplify_value(
                 extract_color(&expression, PropertyValueKind::Brush, &mut value);
                 // TODO: Handle gradients...
             } else if value.code.is_empty() {
-                value.kind = PropertyValueKind::Brush;
+                set_default_brush(PropertyValueKind::Brush, &mut value);
             }
         }
         Type::Bool => {

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -230,7 +230,11 @@ pub fn notify_diagnostics(
     Some(())
 }
 
-pub fn ask_editor_to_show_document(file: &str, selection: lsp_types::Range) {
+pub fn ask_editor_to_show_document(file: &str, selection: lsp_types::Range, take_focus: bool) {
     let Ok(file) = lsp_types::Url::from_file_path(file) else { return };
-    send_message_to_lsp(crate::common::PreviewToLspMessage::ShowDocument { file, selection });
+    send_message_to_lsp(crate::common::PreviewToLspMessage::ShowDocument {
+        file,
+        selection,
+        take_focus,
+    });
 }

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -89,7 +89,7 @@ export struct PropertyValue {
     value-float: float, // float
     value-int: int, // integer, enum/float (current index into visual_items)
     default-selection: int, // enum/float (default index into visual_items)
-    value-string: string, // enum (name), string
+    value-string: string, // enum (name), string, brush (color value)
     visual-items: [string], // enum (enum members), float (units)
     tr-context: string, // string
     tr-plural: string, // string

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -220,7 +220,7 @@ export global Api {
     // Show a position consisting of `line` and `column` in a `file` in the editor
     callback show-document(/* file: */ string, /* line: */ int, /* column: */ int);
     // Show a position consisting of `line` and `column` in a `file` in the editor
-    callback show-document-offset-range(/* url: */ string, /* start_offset: */ int, /* end_offset: */ int);
+    callback show-document-offset-range(/* url: */ string, /* start_offset: */ int, /* end_offset: */ int, /* take-focus: */ bool);
 
     // ## Drawing Area
     // Preview some other component

--- a/tools/lsp/ui/components/expandable-listview.slint
+++ b/tools/lsp/ui/components/expandable-listview.slint
@@ -9,7 +9,6 @@ import { BodyText } from "./body-text.slint";
 import { BodyStrongText } from "./body-strong-text.slint";
 import { StatusLineApi } from "status-line.slint";
 
-
 component HeaderItemTemplate {
     in property <bool> enabled: true;
     in property <string> text;

--- a/tools/lsp/ui/components/state-layer.slint
+++ b/tools/lsp/ui/components/state-layer.slint
@@ -43,7 +43,7 @@ export component StateLayer {
         pressed when root.pressed: {
             state-layer.background: EditorPalette.state-pressed;
         }
-        hoverd when root.has-hover: {
+        hovered when root.has-hover: {
             state-layer.background: EditorPalette.state-hovered;
         }
     ]

--- a/tools/lsp/ui/components/styling.slint
+++ b/tools/lsp/ui/components/styling.slint
@@ -12,6 +12,7 @@ export global Icons {
     out property <image> sidebar-left: @image-url("../assets/layout-sidebar-left.svg");
     out property <image> sidebar-right: @image-url("../assets/layout-sidebar-right.svg");
     out property <image> sync: @image-url("../assets/sync.svg");
+
 }
 
 export struct TextStyle {
@@ -44,6 +45,9 @@ export global EditorFontSettings {
 export global EditorSpaceSettings {
     in property <length> default-spacing: 8px;
     in property <length> default-padding: 8px;
+    in property <length> property-spacing: 2px;
+    in property <length> group-indent: 10px;
+
 }
 
 export global EditorSizeSettings {
@@ -53,6 +57,10 @@ export global EditorSizeSettings {
     in property <length> property-bar-width: 360px;
     in property <length> default-icon-width: 20px;
     in property <length> min-prefix-text-width: 120px;
+    in property <length> eightbit-int-size: 40px;
+    in property <length> hex-size: 80px;
+    in property <length> float-size: 100px;
+    in property <length> length-combo: 70px;
 }
 
 export global EditorPalette {

--- a/tools/lsp/ui/components/styling.slint
+++ b/tools/lsp/ui/components/styling.slint
@@ -50,7 +50,9 @@ export global EditorSizeSettings {
     in property <length> header-height: 32px;
     in property <length> item-height: 24px;
     in property <length> side-bar-width: 280px;
+    in property <length> property-bar-width: 360px;
     in property <length> default-icon-width: 20px;
+    in property <length> min-prefix-text-width: 120px;
 }
 
 export global EditorPalette {

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -25,6 +25,22 @@ component CodeButton inherits Button {
     }
 }
 
+component ResetButton inherits Button {
+    in property <ElementInformation> element-information;
+    in property <PropertyInformation> property-information;
+
+    text: @tr("Reset");
+    clicked => {
+        Api.set-code-binding(
+            element-information.source-uri,
+            element-information.source-version,
+            element-information.range.start,
+            property-information.name,
+            "",
+        );
+    }
+}
+
 component ExpandableGroup {
     in property <ElementInformation> element-information;
     in property <string> text;
@@ -100,9 +116,15 @@ component ExpandableGroup {
                             );
                         }
                     }
-                    if property.value.kind == PropertyValueKind.code: CodeButton {
-                        element-information <=> root.element-information;
-                        property-information: property;
+                    if property.value.kind == PropertyValueKind.code: HorizontalLayout {
+                        ResetButton {
+                            element-information <=> root.element-information;
+                            property-information: property;
+                        }
+                        CodeButton {
+                            element-information <=> root.element-information;
+                            property-information: property;
+                        }
                     }
                 }
             }

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -10,6 +10,21 @@ import { BodyText } from "../components/body-text.slint";
 import { StateLayer } from "../components/state-layer.slint";
 import { EditorSizeSettings, Icons, EditorAnimationSettings, EditorSpaceSettings, EditorSizeSettings } from "../components/styling.slint";
 
+component CodeButton inherits Button {
+    in property <ElementInformation> element-information;
+    in property <PropertyInformation> property-information;
+
+    text: @tr("Code");
+    clicked => {
+        Api.show-document-offset-range(
+            element-information.source-uri,
+            Api.property-declaration-ranges(property-information.name).defined-at.expression-range.start,
+            Api.property-declaration-ranges(property-information.name).defined-at.expression-range.start,
+            true,
+        );
+    }
+}
+
 component ExpandableGroup {
     in property <ElementInformation> element-information;
     in property <string> text;
@@ -84,6 +99,10 @@ component ExpandableGroup {
                                 property.value.tr-plural-expression,
                             );
                         }
+                    }
+                    if property.value.kind == PropertyValueKind.code: CodeButton {
+                        element-information <=> root.element-information;
+                        property-information: property;
                     }
                 }
             }

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -1,30 +1,92 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { LineEdit, Palette, VerticalBox, CheckBox, ComboBox, ScrollView, Button } from "std-widgets.slint";
+import { LineEdit, Palette, VerticalBox, CheckBox, ComboBox, ScrollView, Button, HorizontalBox } from "std-widgets.slint";
 
-import { Api, ElementInformation, PropertyDeclaration, PropertyGroup, PropertyValue, PropertyValueKind } from "../api.slint";
+import { Api, ElementInformation, PropertyDeclaration, PropertyGroup, PropertyInformation, PropertyValue, PropertyValueKind } from "../api.slint";
 import { GroupHeader } from "../components/group.slint";
+import { BodyStrongText } from "../components/body-strong-text.slint";
 import { BodyText } from "../components/body-text.slint";
-import { EditorSizeSettings } from "../components/styling.slint";
+import { StateLayer } from "../components/state-layer.slint";
+import { EditorSizeSettings, Icons, EditorAnimationSettings, EditorSpaceSettings, EditorSizeSettings } from "../components/styling.slint";
 
-component TypeHeader inherits Rectangle {
-    in property <string> type-name;
-    in property <string> id;
+component ExpandableGroup {
+    in property <ElementInformation> element-information;
+    in property <string> text;
+    in property <[PropertyInformation]> properties;
 
-    background: Palette.accent-background;
-    VerticalBox {
-        height: self.min-height;
+    property <bool> open: true;
+    
+    Rectangle {
+        background: Palette.alternate-background;
 
-        Text {
-            text: root.type-name;
-            color: Palette.accent-foreground;
-            font-size: 1.2rem;
-        }
+        content-layer := VerticalLayout {
+            // header
+            Rectangle {
+                touch-area := TouchArea {
+                    clicked => {
+                        root.open = !root.open;
+                    }
+                }
 
-        Text {
-            text: root.id;
-            color: Palette.accent-foreground;
+                state-layer := StateLayer {
+                    width: 100%;
+                    height: 100%;
+                    has-hover: touch-area.has-hover;
+                    pressed: touch-area.pressed;
+                }
+                
+                HorizontalBox {
+                    icon-image := Image {
+                        width: EditorSizeSettings.default-icon-width;
+                        colorize: Palette.foreground;
+                        source: Icons.drop-down;
+                        rotation-origin-x: self.width / 2;
+                        rotation-origin-y: self.height / 2;
+                        
+                        states [
+                            closed when !root.open: {
+                                rotation-angle: -0.25turn;
+                            }
+                        ]
+
+                        animate rotation-angle { duration: EditorAnimationSettings.roation-duration; }
+                    }
+                    
+                    BodyStrongText {
+                        text: root.text;
+                    }
+                }
+            }
+
+            if root.open : VerticalBox {
+                for property in root.properties : HorizontalLayout {
+                    spacing: parent.spacing;
+                    
+                    BodyText {
+                        min-width: EditorSizeSettings.min-prefix-text-width;
+                        text: property.name;
+                    }
+
+                    if property.value.kind == PropertyValueKind.string: LineEdit {
+                        text: property.value.value-string;
+
+                        accepted(text) => {
+                            Api.set-string-binding(
+                                root.element-information.source-uri,
+                                root.element-information.source-version,
+                                root.element-information.range.start,
+                                property.name,
+                                text,
+                                property.value.is-translatable,
+                                property.value.tr-context,
+                                property.value.tr-plural,
+                                property.value.tr-plural-expression,
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -33,170 +95,33 @@ export component PropertyView {
     in property <ElementInformation> current-element <=> Api.current-element;
     in property <[PropertyGroup]> properties <=> Api.properties;
 
-    private property <length> key-width: self.width / 2.5;
+    property <length> key-width: self.width / 2.5;
+    property <bool> element-loaded: root.properties.length > 0;
 
-    width: EditorSizeSettings.side-bar-width;
-
-    background-layer := Rectangle {
-        background: Palette.alternate-background;
-    }
+    width: EditorSizeSettings.property-bar-width;
 
     content-layer := VerticalLayout {
-        padding: background-layer.border-width;
-
         GroupHeader {
-            title: @tr("Properties");
+            title: @tr("{} Properties", root.current-element.type-name);
+            vertical-stretch: 0;
+        }
+        
+        if !root.element-loaded : Text {
+            text: @tr("Select an Element");
+            horizontal-alignment: center;
+            vertical-alignment: center;
+            vertical-stretch: 1;
         }
 
-        ScrollView {
-            VerticalLayout {
-                if root.properties.length > 0: Rectangle {
-                    VerticalLayout {
-                        alignment: start;
+        if root.element-loaded : ScrollView {
+            VerticalBox {
+                alignment: start;
 
-                        header := TypeHeader {
-                            type-name: root.current-element.type-name;
-                            id: root.current-element.id;
-                        }
+                for group in root.properties : ExpandableGroup {
+                    text: group.group-name;
 
-                        for group in root.properties: Rectangle {
-                            VerticalBox {
-                                if group.group-name != "" && group.group-name != root.current-element.type-name: BodyText {
-                                    text: group.group-name;
-                                }
-
-                                for property in group.properties: property-row := HorizontalLayout {
-                                    private property <string> property-name: property.name;
-                                    private property <string> property-type: property.type-name;
-                                    private property <PropertyValue> property-value: property.value;
-
-                                    private property <bool> is-defined: self.property-value.code != "";
-
-                                    private property <brush> text-foreground: property-row.is-defined ? Palette.foreground : Palette.foreground.transparentize(0.5);
-
-                                    spacing: 4px;
-                                    alignment: stretch;
-
-                                    TouchArea {
-                                        width: root.key-width;
-                                        horizontal-stretch: 0;
-
-                                        key := Text {
-                                            width: 100%;
-                                            color: property-row.text-foreground;
-                                            vertical-alignment: center;
-                                            text: property.name;
-                                        }
-
-                                        clicked() => {
-                                            Api.show-document-offset-range(root.current-element.source-uri, Api.property-declaration-ranges(property-name).defined-at.expression-range.start, Api.property-declaration-ranges(property-name).defined-at.expression-range.start);
-                                        }
-                                    }
-
-                                    Rectangle {
-                                        min-height: 20px;
-                                        horizontal-stretch: 1;
-
-                                        private property <bool> have-simple-ui: false;
-
-                                        if property-row.property-value.kind == PropertyValueKind.code && property-row.property-value.code != "": Button {
-                                            text: @tr("Code");
-                                            clicked() => {
-                                                Api.show-document-offset-range(root.current-element.source-uri, Api.property-declaration-ranges(property-name).defined-at.expression-range.start, Api.property-declaration-ranges(property-name).defined-at.expression-range.start);
-                                            }
-                                        }
-                                        if property-row.property-value.kind == PropertyValueKind.code && property-row.property-value.code == "": Text {
-                                            text: @tr("<unset>");
-                                        }
-                                        if property-row.property-value.kind == PropertyValueKind.boolean: CheckBox {
-                                            x: 0;
-                                            checked: property-row.property-value.value_bool;
-
-                                            toggled() => {
-                                                Api.set-code-binding(
-                                                    root.current-element.source-uri,
-                                                    root.current-element.source-version,
-                                                    root.current-element.range.start,
-                                                    property.name,
-                                                    self.checked ? "true" : "false",
-                                                );
-                                            }
-                                        }
-                                        if property-row.property-value.kind == PropertyValueKind.string: LineEdit {
-                                            width: 100%;
-                                            // otherwise this gets too high and covers several rows.
-                                            height: 100%;
-                                            text: property-row.property-value.value-string;
-
-                                            edited(text) => {
-                                                overlay.visible = !Api.test-string-binding(
-                                                    root.current-element.source-uri,
-                                                    root.current-element.source-version,
-                                                    root.current-element.range.start,
-                                                    property.name,
-                                                    text,
-                                                    property-row.property-value.is-translatable,
-                                                    property-row.property-value.tr-context,
-                                                    property-row.property-value.tr-plural,
-                                                    property-row.property-value.tr-plural-expression,
-                                                );
-                                            }
-
-                                            accepted(text) => {
-                                                Api.set-string-binding(
-                                                    root.current-element.source-uri,
-                                                    root.current-element.source-version,
-                                                    root.current-element.range.start,
-                                                    property.name,
-                                                    text,
-                                                    property-row.property-value.is-translatable,
-                                                    property-row.property-value.tr-context,
-                                                    property-row.property-value.tr-plural,
-                                                    property-row.property-value.tr-plural-expression,
-                                                );
-                                            }
-                                        }
-                                        if property-row.property-value.kind == PropertyValueKind.enum: ComboBox {
-                                            width: 100%;
-                                            // otherwise this gets too high and covers several rows.
-                                            height: 100%;
-
-                                            current-index: property-row.property-value.value-int;
-
-                                            model: property-row.property-value.visual-items;
-
-                                            selected(value) => {
-                                                Api.set-code-binding(
-                                                    root.current-element.source-uri,
-                                                    root.current-element.source-version,
-                                                    root.current-element.range.start,
-                                                    property.name,
-                                                    property-value.value_string + "." + value,
-                                                )
-                                            }
-                                        }
-
-                                        overlay := Rectangle {
-                                            visible: false;
-                                            background: #80000040;
-
-                                            width: parent.width - 8px;
-                                            height: parent.height - 8px;
-                                            border-radius: 3px;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if root.current-element.type-name == "": VerticalLayout {
-                    Text {
-                        text: "Select an Element";
-                        horizontal-alignment: center;
-                        vertical-alignment: center;
-                    }
+                    element-information <=> root.current-element;
+                    properties: group.properties;
                 }
             }
         }

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -1,14 +1,19 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { LineEdit, Palette, VerticalBox, CheckBox, ComboBox, ScrollView, Button, HorizontalBox } from "std-widgets.slint";
+import { LineEdit, Palette, VerticalBox, CheckBox, ComboBox, ScrollView, Button, HorizontalBox, SpinBox, Slider } from "std-widgets.slint";
 
 import { Api, ElementInformation, PropertyDeclaration, PropertyGroup, PropertyInformation, PropertyValue, PropertyValueKind } from "../api.slint";
 import { GroupHeader } from "../components/group.slint";
 import { BodyStrongText } from "../components/body-strong-text.slint";
 import { BodyText } from "../components/body-text.slint";
 import { StateLayer } from "../components/state-layer.slint";
-import { EditorSizeSettings, Icons, EditorAnimationSettings, EditorSpaceSettings, EditorSizeSettings } from "../components/styling.slint";
+import { EditorSizeSettings, Icons, EditorAnimationSettings, EditorSpaceSettings, EditorSizeSettings, EditorFontSettings, EditorPalette } from "../components/styling.slint";
+
+export global style {
+    out property <length> grid-margin:5px;
+    out property <length> min-distance:5px;
+}
 
 component CodeButton inherits Button {
     in property <ElementInformation> element-information;
@@ -41,19 +46,214 @@ component ResetButton inherits Button {
     }
 }
 
+component NameLabel inherits HorizontalLayout {
+    in property <string> property-name;
+
+    horizontal-stretch: 0;
+
+    Rectangle {
+        width: EditorSpaceSettings.group-indent;
+    }
+
+    BodyText {
+        min-width: EditorSizeSettings.min-prefix-text-width;
+        text: root.property-name;
+        font-size: 1rem;
+        overflow: elide;
+    }
+}
+
+component FloatWidget inherits HorizontalLayout {
+    in property <ElementInformation> element-information;
+    in property <PropertyInformation> property-information;
+
+    private property <string> current-unit;
+    spacing: EditorSpaceSettings.default-spacing;
+    padding-top: EditorSpaceSettings.property-spacing;
+    alignment: space-between;
+    width: 100%;
+
+    NameLabel {
+        property-name: property-information.name;
+    }
+
+    HorizontalLayout {
+        alignment: end;
+        number := LineEdit {
+            horizontal-alignment: right;
+            text: property-information.value.value-float;
+            min-width: EditorSizeSettings.float-size;
+            max-width: 14rem;
+            horizontal-stretch: 0;
+            font-size: 1rem;
+
+            accepted(text) => {
+                Api.set-code-binding(
+                    root.element-information.source-uri,
+                    root.element-information.source-version,
+                    root.element-information.range.start,
+                    root.property-information.name,
+                    number.text + root.current-unit,
+                );
+            }
+        }
+
+        if property-information.value.visual-items.length > 1: ComboBox {
+            min-width: EditorSizeSettings.length-combo;
+            model: property-information.value.visual-items;
+            current-index: property-information.value.code == "" ? property-information.value.default-selection : property-information.value.value-int;
+
+            changed current-index => {
+                root.current-unit = self.model[self.current-index];
+            }
+
+            horizontal-stretch: 0;
+
+            selected(unit) => {
+                Api.set-code-binding(
+                    root.element-information.source-uri,
+                    root.element-information.source-version,
+                    root.element-information.range.start,
+                    root.property-information.name,
+                    number.text + root.current-unit,
+                );
+            }
+        }
+        if property-information.value.visual-items.length == 1: Text {
+            text: property-information.value.visual-items[0];
+
+            changed text => {
+                root.current-unit = self.text;
+            }
+        }
+    }
+}
+
+component ColorWidget inherits HorizontalLayout {
+    in property <ElementInformation> element-information;
+    in property <PropertyInformation> property-information;
+
+    spacing: EditorSpaceSettings.default-spacing;
+    alignment: space-between;
+    width: 100%;
+
+    NameLabel {
+        property-name: property-information.name;
+    }
+
+    HorizontalLayout {
+        spacing: parent.spacing;
+
+        alignment: end;
+
+        Rectangle {
+            height: 1.8rem;
+            width: 2 * self.height;
+            
+            background: property-information.value.value-brush;
+            border-width: 1px;
+            border-color: Palette.foreground;
+        }
+
+        Text {
+            vertical-alignment: center;
+            text: property-information.value.value-string;
+        }
+    }
+}
+
+export component ExpandableProperty inherits Rectangle {
+    callback toggled;
+    in-out property <bool> checked:false;
+    property <duration> dur:300ms;
+    in-out property <color> headerBG: Palette.alternate-background;
+    in-out property <bool> enabled:true;
+    in property <string> title: "Title";
+    clip: true;
+    height: header.height + EditorSpaceSettings.default-spacing + (root.checked ? content.preferred-height : 0px);
+    animate height {
+        duration: dur;
+        easing: ease-out;
+    }
+
+    VerticalLayout {
+        x: 0;
+        spacing: EditorSpaceSettings.default-spacing;
+        Rectangle {
+            height: 5px;
+        }
+
+        touch-area := TouchArea {
+            clicked => {
+                if (root.enabled) {
+                    root.checked = !root.checked;
+                    root.toggled();
+                }
+            }
+
+            state-layer := StateLayer {
+                width: 100%;
+                height: 100%;
+                has-hover: touch-area.has-hover;
+                pressed: touch-area.pressed;
+            }
+
+            header := Rectangle {
+                width: 100%;
+                height: 30px;
+                background: headerBG;
+            }
+
+            HorizontalLayout {
+                x: 0;
+                y: 0;
+                width: 100%;
+                alignment: stretch;
+
+                accordionIcon := Image {
+                    width: EditorSpaceSettings.group-indent;
+                    source: Icons.add;
+                    colorize: Palette.foreground;
+                    vertical-alignment: top;
+                    visible: state-layer.has-hover;
+                    rotation-angle: root.checked ? 180deg : 0deg;
+                    animate rotation-angle {
+                        duration: dur / 2;
+                        easing: ease-in;
+                    }
+                }
+
+                content := Rectangle {
+                    background: headerBG;
+                    height: root.checked ? self.preferred-height : 10px;
+                    animate height {
+                        duration: dur;
+                        easing: ease-out;
+                    }
+                    VerticalLayout {
+                        width: 100%;
+                        @children
+                    }
+                }
+            }
+        }
+    }
+}
+
 component ExpandableGroup {
     in property <ElementInformation> element-information;
     in property <string> text;
     in property <[PropertyInformation]> properties;
 
     property <bool> open: true;
-    
     Rectangle {
         background: Palette.alternate-background;
 
         content-layer := VerticalLayout {
             // header
-            Rectangle {
+            spacing: EditorSpaceSettings.default-spacing;
+
+            if text != "": Rectangle {
                 touch-area := TouchArea {
                     clicked => {
                         root.open = !root.open;
@@ -66,15 +266,14 @@ component ExpandableGroup {
                     has-hover: touch-area.has-hover;
                     pressed: touch-area.pressed;
                 }
-                
-                HorizontalBox {
+
+                HorizontalLayout {
                     icon-image := Image {
                         width: EditorSizeSettings.default-icon-width;
                         colorize: Palette.foreground;
                         source: Icons.drop-down;
                         rotation-origin-x: self.width / 2;
                         rotation-origin-y: self.height / 2;
-                        
                         states [
                             closed when !root.open: {
                                 rotation-angle: -0.25turn;
@@ -83,47 +282,142 @@ component ExpandableGroup {
 
                         animate rotation-angle { duration: EditorAnimationSettings.roation-duration; }
                     }
-                    
+
                     BodyStrongText {
                         text: root.text;
                     }
                 }
             }
 
-            if root.open : VerticalBox {
-                for property in root.properties : HorizontalLayout {
-                    spacing: parent.spacing;
-                    
-                    BodyText {
-                        min-width: EditorSizeSettings.min-prefix-text-width;
-                        text: property.name;
-                    }
+            if root.open: VerticalLayout {
+                spacing: EditorSpaceSettings.property-spacing;
+                for property in root.properties: HorizontalLayout {
+                    alignment: stretch;
 
-                    if property.value.kind == PropertyValueKind.string: LineEdit {
-                        text: property.value.value-string;
+                    if property.value.kind == PropertyValueKind.boolean: HorizontalLayout {
+                        spacing: EditorSpaceSettings.default-spacing;
 
-                        accepted(text) => {
-                            Api.set-string-binding(
-                                root.element-information.source-uri,
-                                root.element-information.source-version,
-                                root.element-information.range.start,
-                                property.name,
-                                text,
-                                property.value.is-translatable,
-                                property.value.tr-context,
-                                property.value.tr-plural,
-                                property.value.tr-plural-expression,
-                            );
+                        NameLabel {
+                            property-name: property.name;
                         }
+
+                        CheckBox {
+                            checked: property.value.value_bool;
+
+                            toggled() => {
+                                Api.set-code-binding(
+                                    root.element-information.source-uri,
+                                    root.element-information.source-version,
+                                    root.element-information.range.start,
+                                    property.name,
+                                    self.checked ? "true" : "false",
+                                );
+                            }
+                        }
+                    }
+                    if (property.value.kind == PropertyValueKind.color) || (property.value.kind == PropertyValueKind.brush): ColorWidget {
+                        element-information <=> root.element-information;
+                        property-information: property;
                     }
                     if property.value.kind == PropertyValueKind.code: HorizontalLayout {
-                        ResetButton {
-                            element-information <=> root.element-information;
-                            property-information: property;
+                        spacing: EditorSpaceSettings.default-spacing;
+                        alignment: space-between;
+                        padding-top: 2px;
+
+                        NameLabel {
+                            property-name: property.name;
                         }
-                        CodeButton {
-                            element-information <=> root.element-information;
-                            property-information: property;
+
+                        if property.value.code == "": HorizontalLayout {
+                            Text {
+                                text: @tr("unset");
+                            }
+                        }
+                        if property.value.code != "": HorizontalLayout {
+                            ResetButton {
+                                element-information <=> root.element-information;
+                                property-information: property;
+                            }
+
+                            CodeButton {
+                                element-information <=> root.element-information;
+                                property-information: property;
+                            }
+                        }
+                    }
+                    if property.value.kind == PropertyValueKind.enum: HorizontalLayout {
+                        spacing: EditorSpaceSettings.default-spacing;
+
+                        NameLabel {
+                            property-name: property.name;
+                        }
+
+                        HorizontalLayout {
+                            ComboBox {
+                                current-index: property.value.value-int;
+
+                                model: property.value.visual-items;
+
+                                selected(value) => {
+                                    Api.set-code-binding(
+                                        root.element-information.source-uri,
+                                        root.element-information.source-version,
+                                        root.element-information.range.start,
+                                        property.name,
+                                        property.value.value_string + "." + value,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    if property.value.kind == PropertyValueKind.float:  FloatWidget {
+                        element-information <=> root.element-information;
+                        property-information: property;
+                    }
+                    if property.value.kind == PropertyValueKind.integer: HorizontalLayout {
+                        spacing: EditorSpaceSettings.default-spacing;
+
+                        NameLabel {
+                            property-name: property.name;
+                        }
+
+                        LineEdit {
+                            input-type: number;
+                            text: property.value.value-int;
+
+                            accepted(text) => {
+                                Api.set-code-binding(
+                                    root.element-information.source-uri,
+                                    root.element-information.source-version,
+                                    root.element-information.range.start,
+                                    property.name,
+                                    text,
+                                );
+                            }
+                        }
+                    }
+                    if property.value.kind == PropertyValueKind.string: HorizontalLayout {
+                        spacing: EditorSpaceSettings.default-spacing;
+
+                        NameLabel {
+                            property-name: property.name;
+                        }
+
+                        LineEdit {
+                            text: property.value.value-string;
+                            accepted(text) => {
+                                Api.set-string-binding(
+                                    root.element-information.source-uri,
+                                    root.element-information.source-version,
+                                    root.element-information.range.start,
+                                    property.name,
+                                    text,
+                                    property.value.is-translatable,
+                                    property.value.tr-context,
+                                    property.value.tr-plural,
+                                    property.value.tr-plural-expression,
+                                );
+                            }
                         }
                     }
                 }
@@ -146,19 +440,19 @@ export component PropertyView {
             title: @tr("{} Properties", root.current-element.type-name);
             vertical-stretch: 0;
         }
-        
-        if !root.element-loaded : Text {
+
+        if !root.element-loaded: Text {
             text: @tr("Select an Element");
             horizontal-alignment: center;
             vertical-alignment: center;
             vertical-stretch: 1;
         }
 
-        if root.element-loaded : ScrollView {
+        if root.element-loaded: ScrollView {
             VerticalBox {
                 alignment: start;
 
-                for group in root.properties : ExpandableGroup {
+                for group in root.properties: ExpandableGroup {
                     text: group.group-name;
 
                     element-information <=> root.current-element;

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -285,11 +285,13 @@ impl SlintServer {
                     diagnostics,
                 );
             }
-            M::ShowDocument { file, selection } => {
+            M::ShowDocument { file, selection, take_focus } => {
                 let sn = self.ctx.server_notifier.clone();
                 wasm_bindgen_futures::spawn_local(async move {
-                    crate::common::lsp_to_editor::send_show_document_to_editor(sn, file, selection)
-                        .await
+                    crate::common::lsp_to_editor::send_show_document_to_editor(
+                        sn, file, selection, take_focus,
+                    )
+                    .await
                 });
             }
             M::PreviewTypeChanged { is_external: _ } => {


### PR DESCRIPTION
This tries to make the property editor nicer.

There are still a lot of limitations though:

 * No gradients support at all
 * Colors are shown but are not editable at this time. We need more functionality in Slint to work with those (and gradients later!), e.g. conversion from/to string and back.
 * When having a property of type `code` (== I have no special handler implemented) that is not listed in the Element, I have no idea how to create one that is syntactically correct. So that is listed as `unset` instead of having an `Add` button like we originally planed.
 * Editing values is somewhat limited
 * You can start to edit in one LineEdit and then continue in another and that will keep state. That can be confusing, but at least we do keep state of widgets now when updating property data ;-)