### PR TITLE
slint-build: Add config option to set the path for bundled translations

### DIFF
--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -21,7 +21,7 @@ path = "lib.rs"
 default = []
 
 [dependencies]
-i-slint-compiler = { workspace = true, features = ["default", "rust", "display-diagnostics", "software-renderer"] }
+i-slint-compiler = { workspace = true, features = ["default", "rust", "display-diagnostics", "software-renderer", "bundle-translations"] }
 
 spin_on = { workspace = true }
 thiserror = "1"

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -173,6 +173,22 @@ impl CompilerConfiguration {
         config.const_scale_factor = factor as f64;
         Self { config }
     }
+
+    /// Configures the compiler to bundle translations when compiling Slint code.
+    ///
+    /// It expects the path to be the root directory of the translation files.
+    ///
+    /// The translation files should be in the gettext `.po` format and follow this pattern:
+    /// `<path>/<lang>/LC_MESSAGES/<crate>.po`
+    #[must_use]
+    pub fn with_bundled_translations(
+        self,
+        path: impl Into<std::path::PathBuf>,
+    ) -> CompilerConfiguration {
+        let mut config = self.config;
+        config.translation_path_bundle = Some(path.into());
+        Self { config }
+    }
 }
 
 /// Error returned by the `compile` function

--- a/demos/printerdemo/rust/Cargo.toml
+++ b/demos/printerdemo/rust/Cargo.toml
@@ -23,7 +23,7 @@ name = "printerdemo_lib"
 slint = { path = "../../../api/rs/slint", features = ["backend-android-activity-06"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"]}
 
-[target.'cfg(not(target_os = "android"))'.dependencies]
+[target.'cfg(not(any(target_os = "android", target_arch = "wasm32")))'.dependencies]
 slint = { path = "../../../api/rs/slint", features=["gettext"] }
 
 [build-dependencies]

--- a/demos/printerdemo/rust/build.rs
+++ b/demos/printerdemo/rust/build.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 fn main() {
-    slint_build::compile("../ui/printerdemo.slint").unwrap();
-    slint_build::print_rustc_flags().unwrap();
+    let mut config = slint_build::CompilerConfiguration::new();
+    if cfg!(any(target_os = "android", target_arch = "wasm32")) {
+        config = config.with_bundled_translations("../lang");
+    }
+    slint_build::compile_with_config("../ui/printerdemo.slint", config).unwrap();
 }

--- a/demos/printerdemo/rust/lib.rs
+++ b/demos/printerdemo/rust/lib.rs
@@ -102,8 +102,7 @@ pub fn main() {
         },
     );
 
-    // Disable gettext on macOS due to https://github.com/Koka/gettext-rs/issues/114
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
         slint::init_translations!(concat!(env!("CARGO_MANIFEST_DIR"), "/../lang/"));
         main_window.global::<PrinterSettings>().on_change_language(|l| {
@@ -116,6 +115,15 @@ pub fn main() {
             slint::init_translations!(concat!(env!("CARGO_MANIFEST_DIR"), "/../lang/"));
         })
     }
+    #[cfg(any(target_os = "android", target_arch = "wasm32"))]
+    main_window.global::<PrinterSettings>().on_change_language(|l| {
+        let lang = match l {
+            0 => "en",
+            1 => "fr",
+            _ => return,
+        };
+        slint::select_bundled_translation(lang).unwrap();
+    });
 
     main_window.run().unwrap();
 }


### PR DESCRIPTION
Part of #6793
