### PR TITLE
live-preview: Elide text in the selection popup

### DIFF
--- a/tools/lsp/ui/components/selection-popup.slint
+++ b/tools/lsp/ui/components/selection-popup.slint
@@ -174,6 +174,7 @@ component PopupInner inherits Rectangle {
                     if !frame.is-in-root-component: Text {
                         x: EditorSpaceSettings.default-padding;
                         text: frame.file-name;
+                        overflow: elide;
                         color: frame.is-selected ? Palette.accent-foreground : Palette.foreground;
                         font-size: EditorFontSettings.label-sub.font-size - 3px;
                         font-italic: true;
@@ -278,6 +279,7 @@ component PopupInner inherits Rectangle {
 
                             if frame.id != "": Text {
                                 text: frame.id;
+                                overflow: elide;
                                 color: frame.is-selected ? Palette.accent-foreground : Palette.foreground;
                                 font-weight: EditorFontSettings.bold-font-weight;
                                 font-size: EditorFontSettings.label.font-size;
@@ -285,6 +287,7 @@ component PopupInner inherits Rectangle {
 
                             Text {
                                 text: frame.type-name + (frame.is-interactive ? " (TouchArea)" : "");
+                                overflow: elide;
                                 color: frame.is-selected ? Palette.accent-foreground : Palette.foreground;
                                 font-size: EditorFontSettings.label-sub.font-size;
                                 font-italic: true;


### PR DESCRIPTION
Just add eliding to all texts in the Selection Popup. I have not managed to reproduce the horizontal scaling issue yet, but this should fix it :-)
