### PR TITLE
Prospective CI fix for warnings about unexpected cfg

### DIFF
--- a/api/node/build.rs
+++ b/api/node/build.rs
@@ -3,4 +3,7 @@
 
 fn main() {
     napi_build::setup();
+
+    // workaround bug that the `#[napi]` macro generate some invalid `#[cfg(feature="...")]`
+    println!("cargo:rustc-check-cfg=cfg(feature,values(\"noop\", \"used_linker\"))");
 }


### PR DESCRIPTION
```
error: unexpected `cfg` condition value: `noop`
  --> api/node/rust/lib.rs:17:1
   |
17 | #[napi]
   | ^^^^^^^
   |
   = note: expected values for `feature` are: `accessibility`, `backend-linuxkms`, `backend-linuxkms-noseat`, `backend-qt`, `backend-winit`, `backend-winit-wayland`, `backend-winit-x11`, `default`, `renderer-femtovg`, `renderer-skia`, `renderer-skia-opengl`, `renderer-skia-vulkan`, `renderer-software`, and `testing`
   = help: consider adding `noop` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `-D unexpected-cfgs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unexpected_cfgs)]`
   = note: this error originates in the attribute macro `napi` (in Nightly builds, run with -Z macro-backtrace for more info)

error: unexpected `cfg` condition value: `used_linker`
  --> api/node/rust/lib.rs:17:1
   |
17 | #[napi]
   | ^^^^^^^
   |
   = note: expected values for `feature` are: `accessibility`, `backend-linuxkms`, `backend-linuxkms-noseat`, `backend-qt`, `backend-winit`, `backend-winit-wayland`, `backend-winit-x11`, `default`, `renderer-femtovg`, `renderer-skia`, `renderer-skia-opengl`, `renderer-skia-vulkan`, `renderer-software`, and `testing`
   = help: consider adding `used_linker` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: this error originates in the attribute macro `napi::bindgen_prelude::ctor` (in Nightly builds, run with -Z macro-backtrace for more info)a

...
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
