### PR TITLE
LSP: fix reloading loaded dependencies

### DIFF
--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1304,6 +1304,21 @@ impl TypeLoader {
         Self::load_file_impl(&state, path, doc_node, is_builtin, &Default::default()).await;
     }
 
+    /// Reload a cached file
+    ///
+    /// The path must be canonical
+    pub async fn reload_cached_file(&mut self, path: &Path, diag: &mut BuildDiagnostics) {
+        let doc_node = {
+            let Some(LoadedDocument::Invalidated(doc_node)) = self.all_documents.docs.get(path)
+            else {
+                return;
+            };
+            doc_node.clone()
+        };
+        let state = RefCell::new(BorrowedTypeLoader { tl: self, diag });
+        Self::load_file_impl(&state, path, doc_node, false, &Default::default()).await;
+    }
+
     /// Load a file, and its dependency, running the full set of passes.
     ///
     /// the path must be the canonical path

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -282,6 +282,11 @@ impl DocumentCache {
         Ok(())
     }
 
+    pub async fn reload_cached_file(&mut self, url: &Url, diag: &mut BuildDiagnostics) {
+        let Some(path) = uri_to_file(url) else { return };
+        self.type_loader.reload_cached_file(&path, diag).await;
+    }
+
     pub fn drop_document(&mut self, url: &Url) -> Result<()> {
         let path = uri_to_file(url).ok_or("Failed to convert path")?;
         Ok(self.type_loader.drop_document(&path)?)

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -604,6 +604,12 @@ pub(crate) async fn reload_document_impl(
     let mut diag = BuildDiagnostics::default();
     let _ = document_cache.load_url(&url, version, content, &mut diag).await; // ignore url conversion errors
 
+    for dep in &dependencies {
+        if ctx.is_some_and(|ctx| ctx.open_urls.borrow().contains(dep)) {
+            document_cache.reload_cached_file(dep, &mut diag).await;
+        }
+    }
+
     // Always provide diagnostics for all files. Empty diagnostics clear any previous ones.
     let mut lsp_diags: HashMap<Url, Vec<lsp_types::Diagnostic>> =
         core::iter::once(Url::from_file_path(&path).unwrap())

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -170,6 +170,17 @@ impl ServerNotifier {
     pub fn send_message_to_lsp(&self, message: common::PreviewToLspMessage) {
         let _ = self.preview_to_lsp_sender.send(message);
     }
+
+    #[cfg(test)]
+    pub fn dummy() -> Self {
+        Self {
+            sender: crossbeam_channel::unbounded().0,
+            queue: Default::default(),
+            use_external_preview: Default::default(),
+            #[cfg(feature = "preview-engine")]
+            preview_to_lsp_sender: crossbeam_channel::unbounded().0,
+        }
+    }
 }
 
 impl RequestHandler {


### PR DESCRIPTION
The change in https://github.com/slint-ui/slint/pull/6747 invalidated the cache, but it was only reloaded when one of the dependent was reloaded. We need to reload the cache for all open file so that LSP feature continue to work on open document even if they get no changes
