### PR TITLE
Remove stray horizontal line in library view

### DIFF
--- a/tools/lsp/ui/components/group.slint
+++ b/tools/lsp/ui/components/group.slint
@@ -35,12 +35,6 @@ export component Group {
         background: Palette.alternate-background;
     }
 
-    Rectangle {
-        height: 1px;
-        background: Palette.control-background;
-        width: 100%;
-    }
-
     content-layer := VerticalLayout {
         @children
     }


### PR DESCRIPTION
Before:

<img width="726" alt="Screenshot 2024-09-19 at 09 05 11" src="https://github.com/user-attachments/assets/fcfb0a05-6f64-46e7-b0ff-5001222d805a">

After:

<img width="726" alt="Screenshot 2024-09-19 at 09 06 20" src="https://github.com/user-attachments/assets/49bbf001-2e8a-4a49-81d2-d989aaa23dba">
