### PR TITLE
Timer: API changes after API review.

### DIFF
--- a/api/cpp/include/slint_timer.h
+++ b/api/cpp/include/slint_timer.h
@@ -6,8 +6,6 @@
 #pragma once
 
 #include <chrono>
-
-#include <optional>
 #include <slint_timer_internal.h>
 
 namespace slint {
@@ -61,14 +59,10 @@ struct Timer
     /// Returns true if the timer is running; false otherwise.
     bool running() const { return cbindgen_private::slint_timer_running(id); }
     /// Returns the interval of the timer.
-    /// Returns `nullopt` if the timer is not running.
-    std::optional<std::chrono::milliseconds> interval() const
+    /// Returns 0 if the timer was never started.
+    std::chrono::milliseconds interval() const
     {
-        int64_t val = cbindgen_private::slint_timer_interval(id);
-        if (val < 0) {
-            return std::nullopt;
-        }
-        return std::chrono::milliseconds(val);
+        return std::chrono::milliseconds(cbindgen_private::slint_timer_interval(id));
     }
 
     /// Call the callback after the given duration.

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -873,7 +873,7 @@ Timer is not an actual element visible in the tree, therefore it doesn't have th
 
 ### Properties
 
- -  **`interval`** (_in_ _duration_): The interval between timer ticks. (default value: `0ms`)
+ -  **`interval`** (_in_ _duration_): The interval between timer ticks. This property is mandatory.
  -  **`running`** (_in_ _bool_): `true` if the timer is running. (default value: `true`)
 
 ### Callbacks

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2046,7 +2046,7 @@ fn generate_sub_component(
             update_timers
                 .push(format!("   auto interval = std::chrono::milliseconds({interval});"));
             update_timers.push(format!(
-                "   if (!self->{name}.running() || *self->{name}.interval() != interval)"
+                "   if (!self->{name}.running() || self->{name}.interval() != interval)"
             ));
             update_timers.push(format!("       self->{name}.start(slint::TimerMode::Repeated, interval, [self] {{ {callback}; }});"));
             update_timers.push(format!("}} else {{ self->{name}.stop(); }}").into());

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1068,8 +1068,7 @@ fn generate_sub_component(
             quote!(
                 if #running {
                     let interval = core::time::Duration::from_millis(#interval as u64);
-                    let old_interval = self.#ident.interval();
-                    if old_interval != Some(interval) || !self.#ident.running() {
+                    if !self.#ident.running() || interval != self.#ident.interval() {
                         let self_weak = self.self_weak.get().unwrap().clone();
                         self.#ident.start(sp::TimerMode::Repeated, interval, move || {
                             if let Some(self_rc) = self_weak.upgrade() {

--- a/internal/compiler/passes/lower_timers.rs
+++ b/internal/compiler/passes/lower_timers.rs
@@ -42,6 +42,14 @@ fn lower_timer(
         return;
     }
 
+    if !timer_element.borrow().is_binding_set("interval", true) {
+        diag.push_error(
+            "Timer must have a binding set for its 'interval' property".into(),
+            &*timer_element.borrow(),
+        );
+        return;
+    }
+
     // Remove the timer_element from its parent
     let old_size = parent_element.borrow().children.len();
     parent_element.borrow_mut().children.retain(|child| !Rc::ptr_eq(child, timer_element));

--- a/internal/compiler/tests/syntax/elements/timer2.slint
+++ b/internal/compiler/tests/syntax/elements/timer2.slint
@@ -11,4 +11,12 @@ export component Def {
     //       ^error{Timer cannot be directly repeated or conditional}
 
     if false: Abc {}
+
+    Timer {
+//  ^error{Timer must have a binding set for its 'interval' property}
+        running: false;
+    }
+
+    Timer {}
+//  ^error{Timer must have a binding set for its 'interval' property}
 }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2328,8 +2328,7 @@ pub fn update_timers(instance: InstanceRef) {
                 continue;
             }
             let interval = core::time::Duration::from_millis(millis as _);
-            let old_interval = timer.interval();
-            if old_interval != Some(interval) || !timer.running() {
+            if !timer.running() || interval != timer.interval() {
                 let callback = desc.triggered.clone();
                 let self_weak = instance.self_weak().get().unwrap().clone();
                 timer.start(i_slint_core::timers::TimerMode::Repeated, interval, move || {


### PR DESCRIPTION
Make the `interval` property mandatory in Slint.
A default of 0 is not a great default because that's way too often

In the C++/Rust API, 
don't return an Option, just return 0 when the timer is not started.
As discussed in the API review, the rational is that the interval is
just like a field in a struct and when the struct is default
constructed, it is initialized to 0

