### PR TITLE
Fix two issues with the timer handling

### DIFF
--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -261,6 +261,18 @@ impl TimerList {
             // The active timer list is cleared here and not-yet-fired ones are inserted below, in order to allow
             // timer callbacks to register their own timers.
             let timers_to_process = core::mem::take(&mut timers.borrow_mut().active_timers);
+
+            #[cfg(debug_assertions)]
+            {
+                let mut timer_ids = Vec::new();
+                for timer in &timers_to_process {
+                    match timer_ids.binary_search(&timer.id) {
+                        Ok(_) => assert!(false, "Duplicated active timer"),
+                        Err(idx) => timer_ids.insert(idx, timer.id),
+                    }
+                }
+            }
+
             {
                 let mut timers = timers.borrow_mut();
                 for active_timer in &timers_to_process {

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -368,6 +368,7 @@ impl TimerList {
             if self.active_timers[i].id == id {
                 self.active_timers.remove(i);
                 self.timers[id].running = false;
+                debug_assert!(!self.active_timers.iter().any(|t| t.id == id));
                 break;
             } else {
                 i += 1;

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -383,6 +383,7 @@ impl TimerList {
     }
 
     fn register_active_timer(&mut self, new_active_timer: ActiveTimer) {
+        debug_assert!(!self.active_timers.iter().any(|t| t.id == new_active_timer.id));
         let insertion_index = self
             .active_timers
             .partition_point(|existing_timer| existing_timer.timeout < new_active_timer.timeout);

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -383,10 +383,9 @@ impl TimerList {
     }
 
     fn register_active_timer(&mut self, new_active_timer: ActiveTimer) {
-        let insertion_index = lower_bound(&self.active_timers, |existing_timer| {
-            existing_timer.timeout < new_active_timer.timeout
-        });
-
+        let insertion_index = self
+            .active_timers
+            .partition_point(|existing_timer| existing_timer.timeout < new_active_timer.timeout);
         self.active_timers.insert(insertion_index, new_active_timer);
         self.timers[new_active_timer.id].running = true;
     }
@@ -418,23 +417,6 @@ impl TimerList {
 use crate::unsafe_single_threaded::thread_local;
 
 thread_local!(static CURRENT_TIMERS : RefCell<TimerList> = RefCell::default());
-
-fn lower_bound<T>(vec: &[T], mut less_than: impl FnMut(&T) -> bool) -> usize {
-    let mut left = 0;
-    let mut right = vec.len();
-
-    while left != right {
-        let mid = left + (right - left) / 2;
-        let value = &vec[mid];
-        if less_than(value) {
-            left = mid + 1;
-        } else {
-            right = mid;
-        }
-    }
-
-    left
-}
 
 #[cfg(feature = "ffi")]
 pub(crate) mod ffi {


### PR DESCRIPTION
- When stopping a running but not yet expired timer from within the activation callback of an expired timer, the stopping would fail to find the timer in the active_timers list because it was built on the fly. Similarly, restarting a future timer form within the same kind of callback would end up registering the active timer twice. Fix this by doing all the active_timer re-setup before activating any callbacks, so that by the time of activation the data structure is in a good state.
- When two timers expire at the same time and from the callback of the first, the second timer would be dropped/deleted, the timer's `being_activated` was overwritten and the timer was deleted too early, causing a panic. Fix this by preserving the removal state.

Fixes #6187
Fixes #6505