### PR TITLE
live-preview: Reselect element after preview area changed size

### DIFF
--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -301,6 +301,14 @@ export component PreviewView {
                             changed max-width => {
                                 main-resizer.resize-to-preview-constraints(self.width, self.height);
                             }
+
+                            changed width => {
+                                Api.reselect();
+                            }
+
+                            changed height => {
+                                Api.reselect();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This covers one case where the selection rectangles are wrong: When the window size changes.

Fixes: #6438