### PR TITLE
C++: Avoid undefined behaviour when casting float to int

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -707,7 +707,7 @@ public:
     FilterModel(std::shared_ptr<Model<ModelData>> source_model,
                 std::function<bool(const ModelData &)> filter_fn)
         : inner(std::make_shared<private_api::FilterModelInner<ModelData>>(
-                std::move(source_model), std::move(filter_fn), *this))
+                  std::move(source_model), std::move(filter_fn), *this))
     {
         inner->source_model->attach_peer(inner);
     }

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -129,6 +129,13 @@ inline void debug(const SharedString &str)
     cbindgen_private::slint_debug(&str);
 }
 
+constexpr inline int cast_float_to_int(float f)
+{
+    // Casting > int_max, etc. is UB, so clamp.
+    return static_cast<int>(std::min(std::max(f, float(std::numeric_limits<int>::min())),
+                                     float(std::numeric_limits<int>::max())));
+}
+
 } // namespace private_api
 
 template<typename T>
@@ -700,7 +707,7 @@ public:
     FilterModel(std::shared_ptr<Model<ModelData>> source_model,
                 std::function<bool(const ModelData &)> filter_fn)
         : inner(std::make_shared<private_api::FilterModelInner<ModelData>>(
-                  std::move(source_model), std::move(filter_fn), *this))
+                std::move(source_model), std::move(filter_fn), *this))
     {
         inner->source_model->attach_peer(inner);
     }
@@ -788,7 +795,7 @@ public:
     MapModel(std::shared_ptr<Model<SourceModelData>> source_model,
              std::function<MappedModelData(const SourceModelData &)> map_fn)
         : inner(std::make_shared<private_api::MapModelInner<SourceModelData, MappedModelData>>(
-                  *this)),
+                *this)),
           model(source_model),
           map_fn(map_fn)
     {

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -132,8 +132,8 @@ inline void debug(const SharedString &str)
 constexpr inline int cast_float_to_int(float f)
 {
     // Casting > int_max, etc. is UB, so clamp.
-    return static_cast<int>(std::min(std::max(f, float(std::numeric_limits<int>::min())),
-                                     float(std::numeric_limits<int>::max())));
+    return static_cast<int>(std::clamp(f, float(std::numeric_limits<int>::min()),
+                                       float(std::numeric_limits<int>::max())));
 }
 
 } // namespace private_api

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -795,7 +795,7 @@ public:
     MapModel(std::shared_ptr<Model<SourceModelData>> source_model,
              std::function<MappedModelData(const SourceModelData &)> map_fn)
         : inner(std::make_shared<private_api::MapModelInner<SourceModelData, MappedModelData>>(
-                *this)),
+                  *this)),
           model(source_model),
           map_fn(map_fn)
     {

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -132,8 +132,8 @@ inline void debug(const SharedString &str)
 constexpr inline int cast_float_to_int(float f)
 {
     // Casting > int_max, etc. is UB, so clamp.
-    return static_cast<int>(std::clamp(f, float(std::numeric_limits<int>::min()),
-                                       float(std::numeric_limits<int>::max())));
+    return static_cast<int>(std::clamp(double(f), double(std::numeric_limits<int>::min()),
+                                       double(std::numeric_limits<int>::max())));
 }
 
 } // namespace private_api

--- a/api/cpp/include/slint_image.h
+++ b/api/cpp/include/slint_image.h
@@ -298,6 +298,15 @@ inline Image image_from_embedded_textures(const cbindgen_private::types::StaticT
     cbindgen_private::types::slint_image_from_embedded_textures(textures, &img);
     return Image(img);
 }
+
+inline Size<int32_t> signed_image_size(const Image &image)
+{
+    Size<uint32_t> unsigned_size = image.size();
+    // The compiler is told that the size is signed, so we need to cast it to int to
+    // avoid warnings about comparing signed vs.
+    return { static_cast<int>(unsigned_size.width), static_cast<int>(unsigned_size.height) };
+}
+
 }
 
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2973,7 +2973,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             let f = compile_expression(from, ctx);
             match (from.ty(ctx), to) {
                 (Type::Float32, Type::Int32) => {
-                    format!("static_cast<int>({f})")
+                    format!("slint::private_api::cast_float_to_int({f})")
                 }
                 (from, Type::String) if from.as_unit_product().is_some() => {
                     format!("slint::SharedString::from_number({})", f)
@@ -3463,7 +3463,7 @@ fn compile_builtin_function_call(
             format!("{}.with_alpha({})", a.next().unwrap(), a.next().unwrap())
         }
         BuiltinFunction::ImageSize => {
-            format!("{}.size()", a.next().unwrap())
+            format!("slint::private_api::signed_image_size({})", a.next().unwrap())
         }
         BuiltinFunction::ArrayLength => {
             format!("slint::private_api::model_length({})", a.next().unwrap())

--- a/tests/cases/layout/materialized_minmax.slint
+++ b/tests/cases/layout/materialized_minmax.slint
@@ -56,14 +56,12 @@ slint_testing::send_mouse_click(&instance, 5., 5.);
 assert_eq(instance.get_materialized_max_height(), 300);
 assert_eq(instance.get_materialized_min_width(), 50);
 assert_eq(instance.get_materialized_min_height(), 25);
-// FIXME! float max is overflowing on int
-assert_eq(uint32_t(instance.get_materialized_max_width()), uint32_t(std::numeric_limits<int>::max()) + 1);
+assert_eq(instance.get_materialized_max_width(), std::numeric_limits<int>::max());
 
 assert_eq(instance.get_materialized_rect_max_height(), 300);
 assert_eq(instance.get_materialized_rect_min_width(), 50);
 assert_eq(instance.get_materialized_rect_min_height(), 25);
-// FIXME! float max is overflowing on int
-assert_eq(uint32_t(instance.get_materialized_rect_max_width()), uint32_t(std::numeric_limits<int>::max()) + 1);
+assert_eq(instance.get_materialized_rect_max_width(), std::numeric_limits<int>::max());
 ```
 
 


### PR DESCRIPTION
When the truncated float can't be represented as int, it's undefined behaviour to cast. Work around this by clamping.

Unfortunately this has the side-effect of eliminating an implicit sign conversion that causes signed vs. unsigned comparison warning, when comparing images. The compiler is told that the width/height is Type::Int32, when we return it as uint32_t. This is eliminated with a private helper function.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
