### PR TITLE
Avoid building Rust on pnpm install as a default for all projects

### DIFF
--- a/.github/actions/test-online-editor/action.yaml
+++ b/.github/actions/test-online-editor/action.yaml
@@ -57,7 +57,7 @@ runs:
           uses: pnpm/action-setup@v4.0.0
           with:
             version: 9.11.0
-          run: pnpm install --frozen-lockfile --ignore-scripts
+          run: pnpm install --frozen-lockfile
           shell: bash
           working-directory: tools/slintpad
 

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -100,7 +100,7 @@ jobs:
             - name: "Node docs"
 
               run: |
-                  pnpm install --frozen-lockfile --ignore-scripts
+                  pnpm install --frozen-lockfile
                   pnpm run docs
               working-directory: api/node
                 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
                   key: x-napi-v2-${{ steps.node-install.outputs.node-version }} # the cache key consists of a manually bumpable version and the node version, as the cached rustc artifacts contain linking information where to find node.lib, which is in a versioned directory.
             - name: Run pnpm install
               working-directory: api/node
-              run: pnpm install --frozen-lockfile --ignore-scripts
+              run: pnpm install --frozen-lockfile
             - name: Build node plugin in debug
               run: pnpm build:testing
               working-directory: api/node
@@ -345,7 +345,7 @@ jobs:
                   echo 1 > target/debug/slint-lsp
             - name: Run pnpm install
               working-directory: editors/vscode
-              run: pnpm install --frozen-lockfile --ignore-scripts
+              run: pnpm install --frozen-lockfile
             - name: vscode prebuild
               working-directory: editors/vscode
               run: pnpm vscode:prepublish

--- a/.github/workflows/fmt_lint_typecheck.yaml
+++ b/.github/workflows/fmt_lint_typecheck.yaml
@@ -39,7 +39,7 @@ jobs:
               run: biome format biome.json
             - name: Format, Lint on npm projects
               run: |
-                  pnpm install --frozen-lockfile --ignore-scripts
+                  pnpm install --frozen-lockfile
                   pnpm format
                   pnpm lint
             - name: Suggest format changes

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -291,7 +291,7 @@ jobs:
               shell: bash
             - name: "pnpm install"
               working-directory: editors/vscode
-              run: pnpm install --frozen-lockfile --ignore-scripts
+              run: pnpm install --frozen-lockfile
             - name: Install wasm-pack
               run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
             - name: Build package and optionally publish to Visual Studio Marketplace

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -67,7 +67,7 @@ jobs:
               with:
                   name: wasm
             - name: Install NPM dependencies
-              run: pnpm install --frozen-lockfile --ignore-scripts
+              run: pnpm install --frozen-lockfile
               working-directory: tools/slintpad
 
             - name: Compile slintpad

--- a/api/node/package.json
+++ b/api/node/package.json
@@ -36,11 +36,10 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "compile": "tsc",
+    "compile": "tsc --build",
     "build": "napi build --platform --release --js rust-module.cjs --dts rust-module.d.ts -c binaries.json",
     "build:debug": "napi build --platform --js rust-module.cjs --dts rust-module.d.ts -c binaries.json && pnpm compile",
     "build:testing": "napi build --platform --js rust-module.cjs --dts rust-module.d.ts -c binaries.json --features testing && pnpm compile",
-    "install": "node build-on-demand.mjs",
     "docs": "pnpm build && typedoc --hideGenerator --treatWarningsAsErrors --readme cover.md typescript/index.ts",
     "check": "biome check",
     "format": "biome format",

--- a/cspell.json
+++ b/cspell.json
@@ -106,6 +106,7 @@
         "opengl",
         "opengles",
         "pixmap",
+        "prestart",
         "printerdemo",
         "riscv",
         "rowspan",

--- a/demos/home-automation/node/package.json
+++ b/demos/home-automation/node/package.json
@@ -5,10 +5,11 @@
     "type": "module",
     "dependencies": {
         "@biomejs/biome": "1.9.3",
-        "slint-ui": "../../../api/node"
+        "slint-ui": "workspace:*"
     },
     "scripts": {
         "start": "node .",
+        "prestart": "cd ../../../api/node/ && node build-on-demand.mjs && pnpm compile",
         "check": "biome check",
         "format": "biome format",
         "format:fix": "biome format --write",

--- a/demos/printerdemo/node/README
+++ b/demos/printerdemo/node/README
@@ -1,8 +1,4 @@
 Run with
 
-# pushd ../../../api/node
 # pnpm install
-# pnpm compile
-# popd
-# pnpm install --ignore-scripts
 # pnpm start

--- a/demos/printerdemo/node/package.json
+++ b/demos/printerdemo/node/package.json
@@ -4,9 +4,10 @@
     "main": "main.js",
     "type": "module",
     "dependencies": {
-        "slint-ui": "../../../api/node"
+        "slint-ui": "workspace:*"
     },
     "scripts": {
-        "start": "node ."
+        "start": "node .",
+        "prestart": "cd ../../../api/node/ && node build-on-demand.mjs && pnpm compile"
     }
 }

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -45,7 +45,7 @@ The following step will build a local version of the vscode extension and the LS
 cargo install wasm-pack
 cargo build -p slint-lsp
 cd editors/vscode
-pnpm install --frozen-lockfile --ignore-scripts
+pnpm install --frozen-lockfile
 pnpm build:wasm_lsp
 pnpm compile
 ```

--- a/examples/carousel/node/README
+++ b/examples/carousel/node/README
@@ -1,7 +1,3 @@
 Run with
-# pushd ../../../api/node
-# npm install
-# npm run compile
-# popd
-# npm install
-# npm start
+# pnpm install
+# pnpm start

--- a/examples/carousel/node/package.json
+++ b/examples/carousel/node/package.json
@@ -4,9 +4,10 @@
     "main": "main.js",
     "type": "module",
     "dependencies": {
-        "slint-ui": "../../../api/node"
+        "slint-ui": "workspace:*"
     },
     "scripts": {
-        "start": "node ."
+        "start": "node .",
+        "prestart": "cd ../../../api/node/ && node build-on-demand.mjs && pnpm compile"
     }
 }

--- a/examples/imagefilter/node/README
+++ b/examples/imagefilter/node/README
@@ -1,8 +1,3 @@
 Run with
-
-# pushd ../../../api/node
 # pnpm install
-# pnpm run compile
-# popd
-# pnpm install --ignore-scripts
 # pnpm start

--- a/examples/imagefilter/node/package.json
+++ b/examples/imagefilter/node/package.json
@@ -4,7 +4,7 @@
     "main": "main.js",
     "type": "module",
     "dependencies": {
-        "slint-ui": "../../../api/node",
+        "slint-ui": "workspace:*",
         "jimp": "1.6.0"
     },
     "devDependencies": {
@@ -13,7 +13,7 @@
     },
     "scripts": {
         "start": "tsc --build && node ./main.js",
+        "prestart": "cd ../../../api/node/ && node build-on-demand.mjs && pnpm compile",
         "type-check": "tsc --noEmit"
-
     }
 }

--- a/examples/memory/package.json
+++ b/examples/memory/package.json
@@ -4,9 +4,10 @@
     "main": "main.js",
     "type": "module",
     "dependencies": {
-        "slint-ui": "../../api/node"
+        "slint-ui": "workspace:*"
     },
     "scripts": {
-        "start": "node ."
+        "start": "node .",
+        "prestart": "cd ../../api/node/ && node build-on-demand.mjs && pnpm compile"
     }
 }

--- a/examples/todo/node/README
+++ b/examples/todo/node/README
@@ -1,7 +1,3 @@
 Run with
-# pushd ../../../api/node
-# npm install
-# npm run compile
-# popd
-# npm install
-# npm start
+# pnpm install
+# pnpm start

--- a/examples/todo/node/package.json
+++ b/examples/todo/node/package.json
@@ -4,9 +4,10 @@
     "main": "main.js",
     "type": "module",
     "dependencies": {
-        "slint-ui": "../../../api/node"
+        "slint-ui": "workspace:*"
     },
     "scripts": {
-        "start": "node ."
+        "start": "node .",
+        "prestart": "cd ../../../api/node/ && node build-on-demand.mjs && pnpm compile"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,13 +51,13 @@ importers:
         specifier: 1.9.3
         version: 1.9.3
       slint-ui:
-        specifier: ../../../api/node
+        specifier: workspace:*
         version: link:../../../api/node
 
   demos/printerdemo/node:
     dependencies:
       slint-ui:
-        specifier: ../../../api/node
+        specifier: workspace:*
         version: link:../../../api/node
 
   docs/editor:
@@ -146,13 +146,19 @@ importers:
         specifier: 0.1.3
         version: 0.1.3
 
+  examples/carousel/node:
+    dependencies:
+      slint-ui:
+        specifier: workspace:*
+        version: link:../../../api/node
+
   examples/imagefilter/node:
     dependencies:
       jimp:
         specifier: 1.6.0
         version: 1.6.0
       slint-ui:
-        specifier: ../../../api/node
+        specifier: workspace:*
         version: link:../../../api/node
     devDependencies:
       '@types/node':
@@ -161,6 +167,18 @@ importers:
       typescript:
         specifier: 5.6.2
         version: 5.6.2
+
+  examples/memory:
+    dependencies:
+      slint-ui:
+        specifier: workspace:*
+        version: link:../../api/node
+
+  examples/todo/node:
+    dependencies:
+      slint-ui:
+        specifier: workspace:*
+        version: link:../../../api/node
 
   tools/slintpad:
     devDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,7 @@ packages:
   - "demos/printerdemo/node"
   - "demos/home-automation/node"
   - "examples/imagefilter/node"
+  - "examples/carousel/node"
+  - "examples/todo/node"
+  - "examples/memory"
   - "docs/editor"


### PR DESCRIPTION
PNPM runs all the web projects in the monorepo. 'pnpm install' on any of these
projects results in the 'api/node' project always building the Slint rust project.
Several projects do not need rust to be built.

This PR stops Slint for rust being built via the 'install' script hook. Instead any 
projects that do need the rust build will trigger it via their own 'prestart' hook.
This hook will only compile the rust build if it has not already been built. The
api/node project also now uses the 'tsc --build' flag instead of 'tsc' which
means the 'pnpm compile' script that also runs will reuse an existing typescript
build and not compile it from scratch every single time.

This PR also uses PNPM workspaces to use slint via '"slint-ui": "workspace:*"'.
This picks up the api/node version of Slint-UI without the need for a relative path.

Finally several 'pnpm i --ignore-scripts' are simplified to remove the now
unnecessary '--ignore-scripts'. Also various readme's are updated.