### PR TITLE
Window Button Styles

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -284,6 +284,7 @@ impl Type {
             | (Type::Rem, Type::PhysicalLength)
             | (Type::LogicalLength, Type::Rem)
             | (Type::PhysicalLength, Type::Rem)
+            | (Type::Percent, Type::LogicalLength)
             | (Type::Percent, Type::Float32)
             | (Type::Brush, Type::Color)
             | (Type::Color, Type::Brush) => true,

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -12,7 +12,7 @@ pub use crate::future::*;
 use crate::graphics::{Rgba8Pixel, SharedPixelBuffer};
 use crate::input::{KeyEventType, MouseEvent};
 use crate::item_tree::ItemTreeVTable;
-use crate::window::{WindowAdapter, WindowInner};
+use crate::window::{WindowAdapter, WindowInner, WindowStyle as WindowStyleInner};
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
@@ -429,6 +429,10 @@ impl raw_window_handle_06::HasDisplayHandle for WindowHandle {
 #[repr(transparent)]
 pub struct Window(pub(crate) WindowInner);
 
+/// This enum describes the different window styles that can be set on a window.
+/// The window style is a hint to the windowing system how the window should be displayed.
+pub type WindowStyle = WindowStyleInner;
+
 /// This enum describes whether a Window is allowed to be hidden when the user tries to close the window.
 /// It is the return type of the callback provided to [Window::on_close_requested].
 #[derive(Copy, Clone, Debug, PartialEq, Default)]
@@ -565,6 +569,11 @@ impl Window {
     /// Maximize or unmaximize the window.
     pub fn set_maximized(&self, maximized: bool) {
         self.0.set_maximized(maximized);
+    }
+
+    /// Sets the window style for the window.
+    pub fn set_window_style(&self, window_style: WindowStyle) {
+        self.0.set_window_style(window_style);
     }
 
     /// Returns if the window is currently minimized

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -264,7 +264,7 @@ impl Item for Rectangle {
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
     ) -> LayoutInfo {
-        LayoutInfo { stretch: 1., ..LayoutInfo::default() }
+        LayoutInfo { stretch: 1., min: 250.0, ..LayoutInfo::default() }
     }
 
     fn input_event_filter_before_children(

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -343,6 +343,11 @@ impl<'a> WindowProperties<'a> {
     pub fn is_minimized(&self) -> bool {
         self.0.minimized.get()
     }
+
+    /// The widow style
+    pub fn window_style(&self) -> WindowStyle {
+        self.0.window_style.get()
+    }
 }
 
 struct WindowPropertiesTracker {
@@ -406,6 +411,18 @@ struct WindowPinnedFields {
     text_input_focused: Property<bool>,
 }
 
+/// The style of the window.
+/// Values taken from Microsoft's [Window.WindowStyle](https://learn.microsoft.com/en-us/dotnet/api/system.windows.window.windowstyle?view=windowsdesktop-8.0).
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum WindowStyle {
+    /// Only the client area is visible - the title bar and border are not shown.
+    None,
+    /// A window with a single border. This is the default value.
+    SingleBorderWindow,
+    /// A fixed tool window.
+    ToolWindow,
+}
+
 /// Inner datastructure for the [`crate::api::Window`]
 pub struct WindowInner {
     window_adapter_weak: Weak<dyn WindowAdapter>,
@@ -430,6 +447,8 @@ pub struct WindowInner {
     fullscreen: Cell<bool>,
     maximized: Cell<bool>,
     minimized: Cell<bool>,
+
+    window_style: Cell<WindowStyle>,
 
     active_popup: RefCell<Option<PopupWindow>>,
     had_popup_on_press: Cell<bool>,
@@ -489,6 +508,7 @@ impl WindowInner {
             fullscreen: Cell::new(false),
             maximized: Cell::new(false),
             minimized: Cell::new(false),
+            window_style: Cell::new(WindowStyle::SingleBorderWindow),
             focus_item: Default::default(),
             last_ime_text: Default::default(),
             cursor_blinker: Default::default(),
@@ -1163,6 +1183,12 @@ impl WindowInner {
     /// Set the window as maximized or unmaximized
     pub fn set_maximized(&self, maximized: bool) {
         self.maximized.set(maximized);
+        self.update_window_properties()
+    }
+
+    /// Set the window style
+    pub fn set_window_style(&self, window_style: WindowStyle) {
+        self.window_style.set(window_style);
         self.update_window_properties()
     }
 


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Adds three types of window button styles naming was taken from [here](https://learn.microsoft.com/en-us/dotnet/api/system.windows.window.windowstyle?view=windowsdesktop-8.0).

There are a few winit [restrictions](https://smithay.github.io/smithay///winit/window/struct.Window.html#method.set_enabled_buttons).

- Wayland / X11 / Orbital: Not implemented.
- Web / iOS / Android: Unsupported.

## Usage

```rs
let app = AppWindow::new()?;
app.window().set_window_style(slint::WindowStyle::ToolWindow);
app.window().set_window_style(slint::WindowStyle::SingleBorderWindow); // Default
app.window().set_window_style(slint::WindowStyle::None);
```

## Output

### SingleBorderWindow
![image](https://github.com/user-attachments/assets/5a86647b-7a77-462c-a58e-be554a71ca61)

### ToolWindow
![image](https://github.com/user-attachments/assets/aff831ea-b395-4ecb-a1aa-a0658ae47ec1)

### None
**Note:** On windows the `x` is still there just not clickable (not sure about on a different OS)

![image](https://github.com/user-attachments/assets/5f024f48-f51a-4cfa-b88f-b3831faf59fb)
