### PR TITLE
Implement `accessible-delegate-focus` for the AccessKit backend

### DIFF
--- a/internal/compiler/widgets/common/listview.slint
+++ b/internal/compiler/widgets/common/listview.slint
@@ -33,6 +33,8 @@ component StandardListViewBase inherits ListView {
     private property <length> current-item-y: root.item-y(root.focus-item);
     private property <int> focus-item: 0;
 
+    accessible-delegate-focus: root.focus-item;
+
     pure function first-visible-item() -> int {
         return min(root.model.length - 1, max(0, round(-root.viewport-y / root.item-height)));
     }


### PR DESCRIPTION
Fixes #6554 

Considers the `accessible-delegate-focus` property when building tree updates for AccessKit.

This fixes accessibility of both the `StandardListView` and the `TabList`.

The only issue is that it breaks when items are off-screen. In the case of the 7GUIs/CRUD example, only the two first items are shown and arrowing down to the third seem to not trigger a rebuild of the tree, which leads to the "AccessKit focus" being placed on the root window. I suspect a bigger issue here as using the keyboard inside the list view seem to not trigger repaints as well, and seem to interfer with the mouse too.
