### PR TITLE
Allow for percent in ternary

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1200,6 +1200,18 @@ impl Expression {
                     rhs: Box::new(Expression::NumberLiteral(0.01, Unit::None)),
                     op: '*',
                 },
+                (Type::Percent, Type::LogicalLength) => Expression::BinaryExpression {
+                    lhs: Box::new(self),
+                    rhs: Box::new(Expression::FunctionCall {
+                        function: Box::new(Expression::BuiltinFunctionReference(
+                            BuiltinFunction::GetWindowDefaultFontSize,
+                            Some(node.to_source_location()),
+                        )),
+                        arguments: vec![],
+                        source_location: Some(node.to_source_location()),
+                    }),
+                    op: '*',
+                },
                 (
                     ref from_ty @ Type::Struct { fields: ref left, .. },
                     Type::Struct { fields: right, .. },

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -284,8 +284,8 @@ impl Type {
             | (Type::Rem, Type::PhysicalLength)
             | (Type::LogicalLength, Type::Rem)
             | (Type::PhysicalLength, Type::Rem)
-            | (Type::Percent, Type::LogicalLength)
             | (Type::Percent, Type::Float32)
+            | (Type::Percent, Type::LogicalLength)
             | (Type::Brush, Type::Color)
             | (Type::Color, Type::Brush) => true,
             (Type::Struct { fields: a, .. }, Type::Struct { fields: b, .. }) => {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -284,6 +284,7 @@ impl Type {
             | (Type::Rem, Type::PhysicalLength)
             | (Type::LogicalLength, Type::Rem)
             | (Type::PhysicalLength, Type::Rem)
+            | (Type::Percent, Type::LogicalLength)
             | (Type::Percent, Type::Float32)
             | (Type::Brush, Type::Color)
             | (Type::Color, Type::Brush) => true,


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Fixes #6666