### PR TITLE
CI: update Qt, defaults to Qt6 for the linux binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
     build_and_test:
         env:
-            DYLD_FRAMEWORK_PATH: /Users/runner/work/slint/Qt/5.15.2/clang_64/lib
+            DYLD_FRAMEWORK_PATH: /Users/runner/work/slint/Qt/6.2.2/macos/lib
             QT_QPA_PLATFORM: offscreen
             RUSTFLAGS: -D warnings
             CARGO_PROFILE_DEV_DEBUG: 0
@@ -58,9 +58,9 @@ jobs:
                 python-version: '3.10'
             - name: Install Qt
               if: runner.os != 'Windows'
-              uses: jurplel/install-qt-action@v3
+              uses: jurplel/install-qt-action@v4
               with:
-                  version: "5.15.2"
+                  version: "6.2.2"
                   setup-python: false
                   cache: true
             - name: Install ffmpeg and alsa (Linux)
@@ -77,7 +77,7 @@ jobs:
             - uses: ./.github/actions/setup-rust
               with:
                   toolchain: ${{ matrix.rust_version }}
-                  key: x-v2
+                  key: x-v3
             # - name: Pin dependencies to make it build with our MSRV
             #   if: matrix.rust_version == '1.77'
             #   shell: bash
@@ -86,12 +86,12 @@ jobs:
             #         cargo update -p xxx --precise x.y.z
             #       fi
             - name: Run tests (not qt)
-              run: DYLD_FRAMEWORK_PATH=$Qt5_DIR/lib cargo test --verbose --all-features --workspace ${{ matrix.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude mcu-board-support --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python -- --skip=_qt::t
+              run:  cargo test --verbose --all-features --workspace ${{ matrix.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude mcu-board-support --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python -- --skip=_qt::t
               env:
                   SLINT_CREATE_SCREENSHOTS: 1
               shell: bash
             - name: Run tests (qt)
-              run: DYLD_FRAMEWORK_PATH=$Qt5_DIR/lib cargo test --verbose --all-features --workspace ${{ matrix.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude mcu-board-support --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python --bin test-driver-rust -- _qt --test-threads=1
+              run: cargo test --verbose --all-features --workspace ${{ matrix.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude mcu-board-support --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python --bin test-driver-rust -- _qt --test-threads=1
               shell: bash
             - name: Archive screenshots after failed tests
               if: ${{ failure() }}
@@ -120,7 +120,7 @@ jobs:
             - uses: ./.github/actions/install-linux-dependencies
             - name: Install Qt
               if: runner.os != 'Windows'
-              uses: jurplel/install-qt-action@v3
+              uses: jurplel/install-qt-action@v4
               with:
                   version: "5.15.2"
                   setup-python: false
@@ -173,7 +173,7 @@ jobs:
             - uses: ./.github/actions/install-linux-dependencies
             - name: Install Qt
               if: runner.os == 'Linux'
-              uses: jurplel/install-qt-action@v3
+              uses: jurplel/install-qt-action@v4
               with:
                   version: "5.15.2"
                   setup-python: false
@@ -211,7 +211,7 @@ jobs:
                   force-gcc-10: true
             - name: Install Qt
               if: runner.os != 'Windows'
-              uses: jurplel/install-qt-action@v3
+              uses: jurplel/install-qt-action@v4
               with:
                   version: "5.15.2"
                   cache: true
@@ -251,7 +251,7 @@ jobs:
               with:
                   force-gcc-10: true
             - name: Install Qt
-              uses: jurplel/install-qt-action@v3
+              uses: jurplel/install-qt-action@v4
               with:
                   version: 6.5.1
                   cache: true
@@ -299,7 +299,7 @@ jobs:
               with:
                   force-gcc-10: true
             - name: Install Qt (Ubuntu)
-              uses: jurplel/install-qt-action@v3
+              uses: jurplel/install-qt-action@v4
               with:
                   version: 6.5.1
                   cache: true

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
     cmake_package_desktop:
         env:
-            DYLD_FRAMEWORK_PATH: /Users/runner/work/slint/Qt/6.5.1/clang_64/lib
+            DYLD_FRAMEWORK_PATH: /Users/runner/work/slint/Qt/6.2.2/clang_64/lib
             QT_QPA_PLATFORM: offscreen
             CARGO_INCREMENTAL: false
         strategy:
@@ -46,10 +46,10 @@ jobs:
               with:
                   old-ubuntu: true
             - name: Install Qt (Ubuntu)
-              uses: jurplel/install-qt-action@v3
+              uses: jurplel/install-qt-action@v4
               if: matrix.os == 'ubuntu-20.04'
               with:
-                  version: 5.15.2
+                  version: 6.2.2
                   cache: true
             - uses: ./.github/actions/setup-rust
             - uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -61,11 +61,6 @@ jobs:
             - uses: ./.github/actions/setup-rust
               with:
                   target: x86_64-pc-windows-msvc
-            - name: Install Qt
-              uses: jurplel/install-qt-action@v3
-              with:
-                  version: 6.5.1
-                  cache: true
             - uses: baptiste0928/cargo-install@v3
               with:
                   crate: cargo-about
@@ -101,9 +96,9 @@ jobs:
               with:
                   target: x86_64-unknown-linux-gnu
             - name: Install Qt
-              uses: jurplel/install-qt-action@v3
+              uses: jurplel/install-qt-action@v4
               with:
-                  version: 5.15.2
+                  version: 6.2.2
                   cache: true
             - uses: baptiste0928/cargo-install@v3
               with:
@@ -143,7 +138,7 @@ jobs:
             with:
                 crate: cargo-about
           - name: Build
-            run: cross build --target=${{ matrix.target }} --no-default-features --features backend-qt,${{ github.event.inputs.features || inputs.features }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
+            run: cross build --target=${{ matrix.target }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
           - name: Create artifact directory
             run: |
                 mkdir -p slint-${{ github.event.inputs.program || inputs.program }}-${{ matrix.target }}

--- a/internal/backends/qt/build.rs
+++ b/internal/backends/qt/build.rs
@@ -40,6 +40,8 @@ fn main() {
     }
     config.flag_if_supported("-std=c++17");
     config.flag_if_supported("/std:c++17");
+    // Workaround QTBUG-123153
+    config.flag_if_supported("-Wno-template-id-cdtor");
     config.include(std::env::var("DEP_QT_INCLUDE_PATH").unwrap()).build("lib.rs");
 
     println!("cargo:rerun-if-changed=lib.rs");


### PR DESCRIPTION
Closes #6586

ChangeLog: binary package build with Qt now uses Qt6

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
