### PR TITLE
interpreter: Fix wrong parent item tree of the PopupWindow

### DIFF
--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -619,7 +619,7 @@ fn call_builtin_function(
                         )
                     },
                     popup.close_on_click,
-                    component.self_weak().get().unwrap().clone(),
+                    enclosing_component.self_weak().get().unwrap().clone(),
                     component.window_adapter(),
                     &parent_item,
                 );


### PR DESCRIPTION
When calling `popup.show()` the parent itemtree of the popup should be the one from the parent in which the PopupWindow is declared in the source, and not the one of the context in which the `popup.show()` code appears.

Part of issue #6426.
This happens to fix the issue as presented there.

But there is another issue in which we still crash when trying to access global from a popup who's parent has been deleted because the interpreter needs access to the root item tree to access the globals
