### PR TITLE
slintpad: Move the copy URL button to the the back again

### DIFF
--- a/tools/slintpad/src/dialogs.ts
+++ b/tools/slintpad/src/dialogs.ts
@@ -99,8 +99,8 @@ export function report_export_url_dialog(...urls: string[]) {
 
         copy_button.appendChild(copy_i);
 
-        url_line_div.appendChild(copy_button);
         url_line_div.appendChild(p_url);
+        url_line_div.appendChild(copy_button);
 
         elements.push(url_line_div);
     }

--- a/tools/slintpad/styles/content.css
+++ b/tools/slintpad/styles/content.css
@@ -159,12 +159,13 @@
     justify-content: space-between;
 }
 .dialog.report_export_url .copy_url {
-    margin-right: 5px;
+    margin-left: 5px;
     padding: 5px;
 }
 
 .dialog.report_export_url .url .url_text {
     font-family: monospace;
+    overflow-wrap: anywhere;
 }
 
 .dialog.manage_github_dialog .description_area {


### PR DESCRIPTION
This backs out commit 10139a26adbd7b4fd71ad98d48ee84d30a818499

... and then changes the original code to wrap anywhere instead as suggested in #6333.

Fixes: #6333