### PR TITLE
Add API to set the XDG app id

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -1522,4 +1522,13 @@ void blocking_invoke_from_event_loop(Functor f)
 #    endif
 #endif
 
+/// Sets the application id for use on Wayland or X11 with
+/// [xdg](https://specifications.freedesktop.org/desktop-entry-spec/latest/) compliant window
+/// managers. This must be set before the window is shown.
+inline void set_xdg_app_id(const SharedString &xdg_app_id)
+{
+    private_api::assert_main_thread();
+    cbindgen_private::slint_set_xdg_app_id(&xdg_app_id);
+}
+
 } // namespace slint

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -214,3 +214,10 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 }
 #[cfg(feature = "esp-backtrace")]
 use esp_backtrace as _;
+
+#[no_mangle]
+pub unsafe extern "C" fn slint_set_xdg_app_id(_app_id: &SharedString) {
+    #[cfg(feature = "i-slint-backend-selector")]
+    i_slint_backend_selector::with_global_context(|ctx| ctx.set_xdg_app_id(_app_id.clone()))
+        .unwrap();
+}

--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -94,6 +94,12 @@ pub fn init_translations(domain: String, dir_name: String) -> napi::Result<()> {
         .map_err(|e| napi::Error::from_reason(e.to_string()))
 }
 
+#[napi]
+pub fn set_xdg_app_id(app_id: String) -> napi::Result<()> {
+    i_slint_backend_selector::with_global_context(|ctx| ctx.set_xdg_app_id(app_id.into()))
+        .map_err(|e| napi::Error::from_reason(e.to_string()))
+}
+
 pub fn print_to_console(env: Env, function: &str, arguments: core::fmt::Arguments) {
     let Ok(global) = env.get_global() else {
         eprintln!("Unable to obtain global object");

--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -953,6 +953,14 @@ export function initTranslations(domain: string, path: string | URL) {
 }
 
 /**
+ * Sets the application id for use on Wayland or X11 with [xdg](https://specifications.freedesktop.org/desktop-entry-spec/latest/)
+ * compliant window managers. This must be set before the window is shown.
+ */
+export function setXdgAppId(app_id: string) {
+    napi.setXdgAppId(app_id);
+}
+
+/**
  * @hidden
  */
 export namespace private_api {

--- a/api/python/lib.rs
+++ b/api/python/lib.rs
@@ -20,6 +20,11 @@ fn quit_event_loop() -> Result<(), errors::PyEventLoopError> {
     slint_interpreter::quit_event_loop().map_err(|e| e.into())
 }
 
+#[pyfunction]
+fn set_xdg_app_id(app_id: String) -> Result<(), errors::PyPlatformError> {
+    slint_interpreter::set_xdg_app_id(app_id).map_err(|e| e.into())
+}
+
 use pyo3::prelude::*;
 
 #[pymodule]
@@ -44,6 +49,7 @@ fn slint(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<value::PyStruct>()?;
     m.add_function(wrap_pyfunction!(run_event_loop, m)?)?;
     m.add_function(wrap_pyfunction!(quit_event_loop, m)?)?;
+    m.add_function(wrap_pyfunction!(set_xdg_app_id, m)?)?;
 
     Ok(())
 }

--- a/api/python/slint/__init__.py
+++ b/api/python/slint/__init__.py
@@ -317,3 +317,6 @@ Model = models.Model
 Timer = native.Timer
 TimerMode = native.TimerMode
 Struct = native.PyStruct
+
+def set_xdg_app_id(app_id: str):
+    native.set_xdg_app_id(app_id)

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1799,6 +1799,15 @@ impl WindowAdapter for QtWindow {
     }
 
     fn set_visible(&self, visible: bool) -> Result<(), PlatformError> {
+        if let Some(xdg_app_id) = WindowInner::from_pub(&self.window)
+            .xdg_app_id()
+            .map(|s| qttypes::QString::from(s.as_str()))
+        {
+            cpp! {unsafe [xdg_app_id as "QString"] {
+                QGuiApplication::setDesktopFileName(xdg_app_id);
+            }};
+        }
+
         if visible {
             let widget_ptr = self.widget_ptr();
             cpp! {unsafe [widget_ptr as "QWidget*"] {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -1098,3 +1098,12 @@ impl std::error::Error for PlatformError {
 fn error_is_send() {
     let _: Box<dyn std::error::Error + Send + Sync + 'static> = PlatformError::NoPlatform.into();
 }
+
+/// Sets the application id for use on Wayland or X11 with [xdg](https://specifications.freedesktop.org/desktop-entry-spec/latest/)
+/// compliant window managers. This must be set before the window is shown, and has only an effect on Wayland or X11.
+pub fn set_xdg_app_id(app_id: impl Into<SharedString>) -> Result<(), PlatformError> {
+    crate::context::with_global_context(
+        || Err(crate::platform::PlatformError::NoPlatform),
+        |ctx| ctx.set_xdg_app_id(app_id.into()),
+    )
+}

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1249,6 +1249,11 @@ impl WindowInner {
         self.update_window_properties()
     }
 
+    /// Returns the (context global) xdg app id for use with wayland and x11.
+    pub fn xdg_app_id(&self) -> Option<SharedString> {
+        self.ctx.xdg_app_id()
+    }
+
     /// Returns the upgraded window adapter
     pub fn window_adapter(&self) -> Rc<dyn WindowAdapter> {
         self.window_adapter_weak.upgrade().unwrap()


### PR DESCRIPTION
ChangeLog: Added function to set the XDG app id on Wayland/X11. This needs to be added with respective function names in the language sections.

Fixes #1332

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
