### PR TITLE
Error when making a `for` over an empty array

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -265,7 +265,6 @@ impl Type {
             | (Type::Float32, Type::String)
             | (Type::Int32, Type::Float32)
             | (Type::Int32, Type::String)
-            | (Type::Array(_), Type::Model)
             | (Type::Float32, Type::Model)
             | (Type::Int32, Type::Model)
             | (Type::PhysicalLength, Type::LogicalLength)
@@ -277,6 +276,7 @@ impl Type {
             | (Type::Percent, Type::Float32)
             | (Type::Brush, Type::Color)
             | (Type::Color, Type::Brush) => true,
+            (Type::Array(a), Type::Model) if a.is_property_type() => true,
             (Type::Struct(a), Type::Struct(b)) => can_convert_struct(&a.fields, &b.fields),
             (Type::UnitProduct(u), o) => match o.as_unit_product() {
                 Some(o) => unit_product_length_conversion(u.as_slice(), o.as_slice()).is_some(),

--- a/internal/compiler/tests/syntax/lookup/for_lookup.slint
+++ b/internal/compiler/tests/syntax/lookup/for_lookup.slint
@@ -92,4 +92,7 @@ export Hello := Rectangle {
     if self.pressed : TouchArea { }
     //      ^error{Element 'Rectangle' does not have a property 'pressed'}
 
+
+    for i[idx] in [] : Text { text: idx; }
+    //            ^error{Cannot convert \[void] to model}
 }


### PR DESCRIPTION
Instead of panicking.

Attempt to fix it in #6765 didn't work for C++.
Code generation might be hard for C++, so I thought it's better to error out.

Fix #6760
