### PR TITLE
Rust: attempt to gracefully handle situation where the property depends on a binding from a destroyed component

### DIFF
--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -50,14 +50,18 @@ impl<C: 'static> StrongItemTreeRef for Pin<Rc<C>> {
     }
 }
 
-pub fn set_property_binding<T: Clone + 'static, StrongRef: StrongItemTreeRef + 'static>(
+pub fn set_property_binding<
+    T: Clone + Default + 'static,
+    StrongRef: StrongItemTreeRef + 'static,
+>(
     property: Pin<&Property<T>>,
     component_strong: &StrongRef,
     binding: fn(StrongRef) -> T,
 ) {
     let weak = component_strong.to_weak();
-    property
-        .set_binding(move || binding(<StrongRef as StrongItemTreeRef>::from_weak(&weak).unwrap()))
+    property.set_binding(move || {
+        <StrongRef as StrongItemTreeRef>::from_weak(&weak).map(binding).unwrap_or_default()
+    })
 }
 
 pub fn set_animated_property_binding<

--- a/tests/cases/focus/text-input-focused-parent-deleted.slint
+++ b/tests/cases/focus/text-input-focused-parent-deleted.slint
@@ -3,36 +3,60 @@
 
 import { LineEdit } from "std-widgets.slint";
 
+
+component Sub {
+    in-out property <bool> condition: true;
+    in property <bool> enabled: true;
+    callback set-value(string);
+    if condition : HorizontalLayout {
+        LineEdit {
+            accepted => {
+                set-value(self.text);
+            }
+            placeholder-text: "Hello";
+            enabled <=> root.enabled;
+        }
+        LineEdit {
+            enabled <=> root.enabled;
+        }
+    }
+}
+
+component Sub2 {
+    in property <bool> condition;
+    in property <bool> enabled: true;
+    callback focus-c();
+    if !condition: VerticalLayout {
+        if true: LineEdit {  enabled <=> root.enabled;  }
+        if !condition: FocusScope {
+            focus-changed-event => {
+                focus-c();
+            }
+            enabled <=> root.enabled;
+        }
+    }
+}
+
 export component TestCase inherits Window {
     in-out property <bool> condition: true;
 
     out property <string> value;
 
     if condition: VerticalLayout {
-        if condition : HorizontalLayout {
-            LineEdit {
-                accepted => {
-                    value = self.text;
-                    condition = false;
-                }
-                placeholder-text: "Hello";
-            }
-            LineEdit {
-
-            }
-
+        if true: Sub {
+            set-value(v) => { value = v; condition = false; }
+            condition: root.condition;
+            enabled: root.condition;
         }
 
     }
 
-    if !condition: VerticalLayout {
-        LineEdit {   }
-        if !condition: FocusScope {
-            focus-changed-event => {
-                condition = true;
-            }
-        }
+    if true: Sub2 {
+        condition: root.condition;
+        focus-c() => { condition = true; }
+        enabled: !root.condition;
     }
+
 }
 
 /*
@@ -42,7 +66,7 @@ slint_testing::send_keyboard_string_sequence(&instance, "\t");
 slint_testing::send_keyboard_string_sequence(&instance, "hophop\n");
 assert_eq!(instance.get_value(), "hophop");
 assert_eq!(instance.get_condition(), false);
-slint_testing::send_keyboard_string_sequence(&instance, "a\n\tdd\t");
+slint_testing::send_keyboard_string_sequence(&instance, "a\n\tdd\t\t");
 assert_eq!(instance.get_condition(), true);
 slint_testing::send_keyboard_string_sequence(&instance, "\tblop\n\t");
 assert_eq!(instance.get_value(), "blop");

--- a/tests/cases/models/delete_from_clicked.slint
+++ b/tests/cases/models/delete_from_clicked.slint
@@ -18,8 +18,10 @@ export global Glob {
 component Button {
     callback clicked();
     in property <string> text;
+    in property enabled <=> fs.enabled;
+
     HorizontalLayout {
-        FocusScope {
+        fs := FocusScope {
             width: 1px;
             height: 3%;
             key-pressed(k) => {
@@ -37,6 +39,7 @@ component Button {
         Text { text: text; }
         TouchArea {
             clicked => {clicked();}
+            enabled: root.enabled;
         }
     }
 }
@@ -45,10 +48,12 @@ component Button {
 export component TestCase inherits Window {
     width: 300px;
     height: 300px;
+    in property <bool> some-variable: true;
     VerticalLayout {
         for string in Glob.model: Rectangle {
             if Glob.condition: Button {
                 text: string;
+                enabled: some-variable;
                 width: 80%;
                 height: 80%;
                 clicked => {


### PR DESCRIPTION
Note that i was unable to reproduce the panic.

Even when actually trying to produce it in the tests.
I've changed the test to add a few property, this shouldn't reduce the coverage of what they were testing before.

Closes #6262