### PR TITLE
ui-testing: Add support for reading the computed opacity of elements

### DIFF
--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -234,6 +234,7 @@ message ElementPropertiesResponse {
     LogicalSize size = 10;
     LogicalPosition absolute_position = 11;
     AccessibleRole accessible_role = 12;
+    float computed_opacity = 13;
 }
 
 message InvokeElementAccessibilityActionResponse {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -359,6 +359,7 @@ impl TestingClient {
             absolute_position: send_logical_position(element.absolute_position()).into(),
             accessible_role: convert_to_proto_accessible_role(element.accessible_role().unwrap())
                 .unwrap_or_default(),
+            computed_opacity: element.computed_opacity(),
         })
     }
 


### PR DESCRIPTION
This is useful when the UI shows for example labels that appear and the screenshot for referenceing is meant to be taken when the opacity animation is complete and the value is (near) 1.0.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
