### PR TITLE
live-preview: Remove dead code related to design mode

### DIFF
--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -147,8 +147,6 @@ export global Api {
     in property <bool> experimental: false;
     // enable editing mode
     in property <bool> show-preview-ui: true;
-    // Design-mode engaged!
-    in-out property <bool> design-mode;
     // std-widgets are used (=> show style dropdown)
     in-out property <bool> uses-widgets;
 

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -57,7 +57,6 @@ export component PreviewUi inherits Window {
                     show-left-sidebar <=> root.show-left-sidebar;
                     show-right-sidebar <=> root.show-right-sidebar;
 
-                    edit-mode <=> Api.design-mode;
                     current-style <=> Api.current-style;
                     known-styles <=> Api.known-styles;
 
@@ -65,13 +64,11 @@ export component PreviewUi inherits Window {
                         Api.style-changed();
                     }
 
-                    edit:=Button {
+                    edit := Button {
                         icon: Icons.inspect;
                         colorize-icon: preview.select-mode ? false : true;
                         checkable: true;
                         checked <=> preview.select-mode;
-                        enabled: !preview.design-mode;
-                        visible: !preview.design-mode;
                         primary: preview.select-mode;
                     }
                 }

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -24,7 +24,6 @@ enum SelectionKind {
 export enum DrawAreaMode {
     uninitialized,
     viewing,
-    designing,
     selecting,
     error,
 }
@@ -187,7 +186,6 @@ export component PreviewView {
     in property <ComponentItem> visible-component;
     property <DropMark> drop-mark <=> Api.drop-mark;
     property <component-factory> preview-area <=> Api.preview-area;
-    out property <bool> design-mode <=> Api.design-mode;
     in-out property <bool> select-mode: false;
 
     out property <bool> preview-visible: preview-area-container.has-component && !diagnostics.diagnostics-open;
@@ -228,7 +226,7 @@ export component PreviewView {
                     Api.unselect();
                     root.select-mode = false;
                 }
-                mouse-cursor: root.mode == DrawAreaMode.designing || root.mode == DrawAreaMode.selecting ? MouseCursor.crosshair : MouseCursor.default;
+                mouse-cursor: root.mode == DrawAreaMode.selecting ? MouseCursor.crosshair : MouseCursor.default;
 
                 changed has-hover => {
                     StatusLineApi.help-text = "<click> unselect";
@@ -249,8 +247,8 @@ export component PreviewView {
                 private property <length> target-width;
                 private property <length> target-height;
 
-                color: root.design-mode ? Colors.black : Colors.transparent;
-                fill-color: root.design-mode ? Colors.white : Colors.transparent;
+                color: root.select-mode ? Colors.black : Colors.transparent;
+                fill-color: root.select-mode ? Colors.white : Colors.transparent;
 
                 is-moveable: false;
                 is-resizable <=> preview-area-container.is-resizable;
@@ -351,7 +349,7 @@ export component PreviewView {
                         self.selection-kind = SelectionKind.none;
                     }
                     mouse-cursor: crosshair;
-                    enabled: root.mode == DrawAreaMode.designing || root.mode == DrawAreaMode.selecting;
+                    enabled: root.mode == DrawAreaMode.selecting;
 
                     changed has-hover => {
                         if self.has-hover && self.enabled {
@@ -364,7 +362,7 @@ export component PreviewView {
 
                 selection-display-area := Rectangle {
                     for s in root.selections: SelectionFrame {
-                        interactive: root.mode == DrawAreaMode.designing;
+                        interactive: root.mode == DrawAreaMode.selecting;
                         selection: s;
                         resize(x, y, w, h) => {
                             Api.selected-element-resize(x, y, w, h);
@@ -419,13 +417,10 @@ export component PreviewView {
         error when diagnostics.diagnostics-open && preview-area-container.has-component: {
             root.mode: DrawAreaMode.error;
         }
-        designing when root.design-mode && !diagnostics.diagnostics-open && preview-area-container.has-component: {
-            root.mode: DrawAreaMode.designing;
-        }
         selecting when root.select-mode && !diagnostics.diagnostics-open && preview-area-container.has-component: {
             root.mode: DrawAreaMode.selecting;
         }
-        viewing when !root.design-mode && !diagnostics.diagnostics-open && preview-area-container.has-component: {
+        viewing when !root.select-mode && !diagnostics.diagnostics-open && preview-area-container.has-component: {
             root.mode: DrawAreaMode.viewing;
         }
     ]


### PR DESCRIPTION
That mode can no longer get enabled, so get rid of the entire thing.

