### PR TITLE
Node.js: Fix tense in error messages produced when exceptions are throw

### DIFF
--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -55,7 +55,7 @@ pub fn invoke_from_event_loop(env: Env, callback: JsFunction) -> napi::Result<na
     i_slint_core::api::invoke_from_event_loop(move || {
         let function_ref = function_ref.take();
         let Ok(callback) = function_ref.get::<JsFunction>() else {
-            eprintln!("Node.js: JavaScript invoke_from_event_loop throws an exception");
+            eprintln!("Node.js: JavaScript invoke_from_event_loop threw an exception");
             return;
         };
         callback.call_without_args(None).ok();

--- a/api/node/rust/types/model.rs
+++ b/api/node/rust/types/model.rs
@@ -91,7 +91,7 @@ impl Model for JsModel {
 
     fn row_count(&self) -> usize {
         let Ok(model) = self.js_impl.get::<Object>() else {
-            eprintln!("Node.js: JavaScript Model<T>'s rowCount throws an exception");
+            eprintln!("Node.js: JavaScript Model<T>'s rowCount threw an exception");
             return 0;
         };
 
@@ -125,7 +125,7 @@ impl Model for JsModel {
 
     fn row_data(&self, row: usize) -> Option<Self::Data> {
         let Ok(model) = self.js_impl.get::<Object>() else {
-            eprintln!("Node.js: JavaScript Model<T>'s rowData throws an exception");
+            eprintln!("Node.js: JavaScript Model<T>'s rowData threw an exception");
             return None;
         };
 
@@ -160,7 +160,7 @@ impl Model for JsModel {
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
         let Ok(model) = self.js_impl.get::<Object>() else {
-            eprintln!("Node.js: JavaScript Model<T>'s setRowData throws an exception");
+            eprintln!("Node.js: JavaScript Model<T>'s setRowData threw an exception");
             return;
         };
 


### PR DESCRIPTION
At this point the exception _was_ thrown.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
