### PR TITLE
Allow dependabot to raise more PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
+    open-pull-requests-limit: 20
     directory: /
     schedule:
       interval: weekly
@@ -20,6 +21,7 @@ updates:
     
 
   - package-ecosystem: "npm" # See documentation for possible values
+    open-pull-requests-limit: 20
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The previous limit was 5 and this is now raised to 20