### PR TITLE
Stop dependabot grouping large PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,16 +28,12 @@ updates:
       - dependency-name: "@types/node"
       - dependency-name: "@types/vscode"
     groups:
-      vscode_major:
+      codingame:
         patterns:
-          - "*"
-        update-types:
-          - "major"
-      vscode_minor_patch:
+          - "@codingame*"
+      vscode:
         patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+          - "vscode*"
+
      
     


### PR DESCRIPTION
Dependabot will no longer group the npm PR's into 2 huge patch and major PR's. Instead it will now create about 15 small pr's for each of the seperate dependancies. Some things are grouped such as the vscode engine libs and we can group more.

The thinking here is that when this PR lands dependabot will close the old PR's and open 10-20 new ones. Pretty much most of which we can approve right away and will not see again. But now the troublesome ones such as the node api test framework which we don't want to upate for now can be closed. Dependabot will then ignore that framework till a new update comes out.