### PR TITLE
Rename SwipeGestureRecognizer to SwipeGestureHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented in this file.
  - Postfix function on numbers for math function.
  - `changed <property>` callbacks. (#112)
  - `Timer` built-in pseudo-element. (#5724)
- - `SwipeGestureRecognizer` element.
+ - `SwipeGestureHandler` element.
  - Fixed panic when accessing function within a PopupWindow. (#5852)
  - Fixed `@children` order in the root of a component. (#5865)
  - Fix conversion from float to string adding extra decimal precision by limiting to f32

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -281,7 +281,7 @@ fn gen_corelib(
         "ClippedImage",
         "TouchArea",
         "FocusScope",
-        "SwipeGestureRecognizer",
+        "SwipeGestureHandler",
         "Flickable",
         "SimpleText",
         "ComplexText",

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -657,21 +657,20 @@ export component Example inherits Window {
 }
 ```
 
-## `SwipeGestureRecognizer`
+## `SwipeGestureHandler`
 
-Use the `SwipeGestureRecognizer` to react to swipes gesture in some particular direction. Recognition is limited to the element's geometry.
+Use the `SwipeGestureHandler` to handle swipe gesture in some particular direction. Recognition is limited to the element's geometry.
 
-Specify the different swipe directions you'd like to recognise by setting the `swipe-left/right/up/down` properties and react to the gesture in the `swiped` callback.
+Specify the different swipe directions you'd like to handle by setting the `handle-swipe-left/right/up/down` properties and react to the gesture in the `swiped` callback.
 
 Pointer press events on the recognizer's area are forwarded to the children with a small delay.
 If the pointer moves by more than 8 logical pixels in one of the enabled swipe directions, the gesture is recognized, and events are no longer forwarded to the children.
 
 ### Properties
 
--   **`enabled`** (_in_ _bool_): When disabled, the `SwipeGestureRecognizer` doesn't recognize any gestures.
+-   **`enabled`** (_in_ _bool_): When disabled, the `SwipeGestureHandler` doesn't recognize any gestures.
     (default value: `true`)
--   **`swipe-left`**, **`swipe-right`**, **`swipe-up`**, **`swipe-down`** (_out_ _bool_): Enable recognition of  swipes in
-    the corresponding direction. (default value: `false`)
+-   **`handle-swipe-left`**, **`handle-swipe-right`**, **`handle-swipe-up`**, **`handle-swipe-down`** (_out_ _bool_): Enable handling of swipes in the corresponding direction. (default value: `false`)
 -   **`pressed-position`** (_out_ _Point_): The position of the pointer when the swipe started.
 -   **`current-position`** (_out_ _Point_): The current pointer position.
 -   **`swiping`** (_out_ _bool_): `true` while the gesture is recognized, false otherwise.
@@ -697,9 +696,9 @@ export component Example inherits Window {
 
     property <int> current-page: 0;
 
-    sgr := SwipeGestureRecognizer {
-        swipe-right: current-page > 0;
-        swipe-left: current-page < 5;
+    sgr := SwipeGestureHandler {
+        handle-swipe-right: current-page > 0;
+        handle-swipe-left: current-page < 5;
         swiped => {
             if self.current-position.x > self.pressed-position.x + self.width / 4 {
                 current-page -= 1;

--- a/examples/carousel/ui/carousel.slint
+++ b/examples/carousel/ui/carousel.slint
@@ -28,30 +28,27 @@ export component Carousel {
     height: Theme.size-big;
     preferred-width: 100%;
 
-    focus-scope:= FocusScope {
+    focus-scope := FocusScope {
         key-pressed(event) => {
-            if(event.text == Key.UpArrow) {
+            if (event.text == Key.UpArrow) {
                 root.move-focus-up();
                 return accept;
             }
-
-            if(event.text == Key.RightArrow) {
+            if (event.text == Key.RightArrow) {
                 root.move-right();
                 return accept;
             }
-
-            if(event.text == Key.LeftArrow) {
+            if (event.text == Key.LeftArrow) {
                 root.move-left();
                 return accept;
             }
-
             return accept;
         }
     }
 
-    swipe := SwipeGestureRecognizer {
-        swipe-left: true;
-        swipe-right: true;
+    swipe := SwipeGestureHandler {
+        handle-swipe-left: true;
+        handle-swipe-right: true;
 
         swiped => {
             if self.current-position.x > self.pressed-position.x + root.itemWidth / 2 {
@@ -72,16 +69,24 @@ export component Carousel {
 
             Rectangle {
                 property <length> viewport-x: root.center-x - root.selected-index * (root.itemWidth + root.spacing);
-                animate viewport-x { duration: root.duration; easing: ease-in; }
+                animate viewport-x {
+                    duration: root.duration;
+                    easing: ease-in;
+                }
                 property <length> swipe-offset: 0;
                 x: self.viewport-x + swipe-offset;
                 width: inner-layout.preferred-width;
 
                 states [
-                    swipping when swipe.swiping : {
+                    swipping when swipe.swiping: {
                         //x: self.viewport-x + swipe-offset;
                         swipe-offset: (swipe.current-position.x - swipe.pressed-position.x).clamp(-root.itemWidth, root.itemWidth);
-                        out { animate swipe-offset { duration: root.duration; easing: ease-in; } }
+                        out {
+                            animate swipe-offset {
+                                duration: root.duration;
+                                easing: ease-in;
+                            }
+                        }
                     }
                 ]
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -151,12 +151,12 @@ export component Flickable inherits Empty {
     //-default_size_binding:expands_to_parent_geometry
 }
 
-export component SwipeGestureRecognizer {
+export component SwipeGestureHandler {
     in property <bool> enabled: true;
-    in property <bool> swipe-left;
-    in property <bool> swipe-right;
-    in property <bool> swipe-up;
-    in property <bool> swipe-down;
+    in property <bool> handle-swipe-left;
+    in property <bool> handle-swipe-right;
+    in property <bool> handle-swipe-up;
+    in property <bool> handle-swipe-down;
 
     // For the future
     //in property <length> swipe-distance-threshold: 8px;
@@ -177,7 +177,8 @@ export component SwipeGestureRecognizer {
     callback cancelled();
 
     // clears state, invokes swipe-cancelled()
-    function cancel() {}
+    function cancel() {
+    }
 
     //-default_size_binding:expands_to_parent_geometry
 }
@@ -197,7 +198,7 @@ component WindowItem {
     in property <image> icon;
 }
 
-export component Window inherits WindowItem {}
+export component Window inherits WindowItem { }
 
 export component BoxShadow inherits Empty {
     in property <length> border_radius;
@@ -241,12 +242,18 @@ export component TextInput {
     out property <string> preedit-text;
     //-default_size_binding:expands_to_parent_geometry
     //-accepts_focus
-    function set-selection-offsets(start: int, end: int) {}
-    function select-all() {}
-    function clear-selection() {}
-    function cut() {}
-    function copy() {}
-    function paste() {}
+    function set-selection-offsets(start: int, end: int) {
+    }
+    function select-all() {
+    }
+    function clear-selection() {
+    }
+    function cut() {
+    }
+    function copy() {
+    }
+    function paste() {
+    }
 }
 
 export component Clip {
@@ -371,12 +378,17 @@ export component Path {
     in property <bool> clip;
 
     //-disallow_global_types_as_child_elements
-    MoveTo {}
-    LineTo {}
-    ArcTo {}
-    CubicTo {}
-    QuadraticTo {}
-    Close {}
+    MoveTo { }
+
+    LineTo { }
+
+    ArcTo { }
+
+    CubicTo { }
+
+    QuadraticTo { }
+
+    Close { }
 
     //-default_size_binding:expands_to_parent_geometry
 }
@@ -390,7 +402,7 @@ export component TabWidget {
     in-out property <int> current-index;
 
     //-disallow_global_types_as_child_elements
-    Tab {}
+    Tab { }
     //-default_size_binding:expands_to_parent_geometry
     //-is_internal
 }
@@ -418,7 +430,7 @@ export component Timer {
     //-disallow_global_types_as_child_elements
 }
 
-export component Dialog inherits WindowItem {}
+export component Dialog inherits WindowItem { }
 
 component PropertyAnimation {
     in property <duration> delay;
@@ -583,13 +595,13 @@ export component NativeTabWidget {
 }
 
 export component NativeTab {
-    in property<string> title;
-    in property<image> icon;
-    in property<bool> enabled : true;
-    in-out property<int> current; // supposed to be a binding to the tab
-    in property<int> tab-index;
-    in property<int> current-focused;
-    in property<int> num-tabs;
+    in property <string> title;
+    in property <image> icon;
+    in property <bool> enabled: true;
+    in-out property <int> current; // supposed to be a binding to the tab
+    in property <int> tab-index;
+    in property <int> current-focused;
+    in property <int> num-tabs;
     //-is_internal
 }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -535,7 +535,7 @@ declare_item_vtable! {
 }
 
 declare_item_vtable! {
-    fn slint_get_SwipeGestureRecognizerVTable() -> SwipeGestureRecognizerVTable for SwipeGestureRecognizer
+    fn slint_get_SwipeGestureHandlerVTable() -> SwipeGestureHandlerVTable for SwipeGestureHandler
 }
 
 #[repr(C)]

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -343,12 +343,12 @@ impl ItemConsts for FocusScope {
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
-pub struct SwipeGestureRecognizer {
+pub struct SwipeGestureHandler {
     pub enabled: Property<bool>,
-    pub swipe_left: Property<bool>,
-    pub swipe_right: Property<bool>,
-    pub swipe_up: Property<bool>,
-    pub swipe_down: Property<bool>,
+    pub handle_swipe_left: Property<bool>,
+    pub handle_swipe_right: Property<bool>,
+    pub handle_swipe_up: Property<bool>,
+    pub handle_swipe_down: Property<bool>,
 
     pub moved: Callback<VoidArg>,
     pub swiped: Callback<VoidArg>,
@@ -366,7 +366,7 @@ pub struct SwipeGestureRecognizer {
     pub cached_rendering_data: CachedRenderingData,
 }
 
-impl Item for SwipeGestureRecognizer {
+impl Item for SwipeGestureHandler {
     fn init(self: Pin<&Self>, _self_rc: &ItemRc) {}
 
     fn layout_info(
@@ -429,10 +429,10 @@ impl Item for SwipeGestureRecognizer {
                     let dx = position.x - pressed_pos.x as Coord;
                     let dy = position.y - pressed_pos.y as Coord;
                     let threshold = super::flickable::DISTANCE_THRESHOLD.get();
-                    if (self.swipe_down() && dy > threshold)
-                        || (self.swipe_up() && dy < -threshold)
-                        || (self.swipe_left() && dx < -threshold)
-                        || (self.swipe_right() && dx > threshold)
+                    if (self.handle_swipe_down() && dy > threshold)
+                        || (self.handle_swipe_up() && dy < -threshold)
+                        || (self.handle_swipe_left() && dx < -threshold)
+                        || (self.handle_swipe_right() && dx > threshold)
                     {
                         InputEventFilterResult::Intercept
                     } else {
@@ -481,13 +481,13 @@ impl Item for SwipeGestureRecognizer {
                     let dy = position.y - pressed_pos.y as Coord;
                     let threshold = super::flickable::DISTANCE_THRESHOLD.get();
                     let start_swipe = if dy > threshold {
-                        self.swipe_down()
+                        self.handle_swipe_down()
                     } else if dy < -threshold {
-                        self.swipe_up()
+                        self.handle_swipe_up()
                     } else if dx < -threshold {
-                        self.swipe_left()
+                        self.handle_swipe_left()
                     } else if dx > threshold {
-                        self.swipe_right()
+                        self.handle_swipe_right()
                     } else {
                         return InputEventResult::EventIgnored;
                     };
@@ -533,12 +533,12 @@ impl Item for SwipeGestureRecognizer {
     }
 }
 
-impl ItemConsts for SwipeGestureRecognizer {
+impl ItemConsts for SwipeGestureHandler {
     const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
         Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
-impl SwipeGestureRecognizer {
+impl SwipeGestureHandler {
     pub fn copy(self: Pin<&Self>, _: &Rc<dyn WindowAdapter>, _: &ItemRc) {
         self.cancel_impl();
     }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -933,7 +933,7 @@ pub(crate) fn generate_item_tree<'id>(
                 rtti_for::<BorderRectangle>(),
                 rtti_for::<TouchArea>(),
                 rtti_for::<FocusScope>(),
-                rtti_for::<SwipeGestureRecognizer>(),
+                rtti_for::<SwipeGestureHandler>(),
                 rtti_for::<Path>(),
                 rtti_for::<Flickable>(),
                 rtti_for::<WindowItem>(),

--- a/tests/cases/elements/swipegesturehandler.slint
+++ b/tests/cases/elements/swipegesturehandler.slint
@@ -15,33 +15,40 @@ export component TestCase inherits Window {
     out property right-swiping <=> right-gesture.swiping;
 
     function distance(a: Point, b: Point) -> float {
-        return sqrt((a.x/1px - b.x/1px).pow(2) + (a.y/1px - b.y/1px).pow(2));
+        return sqrt((a.x / 1px - b.x / 1px).pow(2) + (a.y / 1px - b.y / 1px).pow(2));
     }
 
-    down-gesture := SwipeGestureRecognizer {
-        swipe-down: true;
-        swipe-left: false;
+    down-gesture := SwipeGestureHandler {
+        handle-swipe-down: true;
+        handle-swipe-left: false;
         swiped => {
             r += "S1(" + distance(self.current-position, self.pressed-position) + ")";
         }
-        cancelled => { r += "C1(" + distance(self.current-position, self.pressed-position) + ")"; }
+        cancelled => {
+            r += "C1(" + distance(self.current-position, self.pressed-position) + ")";
+        }
         VerticalLayout {
-            left-gesture := SwipeGestureRecognizer {
-                swipe-left: true;
+            left-gesture := SwipeGestureHandler {
+                handle-swipe-left: true;
                 swiped => {
                     r += "S2(" + distance(self.current-position, self.pressed-position) + ")";
                 }
                 moved => {
                     r += "M2(" + distance(self.current-position, self.pressed-position) + ")";
                 }
-                cancelled => { r += "C2(" + distance(self.current-position, self.pressed-position) + ")"; }
-
-            }
-            right-gesture := SwipeGestureRecognizer {
-                swipe-right: true;
-                ta := TouchArea {
-                    clicked => { r += "clicked()" }
+                cancelled => {
+                    r += "C2(" + distance(self.current-position, self.pressed-position) + ")";
                 }
+            }
+
+            right-gesture := SwipeGestureHandler {
+                handle-swipe-right: true;
+                ta := TouchArea {
+                    clicked => {
+                        r += "clicked()"
+                    }
+                }
+
                 swiped => {
                     r += "S3(" + distance(self.current-position, self.pressed-position) + ")";
                 }


### PR DESCRIPTION
The origin of this proposal is the name of the `swipe-left`, etc. directional, boolean properties. They're missing another verb in their name. In principle the right choice would be "recognize". That is what the type name suggests, that's the term the documentation uses, so the code should read `recognize-swipe-left: true;`. However that is a long word. "Handle" is a verb that's simpler. It's also more generic (that's a downside), but it's otherwise short enough to make things look "right":

```
SwipeGestureHandler {
    handle-swipe-left: true;
    swiped => { something.naviate-left(); }
}
```

Therefore this patch proposes to rename the type to SwipeGestureHandler and prefixes the boolean directional properties with "handle".

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
