### PR TITLE
Only clone the public properties for the exported component

### DIFF
--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1290,7 +1290,12 @@ pub(crate) fn generate_item_tree<'id>(
         .map(|_| builder.type_builder.add_field_type::<Timer>())
         .collect();
 
-    let public_properties = component.root_element.borrow().property_declarations.clone();
+    // only the public exported component needs the public property list
+    let public_properties = if !component.parent_element.upgrade().is_some() {
+        component.root_element.borrow().property_declarations.clone()
+    } else {
+        Default::default()
+    };
 
     let t = ItemTreeVTable {
         visit_children_item,


### PR DESCRIPTION
Copying potentially thousands of properties for no reason is something that can be easily optimized away to save a bit of time:

Before:
```
Benchmark 1: ./target/release/slint-viewer ../slint-perf/app.slint
  Time (mean ± σ):      1.108 s ±  0.015 s    [User: 0.792 s, System: 0.231 s]
  Range (min … max):    1.085 s …  1.133 s    10 runs
```

After:
```
Benchmark 1: ./target/release/slint-viewer ../slint-perf/app.slint
  Time (mean ± σ):      1.082 s ±  0.019 s    [User: 0.773 s, System: 0.214 s]
  Range (min … max):    1.054 s …  1.117 s    10 runs
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
