### PR TITLE
Node.js: Fix imagefilter model rowData() to be correct

### DIFF
--- a/examples/imagefilter/node/main.ts
+++ b/examples/imagefilter/node/main.ts
@@ -34,8 +34,8 @@ class Filters extends slint.Model<string> {
         return this.#filters.length;
     }
 
-    rowData(row: number): string {
-        return this.#filters[row].name;
+    rowData(row: number): string | undefined {
+        return this.#filters[row]?.name;
     }
 
     setRowData(row: number, data: string): void {


### PR DESCRIPTION
When called with an out of bounds row, undefined should be returned, instead of an exception be thrown.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
