### PR TITLE
swrenderer: Fix drawing of clipped VectorFont

### DIFF
--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1583,6 +1583,7 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
                                     .process_texture(geometry.transformed(self.rotation), texture);
                             }
                             fonts::GlyphAlphaMap::Shared(data) => {
+                                let source_rect = euclid::rect(0, 0, glyph.width.0, glyph.height.0);
                                 self.processor.process_shared_image_buffer(
                                     geometry.transformed(self.rotation),
                                     SharedBufferCommand {
@@ -1590,7 +1591,7 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
                                             data: data.clone(),
                                             width: pixel_stride,
                                         },
-                                        source_rect: PhysicalRect::from_size(source_size),
+                                        source_rect,
                                         extra: SceneTextureExtra {
                                             colorize: color,
                                             // color already is mixed with global alpha


### PR DESCRIPTION
That code was touched recently while doing the signed distance field rendering. The offset is now within the source rectangle. So the SharedBufferCommand's source_rect must include the whole pixmap.

Unfortunately, VectorFont are not covered by the screenshot tests

