### PR TITLE
esp-idf: Add a semaphore in the SlintPlatformConfiguration

### DIFF
--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -54,6 +54,11 @@ struct SlintPlatformConfiguration
     /// Swap the 2 bytes of RGB 565 pixels before sending to the display. Use this
     /// if your CPU is little endian but the display expects big-endian.
     bool color_swap_16 = false;
+
+    /// If not null, the Slint platform will take this semaphore in its event loop when doing
+    /// anything. All operation on the screen and on the Slint component will be done with the
+    /// semaphore acquired. The semaphore stays acquired even when waiting for the screen update
+    SemaphoreHandle_t lock = nullptr;
 };
 
 /**

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -152,9 +152,6 @@ void EspPlatform::run_event_loop()
     bool touch_down = false;
 
     while (true) {
-        if (user_lock) {
-            xSemaphoreTake(user_lock, portMAX_DELAY);
-        }
         slint::platform::update_timers_and_animations();
 
         std::optional<slint::platform::Platform::Task> event;
@@ -233,7 +230,9 @@ void EspPlatform::run_event_loop()
                             }
                         }
                     }
-
+                    if (user_lock) {
+                        xSemaphoreTake(user_lock, portMAX_DELAY);
+                    }
                     if (buffer2) {
                         auto s = region.bounding_box_size();
                         if (s.width > 0 && s.height > 0) {
@@ -289,6 +288,9 @@ void EspPlatform::run_event_loop()
             }
 
             if (m_window->window().has_active_animations()) {
+                if (user_lock) {
+                    xSemaphoreGive(user_lock);
+                }
                 continue;
             }
         }


### PR DESCRIPTION
The semaphore is going to be locked the whole time when Slint is doing stuff.
