### PR TITLE
Set icon also as big winit window icon for increased compatibility.

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -12,6 +12,8 @@ use std::rc::Weak;
 
 #[cfg(target_arch = "wasm32")]
 use winit::platform::web::WindowExtWebSys;
+#[cfg(target_family = "windows")]
+use winit::platform::windows::WindowExtWindows;
 
 use crate::renderer::WinitCompatibleRenderer;
 use const_field_offset::FieldOffsets;
@@ -135,7 +137,11 @@ impl WinitWindowOrNone {
 
     fn set_window_icon(&self, icon: Option<winit::window::Icon>) {
         match self {
-            Self::HasWindow(window) => window.set_window_icon(icon),
+            Self::HasWindow(window) => {
+                #[cfg(target_family = "windows")]
+                window.set_taskbar_icon(icon.as_ref().cloned());
+                window.set_window_icon(icon);
+            }
             Self::None(attributes) => attributes.borrow_mut().window_icon = icon,
         }
     }


### PR DESCRIPTION
Under Windows, the big icon is shown at least in the ancient Alt+Tab dialog, which can be restored via registry tweak.

![alt-tab](https://github.com/user-attachments/assets/59adecda-b5fa-4403-b696-09a2c8d5e5d5)

Previously, Slint windows including the VS Code preview window only had a stock icon in the [old Alt+Tab dialog](https://www.thewindowsclub.com/how-to-change-alttab-settings-in-windows-10) on Windows (which is needed for Alt+Esc to work), because Slint only called winit's [`set_window_icon()`](https://docs.rs/winit/latest/winit/window/struct.Window.html#method.set_window_icon), and not also [`set_taskbar_icon()`](https://docs.rs/winit/latest/winit/platform/windows/trait.WindowExtWindows.html#tymethod.set_taskbar_icon). See also [`WM_SETICON`](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-seticon).

This PR makes Slint now also call `set_taskbar_icon()` with an icon clone.

- On Windows, winit's `Icon` type uses an `Arc` internally. So, cloning, isn't resource-intensive. A test I did with `WM_GETICON` confirmed the same `HICON` handle is returned for the window.
- ~~On Linux, this now clones the inner `rgba: Vec<u8>`. Is this bad?~~
- ~~(For macOS and Android, winit strangely defines `pub(crate) use crate::icon::NoIcon as PlatformIcon;` (a unit struct). Aren't icons supported on these platforms?)~~

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
