### PR TITLE
property editor: Show the default value from base component when no binding exist

### DIFF
--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -350,6 +350,11 @@ impl DocumentCache {
         let (doc, offset) = self.get_document_and_offset(text_document_uri, pos)?;
         self.element_at_document_and_offset(doc, offset)
     }
+
+    #[cfg(test)]
+    pub fn type_loader(&self) -> &TypeLoader {
+        &self.type_loader
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When no bindings exist on the component, the value that is shown in the property editor should be the default value for that property as defined in the base component or in the builtin element. Not just the default value of the type

