### PR TITLE
Reduce SmolStr <-> &str conversions and copies

### DIFF
--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -9,6 +9,7 @@ There is one sub module for every language
 
 // cSpell: ignore deque subcomponent
 
+use smol_str::SmolStr;
 use std::collections::{BTreeSet, HashSet, VecDeque};
 use std::rc::{Rc, Weak};
 
@@ -391,20 +392,20 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
 /// constant properties, these are already initialized
 pub fn handle_property_bindings_init(
     component: &Rc<Component>,
-    mut handle_property: impl FnMut(&ElementRc, &str, &BindingExpression),
+    mut handle_property: impl FnMut(&ElementRc, &SmolStr, &BindingExpression),
 ) {
     fn handle_property_inner(
         component: &Weak<Component>,
         elem: &ElementRc,
-        prop_name: &str,
+        prop_name: &SmolStr,
         binding_expression: &BindingExpression,
-        handle_property: &mut impl FnMut(&ElementRc, &str, &BindingExpression),
+        handle_property: &mut impl FnMut(&ElementRc, &SmolStr, &BindingExpression),
         processed: &mut HashSet<NamedReference>,
     ) {
         if elem.borrow().is_component_placeholder {
             return; // This element does not really exist!
         }
-        let nr = NamedReference::new(elem, prop_name);
+        let nr = NamedReference::new(elem, prop_name.clone());
         if processed.contains(&nr) {
             return;
         }
@@ -450,7 +451,10 @@ pub fn handle_property_bindings_init(
 
 /// Call the given function for each constant property in the Component so one can set
 /// `set_constant` on it.
-pub fn for_each_const_properties(component: &Rc<Component>, mut f: impl FnMut(&ElementRc, &str)) {
+pub fn for_each_const_properties(
+    component: &Rc<Component>,
+    mut f: impl FnMut(&ElementRc, &SmolStr),
+) {
     crate::object_tree::recurse_elem(&component.root_element, &(), &mut |elem: &ElementRc, ()| {
         if elem.borrow().repeated.is_some() || elem.borrow().is_component_placeholder {
             return;
@@ -499,7 +503,7 @@ pub fn for_each_const_properties(component: &Rc<Component>, mut f: impl FnMut(&E
             }
         }
         for c in all_prop {
-            if NamedReference::new(elem, &c).is_constant() {
+            if NamedReference::new(elem, c.clone()).is_constant() {
                 f(elem, &c);
             }
         }

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -83,9 +83,10 @@ pub fn lower_expression(
         tree_Expression::BuiltinMacroReference(_, _) => panic!(),
         tree_Expression::ElementReference(e) => {
             // We map an element reference to a reference to the property "" inside that native item
-            llr_Expression::PropertyReference(
-                ctx.map_property_reference(&NamedReference::new(&e.upgrade().unwrap(), "")),
-            )
+            llr_Expression::PropertyReference(ctx.map_property_reference(&NamedReference::new(
+                &e.upgrade().unwrap(),
+                SmolStr::default(),
+            )))
         }
         tree_Expression::RepeaterIndexReference { element } => {
             repeater_special_property(element, ctx.component, 1)

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -133,7 +133,7 @@ impl LoweredSubComponentMapping {
                     return property_reference_within_sub_component(
                         state.map_property_reference(&NamedReference::new(
                             &base.root_element,
-                            from.name(),
+                            from.name().clone(),
                         )),
                         *sub_component_index,
                     );
@@ -144,7 +144,7 @@ impl LoweredSubComponentMapping {
                 return PropertyReference::InNativeItem {
                     sub_component_path: vec![],
                     item_index: *item_index,
-                    prop_name: from.name().into(),
+                    prop_name: from.name().to_string(),
                 };
             }
             LoweredElement::Repeated { .. } => unreachable!(),
@@ -273,7 +273,7 @@ fn lower_sub_component(
             if let Type::Function(function) = &x.property_type {
                 let function_index = sub_component.functions.len();
                 mapping.property_mapping.insert(
-                    NamedReference::new(element, p),
+                    NamedReference::new(element, p.clone()),
                     PropertyReference::Function { sub_component_path: vec![], function_index },
                 );
                 // TODO: Function could wrap the Rc<langtype::Function>
@@ -289,7 +289,7 @@ fn lower_sub_component(
             }
             let property_index = sub_component.properties.len();
             mapping.property_mapping.insert(
-                NamedReference::new(element, p),
+                NamedReference::new(element, p.clone()),
                 PropertyReference::Local { sub_component_path: vec![], property_index },
             );
             sub_component.properties.push(Property {
@@ -358,7 +358,8 @@ fn lower_sub_component(
         }
 
         for (prop, expr) in &elem.change_callbacks {
-            change_callbacks.push((NamedReference::new(element, prop), expr.borrow().clone()));
+            change_callbacks
+                .push((NamedReference::new(element, prop.clone()), expr.borrow().clone()));
         }
 
         if compiler_config.debug_info {
@@ -372,7 +373,7 @@ fn lower_sub_component(
     });
     let ctx = ExpressionContext { mapping: &mapping, state, parent: parent_context, component };
     crate::generator::handle_property_bindings_init(component, |e, p, binding| {
-        let nr = NamedReference::new(e, p);
+        let nr = NamedReference::new(e, p.clone());
         let prop = ctx.map_property_reference(&nr);
 
         if let Type::Function { .. } = nr.ty() {
@@ -468,7 +469,7 @@ fn lower_sub_component(
     sub_component.timers = component.timers.borrow().iter().map(|t| lower_timer(t, &ctx)).collect();
 
     crate::generator::for_each_const_properties(component, |elem, n| {
-        let x = ctx.map_property_reference(&NamedReference::new(elem, n));
+        let x = ctx.map_property_reference(&NamedReference::new(elem, n.clone()));
         // ensure that all const properties have analysis
         sub_component.prop_analysis.entry(x.clone()).or_insert_with(|| PropAnalysis {
             property_init: None,
@@ -731,7 +732,7 @@ fn lower_global(
             continue;
         }
         let property_index = properties.len();
-        let nr = NamedReference::new(&global.root_element, p);
+        let nr = NamedReference::new(&global.root_element, p.clone());
 
         if let Type::Function(function) = &x.property_type {
             let function_index = functions.len();
@@ -793,7 +794,7 @@ fn lower_global(
         let expression =
             super::lower_expression::lower_expression(&binding.borrow().expression, &ctx);
 
-        let nr = NamedReference::new(&global.root_element, prop);
+        let nr = NamedReference::new(&global.root_element, prop.clone());
         let property_index = match mapping.property_mapping[&nr] {
             PropertyReference::Local { property_index, .. } => property_index,
             PropertyReference::Function { ref sub_component_path, function_index } => {
@@ -815,7 +816,7 @@ fn lower_global(
 
     let mut change_callbacks = BTreeMap::new();
     for (prop, expr) in &global.root_element.borrow().change_callbacks {
-        let nr = NamedReference::new(&global.root_element, prop);
+        let nr = NamedReference::new(&global.root_element, prop.clone());
         let property_index = match mapping.property_mapping[&nr] {
             PropertyReference::Local { property_index, .. } => property_index,
             _ => unreachable!(),
@@ -832,7 +833,7 @@ fn lower_global(
         for (p, x) in &builtin.properties {
             let property_index = properties.len();
             properties.push(Property { name: p.clone(), ty: x.ty.clone(), ..Property::default() });
-            let nr = NamedReference::new(&global.root_element, p);
+            let nr = NamedReference::new(&global.root_element, p.clone());
             state
                 .global_properties
                 .insert(nr, PropertyReference::Global { global_index, property_index });
@@ -937,8 +938,10 @@ fn public_properties(
         .iter()
         .filter(|(_, c)| c.expose_in_public_api)
         .map(|(p, c)| {
-            let property_reference = mapping
-                .map_property_reference(&NamedReference::new(&component.root_element, p), state);
+            let property_reference = mapping.map_property_reference(
+                &NamedReference::new(&component.root_element, p.clone()),
+                state,
+            );
             PublicProperty {
                 name: p.clone(),
                 ty: c.property_type.clone(),

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -596,10 +596,10 @@ pub struct GeometryProps {
 impl GeometryProps {
     pub fn new(element: &ElementRc) -> Self {
         Self {
-            x: NamedReference::new(element, "x"),
-            y: NamedReference::new(element, "y"),
-            width: NamedReference::new(element, "width"),
-            height: NamedReference::new(element, "height"),
+            x: NamedReference::new(element, SmolStr::new_static("x")),
+            y: NamedReference::new(element, SmolStr::new_static("y")),
+            width: NamedReference::new(element, SmolStr::new_static("width")),
+            height: NamedReference::new(element, SmolStr::new_static("height")),
         }
     }
 }
@@ -1575,11 +1575,14 @@ impl Element {
     ) -> ElementRc {
         let is_listview = if parent.borrow().base_type.to_string() == "ListView" {
             Some(ListViewInfo {
-                viewport_y: NamedReference::new(parent, "viewport-y"),
-                viewport_height: NamedReference::new(parent, "viewport-height"),
-                viewport_width: NamedReference::new(parent, "viewport-width"),
-                listview_height: NamedReference::new(parent, "visible-height"),
-                listview_width: NamedReference::new(parent, "visible-width"),
+                viewport_y: NamedReference::new(parent, SmolStr::new_static("viewport-y")),
+                viewport_height: NamedReference::new(
+                    parent,
+                    SmolStr::new_static("viewport-height"),
+                ),
+                viewport_width: NamedReference::new(parent, SmolStr::new_static("viewport-width")),
+                listview_height: NamedReference::new(parent, SmolStr::new_static("visible-height")),
+                listview_width: NamedReference::new(parent, SmolStr::new_static("visible-width")),
             })
         } else {
             None
@@ -1999,7 +2002,7 @@ fn lookup_property_from_qualified_name_for_state(
                 );
             }
             Some((
-                NamedReference::new(r, &lookup_result.resolved_name),
+                NamedReference::new(r, lookup_result.resolved_name.to_smolstr()),
                 lookup_result.property_type,
             ))
         }
@@ -2021,7 +2024,7 @@ fn lookup_property_from_qualified_name_for_state(
                     );
                 }
                 Some((
-                    NamedReference::new(&element, &lookup_result.resolved_name),
+                    NamedReference::new(&element, lookup_result.resolved_name.to_smolstr()),
                     lookup_result.property_type,
                 ))
             } else {
@@ -2251,7 +2254,8 @@ pub fn visit_named_references_in_expression(
         Expression::RepeaterModelReference { element }
         | Expression::RepeaterIndexReference { element } => {
             // FIXME: this is questionable
-            let mut nc = NamedReference::new(&element.upgrade().unwrap(), "$model");
+            let mut nc =
+                NamedReference::new(&element.upgrade().unwrap(), SmolStr::new_static("$model"));
             vis(&mut nc);
             debug_assert!(nc.element().borrow().repeated.is_some());
             *element = Rc::downgrade(&nc.element());
@@ -2709,22 +2713,22 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
         // generate the layout_info_prop that forward to the implicit layout for that item
         let li_v = crate::layout::create_new_prop(
             &new_root,
-            "layoutinfo-v",
+            SmolStr::new_static("layoutinfo-v"),
             crate::typeregister::layout_info_type(),
         );
         let li_h = crate::layout::create_new_prop(
             &new_root,
-            "layoutinfo-h",
+            SmolStr::new_static("layoutinfo-h"),
             crate::typeregister::layout_info_type(),
         );
         let expr_h = crate::layout::implicit_layout_info_call(old_root, Orientation::Horizontal);
         let expr_v = crate::layout::implicit_layout_info_call(old_root, Orientation::Vertical);
         let expr_v =
             BindingExpression::new_with_span(expr_v, old_root.borrow().to_source_location());
-        li_v.element().borrow_mut().bindings.insert(li_v.name().into(), expr_v.into());
+        li_v.element().borrow_mut().bindings.insert(li_v.name().clone(), expr_v.into());
         let expr_h =
             BindingExpression::new_with_span(expr_h, old_root.borrow().to_source_location());
-        li_h.element().borrow_mut().bindings.insert(li_h.name().into(), expr_h.into());
+        li_h.element().borrow_mut().bindings.insert(li_h.name().clone(), expr_h.into());
         Some((li_h.clone(), li_v.clone()))
     });
     new_root.borrow_mut().layout_info_prop = layout_info_prop;
@@ -2754,7 +2758,10 @@ pub fn adjust_geometry_for_injected_parent(injected_parent: &ElementRc, old_elem
     let mut injected_parent_mut = injected_parent.borrow_mut();
     injected_parent_mut.bindings.insert(
         "z".into(),
-        RefCell::new(BindingExpression::new_two_way(NamedReference::new(old_elem, "z"))),
+        RefCell::new(BindingExpression::new_two_way(NamedReference::new(
+            old_elem,
+            SmolStr::new_static("z"),
+        ))),
     );
     // (should be removed by const propagation in the llr)
     injected_parent_mut.property_declarations.insert(
@@ -2765,6 +2772,8 @@ pub fn adjust_geometry_for_injected_parent(injected_parent: &ElementRc, old_elem
     injected_parent_mut.default_fill_parent = std::mem::take(&mut old_elem_mut.default_fill_parent);
     injected_parent_mut.geometry_props.clone_from(&old_elem_mut.geometry_props);
     drop(injected_parent_mut);
-    old_elem_mut.geometry_props.as_mut().unwrap().x = NamedReference::new(injected_parent, "dummy");
-    old_elem_mut.geometry_props.as_mut().unwrap().y = NamedReference::new(injected_parent, "dummy");
+    old_elem_mut.geometry_props.as_mut().unwrap().x =
+        NamedReference::new(injected_parent, SmolStr::new_static("dummy"));
+    old_elem_mut.geometry_props.as_mut().unwrap().y =
+        NamedReference::new(injected_parent, SmolStr::new_static("dummy"));
 }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -53,6 +53,7 @@ mod z_order;
 
 use crate::expression_tree::Expression;
 use crate::namedreference::NamedReference;
+use smol_str::SmolStr;
 
 pub async fn run_passes(
     doc: &mut crate::object_tree::Document,
@@ -133,7 +134,7 @@ pub async fn run_passes(
             "opacity",
             core::iter::empty(),
             None,
-            "Opacity",
+            &SmolStr::new_static("Opacity"),
             &global_type_registry.borrow(),
             diag,
         );
@@ -142,7 +143,7 @@ pub async fn run_passes(
             "cache-rendering-hint",
             core::iter::empty(),
             None,
-            "Layer",
+            &SmolStr::new_static("Layer"),
             &global_type_registry.borrow(),
             diag,
         );
@@ -158,8 +159,8 @@ pub async fn run_passes(
                 lhs: Expression::PropertyReference(NamedReference::new(
                     e,
                     match prop {
-                        "rotation-origin-x" => "width",
-                        "rotation-origin-y" => "height",
+                        "rotation-origin-x" => SmolStr::new_static("width"),
+                        "rotation-origin-y" => SmolStr::new_static("height"),
                         "rotation-angle" => return Expression::Invalid,
                         _ => unreachable!(),
                     },
@@ -168,7 +169,7 @@ pub async fn run_passes(
                 op: '/',
                 rhs: Expression::NumberLiteral(2., Default::default()).into(),
             }),
-            "Rotate",
+            &SmolStr::new_static("Rotate"),
             &global_type_registry.borrow(),
             diag,
         );

--- a/internal/compiler/passes/apply_default_properties_from_style.rs
+++ b/internal/compiler/passes/apply_default_properties_from_style.rs
@@ -9,6 +9,7 @@ use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Expression, NamedReference};
 use crate::langtype::Type;
 use crate::object_tree::Component;
+use smol_str::SmolStr;
 use std::rc::Rc;
 
 /// Ideally we would be able to write this in builtin.slint, but the StyleMetrics is not available there
@@ -28,13 +29,13 @@ pub fn apply_default_properties_from_style(
                     elem.set_binding_if_not_set("text-cursor-width".into(), || {
                         Expression::PropertyReference(NamedReference::new(
                             &style_metrics.root_element,
-                            "text-cursor-width",
+                            SmolStr::new_static("text-cursor-width"),
                         ))
                     });
                     elem.set_binding_if_not_set("color".into(), || {
                         Expression::PropertyReference(NamedReference::new(
                             &palette.root_element,
-                            "foreground",
+                            SmolStr::new_static("foreground"),
                         ))
                         .into()
                     });
@@ -42,7 +43,7 @@ pub fn apply_default_properties_from_style(
                         Expression::Cast {
                             from: Expression::PropertyReference(NamedReference::new(
                                 &palette.root_element,
-                                "selection-background",
+                                SmolStr::new_static("selection-background"),
                             ))
                             .into(),
                             to: Type::Color,
@@ -52,7 +53,7 @@ pub fn apply_default_properties_from_style(
                         Expression::Cast {
                             from: Expression::PropertyReference(NamedReference::new(
                                 &palette.root_element,
-                                "selection-foreground",
+                                SmolStr::new_static("selection-foreground"),
                             ))
                             .into(),
                             to: Type::Color,
@@ -63,7 +64,7 @@ pub fn apply_default_properties_from_style(
                     elem.set_binding_if_not_set("color".into(), || Expression::Cast {
                         from: Expression::PropertyReference(NamedReference::new(
                             &palette.root_element,
-                            "foreground",
+                            SmolStr::new_static("foreground"),
                         ))
                         .into(),
                         to: Type::Brush,
@@ -73,7 +74,7 @@ pub fn apply_default_properties_from_style(
                     elem.set_binding_if_not_set("background".into(), || Expression::Cast {
                         from: Expression::PropertyReference(NamedReference::new(
                             &palette.root_element,
-                            "background",
+                            SmolStr::new_static("background"),
                         ))
                         .into(),
                         to: Type::Brush,
@@ -92,7 +93,7 @@ pub fn apply_default_properties_from_style(
                                 Expression::Cast {
                                     from: Expression::PropertyReference(NamedReference::new(
                                         &style_metrics.root_element,
-                                        property_name,
+                                        SmolStr::new_static(property_name),
                                     ))
                                     .into(),
                                     to: property_type,

--- a/internal/compiler/passes/border_radius.rs
+++ b/internal/compiler/passes/border_radius.rs
@@ -28,7 +28,7 @@ pub fn handle_border_radius(root_component: &Rc<Component>, _diag: &mut BuildDia
                     .iter()
                     .any(|property_name| elem.borrow().is_binding_set(property_name, true))
             {
-                let border_radius = NamedReference::new(elem, "border-radius");
+                let border_radius = NamedReference::new(elem, SmolStr::new_static("border-radius"));
                 for property_name in BORDER_RADIUS_PROPERTIES.iter() {
                     elem.borrow_mut().set_binding_if_not_set(SmolStr::new(property_name), || {
                         Expression::PropertyReference(border_radius.clone())

--- a/internal/compiler/passes/clip.rs
+++ b/internal/compiler/passes/clip.rs
@@ -75,7 +75,11 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
             (
                 SmolStr::new_static(prop),
                 RefCell::new(
-                    Expression::PropertyReference(NamedReference::new(parent_elem, prop)).into(),
+                    Expression::PropertyReference(NamedReference::new(
+                        parent_elem,
+                        SmolStr::new_static(prop),
+                    ))
+                    .into(),
                 ),
             )
         })
@@ -96,7 +100,7 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
                 RefCell::new(
                     Expression::PropertyReference(NamedReference::new(
                         parent_elem,
-                        "border-radius",
+                        SmolStr::new_static("border-radius"),
                     ))
                     .into(),
                 ),
@@ -105,17 +109,28 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
     }
     clip.borrow_mut().bindings.insert(
         SmolStr::new_static("clip"),
-        BindingExpression::new_two_way(NamedReference::new(parent_elem, "clip")).into(),
+        BindingExpression::new_two_way(NamedReference::new(
+            parent_elem,
+            SmolStr::new_static("clip"),
+        ))
+        .into(),
     );
 }
 
-fn copy_optional_binding(parent_elem: &ElementRc, optional_binding: &str, clip: &ElementRc) {
+fn copy_optional_binding(
+    parent_elem: &ElementRc,
+    optional_binding: &'static str,
+    clip: &ElementRc,
+) {
     if parent_elem.borrow().bindings.contains_key(optional_binding) {
         clip.borrow_mut().bindings.insert(
             optional_binding.into(),
             RefCell::new(
-                Expression::PropertyReference(NamedReference::new(parent_elem, optional_binding))
-                    .into(),
+                Expression::PropertyReference(NamedReference::new(
+                    parent_elem,
+                    SmolStr::new_static(optional_binding),
+                ))
+                .into(),
             ),
         );
     }

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -19,7 +19,7 @@ use crate::expression_tree::{
 use crate::langtype::{BuiltinElement, DefaultSizeBinding, Type};
 use crate::layout::{implicit_layout_info_call, LayoutConstraints, Orientation};
 use crate::object_tree::{Component, ElementRc};
-use smol_str::format_smolstr;
+use smol_str::{format_smolstr, SmolStr};
 use std::collections::HashMap;
 
 pub fn default_geometry(root_component: &Rc<Component>, diag: &mut BuildDiagnostics) {
@@ -211,12 +211,12 @@ fn gen_layout_info_prop(elem: &ElementRc, diag: &mut BuildDiagnostics) {
 
     let li_v = crate::layout::create_new_prop(
         elem,
-        "layoutinfo-v",
+        SmolStr::new_static("layoutinfo-v"),
         crate::typeregister::layout_info_type(),
     );
     let li_h = crate::layout::create_new_prop(
         elem,
-        "layoutinfo-h",
+        SmolStr::new_static("layoutinfo-h"),
         crate::typeregister::layout_info_type(),
     );
     elem.borrow_mut().layout_info_prop = Some((li_h.clone(), li_v.clone()));
@@ -249,9 +249,9 @@ fn gen_layout_info_prop(elem: &ElementRc, diag: &mut BuildDiagnostics) {
     }
 
     let expr_v = BindingExpression::new_with_span(expr_v, elem.borrow().to_source_location());
-    li_v.element().borrow_mut().bindings.insert(li_v.name().into(), expr_v.into());
+    li_v.element().borrow_mut().bindings.insert(li_v.name().clone(), expr_v.into());
     let expr_h = BindingExpression::new_with_span(expr_h, elem.borrow().to_source_location());
-    li_h.element().borrow_mut().bindings.insert(li_h.name().into(), expr_h.into());
+    li_h.element().borrow_mut().bindings.insert(li_h.name().clone(), expr_h.into());
 }
 
 fn merge_explicit_constraints(
@@ -313,12 +313,12 @@ fn explicit_layout_info(e: &ElementRc, orientation: Orientation) -> Expression {
         Orientation::Vertical => ("height", "vertical"),
     };
     for (k, v) in [
-        ("min", format!("min-{size}")),
-        ("max", format!("max-{size}")),
-        ("preferred", format!("preferred-{size}")),
-        ("stretch", format!("{orient}-stretch")),
+        ("min", format_smolstr!("min-{size}")),
+        ("max", format_smolstr!("max-{size}")),
+        ("preferred", format_smolstr!("preferred-{size}")),
+        ("stretch", format_smolstr!("{orient}-stretch")),
     ] {
-        values.insert(k.into(), Expression::PropertyReference(NamedReference::new(e, &v)));
+        values.insert(k.into(), Expression::PropertyReference(NamedReference::new(e, v)));
     }
     values.insert("min_percent".into(), Expression::NumberLiteral(0., Unit::None));
     values.insert("max_percent".into(), Expression::NumberLiteral(100., Unit::None));
@@ -331,7 +331,7 @@ fn explicit_layout_info(e: &ElementRc, orientation: Orientation) -> Expression {
 fn fix_percent_size(
     elem: &ElementRc,
     parent: &Option<ElementRc>,
-    property: &str,
+    property: &'static str,
     diag: &mut BuildDiagnostics,
 ) -> bool {
     let elem = elem.borrow();
@@ -343,7 +343,7 @@ fn fix_percent_size(
     if binding.borrow().ty() != Type::Percent {
         let Some(parent) = parent.as_ref() else { return false };
         // Pattern match to check it was already parent.<property>
-        return matches!(&binding.borrow().expression, Expression::PropertyReference(nr) if nr.name() == property && Rc::ptr_eq(&nr.element(), parent));
+        return matches!(&binding.borrow().expression, Expression::PropertyReference(nr) if *nr.name() == property && Rc::ptr_eq(&nr.element(), parent));
     }
     let mut b = binding.borrow_mut();
     if let Some(mut parent) = parent.clone() {
@@ -352,7 +352,7 @@ fn fix_percent_size(
             parent = crate::object_tree::find_parent_element(&parent).unwrap_or(parent)
         }
         debug_assert_eq!(
-            parent.borrow().lookup_property(property).property_type,
+            parent.borrow().lookup_property(&property).property_type,
             Type::LogicalLength
         );
         let fill =
@@ -363,7 +363,10 @@ fn fix_percent_size(
                 &b.span,
                 diag,
             )),
-            rhs: Box::new(Expression::PropertyReference(NamedReference::new(&parent, property))),
+            rhs: Box::new(Expression::PropertyReference(NamedReference::new(
+                &parent,
+                SmolStr::new_static(property),
+            ))),
             op: '*',
         };
         fill
@@ -376,7 +379,7 @@ fn fix_percent_size(
 /// Generate a size property that covers the parent.
 /// Return true if it was changed
 fn make_default_100(prop: &NamedReference, parent_prop: &NamedReference) -> bool {
-    prop.element().borrow_mut().set_binding_if_not_set(prop.name().into(), || {
+    prop.element().borrow_mut().set_binding_if_not_set(prop.name().clone(), || {
         Expression::PropertyReference(parent_prop.clone())
     })
 }
@@ -385,9 +388,12 @@ fn make_default_implicit(elem: &ElementRc, property: &str) {
     let e = crate::builtin_macros::min_max_expression(
         Expression::PropertyReference(NamedReference::new(
             elem,
-            &format!("preferred-{}", property),
+            format_smolstr!("preferred-{}", property),
         )),
-        Expression::PropertyReference(NamedReference::new(elem, &format!("min-{}", property))),
+        Expression::PropertyReference(NamedReference::new(
+            elem,
+            format_smolstr!("min-{}", property),
+        )),
         MinMaxOp::Max,
     );
     elem.borrow_mut().set_binding_if_not_set(property.into(), || e);
@@ -402,24 +408,27 @@ fn make_default_implicit(elem: &ElementRc, property: &str) {
 //
 fn make_default_aspect_ratio_preserving_binding(
     elem: &ElementRc,
-    missing_size_property: &str,
-    given_size_property: &str,
+    missing_size_property: &'static str,
+    given_size_property: &'static str,
 ) {
-    if elem.borrow().is_binding_set(missing_size_property, false) {
+    if elem.borrow().is_binding_set(&missing_size_property, false) {
         return;
     }
 
     debug_assert_eq!(elem.borrow().lookup_property("source").property_type, Type::Image);
 
+    let missing_size_property = SmolStr::new_static(missing_size_property);
+    let given_size_property = SmolStr::new_static(given_size_property);
+
     let ratio = if elem.borrow().is_binding_set("source-clip-height", false) {
         Expression::BinaryExpression {
             lhs: Box::new(Expression::PropertyReference(NamedReference::new(
                 elem,
-                &format!("source-clip-{missing_size_property}"),
+                format_smolstr!("source-clip-{missing_size_property}"),
             ))),
             rhs: Box::new(Expression::PropertyReference(NamedReference::new(
                 elem,
-                &format!("source-clip-{given_size_property}"),
+                format_smolstr!("source-clip-{given_size_property}"),
             ))),
             op: '/',
         }
@@ -438,7 +447,8 @@ fn make_default_aspect_ratio_preserving_binding(
                         None,
                     )),
                     arguments: vec![Expression::PropertyReference(NamedReference::new(
-                        elem, "source",
+                        elem,
+                        SmolStr::new_static("source"),
                     ))],
                     source_location: None,
                 }),
@@ -446,11 +456,11 @@ fn make_default_aspect_ratio_preserving_binding(
             Expression::BinaryExpression {
                 lhs: Box::new(Expression::StructFieldAccess {
                     base: implicit_size_var.clone(),
-                    name: missing_size_property.into(),
+                    name: missing_size_property.clone(),
                 }),
                 rhs: Box::new(Expression::StructFieldAccess {
                     base: implicit_size_var,
-                    name: given_size_property.into(),
+                    name: given_size_property.clone(),
                 }),
                 op: '/',
             },
@@ -462,21 +472,28 @@ fn make_default_aspect_ratio_preserving_binding(
         op: '*',
     };
 
-    elem.borrow_mut().bindings.insert(missing_size_property.into(), RefCell::new(binding.into()));
+    elem.borrow_mut().bindings.insert(missing_size_property, RefCell::new(binding.into()));
 }
 
-fn maybe_center_in_parent(elem: &ElementRc, parent: &ElementRc, pos_prop: &str, size_prop: &str) {
-    if elem.borrow().is_binding_set(pos_prop, false) {
+fn maybe_center_in_parent(
+    elem: &ElementRc,
+    parent: &ElementRc,
+    pos_prop: &'static str,
+    size_prop: &'static str,
+) {
+    if elem.borrow().is_binding_set(&pos_prop, false) {
         return;
     }
 
+    let size_prop = SmolStr::new_static(size_prop);
     let diff = Expression::BinaryExpression {
-        lhs: Expression::PropertyReference(NamedReference::new(parent, size_prop)).into(),
+        lhs: Expression::PropertyReference(NamedReference::new(parent, size_prop.clone())).into(),
         op: '-',
         rhs: Expression::PropertyReference(NamedReference::new(elem, size_prop)).into(),
     };
 
-    elem.borrow_mut().set_binding_if_not_set(pos_prop.into(), || Expression::BinaryExpression {
+    let pos_prop = SmolStr::new_static(pos_prop);
+    elem.borrow_mut().set_binding_if_not_set(pos_prop, || Expression::BinaryExpression {
         lhs: diff.into(),
         op: '/',
         rhs: Expression::NumberLiteral(2., Unit::None).into(),
@@ -490,9 +507,9 @@ fn adjust_image_clip_rect(elem: &ElementRc, builtin: &Rc<BuiltinElement>) {
         elem.borrow().bindings.contains_key(p)
             || elem.borrow().property_analysis.borrow().get(p).map_or(false, |a| a.is_used())
     }) {
-        let source = NamedReference::new(elem, "source");
-        let x = NamedReference::new(elem, "source-clip-x");
-        let y = NamedReference::new(elem, "source-clip-y");
+        let source = NamedReference::new(elem, SmolStr::new_static("source"));
+        let x = NamedReference::new(elem, SmolStr::new_static("source-clip-x"));
+        let y = NamedReference::new(elem, SmolStr::new_static("source-clip-y"));
         let make_expr = |dim: &str, prop: NamedReference| Expression::BinaryExpression {
             lhs: Box::new(Expression::StructFieldAccess {
                 base: Box::new(Expression::FunctionCall {

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -69,10 +69,13 @@ pub fn ensure_window(
     win_elem_mut.children.push(new_root.clone());
     drop(win_elem_mut);
 
-    let make_two_way = |name: &str| {
+    let make_two_way = |name: &'static str| {
         new_root.borrow_mut().bindings.insert(
             name.into(),
-            RefCell::new(BindingExpression::new_two_way(NamedReference::new(&win_elem, name))),
+            RefCell::new(BindingExpression::new_two_way(NamedReference::new(
+                &win_elem,
+                SmolStr::new_static(name),
+            ))),
         );
     };
     make_two_way("width");
@@ -92,7 +95,7 @@ pub fn ensure_window(
             continue;
         }
 
-        must_update.insert(NamedReference::new(&win_elem, &prop));
+        must_update.insert(NamedReference::new(&win_elem, prop.clone()));
 
         if let Some(b) = win_elem.borrow_mut().bindings.remove(&prop) {
             new_root.borrow_mut().bindings.insert(prop.clone(), b);
@@ -104,7 +107,7 @@ pub fn ensure_window(
 
     crate::object_tree::visit_all_named_references(component, &mut |nr| {
         if must_update.contains(nr) {
-            *nr = NamedReference::new(&new_root, nr.name());
+            *nr = NamedReference::new(&new_root, nr.name().clone());
         }
     });
 
@@ -137,7 +140,7 @@ pub fn ensure_window(
         Expression::Cast {
             from: Expression::PropertyReference(NamedReference::new(
                 &style_metrics.root_element,
-                "window-background",
+                SmolStr::new_static("window-background"),
             ))
             .into(),
             to: Type::Brush,

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -13,6 +13,7 @@ use crate::langtype::{ElementType, Function, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::*;
 use by_address::ByAddress;
+use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
 use strum::IntoEnumIterator;
 
@@ -269,7 +270,7 @@ fn call_set_focus_function(
     if declares_focus_function {
         Some(Expression::FunctionCall {
             function: Box::new(Expression::FunctionReference(
-                NamedReference::new(element, function_name),
+                NamedReference::new(element, SmolStr::new_static(function_name)),
                 None,
             )),
             arguments: vec![],

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -511,7 +511,7 @@ fn duplicate_property_animation(
 
 fn fixup_reference(nr: &mut NamedReference, mapping: &Mapping) {
     if let Some(e) = mapping.get(&element_key(nr.element())) {
-        *nr = NamedReference::new(e, nr.name());
+        *nr = NamedReference::new(e, nr.name().clone());
     }
 }
 

--- a/internal/compiler/passes/lower_absolute_coordinates.rs
+++ b/internal/compiler/passes/lower_absolute_coordinates.rs
@@ -4,6 +4,7 @@
 //! This pass creates bindings to "absolute-y" and "absolute-y" properties
 //! that can be used to compute the window-absolute coordinates of elements.
 
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -64,7 +65,8 @@ pub fn lower_absolute_coordinates(component: &Rc<Component>) {
                                 }
                                 .into(),
                                 rhs: Expression::PropertyReference(NamedReference::new(
-                                    &elem, coord,
+                                    &elem,
+                                    SmolStr::new_static(coord),
                                 ))
                                 .into(),
                                 op: '+',
@@ -75,6 +77,6 @@ pub fn lower_absolute_coordinates(component: &Rc<Component>) {
             },
         ]);
 
-        elem.borrow_mut().bindings.insert(nr.name().into(), RefCell::new(binding.into()));
+        elem.borrow_mut().bindings.insert(nr.name().clone(), RefCell::new(binding.into()));
     }
 }

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -8,6 +8,7 @@ use crate::expression_tree::{Expression, NamedReference};
 use crate::langtype::EnumerationValue;
 use crate::object_tree::{Component, ElementRc};
 
+use smol_str::SmolStr;
 use std::rc::Rc;
 
 pub fn lower_accessibility_properties(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
@@ -45,7 +46,7 @@ pub fn lower_accessibility_properties(component: &Rc<Component>, diag: &mut Buil
             {
                 if accessible_role_set {
                     if elem.borrow().is_binding_set(prop_name, false) {
-                        let nr = NamedReference::new(elem, prop_name);
+                        let nr = NamedReference::new(elem, SmolStr::new_static(prop_name));
                         elem.borrow_mut().accessibility_props.0.insert(prop_name.into(), nr);
                     }
                 } else if let Some(b) = elem.borrow().bindings.get(prop_name) {
@@ -69,7 +70,7 @@ fn apply_builtin(e: &ElementRc) {
                 enumeration: enum_ty,
             })
         });
-        let text_prop = NamedReference::new(e, "text");
+        let text_prop = NamedReference::new(e, SmolStr::new_static("text"));
         e.borrow_mut().set_binding_if_not_set("accessible-label".into(), || {
             Expression::PropertyReference(text_prop)
         });

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -8,7 +8,7 @@ use crate::expression_tree::{Expression, NamedReference};
 use crate::langtype::{ElementType, EnumerationValue, Type};
 use crate::object_tree::*;
 use crate::typeregister::TypeRegister;
-use smol_str::format_smolstr;
+use smol_str::{format_smolstr, SmolStr};
 use std::rc::{Rc, Weak};
 
 pub fn lower_popups(
@@ -186,8 +186,8 @@ fn lower_popup_window(
 
     // Take a reference to the x/y coordinates, to be read when calling show_popup(), and
     // converted to absolute coordinates in the run-time library.
-    let coord_x = NamedReference::new(&popup_comp.root_element, "x");
-    let coord_y = NamedReference::new(&popup_comp.root_element, "y");
+    let coord_x = NamedReference::new(&popup_comp.root_element, SmolStr::new_static("x"));
+    let coord_y = NamedReference::new(&popup_comp.root_element, SmolStr::new_static("y"));
 
     // Meanwhile, set the geometry x/y to zero, because we'll be shown as a top-level and
     // children should be rendered starting with a (0, 0) offset.
@@ -196,8 +196,8 @@ fn lower_popup_window(
         let name = format_smolstr!("popup-{}-dummy", popup_mut.id);
         popup_mut.property_declarations.insert(name.clone(), Type::LogicalLength.into());
         drop(popup_mut);
-        let dummy1 = NamedReference::new(&popup_comp.root_element, &name);
-        let dummy2 = NamedReference::new(&popup_comp.root_element, &name);
+        let dummy1 = NamedReference::new(&popup_comp.root_element, name.clone());
+        let dummy2 = NamedReference::new(&popup_comp.root_element, name.clone());
         let mut popup_mut = popup_comp.root_element.borrow_mut();
         popup_mut.geometry_props.as_mut().unwrap().x = dummy1;
         popup_mut.geometry_props.as_mut().unwrap().y = dummy2;

--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -46,15 +46,13 @@ fn create_box_shadow_element(
     };
 
     // FIXME: remove the border-radius manual mapping.
-    if sibling_element.borrow().bindings.contains_key("border-radius") {
+    let border_radius = SmolStr::new_static("border-radius");
+    if sibling_element.borrow().bindings.contains_key(&border_radius) {
         element.bindings.insert(
-            "border-radius".into(),
+            border_radius.clone(),
             RefCell::new(
-                Expression::PropertyReference(NamedReference::new(
-                    sibling_element,
-                    "border-radius",
-                ))
-                .into(),
+                Expression::PropertyReference(NamedReference::new(sibling_element, border_radius))
+                    .into(),
             ),
         );
     }

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -37,8 +37,10 @@ fn lower_state_in_element(
     }
     let has_transitions = !root_element.borrow().transitions.is_empty();
     let state_property_name = compute_state_property_name(root_element);
-    let state_property =
-        Expression::PropertyReference(NamedReference::new(root_element, &state_property_name));
+    let state_property = Expression::PropertyReference(NamedReference::new(
+        root_element,
+        state_property_name.clone(),
+    ));
     let state_property_ref = if has_transitions {
         Expression::StructFieldAccess {
             base: Box::new(state_property.clone()),
@@ -89,7 +91,7 @@ fn lower_state_in_element(
                 true_expr: Box::new(expr),
                 false_expr: Box::new(property_expr),
             };
-            match e.borrow_mut().bindings.entry(ne.name().into()) {
+            match e.borrow_mut().bindings.entry(ne.name().clone()) {
                 std::collections::btree_map::Entry::Occupied(mut e) => {
                     e.get_mut().get_mut().expression = new_expr
                 }
@@ -222,7 +224,7 @@ fn expression_for_property(element: &ElementRc, name: &str) -> ExpressionForProp
                         | Expression::FunctionReference(nr, _) => {
                             let e = nr.element();
                             if Rc::ptr_eq(&e, &elem) {
-                                *nr = NamedReference::new(element, nr.name());
+                                *nr = NamedReference::new(element, nr.name().clone());
                             } else if Weak::ptr_eq(
                                 &e.borrow().enclosing_component,
                                 &elem.borrow().enclosing_component,

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -92,7 +92,11 @@ fn process_tabwidget(
         set_geometry_prop(elem, child, "width", diag);
         set_geometry_prop(elem, child, "height", diag);
         let condition = Expression::BinaryExpression {
-            lhs: Expression::PropertyReference(NamedReference::new(elem, "current-index")).into(),
+            lhs: Expression::PropertyReference(NamedReference::new(
+                elem,
+                SmolStr::new_static("current-index"),
+            ))
+            .into(),
             rhs: Expression::NumberLiteral(index as _, Unit::None).into(),
             op: '=',
         };
@@ -115,15 +119,27 @@ fn process_tabwidget(
         };
         tab.bindings.insert(
             SmolStr::new_static("title"),
-            BindingExpression::new_two_way(NamedReference::new(child, "title")).into(),
+            BindingExpression::new_two_way(NamedReference::new(
+                child,
+                SmolStr::new_static("title"),
+            ))
+            .into(),
         );
         tab.bindings.insert(
             SmolStr::new_static("current"),
-            BindingExpression::new_two_way(NamedReference::new(elem, "current-index")).into(),
+            BindingExpression::new_two_way(NamedReference::new(
+                elem,
+                SmolStr::new_static("current-index"),
+            ))
+            .into(),
         );
         tab.bindings.insert(
             SmolStr::new_static("current-focused"),
-            BindingExpression::new_two_way(NamedReference::new(elem, "current-focused")).into(),
+            BindingExpression::new_two_way(NamedReference::new(
+                elem,
+                SmolStr::new_static("current-focused"),
+            ))
+            .into(),
         );
         tab.bindings.insert(
             SmolStr::new_static("tab-index"),
@@ -154,31 +170,51 @@ fn process_tabwidget(
     );
     tabbar.borrow_mut().bindings.insert(
         SmolStr::new_static("current"),
-        BindingExpression::new_two_way(NamedReference::new(elem, "current-index")).into(),
+        BindingExpression::new_two_way(NamedReference::new(
+            elem,
+            SmolStr::new_static("current-index"),
+        ))
+        .into(),
     );
     elem.borrow_mut().bindings.insert(
         SmolStr::new_static("current-focused"),
-        BindingExpression::new_two_way(NamedReference::new(&tabbar, "current-focused")).into(),
+        BindingExpression::new_two_way(NamedReference::new(
+            &tabbar,
+            SmolStr::new_static("current-focused"),
+        ))
+        .into(),
     );
     elem.borrow_mut().bindings.insert(
         SmolStr::new_static("tabbar-preferred-width"),
-        BindingExpression::new_two_way(NamedReference::new(&tabbar, "preferred-width")).into(),
+        BindingExpression::new_two_way(NamedReference::new(
+            &tabbar,
+            SmolStr::new_static("preferred-width"),
+        ))
+        .into(),
     );
     elem.borrow_mut().bindings.insert(
         SmolStr::new_static("tabbar-preferred-height"),
-        BindingExpression::new_two_way(NamedReference::new(&tabbar, "preferred-height")).into(),
+        BindingExpression::new_two_way(NamedReference::new(
+            &tabbar,
+            SmolStr::new_static("preferred-height"),
+        ))
+        .into(),
     );
 
     if let Some(expr) = children
         .iter()
-        .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-width")))
+        .map(|x| {
+            Expression::PropertyReference(NamedReference::new(x, SmolStr::new_static("min-width")))
+        })
         .reduce(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, MinMaxOp::Max))
     {
         elem.borrow_mut().bindings.insert("content-min-width".into(), RefCell::new(expr.into()));
     };
     if let Some(expr) = children
         .iter()
-        .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-height")))
+        .map(|x| {
+            Expression::PropertyReference(NamedReference::new(x, SmolStr::new_static("min-height")))
+        })
         .reduce(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, MinMaxOp::Max))
     {
         elem.borrow_mut().bindings.insert("content-min-height".into(), RefCell::new(expr.into()));
@@ -198,7 +234,7 @@ fn set_geometry_prop(
         RefCell::new(
             Expression::PropertyReference(NamedReference::new(
                 tab_widget,
-                &format!("content-{}", prop),
+                format_smolstr!("content-{}", prop),
             ))
             .into(),
         ),
@@ -217,7 +253,7 @@ fn set_tabbar_geometry_prop(tab_widget: &ElementRc, tabbar: &ElementRc, prop: &s
         RefCell::new(
             Expression::PropertyReference(NamedReference::new(
                 tab_widget,
-                &format!("tabbar-{}", prop),
+                format_smolstr!("tabbar-{}", prop),
             ))
             .into(),
         ),

--- a/internal/compiler/passes/lower_timers.rs
+++ b/internal/compiler/passes/lower_timers.rs
@@ -7,6 +7,7 @@ use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BuiltinFunction, Expression, NamedReference};
 use crate::langtype::ElementType;
 use crate::object_tree::*;
+use smol_str::SmolStr;
 use std::rc::Rc;
 
 pub fn lower_timers(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
@@ -61,9 +62,9 @@ fn lower_timer(
     parent_component.optimized_elements.borrow_mut().push(timer_element.clone());
 
     parent_component.timers.borrow_mut().push(Timer {
-        interval: NamedReference::new(timer_element, "interval"),
-        running: NamedReference::new(timer_element, "running"),
-        triggered: NamedReference::new(timer_element, "triggered"),
+        interval: NamedReference::new(timer_element, SmolStr::new_static("interval")),
+        running: NamedReference::new(timer_element, SmolStr::new_static("running")),
+        triggered: NamedReference::new(timer_element, SmolStr::new_static("triggered")),
     });
     let update_timers = Expression::FunctionCall {
         function: Expression::BuiltinFunctionReference(BuiltinFunction::UpdateTimers, None).into(),

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -32,7 +32,7 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
 
     recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
         for prop in elem.borrow().bindings.keys() {
-            let nr = NamedReference::new(elem, prop);
+            let nr = NamedReference::new(elem, prop.clone());
             if let std::collections::hash_map::Entry::Vacant(e) = to_materialize.entry(nr) {
                 let elem = elem.borrow();
                 if let Some(ty) =
@@ -48,7 +48,7 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
         let elem = nr.element();
 
         elem.borrow_mut().property_declarations.insert(
-            nr.name().into(),
+            nr.name().clone(),
             PropertyDeclaration { property_type: ty, ..PropertyDeclaration::default() },
         );
 
@@ -61,7 +61,7 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
         if let Some(init_expr) = initialize(&elem, nr.name()) {
             let mut elem_mut = elem.borrow_mut();
             let span = elem_mut.to_source_location();
-            match elem_mut.bindings.entry(nr.name().into()) {
+            match elem_mut.bindings.entry(nr.name().clone()) {
                 std::collections::btree_map::Entry::Vacant(e) => {
                     let mut binding = BindingExpression::new_with_span(init_expr, span);
                     binding.priority = i32::MAX;

--- a/internal/compiler/passes/move_declarations.rs
+++ b/internal/compiler/passes/move_declarations.rs
@@ -55,7 +55,7 @@ fn do_move_declarations(component: &Rc<Component>) {
         for (k, e) in bindings {
             let will_be_moved = elem.borrow().property_declarations.contains_key(&k);
             if will_be_moved {
-                new_root_bindings.insert(map_name(elem, k.as_str()), e);
+                new_root_bindings.insert(map_name(elem, &k), e);
             } else {
                 new_bindings.insert(k, e);
             }
@@ -67,7 +67,7 @@ fn do_move_declarations(component: &Rc<Component>) {
         for (prop, a) in property_analysis {
             let will_be_moved = elem.borrow().property_declarations.contains_key(&prop);
             if will_be_moved {
-                new_root_property_analysis.insert(map_name(elem, prop.as_str()), a);
+                new_root_property_analysis.insert(map_name(elem, &prop), a);
             } else {
                 new_property_analysis.insert(prop, a);
             }
@@ -80,7 +80,7 @@ fn do_move_declarations(component: &Rc<Component>) {
         for (k, e) in change_callbacks {
             let will_be_moved = elem.borrow().property_declarations.contains_key(&k);
             if will_be_moved {
-                new_root_change_callbacks.insert(map_name(elem, k.as_str()), e);
+                new_root_change_callbacks.insert(map_name(elem, &k), e);
             } else {
                 new_change_callbacks.insert(k, e);
             }
@@ -135,11 +135,11 @@ fn fixup_reference(nr: &mut NamedReference) {
     if !Rc::ptr_eq(&e, &component.root_element)
         && e.borrow().property_declarations.contains_key(nr.name())
     {
-        *nr = NamedReference::new(&component.root_element, map_name(&e, nr.name()).as_str());
+        *nr = NamedReference::new(&component.root_element, map_name(&e, nr.name()).into());
     }
 }
 
-fn map_name(e: &ElementRc, s: &str) -> SmolStr {
+fn map_name(e: &ElementRc, s: &SmolStr) -> SmolStr {
     format_smolstr!("{}-{}", e.borrow().id, s)
 }
 

--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -73,7 +73,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
                     diag.push_error("Property cannot alias to itself".into(), &*binding.borrow());
                     continue 'bindings;
                 }
-                property_sets.add_link(NamedReference::new(e, name), nr.clone());
+                property_sets.add_link(NamedReference::new(e, name.clone()), nr.clone());
             }
         }
     };
@@ -136,7 +136,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
             &elem.borrow().enclosing_component,
             &to_elem.borrow().enclosing_component,
         );
-        match to_elem.borrow_mut().bindings.entry(to.name().into()) {
+        match to_elem.borrow_mut().bindings.entry(to.name().clone()) {
             Entry::Occupied(mut e) => {
                 let b = e.get_mut().get_mut();
                 remove_from_binding_expression(b, &to);
@@ -159,7 +159,10 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
             let mut elem = elem.borrow_mut();
             if let Some(old_change_callback) = elem.change_callbacks.remove(remove.name()) {
                 drop(elem);
-                to_elem.borrow_mut().change_callbacks.insert(to.name().into(), old_change_callback);
+                to_elem
+                    .borrow_mut()
+                    .change_callbacks
+                    .insert(to.name().clone(), old_change_callback);
             }
         }
 
@@ -186,7 +189,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
                             .borrow()
                             .property_analysis
                             .borrow_mut()
-                            .entry(to.name().into())
+                            .entry(to.name().clone())
                             .or_default()
                             .merge(&analysis);
                     };
@@ -194,7 +197,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
             } else {
                 // This is not a declaration, we must re-create the binding
                 elem.bindings.insert(
-                    remove.name().into(),
+                    remove.name().clone(),
                     BindingExpression::new_two_way(to.clone()).into(),
                 );
                 drop(elem);

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -8,6 +8,7 @@ Make sure that the Repeated expression are just components without any children
 use crate::expression_tree::{Expression, NamedReference};
 use crate::langtype::ElementType;
 use crate::object_tree::*;
+use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -71,7 +72,7 @@ fn create_repeater_components(component: &Rc<Component>) {
             if !comp.root_element.borrow().is_binding_set("height", false) {
                 let preferred = Expression::PropertyReference(NamedReference::new(
                     &comp.root_element,
-                    "preferred-height",
+                    SmolStr::new_static("preferred-height"),
                 ));
                 comp.root_element
                     .borrow_mut()
@@ -85,7 +86,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 );
             }
 
-            NamedReference::new(&comp.root_element, "y").mark_as_set();
+            NamedReference::new(&comp.root_element, SmolStr::new_static("y")).mark_as_set();
         }
 
         let weak = Rc::downgrade(&comp);
@@ -111,7 +112,7 @@ fn adjust_references(comp: &Rc<Component>) {
         let e = nr.element();
         if e.borrow().repeated.is_some() {
             if let ElementType::Component(c) = e.borrow().base_type.clone() {
-                *nr = NamedReference::new(&c.root_element, nr.name())
+                *nr = NamedReference::new(&c.root_element, nr.name().clone())
             };
         }
     });

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -65,7 +65,7 @@ pub fn handle_visible(
                         let clip_elem = create_visibility_element(&root_elem, &native_clip);
                         object_tree::inject_element_as_repeated_element(&child, clip_elem.clone());
                         // The width and the height must be null
-                        let d = NamedReference::new(&clip_elem, "dummy");
+                        let d = NamedReference::new(&clip_elem, SmolStr::new_static("dummy"));
                         clip_elem.borrow_mut().geometry_props.as_mut().unwrap().width = d.clone();
                         clip_elem.borrow_mut().geometry_props.as_mut().unwrap().height = d;
                     }
@@ -91,7 +91,8 @@ fn create_visibility_element(child: &ElementRc, native_clip: &Rc<NativeClass>) -
             RefCell::new(
                 Expression::UnaryOp {
                     sub: Box::new(Expression::PropertyReference(NamedReference::new(
-                        child, "visible",
+                        child,
+                        SmolStr::new_static("visible"),
                     ))),
                     op: '!',
                 }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -10,6 +10,7 @@ use i_slint_core::model::{Model, ModelRc};
 #[cfg(feature = "internal")]
 use i_slint_core::window::WindowInner;
 use i_slint_core::{PathData, SharedVector};
+use smol_str::{SmolStr, StrExt};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::future::Future;
@@ -437,6 +438,14 @@ impl TryFrom<Value> for i_slint_core::lengths::LogicalLength {
 pub(crate) fn normalize_identifier(ident: &str) -> Cow<'_, str> {
     if ident.contains('_') {
         ident.replace('_', "-").into()
+    } else {
+        ident.into()
+    }
+}
+
+pub(crate) fn normalize_identifier_smolstr(ident: &str) -> SmolStr {
+    if ident.contains('_') {
+        ident.replace_smolstr("_", "-").into()
     } else {
         ident.into()
     }
@@ -1282,7 +1291,7 @@ impl ComponentInstance {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
         comp.description()
-            .invoke(comp.borrow(), &normalize_identifier(name), args)
+            .invoke(comp.borrow(), &normalize_identifier_smolstr(name), args)
             .map_err(|()| InvokeError::NoSuchCallable)
     }
 
@@ -1407,7 +1416,7 @@ impl ComponentInstance {
             .description()
             .get_global(comp.borrow(), &normalize_identifier(global))
             .map_err(|()| InvokeError::NoSuchCallable)?; // FIXME: should there be a NoSuchGlobal error?
-        let callable_name = normalize_identifier(callable_name);
+        let callable_name = normalize_identifier_smolstr(callable_name);
         if matches!(
             comp.description()
                 .original

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1239,7 +1239,7 @@ fn eval_assignment(lhs: &Expression, op: char, rhs: Value, local_context: &mut E
                         &enclosing_component.description.items[element.borrow().id.as_str()];
                     let item =
                         unsafe { item_info.item_from_item_tree(enclosing_component.as_ptr()) };
-                    let p = &item_info.rtti.properties[nr.name()];
+                    let p = &item_info.rtti.properties[nr.name().as_str()];
                     p.set(item, eval(p.get(item)), None).unwrap();
                 }
                 ComponentInstance::GlobalComponent(global) => {
@@ -1470,7 +1470,7 @@ fn check_value_type(value: &Value, ty: &Type) -> bool {
 pub(crate) fn invoke_callback(
     component_instance: ComponentInstance,
     element: &ElementRc,
-    callback_name: &str,
+    callback_name: &SmolStr,
     args: &[Value],
 ) -> Option<Value> {
     generativity::make_guard!(guard);
@@ -1506,7 +1506,11 @@ pub(crate) fn invoke_callback(
             };
             let item_info = &description.items[element.id.as_str()];
             let item = unsafe { item_info.item_from_item_tree(enclosing_component.as_ptr()) };
-            item_info.rtti.callbacks.get(callback_name).map(|callback| callback.call(item, args))
+            item_info
+                .rtti
+                .callbacks
+                .get(callback_name.as_str())
+                .map(|callback| callback.call(item, args))
         }
         ComponentInstance::GlobalComponent(global) => {
             Some(global.as_ref().invoke_callback(callback_name, args).unwrap())

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_invoke(
     let comp = inst.unerase(guard);
     match comp.description().invoke(
         comp.borrow(),
-        &normalize_identifier(std::str::from_utf8(&name).unwrap()),
+        &normalize_identifier_smolstr(std::str::from_utf8(&name).unwrap()),
         args.as_slice(),
     ) {
         Ok(val) => Box::into_raw(Box::new(val)),
@@ -467,7 +467,8 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_invoke_global(
                     args.as_slice().iter().cloned().collect(),
                 )
             } else {
-                g.as_ref().invoke_callback(&normalize_identifier(callable_name), args.as_slice())
+                g.as_ref()
+                    .invoke_callback(&normalize_identifier_smolstr(callable_name), args.as_slice())
             }
         }) {
         Ok(val) => Box::into_raw(Box::new(val)),

--- a/tools/updater/experiments/lookup_changes.rs
+++ b/tools/updater/experiments/lookup_changes.rs
@@ -70,7 +70,7 @@ pub(crate) fn fold_node(
             let prop_name = i_slint_compiler::parser::normalize_identifier(
                 node.child_token(SyntaxKind::Identifier).unwrap().text(),
             );
-            let nr = NamedReference::new(el, &prop_name);
+            let nr = NamedReference::new(el, prop_name);
             if let Some(new_name) = state.lookup_change.property_mappings.get(&nr).cloned() {
                 state.lookup_change.replace_self = Some(
                     state
@@ -96,7 +96,7 @@ pub(crate) fn fold_node(
             let prop_name = i_slint_compiler::parser::normalize_identifier(
                 &node.child_node(SyntaxKind::DeclaredIdentifier).unwrap().text().to_string(),
             );
-            let nr = NamedReference::new(el, &prop_name);
+            let nr = NamedReference::new(el, prop_name);
             if state.lookup_change.property_mappings.contains_key(&nr) {
                 return Ok(true);
             }
@@ -166,7 +166,7 @@ fn fully_qualify_property_access(
                     None => return Ok(false),
                 };
                 let prop_name = i_slint_compiler::parser::normalize_identifier(second.text());
-                let nr = NamedReference::new(&el.upgrade().unwrap(), &prop_name);
+                let nr = NamedReference::new(&el.upgrade().unwrap(), prop_name);
                 if let Some(new_name) = state.lookup_change.property_mappings.get(&nr) {
                     write!(file, "root.{new_name} ")?;
                     Ok(true)
@@ -284,7 +284,7 @@ pub(crate) fn collect_movable_properties(state: &mut crate::State) {
                 c.borrow()
                     .property_declarations
                     .iter()
-                    .map(|(name, _)| NamedReference::new(c, &name)),
+                    .map(|(name, _)| NamedReference::new(c, name.clone())),
             );
             collect_movable_properties_recursive(vec, &c);
         }


### PR DESCRIPTION
SmolStr has an Arc internally for large strings. This allows cheap copies of large strings, but we lose that ability when we convert the SmolStr to a &str and then reconstruct a SmolStr from that slice.

I was hoping for some larger gains here, considering the impact of this code change, but it only removes ~50k allocations, while the impact on the runtime is not noticeable at all.

Still, I believe this is the right thing to do.

Before:
```
        allocations:            2338981

  Time (mean ± σ):     988.3 ms ±  17.9 ms    [User: 690.2 ms, System: 206.4 ms]
  Range (min … max):   956.4 ms … 1016.3 ms    10 runs
```

After:
```
        allocations:            2287723

  Time (mean ± σ):     989.8 ms ±  23.2 ms    [User: 699.2 ms, System: 197.6 ms]
  Range (min … max):   945.3 ms … 1021.4 ms    10 runs
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
