### PR TITLE
Make it easier to preview the properties view

### DIFF
--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -182,7 +182,75 @@ export global Api {
 
     // ## Property Editor
     in-out property <ElementInformation> current-element;
-    in-out property <[PropertyGroup]> properties;
+    in-out property <[PropertyGroup]> properties: [
+        {
+            group-name: "geometry",
+            properties: [
+                {
+                    name: "width",
+                    type-name: "length",
+                    value: {
+                        kind: PropertyValueKind.float,
+                        value-float: 100,
+                        visual-items: ["px", "cm", "mm", "in", "pt", "phx"],
+                    }
+                },
+                {
+                    name: "height",
+                    type-name: "length",
+                    value: {
+                        kind: PropertyValueKind.float,
+                        value-float: 200,
+                        visual-items: ["px", "cm", "mm", "in", "pt", "phx"],
+                    }
+                },
+                {
+                    name: "z",
+                    type-name: "float",
+                    value: {
+                        kind: PropertyValueKind.float,
+                        value-float: 0,
+                    }
+                }
+            ]
+        },
+        {
+            group-name: "Button",
+            properties: [
+                {
+                    name: "text",
+                    type-name: "string",
+                    value: {
+                        is-translatable: true,
+                        kind: PropertyValueKind.string,
+                    }
+                },
+                {
+                    name: "checkable",
+                    type-name: "bool",
+                    value: {
+                        kind: PropertyValueKind.boolean,
+                    }
+                },
+                {
+                    name: "icon",
+                    type-name: "image",
+                    value: {
+                        kind: PropertyValueKind.code,
+                    }
+                },
+                {
+                    name: "color",
+                    type-name: "brush",
+                    value: {
+                        kind: PropertyValueKind.brush,
+                        value-brush: Colors.green,
+                        value-string: "#00ff00"
+                    },
+                }
+            ]
+        }
+    ];
 
     // # Callbacks
 

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -625,7 +625,8 @@ export component PropertyView {
         }
 
         if root.element-loaded: ScrollView {
-            VerticalBox {
+            preferred-height: groups.preferred-height;
+            groups := VerticalBox {
                 alignment: start;
 
                 for group in root.properties: ExpandableGroup {


### PR DESCRIPTION
Provide some dummy property data, and provide a preferred height that makes the preview show the properties.

The data is imperfect. But this is how it looks like then:


<img width="527" alt="Screenshot 2024-09-19 at 09 42 15" src="https://github.com/user-attachments/assets/483d2ac8-925d-455c-b48c-d952377eb34c">
