### PR TITLE
Extend smol_str usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ toml_edit = { version = "0.22.7" }
 ttf-parser = { version = "0.21" }
 # web-sys needs to be >= 0.3.72 for set_fill_style_str
 web-sys = { version = "0.3.72", default-features = false }
+smol_str = { version = "0.3.1" }
 
 raw-window-handle-06 = { package = "raw-window-handle", version = "0.6", features = ["alloc"] }
 

--- a/api/node/Cargo.toml
+++ b/api/node/Cargo.toml
@@ -54,6 +54,7 @@ itertools = { workspace = true }
 send_wrapper = { workspace = true }
 # Removed by node_package xtask
 i-slint-backend-testing = { workspace = true, optional = true }
+smol_str = { workspace = true }
 
 [build-dependencies]
 napi-build = "2.1.0"

--- a/api/node/rust/interpreter/component_compiler.rs
+++ b/api/node/rust/interpreter/component_compiler.rs
@@ -14,6 +14,7 @@ use napi::JsString;
 use napi::JsUnknown;
 use slint_interpreter::Compiler;
 use slint_interpreter::Value;
+use smol_str::StrExt;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -147,14 +148,14 @@ impl JsComponentCompiler {
                     let mut o = env.create_object().ok()?;
 
                     for value in en.values.iter() {
-                        let value = value.replace('-', "_");
+                        let value = value.replace_smolstr("-", "_");
                         o.set_property(
                             env.create_string(&value).ok()?,
                             env.create_string(&value).ok()?.into_unknown(),
                         )
                         .ok()?;
                     }
-                    return Some((en.name.clone(), o.into_unknown()));
+                    return Some((en.name.to_string(), o.into_unknown()));
                 }
                 _ => return None,
             }

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -13,6 +13,7 @@ use napi::bindgen_prelude::*;
 use napi::{Env, JsBoolean, JsNumber, JsObject, JsString, JsUnknown, Result};
 use napi_derive::napi;
 use slint_interpreter::Value;
+use smol_str::SmolStr;
 
 #[napi(js_name = "ValueType")]
 pub enum JsValueType {
@@ -229,7 +230,7 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
                         } else {
                             to_value(env, prop, pro_ty)?
                         };
-                        Ok((pro_name.clone(), prop_value))
+                        Ok((pro_name.to_string(), prop_value))
                     })
                     .collect::<Result<_, _>>()?,
             ))
@@ -260,7 +261,7 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
         }
         Type::Enumeration(e) => {
             let js_string: JsString = unknown.try_into()?;
-            let value: String = js_string.into_utf8()?.as_str()?.into();
+            let value: SmolStr = js_string.into_utf8()?.as_str()?.into();
 
             if !e.values.contains(&value) {
                 return Err(napi::Error::from_reason(format!(
@@ -269,7 +270,7 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
                 )));
             }
 
-            Ok(Value::EnumerationValue(e.name.clone(), value))
+            Ok(Value::EnumerationValue(e.name.to_string(), value.to_string()))
         }
         Type::Invalid
         | Type::Model

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -38,7 +38,7 @@ i-slint-common = { workspace = true, features = ["default"] }
 num_enum = "0.7"
 strum = { workspace = true }
 rowan = { version = "0.15" }
-smol_str = "0.3.1"
+smol_str = { workspace = true }
 derive_more = { workspace = true }
 codemap-diagnostic = { version = "0.1.1", optional = true }
 codemap = { version = "0.1", optional = true }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -7,12 +7,13 @@ use crate::langtype::Type;
 use crate::layout::Orientation;
 use core::num::NonZeroUsize;
 use itertools::Either;
+use smol_str::SmolStr;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub enum Expression {
     /// A string literal. The .0 is the content of the string, without the quotes
-    StringLiteral(String),
+    StringLiteral(SmolStr),
     /// Number
     NumberLiteral(f64),
     /// Bool
@@ -29,14 +30,14 @@ pub enum Expression {
 
     /// Should be directly within a CodeBlock expression, and store the value of the expression in a local variable
     StoreLocalVariable {
-        name: String,
+        name: SmolStr,
         value: Box<Expression>,
     },
 
     /// a reference to the local variable with the given name. The type system should ensure that a variable has been stored
     /// with this name and this type before in one of the statement of an enclosing codeblock
     ReadLocalVariable {
-        name: String,
+        name: SmolStr,
         ty: Type,
     },
 
@@ -44,7 +45,7 @@ pub enum Expression {
     StructFieldAccess {
         /// This expression should have [`Type::Struct`] type
         base: Box<Expression>,
-        name: String,
+        name: SmolStr,
     },
 
     /// Access to a index within an array.
@@ -135,7 +136,7 @@ pub enum Expression {
     },
     Struct {
         ty: Type,
-        values: HashMap<String, Expression>,
+        values: HashMap<SmolStr, Expression>,
     },
 
     EasingCurve(crate::expression_tree::EasingCurve),
@@ -166,7 +167,7 @@ pub enum Expression {
         /// The local variable (as read with [`Self::ReadLocalVariable`]) that contains the sell
         cells_variable: String,
         /// The name for the local variable that contains the repeater indices
-        repeater_indices: Option<String>,
+        repeater_indices: Option<SmolStr>,
         /// Either an expression of type BoxLayoutCellData, or an index to the repeater
         elements: Vec<Either<Expression, u32>>,
         orientation: Orientation,
@@ -211,7 +212,7 @@ impl Expression {
             | Type::Rem
             | Type::UnitProduct(_) => Expression::NumberLiteral(0.),
             Type::Percent => Expression::NumberLiteral(1.),
-            Type::String => Expression::StringLiteral(String::new()),
+            Type::String => Expression::StringLiteral(SmolStr::default()),
             Type::Color => {
                 Expression::Cast { from: Box::new(Expression::NumberLiteral(0.)), to: ty.clone() }
             }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -3,6 +3,7 @@
 
 use super::{EvaluationContext, Expression, ParentCtx};
 use crate::langtype::{NativeClass, Type};
+use smol_str::SmolStr;
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap};
 use std::num::NonZeroUsize;
@@ -50,7 +51,7 @@ pub struct BindingExpression {
 
 #[derive(Debug)]
 pub struct GlobalComponent {
-    pub name: String,
+    pub name: SmolStr,
     pub properties: Vec<Property>,
     pub functions: Vec<Function>,
     /// One entry per property
@@ -62,7 +63,7 @@ pub struct GlobalComponent {
     pub exported: bool,
     /// The extra names under which this component should be accessible
     /// if it is exported several time.
-    pub aliases: Vec<String>,
+    pub aliases: Vec<SmolStr>,
     /// True when this is a built-in global that does not need to be generated
     pub is_builtin: bool,
 
@@ -99,7 +100,7 @@ pub enum PropertyReference {
 
 #[derive(Debug, Default)]
 pub struct Property {
-    pub name: String,
+    pub name: SmolStr,
     pub ty: Type,
     /// The amount of time this property is used of another property
     /// This property is only valid after the [`count_property_use`](super::optim_passes::count_property_use) pass
@@ -108,7 +109,7 @@ pub struct Property {
 
 #[derive(Debug)]
 pub struct Function {
-    pub name: String,
+    pub name: SmolStr,
     pub ret_ty: Type,
     pub args: Vec<Type>,
     pub code: Expression,
@@ -160,7 +161,7 @@ pub struct ComponentContainerElement {
 
 pub struct Item {
     pub ty: Rc<NativeClass>,
-    pub name: String,
+    pub name: SmolStr,
     /// Index in the item tree array
     pub index_in_tree: u32,
 }
@@ -231,7 +232,7 @@ impl TreeNode {
 
 #[derive(Debug)]
 pub struct SubComponent {
-    pub name: String,
+    pub name: SmolStr,
     pub properties: Vec<Property>,
     pub functions: Vec<Function>,
     pub items: Vec<Item>,
@@ -322,7 +323,7 @@ impl SubComponent {
 
 pub struct SubComponentInstance {
     pub ty: Rc<SubComponent>,
-    pub name: String,
+    pub name: SmolStr,
     pub index_in_tree: u32,
     pub index_of_first_child_in_tree: u32,
     pub repeater_offset: u32,
@@ -348,7 +349,7 @@ pub struct ItemTree {
     /// This tree has a parent. e.g: it is a Repeater or a PopupMenu whose property can access
     /// the parent ItemTree.
     /// The String is the type of the parent ItemTree
-    pub parent_context: Option<String>,
+    pub parent_context: Option<SmolStr>,
 }
 
 #[derive(Debug)]
@@ -356,7 +357,7 @@ pub struct PublicComponent {
     pub public_properties: PublicProperties,
     pub private_properties: PrivateProperties,
     pub item_tree: ItemTree,
-    pub name: String,
+    pub name: SmolStr,
 }
 
 #[derive(Debug)]
@@ -439,10 +440,10 @@ impl CompilationUnit {
 
 #[derive(Debug, Clone)]
 pub struct PublicProperty {
-    pub name: String,
+    pub name: SmolStr,
     pub ty: Type,
     pub prop: PropertyReference,
     pub read_only: bool,
 }
 pub type PublicProperties = Vec<PublicProperty>;
-pub type PrivateProperties = Vec<(String, Type)>;
+pub type PrivateProperties = Vec<(SmolStr, Type)>;

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -10,6 +10,7 @@ use crate::llr::item_tree::*;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{self, Component, ElementRc, PropertyAnalysis, PropertyVisibility};
 use crate::CompilerConfiguration;
+use smol_str::{format_smolstr, SmolStr};
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
@@ -181,13 +182,13 @@ impl LoweringState {
     }
 }
 
-fn component_id(component: &Rc<Component>) -> String {
+fn component_id(component: &Rc<Component>) -> SmolStr {
     if component.is_global() {
         component.root_element.borrow().id.clone()
     } else if component.id.is_empty() {
-        format!("Component_{}", component.root_element.borrow().id)
+        format_smolstr!("Component_{}", component.root_element.borrow().id)
     } else {
-        format!("{}_{}", component.id, component.root_element.borrow().id)
+        format_smolstr!("{}_{}", component.id, component.root_element.borrow().id)
     }
 }
 
@@ -261,7 +262,7 @@ fn lower_sub_component(
                     PropertyReference::Function { sub_component_path: vec![], function_index },
                 );
                 sub_component.functions.push(Function {
-                    name: p.into(),
+                    name: p.clone(),
                     ret_ty: (**return_type).clone(),
                     args: args.clone(),
                     // will be replaced later
@@ -275,7 +276,7 @@ fn lower_sub_component(
                 PropertyReference::Local { sub_component_path: vec![], property_index },
             );
             sub_component.properties.push(Property {
-                name: format!("{}_{}", elem.id, p),
+                name: format_smolstr!("{}_{}", elem.id, p),
                 ty: x.property_type.clone(),
                 ..Property::default()
             });
@@ -726,7 +727,7 @@ fn lower_global(
                 PropertyReference::GlobalFunction { global_index, function_index },
             );
             functions.push(Function {
-                name: p.into(),
+                name: p.clone(),
                 ret_ty: (**return_type).clone(),
                 args: args.clone(),
                 // will be replaced later

--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -5,6 +5,7 @@
 This module contains the [`NamedReference`] and its helper
 */
 
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -154,7 +155,7 @@ struct NamedReferenceInner {
     /// The element.
     element: Weak<RefCell<Element>>,
     /// The property name
-    name: String,
+    name: SmolStr,
 }
 
 impl NamedReferenceInner {
@@ -173,8 +174,8 @@ impl NamedReferenceInner {
         let result = if let Some(r) = named_references.get(name) {
             r.clone()
         } else {
-            let r = Rc::new(Self { element: Rc::downgrade(element), name: name.to_owned() });
-            named_references.insert(name.to_owned(), r.clone());
+            let r = Rc::new(Self { element: Rc::downgrade(element), name: name.into() });
+            named_references.insert(name.into(), r.clone());
             r
         };
         drop(named_references);
@@ -195,7 +196,7 @@ impl NamedReferenceInner {
 
 /// Must be put inside the Element and owns all the NamedReferenceInner
 #[derive(Default)]
-pub struct NamedReferenceContainer(RefCell<HashMap<String, Rc<NamedReferenceInner>>>);
+pub struct NamedReferenceContainer(RefCell<HashMap<SmolStr, Rc<NamedReferenceInner>>>);
 
 impl NamedReferenceContainer {
     /// Returns true if there is at least one NamedReference pointing to the property `name` in this element.

--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -130,7 +130,7 @@ impl NamedReference {
             .borrow()
             .property_analysis
             .borrow_mut()
-            .entry(self.name().to_owned())
+            .entry(self.name().into())
             .or_default()
             .is_set = true;
         mark_property_set_derived_in_base(element, self.name())
@@ -230,7 +230,7 @@ pub(crate) fn mark_property_set_derived_in_base(mut element: ElementRc, name: &s
             if element.borrow().property_declarations.contains_key(name) {
                 return;
             };
-            match c.root_element.borrow().property_analysis.borrow_mut().entry(name.to_owned()) {
+            match c.root_element.borrow().property_analysis.borrow_mut().entry(name.into()) {
                 std::collections::hash_map::Entry::Occupied(e) if e.get().is_set_externally => {
                     return;
                 }
@@ -256,7 +256,7 @@ pub(crate) fn mark_property_read_derived_in_base(mut element: ElementRc, name: &
             if element.borrow().property_declarations.contains_key(name) {
                 return;
             };
-            match c.root_element.borrow().property_analysis.borrow_mut().entry(name.to_owned()) {
+            match c.root_element.borrow().property_analysis.borrow_mut().entry(name.into()) {
                 std::collections::hash_map::Entry::Occupied(e) if e.get().is_read_externally => {
                     return;
                 }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -896,7 +896,7 @@ impl Element {
     ) -> ElementRc {
         let base_type = if let Some(base_node) = node.QualifiedName() {
             let base = QualifiedTypeName::from_node(base_node.clone());
-            let base_string = base.to_string();
+            let base_string = base.to_smolstr();
             match parent_type.lookup_type_for_child_element(&base_string, tr) {
                 Ok(ElementType::Component(c)) if c.is_global() => {
                     diag.push_error(
@@ -1509,7 +1509,7 @@ impl Element {
             }
         }
 
-        if r.borrow().base_type.to_string() == "ListView" {
+        if r.borrow().base_type.to_smolstr() == "ListView" {
             let mut seen_for = false;
             for se in node.children() {
                 if se.kind() == SyntaxKind::RepeatedElement && !seen_for {
@@ -1662,7 +1662,7 @@ impl Element {
                 match lookup_result.property_type {
                         Type::Invalid => {
                             if self.base_type != ElementType::Error {
-                                diag.push_error(if self.base_type.to_string() == "Empty" {
+                                diag.push_error(if self.base_type.to_smolstr() == "Empty" {
                                     format!( "Unknown property {unresolved_name}")
                                 } else {
                                     format!( "Unknown property {unresolved_name} in {}", self.base_type)
@@ -1871,7 +1871,7 @@ pub fn type_from_node(
 
         let prop_type = tr.lookup_qualified(&qualified_type.members);
 
-        if prop_type == Type::Invalid && tr.lookup_element(&qualified_type.to_string()).is_err() {
+        if prop_type == Type::Invalid && tr.lookup_element(&qualified_type.to_smolstr()).is_err() {
             diag.push_error(format!("Unknown type '{}'", qualified_type), &qualified_type_node);
         } else if !prop_type.is_property_type() {
             diag.push_error(

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -13,7 +13,7 @@ This module has different sub modules with the actual parser functions
 */
 
 use crate::diagnostics::{BuildDiagnostics, SourceFile, Spanned};
-pub use smol_str::SmolStr;
+use smol_str::{SmolStr, StrExt};
 use std::fmt::Display;
 
 mod document;
@@ -820,11 +820,11 @@ impl SyntaxNode {
             .and_then(|x| x.into_token())
             .map(|token| SyntaxToken { token, source_file: self.source_file.clone() })
     }
-    pub fn child_text(&self, kind: SyntaxKind) -> Option<String> {
+    pub fn child_text(&self, kind: SyntaxKind) -> Option<SmolStr> {
         self.node
             .children_with_tokens()
             .find(|n| n.kind() == kind)
-            .and_then(|x| x.as_token().map(|x| x.text().to_string()))
+            .and_then(|x| x.as_token().map(|x| x.text().into()))
     }
     pub fn kind(&self) -> SyntaxKind {
         self.node.kind()
@@ -1002,12 +1002,12 @@ impl Spanned for Option<SyntaxToken> {
 }
 
 /// return the normalized identifier string of the first SyntaxKind::Identifier in this node
-pub fn identifier_text(node: &SyntaxNode) -> Option<String> {
+pub fn identifier_text(node: &SyntaxNode) -> Option<SmolStr> {
     node.child_text(SyntaxKind::Identifier).map(|x| normalize_identifier(&x))
 }
 
-pub fn normalize_identifier(ident: &str) -> String {
-    ident.replace('_', "-")
+pub fn normalize_identifier(ident: &str) -> SmolStr {
+    ident.replace_smolstr("_", "-")
 }
 
 // Actual parser

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -17,6 +17,8 @@ use crate::namedreference::NamedReference;
 use crate::object_tree::{find_parent_element, Document, ElementRc, PropertyAnimation};
 use derive_more as dm;
 
+use smol_str::ToSmolStr;
+
 /// Maps the alias in the other direction than what the BindingExpression::two_way_binding does.
 /// So if binding for property A has B in its BindingExpression::two_way_binding, then
 /// ReverseAliases maps B to A.
@@ -478,7 +480,7 @@ fn visit_implicit_layout_info_dependencies(
     item: &ElementRc,
     vis: &mut impl FnMut(&PropertyPath, ReadType),
 ) {
-    let base_type = item.borrow().base_type.to_string();
+    let base_type = item.borrow().base_type.to_smolstr();
     const N: ReadType = ReadType::NativeRead;
     match base_type.as_str() {
         "Image" => {

--- a/internal/compiler/passes/border_radius.rs
+++ b/internal/compiler/passes/border_radius.rs
@@ -6,6 +6,7 @@
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Expression, NamedReference};
 use crate::object_tree::Component;
+use smol_str::SmolStr;
 use std::rc::Rc;
 
 pub const BORDER_RADIUS_PROPERTIES: [&str; 4] = [
@@ -29,7 +30,7 @@ pub fn handle_border_radius(root_component: &Rc<Component>, _diag: &mut BuildDia
             {
                 let border_radius = NamedReference::new(elem, "border-radius");
                 for property_name in BORDER_RADIUS_PROPERTIES.iter() {
-                    elem.borrow_mut().set_binding_if_not_set(property_name.to_string(), || {
+                    elem.borrow_mut().set_binding_if_not_set(SmolStr::new(property_name), || {
                         Expression::PropertyReference(border_radius.clone())
                     });
                 }

--- a/internal/compiler/passes/check_public_api.rs
+++ b/internal/compiler/passes/check_public_api.rs
@@ -71,7 +71,7 @@ pub fn check_public_api(
                 if let Ok(ElementType::Component(c)) = doc.local_registry.lookup_element(name) {
                     if let Some(name_ident) = c.node.clone() {
                         doc.exports.add_reexports(
-                            [(ExportedName{ name: name.clone(), name_ident }, Either::Left(c))],
+                            [(ExportedName{ name: name.into(), name_ident }, Either::Left(c))],
                             diag,
                         );
                     }
@@ -105,7 +105,7 @@ fn check_public_api_component(root_component: &Rc<Component>, diag: &mut BuildDi
             } else {
                 d.expose_in_public_api = true;
                 if d.visibility != PropertyVisibility::Output {
-                    pa.entry(n.to_string()).or_default().is_set = true;
+                    pa.entry(n.clone()).or_default().is_set = true;
                 }
             }
         } else {

--- a/internal/compiler/passes/clip.rs
+++ b/internal/compiler/passes/clip.rs
@@ -3,6 +3,7 @@
 
 //! Pass that lowers synthetic `clip` properties to Clip element
 
+use smol_str::{format_smolstr, SmolStr};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -59,7 +60,7 @@ pub fn handle_clip(
 fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
     let mut parent = parent_elem.borrow_mut();
     let clip = Element::make_rc(Element {
-        id: format!("{}-clip", parent.id),
+        id: format_smolstr!("{}-clip", parent.id),
         base_type: crate::langtype::ElementType::Native(native_clip.clone()),
         children: std::mem::take(&mut parent.children),
         enclosing_component: parent.enclosing_component.clone(),
@@ -72,7 +73,7 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
         .iter()
         .map(|prop| {
             (
-                (*prop).to_owned(),
+                SmolStr::new_static(prop),
                 RefCell::new(
                     Expression::PropertyReference(NamedReference::new(parent_elem, prop)).into(),
                 ),
@@ -91,7 +92,7 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
     } else if parent_elem.borrow().bindings.contains_key("border-radius") {
         for prop in super::border_radius::BORDER_RADIUS_PROPERTIES.iter() {
             clip.borrow_mut().bindings.insert(
-                prop.to_string(),
+                SmolStr::new(prop),
                 RefCell::new(
                     Expression::PropertyReference(NamedReference::new(
                         parent_elem,
@@ -103,7 +104,7 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
         }
     }
     clip.borrow_mut().bindings.insert(
-        "clip".to_owned(),
+        SmolStr::new_static("clip"),
         BindingExpression::new_two_way(NamedReference::new(parent_elem, "clip")).into(),
     );
 }
@@ -111,7 +112,7 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
 fn copy_optional_binding(parent_elem: &ElementRc, optional_binding: &str, clip: &ElementRc) {
     if parent_elem.borrow().bindings.contains_key(optional_binding) {
         clip.borrow_mut().bindings.insert(
-            optional_binding.to_string(),
+            optional_binding.into(),
             RefCell::new(
                 Expression::PropertyReference(NamedReference::new(parent_elem, optional_binding))
                     .into(),

--- a/internal/compiler/passes/collect_custom_fonts.rs
+++ b/internal/compiler/passes/collect_custom_fonts.rs
@@ -7,6 +7,7 @@ use crate::{
     expression_tree::{BuiltinFunction, Expression, Unit},
     object_tree::*,
 };
+use smol_str::SmolStr;
 use std::collections::BTreeSet;
 
 /// Fill the root_component's used_globals
@@ -27,7 +28,7 @@ pub fn collect_custom_fonts<'a>(
         Expression::BuiltinFunctionReference(BuiltinFunction::RegisterCustomFontByPath, None)
     };
 
-    let prepare_font_registration_argument: Box<dyn Fn(&String) -> Expression> = if embed_fonts {
+    let prepare_font_registration_argument: Box<dyn Fn(&SmolStr) -> Expression> = if embed_fonts {
         Box::new(|font_path| {
             Expression::NumberLiteral(
                 {

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -15,6 +15,7 @@ use crate::langtype::ElementType;
 use crate::langtype::Type;
 use crate::object_tree::*;
 use crate::EmbedResourcesKind;
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -153,8 +154,8 @@ fn compile_path_from_string_literal(
     let event_enum = crate::typeregister::BUILTIN_ENUMS.with(|e| e.PathEvent.clone());
     let point_type = Type::Struct {
         fields: IntoIterator::into_iter([
-            ("x".to_owned(), Type::Float32),
-            ("y".to_owned(), Type::Float32),
+            (SmolStr::new_static("x"), Type::Float32),
+            (SmolStr::new_static("y"), Type::Float32),
         ])
         .collect(),
         name: Some("slint::private_api::Point".into()),
@@ -207,8 +208,8 @@ fn compile_path_from_string_literal(
         .map(|point| Expression::Struct {
             ty: point_type.clone(),
             values: IntoIterator::into_iter([
-                ("x".to_owned(), Expression::NumberLiteral(point.x as _, Unit::None)),
-                ("y".to_owned(), Expression::NumberLiteral(point.y as _, Unit::None)),
+                (SmolStr::new_static("x"), Expression::NumberLiteral(point.x as _, Unit::None)),
+                (SmolStr::new_static("y"), Expression::NumberLiteral(point.y as _, Unit::None)),
             ])
             .collect(),
         })

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -7,6 +7,7 @@ use crate::expression_tree::*;
 use crate::langtype::ElementType;
 use crate::langtype::Type;
 use crate::object_tree::*;
+use smol_str::{format_smolstr, ToSmolStr};
 
 pub fn const_propagation(component: &Component) {
     visit_all_expressions(component, |expr, ty| {
@@ -38,7 +39,7 @@ fn simplify_expression(expr: &mut Expression) -> bool {
 
             let new = match (*op, &mut **lhs, &mut **rhs) {
                 ('+', Expression::StringLiteral(a), Expression::StringLiteral(b)) => {
-                    Some(Expression::StringLiteral(format!("{}{}", a, b)))
+                    Some(Expression::StringLiteral(format_smolstr!("{}{}", a, b)))
                 }
                 ('+', Expression::NumberLiteral(a, un1), Expression::NumberLiteral(b, un2))
                     if un1 == un2 =>
@@ -116,7 +117,7 @@ fn simplify_expression(expr: &mut Expression) -> bool {
             } else {
                 match (&**from, to) {
                     (Expression::NumberLiteral(x, Unit::None), Type::String) => {
-                        Some(Expression::StringLiteral((*x).to_string()))
+                        Some(Expression::StringLiteral((*x).to_smolstr()))
                     }
                     (Expression::Struct { values, .. }, to @ Type::Struct { .. }) => {
                         Some(Expression::Struct { ty: to.clone(), values: values.clone() })

--- a/internal/compiler/passes/deduplicate_property_read.rs
+++ b/internal/compiler/passes/deduplicate_property_read.rs
@@ -6,6 +6,7 @@
 use crate::expression_tree::*;
 use crate::langtype::Type;
 use crate::object_tree::*;
+use smol_str::{format_smolstr, SmolStr};
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -72,10 +73,10 @@ impl<'a> DedupPropState<'a> {
         }
     }
 
-    fn get_mapping(&self, nr: &NamedReference) -> Option<String> {
+    fn get_mapping(&self, nr: &NamedReference) -> Option<SmolStr> {
         self.parent_state.and_then(|pr| pr.get_mapping(nr)).or_else(|| {
             if self.counts.borrow().counts.get(nr).map_or(false, |c| *c > 1) {
-                Some(format!("tmp_{}_{}", nr.element().borrow().id, nr.name()))
+                Some(format_smolstr!("tmp_{}_{}", nr.element().borrow().id, nr.name()))
             } else {
                 None
             }

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -19,6 +19,7 @@ use crate::expression_tree::{
 use crate::langtype::{BuiltinElement, DefaultSizeBinding, Type};
 use crate::layout::{implicit_layout_info_call, LayoutConstraints, Orientation};
 use crate::object_tree::{Component, ElementRc};
+use smol_str::format_smolstr;
 use std::collections::HashMap;
 
 pub fn default_geometry(root_component: &Rc<Component>, diag: &mut BuildDiagnostics) {
@@ -254,8 +255,10 @@ fn merge_explicit_constraints(
 ) {
     if constraints.has_explicit_restrictions(orientation) {
         static COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-        let unique_name =
-            format!("layout_info_{}", COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
+        let unique_name = format_smolstr!(
+            "layout_info_{}",
+            COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
         let ty = expr.ty();
         let store = Expression::StoreLocalVariable {
             name: unique_name.clone(),
@@ -366,7 +369,7 @@ fn fix_percent_size(
 /// Generate a size property that covers the parent.
 /// Return true if it was changed
 fn make_default_100(prop: &NamedReference, parent_prop: &NamedReference) -> bool {
-    prop.element().borrow_mut().set_binding_if_not_set(prop.name().to_string(), || {
+    prop.element().borrow_mut().set_binding_if_not_set(prop.name().into(), || {
         Expression::PropertyReference(parent_prop.clone())
     })
 }
@@ -455,9 +458,7 @@ fn make_default_aspect_ratio_preserving_binding(
         op: '*',
     };
 
-    elem.borrow_mut()
-        .bindings
-        .insert(missing_size_property.to_string(), RefCell::new(binding.into()));
+    elem.borrow_mut().bindings.insert(missing_size_property.into(), RefCell::new(binding.into()));
 }
 
 fn maybe_center_in_parent(elem: &ElementRc, parent: &ElementRc, pos_prop: &str, size_prop: &str) {

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -255,7 +255,7 @@ fn embed_glyphs_with_fontdb<'a>(
 
         let resource_id = doc.embedded_file_resources.borrow().len();
         doc.embedded_file_resources.borrow_mut().insert(
-            path.to_string_lossy().to_string(),
+            path.to_string_lossy().into(),
             crate::embedded_resources::EmbeddedResources {
                 id: resource_id,
                 kind: crate::embedded_resources::EmbeddedResourcesKind::BitmapFontData(

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -9,6 +9,7 @@ use crate::langtype::Type;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, Element};
 use crate::typeregister::TypeRegister;
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -79,7 +80,7 @@ pub fn ensure_window(
 
     let mut must_update = HashSet::new();
 
-    let mut base_props: HashSet<String> =
+    let mut base_props: HashSet<SmolStr> =
         new_root.borrow().base_type.property_list().into_iter().map(|x| x.0).collect();
     base_props.extend(win_elem.borrow().bindings.keys().cloned());
     for prop in base_props {

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -14,6 +14,7 @@ use crate::expression_tree::{BindingExpression, Expression, MinMaxOp, NamedRefer
 use crate::langtype::{ElementType, NativeClass};
 use crate::object_tree::{Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
+use smol_str::format_smolstr;
 use std::rc::Rc;
 
 pub fn is_flickable_element(element: &ElementRc) -> bool {
@@ -43,7 +44,7 @@ pub fn handle_flickable(root_component: &Rc<Component>, tr: &TypeRegister) {
 fn create_viewport_element(flickable: &ElementRc, native_empty: &Rc<NativeClass>) {
     let children = std::mem::take(&mut flickable.borrow_mut().children);
     let viewport = Element::make_rc(Element {
-        id: format!("{}-viewport", flickable.borrow().id),
+        id: format_smolstr!("{}-viewport", flickable.borrow().id),
         base_type: ElementType::Native(native_empty.clone()),
         children,
         enclosing_component: flickable.borrow().enclosing_component.clone(),
@@ -55,7 +56,7 @@ fn create_viewport_element(flickable: &ElementRc, native_empty: &Rc<NativeClass>
         if let Some(vp_prop) = prop.strip_prefix("viewport-") {
             // bind the viewport's property to the flickable property, such as:  `width <=> parent.viewport-width`
             viewport.borrow_mut().bindings.insert(
-                vp_prop.to_owned(),
+                vp_prop.into(),
                 BindingExpression::new_two_way(NamedReference::new(flickable, prop)).into(),
             );
         }

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -8,6 +8,7 @@ use crate::expression_tree::{BindingExpression, Expression, NamedReference};
 use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use by_address::ByAddress;
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -456,11 +457,11 @@ fn duplicate_popup(p: &PopupWindow, mapping: &mut Mapping, priority_delta: i32) 
 /// Clone and increase the priority of a binding
 /// and duplicate its animation
 fn duplicate_binding(
-    (k, b): (&String, &RefCell<BindingExpression>),
+    (k, b): (&SmolStr, &RefCell<BindingExpression>),
     mapping: &mut Mapping,
     root_component: &Rc<Component>,
     priority_delta: i32,
-) -> (String, RefCell<BindingExpression>) {
+) -> (SmolStr, RefCell<BindingExpression>) {
     let b = b.borrow();
     let b = BindingExpression {
         expression: b.expression.clone(),

--- a/internal/compiler/passes/lower_absolute_coordinates.rs
+++ b/internal/compiler/passes/lower_absolute_coordinates.rs
@@ -59,11 +59,11 @@ pub fn lower_absolute_coordinates(component: &Rc<Component>) {
                 values: IntoIterator::into_iter(["x", "y"])
                     .map(|coord| {
                         (
-                            coord.to_string(),
+                            coord.into(),
                             Expression::BinaryExpression {
                                 lhs: Expression::StructFieldAccess {
                                     base: parent_position_var.clone(),
-                                    name: coord.to_string(),
+                                    name: coord.into(),
                                 }
                                 .into(),
                                 rhs: Expression::PropertyReference(NamedReference::new(
@@ -78,6 +78,6 @@ pub fn lower_absolute_coordinates(component: &Rc<Component>) {
             },
         ]);
 
-        elem.borrow_mut().bindings.insert(nr.name().to_string(), RefCell::new(binding.into()));
+        elem.borrow_mut().bindings.insert(nr.name().into(), RefCell::new(binding.into()));
     }
 }

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -14,6 +14,7 @@ use crate::layout::*;
 use crate::object_tree::*;
 use crate::typeloader::TypeLoader;
 use crate::typeregister::TypeRegister;
+use smol_str::format_smolstr;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -538,7 +539,7 @@ fn lower_dialog_layout(
                                 dialog_element
                                     .borrow_mut()
                                     .property_declarations
-                                    .entry(format!("{}-clicked", kind))
+                                    .entry(format_smolstr!("{}-clicked", kind))
                                     .or_insert_with(|| PropertyDeclaration {
                                         property_type: clicked_ty,
                                         node: None,
@@ -662,14 +663,14 @@ fn create_layout_item(
         }
         let mut item = item.borrow_mut();
         let b = item.bindings.remove(prop).unwrap();
-        item.bindings.insert(format!("min-{}", prop), b.clone());
-        item.bindings.insert(format!("max-{}", prop), b);
+        item.bindings.insert(format_smolstr!("min-{}", prop), b.clone());
+        item.bindings.insert(format_smolstr!("max-{}", prop), b);
         item.property_declarations.insert(
-            format!("min-{}", prop),
+            format_smolstr!("min-{}", prop),
             PropertyDeclaration { property_type: Type::Percent, ..PropertyDeclaration::default() },
         );
         item.property_declarations.insert(
-            format!("max-{}", prop),
+            format_smolstr!("max-{}", prop),
             PropertyDeclaration { property_type: Type::Percent, ..PropertyDeclaration::default() },
         );
     };
@@ -791,15 +792,15 @@ fn adjust_window_layout(component: &Rc<Component>, prop: &str) {
     {
         let mut root = component.root_element.borrow_mut();
         if let Some(b) = root.bindings.remove(prop) {
-            root.bindings.insert(new_prop.name().to_string(), b);
+            root.bindings.insert(new_prop.name().into(), b);
         };
         let mut analysis = root.property_analysis.borrow_mut();
         if let Some(a) = analysis.remove(prop) {
-            analysis.insert(new_prop.name().to_string(), a);
+            analysis.insert(new_prop.name().into(), a);
         };
         drop(analysis);
         root.bindings.insert(
-            prop.to_string(),
+            prop.into(),
             RefCell::new(Expression::PropertyReference(new_prop.clone()).into()),
         );
     }

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -8,6 +8,7 @@ use crate::expression_tree::{Expression, NamedReference};
 use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use crate::typeregister::TypeRegister;
+use smol_str::format_smolstr;
 use std::rc::{Rc, Weak};
 
 pub fn lower_popups(
@@ -128,7 +129,7 @@ fn lower_popup_window(
     // children should be rendered starting with a (0, 0) offset.
     {
         let mut popup_mut = popup_comp.root_element.borrow_mut();
-        let name = format!("popup-{}-dummy", popup_mut.id);
+        let name = format_smolstr!("popup-{}-dummy", popup_mut.id);
         popup_mut.property_declarations.insert(name.clone(), Type::LogicalLength.into());
         drop(popup_mut);
         let dummy1 = NamedReference::new(&popup_comp.root_element, &name);

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -9,6 +9,7 @@ use crate::expression_tree::{BindingExpression, Expression, NamedReference};
 use crate::langtype::Type;
 use crate::object_tree::{self, Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
+use smol_str::format_smolstr;
 use std::rc::Rc;
 
 /// If any element in `component` declares a binding to `property_name`, then a new
@@ -108,12 +109,12 @@ fn create_property_element(
                     bind.expression = default_value_for_extra_properties(child, property_name)
                 }
             }
-            (property_name.to_string(), bind.into())
+            (property_name.into(), bind.into())
         })
         .collect();
 
     let element = Element {
-        id: format!("{}-{}", child.borrow().id, property_name),
+        id: format_smolstr!("{}-{}", child.borrow().id, property_name),
         base_type: type_register.lookup_element(element_name).unwrap(),
         enclosing_component: child.borrow().enclosing_component.clone(),
         bindings,

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -9,7 +9,7 @@ use crate::expression_tree::{BindingExpression, Expression, NamedReference};
 use crate::langtype::Type;
 use crate::object_tree::{self, Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
-use smol_str::format_smolstr;
+use smol_str::{format_smolstr, ToSmolStr};
 use std::rc::Rc;
 
 /// If any element in `component` declares a binding to `property_name`, then a new
@@ -36,7 +36,7 @@ pub(crate) fn lower_property_to_element(
     }
 
     object_tree::recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
-        if elem.borrow().base_type.to_string() == element_name {
+        if elem.borrow().base_type.to_smolstr() == element_name {
             return;
         }
 

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -10,6 +10,7 @@ use crate::expression_tree::*;
 use crate::langtype::ElementType;
 use crate::langtype::Type;
 use crate::object_tree::*;
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::{Rc, Weak};
@@ -88,7 +89,7 @@ fn lower_state_in_element(
                 true_expr: Box::new(expr),
                 false_expr: Box::new(property_expr),
             };
-            match e.borrow_mut().bindings.entry(ne.name().to_owned()) {
+            match e.borrow_mut().bindings.entry(ne.name().into()) {
                 std::collections::btree_map::Entry::Occupied(mut e) => {
                     e.get_mut().get_mut().expression = new_expr
                 }
@@ -126,7 +127,7 @@ fn lower_state_in_element(
 fn lower_transitions_in_element(
     elem: &ElementRc,
     state_property: Expression,
-    states_id: HashMap<String, i32>,
+    states_id: HashMap<SmolStr, i32>,
     affected_properties: HashSet<NamedReference>,
     diag: &mut BuildDiagnostics,
 ) {
@@ -183,14 +184,14 @@ fn lower_transitions_in_element(
 }
 
 /// Returns a suitable unique name for the "state" property
-fn compute_state_property_name(root_element: &ElementRc) -> String {
+fn compute_state_property_name(root_element: &ElementRc) -> SmolStr {
     let mut property_name = "state".to_owned();
     while root_element.borrow().lookup_property(property_name.as_ref()).property_type
         != Type::Invalid
     {
         property_name += "-";
     }
-    property_name
+    property_name.into()
 }
 
 enum ExpressionForProperty {

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -12,6 +12,7 @@ use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BindingExpression, Expression, MinMaxOp, NamedReference, Unit};
 use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
+use smol_str::{format_smolstr, SmolStr};
 use std::cell::RefCell;
 
 pub async fn lower_tabwidget(
@@ -82,7 +83,10 @@ fn process_tabwidget(
         }
         let index = tabs.len();
         child.borrow_mut().base_type = empty_type.clone();
-        child.borrow_mut().property_declarations.insert("title".to_owned(), Type::String.into());
+        child
+            .borrow_mut()
+            .property_declarations
+            .insert(SmolStr::new_static("title"), Type::String.into());
         set_geometry_prop(elem, child, "x", diag);
         set_geometry_prop(elem, child, "y", diag);
         set_geometry_prop(elem, child, "width", diag);
@@ -95,7 +99,7 @@ fn process_tabwidget(
         let old = child
             .borrow_mut()
             .bindings
-            .insert("visible".to_owned(), RefCell::new(condition.into()));
+            .insert(SmolStr::new_static("visible"), RefCell::new(condition.into()));
         if let Some(old) = old {
             diag.push_error(
                 "The property 'visible' cannot be set for Tabs inside a TabWidget".to_owned(),
@@ -104,36 +108,36 @@ fn process_tabwidget(
         }
 
         let mut tab = Element {
-            id: format!("{}-tab{}", elem.borrow().id, index),
+            id: format_smolstr!("{}-tab{}", elem.borrow().id, index),
             base_type: tab_impl.clone(),
             enclosing_component: elem.borrow().enclosing_component.clone(),
             ..Default::default()
         };
         tab.bindings.insert(
-            "title".to_owned(),
+            SmolStr::new_static("title"),
             BindingExpression::new_two_way(NamedReference::new(child, "title")).into(),
         );
         tab.bindings.insert(
-            "current".to_owned(),
+            SmolStr::new_static("current"),
             BindingExpression::new_two_way(NamedReference::new(elem, "current-index")).into(),
         );
         tab.bindings.insert(
-            "current-focused".to_owned(),
+            SmolStr::new_static("current-focused"),
             BindingExpression::new_two_way(NamedReference::new(elem, "current-focused")).into(),
         );
         tab.bindings.insert(
-            "tab-index".to_owned(),
+            SmolStr::new_static("tab-index"),
             RefCell::new(Expression::NumberLiteral(index as _, Unit::None).into()),
         );
         tab.bindings.insert(
-            "num-tabs".to_owned(),
+            SmolStr::new_static("num-tabs"),
             RefCell::new(Expression::NumberLiteral(num_tabs as _, Unit::None).into()),
         );
         tabs.push(Element::make_rc(tab));
     }
 
     let tabbar = Element {
-        id: format!("{}-tabbar", elem.borrow().id),
+        id: format_smolstr!("{}-tabbar", elem.borrow().id),
         base_type: tabbar_impl,
         enclosing_component: elem.borrow().enclosing_component.clone(),
         children: tabs,
@@ -145,23 +149,23 @@ fn process_tabwidget(
     set_tabbar_geometry_prop(elem, &tabbar, "width");
     set_tabbar_geometry_prop(elem, &tabbar, "height");
     tabbar.borrow_mut().bindings.insert(
-        "num-tabs".to_owned(),
+        SmolStr::new_static("num-tabs"),
         RefCell::new(Expression::NumberLiteral(num_tabs as _, Unit::None).into()),
     );
     tabbar.borrow_mut().bindings.insert(
-        "current".to_owned(),
+        SmolStr::new_static("current"),
         BindingExpression::new_two_way(NamedReference::new(elem, "current-index")).into(),
     );
     elem.borrow_mut().bindings.insert(
-        "current-focused".to_owned(),
+        SmolStr::new_static("current-focused"),
         BindingExpression::new_two_way(NamedReference::new(&tabbar, "current-focused")).into(),
     );
     elem.borrow_mut().bindings.insert(
-        "tabbar-preferred-width".to_owned(),
+        SmolStr::new_static("tabbar-preferred-width"),
         BindingExpression::new_two_way(NamedReference::new(&tabbar, "preferred-width")).into(),
     );
     elem.borrow_mut().bindings.insert(
-        "tabbar-preferred-height".to_owned(),
+        SmolStr::new_static("tabbar-preferred-height"),
         BindingExpression::new_two_way(NamedReference::new(&tabbar, "preferred-height")).into(),
     );
 

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -11,6 +11,7 @@ use crate::langtype::{ElementType, Type};
 use crate::layout::Orientation;
 use crate::namedreference::NamedReference;
 use crate::object_tree::*;
+use smol_str::SmolStr;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
@@ -47,7 +48,7 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
         let elem = nr.element();
 
         elem.borrow_mut().property_declarations.insert(
-            nr.name().to_owned(),
+            nr.name().into(),
             PropertyDeclaration { property_type: ty, ..PropertyDeclaration::default() },
         );
 
@@ -84,7 +85,7 @@ fn must_initialize(elem: &Element, prop: &str) -> bool {
 
 /// Returns a type if the property needs to be materialized.
 fn should_materialize(
-    property_declarations: &BTreeMap<String, PropertyDeclaration>,
+    property_declarations: &BTreeMap<SmolStr, PropertyDeclaration>,
     base_type: &ElementType,
     prop: &str,
 ) -> Option<Type> {

--- a/internal/compiler/passes/move_declarations.rs
+++ b/internal/compiler/passes/move_declarations.rs
@@ -7,11 +7,12 @@ use crate::expression_tree::{Expression, NamedReference};
 use crate::langtype::ElementType;
 use crate::object_tree::*;
 use core::cell::RefCell;
+use smol_str::{format_smolstr, SmolStr};
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
 struct Declarations {
-    property_declarations: BTreeMap<String, PropertyDeclaration>,
+    property_declarations: BTreeMap<SmolStr, PropertyDeclaration>,
 }
 impl Declarations {
     fn take_from_element(e: &mut Element) -> Self {
@@ -75,7 +76,7 @@ fn do_move_declarations(component: &Rc<Component>) {
 
         // Also move the changed callback
         let change_callbacks = core::mem::take(&mut elem.borrow_mut().change_callbacks);
-        let mut new_change_callbacks = BTreeMap::<String, RefCell<Vec<Expression>>>::default();
+        let mut new_change_callbacks = BTreeMap::<SmolStr, RefCell<Vec<Expression>>>::default();
         for (k, e) in change_callbacks {
             let will_be_moved = elem.borrow().property_declarations.contains_key(&k);
             if will_be_moved {
@@ -138,8 +139,8 @@ fn fixup_reference(nr: &mut NamedReference) {
     }
 }
 
-fn map_name(e: &ElementRc, s: &str) -> String {
-    format!("{}-{}", e.borrow().id, s)
+fn map_name(e: &ElementRc, s: &str) -> SmolStr {
+    format_smolstr!("{}-{}", e.borrow().id, s)
 }
 
 fn simplify_optimized_items_recursive(component: &Rc<Component>) {

--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -136,7 +136,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
             &elem.borrow().enclosing_component,
             &to_elem.borrow().enclosing_component,
         );
-        match to_elem.borrow_mut().bindings.entry(to.name().to_owned()) {
+        match to_elem.borrow_mut().bindings.entry(to.name().into()) {
             Entry::Occupied(mut e) => {
                 let b = e.get_mut().get_mut();
                 remove_from_binding_expression(b, &to);
@@ -159,10 +159,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
             let mut elem = elem.borrow_mut();
             if let Some(old_change_callback) = elem.change_callbacks.remove(remove.name()) {
                 drop(elem);
-                to_elem
-                    .borrow_mut()
-                    .change_callbacks
-                    .insert(to.name().to_owned(), old_change_callback);
+                to_elem.borrow_mut().change_callbacks.insert(to.name().into(), old_change_callback);
             }
         }
 
@@ -189,7 +186,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
                             .borrow()
                             .property_analysis
                             .borrow_mut()
-                            .entry(to.name().to_owned())
+                            .entry(to.name().into())
                             .or_default()
                             .merge(&analysis);
                     };
@@ -197,7 +194,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
             } else {
                 // This is not a declaration, we must re-create the binding
                 elem.bindings.insert(
-                    remove.name().to_owned(),
+                    remove.name().into(),
                     BindingExpression::new_two_way(to.clone()).into(),
                 );
                 drop(elem);

--- a/internal/compiler/passes/unique_id.rs
+++ b/internal/compiler/passes/unique_id.rs
@@ -30,7 +30,7 @@ fn assign_unique_id_in_component(component: &Rc<Component>, count: &mut u32) {
         let old_id = if !elem_mut.id.is_empty() {
             elem_mut.id.clone()
         } else {
-            elem_mut.base_type.to_string().to_ascii_lowercase().into()
+            elem_mut.base_type.to_smolstr().to_ascii_lowercase().into()
         };
         elem_mut.id = format_smolstr!("{}-{}", old_id, count);
 

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -3,6 +3,7 @@
 
 //! Pass that lowers synthetic `visible` properties to Clip element
 
+use smol_str::{format_smolstr, SmolStr};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -82,11 +83,11 @@ pub fn handle_visible(
 
 fn create_visibility_element(child: &ElementRc, native_clip: &Rc<NativeClass>) -> ElementRc {
     let element = Element {
-        id: format!("{}-visibility", child.borrow().id),
+        id: format_smolstr!("{}-visibility", child.borrow().id),
         base_type: ElementType::Native(native_clip.clone()),
         enclosing_component: child.borrow().enclosing_component.clone(),
         bindings: std::iter::once((
-            "clip".to_owned(),
+            SmolStr::new_static("clip"),
             RefCell::new(
                 Expression::UnaryOp {
                     sub: Box::new(Expression::PropertyReference(NamedReference::new(

--- a/internal/compiler/tests/consistent_styles.rs
+++ b/internal/compiler/tests/consistent_styles.rs
@@ -8,6 +8,7 @@ use i_slint_compiler::langtype::Type;
 use i_slint_compiler::object_tree::PropertyVisibility;
 use i_slint_compiler::typeloader::TypeLoader;
 use i_slint_compiler::typeregister::TypeRegister;
+use smol_str::{SmolStr, ToSmolStr};
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::fmt::Display;
@@ -34,8 +35,8 @@ struct Component {
 
 #[derive(Default)]
 struct Style {
-    components: BTreeMap<String, Component>,
-    structs: BTreeMap<String, Type>,
+    components: BTreeMap<SmolStr, Component>,
+    structs: BTreeMap<SmolStr, Type>,
 }
 
 fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> Component {
@@ -49,7 +50,7 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
                 .filter(|(_, v)| v.visibility != PropertyVisibility::Private)
                 .map(|(k, v)| {
                     (
-                        k.clone(),
+                        k.to_string(),
                         PropertyInfo {
                             ty: v.property_type.clone(),
                             vis: v.visibility,
@@ -64,7 +65,7 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
                 match &role.borrow().expression {
                     Expression::Invalid => (),
                     Expression::EnumerationValue(e) => {
-                        result.accessible_role = Some(e.enumeration.values[e.value].clone())
+                        result.accessible_role = Some(e.enumeration.values[e.value].to_string())
                     }
                     e => panic!(
                         "accessible-role not an EnumerationValue : {e:?}    (for {:?})",
@@ -78,12 +79,12 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
             i_slint_compiler::langtype::ElementType::Component(r) => r.root_element.clone(),
             i_slint_compiler::langtype::ElementType::Builtin(b) => {
                 let builtins = i_slint_compiler::typeregister::reserved_properties()
-                    .map(|x| x.0.to_owned())
+                    .map(|x| x.0.to_smolstr())
                     .collect::<HashSet<_>>();
                 result.properties.extend(
                     b.properties.iter().filter(|(k, _)| !builtins.contains(*k)).map(|(k, v)| {
                         (
-                            k.clone(),
+                            k.to_string(),
                             PropertyInfo {
                                 ty: v.ty.clone(),
                                 vis: v.property_visibility,

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -42,9 +43,9 @@ pub struct ImportedTypes {
 #[derive(Debug)]
 pub struct ImportedName {
     // name of export to match in the other file
-    pub external_name: String,
+    pub external_name: SmolStr,
     // name to be used locally
-    pub internal_name: String,
+    pub internal_name: SmolStr,
 }
 
 impl ImportedName {

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use smol_str::SmolStr;
+use smol_str::{SmolStr, ToSmolStr};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -59,10 +59,10 @@ impl ImportedName {
 
     pub fn from_node(importident: syntax_nodes::ImportIdentifier) -> Self {
         let external_name =
-            parser::normalize_identifier(importident.ExternalName().text().to_string().trim());
+            parser::normalize_identifier(importident.ExternalName().text().to_smolstr().trim());
 
         let internal_name = match importident.InternalName() {
-            Some(name_ident) => parser::normalize_identifier(name_ident.text().to_string().trim()),
+            Some(name_ident) => parser::normalize_identifier(name_ident.text().to_smolstr().trim()),
             None => external_name.clone(),
         };
 

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -134,6 +134,7 @@ document-features = { version = "0.2.0", optional = true }
 spin_on = { workspace = true, optional = true }
 raw-window-handle-06 = { workspace = true, optional = true }
 itertools = { workspace = true }
+smol_str = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 i-slint-backend-winit = { workspace = true }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -962,7 +962,7 @@ impl ComponentDefinition {
         // We create here a 'static guard, because unfortunately the returned type would be restricted to the guard lifetime
         // which is not required, but this is safe because there is only one instance of the unerased type
         let guard = unsafe { generativity::Guard::new(generativity::Id::new()) };
-        self.inner.unerase(guard).properties()
+        self.inner.unerase(guard).properties().map(|(s, t)| (s.to_string(), t))
     }
 
     /// Returns an iterator over all publicly declared properties. Each iterator item is a tuple of property name
@@ -973,7 +973,7 @@ impl ComponentDefinition {
         let guard = unsafe { generativity::Guard::new(generativity::Id::new()) };
         self.inner.unerase(guard).properties().filter_map(|(prop_name, prop_type)| {
             if prop_type.is_property_type() {
-                Some((prop_name, prop_type.into()))
+                Some((prop_name.to_string(), prop_type.into()))
             } else {
                 None
             }
@@ -987,7 +987,7 @@ impl ComponentDefinition {
         let guard = unsafe { generativity::Guard::new(generativity::Id::new()) };
         self.inner.unerase(guard).properties().filter_map(|(prop_name, prop_type)| {
             if matches!(prop_type, LangType::Callback { .. }) {
-                Some(prop_name)
+                Some(prop_name.to_string())
             } else {
                 None
             }
@@ -1001,7 +1001,7 @@ impl ComponentDefinition {
         let guard = unsafe { generativity::Guard::new(generativity::Id::new()) };
         self.inner.unerase(guard).properties().filter_map(|(prop_name, prop_type)| {
             if matches!(prop_type, LangType::Function { .. }) {
-                Some(prop_name)
+                Some(prop_name.to_string())
             } else {
                 None
             }
@@ -1016,7 +1016,7 @@ impl ComponentDefinition {
         // We create here a 'static guard, because unfortunately the returned type would be restricted to the guard lifetime
         // which is not required, but this is safe because there is only one instance of the unerased type
         let guard = unsafe { generativity::Guard::new(generativity::Id::new()) };
-        self.inner.unerase(guard).global_names()
+        self.inner.unerase(guard).global_names().map(|s| s.to_string())
     }
 
     /// List of publicly declared properties or callback in the exported global singleton specified by its name.
@@ -1031,7 +1031,10 @@ impl ComponentDefinition {
         // We create here a 'static guard, because unfortunately the returned type would be restricted to the guard lifetime
         // which is not required, but this is safe because there is only one instance of the unerased type
         let guard = unsafe { generativity::Guard::new(generativity::Id::new()) };
-        self.inner.unerase(guard).global_properties(global_name)
+        self.inner
+            .unerase(guard)
+            .global_properties(global_name)
+            .map(|o| o.map(|(s, t)| (s.to_string(), t)))
     }
 
     /// List of publicly declared properties in the exported global singleton specified by its name.
@@ -1045,7 +1048,7 @@ impl ComponentDefinition {
         self.inner.unerase(guard).global_properties(global_name).map(|iter| {
             iter.filter_map(|(prop_name, prop_type)| {
                 if prop_type.is_property_type() {
-                    Some((prop_name, prop_type.into()))
+                    Some((prop_name.to_string(), prop_type.into()))
                 } else {
                     None
                 }
@@ -1061,7 +1064,7 @@ impl ComponentDefinition {
         self.inner.unerase(guard).global_properties(global_name).map(|iter| {
             iter.filter_map(|(prop_name, prop_type)| {
                 if matches!(prop_type, LangType::Callback { .. }) {
-                    Some(prop_name)
+                    Some(prop_name.to_string())
                 } else {
                     None
                 }
@@ -1077,7 +1080,7 @@ impl ComponentDefinition {
         self.inner.unerase(guard).global_properties(global_name).map(|iter| {
             iter.filter_map(|(prop_name, prop_type)| {
                 if matches!(prop_type, LangType::Function { .. }) {
-                    Some(prop_name)
+                    Some(prop_name.to_string())
                 } else {
                     None
                 }

--- a/internal/interpreter/global_component.rs
+++ b/internal/interpreter/global_component.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use core::pin::Pin;
+use smol_str::SmolStr;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
@@ -19,7 +20,7 @@ pub struct CompiledGlobalCollection {
     pub compiled_globals: Vec<CompiledGlobal>,
     /// Map of all exported global singletons and their index in the compiled_globals vector. The key
     /// is the normalized name of the global.
-    pub exported_globals_by_name: BTreeMap<String, usize>,
+    pub exported_globals_by_name: BTreeMap<SmolStr, usize>,
 }
 
 impl CompiledGlobalCollection {
@@ -59,21 +60,21 @@ pub type GlobalStorage = HashMap<String, Pin<Rc<dyn GlobalComponent>>>;
 
 pub enum CompiledGlobal {
     Builtin {
-        name: String,
+        name: SmolStr,
         element: Rc<i_slint_compiler::langtype::BuiltinElement>,
         // dummy needed for iterator accessor
-        public_properties: BTreeMap<String, PropertyDeclaration>,
+        public_properties: BTreeMap<SmolStr, PropertyDeclaration>,
         /// keep the Component alive as it is boing referenced by `NamedReference`s
         _original: Rc<Component>,
     },
     Component {
         component: ErasedItemTreeDescription,
-        public_properties: BTreeMap<String, PropertyDeclaration>,
+        public_properties: BTreeMap<SmolStr, PropertyDeclaration>,
     },
 }
 
 impl CompiledGlobal {
-    pub fn names(&self) -> Vec<String> {
+    pub fn names(&self) -> Vec<SmolStr> {
         match self {
             CompiledGlobal::Builtin { name, .. } => vec![name.clone()],
             CompiledGlobal::Component { component, .. } => {
@@ -98,7 +99,7 @@ impl CompiledGlobal {
         }
     }
 
-    pub fn public_properties(&self) -> impl Iterator<Item = (&String, &PropertyDeclaration)> + '_ {
+    pub fn public_properties(&self) -> impl Iterator<Item = (&SmolStr, &PropertyDeclaration)> + '_ {
         match self {
             CompiledGlobal::Builtin { public_properties, .. } => public_properties.iter(),
             CompiledGlobal::Component { public_properties, .. } => public_properties.iter(),
@@ -107,7 +108,7 @@ impl CompiledGlobal {
 
     pub fn extend_public_properties(
         &mut self,
-        iter: impl IntoIterator<Item = (String, PropertyDeclaration)>,
+        iter: impl IntoIterator<Item = (SmolStr, PropertyDeclaration)>,
     ) {
         match self {
             CompiledGlobal::Builtin { public_properties, .. } => public_properties.extend(iter),

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -7,6 +7,7 @@ use crate::dynamic_item_tree::{DynamicComponentVRc, ItemTreeBox};
 use i_slint_compiler::object_tree::{Component, Element, ElementRc};
 use i_slint_core::items::ItemRc;
 use i_slint_core::lengths::LogicalRect;
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
@@ -88,7 +89,7 @@ pub(crate) fn element_node_at_source_code_position(
 }
 
 fn fill_highlight_data(
-    repeater_path: &[String],
+    repeater_path: &[SmolStr],
     element: &ElementRc,
     component_instance: &ItemTreeBox,
     root_component_instance: &ItemTreeBox,
@@ -165,7 +166,7 @@ fn find_element_node_at_source_code_position(
     result
 }
 
-fn repeater_path(elem: &ElementRc) -> Option<Vec<String>> {
+fn repeater_path(elem: &ElementRc) -> Option<Vec<SmolStr>> {
     let enclosing = elem.borrow().enclosing_component.upgrade().unwrap();
     if let Some(parent) = enclosing.parent_element.upgrade() {
         // This is not a repeater, it might be a popup menu which is not supported ATM

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -86,6 +86,7 @@ itertools = { workspace = true }
 lsp-types = { version = "0.95.0", features = ["proposed"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+smol_str = { workspace = true }
 
 # for the preview-engine feature
 i-slint-backend-selector = { workspace = true, optional = true }

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -366,7 +366,7 @@ mod tests {
     fn id_at_position(dc: &DocumentCache, url: &Url, line: u32, character: u32) -> Option<String> {
         let result = dc.element_at_position(url, &lsp_types::Position { line, character })?;
         let element = result.element.borrow();
-        Some(element.id.clone())
+        Some(element.id.to_string())
     }
 
     fn base_type_at_position(

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1002,7 +1002,7 @@ fn get_document_symbols(
             Some(DocumentSymbol {
                 range: util::node_to_lsp_range(&component_node),
                 selection_range,
-                name: c.id.clone(),
+                name: c.id.to_string(),
                 kind: if c.is_global() {
                     lsp_types::SymbolKind::OBJECT
                 } else {
@@ -1020,14 +1020,14 @@ fn get_document_symbols(
             selection_range: util::node_to_lsp_range(
                 &node.parent()?.child_node(SyntaxKind::DeclaredIdentifier)?,
             ),
-            name: name.clone(),
+            name: name.to_string(),
             kind: lsp_types::SymbolKind::STRUCT,
             ..ds.clone()
         }),
         Type::Enumeration(enumeration) => enumeration.node.as_ref().map(|node| DocumentSymbol {
             range: util::node_to_lsp_range(node),
             selection_range: util::node_to_lsp_range(&node.DeclaredIdentifier()),
-            name: enumeration.name.clone(),
+            name: enumeration.name.to_string(),
             kind: lsp_types::SymbolKind::ENUM,
             ..ds.clone()
         }),
@@ -1050,7 +1050,7 @@ fn get_document_symbols(
                         element_node.QualifiedName().as_ref()?,
                     ),
                     name: e.base_type.to_string(),
-                    detail: (!e.id.is_empty()).then(|| e.id.clone()),
+                    detail: (!e.id.is_empty()).then(|| e.id.to_string()),
                     kind: lsp_types::SymbolKind::VARIABLE,
                     children: gen_children(child, ds),
                     ..ds.clone()

--- a/tools/lsp/language/token_info.rs
+++ b/tools/lsp/language/token_info.rs
@@ -10,6 +10,7 @@ use i_slint_compiler::namedreference::NamedReference;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{syntax_nodes, SyntaxKind, SyntaxToken};
 use i_slint_compiler::pathutils::clean_path;
+use smol_str::{SmolStr, ToSmolStr};
 use std::path::Path;
 
 pub enum TokenInfo {
@@ -21,7 +22,7 @@ pub enum TokenInfo {
     FileName(std::path::PathBuf),
     LocalProperty(syntax_nodes::PropertyDeclaration),
     LocalCallback(syntax_nodes::CallbackDeclaration),
-    IncompleteNamedReference(ElementType, String),
+    IncompleteNamedReference(ElementType, SmolStr),
 }
 
 pub fn token_info(document_cache: &mut DocumentCache, token: SyntaxToken) -> Option<TokenInfo> {
@@ -194,5 +195,5 @@ fn find_property_declaration_in_base(
         .unwrap_or(&global_tr);
 
     let element_type = crate::util::lookup_current_element_type((*element).clone(), tr)?;
-    Some(TokenInfo::IncompleteNamedReference(element_type, prop_name.to_string()))
+    Some(TokenInfo::IncompleteNamedReference(element_type, prop_name.to_smolstr()))
 }

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -190,7 +190,10 @@ fn property_declaration_ranges(name: slint::SharedString) -> ui::PropertyDeclara
         .with(|preview_state| {
             let preview_state = preview_state.borrow();
 
-            preview_state.property_range_declarations.as_ref().and_then(|d| d.get(&name).cloned())
+            preview_state
+                .property_range_declarations
+                .as_ref()
+                .and_then(|d| d.get(name.as_str()).cloned())
         })
         .unwrap_or_default()
 }

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -8,6 +8,7 @@ use i_slint_compiler::object_tree;
 use i_slint_compiler::parser::{syntax_nodes, SyntaxKind, SyntaxNode, SyntaxToken};
 use i_slint_compiler::parser::{TextRange, TextSize};
 use i_slint_compiler::typeregister::TypeRegister;
+use smol_str::SmolStr;
 
 use crate::common;
 
@@ -146,12 +147,12 @@ pub fn lookup_current_element_type(mut node: SyntaxNode, tr: &TypeRegister) -> O
 #[derive(Debug)]
 pub struct ExpressionContextInfo {
     element: syntax_nodes::Element,
-    property_name: String,
+    property_name: SmolStr,
     is_animate: bool,
 }
 
 impl ExpressionContextInfo {
-    pub fn new(element: syntax_nodes::Element, property_name: String, is_animate: bool) -> Self {
+    pub fn new(element: syntax_nodes::Element, property_name: SmolStr, is_animate: bool) -> Self {
         ExpressionContextInfo { element, property_name, is_animate }
     }
 }
@@ -293,12 +294,12 @@ fn lookup_expression_context(mut n: SyntaxNode) -> Option<ExpressionContextInfo>
             }
             SyntaxKind::ConditionalElement | SyntaxKind::RepeatedElement => {
                 let element = syntax_nodes::Element::new(n.parent()?)?;
-                break (element, "$model".to_string(), false);
+                break (element, "$model".into(), false);
             }
             SyntaxKind::Element => {
                 // oops: missed it
                 let element = syntax_nodes::Element::new(n)?;
-                break (element, String::new(), false);
+                break (element, SmolStr::default(), false);
             }
             _ => n = n.parent()?,
         }

--- a/tools/tr-extractor/Cargo.toml
+++ b/tools/tr-extractor/Cargo.toml
@@ -19,6 +19,7 @@ i-slint-compiler = { workspace = true, features = ["default", "display-diagnosti
 chrono = {version = "0.4.24", default-features = false, features = ["clock"] }
 clap = { workspace = true }
 polib = "0.2"
+smol_str = { workspace = true }
 
 [dev-dependencies]
 itertools = { workspace = true }

--- a/tools/tr-extractor/main.rs
+++ b/tools/tr-extractor/main.rs
@@ -4,6 +4,7 @@
 use clap::Parser;
 use i_slint_compiler::diagnostics::{BuildDiagnostics, Spanned};
 use i_slint_compiler::parser::{syntax_nodes, SyntaxKind, SyntaxNode};
+use smol_str::SmolStr;
 use std::fmt::Write;
 
 type Messages = polib::catalog::Catalog;
@@ -94,7 +95,7 @@ fn process_file(path: std::path::PathBuf, messages: &mut Messages) -> std::io::R
     Ok(())
 }
 
-fn visit_node(node: SyntaxNode, results: &mut Messages, current_context: Option<String>) {
+fn visit_node(node: SyntaxNode, results: &mut Messages, current_context: Option<SmolStr>) {
     for n in node.children() {
         if n.kind() == SyntaxKind::AtTr {
             if let Some(msgid) = n
@@ -146,16 +147,16 @@ fn visit_node(node: SyntaxNode, results: &mut Messages, current_context: Option<
                 } else {
                     let mut builder = if let Some(plural) = plural {
                         let mut builder = polib::message::Message::build_plural();
-                        builder.with_msgid_plural(plural);
+                        builder.with_msgid_plural(plural.into());
                         // Workaround for #4238 : poedit doesn't add the plural by default.
                         builder.with_msgstr_plural(vec![String::new(), String::new()]);
                         builder
                     } else {
                         polib::message::Message::build_singular()
                     };
-                    builder.with_msgid(msgid);
+                    builder.with_msgid(msgid.into());
                     if let Some(msgctxt) = msgctxt {
-                        builder.with_msgctxt(msgctxt);
+                        builder.with_msgctxt(msgctxt.into());
                     }
                     let mut msg = builder.done();
                     update(&mut msg);

--- a/tools/updater/Cargo.toml
+++ b/tools/updater/Cargo.toml
@@ -24,6 +24,7 @@ codemap = "0.1"
 codemap-diagnostic = "0.1.1"
 spin_on = { workspace = true }
 by_address = { workspace = true }
+smol_str = { workspace = true }
 
 [[bin]]
 name = "slint-updater"

--- a/tools/updater/main.rs
+++ b/tools/updater/main.rs
@@ -10,6 +10,7 @@ use i_slint_compiler::diagnostics::BuildDiagnostics;
 use i_slint_compiler::object_tree::{self, Component, Document, ElementRc};
 use i_slint_compiler::parser::{syntax_nodes, NodeOrToken, SyntaxKind, SyntaxNode};
 use i_slint_compiler::typeloader::TypeLoader;
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::io::{BufWriter, Write};
 use std::path::Path;
@@ -168,7 +169,7 @@ fn init_state(syntax_node: &SyntaxNode, diag: &mut BuildDiagnostics) -> State {
 #[derive(Default, Clone)]
 struct State {
     /// When visiting a binding, this is the name of the current property
-    property_name: Option<String>,
+    property_name: Option<SmolStr>,
 
     /// The Document being visited
     current_doc: Option<Rc<Document>>,
@@ -201,7 +202,7 @@ fn visit_node(
                     &syntax_nodes::Component::from(node.clone())
                         .DeclaredIdentifier()
                         .child_text(SyntaxKind::Identifier)
-                        .unwrap_or(String::new()),
+                        .unwrap_or(SmolStr::default()),
                 );
 
                 state.current_component =

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -65,6 +65,7 @@ shlex = "1"
 spin_on = { workspace = true }
 env_logger = "0.11.0"
 itertools = { workspace = true }
+smol_str = { workspace = true }
 
 # Enable image-rs' default features to make all image formats available for preview
 image = { workspace = true, features = ["default"] }


### PR DESCRIPTION
Use SmolStr in more places to reduce the number of string allocations. This slightly improves runtime performance too.

Originally, on my laptop, I measured:

```
    Benchmark 1: ./target/release/slint-viewer ../slint-perf/app.slint
      Time (mean ± σ):     676.6 ms ±  15.6 ms    [User: 594.6 ms, System: 77.4 ms]
      Range (min … max):   662.9 ms … 703.4 ms    10 runs
    
            allocations:            5202354
            temporary allocations:  857511
```

After the last patch this goes down to:

```
    Benchmark 1: ./target/release/slint-viewer ../slint-perf/app.slint
      Time (mean ± σ):     622.6 ms ±  13.9 ms    [User: 556.6 ms, System: 63.5 ms]
      Range (min … max):   609.7 ms … 645.4 ms    10 runs
    
            allocations:            3371931
            temporary allocations:  459315
```