### PR TITLE
Slintpad fixes

### DIFF
--- a/internal/compiler/embedded_resources.rs
+++ b/internal/compiler/embedded_resources.rs
@@ -87,6 +87,8 @@ pub struct BitmapFont {
 
 #[derive(Debug, Clone)]
 pub enum EmbeddedResourcesKind {
+    /// Only List the resource, do not actually embed it
+    ListOnly,
     /// Just put the file content as a resource
     RawData,
     /// The data has been processed in a texture

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -852,6 +852,7 @@ fn embed_resource(
     declarations: &mut Vec<Declaration>,
 ) {
     match &resource.kind {
+        crate::embedded_resources::EmbeddedResourcesKind::ListOnly => {}
         crate::embedded_resources::EmbeddedResourcesKind::RawData => {
             let resource_file = crate::fileaccess::load_file(std::path::Path::new(path)).unwrap(); // embedding pass ensured that the file exists
             let data = resource_file.read();

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2971,6 +2971,9 @@ fn generate_resources(doc: &Document) -> Vec<TokenStream> {
         .map(|(path, er)| {
             let symbol = format_ident!("SLINT_EMBEDDED_RESOURCE_{}", er.id);
             match &er.kind {
+                &crate::embedded_resources::EmbeddedResourcesKind::ListOnly => {
+                    quote!()
+                },
                 crate::embedded_resources::EmbeddedResourcesKind::RawData => {
                     let data = embedded_file_tokens(path);
                     quote!(static #symbol: &'static [u8] = #data;)


### PR DESCRIPTION
Fix loading of additional slint source files as well as of urls in `@image-url`.

This makes the current slintpad render the printerdemo just as slintpad.com does... which still looks like it is missing the tab below the icons. Was that changed?
