### PR TITLE
live-preview: Remove failed attempt to have global shortcuts

### DIFF
--- a/tools/lsp/ui/components/resizer.slint
+++ b/tools/lsp/ui/components/resizer.slint
@@ -64,6 +64,7 @@ export component Resizer {
     callback resize(x: length, y: length, width: length, height: length, done: bool);
     callback can-move-to(x: length, y: length, mouse_x: length, mouse_y: length) -> bool;
     callback move-to(x: length, y: length, mouse_x: length, mouse_y: length);
+    callback clicked(x: length, y: length, modifiers: KeyboardModifiers);
     callback double-clicked(x: length, y: length, modifiers: KeyboardModifiers);
 
     // Private!
@@ -92,6 +93,10 @@ export component Resizer {
 
             double-clicked() => {
                 root.double-clicked(self.mouse-x, self.mouse-y, self.modifiers);
+            }
+
+            clicked() => {
+                root.clicked(self.mouse-x, self.mouse-y, self.modifiers);
             }
 
             moved() => {

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -59,10 +59,6 @@ export component PreviewUi inherits Window {
                     current-style <=> Api.current-style;
                     known-styles <=> Api.known-styles;
 
-                    edit-mode-toggled() => {
-                        key-handler.focus();
-                    }
-
                     style-selected => {
                         Api.style-changed();
                     }
@@ -109,23 +105,6 @@ export component PreviewUi inherits Window {
                 }
 
                 StatusLine { }
-            }
-
-            key-handler := FocusScope {
-                enabled: preview.mode == DrawAreaMode.designing;
-
-                key-released(event) => {
-                    if event.text == Key.Delete {
-                        // This `if` should not be necessary, but without it
-                        // we do trigger deletion of Elements while errors
-                        // are on screen.
-                        if preview.mode == DrawAreaMode.designing {
-                            Api.selected-element-delete();
-                        }
-                        return accept;
-                    }
-                    reject
-                }
             }
         }
     }

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -67,6 +67,10 @@ component SelectionFrame {
     }
 
     if root.interactive && selection.is-primary: Resizer {
+        clicked(x, y, modifiers) => {
+            key-handler.focus();
+        }
+
         double-clicked(x, y, modifiers) => {
             root.select-behind(root.selection.geometry.x + x, root.selection.geometry.y + y, modifiers.control, modifiers.shift);
         }
@@ -128,6 +132,22 @@ component SelectionFrame {
             border-color: root.selection-color;
             border-width: 1px;
             background: parent.resizing || parent.moving ? root.selection-color.with-alpha(0.5) : root.selection-color.with-alpha(0.0);
+        }
+
+        key-handler := FocusScope {
+            enabled <=> root.interactive;
+
+            init => {
+                self.focus();
+            }
+
+            key-pressed(event) => {
+                if event.text == Key.Delete {
+                    Api.selected-element-delete();
+                    return accept;
+                }
+                reject
+            }
         }
     }
 

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -10,11 +10,6 @@ import { BodyText } from "../components/body-text.slint";
 import { StateLayer } from "../components/state-layer.slint";
 import { EditorSizeSettings, Icons, EditorAnimationSettings, EditorSpaceSettings, EditorSizeSettings, EditorFontSettings, EditorPalette } from "../components/styling.slint";
 
-export global style {
-    out property <length> grid-margin:5px;
-    out property <length> min-distance:5px;
-}
-
 component CodeButton inherits Button {
     in property <ElementInformation> element-information;
     in property <PropertyInformation> property-information;
@@ -334,18 +329,6 @@ export component ExpandableProperty inherits Rectangle {
                     }
                 }
             }
-        }
-    }
-}
-
-component DividerLine {
-    VerticalLayout {
-        alignment: end;
-        width: 100%;
-        Rectangle {
-            height: 1px;
-            width: 100%;
-            background: Palette.border.transparentize(0.5);
         }
     }
 }


### PR DESCRIPTION
It does not work too well and it breaks switching between LineEdits in the property editor. Downside: We have no more way to delete the selected element anymore. We could have it in a tool button, but IMHO we should have Undo before we make it that obvious.

We do have fans of the `Del` key handling... I should probably try to come up with something else. The problem is that the FocusScope loses focus as soon as somebody hits `Tab` and then the key will not be recognized anymore.