### PR TITLE
Rust generator: don't run the init code twice for popups

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1442,20 +1442,6 @@ fn generate_item_tree(
         quote!(sp::Rc::new(SharedGlobals::new(sp::VRc::downgrade(&self_dyn_rc))))
     };
 
-    let new_end = if let Some(parent_ctx) = parent_ctx {
-        if parent_ctx.repeater_index.is_some() {
-            // Repeaters run their user_init() code from RepeatedItemTree::init() after update() initialized model_data/index.
-            quote!(core::result::Result::Ok(self_rc))
-        } else {
-            quote! {
-                Self::user_init(sp::VRc::map(self_rc.clone(), |x| x));
-                core::result::Result::Ok(self_rc)
-            }
-        }
-    } else {
-        quote!(core::result::Result::Ok(self_rc))
-    };
-
     let embedding_function = if parent_ctx.is_some() {
         quote!(todo!("Components written in Rust can not get embedded yet."))
     } else {
@@ -1546,7 +1532,7 @@ fn generate_item_tree(
                 let globals = #globals;
                 sp::register_item_tree(&self_dyn_rc, globals.maybe_window_adapter_impl());
                 Self::init(sp::VRc::map(self_rc.clone(), |x| x), globals, 0, 1);
-                #new_end
+                core::result::Result::Ok(self_rc)
             }
 
             fn item_tree() -> &'static [sp::ItemTreeNode] {

--- a/tests/cases/callbacks/init_popup.slint
+++ b/tests/cases/callbacks/init_popup.slint
@@ -7,11 +7,11 @@ TestCase := Rectangle {
     width: 300phx;
     height: 300phx;
 
-    out property <bool> popup-created;
+    out property <int> popup-created;
 
     popup := PopupWindow {
         init => {
-            root.popup-created = true;
+            root.popup-created += 1;
         }
     }
 
@@ -27,21 +27,21 @@ TestCase := Rectangle {
 let instance = TestCase::new().unwrap();
 
 slint_testing::send_mouse_click(&instance, 5., 5.);
-assert!(instance.get_popup_created());
+assert_eq!(instance.get_popup_created(), 1);
 ```
 
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
 slint_testing::send_mouse_click(&instance, 5., 5.);
-assert(instance.get_popup_created());
+assert_eq(instance.get_popup_created(), 1);
 ```
 
 
 ```js
 var instance = new slint.TestCase({});
 slintlib.private_api.send_mouse_click(instance, 5., 5.);
-assert(instance.popup_created);
+assert.equal(instance.popup_created, 1);
 ```
 
 


### PR DESCRIPTION
Don't run the `init=>` callback in popup twice

ChangeLog: rust: Fixed `init=>` callback on PopupWindow ran twice.