### PR TITLE
Interpreter: on wasm, check the user agent to resolve the native style

### DIFF
--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -137,6 +137,7 @@ itertools = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 i-slint-backend-winit = { workspace = true }
+web-sys = { workspace = true, features=[ "Navigator" ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # this line is there to add the "enable" feature by default, but only on linux

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -105,7 +105,7 @@ image = { workspace = true, optional = true, features = ["default"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.5"
 js-sys = { version = "0.3.57" }
-web-sys = { version = "0.3", features=[ "Navigator" ] }
+web-sys = { workspace = true, features=[ "Navigator" ] }
 send_wrapper = { workspace = true }
 serde-wasm-bindgen = "0.6.0"
 wasm-bindgen = "0.2.80"


### PR DESCRIPTION
This impact everything that use the interpreter with wasm:
 - docs preview
 - slintpad
 - vscode wasm preview
