### PR TITLE
Fix missing redraws when embedding Slint into QWidget hierarchy

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1873,7 +1873,11 @@ impl WindowAdapter for QtWindow {
     fn request_redraw(&self) {
         let widget_ptr = self.widget_ptr();
         cpp! {unsafe [widget_ptr as "QWidget*"] {
-            if (auto w = widget_ptr->window()->windowHandle()) {
+            // If embedded as a QWidget, just use regular QWidget::update(), but if we're a top-level,
+            // then use requestUpdate() to achieve frame-throttling.
+            if (widget_ptr->parentWidget()) {
+                widget_ptr->update();
+            } else if (auto w = widget_ptr->window()->windowHandle()) {
                 w->requestUpdate();
             }
         }}


### PR DESCRIPTION
Commit 5718b1589904ef8b2666e4cfc0bbb661a6eaa5c4 regressed this by issuing the update on the window, which breaks when the widget is embedded in a hierarchy (like a QGraphicsView). We really need to mark the widget as dirty, even if that means we don't get frame throttling then.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
