### PR TITLE
Added rejected to TextEdit

### DIFF
--- a/docs/reference/src/language/widgets/textedit.md
+++ b/docs/reference/src/language/widgets/textedit.md
@@ -31,6 +31,7 @@ shortcut will be implemented in a future version: <https://github.com/slint-ui/s
 ### Callbacks
 
 -   **`edited(string)`**: Emitted when the text has changed because the user modified it
+-   **`rejected()`**: Emitted when the user pressed the escape key
 
 ### Example
 

--- a/internal/compiler/widgets/common/textedit-base.slint
+++ b/internal/compiler/widgets/common/textedit-base.slint
@@ -29,28 +29,29 @@ export component TextEditBase inherits Rectangle {
     in property <brush> placeholder-color;
 
     callback edited(/* text */ string);
+    callback rejected(/* text */ string);
 
-    public function set-selection-offsets(start: int,end: int){
+    public function set-selection-offsets(start: int, end: int) {
         text-input.set-selection-offsets(start, end);
     }
 
-    public function select-all(){
+    public function select-all() {
         text-input.select-all();
     }
 
-    public function clear-selection(){
+    public function clear-selection() {
         text-input.clear-selection();
     }
 
-    public function cut(){
+    public function cut() {
         text-input.cut();
     }
 
-    public function copy(){
+    public function copy() {
         text-input.copy();
     }
 
-    public function paste(){
+    public function paste() {
         text-input.paste();
     }
 
@@ -73,6 +74,10 @@ export component TextEditBase inherits Rectangle {
 
             edited => {
                 root.edited(self.text);
+            }
+
+            rejected => {
+                root.rejected(self.text);
             }
 
             cursor-position-changed(cpos) => {

--- a/internal/compiler/widgets/cosmic/textedit.slint
+++ b/internal/compiler/widgets/cosmic/textedit.slint
@@ -22,6 +22,8 @@ export component TextEdit {
     in-out property <length> viewport-height <=> base.viewport-height;
 
     callback edited <=> base.edited;
+    callback rejected <=> base.rejected;
+
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -78,32 +78,34 @@ export component TextEdit {
     in property <string> placeholder-text;
 
     callback edited(/* text */ string);
+    callback rejected(/* text */ string);
+
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
     accessible-placeholder-text: text == "" ? placeholder-text : "";
 
-    public function set-selection-offsets(start: int,end: int){
+    public function set-selection-offsets(start: int, end: int) {
         text-input.set-selection-offsets(start, end);
     }
 
-    public function select-all(){
+    public function select-all() {
         text-input.select-all();
     }
 
-    public function clear-selection(){
+    public function clear-selection() {
         text-input.clear-selection();
     }
 
-    public function cut(){
+    public function cut() {
         text-input.cut();
     }
 
-    public function copy(){
+    public function copy() {
         text-input.copy();
     }
 
-    public function paste(){
+    public function paste() {
         text-input.paste();
     }
 
@@ -155,6 +157,10 @@ export component TextEdit {
 
             edited => {
                 root.edited(self.text);
+            }
+
+            rejected => {
+                root.rejected(self.text);
             }
 
             cursor-position-changed(cpos) => {

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -22,32 +22,34 @@ export component TextEdit {
     in-out property <length> viewport-height <=> base.viewport-height;
 
     callback edited <=> base.edited;
+    callback rejected <=> base.rejected;
+
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
     accessible-placeholder-text: text == "" ? placeholder-text : "";
 
-    public function set-selection-offsets(start: int,end: int){
+    public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);
     }
 
-    public function select-all(){
+    public function select-all() {
         base.select-all();
     }
 
-    public function clear-selection(){
+    public function clear-selection() {
         base.clear-selection();
     }
 
-    public function cut(){
+    public function cut() {
         base.cut();
     }
 
-    public function copy(){
+    public function copy() {
         base.copy();
     }
 
-    public function paste(){
+    public function paste() {
         base.paste();
     }
 

--- a/internal/compiler/widgets/material/textedit.slint
+++ b/internal/compiler/widgets/material/textedit.slint
@@ -22,32 +22,34 @@ export component TextEdit {
     in-out property <length> viewport-height <=> base.viewport-height;
 
     callback edited <=> base.edited;
+    callback rejected <=> base.rejected;
+
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
     accessible-placeholder-text: text == "" ? placeholder-text : "";
 
-    public function set-selection-offsets(start: int,end: int){
+    public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);
     }
 
-    public function select-all(){
+    public function select-all() {
         base.select-all();
     }
 
-    public function clear-selection(){
+    public function clear-selection() {
         base.clear-selection();
     }
 
-    public function cut(){
+    public function cut() {
         base.cut();
     }
 
-    public function copy(){
+    public function copy() {
         base.copy();
     }
 
-    public function paste(){
+    public function paste() {
         base.paste();
     }
 

--- a/internal/compiler/widgets/qt/textedit.slint
+++ b/internal/compiler/widgets/qt/textedit.slint
@@ -21,32 +21,34 @@ export component TextEdit {
     in-out property <length> viewport-height <=> base.viewport-height;
 
     callback edited <=> base.edited;
+    callback rejected <=> base.rejected;
+
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
     accessible-placeholder-text: text == "" ? placeholder-text : "";
 
-    public function set-selection-offsets(start: int,end: int){
+    public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);
     }
 
-    public function select-all(){
+    public function select-all() {
         base.select-all();
     }
 
-    public function clear-selection(){
+    public function clear-selection() {
         base.clear-selection();
     }
 
-    public function cut(){
+    public function cut() {
         base.cut();
     }
 
-    public function copy(){
+    public function copy() {
         base.copy();
     }
 
-    public function paste(){
+    public function paste() {
         base.paste();
     }
 


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

I thought there was only `LineEdit` and `TextInput`, I didn't realize there was also a `TextEdit` in my first pr #6649. This adds the `rejected` callback to `TextEdit` as well.