### PR TITLE
winit: Quieten warning

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -79,6 +79,7 @@ mod accesskit;
 #[cfg(target_arch = "wasm32")]
 pub(crate) mod wasm_input_helper;
 
+/// Create an open GL renderer for the HTML canvas element with the given `canvas_id`
 #[cfg(all(target_arch = "wasm32", feature = "renderer-femtovg"))]
 pub fn create_gl_window_with_canvas_id(
     canvas_id: &str,


### PR DESCRIPTION
I am getting this warning:

```
[INFO]: 🎯  Checking for the Wasm target...
[INFO]: 🌀  Compiling to Wasm...
warning: missing documentation for a function
  --> internal/backends/winit/lib.rs:83:1
   |
83 | / pub fn create_gl_window_with_canvas_id(
84 | |     canvas_id: &str,
85 | | ) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
   | |_________________________________________________^
   |
note: the lint level is defined here
  --> internal/backends/winit/lib.rs:6:9
   |
6  | #![warn(missing_docs)]
   |         ^^^^^^^^^^^^
```

Fix this by adding a tiny bit of documentation

