### PR TITLE
Assorted performance optimizations for langtype and related code

### DIFF
--- a/api/node/rust/interpreter/component_compiler.rs
+++ b/api/node/rust/interpreter/component_compiler.rs
@@ -114,10 +114,11 @@ impl JsComponentCompiler {
     pub fn structs(&self, env: Env) -> HashMap<String, JsUnknown> {
         fn convert_type(env: &Env, ty: &Type) -> Option<(String, JsUnknown)> {
             match ty {
-                Type::Struct { fields, name: Some(name), node: Some(_), .. } => {
+                Type::Struct(s) if s.name.is_some() && s.node.is_some() => {
+                    let name = s.name.as_ref().unwrap();
                     let struct_instance = to_js_unknown(
                         env,
-                        &Value::Struct(slint_interpreter::Struct::from_iter(fields.iter().map(
+                        &Value::Struct(slint_interpreter::Struct::from_iter(s.fields.iter().map(
                             |(name, field_type)| {
                                 (
                                     name.to_string(),

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -216,11 +216,11 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
                 Ok(Value::Image(Image::from_rgba8(pixel_buffer)))
             }
         }
-        Type::Struct { fields, name: _, node: _, rust_attributes: _ } => {
+        Type::Struct(s) => {
             let js_object = unknown.coerce_to_object()?;
 
             Ok(Value::Struct(
-                fields
+                s.fields
                     .iter()
                     .map(|(pro_name, pro_ty)| {
                         let prop: JsUnknown = js_object

--- a/api/python/interpreter.rs
+++ b/api/python/interpreter.rs
@@ -153,9 +153,9 @@ impl CompilationResult {
 
         fn convert_type(py: Python<'_>, ty: &Type) -> Option<(String, PyObject)> {
             match ty {
-                Type::Struct { fields, name: Some(name), node: Some(_), .. } => {
+                Type::Struct(s) if s.name.is_some() && s.node.is_some() => {
                     let struct_instance = PyStruct::from(slint_interpreter::Struct::from_iter(
-                        fields.iter().map(|(name, field_type)| {
+                        s.fields.iter().map(|(name, field_type)| {
                             (
                                 name.to_string(),
                                 slint_interpreter::default_value_for_type(field_type),
@@ -163,7 +163,10 @@ impl CompilationResult {
                         }),
                     ));
 
-                    return Some((name.to_string(), struct_instance.into_py(py)));
+                    return Some((
+                        s.name.as_ref().unwrap().to_string(),
+                        struct_instance.into_py(py),
+                    ));
                 }
                 Type::Enumeration(_en) => {
                     // TODO

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -380,13 +380,13 @@ fn to_debug_string(
             true_expr: Box::new(Expression::StringLiteral("true".into())),
             false_expr: Box::new(Expression::StringLiteral("false".into())),
         },
-        Type::Struct { fields, .. } => {
+        Type::Struct(s) => {
             let local_object = format_smolstr!(
                 "debug_struct{}",
                 COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             );
             let mut string = None;
-            for k in fields.keys() {
+            for k in s.fields.keys() {
                 let field_name = if string.is_some() {
                     format_smolstr!(", {}: ", k)
                 } else {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -278,7 +278,7 @@ impl BuiltinFunction {
             }
             BuiltinFunction::DateNow => {
                 interned_type!(Function {
-                    return_type: Type::Array(Box::new(Type::Int32)),
+                    return_type: Type::Array(Rc::new(Type::Int32)),
                     args: vec![]
                 })
             }
@@ -289,7 +289,7 @@ impl BuiltinFunction {
                 })
             }
             BuiltinFunction::ParseDate => interned_type!(Function {
-                return_type: Type::Array(Box::new(Type::Int32)),
+                return_type: Type::Array(Rc::new(Type::Int32)),
                 args: vec![Type::String, Type::String],
             }),
             BuiltinFunction::SetTextInputFocused => {
@@ -871,7 +871,7 @@ impl Expression {
                 }
             }
             Expression::UnaryOp { sub, .. } => sub.ty(),
-            Expression::Array { element_ty, .. } => Type::Array(Box::new(element_ty.clone())),
+            Expression::Array { element_ty, .. } => Type::Array(Rc::new(element_ty.clone())),
             Expression::Struct { ty, .. } => ty.clone(),
             Expression::PathData { .. } => Type::PathData,
             Expression::StoreLocalVariable { .. } => Type::Void,
@@ -1303,7 +1303,7 @@ impl Expression {
                         .map(|e| e.maybe_convert_to((*target_type).clone(), node, diag))
                         .take_while(|e| !matches!(e, Expression::Invalid))
                         .collect(),
-                    element_ty: *target_type,
+                    element_ty: (*target_type).clone(),
                 },
                 _ => unreachable!(),
             }
@@ -1481,7 +1481,7 @@ fn model_inner_type(model: &Expression) -> Type {
         Expression::CodeBlock(cb) => cb.last().map_or(Type::Invalid, model_inner_type),
         _ => match model.ty() {
             Type::Float32 | Type::Int32 => Type::Int32,
-            Type::Array(elem) => *elem,
+            Type::Array(elem) => (*elem).clone(),
             _ => Type::Invalid,
         },
     }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -161,7 +161,7 @@ declare_builtin_function_types!(
     ItemFontMetrics: (Type::ElementReference) -> crate::typeregister::font_metrics_type(),
     StringToFloat: (Type::String) -> Type::Float32,
     StringIsFloat: (Type::String) -> Type::Bool,
-    ImplicitLayoutInfo(..): (Type::ElementReference) -> crate::layout::layout_info_type(),
+    ImplicitLayoutInfo(..): (Type::ElementReference) -> crate::typeregister::layout_info_type(),
     ColorRgbaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct {
         fields: IntoIterator::into_iter([
             (SmolStr::new_static("red"), Type::Int32),
@@ -792,7 +792,7 @@ impl Expression {
             // invalid because the expression is unreachable
             Expression::ReturnStatement(_) => Type::Invalid,
             Expression::LayoutCacheAccess { .. } => Type::LogicalLength,
-            Expression::ComputeLayoutInfo(..) => crate::layout::layout_info_type(),
+            Expression::ComputeLayoutInfo(..) => crate::typeregister::layout_info_type(),
             Expression::SolveLayout(..) => Type::LayoutCache,
             Expression::MinMax { ty, .. } => ty.clone(),
             Expression::EmptyComponentFactory => Type::ComponentFactory,

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
-use crate::langtype::{BuiltinElement, EnumerationValue, Type};
+use crate::langtype::{BuiltinElement, EnumerationValue, Function, Type};
 use crate::layout::Orientation;
 use crate::lookup::LookupCtx;
 use crate::object_tree::*;
@@ -109,82 +109,73 @@ pub enum BuiltinMacroFunction {
 
 impl BuiltinFunction {
     pub fn ty(&self) -> Type {
-        match self {
-            BuiltinFunction::GetWindowScaleFactor => Type::Function {
-                return_type: Box::new(Type::UnitProduct(vec![(Unit::Phx, 1), (Unit::Px, -1)])),
+        let fun = match self {
+            BuiltinFunction::GetWindowScaleFactor => Function {
+                return_type: Type::UnitProduct(vec![(Unit::Phx, 1), (Unit::Px, -1)]),
                 args: vec![],
             },
             BuiltinFunction::GetWindowDefaultFontSize => {
-                Type::Function { return_type: Box::new(Type::LogicalLength), args: vec![] }
+                Function { return_type: Type::LogicalLength, args: vec![] }
             }
             BuiltinFunction::AnimationTick => {
-                Type::Function { return_type: Type::Duration.into(), args: vec![] }
+                Function { return_type: Type::Duration.into(), args: vec![] }
             }
             BuiltinFunction::Debug => {
-                Type::Function { return_type: Box::new(Type::Void), args: vec![Type::String] }
+                Function { return_type: Type::Void, args: vec![Type::String] }
             }
-            BuiltinFunction::Mod => Type::Function {
-                return_type: Box::new(Type::Int32),
-                args: vec![Type::Int32, Type::Int32],
-            },
+            BuiltinFunction::Mod => {
+                Function { return_type: Type::Int32, args: vec![Type::Int32, Type::Int32] }
+            }
             BuiltinFunction::Round | BuiltinFunction::Ceil | BuiltinFunction::Floor => {
-                Type::Function { return_type: Box::new(Type::Int32), args: vec![Type::Float32] }
+                Function { return_type: Type::Int32, args: vec![Type::Float32] }
             }
             BuiltinFunction::Sqrt | BuiltinFunction::Abs => {
-                Type::Function { return_type: Box::new(Type::Float32), args: vec![Type::Float32] }
+                Function { return_type: Type::Float32, args: vec![Type::Float32] }
             }
             BuiltinFunction::Cos | BuiltinFunction::Sin | BuiltinFunction::Tan => {
-                Type::Function { return_type: Box::new(Type::Float32), args: vec![Type::Angle] }
+                Function { return_type: Type::Float32, args: vec![Type::Angle] }
             }
             BuiltinFunction::ACos | BuiltinFunction::ASin | BuiltinFunction::ATan => {
-                Type::Function { return_type: Box::new(Type::Angle), args: vec![Type::Float32] }
+                Function { return_type: Type::Angle, args: vec![Type::Float32] }
             }
-            BuiltinFunction::ATan2 => Type::Function {
-                return_type: Box::new(Type::Angle),
-                args: vec![Type::Float32, Type::Float32],
-            },
-            BuiltinFunction::Log | BuiltinFunction::Pow => Type::Function {
-                return_type: Box::new(Type::Float32),
-                args: vec![Type::Float32, Type::Float32],
-            },
-            BuiltinFunction::SetFocusItem => Type::Function {
-                return_type: Box::new(Type::Void),
-                args: vec![Type::ElementReference],
-            },
-            BuiltinFunction::ClearFocusItem => Type::Function {
-                return_type: Box::new(Type::Void),
-                args: vec![Type::ElementReference],
-            },
+            BuiltinFunction::ATan2 => {
+                Function { return_type: Type::Angle, args: vec![Type::Float32, Type::Float32] }
+            }
+            BuiltinFunction::Log | BuiltinFunction::Pow => {
+                Function { return_type: Type::Float32, args: vec![Type::Float32, Type::Float32] }
+            }
+            BuiltinFunction::SetFocusItem => {
+                Function { return_type: Type::Void, args: vec![Type::ElementReference] }
+            }
+            BuiltinFunction::ClearFocusItem => {
+                Function { return_type: Type::Void, args: vec![Type::ElementReference] }
+            }
             BuiltinFunction::ShowPopupWindow | BuiltinFunction::ClosePopupWindow => {
-                Type::Function {
-                    return_type: Box::new(Type::Void),
-                    args: vec![Type::ElementReference],
-                }
+                Function { return_type: Type::Void, args: vec![Type::ElementReference] }
             }
-            BuiltinFunction::SetSelectionOffsets => Type::Function {
-                return_type: Box::new(Type::Void),
+            BuiltinFunction::SetSelectionOffsets => Function {
+                return_type: Type::Void,
                 args: vec![Type::ElementReference, Type::Int32, Type::Int32],
             },
-            BuiltinFunction::ItemMemberFunction(..) => Type::Function {
-                return_type: Box::new(Type::Void),
-                args: vec![Type::ElementReference],
-            },
-            BuiltinFunction::ItemFontMetrics => Type::Function {
-                return_type: Box::new(crate::typeregister::font_metrics_type()),
+            BuiltinFunction::ItemMemberFunction(..) => {
+                Function { return_type: Type::Void, args: vec![Type::ElementReference] }
+            }
+            BuiltinFunction::ItemFontMetrics => Function {
+                return_type: crate::typeregister::font_metrics_type(),
                 args: vec![Type::ElementReference],
             },
             BuiltinFunction::StringToFloat => {
-                Type::Function { return_type: Box::new(Type::Float32), args: vec![Type::String] }
+                Function { return_type: Type::Float32, args: vec![Type::String] }
             }
             BuiltinFunction::StringIsFloat => {
-                Type::Function { return_type: Box::new(Type::Bool), args: vec![Type::String] }
+                Function { return_type: Type::Bool, args: vec![Type::String] }
             }
-            BuiltinFunction::ImplicitLayoutInfo(_) => Type::Function {
-                return_type: Box::new(crate::layout::layout_info_type()),
+            BuiltinFunction::ImplicitLayoutInfo(_) => Function {
+                return_type: crate::layout::layout_info_type(),
                 args: vec![Type::ElementReference],
             },
-            BuiltinFunction::ColorRgbaStruct => Type::Function {
-                return_type: Box::new(Type::Struct {
+            BuiltinFunction::ColorRgbaStruct => Function {
+                return_type: Type::Struct {
                     fields: IntoIterator::into_iter([
                         (SmolStr::new_static("red"), Type::Int32),
                         (SmolStr::new_static("green"), Type::Int32),
@@ -195,11 +186,11 @@ impl BuiltinFunction {
                     name: Some("Color".into()),
                     node: None,
                     rust_attributes: None,
-                }),
+                },
                 args: vec![Type::Color],
             },
-            BuiltinFunction::ColorHsvaStruct => Type::Function {
-                return_type: Box::new(Type::Struct {
+            BuiltinFunction::ColorHsvaStruct => Function {
+                return_type: Type::Struct {
                     fields: IntoIterator::into_iter([
                         (SmolStr::new_static("hue"), Type::Float32),
                         (SmolStr::new_static("saturation"), Type::Float32),
@@ -210,31 +201,27 @@ impl BuiltinFunction {
                     name: Some("Color".into()),
                     node: None,
                     rust_attributes: None,
-                }),
+                },
                 args: vec![Type::Color],
             },
-            BuiltinFunction::ColorBrighter => Type::Function {
-                return_type: Box::new(Type::Brush),
-                args: vec![Type::Brush, Type::Float32],
-            },
-            BuiltinFunction::ColorDarker => Type::Function {
-                return_type: Box::new(Type::Brush),
-                args: vec![Type::Brush, Type::Float32],
-            },
-            BuiltinFunction::ColorTransparentize => Type::Function {
-                return_type: Box::new(Type::Brush),
-                args: vec![Type::Brush, Type::Float32],
-            },
-            BuiltinFunction::ColorMix => Type::Function {
-                return_type: Box::new(Type::Color),
+            BuiltinFunction::ColorBrighter => {
+                Function { return_type: Type::Brush, args: vec![Type::Brush, Type::Float32] }
+            }
+            BuiltinFunction::ColorDarker => {
+                Function { return_type: Type::Brush, args: vec![Type::Brush, Type::Float32] }
+            }
+            BuiltinFunction::ColorTransparentize => {
+                Function { return_type: Type::Brush, args: vec![Type::Brush, Type::Float32] }
+            }
+            BuiltinFunction::ColorMix => Function {
+                return_type: Type::Color,
                 args: vec![Type::Color, Type::Color, Type::Float32],
             },
-            BuiltinFunction::ColorWithAlpha => Type::Function {
-                return_type: Box::new(Type::Brush),
-                args: vec![Type::Brush, Type::Float32],
-            },
-            BuiltinFunction::ImageSize => Type::Function {
-                return_type: Box::new(Type::Struct {
+            BuiltinFunction::ColorWithAlpha => {
+                Function { return_type: Type::Brush, args: vec![Type::Brush, Type::Float32] }
+            }
+            BuiltinFunction::ImageSize => Function {
+                return_type: Type::Struct {
                     fields: IntoIterator::into_iter([
                         (SmolStr::new_static("width"), Type::Int32),
                         (SmolStr::new_static("height"), Type::Int32),
@@ -243,71 +230,65 @@ impl BuiltinFunction {
                     name: Some("Size".into()),
                     node: None,
                     rust_attributes: None,
-                }),
+                },
                 args: vec![Type::Image],
             },
             BuiltinFunction::ArrayLength => {
-                Type::Function { return_type: Box::new(Type::Int32), args: vec![Type::Model] }
+                Function { return_type: Type::Int32, args: vec![Type::Model] }
             }
-            BuiltinFunction::Rgb => Type::Function {
-                return_type: Box::new(Type::Color),
+            BuiltinFunction::Rgb => Function {
+                return_type: Type::Color,
                 args: vec![Type::Int32, Type::Int32, Type::Int32, Type::Float32],
             },
-            BuiltinFunction::Hsv => Type::Function {
-                return_type: Box::new(Type::Color),
+            BuiltinFunction::Hsv => Function {
+                return_type: Type::Color,
                 args: vec![Type::Float32, Type::Float32, Type::Float32, Type::Float32],
             },
-            BuiltinFunction::ColorScheme => Type::Function {
-                return_type: Box::new(Type::Enumeration(
+            BuiltinFunction::ColorScheme => Function {
+                return_type: Type::Enumeration(
                     crate::typeregister::BUILTIN_ENUMS.with(|e| e.ColorScheme.clone()),
-                )),
+                ),
                 args: vec![],
             },
-            BuiltinFunction::MonthDayCount => Type::Function {
-                return_type: Box::new(Type::Int32),
-                args: vec![Type::Int32, Type::Int32],
-            },
-            BuiltinFunction::MonthOffset => Type::Function {
-                return_type: Box::new(Type::Int32),
-                args: vec![Type::Int32, Type::Int32],
-            },
-            BuiltinFunction::FormatDate => Type::Function {
-                return_type: Box::new(Type::String),
+            BuiltinFunction::MonthDayCount => {
+                Function { return_type: Type::Int32, args: vec![Type::Int32, Type::Int32] }
+            }
+            BuiltinFunction::MonthOffset => {
+                Function { return_type: Type::Int32, args: vec![Type::Int32, Type::Int32] }
+            }
+            BuiltinFunction::FormatDate => Function {
+                return_type: Type::String,
                 args: vec![Type::String, Type::Int32, Type::Int32, Type::Int32],
             },
-            BuiltinFunction::TextInputFocused => {
-                Type::Function { return_type: Box::new(Type::Bool), args: vec![] }
+            BuiltinFunction::TextInputFocused => Function { return_type: Type::Bool, args: vec![] },
+            BuiltinFunction::DateNow => {
+                Function { return_type: Type::Array(Box::new(Type::Int32)), args: vec![] }
             }
-            BuiltinFunction::DateNow => Type::Function {
-                return_type: Box::new(Type::Array(Box::new(Type::Int32))),
-                args: vec![],
-            },
-            BuiltinFunction::ValidDate => Type::Function {
-                return_type: Box::new(Type::Bool),
-                args: vec![Type::String, Type::String],
-            },
-            BuiltinFunction::ParseDate => Type::Function {
-                return_type: Box::new(Type::Array(Box::new(Type::Int32))),
+            BuiltinFunction::ValidDate => {
+                Function { return_type: Type::Bool, args: vec![Type::String, Type::String] }
+            }
+            BuiltinFunction::ParseDate => Function {
+                return_type: Type::Array(Box::new(Type::Int32)),
                 args: vec![Type::String, Type::String],
             },
             BuiltinFunction::SetTextInputFocused => {
-                Type::Function { return_type: Box::new(Type::Void), args: vec![Type::Bool] }
+                Function { return_type: Type::Void, args: vec![Type::Bool] }
             }
-            BuiltinFunction::ItemAbsolutePosition => Type::Function {
-                return_type: Box::new(crate::typeregister::logical_point_type()),
+            BuiltinFunction::ItemAbsolutePosition => Function {
+                return_type: crate::typeregister::logical_point_type(),
                 args: vec![Type::ElementReference],
             },
             BuiltinFunction::RegisterCustomFontByPath => {
-                Type::Function { return_type: Box::new(Type::Void), args: vec![Type::String] }
+                Function { return_type: Type::Void, args: vec![Type::String] }
             }
             BuiltinFunction::RegisterCustomFontByMemory => {
-                Type::Function { return_type: Box::new(Type::Void), args: vec![Type::Int32] }
+                Function { return_type: Type::Void, args: vec![Type::Int32] }
             }
             BuiltinFunction::RegisterBitmapFont => {
-                Type::Function { return_type: Box::new(Type::Void), args: vec![Type::Int32] }
+                Function { return_type: Type::Void, args: vec![Type::Int32] }
             }
-            BuiltinFunction::Translate => Type::Function {
-                return_type: Box::new(Type::String),
+            BuiltinFunction::Translate => Function {
+                return_type: Type::String,
                 // original, context, domain, args
                 args: vec![
                     Type::String,
@@ -316,13 +297,11 @@ impl BuiltinFunction {
                     Type::Array(Type::String.into()),
                 ],
             },
-            BuiltinFunction::Use24HourFormat => {
-                Type::Function { return_type: Box::new(Type::Bool), args: vec![] }
-            }
-            BuiltinFunction::UpdateTimers => {
-                Type::Function { return_type: Box::new(Type::Void), args: vec![] }
-            }
-        }
+            BuiltinFunction::Use24HourFormat => Function { return_type: Type::Bool, args: vec![] },
+            BuiltinFunction::UpdateTimers => Function { return_type: Type::Void, args: vec![] },
+        };
+
+        Type::Function(Rc::new(fun))
     }
 
     /// It is const if the return value only depends on its argument and has no side effect
@@ -800,8 +779,10 @@ impl Expression {
             Expression::Cast { to, .. } => to.clone(),
             Expression::CodeBlock(sub) => sub.last().map_or(Type::Void, |e| e.ty()),
             Expression::FunctionCall { function, .. } => match function.ty() {
-                Type::Function { return_type, .. } => *return_type,
-                Type::Callback { return_type, .. } => return_type.map_or(Type::Void, |x| *x),
+                Type::Function(function) => function.return_type.clone(),
+                Type::Callback(callback) => {
+                    callback.return_type.as_ref().unwrap_or(&Type::Void).clone()
+                }
                 _ => Type::Invalid,
             },
             Expression::SelfAssignment { .. } => Type::Void,

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -162,19 +162,11 @@ impl BuiltinFunction {
                     args: vec![Type::Float32, Type::Float32]
                 })
             }
-            BuiltinFunction::SetFocusItem => {
-                interned_type!(Function {
-                    return_type: Type::Void,
-                    args: vec![Type::ElementReference]
-                })
-            }
-            BuiltinFunction::ClearFocusItem => {
-                interned_type!(Function {
-                    return_type: Type::Void,
-                    args: vec![Type::ElementReference]
-                })
-            }
-            BuiltinFunction::ShowPopupWindow | BuiltinFunction::ClosePopupWindow => {
+            BuiltinFunction::SetFocusItem
+            | BuiltinFunction::ClearFocusItem
+            | BuiltinFunction::ShowPopupWindow
+            | BuiltinFunction::ClosePopupWindow
+            | BuiltinFunction::ItemMemberFunction(..) => {
                 interned_type!(Function {
                     return_type: Type::Void,
                     args: vec![Type::ElementReference]
@@ -184,12 +176,6 @@ impl BuiltinFunction {
                 return_type: Type::Void,
                 args: vec![Type::ElementReference, Type::Int32, Type::Int32],
             }),
-            BuiltinFunction::ItemMemberFunction(..) => {
-                interned_type!(Function {
-                    return_type: Type::Void,
-                    args: vec![Type::ElementReference]
-                })
-            }
             BuiltinFunction::ItemFontMetrics => interned_type!(Function {
                 return_type: crate::typeregister::font_metrics_type(),
                 args: vec![Type::ElementReference],
@@ -234,19 +220,10 @@ impl BuiltinFunction {
                 })),
                 args: vec![Type::Color],
             }),
-            BuiltinFunction::ColorBrighter => {
-                interned_type!(Function {
-                    return_type: Type::Brush,
-                    args: vec![Type::Brush, Type::Float32]
-                })
-            }
-            BuiltinFunction::ColorDarker => {
-                interned_type!(Function {
-                    return_type: Type::Brush,
-                    args: vec![Type::Brush, Type::Float32]
-                })
-            }
-            BuiltinFunction::ColorTransparentize => {
+            BuiltinFunction::ColorBrighter
+            | BuiltinFunction::ColorDarker
+            | BuiltinFunction::ColorTransparentize
+            | BuiltinFunction::ColorWithAlpha => {
                 interned_type!(Function {
                     return_type: Type::Brush,
                     args: vec![Type::Brush, Type::Float32]
@@ -256,12 +233,6 @@ impl BuiltinFunction {
                 return_type: Type::Color,
                 args: vec![Type::Color, Type::Color, Type::Float32],
             }),
-            BuiltinFunction::ColorWithAlpha => {
-                interned_type!(Function {
-                    return_type: Type::Brush,
-                    args: vec![Type::Brush, Type::Float32]
-                })
-            }
             BuiltinFunction::ImageSize => interned_type!(Function {
                 return_type: Type::Struct(Rc::new(Struct {
                     fields: IntoIterator::into_iter([
@@ -292,13 +263,7 @@ impl BuiltinFunction {
                 ),
                 args: vec![],
             }),
-            BuiltinFunction::MonthDayCount => {
-                interned_type!(Function {
-                    return_type: Type::Int32,
-                    args: vec![Type::Int32, Type::Int32]
-                })
-            }
-            BuiltinFunction::MonthOffset => {
+            BuiltinFunction::MonthDayCount | BuiltinFunction::MonthOffset => {
                 interned_type!(Function {
                     return_type: Type::Int32,
                     args: vec![Type::Int32, Type::Int32]
@@ -337,10 +302,7 @@ impl BuiltinFunction {
             BuiltinFunction::RegisterCustomFontByPath => {
                 interned_type!(Function { return_type: Type::Void, args: vec![Type::String] })
             }
-            BuiltinFunction::RegisterCustomFontByMemory => {
-                interned_type!(Function { return_type: Type::Void, args: vec![Type::Int32] })
-            }
-            BuiltinFunction::RegisterBitmapFont => {
+            BuiltinFunction::RegisterCustomFontByMemory | BuiltinFunction::RegisterBitmapFont => {
                 interned_type!(Function { return_type: Type::Void, args: vec![Type::Int32] })
             }
             BuiltinFunction::Translate => interned_type!(Function {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -259,7 +259,7 @@ impl BuiltinFunction {
             }),
             BuiltinFunction::ColorScheme => interned_type!(Function {
                 return_type: Type::Enumeration(
-                    crate::typeregister::BUILTIN_ENUMS.with(|e| e.ColorScheme.clone()),
+                    crate::typeregister::BUILTIN.with(|e| e.enums.ColorScheme.clone()),
                 ),
                 args: vec![],
             }),

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -464,7 +464,7 @@ pub fn for_each_const_properties(component: &Rc<Component>, mut f: impl FnMut(&E
                     .iter()
                     .filter(|(_, x)| {
                         x.property_type.is_property_type() &&
-                            !matches!( &x.property_type, crate::langtype::Type::Struct { name: Some(name), .. } if name.ends_with("::StateInfo"))
+                            !matches!( &x.property_type, crate::langtype::Type::Struct(s) if s.name.as_ref().map_or(false, |name| name.ends_with("::StateInfo")))
                     })
                     .map(|(k, _)| k.clone()),
             );

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -13,7 +13,7 @@ Some convention used in the generated code:
 */
 
 use crate::expression_tree::{BuiltinFunction, EasingCurve, MinMaxOp, OperatorClass};
-use crate::langtype::{Enumeration, EnumerationValue, Type};
+use crate::langtype::{Enumeration, EnumerationValue, Struct, Type};
 use crate::layout::Orientation;
 use crate::llr::{
     self, EvaluationContext as llr_EvaluationContext, Expression, ParentCtx as llr_ParentCtx,
@@ -92,12 +92,16 @@ fn rust_primitive_type(ty: &Type) -> Option<proc_macro2::TokenStream> {
         Type::Percent => Some(quote!(f32)),
         Type::Bool => Some(quote!(bool)),
         Type::Image => Some(quote!(sp::Image)),
-        Type::Struct { fields, name: None, .. } => {
-            let elem = fields.values().map(rust_primitive_type).collect::<Option<Vec<_>>>()?;
-            // This will produce a tuple
-            Some(quote!((#(#elem,)*)))
+        Type::Struct(s) => {
+            if let Some(name) = &s.name {
+                Some(struct_name_to_tokens(name))
+            } else {
+                let elem =
+                    s.fields.values().map(rust_primitive_type).collect::<Option<Vec<_>>>()?;
+                // This will produce a tuple
+                Some(quote!((#(#elem,)*)))
+            }
         }
-        Type::Struct { name: Some(name), .. } => Some(struct_name_to_tokens(name)),
         Type::Array(o) => {
             let inner = rust_primitive_type(o)?;
             Some(quote!(sp::ModelRc<#inner>))
@@ -154,9 +158,12 @@ pub fn generate(doc: &Document, compiler_config: &CompilerConfiguration) -> Toke
         .structs_and_enums
         .iter()
         .filter_map(|ty| match ty {
-            Type::Struct { fields, name: Some(name), node: Some(_), rust_attributes } => {
-                Some((ident(name), generate_struct(name, fields, rust_attributes)))
-            }
+            Type::Struct(s) => match s.as_ref() {
+                Struct { fields, name: Some(name), node: Some(_), rust_attributes } => {
+                    Some((ident(name), generate_struct(name, fields, rust_attributes)))
+                }
+                _ => None,
+            },
             Type::Enumeration(en) => Some((ident(&en.name), generate_enum(en))),
             _ => None,
         })
@@ -2146,13 +2153,13 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                 (Type::Brush, Type::Color) => {
                     quote!(#f.color())
                 }
-                (Type::Struct { ref fields, .. }, Type::Struct { name: Some(n), .. }) => {
-                    let fields = fields.iter().enumerate().map(|(index, (name, _))| {
+                (Type::Struct (lhs), Type::Struct (rhs)) if rhs.name.is_some() => {
+                    let fields = lhs.fields.iter().enumerate().map(|(index, (name, _))| {
                         let index = proc_macro2::Literal::usize_unsuffixed(index);
                         let name = ident(name);
                         quote!(the_struct.#name =  obj.#index as _;)
                     });
-                    let id = struct_name_to_tokens(n);
+                    let id = struct_name_to_tokens(rhs.name.as_ref().unwrap());
                     quote!({ let obj = #f; let mut the_struct = #id::default(); #(#fields)* the_struct })
                 }
                 (Type::Array(..), Type::PathData)
@@ -2166,7 +2173,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                             .iter()
                             .map(|path_elem_expr|
                                 // Close{} is a struct with no fields in markup, and PathElement::Close has no fields
-                                if matches!(path_elem_expr, Expression::Struct { ty: Type::Struct { fields, .. }, .. } if fields.is_empty()) {
+                                if matches!(path_elem_expr, Expression::Struct { ty: Type::Struct (s), .. } if s.fields.is_empty()) {
                                     quote!(sp::PathElement::Close)
                                 } else {
                                     compile_expression(path_elem_expr, ctx)
@@ -2245,8 +2252,8 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             quote! {args.#i.clone()}
         }
         Expression::StructFieldAccess { base, name } => match base.ty(ctx) {
-            Type::Struct { fields, name: None, .. } => {
-                let index = fields
+            Type::Struct (s) if s.name.is_none() => {
+                let index = s.fields
                     .keys()
                     .position(|k| k == name)
                     .expect("Expression::StructFieldAccess: Cannot find a key in an object");
@@ -2428,18 +2435,18 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             }
         }
         Expression::Struct { ty, values } => {
-            if let Type::Struct { fields, name, .. } = ty {
-                let elem = fields.keys().map(|k| values.get(k).map(|e| compile_expression(e, ctx)));
-                if let Some(name) = name {
+            if let Type::Struct (s) = ty {
+                let elem = s.fields.keys().map(|k| values.get(k).map(|e| compile_expression(e, ctx)));
+                if let Some(name) = &s.name {
                     let name_tokens: TokenStream = struct_name_to_tokens(name.as_str());
-                    let keys = fields.keys().map(|k| ident(k));
+                    let keys = s.fields.keys().map(|k| ident(k));
                     if name.starts_with("slint::private_api::") && name.ends_with("LayoutData") {
                         quote!(#name_tokens{#(#keys: #elem as _,)*})
                     } else {
                         quote!({ let mut the_struct = #name_tokens::default(); #(the_struct.#keys =  #elem as _;)* the_struct})
                     }
                 } else {
-                    let as_ = fields.values().map(|t| {
+                    let as_ = s.fields.values().map(|t| {
                         if t.as_unit_product().is_some() {
                             // number needs to be converted to the right things because intermediate
                             // result might be f64 and that's usually not what the type of the tuple is in the end
@@ -3128,8 +3135,8 @@ fn generate_named_exports(doc: &Document) -> Vec<TokenStream> {
                 Some((&export.0.name, &component.id))
             }
             Either::Right(ty) => match &ty {
-                Type::Struct { name: Some(name), node: Some(_), .. } => {
-                    Some((&export.0.name, name))
+                Type::Struct(s) if s.name.is_some() && s.node.is_some() => {
+                    Some((&export.0.name, s.name.as_ref().unwrap()))
                 }
                 Type::Enumeration(en) => Some((&export.0.name, &en.name)),
                 _ => None,

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -52,16 +52,7 @@ pub enum Type {
     Brush,
     /// This is usually a model
     Array(Box<Type>),
-    Struct {
-        fields: BTreeMap<SmolStr, Type>,
-        /// When declared in .slint as  `struct Foo := { }`, then the name is "Foo"
-        /// When there is no node, but there is a name, then it is a builtin type
-        name: Option<SmolStr>,
-        /// When declared in .slint, this is the node of the declaration.
-        node: Option<syntax_nodes::ObjectType>,
-        /// derived
-        rust_attributes: Option<Vec<SmolStr>>,
-    },
+    Struct(Rc<Struct>),
     Enumeration(Rc<Enumeration>),
 
     /// A type made up of the product of several "unit" types.
@@ -106,8 +97,8 @@ impl core::cmp::PartialEq for Type {
             Type::Easing => matches!(other, Type::Easing),
             Type::Brush => matches!(other, Type::Brush),
             Type::Array(a) => matches!(other, Type::Array(b) if a == b),
-            Type::Struct { fields, name, node: _, rust_attributes: _ } => {
-                matches!(other, Type::Struct{fields:f,name:n,node:_, rust_attributes: _ } if fields == f && name == n)
+            Type::Struct(lhs) => {
+                matches!(other, Type::Struct(rhs) if lhs.fields == rhs.fields && lhs.name == rhs.name)
             }
             Type::Enumeration(lhs) => matches!(other, Type::Enumeration(rhs) if lhs == rhs),
             Type::UnitProduct(a) => matches!(other, Type::UnitProduct(b) if a == b),
@@ -166,15 +157,17 @@ impl Display for Type {
             Type::Bool => write!(f, "bool"),
             Type::Model => write!(f, "model"),
             Type::Array(t) => write!(f, "[{}]", t),
-            Type::Struct { name: Some(name), .. } => write!(f, "{}", name),
-            Type::Struct { fields, name: None, .. } => {
-                write!(f, "{{ ")?;
-                for (k, v) in fields {
-                    write!(f, "{}: {},", k, v)?;
+            Type::Struct(t) => {
+                if let Some(name) = &t.name {
+                    write!(f, "{}", name)
+                } else {
+                    write!(f, "{{ ")?;
+                    for (k, v) in &t.fields {
+                        write!(f, "{}: {},", k, v)?;
+                    }
+                    write!(f, "}}")
                 }
-                write!(f, "}}")
             }
-
             Type::PathData => write!(f, "pathdata"),
             Type::Easing => write!(f, "easing"),
             Type::Brush => write!(f, "brush"),
@@ -281,9 +274,7 @@ impl Type {
             | (Type::Percent, Type::Float32)
             | (Type::Brush, Type::Color)
             | (Type::Color, Type::Brush) => true,
-            (Type::Struct { fields: a, .. }, Type::Struct { fields: b, .. }) => {
-                can_convert_struct(a, b)
-            }
+            (Type::Struct(a), Type::Struct(b)) => can_convert_struct(&a.fields, &b.fields),
             (Type::UnitProduct(u), o) => match o.as_unit_product() {
                 Some(o) => unit_product_length_conversion(u.as_slice(), o.as_slice()).is_some(),
                 None => false,
@@ -801,6 +792,18 @@ pub struct Callback {
 pub struct Function {
     pub return_type: Type,
     pub args: Vec<Type>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Struct {
+    pub fields: BTreeMap<SmolStr, Type>,
+    /// When declared in .slint as  `struct Foo := { }`, then the name is "Foo"
+    /// When there is no node, but there is a name, then it is a builtin type
+    pub name: Option<SmolStr>,
+    /// When declared in .slint, this is the node of the declaration.
+    pub node: Option<syntax_nodes::ObjectType>,
+    /// derived
+    pub rust_attributes: Option<Vec<SmolStr>>,
 }
 
 #[derive(Debug, Clone)]

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -51,7 +51,7 @@ pub enum Type {
     Easing,
     Brush,
     /// This is usually a model
-    Array(Box<Type>),
+    Array(Rc<Type>),
     Struct(Rc<Struct>),
     Enumeration(Rc<Enumeration>),
 

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -5,7 +5,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::*;
-use crate::langtype::{ElementType, PropertyLookupResult, Struct, Type};
+use crate::langtype::{ElementType, PropertyLookupResult, Type};
 use crate::object_tree::{Component, ElementRc};
 
 use smol_str::{format_smolstr, SmolStr};
@@ -485,24 +485,6 @@ impl BoxLayout {
     }
 }
 
-/// The [`Type`] for a runtime LayoutInfo structure
-pub fn layout_info_type() -> Type {
-    Type::Struct(Rc::new(Struct {
-        fields: ["min", "max", "preferred"]
-            .iter()
-            .map(|s| (SmolStr::new_static(s), Type::LogicalLength))
-            .chain(
-                ["min_percent", "max_percent", "stretch"]
-                    .iter()
-                    .map(|s| (SmolStr::new_static(s), Type::Float32)),
-            )
-            .collect(),
-        name: Some("slint::private_api::LayoutInfo".into()),
-        node: None,
-        rust_attributes: None,
-    }))
-}
-
 /// Get the implicit layout info of a particular element
 pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> Expression {
     let mut elem_it = elem.clone();
@@ -538,7 +520,7 @@ pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> 
                 // hard-code the value for rectangle because many rectangle end up optimized away and we
                 // don't want to depend on the element.
                 Expression::Struct {
-                    ty: layout_info_type(),
+                    ty: crate::typeregister::layout_info_type(),
                     values: [("min", 0.), ("max", f32::MAX), ("preferred", 0.)]
                         .iter()
                         .map(|(s, v)| {

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -5,7 +5,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::*;
-use crate::langtype::{ElementType, PropertyLookupResult, Type};
+use crate::langtype::{ElementType, PropertyLookupResult, Struct, Type};
 use crate::object_tree::{Component, ElementRc};
 
 use smol_str::{format_smolstr, SmolStr};
@@ -487,7 +487,7 @@ impl BoxLayout {
 
 /// The [`Type`] for a runtime LayoutInfo structure
 pub fn layout_info_type() -> Type {
-    Type::Struct {
+    Type::Struct(Rc::new(Struct {
         fields: ["min", "max", "preferred"]
             .iter()
             .map(|s| (SmolStr::new_static(s), Type::LogicalLength))
@@ -500,7 +500,7 @@ pub fn layout_info_type() -> Type {
         name: Some("slint::private_api::LayoutInfo".into()),
         node: None,
         rust_attributes: None,
-    }
+    }))
 }
 
 /// Get the implicit layout info of a particular element

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -267,12 +267,12 @@ impl Expression {
             Self::Cast { to, .. } => to.clone(),
             Self::CodeBlock(sub) => sub.last().map_or(Type::Void, |e| e.ty(ctx)),
             Self::BuiltinFunctionCall { function, .. } => match function.ty() {
-                Type::Function { return_type, .. } => *return_type,
+                Type::Function(function) => function.return_type.clone(),
                 _ => unreachable!(),
             },
             Self::CallBackCall { callback, .. } => {
-                if let Type::Callback { return_type, .. } = ctx.property_ty(callback) {
-                    return_type.as_ref().map_or(Type::Void, |x| (**x).clone())
+                if let Type::Callback(callback) = ctx.property_ty(callback) {
+                    callback.return_type.as_ref().unwrap_or(&Type::Void).clone()
                 } else {
                     Type::Invalid
                 }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -262,7 +262,7 @@ impl Expression {
                 _ => unreachable!(),
             },
             Self::ArrayIndex { array, .. } => match array.ty(ctx) {
-                Type::Array(ty) => *ty,
+                Type::Array(ty) => (*ty).clone(),
                 _ => unreachable!(),
             },
             Self::Cast { to, .. } => to.clone(),

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -228,9 +228,10 @@ impl Expression {
                 values: vec![],
                 as_model: true,
             },
-            Type::Struct { fields, .. } => Expression::Struct {
+            Type::Struct(s) => Expression::Struct {
                 ty: ty.clone(),
-                values: fields
+                values: s
+                    .fields
                     .iter()
                     .map(|(k, v)| Some((k.clone(), Expression::default_value_for_type(v)?)))
                     .collect::<Option<_>>()?,
@@ -257,7 +258,7 @@ impl Expression {
             Self::StoreLocalVariable { .. } => Type::Void,
             Self::ReadLocalVariable { ty, .. } => ty.clone(),
             Self::StructFieldAccess { base, name } => match base.ty(ctx) {
-                Type::Struct { fields, .. } => fields[name].clone(),
+                Type::Struct(s) => s.fields[name].clone(),
                 _ => unreachable!(),
             },
             Self::ArrayIndex { array, .. } => match array.ty(ctx) {

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -731,7 +731,7 @@ fn box_layout_data(
         }
         let cells = llr_Expression::ReadLocalVariable {
             name: "cells".into(),
-            ty: Type::Array(Box::new(crate::layout::layout_info_type())),
+            ty: Type::Array(Rc::new(crate::layout::layout_info_type())),
         };
         BoxLayoutDataResult { alignment, cells, compute_cells: Some(("cells".into(), elements)) }
     }

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -19,7 +19,7 @@ use crate::namedreference::NamedReference;
 use crate::object_tree::{Element, ElementRc, PropertyAnimation};
 use crate::{
     expression_tree::{BuiltinFunction, Expression as tree_Expression},
-    typeregister::BUILTIN_ENUMS,
+    typeregister::BUILTIN,
 };
 
 pub struct ExpressionContext<'a> {
@@ -415,7 +415,7 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &ExpressionContext<'_>) -> An
             (SmolStr::new_static("iteration-count"), Type::Float32),
             (
                 SmolStr::new_static("direction"),
-                Type::Enumeration(BUILTIN_ENUMS.with(|e| e.AnimationDirection.clone())),
+                Type::Enumeration(BUILTIN.with(|e| e.enums.AnimationDirection.clone())),
             ),
             (SmolStr::new_static("easing"), Type::Easing),
             (SmolStr::new_static("delay"), Type::Int32),
@@ -546,7 +546,7 @@ fn solve_layout(
             if let (Some(button_roles), Orientation::Horizontal) = (&layout.dialog_button_roles, o)
             {
                 let cells_ty = cells.ty(ctx);
-                let e = crate::typeregister::BUILTIN_ENUMS.with(|e| e.DialogButtonRole.clone());
+                let e = crate::typeregister::BUILTIN.with(|e| e.enums.DialogButtonRole.clone());
                 let roles = button_roles
                     .iter()
                     .map(|r| {
@@ -616,8 +616,8 @@ fn solve_layout(
                     ("padding", padding.ty(ctx), padding),
                     (
                         "alignment",
-                        crate::typeregister::BUILTIN_ENUMS
-                            .with(|e| Type::Enumeration(e.LayoutAlignment.clone())),
+                        crate::typeregister::BUILTIN
+                            .with(|e| Type::Enumeration(e.enums.LayoutAlignment.clone())),
                         bld.alignment,
                     ),
                     ("cells", bld.cells.ty(ctx), bld.cells),
@@ -674,7 +674,7 @@ fn box_layout_data(
     let alignment = if let Some(expr) = &layout.geometry.alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN_ENUMS.with(|e| e.LayoutAlignment.clone());
+        let e = crate::typeregister::BUILTIN.with(|e| e.enums.LayoutAlignment.clone());
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -500,7 +500,7 @@ fn compute_layout_info(
             llr_Expression::ExtraBuiltinFunctionCall {
                 function: "grid_layout_info".into(),
                 arguments: vec![cells, spacing, padding],
-                return_ty: crate::layout::layout_info_type(),
+                return_ty: crate::typeregister::layout_info_type(),
             }
         }
         crate::layout::Layout::BoxLayout(layout) => {
@@ -510,13 +510,13 @@ fn compute_layout_info(
                 llr_Expression::ExtraBuiltinFunctionCall {
                     function: "box_layout_info".into(),
                     arguments: vec![bld.cells, spacing, padding, bld.alignment],
-                    return_ty: crate::layout::layout_info_type(),
+                    return_ty: crate::typeregister::layout_info_type(),
                 }
             } else {
                 llr_Expression::ExtraBuiltinFunctionCall {
                     function: "box_layout_info_ortho".into(),
                     arguments: vec![bld.cells, padding],
-                    return_ty: crate::layout::layout_info_type(),
+                    return_ty: crate::typeregister::layout_info_type(),
                 }
             };
             match bld.compute_cells {
@@ -684,13 +684,7 @@ fn box_layout_data(
     let repeater_count =
         layout.elems.iter().filter(|i| i.element.borrow().repeated.is_some()).count();
 
-    let element_ty = Type::Struct(Rc::new(Struct {
-        fields: IntoIterator::into_iter([("constraint".into(), crate::layout::layout_info_type())])
-            .collect(),
-        name: Some("BoxLayoutCellData".into()),
-        node: None,
-        rust_attributes: None,
-    }));
+    let element_ty = crate::typeregister::box_layout_cell_data_type();
 
     if repeater_count == 0 {
         let cells = llr_Expression::Array {
@@ -702,7 +696,7 @@ fn box_layout_data(
                         get_layout_info(&li.element, ctx, &li.constraints, orientation);
                     make_struct(
                         "BoxLayoutCellData",
-                        [("constraint", crate::layout::layout_info_type(), layout_info)],
+                        [("constraint", crate::typeregister::layout_info_type(), layout_info)],
                     )
                 })
                 .collect(),
@@ -725,13 +719,13 @@ fn box_layout_data(
                     get_layout_info(&item.element, ctx, &item.constraints, orientation);
                 elements.push(Either::Left(make_struct(
                     "BoxLayoutCellData",
-                    [("constraint", crate::layout::layout_info_type(), layout_info)],
+                    [("constraint", crate::typeregister::layout_info_type(), layout_info)],
                 )));
             }
         }
         let cells = llr_Expression::ReadLocalVariable {
             name: "cells".into(),
-            ty: Type::Array(Rc::new(crate::layout::layout_info_type())),
+            ty: Type::Array(Rc::new(crate::typeregister::layout_info_type())),
         };
         BoxLayoutDataResult { alignment, cells, compute_cells: Some(("cells".into(), elements)) }
     }
@@ -755,7 +749,7 @@ fn grid_layout_cell_data(
                 make_struct(
                     "GridLayoutCellData",
                     [
-                        ("constraint", crate::layout::layout_info_type(), layout_info),
+                        ("constraint", crate::typeregister::layout_info_type(), layout_info),
                         ("col_or_row", Type::Int32, llr_Expression::NumberLiteral(col_or_row as _)),
                         ("span", Type::Int32, llr_Expression::NumberLiteral(span as _)),
                     ],
@@ -771,7 +765,7 @@ pub(super) fn grid_layout_cell_data_ty() -> Type {
         fields: IntoIterator::into_iter([
             (SmolStr::new_static("col_or_row"), Type::Int32),
             (SmolStr::new_static("span"), Type::Int32),
-            (SmolStr::new_static("constraint"), crate::layout::layout_info_type()),
+            (SmolStr::new_static("constraint"), crate::typeregister::layout_info_type()),
         ])
         .collect(),
         name: Some("GridLayoutCellData".into()),
@@ -831,7 +825,7 @@ pub fn get_layout_info(
             name: "layout_info".into(),
             value: layout_info.into(),
         };
-        let ty = crate::layout::layout_info_type();
+        let ty = crate::typeregister::layout_info_type();
         let fields = match &ty {
             Type::Struct(s) => &s.fields,
             _ => panic!(),
@@ -869,12 +863,7 @@ fn compile_path(path: &crate::expression_tree::Path, ctx: &ExpressionContext) ->
     fn llr_path_elements(elements: Vec<llr_Expression>) -> llr_Expression {
         llr_Expression::Cast {
             from: llr_Expression::Array {
-                element_ty: Type::Struct(Rc::new(Struct {
-                    fields: Default::default(),
-                    name: Some("PathElement".into()),
-                    node: None,
-                    rust_attributes: None,
-                })),
+                element_ty: crate::typeregister::path_element_type(),
                 values: elements,
                 as_model: false,
             }

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -5,7 +5,7 @@ use by_address::ByAddress;
 
 use super::lower_expression::ExpressionContext;
 use crate::expression_tree::Expression as tree_Expression;
-use crate::langtype::{ElementType, Type};
+use crate::langtype::{ElementType, Struct, Type};
 use crate::llr::item_tree::*;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{self, Component, ElementRc, PropertyAnalysis, PropertyVisibility};
@@ -395,7 +395,7 @@ fn lower_sub_component(
 
             let is_state_info = matches!(
                 e.borrow().lookup_property(p).property_type,
-                Type::Struct { name: Some(name), .. } if name.ends_with("::StateInfo")
+                Type::Struct(s) if s.name.as_ref().map_or(false, |name| name.ends_with("::StateInfo"))
             );
 
             sub_component.property_init.push((
@@ -554,7 +554,7 @@ fn lower_geometry(
             .insert(f.into(), super::Expression::PropertyReference(ctx.map_property_reference(v)));
     }
     super::Expression::Struct {
-        ty: Type::Struct { fields, name: None, node: None, rust_attributes: None },
+        ty: Type::Struct(Rc::new(Struct { fields, name: None, node: None, rust_attributes: None })),
         values,
     }
 }

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -12,8 +12,8 @@ use std::rc::Rc;
 
 use crate::expression_tree::{BuiltinFunction, Expression};
 use crate::langtype::{
-    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, DefaultSizeBinding, ElementType,
-    NativeClass, Type,
+    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, Callback, DefaultSizeBinding,
+    ElementType, NativeClass, Type,
 };
 use crate::object_tree::{self, *};
 use crate::parser::{identifier_text, syntax_nodes, SyntaxKind, SyntaxNode};
@@ -103,7 +103,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
                 .chain(e.CallbackDeclaration().map(|s| {
                     (
                         identifier_text(&s.DeclaredIdentifier()).unwrap(),
-                        BuiltinPropertyInfo::new(Type::Callback {
+                        BuiltinPropertyInfo::new(Type::Callback(Rc::new(Callback{
                             args: s
                                 .CallbackDeclarationParameter()
                                 .map(|a| {
@@ -111,13 +111,13 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
                                 })
                                 .collect(),
                             return_type: s.ReturnType().map(|a| {
-                                Box::new(object_tree::type_from_node(
+                                object_tree::type_from_node(
                                     a.Type(),
                                     *diag.borrow_mut(),
                                     register,
-                                ))
+                                )
                             }),
-                        }),
+                        }))),
                     )
                 }))
         );

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -823,10 +823,10 @@ impl LookupObject for SlintInternal {
             f(
                 "color-scheme",
                 if style.is_some_and(|s| s.ends_with("-light")) {
-                    let e = crate::typeregister::BUILTIN_ENUMS.with(|e| e.ColorScheme.clone());
+                    let e = crate::typeregister::BUILTIN.with(|e| e.enums.ColorScheme.clone());
                     Expression::EnumerationValue(e.try_value_from_string("light").unwrap())
                 } else if style.is_some_and(|s| s.ends_with("-dark")) {
-                    let e = crate::typeregister::BUILTIN_ENUMS.with(|e| e.ColorScheme.clone());
+                    let e = crate::typeregister::BUILTIN.with(|e| e.enums.ColorScheme.clone());
                     Expression::EnumerationValue(e.try_value_from_string("dark").unwrap())
                 } else {
                     Expression::FunctionCall {

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -954,8 +954,8 @@ impl LookupObject for Expression {
         match self {
             Expression::ElementReference(e) => e.upgrade().unwrap().for_each_entry(ctx, f),
             _ => match self.ty() {
-                Type::Struct { fields, .. } => {
-                    for name in fields.keys() {
+                Type::Struct(s) => {
+                    for name in s.fields.keys() {
                         if let Some(r) = f(
                             name,
                             Expression::StructFieldAccess {
@@ -988,7 +988,7 @@ impl LookupObject for Expression {
         match self {
             Expression::ElementReference(e) => e.upgrade().unwrap().lookup(ctx, name),
             _ => match self.ty() {
-                Type::Struct { fields, .. } => fields.contains_key(name).then(|| {
+                Type::Struct(s) => s.fields.contains_key(name).then(|| {
                     LookupResult::from(Expression::StructFieldAccess {
                         base: Box::new(self.clone()),
                         name: name.into(),

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -65,10 +65,8 @@ impl<'a> LookupCtx<'a> {
 
     pub fn return_type(&self) -> &Type {
         match &self.property_type {
-            Type::Callback { return_type, .. } => {
-                return_type.as_ref().map_or(&Type::Void, |b| &(**b))
-            }
-            Type::Function { return_type, .. } => return_type,
+            Type::Callback(callback) => callback.return_type.as_ref().unwrap_or(&Type::Void),
+            Type::Function(function) => &function.return_type,
             _ => &self.property_type,
         }
     }
@@ -196,7 +194,8 @@ impl LookupObject for ArgumentsLookup {
         f: &mut impl FnMut(&str, LookupResult) -> Option<R>,
     ) -> Option<R> {
         let args = match &ctx.property_type {
-            Type::Callback { args, .. } | Type::Function { args, .. } => args,
+            Type::Callback(callback) => &callback.args,
+            Type::Function(function) => &function.args,
             _ => return None,
         };
         for (index, (name, ty)) in ctx.arguments.iter().zip(args.iter()).enumerate() {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2703,12 +2703,12 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
         let li_v = crate::layout::create_new_prop(
             &new_root,
             "layoutinfo-v",
-            crate::layout::layout_info_type(),
+            crate::typeregister::layout_info_type(),
         );
         let li_h = crate::layout::create_new_prop(
             &new_root,
             "layoutinfo-h",
-            crate::layout::layout_info_type(),
+            crate::typeregister::layout_info_type(),
         );
         let expr_h = crate::layout::implicit_layout_info_call(old_root, Orientation::Horizontal);
         let expr_v = crate::layout::implicit_layout_info_call(old_root, Orientation::Vertical);

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1885,7 +1885,7 @@ pub fn type_from_node(
     } else if let Some(object_node) = node.ObjectType() {
         type_struct_from_node(object_node, diag, tr, None, None)
     } else if let Some(array_node) = node.ArrayType() {
-        Type::Array(Box::new(type_from_node(array_node.Type(), diag, tr)))
+        Type::Array(Rc::new(type_from_node(array_node.Type(), diag, tr)))
     } else {
         assert!(diag.has_errors());
         Type::Invalid

--- a/internal/compiler/passes/collect_structs_and_enums.rs
+++ b/internal/compiler/passes/collect_structs_and_enums.rs
@@ -89,17 +89,17 @@ fn visit_declared_type(ty: &Type, visitor: &mut impl FnMut(&SmolStr, &Type)) {
             }
         }
         Type::Array(x) => visit_declared_type(x, visitor),
-        Type::Callback { return_type, args } => {
-            if let Some(rt) = return_type {
+        Type::Callback(callback) => {
+            if let Some(rt) = &callback.return_type {
                 visit_declared_type(rt, visitor);
             }
-            for a in args {
+            for a in &callback.args {
                 visit_declared_type(a, visitor);
             }
         }
-        Type::Function { return_type, args } => {
-            visit_declared_type(return_type, visitor);
-            for a in args {
+        Type::Function(function) => {
+            visit_declared_type(&function.return_type, visitor);
+            for a in &function.args {
                 visit_declared_type(a, visitor);
             }
         }

--- a/internal/compiler/passes/collect_structs_and_enums.rs
+++ b/internal/compiler/passes/collect_structs_and_enums.rs
@@ -61,15 +61,17 @@ fn collect_types_in_component(root_component: &Rc<Component>, hash: &mut BTreeMa
 /// it are placed before in the vector
 fn sort_types(hash: &mut BTreeMap<SmolStr, Type>, vec: &mut Vec<Type>, key: &str) {
     let ty = if let Some(ty) = hash.remove(key) { ty } else { return };
-    if let Type::Struct { fields, name: Some(name), .. } = &ty {
-        if name.contains("::") {
-            // This is a builtin type.
-            // FIXME! there should be a better way to handle builtin struct
-            return;
-        }
+    if let Type::Struct(s) = &ty {
+        if let Some(name) = &s.name {
+            if name.contains("::") {
+                // This is a builtin type.
+                // FIXME! there should be a better way to handle builtin struct
+                return;
+            }
 
-        for sub_ty in fields.values() {
-            visit_declared_type(sub_ty, &mut |name, _| sort_types(hash, vec, name));
+            for sub_ty in s.fields.values() {
+                visit_declared_type(sub_ty, &mut |name, _| sort_types(hash, vec, name));
+            }
         }
     }
     vec.push(ty)
@@ -78,13 +80,13 @@ fn sort_types(hash: &mut BTreeMap<SmolStr, Type>, vec: &mut Vec<Type>, key: &str
 /// Will call the `visitor` for every named struct or enum that is not builtin
 fn visit_declared_type(ty: &Type, visitor: &mut impl FnMut(&SmolStr, &Type)) {
     match ty {
-        Type::Struct { fields, name, node, .. } => {
-            if node.is_some() {
-                if let Some(struct_name) = name.as_ref() {
+        Type::Struct(s) => {
+            if s.node.is_some() {
+                if let Some(struct_name) = s.name.as_ref() {
                     visitor(struct_name, ty);
                 }
             }
-            for sub_ty in fields.values() {
+            for sub_ty in s.fields.values() {
                 visit_declared_type(sub_ty, visitor);
             }
         }

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -12,7 +12,7 @@
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::*;
 use crate::langtype::ElementType;
-use crate::langtype::Type;
+use crate::langtype::{Struct, Type};
 use crate::object_tree::*;
 use crate::EmbedResourcesKind;
 use smol_str::SmolStr;
@@ -152,7 +152,7 @@ fn compile_path_from_string_literal(
     let path = builder.build();
 
     let event_enum = crate::typeregister::BUILTIN_ENUMS.with(|e| e.PathEvent.clone());
-    let point_type = Type::Struct {
+    let point_type = Type::Struct(Rc::new(Struct {
         fields: IntoIterator::into_iter([
             (SmolStr::new_static("x"), Type::Float32),
             (SmolStr::new_static("y"), Type::Float32),
@@ -161,7 +161,7 @@ fn compile_path_from_string_literal(
         name: Some("slint::private_api::Point".into()),
         node: None,
         rust_attributes: None,
-    };
+    }));
 
     let mut points = Vec::new();
     let events = path

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -151,7 +151,7 @@ fn compile_path_from_string_literal(
     )?;
     let path = builder.build();
 
-    let event_enum = crate::typeregister::BUILTIN_ENUMS.with(|e| e.PathEvent.clone());
+    let event_enum = crate::typeregister::BUILTIN.with(|e| e.enums.PathEvent.clone());
     let point_type = Type::Struct(Rc::new(Struct {
         fields: IntoIterator::into_iter([
             (SmolStr::new_static("x"), Type::Float32),

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -23,7 +23,12 @@ fn simplify_expression(expr: &mut Expression) -> bool {
     match expr {
         Expression::PropertyReference(nr) => {
             if nr.is_constant()
-                && !matches!(nr.ty(), Type::Struct { name: Some(name), .. } if name.ends_with("::StateInfo"))
+                && !match nr.ty() {
+                    Type::Struct(s) => {
+                        s.name.as_ref().map_or(false, |name| name.ends_with("::StateInfo"))
+                    }
+                    _ => false,
+                }
             {
                 // Inline the constant value
                 if let Some(result) = extract_constant_property_reference(nr) {

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -209,10 +209,16 @@ fn gen_layout_info_prop(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         return;
     }
 
-    let li_v =
-        crate::layout::create_new_prop(elem, "layoutinfo-v", crate::layout::layout_info_type());
-    let li_h =
-        crate::layout::create_new_prop(elem, "layoutinfo-h", crate::layout::layout_info_type());
+    let li_v = crate::layout::create_new_prop(
+        elem,
+        "layoutinfo-v",
+        crate::typeregister::layout_info_type(),
+    );
+    let li_h = crate::layout::create_new_prop(
+        elem,
+        "layoutinfo-h",
+        crate::typeregister::layout_info_type(),
+    );
     elem.borrow_mut().layout_info_prop = Some((li_h.clone(), li_v.clone()));
     let mut expr_h = implicit_layout_info_call(elem, Orientation::Horizontal);
     let mut expr_v = implicit_layout_info_call(elem, Orientation::Vertical);
@@ -316,7 +322,7 @@ fn explicit_layout_info(e: &ElementRc, orientation: Orientation) -> Expression {
     }
     values.insert("min_percent".into(), Expression::NumberLiteral(0., Unit::None));
     values.insert("max_percent".into(), Expression::NumberLiteral(100., Unit::None));
-    Expression::Struct { ty: crate::layout::layout_info_type(), values }
+    Expression::Struct { ty: crate::typeregister::layout_info_type(), values }
 }
 
 /// Replace expression such as  `"width: 30%;` with `width: 0.3 * parent.width;`

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -264,8 +264,9 @@ fn merge_explicit_constraints(
             name: unique_name.clone(),
             value: Box::new(std::mem::take(expr)),
         };
-        let Type::Struct { fields, .. } = &ty else { unreachable!() };
-        let mut values = fields
+        let Type::Struct(s) = &ty else { unreachable!() };
+        let mut values = s
+            .fields
             .keys()
             .map(|p| {
                 (

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -420,7 +420,7 @@ fn make_default_aspect_ratio_preserving_binding(
         let implicit_size_var = Box::new(Expression::ReadLocalVariable {
             name: "image_implicit_size".into(),
             ty: match BuiltinFunction::ImageSize.ty() {
-                Type::Function { return_type, .. } => *return_type,
+                Type::Function(function) => function.return_type.clone(),
                 _ => panic!("invalid type for ImplicitItemSize built-in function"),
             },
         });

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::expression_tree::{BuiltinFunction, Expression};
-use crate::langtype::{ElementType, Type};
+use crate::langtype::{ElementType, Function, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::*;
 use by_address::ByAddress;
@@ -51,10 +51,10 @@ pub fn replace_forward_focus_bindings_with_focus_functions(
                     component.root_element.borrow_mut().property_declarations.insert(
                         function.name().into(),
                         PropertyDeclaration {
-                            property_type: Type::Function {
+                            property_type: Type::Function(Rc::new(Function {
                                 return_type: Type::Void.into(),
                                 args: vec![],
-                            },
+                            })),
                             visibility: PropertyVisibility::Public,
                             ..Default::default()
                         },

--- a/internal/compiler/passes/lower_absolute_coordinates.rs
+++ b/internal/compiler/passes/lower_absolute_coordinates.rs
@@ -26,7 +26,7 @@ pub fn lower_absolute_coordinates(component: &Rc<Component>) {
     });
 
     let point_type = match BuiltinFunction::ItemAbsolutePosition.ty() {
-        crate::langtype::Type::Function { return_type, .. } => return_type.as_ref().clone(),
+        crate::langtype::Type::Function(sig) => sig.return_type.clone(),
         _ => unreachable!(),
     };
 

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -63,7 +63,7 @@ fn apply_builtin(e: &ElementRc) {
     let bty = if let Some(bty) = e.borrow().builtin_type() { bty } else { return };
     if bty.name == "Text" {
         e.borrow_mut().set_binding_if_not_set("accessible-role".into(), || {
-            let enum_ty = crate::typeregister::BUILTIN_ENUMS.with(|e| e.AccessibleRole.clone());
+            let enum_ty = crate::typeregister::BUILTIN.with(|e| e.enums.AccessibleRole.clone());
             Expression::EnumerationValue(EnumerationValue {
                 value: enum_ty.values.iter().position(|v| v == "text").unwrap(),
                 enumeration: enum_ty,

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -13,7 +13,7 @@ use crate::langtype::Type;
 use crate::layout::*;
 use crate::object_tree::*;
 use crate::typeloader::TypeLoader;
-use crate::typeregister::TypeRegister;
+use crate::typeregister::{layout_info_type, TypeRegister};
 use smol_str::format_smolstr;
 use std::cell::RefCell;
 use std::collections::HashSet;

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -157,7 +157,7 @@ fn lower_popup_window(
             }
         },
         None => {
-            let enum_ty = crate::typeregister::BUILTIN_ENUMS.with(|e| e.PopupClosePolicy.clone());
+            let enum_ty = crate::typeregister::BUILTIN.with(|e| e.enums.PopupClosePolicy.clone());
 
             let mut value = String::from("close-on-click");
 

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -21,7 +21,7 @@ pub fn lower_states(
     diag: &mut BuildDiagnostics,
 ) {
     let state_info_type = tr.lookup("StateInfo");
-    assert!(matches!(state_info_type, Type::Struct { name: Some(_), .. }));
+    assert!(matches!(state_info_type, Type::Struct(ref s) if s.name.is_some()));
     recurse_elem(&component.root_element, &(), &mut |elem, _| {
         lower_state_in_element(elem, &state_info_type, diag)
     });

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -116,7 +116,7 @@ fn should_materialize(
         } else if prop == "close-policy" {
             // PopupWindow::close-policy
             return Some(Type::Enumeration(
-                crate::typeregister::BUILTIN_ENUMS.with(|e| e.PopupClosePolicy.clone()),
+                crate::typeregister::BUILTIN.with(|e| e.enums.PopupClosePolicy.clone()),
             ));
         }
     }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1302,7 +1302,10 @@ impl Expression {
                     } else if *rhs == Type::Void {
                         lhs
                     } else {
-                        Self::common_target_type_for_type_list([*lhs, *rhs].into_iter()).into()
+                        Self::common_target_type_for_type_list(
+                            [(*lhs).clone(), (*rhs).clone()].into_iter(),
+                        )
+                        .into()
                     }),
                     (Type::Color, Type::Brush) | (Type::Brush, Type::Color) => Type::Brush,
                     (target_type, expr_ty) => {

--- a/internal/compiler/tests/consistent_styles.rs
+++ b/internal/compiler/tests/consistent_styles.rs
@@ -4,7 +4,7 @@
 //! Test that all styles have the same API.
 
 use i_slint_compiler::expression_tree::Expression;
-use i_slint_compiler::langtype::Type;
+use i_slint_compiler::langtype::{Function, Type};
 use i_slint_compiler::object_tree::PropertyVisibility;
 use i_slint_compiler::typeloader::TypeLoader;
 use i_slint_compiler::typeregister::TypeRegister;
@@ -98,7 +98,10 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
                     result.properties.insert(
                         "focus".into(),
                         PropertyInfo {
-                            ty: Type::Function { return_type: Type::Void.into(), args: vec![] },
+                            ty: Type::Function(Rc::new(Function {
+                                return_type: Type::Void.into(),
+                                args: vec![],
+                            })),
                             vis: PropertyVisibility::Public,
                             pure: false,
                         },
@@ -106,7 +109,10 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
                     result.properties.insert(
                         "clear-focus".into(),
                         PropertyInfo {
-                            ty: Type::Function { return_type: Type::Void.into(), args: vec![] },
+                            ty: Type::Function(Rc::new(Function {
+                                return_type: Type::Void.into(),
+                                args: vec![],
+                            })),
                             vis: PropertyVisibility::Public,
                             pure: false,
                         },

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -83,10 +83,27 @@ pub struct BuiltinTypes {
     pub strarg_callback_type: Type,
     pub logical_point_type: Type,
     pub font_metrics_type: Type,
+    pub layout_info_type: Type,
+    pub path_element_type: Type,
+    pub box_layout_cell_data_type: Type,
 }
 
 impl BuiltinTypes {
     fn new() -> Self {
+        let layout_info_type = Type::Struct(Rc::new(Struct {
+            fields: ["min", "max", "preferred"]
+                .iter()
+                .map(|s| (SmolStr::new_static(s), Type::LogicalLength))
+                .chain(
+                    ["min_percent", "max_percent", "stretch"]
+                        .iter()
+                        .map(|s| (SmolStr::new_static(s), Type::Float32)),
+                )
+                .collect(),
+            name: Some("slint::private_api::LayoutInfo".into()),
+            node: None,
+            rust_attributes: None,
+        }));
         Self {
             enums: BuiltinEnums::new(),
             logical_point_type: Type::Struct(Rc::new(Struct {
@@ -118,6 +135,20 @@ impl BuiltinTypes {
             strarg_callback_type: Type::Callback(Rc::new(Callback {
                 return_type: None,
                 args: vec![Type::String],
+            })),
+            layout_info_type: layout_info_type.clone(),
+            path_element_type: Type::Struct(Rc::new(Struct {
+                fields: Default::default(),
+                name: Some("PathElement".into()),
+                node: None,
+                rust_attributes: None,
+            })),
+            box_layout_cell_data_type: Type::Struct(Rc::new(Struct {
+                fields: IntoIterator::into_iter([("constraint".into(), layout_info_type)])
+                    .collect(),
+                name: Some("BoxLayoutCellData".into()),
+                node: None,
+                rust_attributes: None,
             })),
         }
     }
@@ -632,4 +663,19 @@ pub fn logical_point_type() -> Type {
 
 pub fn font_metrics_type() -> Type {
     BUILTIN.with(|types| types.font_metrics_type.clone())
+}
+
+/// The [`Type`] for a runtime LayoutInfo structure
+pub fn layout_info_type() -> Type {
+    BUILTIN.with(|types| types.layout_info_type.clone())
+}
+
+/// The [`Type`] for a runtime PathElement structure
+pub fn path_element_type() -> Type {
+    BUILTIN.with(|types| types.path_element_type.clone())
+}
+
+/// The [`Type`] for a runtime BoxLayoutCellData structure
+pub fn box_layout_cell_data_type() -> Type {
+    BUILTIN.with(|types| types.box_layout_cell_data_type.clone())
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -77,8 +77,18 @@ macro_rules! declare_enums {
 
 i_slint_common::for_each_enums!(declare_enums);
 
+pub struct BuiltinTypes {
+    pub enums: BuiltinEnums,
+}
+
+impl BuiltinTypes {
+    fn new() -> Self {
+        Self { enums: BuiltinEnums::new() }
+    }
+}
+
 thread_local! {
-    pub static BUILTIN_ENUMS: BuiltinEnums = BuiltinEnums::new();
+    pub static BUILTIN: BuiltinTypes = BuiltinTypes::new();
 }
 
 const RESERVED_OTHER_PROPERTIES: &[(&str, Type)] = &[
@@ -163,12 +173,12 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
             ("clear-focus", BuiltinFunction::ClearFocusItem.ty(), PropertyVisibility::Public),
             (
                 "dialog-button-role",
-                Type::Enumeration(BUILTIN_ENUMS.with(|e| e.DialogButtonRole.clone())),
+                Type::Enumeration(BUILTIN.with(|e| e.enums.DialogButtonRole.clone())),
                 PropertyVisibility::Constexpr,
             ),
             (
                 "accessible-role",
-                Type::Enumeration(BUILTIN_ENUMS.with(|e| e.AccessibleRole.clone())),
+                Type::Enumeration(BUILTIN.with(|e| e.enums.AccessibleRole.clone())),
                 PropertyVisibility::Constexpr,
             ),
         ]))
@@ -304,7 +314,7 @@ impl TypeRegister {
         register.insert_type(Type::Rem);
         register.types.insert("Point".into(), logical_point_type());
 
-        BUILTIN_ENUMS.with(|e| e.fill_register(&mut register));
+        BUILTIN.with(|e| e.enums.fill_register(&mut register));
 
         register.supported_property_animation_types.insert(Type::Float32.to_string());
         register.supported_property_animation_types.insert(Type::Int32.to_string());
@@ -323,7 +333,7 @@ impl TypeRegister {
             ($pub_type:ident, Coord) => { Type::LogicalLength };
             ($pub_type:ident, KeyboardModifiers) => { $pub_type.clone() };
             ($pub_type:ident, $_:ident) => {
-                BUILTIN_ENUMS.with(|e| Type::Enumeration(e.$pub_type.clone()))
+                BUILTIN.with(|e| Type::Enumeration(e.enums.$pub_type.clone()))
             };
         }
         #[rustfmt::skip]

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 use crate::expression_tree::BuiltinFunction;
 use crate::langtype::{
     BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, Callback, ElementType,
-    Enumeration, PropertyLookupResult, Type,
+    Enumeration, PropertyLookupResult, Struct, Type,
 };
 use crate::object_tree::{Component, PropertyVisibility};
 use crate::typeloader;
@@ -340,14 +340,14 @@ impl TypeRegister {
                     }
                 }
             )*) => { $(
-                let $Name = Type::Struct {
+                let $Name = Type::Struct(Rc::new(Struct{
                     fields: BTreeMap::from([
                         $((stringify!($pub_field).replace_smolstr("_", "-"), map_type!($pub_type, $pub_type))),*
                     ]),
                     name: Some(format_smolstr!("{}", $inner_name)),
                     node: None,
                     rust_attributes: None,
-                };
+                }));
                 register.insert_type_with_name(maybe_clone!($Name, $Name), SmolStr::new(stringify!($Name)));
             )* };
         }
@@ -585,29 +585,35 @@ impl TypeRegister {
 }
 
 pub fn logical_point_type() -> Type {
-    Type::Struct {
-        fields: IntoIterator::into_iter([
-            (SmolStr::new_static("x"), Type::LogicalLength),
-            (SmolStr::new_static("y"), Type::LogicalLength),
-        ])
-        .collect(),
-        name: Some("slint::LogicalPosition".into()),
-        node: None,
-        rust_attributes: None,
+    thread_local! {
+        static TYPE: Type = Type::Struct(Rc::new(Struct {
+            fields: IntoIterator::into_iter([
+                (SmolStr::new_static("x"), Type::LogicalLength),
+                (SmolStr::new_static("y"), Type::LogicalLength),
+            ])
+            .collect(),
+            name: Some("slint::LogicalPosition".into()),
+            node: None,
+            rust_attributes: None,
+        }));
     }
+    TYPE.with(|t| t.clone())
 }
 
 pub fn font_metrics_type() -> Type {
-    Type::Struct {
-        fields: IntoIterator::into_iter([
-            (SmolStr::new_static("ascent"), Type::LogicalLength),
-            (SmolStr::new_static("descent"), Type::LogicalLength),
-            (SmolStr::new_static("x-height"), Type::LogicalLength),
-            (SmolStr::new_static("cap-height"), Type::LogicalLength),
-        ])
-        .collect(),
-        name: Some("slint::private_api::FontMetrics".into()),
-        node: None,
-        rust_attributes: None,
+    thread_local! {
+        static TYPE: Type = Type::Struct(Rc::new(Struct {
+            fields: IntoIterator::into_iter([
+                (SmolStr::new_static("ascent"), Type::LogicalLength),
+                (SmolStr::new_static("descent"), Type::LogicalLength),
+                (SmolStr::new_static("x-height"), Type::LogicalLength),
+                (SmolStr::new_static("cap-height"), Type::LogicalLength),
+            ])
+            .collect(),
+            name: Some("slint::private_api::FontMetrics".into()),
+            node: None,
+            rust_attributes: None,
+        }));
     }
+    TYPE.with(|t| t.clone())
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -79,11 +79,47 @@ i_slint_common::for_each_enums!(declare_enums);
 
 pub struct BuiltinTypes {
     pub enums: BuiltinEnums,
+    pub noarg_callback_type: Type,
+    pub strarg_callback_type: Type,
+    pub logical_point_type: Type,
+    pub font_metrics_type: Type,
 }
 
 impl BuiltinTypes {
     fn new() -> Self {
-        Self { enums: BuiltinEnums::new() }
+        Self {
+            enums: BuiltinEnums::new(),
+            logical_point_type: Type::Struct(Rc::new(Struct {
+                fields: IntoIterator::into_iter([
+                    (SmolStr::new_static("x"), Type::LogicalLength),
+                    (SmolStr::new_static("y"), Type::LogicalLength),
+                ])
+                .collect(),
+                name: Some("slint::LogicalPosition".into()),
+                node: None,
+                rust_attributes: None,
+            })),
+            font_metrics_type: Type::Struct(Rc::new(Struct {
+                fields: IntoIterator::into_iter([
+                    (SmolStr::new_static("ascent"), Type::LogicalLength),
+                    (SmolStr::new_static("descent"), Type::LogicalLength),
+                    (SmolStr::new_static("x-height"), Type::LogicalLength),
+                    (SmolStr::new_static("cap-height"), Type::LogicalLength),
+                ])
+                .collect(),
+                name: Some("slint::private_api::FontMetrics".into()),
+                node: None,
+                rust_attributes: None,
+            })),
+            noarg_callback_type: Type::Callback(Rc::new(Callback {
+                return_type: None,
+                args: vec![],
+            })),
+            strarg_callback_type: Type::Callback(Rc::new(Callback {
+                return_type: None,
+                args: vec![Type::String],
+            })),
+        }
     }
 }
 
@@ -112,19 +148,11 @@ pub const RESERVED_ROTATION_PROPERTIES: &[(&str, Type)] = &[
 ];
 
 fn noarg_callback_type() -> Type {
-    thread_local! {
-        static TYPE: Type = Type::Callback(Rc::new(Callback { return_type: None, args: vec![] }));
-    }
-
-    TYPE.with(|t| t.clone())
+    BUILTIN.with(|types| types.noarg_callback_type.clone())
 }
 
 fn strarg_callback_type() -> Type {
-    thread_local! {
-        static TYPE: Type = Type::Callback(Rc::new(Callback { return_type: None, args: vec![Type::String] }));
-    }
-
-    TYPE.with(|t| t.clone())
+    BUILTIN.with(|types| types.strarg_callback_type.clone())
 }
 
 pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str, Type)> {
@@ -599,35 +627,9 @@ impl TypeRegister {
 }
 
 pub fn logical_point_type() -> Type {
-    thread_local! {
-        static TYPE: Type = Type::Struct(Rc::new(Struct {
-            fields: IntoIterator::into_iter([
-                (SmolStr::new_static("x"), Type::LogicalLength),
-                (SmolStr::new_static("y"), Type::LogicalLength),
-            ])
-            .collect(),
-            name: Some("slint::LogicalPosition".into()),
-            node: None,
-            rust_attributes: None,
-        }));
-    }
-    TYPE.with(|t| t.clone())
+    BUILTIN.with(|types| types.logical_point_type.clone())
 }
 
 pub fn font_metrics_type() -> Type {
-    thread_local! {
-        static TYPE: Type = Type::Struct(Rc::new(Struct {
-            fields: IntoIterator::into_iter([
-                (SmolStr::new_static("ascent"), Type::LogicalLength),
-                (SmolStr::new_static("descent"), Type::LogicalLength),
-                (SmolStr::new_static("x-height"), Type::LogicalLength),
-                (SmolStr::new_static("cap-height"), Type::LogicalLength),
-            ])
-            .collect(),
-            name: Some("slint::private_api::FontMetrics".into()),
-            node: None,
-            rust_attributes: None,
-        }));
-    }
-    TYPE.with(|t| t.clone())
+    BUILTIN.with(|types| types.font_metrics_type.clone())
 }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2022,7 +2022,7 @@ fn lang_type_to_value_type() {
     assert_eq!(ValueType::from(LangType::String), ValueType::String);
     assert_eq!(ValueType::from(LangType::Color), ValueType::Brush);
     assert_eq!(ValueType::from(LangType::Brush), ValueType::Brush);
-    assert_eq!(ValueType::from(LangType::Array(Box::new(LangType::Void))), ValueType::Model);
+    assert_eq!(ValueType::from(LangType::Array(Rc::new(LangType::Void))), ValueType::Model);
     assert_eq!(ValueType::from(LangType::Bool), ValueType::Bool);
     assert_eq!(
         ValueType::from(LangType::Struct(Rc::new(LangStruct {

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -2007,6 +2007,7 @@ fn component_definition_model_properties() {
 
 #[test]
 fn lang_type_to_value_type() {
+    use i_slint_compiler::langtype::Struct as LangStruct;
     use std::collections::BTreeMap;
 
     assert_eq!(ValueType::from(LangType::Void), ValueType::Void);
@@ -2024,12 +2025,12 @@ fn lang_type_to_value_type() {
     assert_eq!(ValueType::from(LangType::Array(Box::new(LangType::Void))), ValueType::Model);
     assert_eq!(ValueType::from(LangType::Bool), ValueType::Bool);
     assert_eq!(
-        ValueType::from(LangType::Struct {
+        ValueType::from(LangType::Struct(Rc::new(LangStruct {
             fields: BTreeMap::default(),
             name: None,
             node: None,
             rust_attributes: None
-        }),
+        }))),
         ValueType::Struct
     );
     assert_eq!(ValueType::from(LangType::Image), ValueType::Image);

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1445,8 +1445,8 @@ fn check_value_type(value: &Value, ty: &Type) -> bool {
         Type::Array(inner) => {
             matches!(value, Value::Model(m) if m.iter().all(|v| check_value_type(&v, inner)))
         }
-        Type::Struct { fields, .. } => {
-            matches!(value, Value::Struct(str) if str.iter().all(|(k, v)| fields.get(k).map_or(false, |ty| check_value_type(v, ty))))
+        Type::Struct(s) => {
+            matches!(value, Value::Struct(str) if str.iter().all(|(k, v)| s.fields.get(k).map_or(false, |ty| check_value_type(v, ty))))
         }
         Type::Enumeration(en) => {
             matches!(value, Value::EnumerationValue(name, _) if name == en.name.as_str())
@@ -1688,8 +1688,8 @@ pub fn default_value_for_type(ty: &Type) -> Value {
         Type::Image => Value::Image(Default::default()),
         Type::Bool => Value::Bool(false),
         Type::Callback { .. } => Value::Void,
-        Type::Struct { fields, .. } => Value::Struct(
-            fields
+        Type::Struct(s) => Value::Struct(
+            s.fields
                 .iter()
                 .map(|(n, t)| (n.to_string(), default_value_for_type(t)))
                 .collect::<Struct>(),

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1474,7 +1474,7 @@ pub(crate) fn invoke_callback(
                     let res = callback.call(args);
                     return Some(if res != Value::Void {
                         res
-                    } else if let Some(Type::Callback { return_type: Some(rt), .. }) = description
+                    } else if let Some(Type::Callback(callback)) = description
                         .original
                         .root_element
                         .borrow()
@@ -1485,7 +1485,7 @@ pub(crate) fn invoke_callback(
                         // If the callback was not set, the return value will be Value::Void, but we need
                         // to make sure that the value is actually of the right type as returned by the
                         // callback, otherwise we will get panics later
-                        default_value_for_type(rt)
+                        default_value_for_type(callback.return_type.as_ref().unwrap_or(&Type::Void))
                     } else {
                         res
                     });

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1015,12 +1015,12 @@ fn get_document_symbols(
         .collect::<Vec<_>>();
 
     r.extend(inner_types.iter().filter_map(|c| match c {
-        Type::Struct { name: Some(name), node: Some(node), .. } => Some(DocumentSymbol {
-            range: util::node_to_lsp_range(node.parent().as_ref()?),
+        Type::Struct(s) if s.name.is_some() && s.node.is_some() => Some(DocumentSymbol {
+            range: util::node_to_lsp_range(s.node.as_ref().unwrap().parent().as_ref()?),
             selection_range: util::node_to_lsp_range(
-                &node.parent()?.child_node(SyntaxKind::DeclaredIdentifier)?,
+                &s.node.as_ref().unwrap().parent()?.child_node(SyntaxKind::DeclaredIdentifier)?,
             ),
-            name: name.to_string(),
+            name: s.name.as_ref().unwrap().to_string(),
             kind: lsp_types::SymbolKind::STRUCT,
             ..ds.clone()
         }),

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -61,7 +61,9 @@ pub fn goto_definition(
 
 fn goto_type(ty: &Type) -> Option<GotoDefinitionResponse> {
     match ty {
-        Type::Struct { node: Some(node), .. } => goto_node(node.parent().as_ref()?),
+        Type::Struct(s) if s.node.is_some() => {
+            goto_node(s.node.as_ref().unwrap().parent().as_ref()?)
+        }
         Type::Enumeration(e) => goto_node(e.node.as_ref()?),
         _ => None,
     }

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -53,17 +53,17 @@ pub fn get_tooltip(document_cache: &mut DocumentCache, token: SyntaxToken) -> Op
 
 fn from_prop_result(prop_info: PropertyLookupResult) -> Option<MarkupContent> {
     let pure = if prop_info.declared_pure.is_some_and(|x| x) { "pure " } else { "" };
-    if let Type::Callback { return_type, args } = &prop_info.property_type {
-        let ret = return_type.as_ref().map(|x| format!(" -> {}", x)).unwrap_or_default();
-        let args = args.iter().map(|x| x.to_string()).join(", ");
+    if let Type::Callback(callback) = &prop_info.property_type {
+        let ret = callback.return_type.as_ref().map(|x| format!(" -> {}", x)).unwrap_or_default();
+        let args = callback.args.iter().map(|x| x.to_string()).join(", ");
         Some(from_slint_code(&format!("{pure}callback {}({args}){ret}", prop_info.resolved_name)))
-    } else if let Type::Function { return_type, args } = &prop_info.property_type {
-        let ret = if matches!(**return_type, Type::Void) {
+    } else if let Type::Function(function) = &prop_info.property_type {
+        let ret = if matches!(function.return_type, Type::Void) {
             String::new()
         } else {
-            format!(" -> {return_type}")
+            format!(" -> {}", function.return_type)
         };
-        let args = args.iter().map(|x| x.to_string()).join(", ");
+        let args = function.args.iter().map(|x| x.to_string()).join(", ");
         Some(from_slint_code(&format!("{pure}function {}({args}){ret}", prop_info.resolved_name)))
     } else if prop_info.property_type.is_property_type() {
         Some(from_slint_code(&format!(

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -509,7 +509,7 @@ pub(super) fn get_properties(
             name: "accessible-role".into(),
             priority: DEFAULT_PRIORITY - 100,
             ty: Type::Enumeration(
-                i_slint_compiler::typeregister::BUILTIN_ENUMS.with(|e| e.AccessibleRole.clone()),
+                i_slint_compiler::typeregister::BUILTIN.with(|e| e.enums.AccessibleRole.clone()),
             ),
             declared_at: None,
             defined_at: None,

--- a/tools/updater/experiments/purity.rs
+++ b/tools/updater/experiments/purity.rs
@@ -33,8 +33,8 @@ pub(crate) fn fold_node(
                     let lk = nr.element().borrow().lookup_property(nr.name());
                     if lk.declared_pure == Some(true) {
                         write!(file, "pure ")?;
-                    } else if let Type::Callback { return_type, .. } = lk.property_type {
-                        if return_type.is_some() {
+                    } else if let Type::Callback(callback) = lk.property_type {
+                        if callback.return_type.is_some() {
                             write!(file, "pure ")?;
                         }
                     }

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -405,11 +405,11 @@ fn load_data(
                     _ => slint_interpreter::Value::Void,
                 },
                 serde_json::Value::Object(obj) => match t {
-                    i_slint_compiler::langtype::Type::Struct { fields, .. } => obj
+                    i_slint_compiler::langtype::Type::Struct(s) => obj
                         .iter()
                         .filter_map(|(k, v)| {
                             let k = k.to_smolstr();
-                            match fields.get(&k) {
+                            match s.fields.get(&k) {
                                 Some(t) => Some((k.to_string(), from_json(t, v))),
                                 None => {
                                     eprintln!("Warning: ignoring unknown property: {}", k);


### PR DESCRIPTION
Most notably, these patches make `langtype::Type` cheap to copy by wrapping its non-trivial internals in `Rc` instead of `Box`, which removes a lot of allocations during runtime.

Before:
```
Benchmark 1: ./target/release/slint-viewer ../slint-perf/app.slint
  Time (mean ± σ):      1.089 s ±  0.026 s    [User: 0.771 s, System: 0.216 s]
  Range (min … max):    1.046 s …  1.130 s    10 runs

        allocations:            3152149
```

After:
```
  Time (mean ± σ):     996.9 ms ±  17.7 ms    [User: 708.9 ms, System: 202.9 ms]
  Range (min … max):   977.8 ms … 1033.1 ms    10 runs

        allocations:            2686677
```