### PR TITLE
Fix changed callback of an unused property

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -583,7 +583,8 @@ fn propagate_is_set_on_aliases(doc: &Document, reverse_aliases: &mut ReverseAlia
     }
 }
 
-/// Make sure that the is_set_externally is true for all bindings
+/// Make sure that the is_set_externally is true for all bindings.
+/// And change bindings are used externally
 fn mark_used_base_properties(doc: &Document) {
     doc.visit_all_used_components(|component| {
         crate::object_tree::recurse_elem_including_sub_components_no_borrow(
@@ -600,6 +601,12 @@ fn mark_used_base_properties(doc: &Document) {
                             name,
                         );
                     }
+                }
+                for name in element.borrow().change_callbacks.keys() {
+                    crate::namedreference::mark_property_read_derived_in_base(
+                        element.clone(),
+                        name,
+                    );
                 }
             },
         );

--- a/tests/cases/properties/changes.slint
+++ b/tests/cases/properties/changes.slint
@@ -48,6 +48,11 @@ component SubCompoInline {
     @children
 }
 
+component WithAliasToNative {
+    out property has-focus <=> ti.has_focus;
+    ti := TextInput {}
+}
+
 
 export component TestCase inherits Window {
     in-out property <string> result;
@@ -65,6 +70,11 @@ export component TestCase inherits Window {
     out property<int> count;
     changed result => {
         count += 1;
+    }
+
+    WithAliasToNative {
+        // just make sure this compiles despite has_focus being unused otherwise
+        changed has_focus => { }
     }
 
     chaining := Chaining {}


### PR DESCRIPTION
If the property was not used, it was optimized out and the compiler would panic
Fixes #6331

ChangeLog: compiler: Fix changed callback of an unused property
