### PR TITLE
C++: Add size() method to SharedString

### DIFF
--- a/api/cpp/include/slint_string.h
+++ b/api/cpp/include/slint_string.h
@@ -83,6 +83,8 @@ struct SharedString
     /// Provides a raw pointer to the string data. The returned pointer is only valid as long as at
     /// least this SharedString exists.
     auto data() const -> const char * { return cbindgen_private::slint_shared_string_bytes(this); }
+    /// Size of the string, in bytes. This excludes the terminating null character.
+    std::size_t size() const { return std::string_view(*this).size(); }
 
     /// Returns a pointer to the first character. It is only safe to dereference the pointer if the
     /// string contains at least one character.

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -13,6 +13,7 @@ SCENARIO("SharedString API")
     slint::SharedString str;
 
     REQUIRE(str.empty());
+    REQUIRE(str.size() == 0);
     REQUIRE(str == "");
     REQUIRE(std::string_view(str.data()) == ""); // this test null termination of data()
 
@@ -44,6 +45,12 @@ SCENARIO("SharedString API")
     {
         str = "Hello";
         REQUIRE(str.begin() + std::string_view(str).size() == str.end());
+    }
+
+    SECTION("size")
+    {
+        str = "Hello";
+        REQUIRE(str.size() == 5);
     }
 }
 


### PR DESCRIPTION
The length is an important property of a string and should be available as a getter IMO. The new `size()` method is consistent with `std::string`.

This is my first contribution and I didn't open an issue for it :see_no_evil: Don't hesitate to ask me for adjusting anything or close the PR if a `size()` method is not desired.

I suspect the API documentation will be auto-generated from the code(?).