### PR TITLE
Enable support for WASM builds with the software renderer

### DIFF
--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -91,6 +91,9 @@ bitflags = { version = "2.4.2"}
 
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 
+rustybuzz = { workspace = true, optional = true }
+fontdue = { workspace = true, optional = true }
+
 [target.'cfg(target_family = "unix")'.dependencies]
 gettext-rs = { version = "0.7.1", optional = true, features = ["gettext-system"] }
 
@@ -101,8 +104,6 @@ web-sys = { workspace = true, features = [ "HtmlImageElement" ] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { workspace = true, optional = true, default-features = true }
-rustybuzz = { workspace = true, optional = true }
-fontdue = { workspace = true, optional = true }
 
 [dev-dependencies]
 slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -722,7 +722,7 @@ impl RendererSealed for SoftwareRenderer {
                     paragraph.byte_offset_for_position((pos.x_length(), pos.y_length())),
                 )
             }
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             fonts::Font::VectorFont(vf) => {
                 let layout = fonts::text_layout_for_font(&vf, &font_request, scale_factor);
 
@@ -777,7 +777,7 @@ impl RendererSealed for SoftwareRenderer {
 
                 (paragraph.cursor_pos_for_byte_offset(byte_offset), pf.height())
             }
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             fonts::Font::VectorFont(vf) => {
                 let layout = fonts::text_layout_for_font(&vf, &font_request, scale_factor);
 
@@ -831,7 +831,7 @@ impl RendererSealed for SoftwareRenderer {
         fonts::register_bitmap_font(font_data);
     }
 
-    #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+    #[cfg(feature = "software-renderer-systemfonts")]
     fn register_font_from_memory(
         &self,
         data: &'static [u8],
@@ -1968,7 +1968,7 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
 
                 self.draw_text_paragraph(&paragraph, physical_clip, offset, color, None);
             }
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             fonts::Font::VectorFont(vf) => {
                 let layout = fonts::text_layout_for_font(&vf, &font_request, self.scale_factor);
                 let (horizontal_alignment, vertical_alignment) = text.alignment();
@@ -2047,7 +2047,7 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
                     (paragraph.cursor_pos_for_byte_offset(cursor_offset), pf.height())
                 })
             }
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             fonts::Font::VectorFont(vf) => {
                 let paragraph = TextParagraphLayout {
                     string: &text_visual_representation.text,
@@ -2229,7 +2229,7 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
 
                 self.draw_text_paragraph(&paragraph, clip, Default::default(), color, None);
             }
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             fonts::Font::VectorFont(vf) => {
                 let layout = fonts::text_layout_for_font(&vf, &font_request, self.scale_factor);
 

--- a/internal/core/software_renderer/fonts.rs
+++ b/internal/core/software_renderer/fonts.rs
@@ -48,16 +48,16 @@ pub trait GlyphRenderer {
 pub(super) const DEFAULT_FONT_SIZE: LogicalLength = LogicalLength::new(12 as Coord);
 
 mod pixelfont;
-#[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+#[cfg(feature = "software-renderer-systemfonts")]
 pub mod vectorfont;
 
-#[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+#[cfg(feature = "software-renderer-systemfonts")]
 pub mod systemfonts;
 
 #[derive(derive_more::From)]
 pub enum Font {
     PixelFont(pixelfont::PixelFont),
-    #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+    #[cfg(feature = "software-renderer-systemfonts")]
     VectorFont(vectorfont::VectorFont),
 }
 
@@ -65,7 +65,7 @@ impl crate::textlayout::FontMetrics<PhysicalLength> for Font {
     fn ascent(&self) -> PhysicalLength {
         match self {
             Font::PixelFont(pixel_font) => pixel_font.ascent(),
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             Font::VectorFont(vector_font) => vector_font.ascent(),
         }
     }
@@ -73,7 +73,7 @@ impl crate::textlayout::FontMetrics<PhysicalLength> for Font {
     fn height(&self) -> PhysicalLength {
         match self {
             Font::PixelFont(pixel_font) => pixel_font.height(),
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             Font::VectorFont(vector_font) => vector_font.height(),
         }
     }
@@ -81,7 +81,7 @@ impl crate::textlayout::FontMetrics<PhysicalLength> for Font {
     fn descent(&self) -> PhysicalLength {
         match self {
             Font::PixelFont(pixel_font) => pixel_font.descent(),
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             Font::VectorFont(vector_font) => vector_font.descent(),
         }
     }
@@ -89,7 +89,7 @@ impl crate::textlayout::FontMetrics<PhysicalLength> for Font {
     fn x_height(&self) -> PhysicalLength {
         match self {
             Font::PixelFont(pixel_font) => pixel_font.x_height(),
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             Font::VectorFont(vector_font) => vector_font.x_height(),
         }
     }
@@ -97,7 +97,7 @@ impl crate::textlayout::FontMetrics<PhysicalLength> for Font {
     fn cap_height(&self) -> PhysicalLength {
         match self {
             Font::PixelFont(pixel_font) => pixel_font.cap_height(),
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             Font::VectorFont(vector_font) => vector_font.cap_height(),
         }
     }
@@ -128,7 +128,7 @@ pub fn match_font(request: &FontRequest, scale_factor: ScaleFactor) -> Font {
     let font = match bitmap_font {
         Some(bitmap_font) => bitmap_font,
         None => {
-            #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+            #[cfg(feature = "software-renderer-systemfonts")]
             if let Some(vectorfont) = systemfonts::match_font(request, scale_factor) {
                 return vectorfont.into();
             }
@@ -143,12 +143,9 @@ pub fn match_font(request: &FontRequest, scale_factor: ScaleFactor) -> Font {
             }) {
                 fallback_bitmap_font
             } else {
-                #[cfg(all(
-                    feature = "software-renderer-systemfonts",
-                    not(target_arch = "wasm32")
-                ))]
+                #[cfg(feature = "software-renderer-systemfonts")]
                 return systemfonts::fallbackfont(request, scale_factor).into();
-                #[cfg(any(not(feature = "software-renderer-systemfonts"), target_arch = "wasm32"))]
+                #[cfg(not(feature = "software-renderer-systemfonts"))]
                 panic!("No font fallback found. The software renderer requires enabling the `EmbedForSoftwareRenderer` option when compiling slint files.")
             }
         }
@@ -202,7 +199,7 @@ pub fn text_size(
                 text_wrap,
             )
         }
-        #[cfg(all(feature = "software-renderer-systemfonts", not(target_arch = "wasm32")))]
+        #[cfg(feature = "software-renderer-systemfonts")]
         Font::VectorFont(vf) => {
             let layout = text_layout_for_font(&vf, &font_request, scale_factor);
             layout.text_size(

--- a/internal/core/software_renderer/fonts/systemfonts.rs
+++ b/internal/core/software_renderer/fonts/systemfonts.rs
@@ -84,6 +84,7 @@ pub fn register_font_from_memory(data: &'static [u8]) -> Result<(), Box<dyn std:
     Ok(())
 }
 
+#[cfg(not(target_family = "wasm"))]
 pub fn register_font_from_path(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let requested_path = path.canonicalize().unwrap_or_else(|_| path.to_owned());
     sharedfontdb::FONT_DB.with_borrow_mut(|fonts| {


### PR DESCRIPTION
Everything is already working, just had to play around with a few cfgs. The sharedfontdb module already takes care of including DejaVuSans as default fallback font.

The rest is plug and play. This works if the project is compiled with Rust directly, rendere-femtovg is excluded but renderer-software is included. Then it gets selected as default renderer and this all works. I'll create a separate PR for allowing selecting the software renderer for the wasm-interpreter.
