### PR TITLE
Fix panic when a layout constraint has an Expression::Invalid as binding

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -406,7 +406,9 @@ fn find_binding<R>(
     let mut depth = 0;
     loop {
         if let Some(b) = element.borrow().bindings.get(name) {
-            return Some(f(&b.borrow(), &element.borrow().enclosing_component, depth));
+            if b.borrow().has_binding() {
+                return Some(f(&b.borrow(), &element.borrow().enclosing_component, depth));
+            }
         }
         let e = match &element.borrow().base_type {
             ElementType::Component(base) => base.root_element.clone(),

--- a/internal/compiler/tests/syntax/fuzzing/6590.slint
+++ b/internal/compiler/tests/syntax/fuzzing/6590.slint
@@ -1,0 +1,9 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+   component A inherits Window {
+// ^warning{Component is implicitly marked for export. This is deprecated and it should be explicitly exported}
+    preferred-height: x;
+//                    ^error{Unknown unqualified identifier 'x'. Did you mean 'self.x'?}
+    Image { }
+}


### PR DESCRIPTION
We can detect this case earlier

Fix #6590


