### PR TITLE
Fix invalid node generated while parsing invalid `@tr`

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -121,9 +121,9 @@ macro_rules! node_accessors {
         #[track_caller]
         pub fn $kind(&self) -> ($kind, $kind) {
             let mut it = self.0.children().filter(|n| n.kind() == SyntaxKind::$kind);
-            let a = it.next().expect(stringify!("Missing first ", $kind));
-            let b = it.next().expect(stringify!("Missing second ", $kind));
-            debug_assert!(it.next().is_none(), stringify!("More ", $kind, " than expected"));
+            let a = it.next().expect(stringify!(Missing first $kind));
+            let b = it.next().expect(stringify!(Missing second $kind));
+            debug_assert!(it.next().is_none(), stringify!(More $kind than expected));
             (a.into(), b.into())
         }
     };
@@ -132,10 +132,10 @@ macro_rules! node_accessors {
         #[track_caller]
         pub fn $kind(&self) -> ($kind, $kind, $kind) {
             let mut it = self.0.children().filter(|n| n.kind() == SyntaxKind::$kind);
-            let a = it.next().expect(stringify!("Missing first ", $kind));
-            let b = it.next().expect(stringify!("Missing second ", $kind));
-            let c = it.next().expect(stringify!("Missing third ", $kind));
-            debug_assert!(it.next().is_none(), stringify!("More ", $kind, " than expected"));
+            let a = it.next().expect(stringify!(Missing first $kind));
+            let b = it.next().expect(stringify!(Missing second $kind));
+            let c = it.next().expect(stringify!(Missing third $kind));
+            debug_assert!(it.next().is_none(), stringify!(More $kind than expected));
             (a.into(), b.into(), c.into())
         }
     };
@@ -143,7 +143,7 @@ macro_rules! node_accessors {
         #[allow(non_snake_case)]
         #[track_caller]
         pub fn $kind(&self) -> $kind {
-            self.0.child_node(SyntaxKind::$kind).expect(stringify!("Missing ", $kind)).into()
+            self.0.child_node(SyntaxKind::$kind).expect(stringify!(Missing $kind)).into()
         }
     };
 

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -399,10 +399,11 @@ fn parse_tr(p: &mut impl Parser) {
     if p.peek().kind() == SyntaxKind::Pipe {
         let mut p = p.start_node(SyntaxKind::TrPlural);
         p.consume();
-        if !consume_literal(&mut *p) || !p.expect(SyntaxKind::Percent) || !parse_expression(&mut *p)
-        {
+        if !consume_literal(&mut *p) || !p.expect(SyntaxKind::Percent) {
+            let _ = p.start_node(SyntaxKind::Expression);
             return;
         }
+        parse_expression(&mut *p);
     }
 
     while p.test(SyntaxKind::Comma) {

--- a/internal/compiler/tests/syntax/fuzzing/6512.slint
+++ b/internal/compiler/tests/syntax/fuzzing/6512.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component T{function r@tr""|
+//                    ^error{Syntax error: expected '\('}
+//                    ^^error{Syntax error: expected '\{'}
+//                       ^^^error{Syntax error: expected '\('}
+
+  ""}}}
+//  ^error{Syntax error: expected '%'}
+//    ^^error{Parse error: expected a top-level item such as a component, a struct, or a global}


### PR DESCRIPTION
Fixes #6512

The TrPlural must always have an expression otherwise it panics later. (Also adjust the panic message when nodes are missing)

(edit: in the first push of this PR, i had the wrong issue number)

