### PR TITLE
Associate `PopupWindow`s with an ID for their active popup

### DIFF
--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -114,7 +114,7 @@ public:
         cbindgen_private::Point p = pos(popup);
         auto popup_dyn = popup.into_dyn();
         return cbindgen_private::slint_windowrc_show_popup(&inner, &popup_dyn, p, close_policy,
-                                                            &parent_item);
+                                                           &parent_item);
     }
 
     void close_popup(uint32_t popup_id) const

--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -117,7 +117,11 @@ public:
                                                     &parent_item);
     }
 
-    void close_popup(uint32_t popup_id) const { cbindgen_private::slint_windowrc_close_popup(&inner, popup_id); }
+    void close_popup(uint32_t popup_id) const {
+        if (popup_id > 0) {
+            cbindgen_private::slint_windowrc_close_popup(&inner, popup_id);
+        }
+    }
 
     template<std::invocable<RenderingState, GraphicsAPI> F>
     std::optional<SetRenderingNotifierError> set_rendering_notifier(F callback) const

--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -106,18 +106,18 @@ public:
     }
 
     template<typename Component, typename Parent, typename PosGetter>
-    void show_popup(const Parent *parent_component, PosGetter pos,
+    uint32_t show_popup(const Parent *parent_component, PosGetter pos,
                     cbindgen_private::PopupClosePolicy close_policy,
                     cbindgen_private::ItemRc parent_item) const
     {
         auto popup = Component::create(parent_component);
         cbindgen_private::Point p = pos(popup);
         auto popup_dyn = popup.into_dyn();
-        cbindgen_private::slint_windowrc_show_popup(&inner, &popup_dyn, p, close_policy,
+        return cbindgen_private::slint_windowrc_show_popup(&inner, &popup_dyn, p, close_policy,
                                                     &parent_item);
     }
 
-    void close_popup() const { cbindgen_private::slint_windowrc_close_popup(&inner); }
+    void close_popup(uint32_t popup_id) const { cbindgen_private::slint_windowrc_close_popup(&inner, popup_id); }
 
     template<std::invocable<RenderingState, GraphicsAPI> F>
     std::optional<SetRenderingNotifierError> set_rendering_notifier(F callback) const

--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -107,17 +107,18 @@ public:
 
     template<typename Component, typename Parent, typename PosGetter>
     uint32_t show_popup(const Parent *parent_component, PosGetter pos,
-                    cbindgen_private::PopupClosePolicy close_policy,
-                    cbindgen_private::ItemRc parent_item) const
+                        cbindgen_private::PopupClosePolicy close_policy,
+                        cbindgen_private::ItemRc parent_item) const
     {
         auto popup = Component::create(parent_component);
         cbindgen_private::Point p = pos(popup);
         auto popup_dyn = popup.into_dyn();
         return cbindgen_private::slint_windowrc_show_popup(&inner, &popup_dyn, p, close_policy,
-                                                    &parent_item);
+                                                            &parent_item);
     }
 
-    void close_popup(uint32_t popup_id) const {
+    void close_popup(uint32_t popup_id) const
+    {
         if (popup_id > 0) {
             cbindgen_private::slint_windowrc_close_popup(&inner, popup_id);
         }

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -165,7 +165,7 @@ cpp! {{
                 void *parent_window = p->rust_window;
                 bool inside = rect().contains(event->pos());
                 bool close_on_click = rust!(Slint_mouseReleaseEventPopup [parent_window: &QtWindow as "void*", inside: bool as "bool"] -> bool as "bool" {
-                    let close_policy = parent_window.close_policy();
+                    let close_policy = parent_window.top_close_policy();
                     close_policy == PopupClosePolicy::CloseOnClick || (close_policy == PopupClosePolicy::CloseOnClickOutside && !inside)
                 });
                 if (close_on_click) {
@@ -182,7 +182,7 @@ cpp! {{
             });
             if (parent_of_popup_to_close) {
                 rust!(Slint_mouseReleaseEventClosePopup [parent_of_popup_to_close: &QtWindow as "void*"] {
-                    parent_of_popup_to_close.close_popup();
+                    parent_of_popup_to_close.close_top_popup();
                 });
             }
         }
@@ -1746,12 +1746,12 @@ impl QtWindow {
         timer_event();
     }
 
-    fn close_popup(&self) {
-        WindowInner::from_pub(&self.window).close_popup();
+    fn close_top_popup(&self) {
+        WindowInner::from_pub(&self.window).close_top_popup();
     }
 
-    fn close_policy(&self) -> PopupClosePolicy {
-        WindowInner::from_pub(&self.window).close_policy()
+    fn top_close_policy(&self) -> PopupClosePolicy {
+        WindowInner::from_pub(&self.window).top_close_policy()
     }
 
     fn window_state_event(&self) {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1969,6 +1969,17 @@ fn generate_sub_component(
         ));
     }
 
+    for (i, _) in component.popup_windows.iter().enumerate() {
+        target_struct.members.push((
+            field_access,
+            Declaration::Var(Var {
+                ty: ident("uint32_t"),
+                name: format_smolstr!("popup_id_{}", i),
+                ..Default::default()
+            }),
+        ));
+    }
+
     for (prop1, prop2) in &component.two_way_bindings {
         init.push(format!(
             "slint::private_api::Property<{ty}>::link_two_way(&{p1}, &{p2});",
@@ -3613,15 +3624,28 @@ fn compile_builtin_function_call(
                 let position = compile_expression(&popup.position.borrow(), &popup_ctx);
                 let close_policy = compile_expression(close_policy, ctx);
                 format!(
-                    "{window}.show_popup<{popup_window_id}>({component_access}, [=](auto self) {{ return {position}; }}, {close_policy}, {{ {parent_component} }})"
+                    "{window}.close_popup({component_access}->popup_id_{popup_index}); {component_access}->popup_id_{popup_index} = {window}.show_popup<{popup_window_id}>({component_access}, [=](auto self) {{ return {position}; }}, {close_policy}, {{ {parent_component} }})"
                 )
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {:?}", arguments)
             }
         }
         BuiltinFunction::ClosePopupWindow => {
-            let window = access_window_field(ctx);
-            format!("{window}.close_popup()")
+            if let [llr::Expression::NumberLiteral(popup_index), llr::Expression::PropertyReference(parent_ref)] = arguments {
+                let mut parent_ctx = ctx;
+                let mut component_access = "self".into();
+
+                if let llr::PropertyReference::InParent { level, .. } = parent_ref {
+                    for _ in 0..level.get() {
+                        component_access = format!("{}->parent", component_access);
+                        parent_ctx = parent_ctx.parent.as_ref().unwrap().ctx;
+                    }
+                };
+                let window = access_window_field(ctx);
+                format!("{window}.close_popup({component_access}->popup_id_{popup_index})")
+            } else {
+                panic!("internal error: invalid args to ClosePopupWindow {:?}", arguments)
+            }
         }
         BuiltinFunction::SetSelectionOffsets => {
             if let [llr::Expression::PropertyReference(pr), from, to] = arguments {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1973,7 +1973,7 @@ fn generate_sub_component(
         target_struct.members.push((
             field_access,
             Declaration::Var(Var {
-                ty: ident("uint32_t"),
+                ty: ident("mutable uint32_t"),
                 name: format_smolstr!("popup_id_{}", i),
                 ..Default::default()
             }),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1001,6 +1001,9 @@ fn generate_sub_component(
         sub_component_types.push(sub_component_id);
     }
 
+    let popup_id_names =
+        component.popup_windows.iter().enumerate().map(|(i, _)| internal_popup_id(i));
+
     for (prop1, prop2) in &component.two_way_bindings {
         let p1 = access_member(prop1, &ctx);
         let p2 = access_member(prop2, &ctx);
@@ -1116,6 +1119,7 @@ fn generate_sub_component(
         struct #inner_component_id {
             #(#item_names : sp::#item_types,)*
             #(#sub_component_names : #sub_component_types,)*
+            #(#popup_id_names : ::core::cell::Cell<u32>,)*
             #(#declared_property_vars : sp::Property<#declared_property_types>,)*
             #(#declared_callbacks : sp::Callback<(#(#declared_callbacks_types,)*), #declared_callbacks_ret>,)*
             #(#repeated_element_names : sp::Repeater<#repeated_element_components>,)*
@@ -1817,6 +1821,12 @@ fn generate_repeated_component(
 /// Return an identifier suitable for this component for internal use
 fn inner_component_id(component: &llr::SubComponent) -> proc_macro2::Ident {
     format_ident!("Inner{}", ident(&component.name))
+}
+
+fn internal_popup_id(index: usize) -> proc_macro2::Ident {
+    let mut name = index.to_string();
+    name.insert_str(0, "popup_id_");
+    ident(&name)
 }
 
 fn global_inner_name(g: &llr::GlobalComponent) -> TokenStream {
@@ -2660,27 +2670,53 @@ fn compile_builtin_function_call(
 
                 let close_policy = compile_expression(close_policy, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
+                let popup_id_name = internal_popup_id(*popup_index as usize);
                 quote!({
                     let popup_instance = #popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone()).unwrap();
                     let popup_instance_vrc = sp::VRc::map(popup_instance.clone(), |x| x);
                     #popup_window_id::user_init(popup_instance_vrc.clone());
                     let position = { let _self = popup_instance_vrc.as_pin_ref(); #position };
-                    sp::WindowInner::from_pub(#window_adapter_tokens.window()).show_popup(
-                        &sp::VRc::into_dyn(popup_instance.into()),
-                        position,
-                        #close_policy,
-                        #parent_component
-                    )
+                    let current_id = #component_access_tokens.#popup_id_name.take();
+                    if current_id > 0 {
+                        sp::WindowInner::from_pub(#window_adapter_tokens.window()).close_popup(current_id);
+                    }
+                    #component_access_tokens.#popup_id_name.replace(
+                        sp::WindowInner::from_pub(#window_adapter_tokens.window()).show_popup(
+                            &sp::VRc::into_dyn(popup_instance.into()),
+                            position,
+                            #close_policy,
+                            #parent_component
+                        )
+                    );
                 })
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {:?}", arguments)
             }
         }
         BuiltinFunction::ClosePopupWindow => {
-            let window_adapter_tokens = access_window_adapter_field(ctx);
-            quote!(
-                sp::WindowInner::from_pub(#window_adapter_tokens.window()).close_popup()
-            )
+            if let [Expression::NumberLiteral(popup_index), Expression::PropertyReference(parent_ref)] =
+                arguments
+            {
+                let mut parent_ctx = ctx;
+                let mut component_access_tokens = quote!(_self);
+                if let llr::PropertyReference::InParent { level, .. } = parent_ref {
+                    for _ in 0..level.get() {
+                        component_access_tokens =
+                            quote!(#component_access_tokens.parent.upgrade().unwrap().as_pin_ref());
+                        parent_ctx = parent_ctx.parent.as_ref().unwrap().ctx;
+                    }
+                }
+                let window_adapter_tokens = access_window_adapter_field(ctx);
+                let popup_id_name = internal_popup_id(*popup_index as usize);
+                quote!(
+                    let current_id = #component_access_tokens.#popup_id_name.take();
+                    if current_id > 0 {
+                        sp::WindowInner::from_pub(#window_adapter_tokens.window()).close_popup(current_id);
+                    }
+                )
+            } else {
+                panic!("internal error: invalid args to ClosePopupWindow {:?}", arguments)
+            }
         }
         BuiltinFunction::SetSelectionOffsets => {
             if let [llr::Expression::PropertyReference(pr), from, to] = arguments {

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -122,11 +122,7 @@ pub fn lower_expression(
                 lower_show_popup(arguments, ctx)
             }
             tree_Expression::BuiltinFunctionReference(BuiltinFunction::ClosePopupWindow, _) => {
-                // FIXME: right now, `popup.close()` will close any visible popup, as the popup argument is ignored
-                llr_Expression::BuiltinFunctionCall {
-                    function: BuiltinFunction::ClosePopupWindow,
-                    arguments: vec![],
-                }
+                lower_close_popup(arguments, ctx)
             }
             tree_Expression::BuiltinFunctionReference(f, _) => {
                 let mut arguments =
@@ -393,6 +389,38 @@ fn lower_show_popup(args: &[tree_Expression], ctx: &ExpressionContext) -> llr_Ex
                 llr_Expression::EnumerationValue(popup.close_policy.clone()),
                 item_ref,
             ],
+        }
+    } else {
+        panic!("invalid arguments to ShowPopupWindow");
+    }
+}
+
+fn lower_close_popup(args: &[tree_Expression], ctx: &ExpressionContext) -> llr_Expression {
+    if let [tree_Expression::ElementReference(e)] = args {
+        let popup_window = e.upgrade().unwrap();
+        let pop_comp = popup_window.borrow().enclosing_component.upgrade().unwrap();
+        let parent_component = pop_comp
+            .parent_element
+            .upgrade()
+            .unwrap()
+            .borrow()
+            .enclosing_component
+            .upgrade()
+            .unwrap();
+        let popup_list = parent_component.popup_windows.borrow();
+        let (popup_index, popup) = popup_list
+            .iter()
+            .enumerate()
+            .find(|(_, p)| Rc::ptr_eq(&p.component, &pop_comp))
+            .unwrap();
+        let item_ref = lower_expression(
+            &tree_Expression::ElementReference(Rc::downgrade(&popup.parent_element)),
+            ctx,
+        );
+
+        llr_Expression::BuiltinFunctionCall {
+            function: BuiltinFunction::ClosePopupWindow,
+            arguments: vec![llr_Expression::NumberLiteral(popup_index as _), item_ref],
         }
     } else {
         panic!("invalid arguments to ShowPopupWindow");

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -614,6 +614,7 @@ fn call_builtin_function(
                 .expect("Invalid internal enumeration representation for close policy");
 
                 crate::dynamic_item_tree::show_popup(
+                    component,
                     popup,
                     |instance_ref| {
                         let comp = ComponentInstance::InstanceRef(instance_ref);
@@ -633,7 +634,7 @@ fn call_builtin_function(
                 );
                 Value::Void
             } else {
-                panic!("internal error: argument to SetFocusItem must be an element")
+                panic!("internal error: argument to ShowPopupWindow must be an element")
             }
         }
         BuiltinFunction::ClosePopupWindow => {
@@ -644,7 +645,7 @@ fn call_builtin_function(
                 }
             };
 
-            component.access_window(|window| window.close_popup());
+            crate::dynamic_item_tree::close_popup(component, component.window_adapter());
 
             Value::Void
         }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -614,6 +614,7 @@ fn call_builtin_function(
                 .expect("Invalid internal enumeration representation for close policy");
 
                 crate::dynamic_item_tree::show_popup(
+                    popup_window,
                     component,
                     popup,
                     |instance_ref| {
@@ -645,9 +646,18 @@ fn call_builtin_function(
                 }
             };
 
-            crate::dynamic_item_tree::close_popup(component, component.window_adapter());
+            if let Expression::ElementReference(popup_window) = &arguments[0] {
+                let popup_window = popup_window.upgrade().unwrap();
+                crate::dynamic_item_tree::close_popup(
+                    popup_window,
+                    component,
+                    component.window_adapter(),
+                );
 
-            Value::Void
+                Value::Void
+            } else {
+                panic!("internal error: argument to ClosePopupWindow must be an element")
+            }
         }
         BuiltinFunction::SetSelectionOffsets => {
             if arguments.len() != 3 {

--- a/tests/cases/elements/popupwindow_nested.slint
+++ b/tests/cases/elements/popupwindow_nested.slint
@@ -263,6 +263,33 @@ instance.set_result("".into());
 
 slint_testing::send_mouse_click(&instance, 20., 310.);
 assert_eq!(instance.get_result(), "Root");
+instance.set_result("".into());
+
+// open both popups
+slint_testing::send_mouse_click(&instance, 380., 10.);
+
+// close popup1
+slint_testing::send_mouse_click(&instance, 150., 210. + 40.);
+assert_eq!(instance.get_result(), "C1");
+instance.set_result("".into());
+
+// popup2 is still open and can be closed
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq!(instance.get_result(), "C2");
+instance.set_result("".into());
+
+// open both popups
+slint_testing::send_mouse_click(&instance, 380., 10.);
+
+// close popup2
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq!(instance.get_result(), "C2");
+instance.set_result("".into());
+
+// popup1 is still open
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq!(instance.get_result(), "P1");
+instance.set_result("".into());
 ```
 
 ```cpp
@@ -343,6 +370,33 @@ instance.set_result("");
 
 slint_testing::send_mouse_click(&instance, 20., 310.);
 assert_eq(instance.get_result(), "Root");
+instance.set_result("");
+
+// open both popups
+slint_testing::send_mouse_click(&instance, 380., 10.);
+
+// close popup1
+slint_testing::send_mouse_click(&instance, 150., 210. + 40.);
+assert_eq(instance.get_result(), "C1");
+instance.set_result("");
+
+// popup2 is still open and can be closed
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq(instance.get_result(), "C2");
+instance.set_result("");
+
+// open both popups
+slint_testing::send_mouse_click(&instance, 380., 10.);
+
+// close popup2
+slint_testing::send_mouse_click(&instance, 40., 210. + 40.);
+assert_eq(instance.get_result(), "C2");
+instance.set_result("");
+
+// popup1 is still open
+slint_testing::send_mouse_click(&instance, 210., 90.);
+assert_eq(instance.get_result(), "P1");
+instance.set_result("");
 ```
 
 */

--- a/tests/cases/elements/popupwindow_open_twice.slint
+++ b/tests/cases/elements/popupwindow_open_twice.slint
@@ -3,12 +3,64 @@
 
 import { Button } from "std-widgets.slint";
 
-export component TestCase inherits Window {
-    width: 400px;
-    height: 400px;
+component PopupContainer inherits Rectangle {
+	width: 400px;
+    height: 300px;
 
-    in-out property <int> popup_click_count;
-	in-out property <length> popup_x;
+	in-out property <int> popup_click_count;
+	
+	callback first_reached;
+	callback second_reached;
+	
+	property <length> popup_x;
+	property <bool> first_sent: false;
+	property <bool> second_sent: false;
+
+	public function show(second: bool) {
+		popup_x = !second ? 0px : 200px;
+		popup.show();
+	}
+
+	public function close() {
+		popup.close();
+	}
+
+    popup := PopupWindow {
+        x: popup_x;
+		y: 100px;
+		width: 200px;
+		height: 200px;
+		close-policy: no-auto-close;
+
+		Rectangle {
+			background: red;
+		}
+
+		TouchArea {
+			clicked => {
+				popup_click_count += 1;
+
+				if (popup_x == 0px) {
+					if (!first_sent) {
+						first_reached();
+						first_sent = true;
+					}
+				} else {
+					if (!second_sent	) {
+						second_reached();
+						second_sent = true;
+					}
+				}
+			}
+		}
+    }
+}
+
+export component TestCase inherits Window {
+	width: 400px;
+	height: 400px;
+
+	in-out property <int> popup_click_count;
 
 	VerticalLayout {
 		alignment: start;
@@ -17,31 +69,35 @@ export component TestCase inherits Window {
 			Button {
 				text: "Open";
 				clicked => {
-					popup_x = 0px;
-					popup.show();
+					cnt1.show(false);
 				}
 			}
 		}
 	}
 
-    popup := PopupWindow {
-        x: popup_x;
-		y: 200px;
-		width: 200px;
-		height: 200px;
-		close-policy: no-auto-close;
+	cnt1 := PopupContainer {
+		x: 0px;
+		y: 100px;
+		popup_click_count <=> popup_click_count;
 
-		TouchArea {
-			clicked => {
-				popup_click_count += 1;
-
-				if (popup_x == 0px) {
-					popup_x = 200px;
-					popup.show();
-				}
-			}
+		first_reached => {
+			cnt1.show(true);
 		}
-    }
+
+		second_reached => {
+			cnt2.show(false);
+		}
+	}
+
+	cnt2 := PopupContainer {
+		x: 0px;
+		y: 100px;
+		popup_click_count <=> popup_click_count;
+
+		first_reached => {
+			cnt2.close();
+		}
+	}
 }
 
 /*
@@ -62,10 +118,19 @@ assert_eq!(instance.get_popup_click_count(), 1);
 slint_testing::send_mouse_click(&instance, 10., 210.);
 assert_eq!(instance.get_popup_click_count(), 1);
 
-// now open on the right
+// popup is now open on the right
+// open a second popup on the left in the second container
 slint_testing::send_mouse_click(&instance, 210., 210.);
 assert_eq!(instance.get_popup_click_count(), 2);
 
+// second popup is still open on the left
+// close the second popup
+slint_testing::send_mouse_click(&instance, 10., 210.);
+assert_eq!(instance.get_popup_click_count(), 3);
+
+// first popup is still open as multiple of the same "PopupWindow" across different component instances is fine
+slint_testing::send_mouse_click(&instance, 210., 210.);
+assert_eq!(instance.get_popup_click_count(), 4);
 ```
 
 ```cpp
@@ -83,9 +148,22 @@ assert_eq(instance.get_popup_click_count(), 1);
 slint_testing::send_mouse_click(&instance, 10., 210.);
 assert_eq(instance.get_popup_click_count(), 1);
 
-// now open on the right
+// popup is now open on the right
+// open a second popup on the left in the second container
 slint_testing::send_mouse_click(&instance, 210., 210.);
 assert_eq(instance.get_popup_click_count(), 2);
+
+// open on the left from the second container
+slint_testing::send_mouse_click(&instance, 380., 10.);
+
+// second popup is still open on the left
+// close the second popup
+slint_testing::send_mouse_click(&instance, 10., 210.);
+assert_eq(instance.get_popup_click_count(), 3);
+
+// first popup is still open as multiple of the same "PopupWindow" across different component instances is fine
+slint_testing::send_mouse_click(&instance, 210., 210.);
+assert_eq(instance.get_popup_click_count(), 4);
 ```
 
 */

--- a/tests/cases/elements/popupwindow_open_twice.slint
+++ b/tests/cases/elements/popupwindow_open_twice.slint
@@ -1,0 +1,91 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Button } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    width: 400px;
+    height: 400px;
+
+    in-out property <int> popup_click_count;
+	in-out property <length> popup_x;
+
+	VerticalLayout {
+		alignment: start;
+
+		HorizontalLayout {
+			Button {
+				text: "Open";
+				clicked => {
+					popup_x = 0px;
+					popup.show();
+				}
+			}
+		}
+	}
+
+    popup := PopupWindow {
+        x: popup_x;
+		y: 200px;
+		width: 200px;
+		height: 200px;
+		close-policy: no-auto-close;
+
+		TouchArea {
+			clicked => {
+				popup_click_count += 1;
+
+				if (popup_x == 0px) {
+					popup_x = 200px;
+					popup.show();
+				}
+			}
+		}
+    }
+}
+
+/*
+
+```rust
+#[allow(unused)]
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
+let instance = TestCase::new().unwrap();
+
+// open on the left
+slint_testing::send_mouse_click(&instance, 20., 10.);
+
+// use left popup to open on the right
+slint_testing::send_mouse_click(&instance, 10., 210.);
+assert_eq!(instance.get_popup_click_count(), 1);
+
+// no longer open on the left
+slint_testing::send_mouse_click(&instance, 10., 210.);
+assert_eq!(instance.get_popup_click_count(), 1);
+
+// now open on the right
+slint_testing::send_mouse_click(&instance, 210., 210.);
+assert_eq!(instance.get_popup_click_count(), 2);
+
+```
+
+```cpp
+auto handle = TestCase::create();
+TestCase &instance = *handle;
+
+// open on the left
+slint_testing::send_mouse_click(&instance, 20., 10.);
+
+// use left popup to open on the right
+slint_testing::send_mouse_click(&instance, 10., 210.);
+assert_eq(instance.get_popup_click_count(), 1);
+
+// no longer open on the left
+slint_testing::send_mouse_click(&instance, 10., 210.);
+assert_eq(instance.get_popup_click_count(), 1);
+
+// now open on the right
+slint_testing::send_mouse_click(&instance, 210., 210.);
+assert_eq(instance.get_popup_click_count(), 2);
+```
+
+*/

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1358,8 +1358,8 @@ fn set_preview_factory(
     callback: Box<dyn Fn(ComponentInstance)>,
     behavior: LoadBehavior,
 ) {
-    // Ensure that the popup is closed as it is related to the old factory
-    i_slint_core::window::WindowInner::from_pub(ui.window()).close_popup();
+    // Ensure that any popups are closed as they are related to the old factory
+    i_slint_core::window::WindowInner::from_pub(ui.window()).close_all_popups();
 
     let factory = slint::ComponentFactory::new(move |ctx: FactoryContext| {
         let instance = compiled.create_embedded(ctx).unwrap();


### PR DESCRIPTION
Each PopupWindow stores an ID for the active popup associated with it so `popup.close();` closes the correct popup, and so a single PopupWindow cannot be opened multiple times.