### PR TITLE
Add support for a font-metrics property to Text/TextInput.

### DIFF
--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -784,6 +784,7 @@ When not part of a layout, its width or height defaults to 100% of the parent el
 -   **`font-size`** (_in_ _length_): The font size of the text.
 -   **`font-weight`** (_in_ _int_): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
 -   **`font-italic`** (_in_ _bool_): Whether or not the font face should be drawn italicized or not. (default value: false)
+-   **`font-metrics`** (_out_ _struct [`FontMetrics`](structs.md#fontmetrics)_): The design metrics of the font scaled to the font pixel size used by the element.
 -   **`has-focus`** (_out_ _bool_): `TextInput` sets this to `true` when it's focused. Only then it receives [`KeyEvent`](structs.md#keyevent)s.
 -   **`horizontal-alignment`** (_in_ _enum [`TextHorizontalAlignment`](enums.md#texthorizontalalignment)_): The horizontal alignment of the text.
 -   **`input-type`** (_in_ _enum [`InputType`](enums.md#inputtype)_): Use this to configure `TextInput` for editing special input, such as password fields. (default value: `text`)
@@ -847,6 +848,7 @@ and the text itself.
 -   **`font-size`** (_in_ _length_): The font size of the text.
 -   **`font-weight`** (_in_ _int_): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
 -   **`font-italic`** (_in_ _bool_): Whether or not the font face should be drawn italicized or not. (default value: false)
+-   **`font-metrics`** (_out_ _struct [`FontMetrics`](structs.md#fontmetrics)_): The design metrics of the font scaled to the font pixel size used by the element.
 -   **`horizontal-alignment`** (_in_ _enum [`TextHorizontalAlignment`](enums.md#texthorizontalalignment)_): The horizontal alignment of the text.
 -   **`letter-spacing`** (_in_ _length_): The letter spacing allows changing the spacing between the glyphs. A positive value increases the spacing and a negative value decreases the distance. (default value: 0)
 -   **`overflow`** (_in_ _enum [`TextOverflow`](enums.md#textoverflow)_): What happens when the text overflows (default value: clip).

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -173,6 +173,14 @@ impl RendererSealed for TestingWindow {
         LogicalSize::new(text.len() as f32 * 10., 10.)
     }
 
+    fn font_metrics(
+        &self,
+        _font_request: i_slint_core::graphics::FontRequest,
+        _scale_factor: ScaleFactor,
+    ) -> i_slint_core::items::FontMetrics {
+        i_slint_core::items::FontMetrics { ascent: 7., descent: 3., x_height: 3., cap_height: 7. }
+    }
+
     // this works only for single line text
     fn text_input_byte_offset_for_position(
         &self,

--- a/internal/common/Cargo.toml
+++ b/internal/common/Cargo.toml
@@ -18,10 +18,11 @@ path = "lib.rs"
 
 [features]
 default = []
-shared-fontdb = ["dep:fontdb", "dep:libloading", "derive_more", "cfg-if"]
+shared-fontdb = ["dep:fontdb", "dep:libloading", "derive_more", "cfg-if", "dep:ttf-parser"]
 
 [dependencies]
 fontdb = { workspace = true, optional = true }
+ttf-parser = { workspace = true, optional = true }
 derive_more = { workspace = true, optional = true }
 cfg-if = { version = "1", optional = true }
 

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -162,6 +162,26 @@ macro_rules! for_each_builtin_structs {
                     change_time: crate::animations::Instant,
                 }
             }
+
+            /// A structure to hold metrics of a font for a specified pixel size.
+            struct FontMetrics {
+                @name = "slint::private_api::FontMetrics"
+                export {
+                    /// The distance between the baseline and the top of the tallest glyph in the font.
+                    ascent: Coord,
+                    /// The distance between the baseline and the bottom of the tallest glyph in the font.
+                    /// This is usually negative.
+                    descent: Coord,
+                    /// The distance between the baseline and the horizontal midpoint of the tallest glyph in the font,
+                    /// or zero if not specified by the font.
+                    x_height: Coord,
+                    /// The distance between the baseline and the top of a regular upper-case glyph in the font,
+                    /// or zero if not specified by the font.
+                    cap_height: Coord,
+                }
+                private {
+                }
+            }
         ];
     };
 }

--- a/internal/common/sharedfontdb.rs
+++ b/internal/common/sharedfontdb.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 pub use fontdb;
+pub use ttf_parser;
 
 #[derive(derive_more::Deref)]
 pub struct FontDatabase {
@@ -219,4 +220,27 @@ pub fn register_font_from_path(_path: &std::path::Path) -> Result<(), Box<dyn st
         "Registering fonts from paths is not supported in WASM builds",
     )
     .into());
+}
+
+/// Font metrics in design space. Scale with desired pixel size and divided by units_per_em
+/// to obtain pixel metrics.
+#[derive(Clone)]
+pub struct DesignFontMetrics {
+    pub ascent: f32,
+    pub descent: f32,
+    pub x_height: f32,
+    pub cap_height: f32,
+    pub units_per_em: f32,
+}
+
+impl DesignFontMetrics {
+    pub fn new(face: ttf_parser::Face<'_>) -> Self {
+        Self {
+            ascent: face.ascender() as f32,
+            descent: face.descender() as f32,
+            x_height: face.x_height().unwrap_or_default() as f32,
+            cap_height: face.capital_height().unwrap_or_default() as f32,
+            units_per_em: face.units_per_em() as f32,
+        }
+    }
 }

--- a/internal/compiler/embedded_resources.rs
+++ b/internal/compiler/embedded_resources.rs
@@ -78,6 +78,8 @@ pub struct BitmapFont {
     pub units_per_em: f32,
     pub ascent: f32,
     pub descent: f32,
+    pub x_height: f32,
+    pub cap_height: f32,
     pub glyphs: Vec<BitmapGlyphs>,
     pub weight: u16,
     pub italic: bool,

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -45,6 +45,7 @@ pub enum BuiltinFunction {
     SetSelectionOffsets,
     /// A function that belongs to an item (such as TextInput's select-all function).
     ItemMemberFunction(String),
+    ItemFontMetrics,
     /// the "42".to_float()
     StringToFloat,
     /// the "42".is_float()
@@ -165,6 +166,10 @@ impl BuiltinFunction {
             },
             BuiltinFunction::ItemMemberFunction(..) => Type::Function {
                 return_type: Box::new(Type::Void),
+                args: vec![Type::ElementReference],
+            },
+            BuiltinFunction::ItemFontMetrics => Type::Function {
+                return_type: Box::new(crate::typeregister::font_metrics_type()),
                 args: vec![Type::ElementReference],
             },
             BuiltinFunction::StringToFloat => {
@@ -353,6 +358,7 @@ impl BuiltinFunction {
             BuiltinFunction::ShowPopupWindow | BuiltinFunction::ClosePopupWindow => false,
             BuiltinFunction::SetSelectionOffsets => false,
             BuiltinFunction::ItemMemberFunction(..) => false,
+            BuiltinFunction::ItemFontMetrics => false, // depends also on Window's font properties
             BuiltinFunction::StringToFloat | BuiltinFunction::StringIsFloat => true,
             BuiltinFunction::ColorRgbaStruct
             | BuiltinFunction::ColorHsvaStruct
@@ -419,6 +425,7 @@ impl BuiltinFunction {
             BuiltinFunction::ShowPopupWindow | BuiltinFunction::ClosePopupWindow => false,
             BuiltinFunction::SetSelectionOffsets => false,
             BuiltinFunction::ItemMemberFunction(..) => false,
+            BuiltinFunction::ItemFontMetrics => true,
             BuiltinFunction::StringToFloat | BuiltinFunction::StringIsFloat => true,
             BuiltinFunction::ColorRgbaStruct
             | BuiltinFunction::ColorHsvaStruct

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -899,6 +899,8 @@ fn embed_resource(
                 units_per_em,
                 ascent,
                 descent,
+                x_height,
+                cap_height,
                 glyphs,
                 weight,
                 italic,
@@ -998,6 +1000,8 @@ fn embed_resource(
                         .units_per_em = {units_per_em},
                         .ascent = {ascent},
                         .descent = {descent},
+                        .x_height = {x_height},
+                        .cap_height = {cap_height},
                         .glyphs = slint::cbindgen_private::Slice<slint::cbindgen_private::BitmapGlyphs>{{ {glyphsets_var}, {glyphsets_size} }},
                         .weight = {weight},
                         .italic = {italic},
@@ -3540,6 +3544,20 @@ fn compile_builtin_function_call(
                 format!("{function_name}(&{item}, &{window}.handle(), &{item_rc})")
             } else {
                 panic!("internal error: invalid args to ItemMemberFunction {:?}", arguments)
+            }
+        }
+        BuiltinFunction::ItemFontMetrics => {
+            if let [llr::Expression::PropertyReference(pr)] = arguments {
+                let item_rc = access_item_rc(pr, ctx);
+                let window = access_window_field(ctx);
+
+                let function_name = format!(
+                    "slint_cpp_text_item_fontmetrics",
+                );
+
+                format!("{function_name}(&{window}.handle(), &{item_rc})")
+            } else {
+                panic!("internal error: invalid args to ItemFontMetrics {:?}", arguments)
             }
         }
         BuiltinFunction::ItemAbsolutePosition => {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2644,6 +2644,19 @@ fn compile_builtin_function_call(
                 panic!("internal error: invalid args to ItemMemberFunction {:?}", arguments)
             }
         }
+        BuiltinFunction::ItemFontMetrics => {
+            if let [Expression::PropertyReference(pr)] = arguments {
+                let item = access_member(pr, ctx);
+                let window_adapter_tokens = access_window_adapter_field(ctx);
+                item.then(|item| {
+                    quote!(
+                        #item.font_metrics(#window_adapter_tokens)
+                    )
+                })
+            } else {
+                panic!("internal error: invalid args to ItemMemberFunction {:?}", arguments)
+            }
+        }
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
             if let [Expression::PropertyReference(pr)] = arguments {
                 let item = access_member(pr, ctx);
@@ -2985,7 +2998,7 @@ fn generate_resources(doc: &Document) -> Vec<TokenStream> {
                     )
                 },
                 #[cfg(feature = "software-renderer")]
-                crate::embedded_resources::EmbeddedResourcesKind::BitmapFontData(crate::embedded_resources::BitmapFont { family_name, character_map, units_per_em, ascent, descent, glyphs, weight, italic }) => {
+                crate::embedded_resources::EmbeddedResourcesKind::BitmapFontData(crate::embedded_resources::BitmapFont { family_name, character_map, units_per_em, ascent, descent, x_height, cap_height, glyphs, weight, italic }) => {
 
                     let character_map_size = character_map.len();
 
@@ -3037,6 +3050,8 @@ fn generate_resources(doc: &Document) -> Vec<TokenStream> {
                             units_per_em: #units_per_em,
                             ascent: #ascent,
                             descent: #descent,
+                            x_height: #x_height,
+                            cap_height: #cap_height,
                             glyphs: sp::Slice::from_slice({
                                 #link_section
                                 static GLYPHS : [sp::BitmapGlyphs; #glyphs_size] = [#(#glyphs),*];

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -99,6 +99,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::ShowPopupWindow | BuiltinFunction::ClosePopupWindow => isize::MAX,
         BuiltinFunction::SetSelectionOffsets => isize::MAX,
         BuiltinFunction::ItemMemberFunction(..) => isize::MAX,
+        BuiltinFunction::ItemFontMetrics => isize::MAX,
         BuiltinFunction::StringToFloat => 50,
         BuiltinFunction::StringIsFloat => 50,
         BuiltinFunction::ColorRgbaStruct => 50,

--- a/internal/compiler/tests/syntax/elements/text.slint
+++ b/internal/compiler/tests/syntax/elements/text.slint
@@ -1,0 +1,13 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Foo inherits Rectangle {
+    Text {
+        font-metrics: 42;
+//      ^error{Cannot assign to output property 'font-metrics'}
+//                    ^^error{Cannot convert float to FontMetrics}        
+
+    }
+
+    property <length> font-metrics: 100px;
+}

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -370,6 +370,21 @@ impl TypeRegister {
             _ => unreachable!(),
         };
 
+        let font_metrics_prop = crate::langtype::ReservedBuiltinPropertyInfo {
+            ty: font_metrics_type(),
+            property_visibility: PropertyVisibility::Output,
+            init_expr_fn: |elem| crate::expression_tree::Expression::FunctionCall {
+                function: Box::new(crate::expression_tree::Expression::BuiltinFunctionReference(
+                    BuiltinFunction::ItemFontMetrics,
+                    None,
+                )),
+                arguments: vec![crate::expression_tree::Expression::ElementReference(
+                    Rc::downgrade(elem),
+                )],
+                source_location: None,
+            },
+        };
+
         match &mut register.elements.get_mut("TextInput").unwrap() {
             ElementType::Builtin(ref mut b) => {
                 let text_input = Rc::get_mut(b).unwrap();
@@ -380,6 +395,18 @@ impl TypeRegister {
                 text_input
                     .member_functions
                     .insert("set-selection-offsets".into(), BuiltinFunction::SetSelectionOffsets);
+                text_input
+                    .reserved_properties
+                    .insert("font-metrics".into(), font_metrics_prop.clone());
+            }
+
+            _ => unreachable!(),
+        };
+
+        match &mut register.elements.get_mut("Text").unwrap() {
+            ElementType::Builtin(ref mut b) => {
+                let text = Rc::get_mut(b).unwrap();
+                text.reserved_properties.insert("font-metrics".into(), font_metrics_prop);
             }
 
             _ => unreachable!(),
@@ -544,6 +571,21 @@ pub fn logical_point_type() -> Type {
         ])
         .collect(),
         name: Some("slint::LogicalPosition".into()),
+        node: None,
+        rust_attributes: None,
+    }
+}
+
+pub fn font_metrics_type() -> Type {
+    Type::Struct {
+        fields: IntoIterator::into_iter([
+            ("ascent".to_string(), Type::LogicalLength),
+            ("descent".to_string(), Type::LogicalLength),
+            ("x-height".to_string(), Type::LogicalLength),
+            ("cap-height".to_string(), Type::LogicalLength),
+        ])
+        .collect(),
+        name: Some("slint::private_api::FontMetrics".into()),
         node: None,
         rust_attributes: None,
     }

--- a/internal/core/graphics/bitmapfont.rs
+++ b/internal/core/graphics/bitmapfont.rs
@@ -56,6 +56,10 @@ pub struct BitmapFont {
     pub ascent: f32,
     /// The font descent in design metrics (typically negative)
     pub descent: f32,
+    /// The font's x-height.
+    pub x_height: f32,
+    /// The font's cap-height.
+    pub cap_height: f32,
     /// A vector of pre-rendered glyph sets. Each glyph set must have the same number of glyphs,
     /// which must be at least as big as the largest glyph index in the character map.
     pub glyphs: Slice<'static, BitmapGlyphs>,

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -38,6 +38,13 @@ pub trait RendererSealed {
         text_wrap: TextWrap,
     ) -> LogicalSize;
 
+    /// Returns the metrics of the given font.
+    fn font_metrics(
+        &self,
+        font_request: crate::graphics::FontRequest,
+        scale_factor: ScaleFactor,
+    ) -> crate::items::FontMetrics;
+
     /// Returns the (UTF-8) byte offset in the text property that refers to the character that contributed to
     /// the glyph cluster that's visually nearest to the given coordinate. This is used for hit-testing,
     /// for example when receiving a mouse click into a text field. Then this function returns the "cursor"

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -47,6 +47,7 @@ macro_rules! declare_ValueType_2 {
             crate::lengths::LogicalLength,
             crate::component_factory::ComponentFactory,
             crate::api::LogicalPosition,
+            crate::items::FontMetrics,
             $(crate::items::$Name,)*
         ];
     };

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -672,6 +672,14 @@ impl RendererSealed for SoftwareRenderer {
         fonts::text_size(font_request, text, max_width, scale_factor, text_wrap)
     }
 
+    fn font_metrics(
+        &self,
+        font_request: crate::graphics::FontRequest,
+        scale_factor: ScaleFactor,
+    ) -> crate::items::FontMetrics {
+        fonts::font_metrics(font_request, scale_factor)
+    }
+
     fn text_input_byte_offset_for_position(
         &self,
         text_input: Pin<&crate::items::TextInput>,

--- a/internal/core/software_renderer/fonts.rs
+++ b/internal/core/software_renderer/fonts.rs
@@ -13,7 +13,7 @@ use super::{PhysicalLength, PhysicalSize};
 use crate::graphics::{BitmapFont, FontRequest};
 use crate::items::TextWrap;
 use crate::lengths::{LogicalLength, LogicalSize, ScaleFactor};
-use crate::textlayout::TextLayout;
+use crate::textlayout::{FontMetrics, TextLayout};
 use crate::Coord;
 
 thread_local! {
@@ -59,6 +59,48 @@ pub enum Font {
     PixelFont(pixelfont::PixelFont),
     #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
     VectorFont(vectorfont::VectorFont),
+}
+
+impl crate::textlayout::FontMetrics<PhysicalLength> for Font {
+    fn ascent(&self) -> PhysicalLength {
+        match self {
+            Font::PixelFont(pixel_font) => pixel_font.ascent(),
+            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            Font::VectorFont(vector_font) => vector_font.ascent(),
+        }
+    }
+
+    fn height(&self) -> PhysicalLength {
+        match self {
+            Font::PixelFont(pixel_font) => pixel_font.height(),
+            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            Font::VectorFont(vector_font) => vector_font.height(),
+        }
+    }
+
+    fn descent(&self) -> PhysicalLength {
+        match self {
+            Font::PixelFont(pixel_font) => pixel_font.descent(),
+            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            Font::VectorFont(vector_font) => vector_font.descent(),
+        }
+    }
+
+    fn x_height(&self) -> PhysicalLength {
+        match self {
+            Font::PixelFont(pixel_font) => pixel_font.x_height(),
+            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            Font::VectorFont(vector_font) => vector_font.x_height(),
+        }
+    }
+
+    fn cap_height(&self) -> PhysicalLength {
+        match self {
+            Font::PixelFont(pixel_font) => pixel_font.cap_height(),
+            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            Font::VectorFont(vector_font) => vector_font.cap_height(),
+        }
+    }
 }
 
 pub fn match_font(request: &FontRequest, scale_factor: ScaleFactor) -> Font {
@@ -172,4 +214,23 @@ pub fn text_size(
     };
 
     (PhysicalSize::from_lengths(longest_line_width, height).cast() / scale_factor).cast()
+}
+
+pub fn font_metrics(
+    font_request: FontRequest,
+    scale_factor: ScaleFactor,
+) -> crate::items::FontMetrics {
+    let font = match_font(&font_request, scale_factor);
+
+    let ascent: LogicalLength = font.ascent().cast() / scale_factor;
+    let descent: LogicalLength = font.descent().cast() / scale_factor;
+    let x_height: LogicalLength = font.x_height().cast() / scale_factor;
+    let cap_height: LogicalLength = font.cap_height().cast() / scale_factor;
+
+    crate::items::FontMetrics {
+        ascent: ascent.get() as _,
+        descent: descent.get() as _,
+        x_height: x_height.get() as _,
+        cap_height: cap_height.get() as _,
+    }
 }

--- a/internal/core/software_renderer/fonts/pixelfont.rs
+++ b/internal/core/software_renderer/fonts/pixelfont.rs
@@ -26,6 +26,14 @@ impl BitmapGlyphs {
     pub fn pixel_size(&self) -> PhysicalLength {
         PhysicalLength::new(self.pixel_size)
     }
+    /// Returns the x-height of the font scaled to the font's pixel size.
+    pub fn x_height(&self, font: &BitmapFont) -> PhysicalLength {
+        (PhysicalLength::new(self.pixel_size).cast() * font.x_height / font.units_per_em).cast()
+    }
+    /// Returns the cap-height of the font scaled to the font's pixel size.
+    pub fn cap_height(&self, font: &BitmapFont) -> PhysicalLength {
+        (PhysicalLength::new(self.pixel_size).cast() * font.cap_height / font.units_per_em).cast()
+    }
 }
 
 // A font that is resolved to a specific pixel size.
@@ -126,5 +134,13 @@ impl crate::textlayout::FontMetrics<PhysicalLength> for PixelFont {
 
     fn height(&self) -> PhysicalLength {
         self.glyphs.height(self.bitmap_font)
+    }
+
+    fn x_height(&self) -> PhysicalLength {
+        self.glyphs.x_height(&self.bitmap_font)
+    }
+
+    fn cap_height(&self) -> PhysicalLength {
+        self.glyphs.cap_height(&self.bitmap_font)
     }
 }

--- a/internal/core/software_renderer/fonts/vectorfont.rs
+++ b/internal/core/software_renderer/fonts/vectorfont.rs
@@ -52,6 +52,8 @@ pub struct VectorFont {
     height: PhysicalLength,
     scale: FontScaleFactor,
     pixel_size: PhysicalLength,
+    x_height: PhysicalLength,
+    cap_height: PhysicalLength,
 }
 
 impl VectorFont {
@@ -68,6 +70,9 @@ impl VectorFont {
                     let ascender = FontLength::new(face.ascender() as _);
                     let descender = FontLength::new(face.descender() as _);
                     let height = FontLength::new(face.height() as _);
+                    let x_height = FontLength::new(face.x_height().unwrap_or_default() as _);
+                    let cap_height =
+                        FontLength::new(face.capital_height().unwrap_or_default() as _);
                     let units_per_em = face.units_per_em();
                     let scale = FontScaleFactor::new(pixel_size.get() as f32 / units_per_em as f32);
                     Self {
@@ -78,6 +83,8 @@ impl VectorFont {
                         height: (height.cast() * scale).cast(),
                         scale,
                         pixel_size,
+                        x_height: (x_height.cast() * scale).cast(),
+                        cap_height: (cap_height.cast() * scale).cast(),
                     }
                 })
                 .unwrap()
@@ -172,6 +179,14 @@ impl crate::textlayout::FontMetrics<PhysicalLength> for VectorFont {
 
     fn descent(&self) -> PhysicalLength {
         self.descender
+    }
+
+    fn x_height(&self) -> PhysicalLength {
+        self.x_height
+    }
+
+    fn cap_height(&self) -> PhysicalLength {
+        self.cap_height
     }
 }
 

--- a/internal/core/textlayout/shaping.rs
+++ b/internal/core/textlayout/shaping.rs
@@ -74,6 +74,8 @@ pub trait FontMetrics<Length: Copy + core::ops::Sub<Output = Length>> {
     }
     fn ascent(&self) -> Length;
     fn descent(&self) -> Length;
+    fn x_height(&self) -> Length;
+    fn cap_height(&self) -> Length;
 }
 
 pub trait AbstractFont: TextShaper + FontMetrics<<Self as TextShaper>::Length> {}
@@ -297,6 +299,14 @@ impl<'a> FontMetrics<f32> for &rustybuzz::Face<'a> {
 
     fn descent(&self) -> f32 {
         self.descender() as _
+    }
+
+    fn x_height(&self) -> f32 {
+        rustybuzz::ttf_parser::Face::x_height(self).unwrap_or_default() as _
+    }
+
+    fn cap_height(&self) -> f32 {
+        rustybuzz::ttf_parser::Face::capital_height(self).unwrap_or_default() as _
     }
 }
 

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -357,6 +357,14 @@ impl RendererSealed for FemtoVGRenderer {
         crate::fonts::text_size(&font_request, scale_factor, text, max_width)
     }
 
+    fn font_metrics(
+        &self,
+        font_request: i_slint_core::graphics::FontRequest,
+        _scale_factor: ScaleFactor,
+    ) -> i_slint_core::items::FontMetrics {
+        crate::fonts::font_metrics(font_request)
+    }
+
     fn text_input_byte_offset_for_position(
         &self,
         text_input: Pin<&i_slint_core::items::TextInput>,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -426,6 +426,14 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
             / scale_factor
     }
 
+    fn font_metrics(
+        &self,
+        font_request: i_slint_core::graphics::FontRequest,
+        scale_factor: ScaleFactor,
+    ) -> i_slint_core::items::FontMetrics {
+        textlayout::font_metrics(font_request, scale_factor)
+    }
+
     fn text_input_byte_offset_for_position(
         &self,
         text_input: std::pin::Pin<&i_slint_core::items::TextInput>,

--- a/tests/cases/text/metrics.slint
+++ b/tests/cases/text/metrics.slint
@@ -1,0 +1,35 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    width: 100phx;
+    height: 100phx;
+    simple-text := Text { }
+
+    complex-text := Text {
+        stroke-width: 2px;
+    }
+
+    text-input := TextInput { }
+
+    out property <bool> test: simple-text.font-metrics.ascent == complex-text.font-metrics.ascent && complex-text.font-metrics.ascent == text-input.font-metrics.ascent && text-input.font-metrics.ascent == 7px;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test, 1);
+```
+
+*/

--- a/tests/manual/font-metrics.slint
+++ b/tests/manual/font-metrics.slint
@@ -1,0 +1,91 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Slider, Palette } from "std-widgets.slint";
+
+component MetricsLabel {
+    in property <string> name;
+    in property <length> value;
+    in property <length> baseline;
+    in property <color> color: t.color;
+    out property <length> text-width: t.preferred-width;
+
+    Rectangle {
+        y: root.baseline - root.value;
+        height: 1px;
+        border-color: root.color;
+        border-width: 1px;
+
+        t := Text {
+            x: 0; //parent.width - self.width;
+            y: - self.height;
+            text: {
+                if root.name == "baseline" {
+                    return root.name;
+                }
+                "\{root.name} (\{Math.round(root.value / 1px)}px)";
+            }
+        }
+    }
+}
+
+import "../../../examples/printerdemo/ui/fonts/NotoSans-Regular.ttf";
+
+export component AppWindow inherits Window {
+    width: l.x + l.width;
+    height: l.y + 2 * l.font-size;
+
+    l := Text {
+        y: self.font-size / 2;
+        x: max(baseline.text-width, ascent.text-width, descent.text-width, x-height.text-width, cap-height.text-width);
+        text: "Sphinx";
+        font-family: "Noto Sans";
+        font-size: 96px;
+    }
+
+    baseline := MetricsLabel {
+        x: 0;
+        y: l.y;
+        width: 100%;
+        name: "baseline";
+        value: 0;
+        baseline: l.font-metrics.ascent;
+        color: red;
+    }
+
+    ascent := MetricsLabel {
+        x: 0;
+        y: l.y;
+        width: 100%;
+        name: "ascent";
+        value: l.font-metrics.ascent;
+        baseline: l.font-metrics.ascent;
+    }
+
+    descent := MetricsLabel {
+        x: 0;
+        y: l.y;
+        width: 100%;
+        name: "descent";
+        value: l.font-metrics.descent;
+        baseline: l.font-metrics.ascent;
+    }
+
+    x-height := MetricsLabel {
+        x: 0;
+        y: l.y;
+        width: 100%;
+        name: "x-height";
+        value: l.font-metrics.x-height;
+        baseline: l.font-metrics.ascent;
+    }
+
+    cap-height := MetricsLabel {
+        x: 0;
+        y: l.y;
+        width: 100%;
+        name: "cap-height";
+        value: l.font-metrics.cap-height;
+        baseline: l.font-metrics.ascent;
+    }
+}


### PR DESCRIPTION
The struct held provides access to the design metrics of the font scaled to the font pixel size used by the element.

ChangeLog: Slint Language: Added font-metrics property to `Text` and `TextInput`.

Closes #6047

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
