### PR TITLE
vtable: Prospective fix for warning with the nightly rust compiler

### DIFF
--- a/helper_crates/vtable/macro/macro.rs
+++ b/helper_crates/vtable/macro/macro.rs
@@ -753,30 +753,30 @@ and implements HasStaticVTable for it.
             }
 
             #(#drop_impls)*
-        }
-        #[doc(inline)]
-        #[macro_use]
-        #vis use #module_name::*;
 
-        #[macro_export]
-        #[doc = #static_vtable_macro_doc]
-        macro_rules! #static_vtable_macro_name {
-            ($(#[$meta:meta])* $vis:vis static $ident:ident for $ty:ty) => {
-                $(#[$meta])* $vis static $ident : #vtable_name = {
-                    use vtable::*;
-                    type T = $ty;
-                    #vtable_name {
-                        #(#vtable_ctor)*
-                    }
-                };
-                #[allow(unsafe_code)]
-                unsafe impl vtable::HasStaticVTable<#vtable_name> for $ty {
-                    fn static_vtable() -> &'static #vtable_name {
-                        &$ident
+            #[macro_export]
+            #[doc = #static_vtable_macro_doc]
+            macro_rules! #static_vtable_macro_name {
+                ($(#[$meta:meta])* $vis:vis static $ident:ident for $ty:ty) => {
+                    $(#[$meta])* $vis static $ident : #vtable_name = {
+                        use vtable::*;
+                        type T = $ty;
+                        #vtable_name {
+                            #(#vtable_ctor)*
+                        }
+                    };
+                    #[allow(unsafe_code)]
+                    unsafe impl vtable::HasStaticVTable<#vtable_name> for $ty {
+                        fn static_vtable() -> &'static #vtable_name {
+                            &$ident
+                        }
                     }
                 }
             }
         }
+        #[doc(inline)]
+        #[macro_use]
+        #vis use #module_name::*;
     );
     //println!("{}", result);
     result.into()


### PR DESCRIPTION
```
warning: non-local `macro_rules!` definition, `#[macro_export]` macro should be written at top level module
   --> helper_crates/vtable/tests/test_vtable.rs:159:5
    |
159 |     #[vtable]
    |     ^^^^^^^^^ in this procedural macro expansion
    |
    = help: remove the `#[macro_export]` or move this `macro_rules!` outside the of the current function `test3`
```

Put the macro in the module with everything else, so it is re-exported with the same visibility
