### PR TITLE
Add PlatformBuilder API for requesting backend features

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -399,6 +399,8 @@ macro_rules! init_translations {
 pub mod platform {
     pub use i_slint_core::platform::*;
 
+    pub use i_slint_backend_selector::PlatformBuilder;
+
     /// This module contains the [`femtovg_renderer::FemtoVGRenderer`] and related types.
     ///
     /// It is only enabled when the `renderer-femtovg` Slint feature is enabled.

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -221,6 +221,7 @@ impl AndroidWindowAdapter {
                         Rc::new(w),
                         Rc::new(raw_window_handle::DisplayHandle::android()),
                         size,
+                        None,
                     )?;
                     self.resize();
                 }

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -61,6 +61,7 @@ impl SkiaRendererAdapter {
                 display.clone(),
                 display.clone(),
                 size,
+                None,
                 display.config_template_builder(),
                 Some(&|config| display.filter_gl_config(config)),
             )?;

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -84,17 +84,16 @@ impl PlatformBuilder {
     /// use i_slint_backend_selector::PlatformBuilder;
     ///
     /// let platform = PlatformBuilder::new()
-    ///     .with_opengl_api(OpenGLAPI::GL)
+    ///     .with_opengl_api(OpenGLAPI::GL(None))
     ///     .build()
     ///     .unwrap();
-    /// slint::platform::set_platform(platform).unwrap();
+    /// platform::set_platform(platform).unwrap();
     /// ```
     pub fn build(self) -> Result<Box<dyn Platform + 'static>, PlatformError> {
         let builder = i_slint_backend_winit::Backend::builder().with_allow_fallback(false);
 
         let builder = match self.opengl_api {
-            Some(OpenGLAPI::GL) => builder.with_opengl_api(OpenGLAPI::GL),
-            Some(OpenGLAPI::GLES) => builder.with_opengl_api(OpenGLAPI::GLES),
+            Some(api) => builder.with_opengl_api(api),
             None => builder,
         };
 

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -90,7 +90,7 @@ impl PlatformBuilder {
     /// slint::platform::set_platform(platform).unwrap();
     /// ```
     pub fn build(self) -> Result<Box<dyn Platform + 'static>, PlatformError> {
-        let builder = i_slint_backend_winit::Backend::builder();
+        let builder = i_slint_backend_winit::Backend::builder().with_allow_fallback(false);
 
         let builder = match self.opengl_api {
             Some(OpenGLAPI::GL) => builder.with_opengl_api(OpenGLAPI::GL),

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -90,21 +90,27 @@ impl PlatformBuilder {
     /// platform::set_platform(platform).unwrap();
     /// ```
     pub fn build(self) -> Result<Box<dyn Platform + 'static>, PlatformError> {
-        let builder = i_slint_backend_winit::Backend::builder().with_allow_fallback(false);
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "i-slint-backend-winit")] {
+                let builder = i_slint_backend_winit::Backend::builder().with_allow_fallback(false);
 
-        let builder = match self.opengl_api {
-            Some(api) => builder.with_opengl_api(api),
-            None => builder,
-        };
+                let builder = match self.opengl_api {
+                    Some(api) => builder.with_opengl_api(api),
+                    None => builder,
+                };
 
-        let builder = match self.renderer {
-            Some(SlintRenderer::Femtovg) => builder.with_renderer_name("femtovg"),
-            Some(SlintRenderer::Skia) => builder.with_renderer_name("skia"),
-            Some(SlintRenderer::Software) => builder.with_renderer_name("software"),
-            None => builder,
-        };
+                let builder = match self.renderer {
+                    Some(SlintRenderer::Femtovg) => builder.with_renderer_name("femtovg"),
+                    Some(SlintRenderer::Skia) => builder.with_renderer_name("skia"),
+                    Some(SlintRenderer::Software) => builder.with_renderer_name("software"),
+                    None => builder,
+                };
 
-        Ok(Box::new(builder.build()?))
+                Ok(Box::new(builder.build()?))
+            } else {
+                Err(PlatformError::NoPlatform)
+            }
+        }
     }
 }
 

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -4,8 +4,8 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::Renderer;
+use i_slint_core::{platform::PlatformError, OpenGLAPI};
 use i_slint_renderer_femtovg::{FemtoVGRenderer, FemtoVGRendererExt};
 
 #[cfg(target_arch = "wasm32")]
@@ -42,10 +42,15 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn resume(
         &self,
         window_attributes: winit::window::WindowAttributes,
+        #[cfg_attr(target_arch = "wasm32", allow(unused_variables))] opengl_api: Option<OpenGLAPI>,
     ) -> Result<Rc<winit::window::Window>, PlatformError> {
         #[cfg(not(target_arch = "wasm32"))]
         let (winit_window, opengl_context) = crate::event_loop::with_window_target(|event_loop| {
-            Ok(glcontext::OpenGLContext::new_context(window_attributes, event_loop.event_loop())?)
+            Ok(glcontext::OpenGLContext::new_context(
+                window_attributes,
+                event_loop.event_loop(),
+                opengl_api,
+            )?)
         })?;
 
         #[cfg(target_arch = "wasm32")]

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use crate::winitwindowadapter::physical_size_to_slint;
 use i_slint_core::platform::PlatformError;
+use i_slint_core::OpenGLAPI;
 
 pub struct WinitSkiaRenderer {
     renderer: i_slint_renderer_skia::SkiaRenderer,
@@ -54,6 +55,7 @@ impl super::WinitCompatibleRenderer for WinitSkiaRenderer {
     fn resume(
         &self,
         window_attributes: winit::window::WindowAttributes,
+        opengl_api: Option<OpenGLAPI>,
     ) -> Result<Rc<winit::window::Window>, PlatformError> {
         let winit_window = Rc::new(crate::event_loop::with_window_target(|event_loop| {
             event_loop.create_window(window_attributes).map_err(|winit_os_error| {
@@ -68,6 +70,7 @@ impl super::WinitCompatibleRenderer for WinitSkiaRenderer {
             winit_window.clone(),
             winit_window.clone(),
             physical_size_to_slint(&size),
+            opengl_api,
         )?;
 
         self.renderer.set_pre_present_callback(Some(Box::new({

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -5,10 +5,10 @@
 
 use core::num::NonZeroU32;
 use core::ops::DerefMut;
-use i_slint_core::graphics::Rgb8Pixel;
 use i_slint_core::platform::PlatformError;
 pub use i_slint_core::software_renderer::SoftwareRenderer;
 use i_slint_core::software_renderer::{PremultipliedRgbaColor, RepaintBufferType, TargetPixel};
+use i_slint_core::{graphics::Rgb8Pixel, OpenGLAPI};
 use std::{cell::RefCell, rc::Rc};
 
 use super::WinitCompatibleRenderer;
@@ -173,6 +173,7 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
     fn resume(
         &self,
         window_attributes: winit::window::WindowAttributes,
+        _opengl_api: Option<OpenGLAPI>,
     ) -> Result<Rc<winit::window::Window>, PlatformError> {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             event_loop.create_window(window_attributes).map_err(|winit_os_error| {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -292,6 +292,17 @@ pub enum OpenGLAPI {
     GLES,
 }
 
+/// This enum specifies which OpenGL API should be used.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SlintRenderer {
+    /// The femtovg renderer
+    Femtovg,
+    /// The Skia renderer
+    Skia,
+    /// The software renderer
+    Software,
+}
+
 /// This enum describes the different rendering states, that will be provided
 /// to the parameter of the callback for `set_rendering_notifier` on the `slint::Window`.
 #[derive(Debug, Clone)]

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -283,13 +283,22 @@ impl<'a> core::fmt::Debug for GraphicsAPI<'a> {
     }
 }
 
+/// API Version
+#[derive(Debug, Clone, PartialEq)]
+pub struct APIVersion {
+    /// Major API version
+    pub major: u8,
+    /// Minor API version
+    pub minor: u8,
+}
+
 /// This enum specifies which OpenGL API should be used.
 #[derive(Debug, Clone, PartialEq)]
 pub enum OpenGLAPI {
     /// OpenGL
-    GL,
+    GL(Option<APIVersion>),
     /// OpenGL ES
-    GLES,
+    GLES(Option<APIVersion>),
 }
 
 /// This enum specifies which OpenGL API should be used.

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -283,6 +283,15 @@ impl<'a> core::fmt::Debug for GraphicsAPI<'a> {
     }
 }
 
+/// This enum specifies which OpenGL API should be used.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OpenGLAPI {
+    /// OpenGL
+    GL,
+    /// OpenGL ES
+    GLES,
+}
+
 /// This enum describes the different rendering states, that will be provided
 /// to the parameter of the callback for `set_rendering_notifier` on the `slint::Window`.
 #[derive(Debug, Clone)]

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -301,7 +301,7 @@ pub enum OpenGLAPI {
     GLES(Option<APIVersion>),
 }
 
-/// This enum specifies which OpenGL API should be used.
+/// This enum specifies which renderer should be used.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SlintRenderer {
     /// The femtovg renderer

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -84,6 +84,9 @@ pub use graphics::BorderRadius;
 
 pub use context::{with_global_context, SlintContext};
 
+#[doc(inline)]
+pub use api::OpenGLAPI;
+
 #[cfg(not(slint_int_coord))]
 pub type Coord = f32;
 #[cfg(slint_int_coord)]

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -85,7 +85,7 @@ pub use graphics::BorderRadius;
 pub use context::{with_global_context, SlintContext};
 
 #[doc(inline)]
-pub use api::OpenGLAPI;
+pub use api::{OpenGLAPI, SlintRenderer};
 
 #[cfg(not(slint_int_coord))]
 pub type Coord = f32;

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
+use i_slint_core::api::{OpenGLAPI, PhysicalSize as PhysicalWindowSize};
 use i_slint_core::platform::PlatformError;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -255,6 +255,7 @@ impl super::Surface for D3DSurface {
         window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
         _display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
+        _opengl_api: Option<OpenGLAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
         let factory_flags = 0;
         /*

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -3,7 +3,7 @@
 
 use core_graphics_types::geometry::CGSize;
 use foreign_types::{ForeignType, ForeignTypeRef};
-use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
+use i_slint_core::api::{OpenGLAPI, PhysicalSize as PhysicalWindowSize};
 use metal::MTLPixelFormat;
 use objc::{msg_send, sel, sel_impl};
 use objc::{
@@ -37,6 +37,7 @@ impl super::Surface for MetalSurface {
         window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
         _display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
+        _opengl_api: Option<OpenGLAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
         let layer = match window_handle
             .window_handle()

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
+use i_slint_core::OpenGLAPI;
 
 use std::cell::RefCell;
 use std::num::NonZeroU32;
@@ -84,6 +85,7 @@ impl super::Surface for SoftwareSurface {
         window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
         display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
         _size: PhysicalWindowSize,
+        _opengl_api: Option<OpenGLAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
         let _context = softbuffer::Context::new(display_handle)
             .map_err(|e| format!("Error creating softbuffer context: {e}"))?;

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -5,7 +5,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
+use i_slint_core::api::{OpenGLAPI, PhysicalSize as PhysicalWindowSize};
 
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{
@@ -160,6 +160,7 @@ impl super::Surface for VulkanSurface {
         window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
         display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
+        _opengl_api: Option<OpenGLAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
         let library = VulkanLibrary::new()
             .map_err(|load_err| format!("Error loading vulkan library: {load_err}"))?;


### PR DESCRIPTION
<!--
- [] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

For now, allow the API consumer to request an OpenGL API (OpenGL or OpenGL ES) and a backend (Skia, femtovg, or software).

This is a rough draft:
- Currently only implemented for winit.
- I'm not a fan of how I threaded `OpenGLApi` everywhere (especially in functions that have nothing to do with OpenGL like `SoftwareSurface::new()` but share a trait with OpenGL functions), but I wanted to get a rough initial implementation up to start the conversation.
  - Specifically, it feels awkward passing it through `WinitCompatibleRenderer::resume` but that seemed to be the common point between Skia and femtovg where the OpenGL context is created.

Related discussion: https://github.com/slint-ui/slint/discussions/6482

ChangeLog: Add PlatformBuilder API for requesting backend features