### PR TITLE
Fix parsing of unfinished `import` statement

### DIFF
--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -332,13 +332,12 @@ fn parse_import_identifier_list(p: &mut impl Parser) -> bool {
                 p.consume();
                 return true;
             }
-            SyntaxKind::Eof => return false,
             SyntaxKind::Comma => {
                 p.consume();
             }
             _ => {
-                p.consume();
-                p.error("Expected comma")
+                p.error("Expected comma or brace");
+                return false;
             }
         }
     }

--- a/internal/compiler/tests/syntax/fuzzing/6588.slint
+++ b/internal/compiler/tests/syntax/fuzzing/6588.slint
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+//^^^error{Expected comma or brace}
+
+import { Bmp
+

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -124,10 +124,14 @@ fn process_diagnostics(
         let offset = loop {
             line_counter += 1;
             if line_counter >= lines_to_source {
-                break line_offset;
+                break line_offset + column;
             }
-            line_offset = source[..line_offset].rfind('\n').unwrap_or(0);
-        } + column;
+            if let Some(o) = source[..line_offset].rfind('\n') {
+                line_offset = o;
+            } else {
+                break 1;
+            };
+        };
 
         let expected_diag_level = match warning_or_error {
             "warning" => i_slint_compiler::diagnostics::DiagnosticLevel::Warning,


### PR DESCRIPTION
Fix #6588

Note for the test: parse error at the end of the file are actually reported at offset 0. Use a trick to add more `^` at the beginning to mean that.
(Offset 0 is actually offset 1 as the column starts at 1)
