### PR TITLE
live-preview: Fix panic when dragging elements onto layouts

### DIFF
--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -245,10 +245,7 @@ fn calculate_drop_information_for_layout(
             ) {
                 let hit_rect = LogicalRect::new(
                     LogicalPoint::new(hit_zone.start, geometry.origin.y),
-                    LogicalSize::new(
-                        hit_zone.end - hit_zone.start,
-                        geometry.origin.y + geometry.size.height,
-                    ),
+                    LogicalSize::new(hit_zone.end - hit_zone.start, geometry.size.height),
                 );
                 if hit_rect.contains(position) {
                     return (
@@ -275,10 +272,7 @@ fn calculate_drop_information_for_layout(
             ) {
                 let hit_rect = LogicalRect::new(
                     LogicalPoint::new(geometry.origin.x, hit_zone.start),
-                    LogicalSize::new(
-                        geometry.origin.x + geometry.size.width,
-                        hit_zone.end - hit_zone.start,
-                    ),
+                    LogicalSize::new(geometry.size.width, hit_zone.end - hit_zone.start),
                 );
                 if hit_rect.contains(position) {
                     return (


### PR DESCRIPTION
Fix panic when dragging objects onto layouts that have an x/y coordinate set. The hit rect was miscalculated, taking the origin of the layout into account when calculating its size.

