### PR TITLE
Android: handle properly the Destroy event

### DIFF
--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -250,6 +250,9 @@ impl AndroidWindowAdapter {
                     });
                 }
             }
+            PollEvent::Main(MainEvent::Destroy) => {
+                return Ok(ControlFlow::Break(()));
+            }
             _ => (),
         }
         Ok(ControlFlow::Continue(()))

--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -114,14 +114,14 @@ impl i_slint_core::platform::Platform for AndroidPlatform {
                     event_listener(&e)
                 }
             });
-            if matches!(r.map_err(|e| PlatformError::from(e.to_string()))?, ControlFlow::Break(()))
-            {
-                return Ok(());
+            if r?.is_break() {
+                break;
             }
             if self.window.pending_redraw.take() {
                 self.window.do_render()?;
             }
         }
+        Ok(())
     }
 
     fn new_event_loop_proxy(&self) -> Option<Box<dyn i_slint_core::platform::EventLoopProxy>> {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -966,9 +966,11 @@ pub use weak_handle::*;
 /// handle.run().unwrap();
 /// ```
 pub fn invoke_from_event_loop(func: impl FnOnce() + Send + 'static) -> Result<(), EventLoopError> {
-    crate::platform::event_loop_proxy()
-        .ok_or(EventLoopError::NoEventLoopProvider)?
-        .invoke_from_event_loop(alloc::boxed::Box::new(func))
+    crate::platform::with_event_loop_proxy(|proxy| {
+        proxy
+            .ok_or(EventLoopError::NoEventLoopProvider)?
+            .invoke_from_event_loop(alloc::boxed::Box::new(func))
+    })
 }
 
 /// Schedules the main event loop for termination. This function is meant
@@ -978,9 +980,9 @@ pub fn invoke_from_event_loop(func: impl FnOnce() + Send + 'static) -> Result<()
 ///
 /// This function can be called from any thread
 pub fn quit_event_loop() -> Result<(), EventLoopError> {
-    crate::platform::event_loop_proxy()
-        .ok_or(EventLoopError::NoEventLoopProvider)?
-        .quit_event_loop()
+    crate::platform::with_event_loop_proxy(|proxy| {
+        proxy.ok_or(EventLoopError::NoEventLoopProvider)?.quit_event_loop()
+    })
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
Destroy means we need to exit the event loop.
And android_main will be called again from another thread, so we need to support reseting the proxy

There is also a bug in the timer when exiting the app that this worked around

Fix #6626
