### PR TITLE
Implemented [&]Cow<str> for SharedString

### DIFF
--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -9,11 +9,9 @@
 use crate::SharedVector;
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
+use alloc::borrow::Cow;
 use core::fmt::{Debug, Display, Write};
 use core::ops::Deref;
-
-#[cfg(feature = "std")]
-use std::borrow::Cow;
 
 /// This macro is the same as [`std::format!`], but it returns a [`SharedString`] instead.
 ///
@@ -215,14 +213,12 @@ impl From<&String> for SharedString {
     }
 }
 
-#[cfg(feature = "std")]
 impl From<Cow<'_, str>> for SharedString {
     fn from(s: Cow<'_, str>) -> Self {
         s.as_ref().into()
     }
 }
 
-#[cfg(feature = "std")]
 impl From<&Cow<'_, str>> for SharedString {
     fn from(s: &Cow<'_, str>) -> Self {
         s.as_ref().into()
@@ -460,7 +456,6 @@ fn test_serialize_deserialize_sharedstring() {
     assert_eq!(v, deserialized);
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn test_from_cow() {
     let borrowed = Cow::from("Foo");

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -459,3 +459,14 @@ fn test_serialize_deserialize_sharedstring() {
     let deserialized: SharedString = serde_json::from_str(&serialized).unwrap();
     assert_eq!(v, deserialized);
 }
+
+#[cfg(feature = "std")]
+#[test]
+fn test_from_cow() {
+    let borrowed = Cow::from("Foo");
+    let owned = Cow::from("Bar".to_string());
+    assert_eq!(SharedString::from("Foo"), SharedString::from(&borrowed));
+    assert_eq!(SharedString::from("Foo"), SharedString::from(borrowed));
+    assert_eq!(SharedString::from("Bar"), SharedString::from(&owned));
+    assert_eq!(SharedString::from("Bar"), SharedString::from(owned));
+}

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -12,6 +12,8 @@ use alloc::string::String;
 use core::fmt::{Debug, Display, Write};
 use core::ops::Deref;
 
+use std::borrow::Cow;
+
 /// This macro is the same as [`std::format!`], but it returns a [`SharedString`] instead.
 ///
 /// ### Example
@@ -209,6 +211,18 @@ impl From<String> for SharedString {
 impl From<&String> for SharedString {
     fn from(s: &String) -> Self {
         s.as_str().into()
+    }
+}
+
+impl From<Cow<'_, str>> for SharedString {
+    fn from(s: Cow<'_, str>) -> Self {
+        s.as_ref().into()
+    }
+}
+
+impl From<&Cow<'_, str>> for SharedString {
+    fn from(s: &Cow<'_, str>) -> Self {
+        s.as_ref().into()
     }
 }
 

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -12,6 +12,7 @@ use alloc::string::String;
 use core::fmt::{Debug, Display, Write};
 use core::ops::Deref;
 
+#[cfg(feature = "std")]
 use std::borrow::Cow;
 
 /// This macro is the same as [`std::format!`], but it returns a [`SharedString`] instead.
@@ -214,12 +215,14 @@ impl From<&String> for SharedString {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<Cow<'_, str>> for SharedString {
     fn from(s: Cow<'_, str>) -> Self {
         s.as_ref().into()
     }
 }
 
+#[cfg(feature = "std")]
 impl From<&Cow<'_, str>> for SharedString {
     fn from(s: &Cow<'_, str>) -> Self {
         s.as_ref().into()


### PR DESCRIPTION
Title is self-explanatory
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
