### PR TITLE
slintpad: Move the copy URL button to the front

### DIFF
--- a/tools/slintpad/src/dialogs.ts
+++ b/tools/slintpad/src/dialogs.ts
@@ -99,8 +99,8 @@ export function report_export_url_dialog(...urls: string[]) {
 
         copy_button.appendChild(copy_i);
 
-        url_line_div.appendChild(p_url);
         url_line_div.appendChild(copy_button);
+        url_line_div.appendChild(p_url);
 
         elements.push(url_line_div);
     }

--- a/tools/slintpad/styles/content.css
+++ b/tools/slintpad/styles/content.css
@@ -159,7 +159,7 @@
     justify-content: space-between;
 }
 .dialog.report_export_url .copy_url {
-    margin-left: 5px;
+    margin-right: 5px;
     padding: 5px;
 }
 


### PR DESCRIPTION
.. and only print the URL after it: That way the button stays visible at all times.

Closes: #6318

