### PR TITLE
Remove recurse_elem_*no_borrow variants

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -125,11 +125,9 @@ fn perform_binding_analysis(
 ) {
     let mut context = AnalysisContext::default();
     doc.visit_all_used_components(|component| {
-        crate::object_tree::recurse_elem_including_sub_components_no_borrow(
-            component,
-            &(),
-            &mut |e, _| analyze_element(e, &mut context, reverse_aliases, diag),
-        )
+        crate::object_tree::recurse_elem_including_sub_components(component, &(), &mut |e, _| {
+            analyze_element(e, &mut context, reverse_aliases, diag)
+        })
     });
 }
 
@@ -530,11 +528,9 @@ fn visit_implicit_layout_info_dependencies(
 /// ```
 fn propagate_is_set_on_aliases(doc: &Document, reverse_aliases: &mut ReverseAliases) {
     doc.visit_all_used_components(|component| {
-        crate::object_tree::recurse_elem_including_sub_components_no_borrow(
-            component,
-            &(),
-            &mut |e, _| visit_element(e, reverse_aliases),
-        );
+        crate::object_tree::recurse_elem_including_sub_components(component, &(), &mut |e, _| {
+            visit_element(e, reverse_aliases)
+        });
     });
 
     fn visit_element(e: &ElementRc, reverse_aliases: &mut ReverseAliases) {
@@ -596,7 +592,7 @@ fn propagate_is_set_on_aliases(doc: &Document, reverse_aliases: &mut ReverseAlia
 /// And change bindings are used externally
 fn mark_used_base_properties(doc: &Document) {
     doc.visit_all_used_components(|component| {
-        crate::object_tree::recurse_elem_including_sub_components_no_borrow(
+        crate::object_tree::recurse_elem_including_sub_components(
             component,
             &(),
             &mut |element, _| {

--- a/internal/compiler/passes/border_radius.rs
+++ b/internal/compiler/passes/border_radius.rs
@@ -17,7 +17,7 @@ pub const BORDER_RADIUS_PROPERTIES: [&str; 4] = [
 ];
 
 pub fn handle_border_radius(root_component: &Rc<Component>, _diag: &mut BuildDiagnostics) {
-    crate::object_tree::recurse_elem_including_sub_components_no_borrow(
+    crate::object_tree::recurse_elem_including_sub_components(
         root_component,
         &(),
         &mut |elem, _| {

--- a/internal/compiler/passes/collect_structs_and_enums.rs
+++ b/internal/compiler/passes/collect_structs_and_enums.rs
@@ -39,7 +39,7 @@ fn maybe_collect_object(ty: &Type, hash: &mut BTreeMap<SmolStr, Type>) {
 }
 
 fn collect_types_in_component(root_component: &Rc<Component>, hash: &mut BTreeMap<SmolStr, Type>) {
-    recurse_elem_including_sub_components_no_borrow(root_component, &(), &mut |elem, _| {
+    recurse_elem_including_sub_components(root_component, &(), &mut |elem, _| {
         for x in elem.borrow().property_declarations.values() {
             maybe_collect_object(&x.property_type, hash);
         }

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -89,7 +89,7 @@ impl<'a> LocalFocusForwards<'a> {
     fn collect(component: &Rc<Component>, diag: &'a mut BuildDiagnostics) -> Self {
         let mut forwards = HashMap::new();
 
-        recurse_elem_no_borrow(&component.root_element, &(), &mut |elem, _| {
+        recurse_elem(&component.root_element, &(), &mut |elem, _| {
             let Some(forward_focus_binding) =
                 elem.borrow_mut().bindings.remove("forward-focus").map(RefCell::into_inner)
             else {

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -22,28 +22,23 @@ struct ComponentScope(Vec<ElementRc>);
 pub fn resolve_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
     for component in doc.inner_components.iter() {
         let scope = ComponentScope(vec![]);
-        crate::object_tree::recurse_elem_no_borrow(
-            &component.root_element,
-            &scope,
-            &mut |elem, scope| {
-                let mut new_scope = scope.clone();
-                new_scope.0.push(elem.clone());
+        crate::object_tree::recurse_elem(&component.root_element, &scope, &mut |elem, scope| {
+            let mut new_scope = scope.clone();
+            new_scope.0.push(elem.clone());
 
-                let mut need_resolving = vec![];
-                for (prop, decl) in elem.borrow().property_declarations.iter() {
-                    if matches!(decl.property_type, Type::InferredProperty | Type::InferredCallback)
-                    {
-                        need_resolving.push(prop.clone());
-                    }
+            let mut need_resolving = vec![];
+            for (prop, decl) in elem.borrow().property_declarations.iter() {
+                if matches!(decl.property_type, Type::InferredProperty | Type::InferredCallback) {
+                    need_resolving.push(prop.clone());
                 }
-                // make it deterministic
-                need_resolving.sort();
-                for n in need_resolving {
-                    resolve_alias(elem, &n, &new_scope, &doc.local_registry, diag);
-                }
-                new_scope
-            },
-        );
+            }
+            // make it deterministic
+            need_resolving.sort();
+            for n in need_resolving {
+                resolve_alias(elem, &n, &new_scope, &doc.local_registry, diag);
+            }
+            new_scope
+        });
     }
 }
 

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -26,7 +26,7 @@ pub fn inline(doc: &Document, inline_selection: InlineSelection, diag: &mut Buil
         inline_selection: InlineSelection,
         diag: &mut BuildDiagnostics,
     ) {
-        recurse_elem_no_borrow(&component.root_element, &(), &mut |elem, _| {
+        recurse_elem(&component.root_element, &(), &mut |elem, _| {
             let base = elem.borrow().base_type.clone();
             if let ElementType::Component(c) = base {
                 // First, make sure that the component itself is properly inlined
@@ -293,7 +293,7 @@ fn inline_element(
     }
     // If some element were moved into PopupWindow, we need to report error if they are used outside of the popup window.
     if !moved_into_popup.is_empty() {
-        recurse_elem_no_borrow(&root_component.root_element.clone(), &(), &mut |e, _| {
+        recurse_elem(&root_component.root_element.clone(), &(), &mut |e, _| {
             if !moved_into_popup.contains(&element_key(e.clone())) {
                 visit_all_named_references_in_element(e, |nr| {
                     if moved_into_popup.contains(&element_key(nr.element())) {

--- a/internal/compiler/passes/lower_absolute_coordinates.rs
+++ b/internal/compiler/passes/lower_absolute_coordinates.rs
@@ -10,14 +10,13 @@ use std::rc::Rc;
 use crate::expression_tree::{BuiltinFunction, Expression};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
-    recurse_elem_including_sub_components_no_borrow, visit_all_named_references_in_element,
-    Component,
+    recurse_elem_including_sub_components, visit_all_named_references_in_element, Component,
 };
 
 pub fn lower_absolute_coordinates(component: &Rc<Component>) {
     let mut to_materialize = std::collections::HashSet::new();
 
-    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+    recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
         visit_all_named_references_in_element(elem, |nr| {
             if nr.name() == "absolute-position" {
                 to_materialize.insert(nr.clone());

--- a/internal/compiler/passes/lower_component_container.rs
+++ b/internal/compiler/passes/lower_component_container.rs
@@ -14,7 +14,7 @@ pub fn lower_component_container(
 ) {
     let empty_type = type_register.empty_type();
 
-    recurse_elem_including_sub_components_no_borrow(component, &None, &mut |elem, _| {
+    recurse_elem_including_sub_components(component, &None, &mut |elem, _| {
         if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "ComponentContainer") {
             diagnose_component_container(elem, diag);
             process_component_container(elem, &empty_type);

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -18,22 +18,21 @@ pub fn lower_popups(
 ) {
     let window_type = type_register.lookup_builtin_element("Window").unwrap();
 
-    recurse_elem_including_sub_components_no_borrow(
-        component,
-        &None,
-        &mut |elem, parent_element: &Option<ElementRc>| {
-            let is_popup = match &elem.borrow().base_type {
-                ElementType::Builtin(base_type) => base_type.name == "PopupWindow",
-                ElementType::Component(base_type) => base_type.inherits_popup_window.get(),
-                _ => false,
-            };
+    recurse_elem_including_sub_components(component, &None, &mut |elem,
+                                                                  parent_element: &Option<
+        ElementRc,
+    >| {
+        let is_popup = match &elem.borrow().base_type {
+            ElementType::Builtin(base_type) => base_type.name == "PopupWindow",
+            ElementType::Component(base_type) => base_type.inherits_popup_window.get(),
+            _ => false,
+        };
 
-            if is_popup {
-                lower_popup_window(elem, parent_element.as_ref(), &window_type, diag);
-            }
-            Some(elem.clone())
-        },
-    )
+        if is_popup {
+            lower_popup_window(elem, parent_element.as_ref(), &window_type, diag);
+        }
+        Some(elem.clone())
+    })
 }
 
 fn lower_popup_window(

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -35,7 +35,7 @@ pub(crate) fn lower_property_to_element(
         );
     }
 
-    object_tree::recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+    object_tree::recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
         if elem.borrow().base_type.to_smolstr() == element_name {
             return;
         }

--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -118,7 +118,7 @@ pub fn lower_shadow_properties(
         );
     }
 
-    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+    recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
         // When encountering a repeater where the repeated element has a `drop-shadow` property, we create a new
         // dedicated shadow element and make the previously repeated element a child of that. This ensures rendering
         // underneath while maintaining the hierarchy for the repeater.

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -37,7 +37,7 @@ pub async fn lower_tabwidget(
     let empty_type = type_loader.global_type_registry.borrow().empty_type();
 
     doc.visit_all_used_components(|component| {
-        recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+        recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
             if matches!(&elem.borrow().builtin_type(), Some(b) if b.name == "TabWidget") {
                 process_tabwidget(
                     elem,

--- a/internal/compiler/passes/lower_timers.rs
+++ b/internal/compiler/passes/lower_timers.rs
@@ -10,17 +10,16 @@ use crate::object_tree::*;
 use std::rc::Rc;
 
 pub fn lower_timers(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
-    recurse_elem_including_sub_components_no_borrow(
-        component,
-        &None,
-        &mut |elem, parent_element: &Option<ElementRc>| {
-            let is_timer = matches!(&elem.borrow().base_type, ElementType::Builtin(base_type) if base_type.name == "Timer");
-            if is_timer {
-                lower_timer(elem, parent_element.as_ref(), diag);
-            }
-            Some(elem.clone())
-        },
-    )
+    recurse_elem_including_sub_components(component, &None, &mut |elem,
+                                                                  parent_element: &Option<
+        ElementRc,
+    >| {
+        let is_timer = matches!(&elem.borrow().base_type, ElementType::Builtin(base_type) if base_type.name == "Timer");
+        if is_timer {
+            lower_timer(elem, parent_element.as_ref(), diag);
+        }
+        Some(elem.clone())
+    })
 }
 
 fn lower_timer(

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -30,7 +30,7 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
         }
     });
 
-    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+    recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
         for prop in elem.borrow().bindings.keys() {
             let nr = NamedReference::new(elem, prop);
             if let std::collections::hash_map::Entry::Vacant(e) = to_materialize.entry(nr) {

--- a/internal/compiler/passes/purity_check.rs
+++ b/internal/compiler/passes/purity_check.rs
@@ -9,7 +9,7 @@ use crate::expression_tree::{Expression, NamedReference};
 /// Check that pure expression only call pure functions
 pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnostics) {
     for component in &doc.inner_components {
-        crate::object_tree::recurse_elem_including_sub_components_no_borrow(
+        crate::object_tree::recurse_elem_including_sub_components(
             component,
             &(),
             &mut |elem, &()| {

--- a/internal/compiler/passes/remove_unused_properties.rs
+++ b/internal/compiler/passes/remove_unused_properties.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 
 pub fn remove_unused_properties(doc: &Document) {
     fn recurse_remove_unused_properties(component: &Component) {
-        crate::object_tree::recurse_elem_including_sub_components_no_borrow(
+        crate::object_tree::recurse_elem_including_sub_components(
             component,
             &(),
             &mut |elem, _| {


### PR DESCRIPTION
All users compile fine with the no-`_no_borrow` variants and those are faster since we don't have to copy the children vector to do the iteration there. This removes ~47k allocations in my benchmark case.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
