### PR TITLE
WIP: compiler: Add a `ListResources` option for resource embedding

### DIFF
--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -47,6 +47,8 @@ pub enum EmbedResourcesKind {
     Nothing,
     /// Only embed builtin resources
     OnlyBuiltinResources,
+    /// Do not embed resources, but list them in the Document as it they were embedded
+    ListAllResources,
     /// Embed all images resources (the content of their files)
     EmbedAllResources,
     #[cfg(feature = "software-renderer")]

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -94,7 +94,7 @@ fn embed_images_from_expression(
                 && (embed_files != EmbedResourcesKind::OnlyBuiltinResources
                     || path.starts_with("builtin:/"))
             {
-                *resource_ref = embed_image(
+                let image_ref = embed_image(
                     global_embedded_resources,
                     embed_files,
                     path,
@@ -102,6 +102,9 @@ fn embed_images_from_expression(
                     diag,
                     source_location,
                 );
+                if embed_files != EmbedResourcesKind::ListAllResources {
+                    *resource_ref = image_ref;
+                }
             }
         }
     };
@@ -161,6 +164,7 @@ fn embed_image(
             }
         }
     };
+
     match e.kind {
         #[cfg(feature = "software-renderer")]
         EmbeddedResourcesKind::TextureData { .. } => {

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -8,9 +8,9 @@ use crate::common::{
 use crate::lsp_ext::Health;
 use crate::preview::element_selection::ElementSelection;
 use crate::util;
-use i_slint_compiler::diagnostics;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{syntax_nodes, TextSize};
+use i_slint_compiler::{diagnostics, EmbedResourcesKind};
 use i_slint_core::component_factory::FactoryContext;
 use i_slint_core::lengths::{LogicalPoint, LogicalRect, LogicalSize};
 use i_slint_core::model::VecModel;
@@ -1231,6 +1231,7 @@ async fn parse_source(
     {
         cc.resource_url_mapper = resource_url_mapper();
     }
+    cc.embed_resources = EmbedResourcesKind::ListAllResources;
 
     if !style.is_empty() {
         cc.style = Some(style);


### PR DESCRIPTION
... which will list all resources that are not going to get embedded as `None` in the Document's `embedded_file_reosurces`.

The idea is to use that field to find all used resources in the live preview so that we know what we can watch.

This is at this point a demo to show what using the `Document::embedded_file_resources` for resource listing in the live preview would entail for the compiler.

I'd suggest to rename the field itself to `resources` and to collect this information even when no embedding is requested (most users won't see it anyway) to not have this `ListAllResources` enum value... 