### PR TITLE
Text layout: fix `char-wrap` doesn't wrap between lines

### DIFF
--- a/internal/core/textlayout/fragments.rs
+++ b/internal/core/textlayout/fragments.rs
@@ -48,6 +48,9 @@ impl<'a, Length: Clone + Default + core::ops::AddAssign + Zero + Copy> Iterator
         let mut fragment = Self::Item::default();
 
         let next_break_offset = if self.break_anywhere {
+            if first_glyph_cluster.is_line_or_paragraph_separator {
+                fragment.trailing_mandatory_break = true;
+            }
             0
         } else if let Some((next_break_offset, break_type)) = self.line_breaks.next() {
             if matches!(break_type, BreakOpportunity::Mandatory) {
@@ -106,7 +109,7 @@ impl<'a, Length: Clone + Default + core::ops::AddAssign + Zero + Copy> Iterator
         // Make sure that adjacent fragments are advanced in their byte range:
         // this assertion should hold: fragment.byte_range.end + fragment.trailing_whitespace_bytes == next_fragment.byte_range.start
         // That means characters causing mandatory breaks need to be included.
-        if fragment.trailing_mandatory_break {
+        if fragment.trailing_mandatory_break && !self.break_anywhere {
             fragment.trailing_whitespace_bytes = next_break_offset - fragment.byte_range.end;
         }
 

--- a/internal/core/textlayout/linebreaker.rs
+++ b/internal/core/textlayout/linebreaker.rs
@@ -622,3 +622,20 @@ fn zero_width_char_wrap() {
     .collect::<Vec<_>>();
     assert_eq!(lines, ["H", "e", "", "H", "e", "o"]);
 }
+
+#[test]
+fn char_wrap_sentences() {
+    let font = FixedTestFont;
+    let text = "Hello world\nHow are you?";
+    let shape_buffer = ShapeBuffer::new(&TextLayout { font: &font, letter_spacing: None }, text);
+    let lines = TextLineBreaker::<FixedTestFont>::new(
+        text,
+        &shape_buffer,
+        Some(80.),
+        None,
+        TextWrap::CharWrap,
+    )
+    .map(|t| t.line_text(text))
+    .collect::<Vec<_>>();
+    assert_eq!(lines, ["Hello wo", "rld", "How are", "you?"]);
+}


### PR DESCRIPTION
Fixes #6346

ChangeLog: Software renderer: fixed `char-wrap` not braking between lines

