### PR TITLE
femtovg: Fix warning about deprecated web_sys::set_fill_style

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,8 @@ spin_on = { version = "0.1" }
 strum = { version = "0.26.1", default-features = false, features = ["derive"] }
 toml_edit = { version = "0.22.7" }
 ttf-parser = { version = "0.21" }
+# web-sys needs to be >= 0.3.72 for set_fill_style_str
+web-sys = { version = "0.3.72", default-features = false }
 
 raw-window-handle-06 = { package = "raw-window-handle", version = "0.6", features = ["alloc"] }
 

--- a/api/wasm-interpreter/Cargo.toml
+++ b/api/wasm-interpreter/Cargo.toml
@@ -26,16 +26,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 js-sys = "0.3.44"
 wasm-bindgen-futures = { version = "0.4.18" }
 wasm-bindgen = { version = "0.2.66" }
-
-[dependencies.web-sys]
-version = "0.3"
-features = [
-  'Request',
-  'RequestInit',
-  'RequestMode',
-  'Response',
-  'Window',
-]
+web-sys = { workspace = true,  features = ["Request", "RequestInit", "RequestMode", "Response", "Window"] }
 
 #[dev-dependencies]
 #wasm-bindgen-test = "0.3.13"

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -61,7 +61,7 @@ bytemuck = { workspace = true, optional = true, features = ["derive"] }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3", features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap", "ClipboardEvent", "DataTransfer"] }
+web-sys = { workspace = true, features=["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap", "ClipboardEvent", "DataTransfer"] }
 wasm-bindgen = { version = "0.2" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -97,7 +97,7 @@ gettext-rs = { version = "0.7.1", optional = true, features = ["gettext-system"]
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2" }
-web-sys = { version = "0.3", features = [ "HtmlImageElement" ] }
+web-sys = { workspace = true, features = [ "HtmlImageElement" ] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { workspace = true, optional = true, default-features = true }

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -50,5 +50,5 @@ core-foundation = { version = "0.9.1" }
 core-text = { version = "20.1.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3", features=["console", "WebGlContextAttributes", "CanvasRenderingContext2d", "HtmlInputElement", "HtmlCanvasElement", "Window", "Document"] }
+web-sys = { workspace = true, features=["console", "WebGlContextAttributes", "CanvasRenderingContext2d", "HtmlInputElement", "HtmlCanvasElement", "Window", "Document"] }
 wasm-bindgen = { version = "0.2" }

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -645,7 +645,7 @@ impl FemtoVGRendererExt for FemtoVGRenderer {
                     .unwrap();
                 context_2d.set_font("20px serif");
                 // We don't know if we're rendering on dark or white background, so choose a "color" in the middle for the text.
-                context_2d.set_fill_style(&wasm_bindgen::JsValue::from_str("red"));
+                context_2d.set_fill_style_str("red");
                 context_2d
                     .fill_text("Slint requires WebGL to be enabled in your browser", 0., 30.)
                     .unwrap();


### PR DESCRIPTION
Use set_fill_style_str instead, it avoids constructing a JSValue from a str.
