### PR TITLE
Binding between a read only property to input-output is deprecated

### DIFF
--- a/docs/reference/src/language/syntax/properties.md
+++ b/docs/reference/src/language/syntax/properties.md
@@ -95,6 +95,8 @@ together and always contain the same value.
 
 The right hand side of the `<=>` must be a reference to a property of the same type.
 The property type is optional with two-way bindings, it will be inferred if not specified.
+The initial value of a linked property will be the value of the right hand side of the binding.
+The two linked properties must be compatible in terms of input/output.
 
 ```slint,no-preview
 export component Example  {

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1618,6 +1618,11 @@ fn resolve_two_way_bindings(
                                     } else {
                                         diag.push_error("Cannot link input property".into(), &node);
                                     }
+                                } else if rhs_lookup.property_visibility
+                                    == PropertyVisibility::InOut
+                                {
+                                    diag.push_warning("Linking input properties to input output properties is deprecated".into(), &node);
+                                    marked_linked_read_only(&nr.element(), nr.name());
                                 } else {
                                     // This is allowed, but then the rhs must also become read only.
                                     marked_linked_read_only(&nr.element(), nr.name());

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -85,6 +85,7 @@ export component C3 {
     // checked is "input/output" in Button
     out <=> b.checked;
     in <=> b.checked;
+//  ^warning{Linking input properties to input output properties is deprecated}
     inout <=> b.checked;
     priv <=> b.checked;
 
@@ -289,6 +290,28 @@ export component C11 {
 //          ^error{Assignment on a input property}
             inout = !inout;
             priv = !priv;
+        }
+    }
+}
+
+export component C12 {
+    in property <bool> in1 <=> btn.pressed;
+//                         ^error{Cannot link to a output property}
+    in property <bool> in2 <=> btn.checked;
+//                         ^warning{Linking input properties to input output properties is deprecated}
+    in property <bool> in3 <=> btn.enabled;
+    in property <bool> in4 <=> btn.accessible-checked;
+    in property <bool> in5 <=> inout1;
+//                         ^error{Cannot link input property}
+
+    in-out property <bool> inout1;
+
+    btn := Button {
+        clicked => {
+            self.checked = !self.checked;
+//          ^error{Cannot modify a property that is linked to a read-only property}
+            self.enabled = !self.enabled;
+//          ^error{Cannot modify a property that is linked to a read-only property}
         }
     }
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -131,8 +131,8 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
         .chain(RESERVED_OTHER_PROPERTIES.iter())
         .chain(RESERVED_DROP_SHADOW_PROPERTIES.iter())
         .chain(RESERVED_ROTATION_PROPERTIES.iter())
-        .map(|(k, v)| (*k, v.clone(), PropertyVisibility::InOut))
-        .chain(reserved_accessibility_properties().map(|(k, v)| (k, v, PropertyVisibility::InOut)))
+        .map(|(k, v)| (*k, v.clone(), PropertyVisibility::Input))
+        .chain(reserved_accessibility_properties().map(|(k, v)| (k, v, PropertyVisibility::Input)))
         .chain(
             RESERVED_GRIDLAYOUT_PROPERTIES
                 .iter()

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component LineEditBase inherits Rectangle {
-    in-out property <string> placeholder-text;
-    in-out property <length> font-size <=> i-text-input.font-size;
+    in property <string> placeholder-text;
+    in property <length> font-size <=> i-text-input.font-size;
     in-out property <string> text <=> i-text-input.text;
     in-out property <brush> placeholder-color;
-    in-out property <bool> enabled <=> i-text-input.enabled;
-    in-out property <bool> has-focus: i-text-input.has-focus;
-    in-out property <InputType> input-type <=> i-text-input.input-type;
-    in-out property <TextHorizontalAlignment> horizontal-alignment <=> i-text-input.horizontal-alignment;
-    in-out property <bool> read-only <=> i-text-input.read-only;
+    in property <bool> enabled <=> i-text-input.enabled;
+    out property <bool> has-focus: i-text-input.has-focus;
+    in property <InputType> input-type <=> i-text-input.input-type;
+    in property <TextHorizontalAlignment> horizontal-alignment <=> i-text-input.horizontal-alignment;
+    in property <bool> read-only <=> i-text-input.read-only;
     in property <int> font-weight <=> i-text-input.font-weight;
     in property <brush> text-color;
     in property <color> selection-background-color <=> i-text-input.selection-background-color;

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -171,12 +171,12 @@ component SelectionFrame {
 }
 
 export component PreviewView {
-    in property <[Diagnostics]> diagnostics <=> Api.diagnostics;
-    in property <[Selection]> selections <=> Api.selections;
+    property <[Diagnostics]> diagnostics <=> Api.diagnostics;
+    property <[Selection]> selections <=> Api.selections;
     in property <ComponentItem> visible-component;
-    in property <DropMark> drop-mark <=> Api.drop-mark;
-    in property <component-factory> preview-area <=> Api.preview-area;
-    in property <bool> design-mode <=> Api.design-mode;
+    property <DropMark> drop-mark <=> Api.drop-mark;
+    property <component-factory> preview-area <=> Api.preview-area;
+    out property <bool> design-mode <=> Api.design-mode;
     in-out property <bool> select-mode: false;
 
     out property <bool> preview-visible: preview-area-container.has-component && !diagnostics.diagnostics-open;

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -579,8 +579,8 @@ component ExpandableGroup {
 }
 
 export component PropertyView {
-    in property <ElementInformation> current-element <=> Api.current-element;
-    in property <[PropertyGroup]> properties <=> Api.properties;
+    property <ElementInformation> current-element <=> Api.current-element;
+    property <[PropertyGroup]> properties <=> Api.properties;
 
     property <length> key-width: self.width / 2.5;
     property <bool> element-loaded: root.properties.length > 0;


### PR DESCRIPTION
ChangeLog: deprecated two way binding between `in` and `in-out` property

Fixes #6400
