### PR TITLE
Optimize: Filter/map rowan nodes instead of doing multiple lookups

### DIFF
--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -138,11 +138,11 @@ impl Expression {
     pub fn from_binding_expression_node(node: SyntaxNode, ctx: &mut LookupCtx) -> Self {
         debug_assert_eq!(node.kind(), SyntaxKind::BindingExpression);
         let e = node
-            .child_node(SyntaxKind::Expression)
-            .map(|n| Self::from_expression_node(n.into(), ctx))
-            .or_else(|| {
-                node.child_node(SyntaxKind::CodeBlock)
-                    .map(|c| Self::from_codeblock_node(c.into(), ctx))
+            .children()
+            .find_map(|n| match n.kind() {
+                SyntaxKind::Expression => Some(Self::from_expression_node(n.into(), ctx)),
+                SyntaxKind::CodeBlock => Some(Self::from_codeblock_node(n.into(), ctx)),
+                _ => None,
             })
             .unwrap_or(Self::Invalid);
         if ctx.property_type == Type::LogicalLength && e.ty() == Type::Percent {
@@ -255,76 +255,93 @@ impl Expression {
     }
 
     fn from_expression_node(node: syntax_nodes::Expression, ctx: &mut LookupCtx) -> Self {
-        node.Expression()
-            .map(|n| Self::from_expression_node(n, ctx))
-            .or_else(|| node.AtImageUrl().map(|n| Self::from_at_image_url_node(n, ctx)))
-            .or_else(|| node.AtGradient().map(|n| Self::from_at_gradient(n, ctx)))
-            .or_else(|| node.AtTr().map(|n| Self::from_at_tr(n, ctx)))
-            .or_else(|| {
-                node.QualifiedName().map(|n| {
-                    let exp =
-                        Self::from_qualified_name_node(n.clone(), ctx, LookupPhase::default());
-                    if matches!(exp.ty(), Type::Function { .. } | Type::Callback { .. }) {
-                        ctx.diag.push_error(
-                            format!(
-                                "'{}' must be called. Did you forgot the '()'?",
-                                QualifiedTypeName::from_node(n.clone())
-                            ),
-                            &n,
-                        )
+        node.children_with_tokens()
+            .find_map(|child| match child {
+                NodeOrToken::Node(node) => match node.kind() {
+                    SyntaxKind::Expression => Some(Self::from_expression_node(node.into(), ctx)),
+                    SyntaxKind::AtImageUrl => Some(Self::from_at_image_url_node(node.into(), ctx)),
+                    SyntaxKind::AtGradient => Some(Self::from_at_gradient(node.into(), ctx)),
+                    SyntaxKind::AtTr => Some(Self::from_at_tr(node.into(), ctx)),
+                    SyntaxKind::QualifiedName => {
+                        let exp = Self::from_qualified_name_node(
+                            node.clone().into(),
+                            ctx,
+                            LookupPhase::default(),
+                        );
+                        if matches!(exp.ty(), Type::Function { .. } | Type::Callback { .. }) {
+                            ctx.diag.push_error(
+                                format!(
+                                    "'{}' must be called. Did you forgot the '()'?",
+                                    QualifiedTypeName::from_node(node.clone().into())
+                                ),
+                                &node,
+                            )
+                        }
+                        Some(exp)
                     }
-                    exp
-                })
+                    SyntaxKind::FunctionCallExpression => {
+                        Some(Self::from_function_call_node(node.into(), ctx))
+                    }
+                    SyntaxKind::MemberAccess => {
+                        Some(Self::from_member_access_node(node.into(), ctx))
+                    }
+                    SyntaxKind::IndexExpression => {
+                        Some(Self::from_index_expression_node(node.into(), ctx))
+                    }
+                    SyntaxKind::SelfAssignment => {
+                        Some(Self::from_self_assignment_node(node.into(), ctx))
+                    }
+                    SyntaxKind::BinaryExpression => {
+                        Some(Self::from_binary_expression_node(node.into(), ctx))
+                    }
+                    SyntaxKind::UnaryOpExpression => {
+                        Some(Self::from_unaryop_expression_node(node.into(), ctx))
+                    }
+                    SyntaxKind::ConditionalExpression => {
+                        Some(Self::from_conditional_expression_node(node.into(), ctx))
+                    }
+                    SyntaxKind::ObjectLiteral => {
+                        Some(Self::from_object_literal_node(node.into(), ctx))
+                    }
+                    SyntaxKind::Array => Some(Self::from_array_node(node.into(), ctx)),
+                    SyntaxKind::CodeBlock => Some(Self::from_codeblock_node(node.into(), ctx)),
+                    SyntaxKind::StringTemplate => {
+                        Some(Self::from_string_template_node(node.into(), ctx))
+                    }
+                    _ => None,
+                },
+                NodeOrToken::Token(token) => match token.kind() {
+                    SyntaxKind::StringLiteral => Some(
+                        crate::literals::unescape_string(token.text())
+                            .map(Self::StringLiteral)
+                            .unwrap_or_else(|| {
+                                ctx.diag.push_error("Cannot parse string literal".into(), &token);
+                                Self::Invalid
+                            }),
+                    ),
+                    SyntaxKind::NumberLiteral => Some(
+                        crate::literals::parse_number_literal(token.text().into()).unwrap_or_else(
+                            |e| {
+                                ctx.diag.push_error(e.to_string(), &node);
+                                Self::Invalid
+                            },
+                        ),
+                    ),
+                    SyntaxKind::ColorLiteral => Some(
+                        crate::literals::parse_color_literal(token.text())
+                            .map(|i| Expression::Cast {
+                                from: Box::new(Expression::NumberLiteral(i as _, Unit::None)),
+                                to: Type::Color,
+                            })
+                            .unwrap_or_else(|| {
+                                ctx.diag.push_error("Invalid color literal".into(), &node);
+                                Self::Invalid
+                            }),
+                    ),
+
+                    _ => None,
+                },
             })
-            .or_else(|| {
-                node.child_text(SyntaxKind::StringLiteral).map(|s| {
-                    crate::literals::unescape_string(&s).map(Self::StringLiteral).unwrap_or_else(
-                        || {
-                            ctx.diag.push_error("Cannot parse string literal".into(), &node);
-                            Self::Invalid
-                        },
-                    )
-                })
-            })
-            .or_else(|| {
-                node.child_text(SyntaxKind::NumberLiteral)
-                    .map(crate::literals::parse_number_literal)
-                    .transpose()
-                    .unwrap_or_else(|e| {
-                        ctx.diag.push_error(e.to_string(), &node);
-                        Some(Self::Invalid)
-                    })
-            })
-            .or_else(|| {
-                node.child_text(SyntaxKind::ColorLiteral).map(|s| {
-                    crate::literals::parse_color_literal(&s)
-                        .map(|i| Expression::Cast {
-                            from: Box::new(Expression::NumberLiteral(i as _, Unit::None)),
-                            to: Type::Color,
-                        })
-                        .unwrap_or_else(|| {
-                            ctx.diag.push_error("Invalid color literal".into(), &node);
-                            Self::Invalid
-                        })
-                })
-            })
-            .or_else(|| {
-                node.FunctionCallExpression().map(|n| Self::from_function_call_node(n, ctx))
-            })
-            .or_else(|| node.MemberAccess().map(|n| Self::from_member_access_node(n, ctx)))
-            .or_else(|| node.IndexExpression().map(|n| Self::from_index_expression_node(n, ctx)))
-            .or_else(|| node.SelfAssignment().map(|n| Self::from_self_assignment_node(n, ctx)))
-            .or_else(|| node.BinaryExpression().map(|n| Self::from_binary_expression_node(n, ctx)))
-            .or_else(|| {
-                node.UnaryOpExpression().map(|n| Self::from_unaryop_expression_node(n, ctx))
-            })
-            .or_else(|| {
-                node.ConditionalExpression().map(|n| Self::from_conditional_expression_node(n, ctx))
-            })
-            .or_else(|| node.ObjectLiteral().map(|n| Self::from_object_literal_node(n, ctx)))
-            .or_else(|| node.Array().map(|n| Self::from_array_node(n, ctx)))
-            .or_else(|| node.CodeBlock().map(|n| Self::from_codeblock_node(n, ctx)))
-            .or_else(|| node.StringTemplate().map(|n| Self::from_string_template_node(n, ctx)))
             .unwrap_or(Self::Invalid)
     }
 
@@ -977,12 +994,16 @@ impl Expression {
     ) -> Expression {
         let (lhs_n, rhs_n) = node.Expression();
         let mut lhs = Self::from_expression_node(lhs_n.clone(), ctx);
-        let op = None
-            .or_else(|| node.child_token(SyntaxKind::PlusEqual).and(Some('+')))
-            .or_else(|| node.child_token(SyntaxKind::MinusEqual).and(Some('-')))
-            .or_else(|| node.child_token(SyntaxKind::StarEqual).and(Some('*')))
-            .or_else(|| node.child_token(SyntaxKind::DivEqual).and(Some('/')))
-            .or_else(|| node.child_token(SyntaxKind::Equal).and(Some('=')))
+        let op = node
+            .children_with_tokens()
+            .find_map(|n| match n.kind() {
+                SyntaxKind::PlusEqual => Some('+'),
+                SyntaxKind::MinusEqual => Some('-'),
+                SyntaxKind::StarEqual => Some('*'),
+                SyntaxKind::DivEqual => Some('/'),
+                SyntaxKind::Equal => Some('='),
+                _ => None,
+            })
             .unwrap_or('_');
         if lhs.ty() != Type::Invalid {
             lhs.try_set_rw(ctx, if op == '=' { "Assignment" } else { "Self assignment" }, &node);
@@ -1016,19 +1037,23 @@ impl Expression {
         node: syntax_nodes::BinaryExpression,
         ctx: &mut LookupCtx,
     ) -> Expression {
-        let op = None
-            .or_else(|| node.child_token(SyntaxKind::Plus).and(Some('+')))
-            .or_else(|| node.child_token(SyntaxKind::Minus).and(Some('-')))
-            .or_else(|| node.child_token(SyntaxKind::Star).and(Some('*')))
-            .or_else(|| node.child_token(SyntaxKind::Div).and(Some('/')))
-            .or_else(|| node.child_token(SyntaxKind::LessEqual).and(Some('≤')))
-            .or_else(|| node.child_token(SyntaxKind::GreaterEqual).and(Some('≥')))
-            .or_else(|| node.child_token(SyntaxKind::LAngle).and(Some('<')))
-            .or_else(|| node.child_token(SyntaxKind::RAngle).and(Some('>')))
-            .or_else(|| node.child_token(SyntaxKind::EqualEqual).and(Some('=')))
-            .or_else(|| node.child_token(SyntaxKind::NotEqual).and(Some('!')))
-            .or_else(|| node.child_token(SyntaxKind::AndAnd).and(Some('&')))
-            .or_else(|| node.child_token(SyntaxKind::OrOr).and(Some('|')))
+        let op = node
+            .children_with_tokens()
+            .find_map(|n| match n.kind() {
+                SyntaxKind::Plus => Some('+'),
+                SyntaxKind::Minus => Some('-'),
+                SyntaxKind::Star => Some('*'),
+                SyntaxKind::Div => Some('/'),
+                SyntaxKind::LessEqual => Some('≤'),
+                SyntaxKind::GreaterEqual => Some('≥'),
+                SyntaxKind::LAngle => Some('<'),
+                SyntaxKind::RAngle => Some('>'),
+                SyntaxKind::EqualEqual => Some('='),
+                SyntaxKind::NotEqual => Some('!'),
+                SyntaxKind::AndAnd => Some('&'),
+                SyntaxKind::OrOr => Some('|'),
+                _ => None,
+            })
             .unwrap_or('_');
 
         let (lhs_n, rhs_n) = node.Expression();
@@ -1111,10 +1136,14 @@ impl Expression {
         let exp_n = node.Expression();
         let exp = Self::from_expression_node(exp_n, ctx);
 
-        let op = None
-            .or_else(|| node.child_token(SyntaxKind::Plus).and(Some('+')))
-            .or_else(|| node.child_token(SyntaxKind::Minus).and(Some('-')))
-            .or_else(|| node.child_token(SyntaxKind::Bang).and(Some('!')))
+        let op = node
+            .children_with_tokens()
+            .find_map(|n| match n.kind() {
+                SyntaxKind::Plus => Some('+'),
+                SyntaxKind::Minus => Some('-'),
+                SyntaxKind::Bang => Some('!'),
+                _ => None,
+            })
             .unwrap_or('_');
 
         let exp = match op {


### PR DESCRIPTION
Instead of doing potentially multiple calls in the chained calls, each of which would allocate in rowan, we now only call the iterator function once and then leverage `find_map`. This is arguably even more readable and it removes ~300k allocations and speeds up parsing.

Before:
```
  Time (mean ± σ):     930.7 ms ±  15.1 ms    [User: 678.7 ms, System: 165.5 ms]
  Range (min … max):   906.4 ms … 956.3 ms    10 runs

    allocations: 2339130

```

After:
```
  Time (mean ± σ):     914.6 ms ±  22.7 ms    [User: 649.6 ms, System: 174.5 ms]
  Range (min … max):   874.8 ms … 946.3 ms    10 runs

    allocations: 2017915

```

**NOTE:** The absolute numbers above are not correct as I measured this on top of my other changes. The relative impact should be still applicable though.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
