### PR TITLE
doc: Fix typo in plurals example

### DIFF
--- a/docs/reference/src/language/concepts/translations.md
+++ b/docs/reference/src/language/concepts/translations.md
@@ -73,7 +73,7 @@ Use `{n}` in the format string to access the expression after the `%`.
 export component Example inherits Text {
     in property <int> score;
     in property <int> name;
-    text: @tr("Hello {0}, you have one point" | "Hello {0}, you have {n} point" % score, name);
+    text: @tr("Hello {0}, you have one point" | "Hello {0}, you have {n} points" % score, name);
 }
 ```
 


### PR DESCRIPTION
When the score is not one, plural form should be used

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
