### PR TITLE
CI: switch from macOS-12 runners to macOS-13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,12 +29,12 @@ jobs:
             SLINT_EMIT_DEBUG_INFO: 1
         strategy:
             matrix:
-                os: [ubuntu-22.04, macos-12, windows-2022]
+                os: [ubuntu-22.04, macos-13, windows-2022]
                 rust_version: [stable, "1.77"]
                 include:
                     - os: windows-2022
                       extra_args: "--exclude ffmpeg --exclude gstreamer-player"
-                    - os: macos-12
+                    - os: macos-13
                       extra_args: "--exclude ffmpeg --exclude gstreamer-player"
                     - os: windows-2022
                       rust_version: "beta"
@@ -42,7 +42,7 @@ jobs:
                     - os: ubuntu-22.04
                       rust_version: "nightly"
                 exclude:
-                    - os: macos-12
+                    - os: macos-13
                       rust_version: "1.77"
                     # We already test 1.77 and nightly. Stable is in the middle and already covered by other jobs
                     - os: ubuntu-22.04
@@ -111,7 +111,7 @@ jobs:
             RUST_BACKTRACE: 1
         strategy:
             matrix:
-                os: [ubuntu-22.04, macos-12, windows-2022]
+                os: [ubuntu-22.04, macos-13, windows-2022]
 
         runs-on: ${{ matrix.os }}
 
@@ -171,7 +171,7 @@ jobs:
             RUST_BACKTRACE: full
         strategy:
             matrix:
-                os: [ubuntu-22.04, macos-12, windows-2022]
+                os: [ubuntu-22.04, macos-13, windows-2022]
 
         runs-on: ${{ matrix.os }}
 
@@ -208,7 +208,7 @@ jobs:
             CARGO_PROFILE_DEV_DEBUG: 0
         strategy:
             matrix:
-                os: [ubuntu-22.04, macos-12, windows-2022]
+                os: [ubuntu-22.04, macos-13, windows-2022]
         runs-on: ${{ matrix.os }}
 
         steps:
@@ -245,7 +245,7 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - os: macos-12
+                    - os: macos-13
                       rust_version: "1.77"
                     - os: windows-2022
                       rust_version: "nightly"

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -116,7 +116,7 @@ jobs:
     build_vscode_lsp_macos_x86_64:
         env:
             SLINT_NO_QT: 1
-        runs-on: macos-12
+        runs-on: macos-13
         steps:
             - uses: actions/checkout@v4
             - uses: ./.github/actions/setup-rust
@@ -162,7 +162,7 @@ jobs:
 
     build_vscode_lsp_macos_bundle:
         needs: [build_vscode_lsp_macos_x86_64, build_vscode_lsp_macos_aarch64]
-        runs-on: macos-12
+        runs-on: macos-13
         steps:
             - uses: actions/checkout@v4
               with:
@@ -232,7 +232,7 @@ jobs:
                 build_vscode_cross_linux_lsp,
                 check-for-secrets,
             ]
-        runs-on: macos-12
+        runs-on: macos-13
         if: ${{ needs.check-for-secrets.outputs.has-openvsx-pat == 'yes' && needs.check-for-secrets.outputs.has-vscode-marketplace-pat == 'yes' }}
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -59,7 +59,7 @@ jobs:
                     - os: ubuntu-20.04
                       rust-target: x86_64-unknown-linux-gnu
                       napi-rs-target: linux-x64-gnu
-                    - os: macos-12
+                    - os: macos-13
                       rust-target: x86_64-apple-darwin
                       napi-rs-target: darwin-x64
                     - os: macos-14

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -159,7 +159,7 @@ jobs:
                 path: slint-${{ github.event.inputs.program || inputs.program }}-${{ matrix.target }}.tar.gz
 
     build_macos:
-        runs-on: macos-12
+        runs-on: macos-13
         steps:
             - uses: actions/checkout@v4
             - uses: ./.github/actions/setup-rust

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -180,6 +180,7 @@ pub mod re_exports {
     pub use core::result::{Result, Result::*};
     pub use i_slint_core::format;
     // This one is empty when Qt is not available, which triggers a warning
+    pub use euclid::approxeq::ApproxEq;
     #[allow(unused_imports)]
     pub use i_slint_backend_selector::native_widgets::*;
     pub use i_slint_core::accessibility::{

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3125,7 +3125,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
 
             let lhs_ty = lhs.ty(ctx);
 
-            if (lhs_ty == Type::Float32 || lhs_ty.as_unit_product().is_some()) && (*op == '=' || *op == '!') {
+            if lhs_ty.as_unit_product().is_some() && (*op == '=' || *op == '!') {
                 let op = if *op == '=' { "<" } else { ">=" };
                 format!("(std::abs(float({lhs_str} - {rhs_str})) {op} std::numeric_limits<float>::epsilon())")
             }  else {


### PR DESCRIPTION
macOS 12 will be phased out later this year and start failing randomly:

https://github.com/actions/runner-images/issues/10721

macOS-13 runners are still on x86-64, so this should be a no-op.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
