### PR TITLE
live-preview: Allow resizing if only one of the dimention is contrained

### DIFF
--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -261,7 +261,7 @@ export component PreviewView {
 
                     HorizontalLayout {
                         preview-area-container := ComponentContainer {
-                            property <bool> is-resizable: (self.min-width != self.max-width && self.min-height != self.max-height) && self.has-component;
+                            property <bool> is-resizable: (self.min-width != self.max-width || self.min-height != self.max-height) && self.has-component;
 
                             component-factory: root.preview-area;
 


### PR DESCRIPTION
If the height is contreained but not the width, we should still be able to resize
