### PR TITLE
Pin Python version for Skia builds on macOS

### DIFF
--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -58,6 +58,10 @@ jobs:
             - name: Prepare licenses
               run: bash -x ../../scripts/prepare_binary_package.sh ../..
               working-directory: api/cpp/
+            # Pin Python version until https://github.com/slint-ui/slint/issues/6615 is fixed.   
+            - uses: actions/setup-python@v5
+              with:
+                python-version: '3.12'
             - uses: ilammy/msvc-dev-cmd@v1
             - name: Select MSVC (windows)
               run: |

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -141,12 +141,16 @@ jobs:
     build_vscode_lsp_macos_aarch64:
         env:
             SLINT_NO_QT: 1
-        runs-on: macos-latest
+        runs-on: macos-14
         steps:
             - uses: actions/checkout@v4
             - uses: ./.github/actions/setup-rust
               with:
                   target: aarch64-apple-darwin
+            # Pin Python version until https://github.com/slint-ui/slint/issues/6615 is fixed.   
+            - uses: actions/setup-python@v5
+              with:
+                python-version: '3.12'
             - name: Build AArch64 LSP
               run: cargo build --target aarch64-apple-darwin --features ${{ env.SLINT_BINARY_FEATURES }} --release -p slint-lsp
             - name: Create artifact directory

--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -83,7 +83,11 @@ jobs:
                   target: ${{ matrix.rust-target }}
             - name: Upgrade LLVM for Skia build on Windows
               if: runner.os == 'Windows'
-              run: choco upgrade llvm    
+              run: choco upgrade llvm 
+            # Pin Python version until https://github.com/slint-ui/slint/issues/6615 is fixed.   
+            - uses: actions/setup-python@v5
+              with:
+                python-version: '3.12'
             # Setup .npmrc file to publish to npm
             - uses: actions/setup-node@v4
               with:


### PR DESCRIPTION
The Python version installed on the GH runners via homebrew removes the pipes module, which the Skia build needs until https://github.com/slint-ui/slint/issues/6615 is fixed.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
