### PR TITLE
LSP: report that we use UTF-8 to client that supports it

### DIFF
--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -208,6 +208,13 @@ impl RequestHandler {
 pub fn server_initialize_result(client_cap: &ClientCapabilities) -> InitializeResult {
     InitializeResult {
         capabilities: ServerCapabilities {
+            // Note: we only support UTF8 at the moment (which is a bug, as the spec says that support for utf-16 is mandatory)
+            position_encoding: client_cap
+                .general
+                .as_ref()
+                .and_then(|x| x.position_encodings.as_ref())
+                .and_then(|x| x.iter().find(|x| *x == &lsp_types::PositionEncodingKind::UTF8))
+                .cloned(),
             hover_provider: Some(true.into()),
             signature_help_provider: Some(lsp_types::SignatureHelpOptions {
                 trigger_characters: Some(vec!["(".to_owned(), ",".to_owned()]),


### PR DESCRIPTION
Version 3.17 of the spec added a `position_encoding` field in the ServerCapabilities, so use that.

Note that the spec says that UTF-16 is mendatory, and vscode only support utf-16, meaning we currently have a bug when having non-ascii in the source (#5669)
