### PR TITLE
Add set-related accessible properties

### DIFF
--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -3,6 +3,7 @@
 
 #include "slint.h"
 #include "slint_testing_internal.h"
+#include <cstdint>
 #include <optional>
 #include <string_view>
 #include <type_traits>
@@ -351,6 +352,19 @@ public:
                 return true;
             else if (*result == "false")
                 return false;
+        }
+        return std::nullopt;
+    }
+
+    /// Returns the accessible-position-in-set of that element, if any.
+    std::optional<uintptr_t> accessible_position_in_set() const
+    {
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::PositionInSet)) {
+            uintptr_t value = 0;
+            if (cbindgen_private::slint_string_to_usize(&*result, &value)) {
+                return value;
+            }
         }
         return std::nullopt;
     }

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -369,6 +369,19 @@ public:
         return std::nullopt;
     }
 
+    /// Returns the accessible-size-of-set of that element, if any.
+    std::optional<uintptr_t> accessible_size_of_set() const
+    {
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::SizeOfSet)) {
+            uintptr_t value = 0;
+            if (cbindgen_private::slint_string_to_usize(&*result, &value)) {
+                return value;
+            }
+        }
+        return std::nullopt;
+    }
+
     /// Sets the accessible-value of that element.
     ///
     /// Setting the value will invoke the `accessible-action-set-value` callback.

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -153,6 +153,17 @@ pub extern "C" fn slint_string_to_float(string: &SharedString, value: &mut f32) 
 }
 
 #[no_mangle]
+pub extern "C" fn slint_string_to_usize(string: &SharedString, value: &mut usize) -> bool {
+    match string.as_str().parse::<usize>() {
+        Ok(v) => {
+            *value = v;
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn slint_debug(string: &SharedString) {
     i_slint_core::debug_log!("{string}");
 }

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -79,6 +79,7 @@ Use the following `accessible-` properties to make your items interact well with
 -   **`accessible-selectable`** (_in_ _bool_): Whether the element can be selected or not.
 -   **`accessible-selected`** (_in_ _bool_): Whether the element is selected or not. This maps to the "is-selected" state of listview items.
 -   **`accessible-position-in-set`** (_in_ _int_): The index (starting from 1) of this element in a group of similar elements. Applies to list items, radio buttons and other elements.
+-   **`accessible-size-of-set`** (_in_ _int_): The total number of elements in a group. Applies to all elements of a group like list items, radio buttons and other elements, but not to their parent container like list views, radio button groups or other grouping elements.
 
 You can also use the following callbacks that are going to be called by the accessibility framework:
 

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -78,7 +78,7 @@ Use the following `accessible-` properties to make your items interact well with
 -   **`accessible-placeholder-text`** (_in_ _string_): A placeholder text to use when the item's value is empty. Applies to text elements.
 -   **`accessible-selectable`** (_in_ _bool_): Whether the element can be selected or not.
 -   **`accessible-selected`** (_in_ _bool_): Whether the element is selected or not. This maps to the "is-selected" state of listview items.
--   **`accessible-position-in-set`** (_in_ _int_): The index (starting from 1) of this element in a group of similar elements. Applies to list items, radio buttons and other elements.
+-   **`accessible-position-in-set`** (_in_ _int_): The index (starting from 0) of this element in a group of similar elements. Applies to list items, radio buttons and other elements.
 -   **`accessible-size-of-set`** (_in_ _int_): The total number of elements in a group. Applies to all elements of a group like list items, radio buttons and other elements, but not to their parent container like list views, radio button groups or other grouping elements.
 
 You can also use the following callbacks that are going to be called by the accessibility framework:

--- a/docs/reference/src/language/builtins/elements.md
+++ b/docs/reference/src/language/builtins/elements.md
@@ -78,6 +78,7 @@ Use the following `accessible-` properties to make your items interact well with
 -   **`accessible-placeholder-text`** (_in_ _string_): A placeholder text to use when the item's value is empty. Applies to text elements.
 -   **`accessible-selectable`** (_in_ _bool_): Whether the element can be selected or not.
 -   **`accessible-selected`** (_in_ _bool_): Whether the element is selected or not. This maps to the "is-selected" state of listview items.
+-   **`accessible-position-in-set`** (_in_ _int_): The index (starting from 1) of this element in a group of similar elements. Applies to list items, radio buttons and other elements.
 
 You can also use the following callbacks that are going to be called by the accessibility framework:
 

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -11,6 +11,7 @@ use super::*;
 pub struct NativeStandardListViewItem {
     pub item: Property<i_slint_core::model::StandardListViewItem>,
     pub index: Property<i32>,
+    pub total_items: Property<i32>,
     pub is_selected: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
     pub has_hover: Property<bool>,

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -621,6 +621,17 @@ impl ElementHandle {
             .and_then(|item| item.parse().ok())
     }
 
+    /// Returns the value of the element's `accessible-position-in-set` property, if present.
+    pub fn accessible_position_in_set(&self) -> Option<usize> {
+        if self.element_index != 0 {
+            return None;
+        }
+        self.item.upgrade().and_then(|item| {
+            item.accessible_string_property(AccessibleStringProperty::PositionInSet)
+                .and_then(|s| s.parse().ok())
+        })
+    }
+
     /// Returns the size of the element in logical pixels. This corresponds to the value of the `width` and
     /// `height` properties in Slint code. Returns a zero size if the element is not valid.
     pub fn size(&self) -> i_slint_core::api::LogicalSize {

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -632,6 +632,17 @@ impl ElementHandle {
         })
     }
 
+    /// Returns the value of the element's `accessible-size-of-set` property, if present.
+    pub fn accessible_size_of_set(&self) -> Option<usize> {
+        if self.element_index != 0 {
+            return None;
+        }
+        self.item.upgrade().and_then(|item| {
+            item.accessible_string_property(AccessibleStringProperty::SizeOfSet)
+                .and_then(|s| s.parse().ok())
+        })
+    }
+
     /// Returns the size of the element in logical pixels. This corresponds to the value of the `width` and
     /// `height` properties in Slint code. Returns a zero size if the element is not valid.
     pub fn size(&self) -> i_slint_core::api::LogicalSize {

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -489,6 +489,13 @@ impl NodeCollection {
             );
         }
 
+        if let Some(position_in_set) = item
+            .accessible_string_property(AccessibleStringProperty::PositionInSet)
+            .and_then(|s| s.parse::<usize>().ok())
+        {
+            builder.set_position_in_set(position_in_set);
+        }
+
         let supported = item.supported_accessibility_actions();
         if supported.contains(SupportedAccessibilityAction::Default) {
             builder.add_action(accesskit::Action::Default);

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -495,6 +495,12 @@ impl NodeCollection {
         {
             builder.set_position_in_set(position_in_set);
         }
+        if let Some(size_of_set) = item
+            .accessible_string_property(AccessibleStringProperty::SizeOfSet)
+            .and_then(|s| s.parse::<usize>().ok())
+        {
+            builder.set_size_of_set(size_of_set);
+        }
 
         let supported = item.supported_accessibility_actions();
         if supported.contains(SupportedAccessibilityAction::Default) {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -547,6 +547,7 @@ export component NativeScrollView {
 
 export component NativeStandardListViewItem {
     in property <int> index;
+    in property <int> total-items;
     in property <StandardListViewItem> item;
     in-out property <bool> is_selected;
     in property <bool> has_hover;

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -124,6 +124,7 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ),
         ("accessible-selectable", Type::Bool),
         ("accessible-selected", Type::Bool),
+        ("accessible-position-in-set", Type::Int32),
     ]
     .into_iter()
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -125,6 +125,7 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-selectable", Type::Bool),
         ("accessible-selected", Type::Bool),
         ("accessible-position-in-set", Type::Int32),
+        ("accessible-size-of-set", Type::Int32),
     ]
     .into_iter()
 }

--- a/internal/compiler/widgets/common/listview.slint
+++ b/internal/compiler/widgets/common/listview.slint
@@ -89,6 +89,7 @@ component StandardListViewBase inherits ListView {
         height: self.min-height;
         item: item;
         index: index;
+        total-items: root.model.length;
         is-selected: index == root.current-item;
         has-focus: root.has-focus && index == root.focus-item;
         has-hover: i-touch-area.has-hover;

--- a/internal/compiler/widgets/cosmic/components.slint
+++ b/internal/compiler/widgets/cosmic/components.slint
@@ -106,6 +106,7 @@ export component ListItem {
     accessible-label: root.item.text;
     accessible-selectable: true;
     accessible-selected: root.is-selected;
+    accessible-position-in-set: root.index + 1;
 
     states [
         is-selected when root.is-selected : {

--- a/internal/compiler/widgets/cosmic/components.slint
+++ b/internal/compiler/widgets/cosmic/components.slint
@@ -107,7 +107,7 @@ export component ListItem {
     accessible-label: root.item.text;
     accessible-selectable: true;
     accessible-selected: root.is-selected;
-    accessible-position-in-set: root.index + 1;
+    accessible-position-in-set: root.index;
     accessible-size-of-set: root.total-items;
 
     states [

--- a/internal/compiler/widgets/cosmic/components.slint
+++ b/internal/compiler/widgets/cosmic/components.slint
@@ -95,6 +95,7 @@ export component ListItem {
     in property <bool> has-hover;
     in property <bool> pressed;
     in property <int> index;
+    in property <int> total-items;
     in property <length> pressed-x;
     in property <length> pressed-y;
 
@@ -107,6 +108,7 @@ export component ListItem {
     accessible-selectable: true;
     accessible-selected: root.is-selected;
     accessible-position-in-set: root.index + 1;
+    accessible-size-of-set: root.total-items;
 
     states [
         is-selected when root.is-selected : {

--- a/internal/compiler/widgets/cupertino/components.slint
+++ b/internal/compiler/widgets/cupertino/components.slint
@@ -51,6 +51,7 @@ export component ListItem {
     in property <bool> has-hover;
     in property <bool> pressed;
     in property <int> index;
+    in property <int> total-items;
     in property <length> pressed-x;
     in property <length> pressed-y;
 
@@ -63,6 +64,7 @@ export component ListItem {
     accessible-selectable: true;
     accessible-selected: root.is-selected;
     accessible-position-in-set: root.index + 1;
+    accessible-size-of-set: root.total-items;
 
     states [
         has-focus when root.has-focus : {

--- a/internal/compiler/widgets/cupertino/components.slint
+++ b/internal/compiler/widgets/cupertino/components.slint
@@ -63,7 +63,7 @@ export component ListItem {
     accessible-label: root.item.text;
     accessible-selectable: true;
     accessible-selected: root.is-selected;
-    accessible-position-in-set: root.index + 1;
+    accessible-position-in-set: root.index;
     accessible-size-of-set: root.total-items;
 
     states [

--- a/internal/compiler/widgets/cupertino/components.slint
+++ b/internal/compiler/widgets/cupertino/components.slint
@@ -62,6 +62,7 @@ export component ListItem {
     accessible-label: root.item.text;
     accessible-selectable: true;
     accessible-selected: root.is-selected;
+    accessible-position-in-set: root.index + 1;
 
     states [
         has-focus when root.has-focus : {

--- a/internal/compiler/widgets/fluent/components.slint
+++ b/internal/compiler/widgets/fluent/components.slint
@@ -51,7 +51,7 @@ export component ListItem {
     accessible-label: root.item.text;
     accessible-selectable: true;
     accessible-selected: root.is-selected;
-    accessible-position-in-set: root.index + 1;
+    accessible-position-in-set: root.index;
     accessible-size-of-set: root.total-items;
 
     states [

--- a/internal/compiler/widgets/fluent/components.slint
+++ b/internal/compiler/widgets/fluent/components.slint
@@ -39,6 +39,7 @@ export component ListItem {
     in property <bool> has-hover;
     in property <bool> pressed;
     in property <int> index;
+    in property <int> total-items;
     in property <length> pressed-x;
     in property <length> pressed-y;
 
@@ -51,6 +52,7 @@ export component ListItem {
     accessible-selectable: true;
     accessible-selected: root.is-selected;
     accessible-position-in-set: root.index + 1;
+    accessible-size-of-set: root.total-items;
 
     states [
         pressed when root.pressed : {

--- a/internal/compiler/widgets/fluent/components.slint
+++ b/internal/compiler/widgets/fluent/components.slint
@@ -50,6 +50,7 @@ export component ListItem {
     accessible-label: root.item.text;
     accessible-selectable: true;
     accessible-selected: root.is-selected;
+    accessible-position-in-set: root.index + 1;
 
     states [
         pressed when root.pressed : {

--- a/internal/compiler/widgets/material/components.slint
+++ b/internal/compiler/widgets/material/components.slint
@@ -108,6 +108,7 @@ export component ListItem {
     accessible-label: root.item.text;
     accessible-selectable: true;
     accessible-selected: root.is-selected;
+    accessible-position-in-set: root.index + 1;
 
     states [
         pressed when root.pressed: {

--- a/internal/compiler/widgets/material/components.slint
+++ b/internal/compiler/widgets/material/components.slint
@@ -109,7 +109,7 @@ export component ListItem {
     accessible-label: root.item.text;
     accessible-selectable: true;
     accessible-selected: root.is-selected;
-    accessible-position-in-set: root.index + 1;
+    accessible-position-in-set: root.index;
     accessible-size-of-set: root.total-items;
 
     states [

--- a/internal/compiler/widgets/material/components.slint
+++ b/internal/compiler/widgets/material/components.slint
@@ -97,6 +97,7 @@ export component ListItem {
     in property <bool> has_focus;
     in property <bool> pressed;
     in property <int> index;
+    in property <int> total-items;
     in property <length> pressed-x;
     in property <length> pressed-y;
 
@@ -109,6 +110,7 @@ export component ListItem {
     accessible-selectable: true;
     accessible-selected: root.is-selected;
     accessible-position-in-set: root.index + 1;
+    accessible-size-of-set: root.total-items;
 
     states [
         pressed when root.pressed: {

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -22,6 +22,7 @@ pub enum AccessibleStringProperty {
     Enabled,
     Label,
     PlaceholderText,
+    PositionInSet,
     Selectable,
     Selected,
     Value,

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -25,6 +25,7 @@ pub enum AccessibleStringProperty {
     PositionInSet,
     Selectable,
     Selected,
+    SizeOfSet,
     Value,
     ValueMaximum,
     ValueMinimum,


### PR DESCRIPTION
These two properties aren't yet implemented by AccessKit's platform adapters but I have tested that they indeed work as expected on my work-in-progress branch to add listbox support to AccessKit.

They allow assistive technologies to provide hints to users about where they are inside group widgets, to quickly tell how many choices are available (radio buttons) or their location in a potentially large list (list views, equivalent to the visual indication given by the scroll bar). They are especially useful if not elements are currently present in the tree. They correspond to ARIA's `aria-posinset` and `aria-setsize` properties.

Changelog: Add `accessible-position-in-set` and `accessible-size-of-set` properties