### PR TITLE
lsp: Ignore url schemes

### DIFF
--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -24,7 +24,25 @@ function startClient(
     //let args = vscode.workspace.getConfiguration('slint').get<[string]>('lsp-args');
 
     // Options to control the language client
-    const clientOptions = common.languageClientOptions(telemetryLogger);
+    // Note: This works with way more schemes than the native LSP as it goes
+    // through VSCode to open files by necessity.
+    // https://github.com/microsoft/vscode/blob/main/src/vs/base/common/network.ts
+    // lists all the known schemes in VSCode (without extensions). I err on the
+    // side of allowing too much here I think...
+    const clientOptions = common.languageClientOptions(
+        [
+            "file",
+            "http",
+            "https",
+            "inmemory",
+            "vscode-file",
+            "vscode-remote",
+            "vscode-remote-resource",
+            "vscode-vfs", // github.dev uses this
+            "vsls",
+        ],
+        telemetryLogger,
+    );
     clientOptions.synchronize = {};
     clientOptions.initializationOptions = {};
 

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -100,10 +100,17 @@ export function setServerStatus(
 // as needed and makes the triggering side so much simpler!
 
 export function languageClientOptions(
+    schemes: string[],
     telemetryLogger: vscode.TelemetryLogger,
 ): LanguageClientOptions {
+    var document_selector = [];
+    for (var scheme of schemes) {
+        document_selector.push({ scheme: scheme, language: "slint" });
+        document_selector.push({ scheme: scheme, language: "rust" });
+    }
+
     return {
-        documentSelector: [{ language: "slint" }, { language: "rust" }],
+        documentSelector: document_selector,
         middleware: {
             async provideCodeActions(
                 document: vscode.TextDocument,

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -195,7 +195,7 @@ function startClient(
         "slint-lsp",
         "Slint",
         serverOptions,
-        common.languageClientOptions(telemetryLogger),
+        common.languageClientOptions(["file"], telemetryLogger),
     );
 
     common.prepare_client(cl);


### PR DESCRIPTION
Since we work on file paths in the compiler but get URLs from the editor, we end up normalizing URLs down to paths.

In #6375 we open a git diff view, which VSCode considers to be `slint` language to highlight it properly. So it will also sends data to the LSP, using `git:/file/path?lots&of&meta&data` as the buffers URL. We normalize that to /file/path and then update that files contents with (parts of) the diff view. Not too surprising: This triggers errors.

The normalization does not happen in the same way in WASM, so slintpad should be immune to the problem.

I considered to just reject "old" versions, but that can go wrong if you open a diff view first and only then the actual file. It will take a couple of changes to the file to be "newer" than the diff and it will be ignored till then.

An alternative is to remember the base URL we mapped into the internal clean URL first and reject any content form other URLs that map to the same internal URL. Again this will fail when you open the diff view first and it won't "auto-fix" itself afterwards. 

So the only possible approach seems to be filtering the  source URL based on its scheme. We use several, so this is not ideal, but the best option I see right now.

Fixes: #6375