### PR TITLE
Skia: Fix opacity not being applied to box shadows correctly

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -811,7 +811,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
         self.canvas.draw_image(
             cached_shadow_image,
             to_skia_point(offset - PhysicalPoint::from_lengths(blur, blur).to_vector()),
-            None,
+            self.default_paint().as_ref(),
         );
     }
 


### PR DESCRIPTION
When a box shadow is the only child of an opacity item, we don't create an intermediate opacity layer (good). Without the opacity layer, it's mandatory to apply the current opacity though, which commit b5c61fb2f5198389995a9e7f812f2b2cfeb51c24 did, except it missed this one draw_image call for the box shadow itself.

Fixes #6359

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
