### PR TITLE
live-preview: Re-ordering of properties in property editor

### DIFF
--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -121,6 +121,7 @@ export struct PropertyInformation {
     name: string,
     type-name: string,
     value: PropertyValue,
+    display-priority: int,
 }
 
 /// Information on one Property


### PR DESCRIPTION
All other tools have custom widgets for x/y, width/height, etc., let's try to come close by at least presenting the properties in in a logical order that lends itself to data input.

This reorders geometry to show `x`, `y`, `width` and `height` followed by `z`.

It also orders layout as `min-width`, `min-height`, `preferred-width/-height', and `max-width/height` followed by horizontal and vertical stretch.