### PR TITLE
Calling `focus()` on a focusable item that's already focused should b…

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -726,9 +726,15 @@ impl WindowInner {
         if self.prevent_focus_change.get() {
             return;
         }
-        if !set_focus {
-            let current_focus_item = self.focus_item.borrow().clone();
-            if let Some(current_focus_item_rc) = current_focus_item.upgrade() {
+
+        let current_focus_item = self.focus_item.borrow().clone();
+        if let Some(current_focus_item_rc) = current_focus_item.upgrade() {
+            if set_focus {
+                if current_focus_item_rc == *new_focus_item {
+                    // don't send focus out and in even to the same item if focus doesn't change
+                    return;
+                }
+            } else {
                 if current_focus_item_rc != *new_focus_item {
                     // can't clear focus unless called with currently focused item.
                     return;

--- a/tests/cases/focus/focus_change_event.slint
+++ b/tests/cases/focus/focus_change_event.slint
@@ -1,20 +1,26 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
     forward-focus: focus-scope;
 
-    focus-scope := FocusScope {}
+    focus-scope := FocusScope { }
 
-    FocusScope {
+    fs := FocusScope {
         focus-changed-event => {
+            root.focus-changed-event-counter += 1;
             scope-focused = self.has-focus;
         }
     }
 
-    property <bool> scope-focused;
+    public function set-focus() {
+        fs.focus();
+    }
+
+    out property <bool> scope-focused;
+    out property <int> focus-changed-event-counter: 0;
 }
 
 /*
@@ -23,40 +29,65 @@ use slint::platform::Key;
 
 let instance = TestCase::new().unwrap();
 assert!(!instance.get_scope_focused());
+assert_eq!(instance.get_focus_changed_event_counter(), 0);
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert!(instance.get_scope_focused());
+assert_eq!(instance.get_focus_changed_event_counter(), 1);
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert!(!instance.get_scope_focused());
+assert_eq!(instance.get_focus_changed_event_counter(), 2);
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert!(instance.get_scope_focused());
+assert_eq!(instance.get_focus_changed_event_counter(), 3);
 
 // alt-tab don't change focus
 slint_testing::send_keyboard_char(&instance, Key::Alt.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 slint_testing::send_keyboard_char(&instance, Key::Alt.into(), false);
 assert!(instance.get_scope_focused());
+assert_eq!(instance.get_focus_changed_event_counter(), 3);
+
+// calling `focus()` on focused item doesn't trigger change
+instance.invoke_set_focus();
+assert_eq!(instance.get_focus_changed_event_counter(), 3);
 ```
 
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
 assert(!instance.get_scope_focused());
+assert_eq(instance.get_focus_changed_event_counter(), 0);
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert(instance.get_scope_focused());
+assert_eq(instance.get_focus_changed_event_counter(), 1);
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert(!instance.get_scope_focused());
+assert_eq(instance.get_focus_changed_event_counter(), 2);
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert(instance.get_scope_focused());
+assert_eq(instance.get_focus_changed_event_counter(), 3);
+
+// calling `focus()` on focused item doesn't trigger change
+instance.invoke_set_focus();
+assert_eq(instance.get_focus_changed_event_counter(), 3);
 ```
 
 ```js
 var instance = new slint.TestCase();
 assert(!instance.scope_focused);
+assert.equal(instance.focus_changed_event_counter, 0);
 slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
 assert(instance.scope_focused);
+assert.equal(instance.focus_changed_event_counter, 1);
 slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
 assert(!instance.scope_focused);
+assert.equal(instance.focus_changed_event_counter, 2);
 slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
 assert(instance.scope_focused);
+assert.equal(instance.focus_changed_event_counter, 3);
+
+// calling `focus()` on focused item doesn't trigger change
+instance.set_focus();
+assert.equal(instance.focus_changed_event_counter, 3);
 ```
 */


### PR DESCRIPTION
…e a no-op

Fixes #6403

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
