### PR TITLE
lsp: Use constant instead of repeating a `slint/showPreview`

### DIFF
--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -42,7 +42,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
 
-const SHOW_PREVIEW_COMMAND: &str = "slint/showPreview";
+pub const SHOW_PREVIEW_COMMAND: &str = "slint/showPreview";
 
 fn command_list() -> Vec<String> {
     vec![

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -466,7 +466,7 @@ async fn handle_notification(req: lsp_server::Notification, ctx: &Rc<Context>) -
         }
 
         #[cfg(any(feature = "preview-builtin", feature = "preview-external"))]
-        "slint/showPreview" => {
+        language::SHOW_PREVIEW_COMMAND => {
             match language::show_preview_command(
                 req.params.as_array().map_or(&[], |x| x.as_slice()),
                 ctx,


### PR DESCRIPTION
Another small polish
