### PR TITLE
Add `accessible-selectable` and `accessible-selected` properties

### DIFF
--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -316,6 +316,32 @@ public:
         return std::nullopt;
     }
 
+    /// Returns the accessible-selected of that element, if any.
+    std::optional<bool> accessible_selected() const
+    {
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::Selected)) {
+            if (*result == "true")
+                return true;
+            else if (*result == "false")
+                return false;
+        }
+        return std::nullopt;
+    }
+
+    /// Returns the accessible-selectable of that element, if any.
+    std::optional<bool> accessible_selectable() const
+    {
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::Selectable)) {
+            if (*result == "true")
+                return true;
+            else if (*result == "false")
+                return false;
+        }
+        return std::nullopt;
+    }
+
     /// Sets the accessible-value of that element.
     ///
     /// Setting the value will invoke the `accessible-action-set-value` callback.

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -75,8 +75,8 @@ Use the following `accessible-` properties to make your items interact well with
 -   **`accessible-value-step`** (_in_ _float_) The smallest increment or decrement by which the current value can change. This corresponds to the step by which a handle on a slider can be dragged.
 -   **`accessible-value`** (_in_ _string_): The current value of the item.
 -   **`accessible-placeholder-text`** (_in_ _string_): A placeholder text to use when the item's value is empty. Applies to text elements.
--   **`accessible-selectable`** (_in_ _bool_): Whether the element can be checked or not.
--   **`accessible-selected`** (_in_ _bool_): Whether the element is checked or not. This maps to the "is-selected" state of listview items.
+-   **`accessible-selectable`** (_in_ _bool_): Whether the element can be selected or not.
+-   **`accessible-selected`** (_in_ _bool_): Whether the element is selected or not. This maps to the "is-selected" state of listview items.
 
 You can also use the following callbacks that are going to be called by the accessibility framework:
 

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -75,6 +75,8 @@ Use the following `accessible-` properties to make your items interact well with
 -   **`accessible-value-step`** (_in_ _float_) The smallest increment or decrement by which the current value can change. This corresponds to the step by which a handle on a slider can be dragged.
 -   **`accessible-value`** (_in_ _string_): The current value of the item.
 -   **`accessible-placeholder-text`** (_in_ _string_): A placeholder text to use when the item's value is empty. Applies to text elements.
+-   **`accessible-selectable`** (_in_ _bool_): Whether the element can be checked or not.
+-   **`accessible-selected`** (_in_ _bool_): Whether the element is checked or not. This maps to the "is-selected" state of listview items.
 
 You can also use the following callbacks that are going to be called by the accessibility framework:
 

--- a/examples/energy-monitor/ui/widgets/list_view.slint
+++ b/examples/energy-monitor/ui/widgets/list_view.slint
@@ -36,6 +36,8 @@ component ListViewItem {
         padding-right: Theme.spaces.medium;
         spacing: Theme.spaces.medium;
         accessible-role: list-item;
+        accessible-selectable: true;
+        accessible-selected: root.selected;
 
         i-text := Text {
             horizontal-stretch: 1;

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -588,6 +588,28 @@ impl ElementHandle {
             .and_then(|item| item.parse().ok())
     }
 
+    /// Returns the value of the `accessible-selected` property, if present
+    pub fn accessible_selected(&self) -> Option<bool> {
+        if self.element_index != 0 {
+            return None;
+        }
+        self.item
+            .upgrade()
+            .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Selected))
+            .and_then(|item| item.parse().ok())
+    }
+
+    /// Returns the value of the `accessible-selectable` property, if present
+    pub fn accessible_selectable(&self) -> Option<bool> {
+        if self.element_index != 0 {
+            return None;
+        }
+        self.item
+            .upgrade()
+            .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Selectable))
+            .and_then(|item| item.parse().ok())
+    }
+
     /// Returns the size of the element in logical pixels. This corresponds to the value of the `width` and
     /// `height` properties in Slint code. Returns a zero size if the element is not valid.
     pub fn size(&self) -> i_slint_core::api::LogicalSize {

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -455,6 +455,16 @@ impl NodeCollection {
             builder.set_placeholder(placeholder.to_string());
         }
 
+        if item
+            .accessible_string_property(AccessibleStringProperty::Selectable)
+            .is_some_and(|x| x == "true")
+        {
+            builder.set_selected(
+                item.accessible_string_property(AccessibleStringProperty::Selected)
+                    .is_some_and(|x| x == "true"),
+            );
+        }
+
         let supported = item.supported_accessibility_actions();
         if supported.contains(SupportedAccessibilityAction::Default) {
             builder.add_action(accesskit::Action::Default);

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -120,6 +120,8 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
             "accessible-action-set-value",
             Type::Callback { return_type: None, args: vec![Type::String] },
         ),
+        ("accessible-selectable", Type::Bool),
+        ("accessible-selected", Type::Bool),
     ]
     .into_iter()
 }

--- a/internal/compiler/widgets/cosmic/components.slint
+++ b/internal/compiler/widgets/cosmic/components.slint
@@ -112,6 +112,8 @@ export component ListItem {
     layout := HorizontalLayout {
         padding-bottom: 8px;
         accessible-role: list-item;
+        accessible-selectable: true;
+        accessible-selected: root.is-selected;
 
         StateLayerBase {
             width: 100%;

--- a/internal/compiler/widgets/cupertino/components.slint
+++ b/internal/compiler/widgets/cupertino/components.slint
@@ -74,6 +74,8 @@ export component ListItem {
         padding-left: root.padding-horizontal;
         padding-right: root.padding-horizontal;
         accessible-role: list-item;
+        accessible-selectable: true;
+        accessible-selected: root.is-selected;
 
         i-background := Rectangle {
             background: transparent;

--- a/internal/compiler/widgets/fluent/components.slint
+++ b/internal/compiler/widgets/fluent/components.slint
@@ -79,6 +79,8 @@ export component ListItem {
             padding-right: 16px;
             spacing: 4px;
             accessible-role: list-item;
+            accessible-selectable: true;
+            accessible-selected: root.is-selected;
 
             i-text := Text {
                 text: root.item.text;

--- a/internal/compiler/widgets/material/components.slint
+++ b/internal/compiler/widgets/material/components.slint
@@ -146,6 +146,8 @@ export component ListItem {
         padding-left: 12px;
         padding-right: 12px;
         accessible-role: list-item;
+        accessible-selectable: true;
+        accessible-selected: root.is-selected;
 
         label := Text {
             text: root.item.text;

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -21,6 +21,8 @@ pub enum AccessibleStringProperty {
     Description,
     Label,
     PlaceholderText,
+    Selectable,
+    Selected,
     Value,
     ValueMaximum,
     ValueMinimum,


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Adds the `accessible-selectable` and `accessible-selected` properties which applies to list items. Uses them in the standard list view and in examples where appropriate. Implements them in the AccessKit backend.