### PR TITLE
Layouting: Take in account explicit constraints when generating layout info base on content

### DIFF
--- a/examples/weather-demo/ui/about-box.slint
+++ b/examples/weather-demo/ui/about-box.slint
@@ -6,9 +6,6 @@ import { AppText } from "./controls/generic.slint";
 import { AboutSlint } from "std-widgets.slint";
 
 component AboutFelgo {
-    width: 100%;
-    height: 100%;
-
     VerticalLayout {
         spacing: 5px;
 
@@ -81,7 +78,7 @@ export component AboutBox {
                     padding-bottom: 10px;
                 }
             }
-            
+
             AboutSlint {
                 max-width: 200px;
             }

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -179,10 +179,10 @@ impl LayoutConstraints {
             apply_size_constraint("height", s, enclosing, depth, &mut constraints.max_height);
         });
         find_binding(element, "width", |s, enclosing, depth| {
+            constraints.fixed_width = true;
             if s.expression.ty() == Type::Percent {
                 apply_size_constraint("width", s, enclosing, depth, &mut constraints.min_width);
             } else {
-                constraints.fixed_width = true;
                 apply_size_constraint("width", s, enclosing, depth, &mut constraints.min_width);
                 apply_size_constraint("width", s, enclosing, depth, &mut constraints.max_width);
             }

--- a/tests/cases/layout/issue6285_auto_explicit_restrictions.slint
+++ b/tests/cases/layout/issue6285_auto_explicit_restrictions.slint
@@ -1,0 +1,72 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+
+component C1  {
+    Rectangle {
+        min-width: 200px;
+        min-height: 300px;
+        inner := Rectangle {}
+    }
+}
+component C2 {
+    Rectangle {
+        min-width: 200px;
+        min-height: 300px;
+        inner := Rectangle {  width: 100%;  }
+    }
+}
+
+component FillParent {
+    preferred-height: 100%;
+    preferred-width: 100%;
+    min-height: l.min-height;
+    min-width: l.min-width;
+
+    l := VerticalLayout {
+        Text {}
+    }
+}
+
+export component Bug6315  {
+    r := Rectangle {
+        width: self.preferred-width;
+        r2 := Rectangle {
+            preferred-width: 100px;
+            Rectangle {
+               preferred-width: 40px;
+            }
+        }
+    }
+
+    Text {
+        text: (
+            "\{r.width / 1px}, " +
+            "\{r2.width / 1px}, " +
+            ""
+        );
+    }
+    out property <bool> ok: r.width == 100px && r2.width == 100px;
+}
+
+
+export component W inherits Window {
+
+    Rectangle {
+        VerticalLayout {
+            FillParent {
+                min-height: self.preferred-height;
+            }
+        }
+    }
+
+    c1:= C1 {}
+    c2:= C2 {}
+
+    bug-6315 := Bug6315 {}
+
+
+    out property <bool> test: c1.min-height == 300px && c1.min-width == 200px
+        && c2.min-height == 300px && c2.min-width == 200px
+        && bug-6315.ok;
+}


### PR DESCRIPTION
Fixes #6285

ChangeLog: Fixed geometry constraints when they are partially infered from the content, and partially infered from the explicit constraints
