### PR TITLE
Don't depends inconditionally on critical-section for portable-atomic

### DIFF
--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -29,7 +29,6 @@ i-slint-core-macros = { version = "=1.9.0", path = "../../internal/core-macros" 
 
 derive_more = { workspace = true }
 embedded-graphics = { version = "0.8", optional = true }
-once_cell = { version = "1.9", default-features = false, features = ["alloc"] }
 pin-weak = { version = "1", default-features = false }
 rgb = "0.8.27"
 cfg-if = "1"

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -28,7 +28,7 @@ std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algor
 # Unsafe feature meaning that there is only one core running and all thread_local are static.
 # You can only enable this feature if you are sure that any API of this crate is only called
 # from a single core, and not in a interrupt or signal handler.
-unsafe-single-threaded = []
+unsafe-single-threaded = ["portable-atomic/unsafe-assume-single-core", "once_cell/portable-atomic"]
 
 unicode = ["unicode-script", "unicode-linebreak"]
 
@@ -53,7 +53,7 @@ i-slint-core-macros = { workspace = true, features = ["default"] }
 const-field-offset = { version = "0.1.5", path = "../../helper_crates/const-field-offset" }
 vtable = { workspace = true }
 
-portable-atomic = { version = "1", features = ["critical-section"] }
+portable-atomic = { version = "1" }
 auto_enums = "0.8.0"
 cfg-if = "1"
 derive_more = { workspace = true }
@@ -63,7 +63,7 @@ lyon_geom = { version = "1.0", optional = true  }
 lyon_path = { version = "1.0", optional = true }
 lyon_extra = { version = "1.0.1", optional = true }
 num-traits = { version = "0.2", default-features = false }
-once_cell = { version = "1.5", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.5", default-features = false }
 pin-project = "1"
 pin-weak = { version = "1.1", default-features = false }
 # Note: the rgb version is extracted in ci.yaml for rustdoc builds


### PR DESCRIPTION
This should fix the compilation (link) of the esp-edf build for esp32s2 in the nightly test CI, as that platform doesn't have atomic, and also we don't provide an implementation of the critical-section function from the slint-cpp crate.

Use the unsafe-single-threaded feature instead.

CC #5057
