### PR TITLE
Fix calling init to all the items on a ListView

### DIFF
--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1032,6 +1032,8 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
         let first_item_y = inner.anchor_y;
         let last_item_bottom = first_item_y + element_height * inner.instances.len() as Coord;
 
+        let mut indices_to_init = Vec::new();
+
         let (mut new_offset, mut new_offset_y) = if first_item_y > -vp_y + one_and_a_half_screen
             || last_item_bottom + element_height < -vp_y
         {
@@ -1044,10 +1046,11 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
             let mut it_y = first_item_y;
             let mut new_offset = inner.offset;
             debug_assert!(it_y <= -vp_y); // we scrolled down, the anchor should be hidden
-            for c in inner.instances.iter_mut() {
+            for (i, c) in inner.instances.iter_mut().enumerate() {
                 if c.0 == RepeatedInstanceState::Dirty {
                     if c.1.is_none() {
                         c.1 = Some(init());
+                        indices_to_init.push(i);
                     }
                     if let Some(data) = model.row_data(new_offset) {
                         c.1.as_ref().unwrap().update(new_offset, data);
@@ -1093,6 +1096,10 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
                 new_instances.push(new_instance);
             }
             if !new_instances.is_empty() {
+                for x in &mut indices_to_init {
+                    *x += new_instances.len();
+                }
+                indices_to_init.extend(0..new_instances.len());
                 inner.instances.splice(
                     0..0,
                     new_instances
@@ -1117,6 +1124,7 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
                 if c.0 == RepeatedInstanceState::Dirty {
                     if c.1.is_none() {
                         c.1 = Some(init());
+                        indices_to_init.push(instances_begin + idx - new_offset)
                     }
                     if let Some(data) = model.row_data(idx) {
                         c.1.as_ref().unwrap().update(idx, data);
@@ -1139,6 +1147,7 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
                     new_instance.update(idx, data);
                 }
                 new_instance.as_pin_ref().listview_layout(&mut y, viewport_width);
+                indices_to_init.push(inner.instances.len());
                 inner.instances.push((RepeatedInstanceState::Clean, Some(new_instance)));
                 idx += 1;
             }
@@ -1153,10 +1162,19 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
             if new_offset != inner.offset {
                 let instances_begin = new_offset - inner.offset;
                 inner.instances.splice(0..instances_begin, core::iter::empty());
+                indices_to_init.retain_mut(|idx| {
+                    if *idx < instances_begin {
+                        false
+                    } else {
+                        *idx -= instances_begin;
+                        true
+                    }
+                });
                 inner.offset = new_offset;
             }
             if inner.instances.len() != idx - new_offset {
                 inner.instances.splice(idx - new_offset.., core::iter::empty());
+                indices_to_init.retain(|x| *x < idx - new_offset);
             }
 
             if inner.instances.is_empty() {
@@ -1171,6 +1189,11 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
             viewport_y.set(new_viewport_y);
             inner.previous_viewport_y = new_viewport_y;
             break;
+        }
+        drop(inner);
+        let inner = self.0.inner.borrow();
+        for item in indices_to_init.into_iter().filter_map(|index| inner.instances.get(index)) {
+            item.1.as_ref().unwrap().init();
         }
     }
 

--- a/tests/cases/callbacks/init_listview.slint
+++ b/tests/cases/callbacks/init_listview.slint
@@ -1,0 +1,91 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Verify that the init callback is invoked in the correct order
+
+
+import { ListView } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+    in-out property <string> result;
+    lv := ListView {
+        for idx in 30 : Rectangle {
+            height: 100px;
+            init => { result += "(" + idx + ")"; }
+        }
+    }
+    in-out property scroll <=> lv.viewport-y;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_result(), "(0)(1)(2)");
+instance.set_result("".into());
+instance.set_scroll(-150.);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_result(), "(3)(4)");
+instance.set_result("".into());
+instance.set_scroll(-1000.);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_result(), "(10)(11)(12)");
+instance.set_result("".into());
+instance.set_scroll(-850.);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_result(), "(8)(9)");
+
+
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+slint_testing::send_mouse_click(&instance, 5., 5.);
+
+// FIXME: In C++ ensure_updated_listview doesn't do the smart way to only instentiate visible items
+assert_eq(instance.get_result(), "(0)(1)(2)(3)(4)(5)(6)(7)(8)(9)(10)(11)(12)(13)(14)(15)(16)(17)(18)(19)(20)(21)(22)(23)(24)(25)(26)(27)(28)(29)");
+if(false) {
+
+assert_eq(instance.get_result(), "(0)(1)(2)");
+instance.set_result("");
+instance.set_scroll(-150.);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_result(), "(3)(4)");
+instance.set_result("");
+instance.set_scroll(-1000.);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_result(), "(10)(11)(12)");
+instance.set_result("");
+instance.set_scroll(-850.);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_result(), "(8)(9)");
+
+}
+```
+
+
+```js
+var instance = new slint.TestCase({});
+
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+assert.equal(instance.result, "(0)(1)(2)");
+instance.result = "";
+instance.scroll = -150.;
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+assert.equal(instance.result, "(3)(4)");
+instance.result = "";
+instance.scroll = -1000.;
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+assert.equal(instance.result, "(10)(11)(12)");
+instance.result = "";
+instance.scroll = -850.;
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+assert.equal(instance.result, "(8)(9)");
+```
+
+
+*/


### PR DESCRIPTION
This also fix changed event not working as they rely on the init to the setup

Fixes #6836

ChangeLog: fix init and changed callback not always being called in ListView
