### PR TITLE
Fluent CheckBox: text should be using the normal text color

### DIFF
--- a/internal/compiler/widgets/fluent/checkbox.slint
+++ b/internal/compiler/widgets/fluent/checkbox.slint
@@ -12,7 +12,7 @@ export component CheckBox {
 
     callback toggled;
 
-    private property <color> text-color: FluentPalette.text-secondary;
+    private property <color> text-color: FluentPalette.foreground;
 
     min-height: max(32px, i-layout.min-height);
     accessible-checkable: true;


### PR DESCRIPTION
ChangeLog: Checkbox: fix text color in fluent style 
Fixes #6239


