### PR TITLE
SwipeGestureHandler: improve behavior

### DIFF
--- a/tests/cases/elements/swipegesturehandler.slint
+++ b/tests/cases/elements/swipegesturehandler.slint
@@ -163,5 +163,54 @@ assert_eq!(instance.get_right_swiping(), false);
 assert_eq!(instance.get_ta_hover(), false);
 ```
 
+```rust
+use slint::{platform::WindowEvent, LogicalPosition, platform::PointerEventButton};
+
+// swipe two swipe area at the same time
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_enabled(), true);
+assert_eq!(instance.get_r(), "");
+assert_eq!(instance.get_ta_hover(), false);
+assert_eq!(instance.get_ta_pressed(), false);
+assert_eq!(instance.get_down_swiping(), false);
+assert_eq!(instance.get_left_swiping(), false);
+assert_eq!(instance.get_right_swiping(), false);
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(100.0, 400.0) });
+assert_eq!(instance.get_ta_hover(), true);
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(100.0, 400.0), button: PointerEventButton::Left });
+assert_eq!(instance.get_ta_hover(), true);
+assert_eq!(instance.get_ta_pressed(), false);
+// wait a very long time
+slint_testing::mock_elapsed_time(1300);
+assert_eq!(instance.get_ta_hover(), true);
+assert_eq!(instance.get_ta_pressed(), true);
+// up right
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(130.0, 380.0) });
+assert_eq!(instance.get_r(), "");
+assert_eq!(instance.get_ta_hover(), false, "hover was cancelled");
+assert_eq!(instance.get_ta_pressed(), false);
+assert_eq!(instance.get_down_swiping(), false);
+assert_eq!(instance.get_left_swiping(), false);
+assert_eq!(instance.get_right_swiping(), true);
+// now down right: this cancel the previous swipe
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(110.0, 519.0) });
+assert_eq!(instance.get_r(), "");
+assert_eq!(instance.get_ta_hover(), false);
+assert_eq!(instance.get_ta_pressed(), false);
+assert_eq!(instance.get_down_swiping(), true);
+assert_eq!(instance.get_left_swiping(), false);
+assert_eq!(instance.get_right_swiping(), false, "got cancelled");
+
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(220.0, 519.0), button: PointerEventButton::Left });
+assert_eq!(instance.get_r(), "S1(169)");
+assert_eq!(instance.get_ta_hover(), false, "FIXME: or should it be true as the mouse is still over it?");
+assert_eq!(instance.get_ta_pressed(), false);
+assert_eq!(instance.get_down_swiping(), false);
+assert_eq!(instance.get_left_swiping(), false);
+assert_eq!(instance.get_right_swiping(), false);
+```
+
 
 */


### PR DESCRIPTION
 - Remove the duration threshold
 - Always register the swipe even if the pointer went in another direction before
 - set the current position on the release event (in case there was no mouve to that position before)

ChangeLog: adjusted threshold in the SwipeGestureHandler

Closes #6344
Probably also helps for #6350
