### PR TITLE
Fix compiler panic binding to property with syntax error

### DIFF
--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1562,6 +1562,11 @@ fn resolve_two_way_bindings(
 
                             // Check the compatibility.
                             let mut rhs_lookup = nr.element().borrow().lookup_property(nr.name());
+                            if rhs_lookup.property_type == Type::Invalid {
+                                // An attempt to resolve this already failed when trying to resolve the property type
+                                assert!(diag.has_errors());
+                                continue;
+                            }
                             rhs_lookup.is_local_to_component &=
                                 lookup_ctx.is_local_element(&nr.element());
 

--- a/internal/compiler/tests/syntax/fuzzing/6519.slint
+++ b/internal/compiler/tests/syntax/fuzzing/6519.slint
@@ -1,0 +1,19 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Button{
+    property<bool>checked
+   }
+// ^error{Syntax error: expected ';'}
+export component C{
+    in property<b in
+//                ^error{Syntax error: expected '>'}
+    Button {
+//  ^error{Syntax error: expected ';'}
+        checked<=>in obal
+//                   ^error{Syntax error: expected ';'}
+//                       ^^error{Parse error}
+
+    }
+}
+

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -5,6 +5,7 @@ export component Button {
     in property<bool> enabled : true;
     out property <bool> pressed;
     in-out property <bool> checked;
+    property <bool> internal;
     callback clicked();
 }
 
@@ -303,6 +304,9 @@ export component C12 {
     in property <bool> in4 <=> btn.accessible-checked;
     in property <bool> in5 <=> inout1;
 //                         ^error{Cannot link input property}
+
+    in property <bool> boggus1 <=> btn.internal;
+//                                     ^error{The property 'internal' is private. Annotate it with}
 
     in-out property <bool> inout1;
 


### PR DESCRIPTION
Fixes #6519

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
