### PR TITLE
Software renderer: fix drawing partialy clipped texture with rotation

### DIFF
--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -937,6 +937,7 @@ fn render_window_frame_by_line(
                                     texture,
                                     range_buffer,
                                     extra_left_clip,
+                                    extra_right_clip,
                                 );
                             }
                             SceneCommand::SharedBuffer { shared_buffer_index } => {
@@ -949,6 +950,7 @@ fn render_window_frame_by_line(
                                     &texture,
                                     range_buffer,
                                     extra_left_clip,
+                                    extra_right_clip,
                                 );
                             }
                             SceneCommand::RoundedRectangle { rectangle_index } => {
@@ -1455,7 +1457,7 @@ fn prepare_scene(
     let mut prepare_scene = prepare_scene;
     for rect in dirty_region.iter() {
         prepare_scene.processor.process_rounded_rectangle(
-            rect.to_rect(),
+            euclid::rect(rect.0.x as _, rect.0.y as _, rect.1.width as _, rect.1.height as _),
             RoundedRectangle {
                 radius: BorderRadius::default(),
                 width: Length::new(1),
@@ -1527,13 +1529,14 @@ impl<'a, T: TargetPixel> RenderToBuffer<'a, T> {
     }
 
     fn process_texture_impl(&mut self, geometry: PhysicalRect, texture: SceneTexture<'_>) {
-        self.foreach_ranges(&geometry, |line, buffer, extra_left_clip, _extra_right_clip| {
+        self.foreach_ranges(&geometry, |line, buffer, extra_left_clip, extra_right_clip| {
             draw_functions::draw_texture_line(
                 &geometry,
                 PhysicalLength::new(line),
                 &texture,
                 buffer,
                 extra_left_clip,
+                extra_right_clip,
             );
         });
     }


### PR DESCRIPTION
We were assuming that the extra clip was always on a unrotated image, the rendering code didn't account for rotated screens
