### PR TITLE
Support saving/loading images via their path

### DIFF
--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -159,6 +159,9 @@ fn main() -> Result<()> {
                     slint_interpreter::Value::EnumerationValue(_class, value) => {
                         Some(value.as_str().into())
                     }
+                    slint_interpreter::Value::Image(image) => {
+                        image.path().and_then(|path| path.to_str()).map(|path| path.into())
+                    }
                     _ => None,
                 }
             }
@@ -365,6 +368,15 @@ fn load_data(
                     }
                     i_slint_compiler::langtype::Type::String => {
                         SharedString::from(s.as_str()).into()
+                    }
+                    i_slint_compiler::langtype::Type::Image => {
+                        match slint_interpreter::Image::load_from_path(std::path::Path::new(s)) {
+                            Ok(image) => image.into(),
+                            Err(_) => {
+                                eprintln!("Warning: Failed to load image from path: {}", s);
+                                slint_interpreter::Value::Void
+                            }
+                        }
                     }
                     _ => slint_interpreter::Value::Void,
                 },


### PR DESCRIPTION
This assumes any string value for an image property is a path. This could be expanded in the future to support loading raw pixel values by e.g. parsing a data URI.

ChangeLog: viewer: `--save-data`/`--load-data`: support for images with paths

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Closes #6169.