### PR TITLE
TextInput: don't reset mouse cursor when left-clicking

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -632,6 +632,8 @@ impl Item for TextInput {
                 );
                 self.paste_clipboard(window_adapter, self_rc, Clipboard::SelectionClipboard);
             }
+            // Other mouse buttons should still be accepted even if we don't handle them
+            MouseEvent::Released { .. } => {}
             MouseEvent::Exit => {
                 if let Some(x) = window_adapter.internal(crate::InternalToken) {
                     x.set_mouse_cursor(super::MouseCursor::Default);

--- a/tests/cases/widgets/textedit.slint
+++ b/tests/cases/widgets/textedit.slint
@@ -32,12 +32,26 @@ instance.on_edited({
     edits.borrow_mut().push(val);
 }});
 
-slint_testing::send_mouse_click(&instance, 5., 5.);
+slint_testing::send_mouse_click(&instance, 25., 25.);
 assert!(instance.get_textedit_focused());
 assert!(edits.borrow().is_empty());
 
 slint_testing::send_keyboard_string_sequence(&instance, "hello");
 assert_eq!(edits.borrow().clone(), vec!["h", "he", "hel", "hell", "hello"]);
+
+
+// Test mouse cursor for issue 6444
+use slint::{LogicalPosition, platform::{WindowEvent, PointerEventButton}};
+use slint::private_unstable_api::re_exports::MouseCursor;
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Text, "after previous click");
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(50.0, 50.0), button: PointerEventButton::Right });
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Text, "right button pressed");
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(50.0, 50.0), button: PointerEventButton::Right });
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Text, "right button released");
+instance.window().dispatch_event(WindowEvent::PointerExited { });
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
+
+
 ```
 
 */


### PR DESCRIPTION
ChangeLog: Fixed TextInput mouse cursor after left click

Fixes #6444
