### PR TITLE
Support for multiple PopupWindow

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -160,10 +160,10 @@ cpp! {{
             void *parent_of_popup_to_close = nullptr;
             if (auto p = dynamic_cast<const SlintWidget*>(parent())) {
                 void *parent_window = p->rust_window;
-                bool close_on_click = rust!(Slint_mouseReleaseEventPopup [parent_window: &QtWindow as "void*"] -> bool as "bool" {
+                bool inside = rect().contains(event->pos());
+                bool close_on_click = rust!(Slint_mouseReleaseEventPopup [parent_window: &QtWindow as "void*", inside: bool as "bool"] -> bool as "bool" {
                     let close_policy = parent_window.close_policy();
-
-                    close_policy == PopupClosePolicy::CloseOnClick || close_policy == PopupClosePolicy::CloseOnClickOutside
+                    close_policy == PopupClosePolicy::CloseOnClick || (close_policy == PopupClosePolicy::CloseOnClickOutside && !inside)
                 });
                 if (close_on_click) {
                     parent_of_popup_to_close = parent_window;

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -159,6 +159,9 @@ cpp! {{
 
             void *parent_of_popup_to_close = nullptr;
             if (auto p = dynamic_cast<const SlintWidget*>(parent())) {
+                while (auto pp = dynamic_cast<const SlintWidget*>(p->parent())) {
+                    p = pp;
+                }
                 void *parent_window = p->rust_window;
                 bool inside = rect().contains(event->pos());
                 bool close_on_click = rust!(Slint_mouseReleaseEventPopup [parent_window: &QtWindow as "void*", inside: bool as "bool"] -> bool as "bool" {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -17,8 +17,7 @@ use crate::input::{
 };
 use crate::item_tree::ItemRc;
 use crate::item_tree::{ItemTreeRc, ItemTreeRef, ItemTreeVTable, ItemTreeWeak};
-use crate::items::PopupClosePolicy;
-use crate::items::{ColorScheme, InputType, ItemRef, MouseCursor};
+use crate::items::{ColorScheme, InputType, ItemRef, MouseCursor, PopupClosePolicy};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, SizeLengths};
 use crate::properties::{Property, PropertyTracker};
 use crate::renderer::Renderer;
@@ -26,6 +25,8 @@ use crate::{Callback, Coord, SharedString};
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 use alloc::rc::{Rc, Weak};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
 use core::pin::Pin;
 use euclid::num::Zero;
@@ -431,7 +432,8 @@ pub struct WindowInner {
     maximized: Cell<bool>,
     minimized: Cell<bool>,
 
-    active_popup: RefCell<Option<PopupWindow>>,
+    /// Stack of currently active popups
+    active_popups: RefCell<Vec<PopupWindow>>,
     had_popup_on_press: Cell<bool>,
     close_requested: Callback<(), CloseRequestResponse>,
     click_state: ClickState,
@@ -492,7 +494,7 @@ impl WindowInner {
             focus_item: Default::default(),
             last_ime_text: Default::default(),
             cursor_blinker: Default::default(),
-            active_popup: Default::default(),
+            active_popups: Default::default(),
             had_popup_on_press: Default::default(),
             close_requested: Default::default(),
             click_state: ClickState::default(),
@@ -575,7 +577,7 @@ impl WindowInner {
         }
 
         if pressed_event {
-            self.had_popup_on_press.set(self.active_popup.borrow().is_some());
+            self.had_popup_on_press.set(!self.active_popups.borrow().is_empty());
         }
 
         let close_policy = self.close_policy();
@@ -588,7 +590,7 @@ impl WindowInner {
                 location: PopupWindowLocation::ChildWindow(coordinates),
                 component,
                 ..
-            }) = self.active_popup.borrow().as_ref()
+            }) = self.active_popups.borrow().last()
             {
                 let geom = ItemTreeRc::borrow_pin(component).as_ref().item_geometry(0);
 
@@ -800,7 +802,7 @@ impl WindowInner {
 
     fn move_focus(&self, start_item: ItemRc, forward: impl Fn(ItemRc) -> ItemRc) -> Option<ItemRc> {
         let mut current_item = start_item;
-        let mut visited = alloc::vec::Vec::new();
+        let mut visited = Vec::new();
 
         loop {
             if current_item.is_visible()
@@ -899,32 +901,29 @@ impl WindowInner {
         &self,
         render_components: impl FnOnce(&[(&ItemTreeRc, LogicalPoint)]) -> T,
     ) -> Option<T> {
-        let draw_fn = || {
-            let component_rc = self.try_component()?;
-
-            let popup_component =
-                self.active_popup.borrow().as_ref().and_then(|popup| match popup.location {
-                    PopupWindowLocation::TopLevel(..) => None,
-                    PopupWindowLocation::ChildWindow(coordinates) => {
-                        Some((popup.component.clone(), coordinates))
+        let component_rc = self.try_component()?;
+        Some(self.pinned_fields.as_ref().project_ref().redraw_tracker.evaluate_as_dependency_root(
+            || {
+                if !self
+                    .active_popups
+                    .borrow()
+                    .iter()
+                    .any(|p| matches!(p.location, PopupWindowLocation::ChildWindow(..)))
+                {
+                    render_components(&[(&component_rc, LogicalPoint::default())])
+                } else {
+                    let borrow = self.active_popups.borrow();
+                    let mut cmps = Vec::with_capacity(borrow.len() + 1);
+                    cmps.push((&component_rc, LogicalPoint::default()));
+                    for popup in borrow.iter() {
+                        if let PopupWindowLocation::ChildWindow(location) = &popup.location {
+                            cmps.push((&popup.component, *location));
+                        }
                     }
-                });
-
-            Some(if let Some((popup_component, popup_coordinates)) = popup_component {
-                render_components(&[
-                    (&component_rc, LogicalPoint::default()),
-                    (&popup_component, popup_coordinates),
-                ])
-            } else {
-                render_components(&[(&component_rc, LogicalPoint::default())])
-            })
-        };
-
-        self.pinned_fields
-            .as_ref()
-            .project_ref()
-            .redraw_tracker
-            .evaluate_as_dependency_root(draw_fn)
+                    render_components(&cmps)
+                }
+            },
+        ))
     }
 
     /// Registers the window with the windowing system, in order to render the component's items and react
@@ -983,6 +982,34 @@ impl WindowInner {
         let position = parent_item.map_to_window(
             parent_item.geometry().origin + LogicalPoint::from_untyped(position).to_vector(),
         );
+        let root_of = |mut item_tree: ItemTreeRc| loop {
+            if ItemRc::new(item_tree.clone(), 0).downcast::<crate::items::WindowItem>().is_some() {
+                return item_tree;
+            }
+            let mut r = crate::item_tree::ItemWeak::default();
+            ItemTreeRc::borrow_pin(&item_tree).as_ref().parent_node(&mut r);
+            match r.upgrade() {
+                None => return item_tree,
+                Some(x) => item_tree = x.item_tree().clone(),
+            }
+        };
+        let parent_root_item_tree = root_of(parent_item.item_tree().clone());
+        let (parent_window_adapter, position) = if let Some(parent_popup) = self
+            .active_popups
+            .borrow()
+            .iter()
+            .find(|p| ItemTreeRc::ptr_eq(&p.component, &parent_root_item_tree))
+        {
+            match &parent_popup.location {
+                PopupWindowLocation::TopLevel(wa) => (wa.clone(), position),
+                PopupWindowLocation::ChildWindow(offset) => {
+                    (self.window_adapter(), position + offset.to_vector())
+                }
+            }
+        } else {
+            (self.window_adapter(), position)
+        };
+
         let popup_component = ItemTreeRc::borrow_pin(popup_componentrc);
         let popup_root = popup_component.as_ref().get_item_ref(0);
 
@@ -1019,8 +1046,7 @@ impl WindowInner {
             height_property.set(size.height_length());
         };
 
-        let location = match self
-            .window_adapter()
+        let location = match parent_window_adapter
             .internal(crate::InternalToken)
             .and_then(|x| x.create_popup(LogicalRect::new(position, size)))
         {
@@ -1042,17 +1068,17 @@ impl WindowInner {
             }
         };
 
-        self.active_popup.replace(Some(PopupWindow {
+        self.active_popups.borrow_mut().push(PopupWindow {
             location,
             component: popup_componentrc.clone(),
             close_policy,
-        }));
+        });
     }
 
     /// Removes any active popup.
     /// TODO: this function should take a component ref as parameter, to close a specific popup - i.e. when popup menus create a hierarchy of popups.
     pub fn close_popup(&self) {
-        if let Some(current_popup) = self.active_popup.replace(None) {
+        if let Some(current_popup) = self.active_popups.borrow_mut().pop() {
             match current_popup.location {
                 PopupWindowLocation::ChildWindow(offset) => {
                     // Refresh the area that was previously covered by the popup.
@@ -1077,9 +1103,9 @@ impl WindowInner {
 
     /// Returns the close policy of the active popup. PopupClosePolicy::NoAutoClose if there is no active popup.
     pub fn close_policy(&self) -> PopupClosePolicy {
-        self.active_popup
+        self.active_popups
             .borrow()
-            .as_ref()
+            .last()
             .map_or(PopupClosePolicy::NoAutoClose, |popup| popup.close_policy)
     }
 

--- a/tests/cases/elements/popupwindow_nested.slint
+++ b/tests/cases/elements/popupwindow_nested.slint
@@ -1,0 +1,348 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Button } from "std-widgets.slint";
+
+
+
+// reimplemtns ComboBox so it doesn't depend on the style
+// (taken from the printerdemo)
+export component ComboBox inherits Rectangle {
+    in-out property <string> value: "aaaaaa";
+    in property <[string]> model: ["aaaaaa", "bbbbbb", "cccccc"];
+    callback selected(string);
+    border-radius: 3px;
+    border-width: 2px;
+    border-color: yellow;
+    height: 35px;
+    min-width: label.x + label.width + i.width;
+
+    label := Text {
+        vertical-alignment: center;
+        horizontal-alignment: left;
+        text <=> root.value;
+        height: 100%;
+        x: 12px;
+    }
+
+    i := Text {
+        width: self.preferred-width;
+        x: parent.width - self.width - 5px;
+        text: "▼";
+    }
+
+    TouchArea {
+        clicked => { popup.show(); }
+
+        width: 100%;
+        height: 100%;
+    }
+
+    popup := PopupWindow {
+        x:0;
+        y: root.height;
+        width: root.width;
+
+        Rectangle {
+            background: #eee;
+            border-radius: 3px;
+            border-width: 2px;
+            border-color: yellow;
+        }
+
+        VerticalLayout {
+            spacing: 6px;
+            padding: 3px;
+
+            for value in root.model: Rectangle {
+                border-radius: 3px;
+                background: item-area.has-hover ? #eef : #fff;
+                height: 25px;
+
+                HorizontalLayout {
+                    Text {
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                        text: value;
+                        color: black;
+                    }
+                }
+
+                item-area := TouchArea {
+                    clicked => {
+                        root.value = value;
+                        root.selected(value);
+                    }
+                }
+            }
+        }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 400px;
+    height: 400px;
+
+    in-out property <string> result;
+
+    TouchArea {
+        clicked => { result += "Root"; }
+    }
+
+
+    VerticalLayout {
+        alignment: start;
+        HorizontalLayout {
+            Button {
+                text: "Open Popup1";
+                clicked => {
+                    popup1.show();
+                }
+            }
+            Button {
+                text: "Open Popup2";
+                clicked => {
+                    popup2.show();
+                }
+            }
+            Button {
+                text: "Open two popups";
+                clicked => {
+                    popup1.show();
+                    popup2.show();
+                }
+            }
+        }
+    }
+
+    popup1 := PopupWindow {
+        x: 200px; y: 50px;
+        Rectangle {
+            border-width: 1px;
+            border-color: green;
+            background: red;
+        }
+        VerticalLayout {
+            padding: 3px;
+            ComboBox {
+                model: ["First", "Second", "Third"];
+                selected(value) => {
+                    result += value;
+                }
+            }
+            TouchArea {
+                height: 20px;
+                clicked => {
+                    result += "P1";
+                }
+            }
+        }
+        close-policy: close-on-click-outside;
+    }
+
+    popup2 := PopupWindow {
+        x: 20px; y: 200px;
+        width: 350px;
+        Rectangle {
+            border-width: 1px;
+            border-color: pink;
+            background: orange;
+        }
+        VerticalLayout {
+            padding: 3px;
+            ComboBox {
+                model: ["Aaaa", "Bbbb", "Cccc"];
+                selected(value) => {
+                    result += value;
+                }
+            }
+            HorizontalLayout {
+                Button {
+                    text: "close this";
+                    clicked => {
+                        result += "C2";
+                        popup2.close();
+                    }
+                }
+                Button {
+                    text: "close popup1";
+                    clicked => {
+                        result += "C1";
+                        popup1.close();
+                    }
+                }
+                Button {
+                    text: "open popup1";
+                    clicked => {
+                        result += "O1";
+                        popup1.show();
+                    }
+                }
+            }
+        }
+        close-policy: no-auto-close;
+    }
+}
+/*
+
+```rust
+#[allow(unused)]
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
+let instance = TestCase::new().unwrap();
+
+// open both popups
+slint_testing::send_mouse_click(&instance, 380., 10.);
+
+// clicking in P1 doesn nothing
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq!(instance.get_result(), "");
+
+// go in the popup1 combobox
+slint_testing::send_mouse_click(&instance, 40., 210.);
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq!(instance.get_result(), "Aaaa");
+instance.set_result("".into());
+
+// "close this"
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq!(instance.get_result(), "C2");
+instance.set_result("".into());
+// clicking in P1
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq!(instance.get_result(), "P1");
+instance.set_result("".into());
+// open P1 combobox
+slint_testing::send_mouse_click(&instance, 210., 60.);
+slint_testing::send_mouse_click(&instance, 210., 60. + 40.);
+assert_eq!(instance.get_result(), "First");
+instance.set_result("".into());
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq!(instance.get_result(), "P1");
+instance.set_result("".into());
+
+// click outside
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq!(instance.get_result(), "");
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq!(instance.get_result(), "Root");
+instance.set_result("".into());
+
+// open popup2
+slint_testing::send_mouse_click(&instance, 200., 10.);
+assert_eq!(instance.get_result(), "");
+// open popup1 from popup2
+slint_testing::send_mouse_click(&instance, 300., 210. + 40.);
+assert_eq!(instance.get_result(), "O1");
+instance.set_result("".into());
+
+// open P1 combobox
+slint_testing::send_mouse_click(&instance, 210., 60.);
+// click outside closes the combobox
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq!(instance.get_result(), "");
+// but P1 is still open
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq!(instance.get_result(), "P1");
+instance.set_result("".into());
+
+// click outside closes P1
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq!(instance.get_result(), "");
+
+// but p2 is still open
+// Open its combobox
+slint_testing::send_mouse_click(&instance, 40., 210.);
+// but click outside closes it
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq!(instance.get_result(), "");
+
+// "close this" closes p2
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq!(instance.get_result(), "C2");
+instance.set_result("".into());
+
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq!(instance.get_result(), "Root");
+```
+
+```cpp
+auto handle = TestCase::create();
+TestCase &instance = *handle;
+
+// open both popups
+slint_testing::send_mouse_click(&instance, 380., 10.);
+
+// clicking in P1 doesn nothing
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq(instance.get_result(), "");
+
+// go in the popup1 combobox
+slint_testing::send_mouse_click(&instance, 40., 210.);
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq(instance.get_result(), "Aaaa");
+instance.set_result("");
+
+// "close this"
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq(instance.get_result(), "C2");
+instance.set_result("");
+// clicking in P1
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq(instance.get_result(), "P1");
+instance.set_result("");
+// open P1 combobox
+slint_testing::send_mouse_click(&instance, 210., 60.);
+slint_testing::send_mouse_click(&instance, 210., 60. + 40.);
+assert_eq(instance.get_result(), "First");
+instance.set_result("");
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq(instance.get_result(), "P1");
+instance.set_result("");
+
+// click outside
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq(instance.get_result(), "");
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq(instance.get_result(), "Root");
+instance.set_result("");
+
+// open popup2
+slint_testing::send_mouse_click(&instance, 200., 10.);
+assert_eq(instance.get_result(), "");
+// open popup1 from popup2
+slint_testing::send_mouse_click(&instance, 20., 310.);
+slint_testing::send_mouse_click(&instance, 300., 210. + 35.);
+assert_eq(instance.get_result(), "O1");
+instance.set_result("");
+
+// open P1 combobox
+slint_testing::send_mouse_click(&instance, 210., 60.);
+// click outside closes the combobox
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq(instance.get_result(), "");
+// but P1 is still open
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq(instance.get_result(), "P1");
+instance.set_result("");
+
+// click outside closes P1
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq(instance.get_result(), "");
+
+// but p2 is still open
+// Open its combobox
+slint_testing::send_mouse_click(&instance, 40., 210.);
+// but click outside closes it
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq(instance.get_result(), "");
+
+// "close this" closes p2
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq(instance.get_result(), "C2");
+instance.set_result("");
+
+slint_testing::send_mouse_click(&instance, 20., 310.);
+assert_eq(instance.get_result(), "Root");
+```
+
+*/


### PR DESCRIPTION
Fixes https://github.com/slint-ui/slint/issues/4356

Still not perfect:
 - Calling several times `popup.show()` on the same popup, will open
   that popup multiple times (instead of being a noop once opened)
 - Calling `some-popup.close()` will always close the top of the stack,
   without considering if it is the `some-popup` or another popup.

Both problems are because we don't remember whether a particular popup
is open and we don't associate `close()` with a particular popup