### PR TITLE
live-preview: Always consider min/max size of the preview

### DIFF
--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -256,24 +256,22 @@ export component PreviewView {
                 width: preview-area-container.width;
                 height: preview-area-container.height;
 
-                // Also make a condition that abuses the fact that the init callback
-                // is called every time the condition is dirty, to make sure that the size
-                // is within the bounds.
-                // Query the preview-area to make sure this is evaluated when it changes
                 changed component-factory => {
                     if Api.resize-to-preferred-size {
                         self.target-width = preview-area-container.preferred-width.abs() < 0.5px ? drawing-rect.width - scroll-view.border : preview-area-container.preferred-width;
                         self.target-height = preview-area-container.preferred-height.abs() < 0.5px ? drawing-rect.height - scroll-view.border : preview-area-container.preferred-height;
 
-                        preview-area-container.width = clamp(self.target-width, max(preview-area-container.min-width, 16px), max(preview-area-container.max-width, 16px));
-                        preview-area-container.height = clamp(self.target-height, max(preview-area-container.min-height, 16px), max(preview-area-container.max-height, 16px));
-
+                        resize-to-preview-constraints(self.target-width, self.target-height);
                     } else {
-                        preview-area-container.width = clamp(preview-area-container.width, max(preview-area-container.min-width, 16px), max(preview-area-container.max-width, 16px));
-                        preview-area-container.height = clamp(preview-area-container.height, max(preview-area-container.min-height, 16px),  max(preview-area-container.max-height, 16px));
+                        resize-to-preview-constraints(preview-area-container.width, preview-area-container.height);
                     }
 
                     Api.resize-to-preferred-size = false;
+                }
+
+                function resize-to-preview-constraints(width: length, height: length) {
+                    preview-area-container.width = clamp(width, max(preview-area-container.min-width, 16px), max(preview-area-container.max-width, 16px));
+                    preview-area-container.height = clamp(height, max(preview-area-container.min-height, 16px),  max(preview-area-container.max-height, 16px));
                 }
 
                 Rectangle {
@@ -294,6 +292,14 @@ export component PreviewView {
                             init => {
                                 self.width = max(self.preferred-width, self.min-width);
                                 self.height = max(self.preferred-height, self.min-height);
+                            }
+
+                            changed min-width => {
+                                main-resizer.resize-to-preview-constraints(self.width, self.height);
+                            }
+
+                            changed max-width => {
+                                main-resizer.resize-to-preview-constraints(self.width, self.height);
                             }
                         }
                     }


### PR DESCRIPTION
Consider changes to min/max size of the preview whenever they change and extract some common lines into a function.

Fixes: #6377