### PR TITLE
Fix `ListItem` accessible tree representation

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -414,6 +414,7 @@ impl NodeCollection {
             Role::Button
                 | Role::CheckBox
                 | Role::ComboBox
+                | Role::ListBoxOption
                 | Role::Slider
                 | Role::SpinButton
                 | Role::Tab

--- a/internal/compiler/widgets/cosmic/components.slint
+++ b/internal/compiler/widgets/cosmic/components.slint
@@ -102,6 +102,10 @@ export component ListItem {
     min-height: max(CosmicSizeSettings.item-height, layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 1;
+    accessible-role: list-item;
+    accessible-label: root.item.text;
+    accessible-selectable: true;
+    accessible-selected: root.is-selected;
 
     states [
         is-selected when root.is-selected : {
@@ -111,9 +115,6 @@ export component ListItem {
 
     layout := HorizontalLayout {
         padding-bottom: 8px;
-        accessible-role: list-item;
-        accessible-selectable: true;
-        accessible-selected: root.is-selected;
 
         StateLayerBase {
             width: 100%;
@@ -137,6 +138,7 @@ export component ListItem {
                     vertical-alignment: center;
                     horizontal-alignment: left;
                     overflow: elide;
+                    accessible-role: none;
                 }
 
                 Image {

--- a/internal/compiler/widgets/cupertino/components.slint
+++ b/internal/compiler/widgets/cupertino/components.slint
@@ -58,6 +58,10 @@ export component ListItem {
     min-height: max(CupertinoSizeSettings.item-height, i-layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 1;
+    accessible-role: list-item;
+    accessible-label: root.item.text;
+    accessible-selectable: true;
+    accessible-selected: root.is-selected;
 
     states [
         has-focus when root.has-focus : {
@@ -73,9 +77,6 @@ export component ListItem {
     i-layout := VerticalLayout {
         padding-left: root.padding-horizontal;
         padding-right: root.padding-horizontal;
-        accessible-role: list-item;
-        accessible-selectable: true;
-        accessible-selected: root.is-selected;
 
         i-background := Rectangle {
             background: transparent;
@@ -102,6 +103,7 @@ export component ListItem {
                     vertical-alignment: center;
                     horizontal-alignment: left;
                     overflow: elide;
+                    accessible-role: none;
                 }
             }
         }

--- a/internal/compiler/widgets/fluent/components.slint
+++ b/internal/compiler/widgets/fluent/components.slint
@@ -46,6 +46,10 @@ export component ListItem {
     min-height: max(FluentSizeSettings.item-height, i-layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 1;
+    accessible-role: list-item;
+    accessible-label: root.item.text;
+    accessible-selectable: true;
+    accessible-selected: root.is-selected;
 
     states [
         pressed when root.pressed : {
@@ -78,9 +82,6 @@ export component ListItem {
             padding-left: 16px;
             padding-right: 16px;
             spacing: 4px;
-            accessible-role: list-item;
-            accessible-selectable: true;
-            accessible-selected: root.is-selected;
 
             i-text := Text {
                 text: root.item.text;
@@ -90,6 +91,7 @@ export component ListItem {
                 vertical-alignment: center;
                 horizontal-alignment: left;
                 overflow: elide;
+                accessible-role: none;
 
                 animate color { duration: 200ms; }
             }

--- a/internal/compiler/widgets/material/components.slint
+++ b/internal/compiler/widgets/material/components.slint
@@ -104,6 +104,10 @@ export component ListItem {
     min-height: max(MaterialSizeSettings.item-height, i-layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 1;
+    accessible-role: list-item;
+    accessible-label: root.item.text;
+    accessible-selectable: true;
+    accessible-selected: root.is-selected;
 
     states [
         pressed when root.pressed: {
@@ -145,9 +149,6 @@ export component ListItem {
     i-layout := HorizontalLayout {
         padding-left: 12px;
         padding-right: 12px;
-        accessible-role: list-item;
-        accessible-selectable: true;
-        accessible-selected: root.is-selected;
 
         label := Text {
             text: root.item.text;
@@ -157,6 +158,7 @@ export component ListItem {
             //font-family: MaterialFontSettings.label-large.font;
             font-size: MaterialFontSettings.label-large.font-size;
             font-weight: MaterialFontSettings.label-large.font-weight;
+            accessible-role: none;
         }
     }
 


### PR DESCRIPTION
We need to explicitly set the `accessible-label` property on the `ListItem` for the label to appear in the accessibility tree. I decided to move all accessibility related properties in the same place to be consistent and to ease maintenance.

Also tell AccessKit that `ListItem` components can receive keyboard focus, as described in #6554.
