### PR TITLE
live-preview: Reload when images change on disc

### DIFF
--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -102,7 +102,7 @@ async fn register_file_watcher(ctx: &Context) -> common::Result<()> {
     {
         let fs_watcher = lsp_types::DidChangeWatchedFilesRegistrationOptions {
             watchers: vec![lsp_types::FileSystemWatcher {
-                glob_pattern: lsp_types::GlobPattern::String("**/*.slint".to_string()),
+                glob_pattern: lsp_types::GlobPattern::String("**/*".to_string()),
                 kind: Some(lsp_types::WatchKind::Change | lsp_types::WatchKind::Delete),
             }],
         };


### PR DESCRIPTION
These are two patches:

1. Store the absolute image path to the `Expression::ImageReference`
2. Use that data in the live-preview

I am a bit uncertain whether 1. is actually needed: The "normal" images I expect to see in the Live Preview have a `resource_ref` of `Absolute(String)`, which contains the absolute path to the image already. I just wanted to make sure this will continue to work, even if we start to embed images (or decide to add some other way to access image data).

Something else I am not too happy about is that I am back to watching `**/*`. I *suspect* that VSCode watches everything anyway and the pattern I pass to VSCode is just filtering what gets sent to my LS (which reduces the amount of data to serialize/sent/deserialize by a bit).