### PR TITLE
live-preview: Default to "native" as expected (if that is available!)

### DIFF
--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -35,7 +35,12 @@ pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, Platfor
     let style = if known_styles.contains(&style.as_str()) {
         style
     } else {
-        known_styles.first().map(|s| s.to_string()).unwrap_or_default()
+        known_styles
+            .iter()
+            .find(|x| **x == "native")
+            .or_else(|| known_styles.first())
+            .map(|s| s.to_string())
+            .unwrap_or_default()
     };
 
     let style_model = Rc::new({


### PR DESCRIPTION
"native used to be the first. That is no longer the case as we sort the list.

So look for native, or take the first if that is not in the list or default to a default constructed string.

The "use first" is unnecessary at this time as "native" is always in the list, but I thought I'll keep that just in case we remove native at some point.