### PR TITLE
vscode: Update TextMate grammar

### DIFF
--- a/editors/vscode/slint.tmLanguage.json
+++ b/editors/vscode/slint.tmLanguage.json
@@ -155,10 +155,6 @@
                     }
                 },
                 {
-                    "match": "(?<!-)\\b(blue|red|green|yellow|red|black|linear|ease-in-quad|ease-out-quad|ease-in-out-quad|ease|ease-in|ease-out|ease-in-out|ease-in-quart|ease-out-quart|ease-in-out-quart|ease-in-quint|ease-out-quint|ease-in-out-quint|ease-in-expo|ease-out-expo|ease-in-out-expo|ease-in-sine|ease-out-sine|ease-in-out-sine|ease-in-back|ease-out-back|ease-in-out-back|ease-in-circ|ease-out-circ|ease-in-out-circ|ease-in-elastic|ease-out-elastic|ease-in-out-elastic|ease-in-bounce|ease-out-bounce|ease-in-out-bounce|cubic-bezier)\\b(?!-)",
-                    "name": "support.constant"
-                },
-                {
                     "include": "#property"
                 }
             ]
@@ -190,6 +186,18 @@
                 {
                     "match": "\\b\\d+(\\.\\d*)?(%|px|phx|pt|in|mm|cm|ms|s|deg|rad|turn)?\\b",
                     "name": "constant.numeric"
+                },
+                {
+                    "match": "(?<!-)\\b(linear|ease-in-quad|ease-out-quad|ease-in-out-quad|ease|ease-in|ease-out|ease-in-out|ease-in-quart|ease-out-quart|ease-in-out-quart|ease-in-quint|ease-out-quint|ease-in-out-quint|ease-in-expo|ease-out-expo|ease-in-out-expo|ease-in-sine|ease-out-sine|ease-in-out-sine|ease-in-back|ease-out-back|ease-in-out-back|ease-in-circ|ease-out-circ|ease-in-out-circ|ease-in-elastic|ease-out-elastic|ease-in-out-elastic|ease-in-bounce|ease-out-bounce|ease-in-out-bounce|cubic-bezier)\\b(?!-)",
+                    "name": "support.constant"
+                },
+                {
+                    "match": "(?<!-)\\b(aliceblue|antiquewhite|aqua|aquamarine|azure|beige|bisque|black|blanchedalmond|blue|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|fuchsia|gainsboro|ghostwhite|gold|goldenrod|gray|green|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|lime|limegreen|linen|magenta|maroon|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|navy|oldlace|olive|olivedrab|orange|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|purple|rebeccapurple|red|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|silver|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|teal|thistle|tomato|transparent|turquoise|violet|wheat|white|whitesmoke|yellow|yellowgreen)\\b(?!-)",
+                    "name": "support.constant"
+                },
+                {
+                    "match": "(?<!-)\\b(true|false)\\b(?!-)",
+                    "name": "constant.language"
                 }
             ]
         },
@@ -217,8 +225,11 @@
                             "name": "variable.parameter"
                         },
                         {
-                            "match": "\\b(<=>|:)\\b",
+                            "match": "\\b(<=>|:|?)\\b",
                             "name": "keyword.operator"
+                        },
+                        {
+                            "include": "#general"
                         }
                     ]
                 }


### PR DESCRIPTION
1. Add in all the color names
2. Move more constants into the general section
3. Apply the general section when parsing properties

Fixes: #6323