### PR TITLE
live-preview: Stay in select-mode after selecting something

### DIFF
--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -226,7 +226,6 @@ export component PreviewView {
             unselect-area := TouchArea {
                 clicked => {
                     Api.unselect();
-                    root.select-mode = false;
                 }
                 mouse-cursor: root.mode == DrawAreaMode.designing || root.mode == DrawAreaMode.selecting ? MouseCursor.crosshair : MouseCursor.default;
 
@@ -346,7 +345,6 @@ export component PreviewView {
                             } else if (self.selection-kind == SelectionKind.select-at) {
                                 Api.select-at(self.selection-x, self.selection-y, event.modifiers.control);
                             }
-                            root.select-mode = false;
                         }
                         self.selection-kind = SelectionKind.none;
                     }


### PR DESCRIPTION
@szecket brought this up as part of a bigger patch set. I just extracted this out.