### PR TITLE
Remove dependency on Cargo variables in a helper function for the Slint to Rust compiler

### DIFF
--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -398,7 +398,7 @@ pub fn compile_with_config(
 
 /// Compile the input file to an output file and list dependencies.
 pub fn compile_input_output_with_config(
-    input_slint_file_path: impl AsRef<std::path::Path> + Clone,
+    input_slint_file_path: impl AsRef<std::path::Path>,
     output_rust_file_path: impl AsRef<std::path::Path>,
     config: CompilerConfiguration,
 ) -> Result<Vec<std::path::PathBuf>, CompileError> {
@@ -447,7 +447,7 @@ pub fn compile_input_output_with_config(
     });
 
     write!(code_formatter, "{}", generated).map_err(CompileError::SaveError)?;
-    dependencies.push(input_slint_file_path.clone());
+    dependencies.push(input_slint_file_path.as_ref().to_path_buf());
 
     for resource in doc.embedded_file_resources.borrow().keys() {
         if !resource.starts_with("builtin:") {

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -379,7 +379,7 @@ pub fn compile_with_config(
         );
 
     let paths_dependencies =
-        compile_input_output_with_config(path, absolute_rust_output_file_path.clone(), config)?;
+        compile_with_output(path, absolute_rust_output_file_path.clone(), config)?;
 
     for path_dependency in paths_dependencies {
         println!("cargo:rerun-if-changed={}", path_dependency.display());
@@ -401,7 +401,7 @@ pub fn compile_with_config(
 }
 
 /// Compile the input file to an output file and list dependencies.
-pub fn compile_input_output_with_config(
+pub fn compile_with_output(
     input_slint_file_path: impl AsRef<std::path::Path>,
     output_rust_file_path: impl AsRef<std::path::Path>,
     config: CompilerConfiguration,
@@ -455,7 +455,6 @@ pub fn compile_input_output_with_config(
 
     for resource in doc.embedded_file_resources.borrow().keys() {
         if !resource.starts_with("builtin:") {
-            println!("cargo:rerun-if-changed={}", resource);
             dependencies.push(Path::new(resource).to_path_buf());
         }
     }


### PR DESCRIPTION
The `compile_with_config` function has a dependency on environment variables. It would be better if I could run a function that doesn't depend on these variables, so I can also run it inside a build system such as Bazel. I introduced a new function `compile_input_output_with_config` that doesn't need environment variables. If necessary I can also still add some tests.