### PR TITLE
live-preview: Do not fail to render when top level sources are not lo…

### DIFF
--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1297,7 +1297,13 @@ async fn reload_preview_impl(
     start_parsing();
 
     let path = component.url.to_file_path().unwrap_or(PathBuf::from(&component.url.to_string()));
-    let (version, source) = get_url_from_cache(&component.url).unwrap_or_default();
+    let (version, source) = get_url_from_cache(&component.url).unwrap_or_else(|| {
+        if cfg!(not(target_arch = "wasm32")) {
+            (None, std::fs::read_to_string(&path).unwrap_or_default())
+        } else {
+            (None, String::new())
+        }
+    });
 
     let (diagnostics, compiled, open_import_fallback, source_file_versions) = parse_source(
         config.include_paths,


### PR DESCRIPTION
…aded

Ths can open one file in VSCode and show the preview. Then you click on another file in the file tree, which will replace the current file.

This replacement invalidates the data stored in the live-previews caches, so it used to render an empty file. Read the data from disc instead -- if that is an option.
