### PR TITLE
live-preview: Handle cache invalidation better

### DIFF
--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1233,7 +1233,7 @@ impl TypeLoader {
                 Ok(source) => syntax_nodes::Document::new(crate::parser::parse(
                     source,
                     Some(&path_canon),
-                    &mut state.borrow_mut().diag,
+                    state.borrow_mut().diag,
                 )),
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                     state.borrow_mut().diag.push_error(

--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -353,7 +353,7 @@ fn insert_position_at_end(
         };
 
         let url = lsp_types::Url::from_file_path(node.source_file.path()).ok()?;
-        let (version, _) = preview::get_url_from_cache(&url)?;
+        let (version, _) = preview::get_url_from_cache(&url);
 
         Some(InsertInformation {
             insertion_position: common::VersionedPosition::new(
@@ -411,7 +411,7 @@ fn insert_position_before_child(
             };
 
             let url = lsp_types::Url::from_file_path(child_node.source_file.path()).ok()?;
-            let (version, _) = preview::get_url_from_cache(&url)?;
+            let (version, _) = preview::get_url_from_cache(&url);
 
             return Some(InsertInformation {
                 insertion_position: common::VersionedPosition::new(


### PR DESCRIPTION
The live preview refreshed itself way too often, e.g. sometimes when the selection changed.

This was caused by the editor switching to a different file. Doing so it invalidates the current file and then changes and sets contents for the new file. The invalidation of a buffer typically coused the preview to refresh.

So only mark the a file becoming invalidated as "from disk", but keep the contents. The LSP will send us fresh data read from disk as soon as it reads it from there. We only need to refresh *if* the source code from disk differs from the last version we got from the editor.