### PR TITLE
Use "C-unwind" API in our vtable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ slint-cpp = { version = "=1.12.0", path = "api/cpp", default-features = false }
 slint-interpreter = { version = "=1.12.0", path = "internal/interpreter", default-features = false }
 slint-macros = { version = "=1.12.0", path = "api/rs/macros", default-features = false }
 
-vtable = { version = "0.2", path = "helper_crates/vtable", default-features = false }
+vtable = { version = "0.2.1", path = "helper_crates/vtable", default-features = false }
 
 by_address = { version = "1.0.4" }
 bytemuck = { version = "1.13.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ slint-cpp = { version = "=1.12.0", path = "api/cpp", default-features = false }
 slint-interpreter = { version = "=1.12.0", path = "internal/interpreter", default-features = false }
 slint-macros = { version = "=1.12.0", path = "api/rs/macros", default-features = false }
 
-vtable = { version = "0.2.1", path = "helper_crates/vtable", default-features = false }
+vtable = { version = "0.3", path = "helper_crates/vtable" }
 
 by_address = { version = "1.0.4" }
 bytemuck = { version = "1.13.1" }

--- a/helper_crates/vtable/CHANGELOG.md
+++ b/helper_crates/vtable/CHANGELOG.md
@@ -3,6 +3,10 @@
 # Changelog
 All notable changes to this crate will be documented in this file.
 
+## [0.3.0]
+
+ - Don't automatically add "extern C" to the function that do not have it.
+
 ## [0.2.1] - 2024-12-18
 
  - Fixed Warnings

--- a/helper_crates/vtable/Cargo.toml
+++ b/helper_crates/vtable/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "vtable"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ homepage = "https://slint.dev"
 [lib]
 
 [dependencies]
-vtable-macro = { version = "=0.2.1", path = "./macro" }
+vtable-macro = { version = "=0.3.0", path = "./macro" }
 const-field-offset = { version = "0.1", path = "../const-field-offset" }
 stable_deref_trait = { version = "1.2.0", default-features = false }
 portable-atomic = "1"

--- a/helper_crates/vtable/macro/Cargo.toml
+++ b/helper_crates/vtable/macro/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "vtable-macro"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Slint Developers <info@slint.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/helper_crates/vtable/src/lib.rs
+++ b/helper_crates/vtable/src/lib.rs
@@ -26,6 +26,7 @@ struct AnimalVTable {
     /// the self object.
     ///
     /// Note: the #[vtable] macro will automatically add `extern "C"` if that is missing.
+    /// (unless `no_extern` is specified)
     make_noise: fn(VRef<AnimalVTable>, i32) -> i32,
 
     /// if there is a 'drop' member, it is considered as the destructor.

--- a/helper_crates/vtable/src/lib.rs
+++ b/helper_crates/vtable/src/lib.rs
@@ -24,9 +24,6 @@ use vtable::*;
 struct AnimalVTable {
     /// pointer to a function that makes a noise.  The `VRef<AnimalVTable>` is the type of
     /// the self object.
-    ///
-    /// Note: the #[vtable] macro will automatically add `extern "C"` if that is missing.
-    /// (unless `no_extern` is specified)
     make_noise: fn(VRef<AnimalVTable>, i32) -> i32,
 
     /// if there is a 'drop' member, it is considered as the destructor.

--- a/helper_crates/vtable/tests/test_vtable.rs
+++ b/helper_crates/vtable/tests/test_vtable.rs
@@ -13,10 +13,10 @@ use vtable::*;
 /// This is the actual doc
 struct HelloVTable {
     foo: fn(VRef<'_, HelloVTable>, u32) -> u32,
-    foo_mut: fn(VRefMut<'_, HelloVTable>, u32) -> u32,
+    foo_mut: extern "C" fn(VRefMut<'_, HelloVTable>, u32) -> u32,
     construct: fn(*const HelloVTable, u32) -> VBox<HelloVTable>,
     assoc: fn(*const HelloVTable) -> isize,
-    with_lifetime: fn(VRef<'_, HelloVTable>) -> &'_ u32,
+    with_lifetime: extern "C-unwind" fn(VRef<'_, HelloVTable>) -> &'_ u32,
 
     drop: fn(VRefMut<'_, HelloVTable>),
 

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -20,15 +20,16 @@ mod htmlimage;
 mod svg;
 
 #[allow(missing_docs)]
-#[vtable::vtable]
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
+#[vtable::vtable(no_extern)]
 #[repr(C)]
 pub struct OpaqueImageVTable {
-    drop_in_place: fn(VRefMut<OpaqueImageVTable>) -> Layout,
-    dealloc: fn(&OpaqueImageVTable, ptr: *mut u8, layout: Layout),
+    drop_in_place: extern "C-unwind" fn(VRefMut<OpaqueImageVTable>) -> Layout,
+    dealloc: extern "C-unwind" fn(&OpaqueImageVTable, ptr: *mut u8, layout: Layout),
     /// Returns the image size
-    size: fn(VRef<OpaqueImageVTable>) -> IntSize,
+    size: extern "C-unwind" fn(VRef<OpaqueImageVTable>) -> IntSize,
     /// Returns a cache key
-    cache_key: fn(VRef<OpaqueImageVTable>) -> ImageCacheKey,
+    cache_key: extern "C-unwind" fn(VRef<OpaqueImageVTable>) -> ImageCacheKey,
 }
 
 #[cfg(feature = "svg")]

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -21,7 +21,7 @@ mod svg;
 
 #[allow(missing_docs)]
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-#[vtable::vtable(no_extern)]
+#[vtable::vtable]
 #[repr(C)]
 pub struct OpaqueImageVTable {
     drop_in_place: extern "C-unwind" fn(VRefMut<OpaqueImageVTable>) -> Layout,

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -41,7 +41,8 @@ impl From<IndexRange> for core::ops::Range<usize> {
 }
 
 /// A ItemTree is representing an unit that is allocated together
-#[vtable]
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
+#[vtable(no_extern)]
 #[repr(C)]
 pub struct ItemTreeVTable {
     /// Visit the children of the item at index `index`.
@@ -150,10 +151,10 @@ pub struct ItemTreeVTable {
     ),
 
     /// in-place destructor (for VRc)
-    pub drop_in_place: unsafe fn(VRefMut<ItemTreeVTable>) -> vtable::Layout,
+    pub drop_in_place: unsafe extern "C-unwind" fn(VRefMut<ItemTreeVTable>) -> vtable::Layout,
 
     /// dealloc function (for VRc)
-    pub dealloc: unsafe fn(&ItemTreeVTable, ptr: *mut u8, layout: vtable::Layout),
+    pub dealloc: unsafe extern "C-unwind" fn(&ItemTreeVTable, ptr: *mut u8, layout: vtable::Layout),
 }
 
 #[cfg(test)]
@@ -1047,8 +1048,9 @@ impl<'a> From<&'a [ItemTreeNode]> for ItemTreeNodeArray<'a> {
     }
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
+#[vtable(no_extern)]
 #[repr(C)]
-#[vtable]
 /// Object to be passed in visit_item_children method of the ItemTree.
 pub struct ItemVisitorVTable {
     /// Called for each child of the visited item
@@ -1057,14 +1059,14 @@ pub struct ItemVisitorVTable {
     /// as the parent's ItemTree.
     /// `index` is to be used again in the visit_item_children function of the ItemTree (the one passed as parameter)
     /// and `item` is a reference to the item itself
-    visit_item: fn(
+    visit_item: extern "C-unwind" fn(
         VRefMut<ItemVisitorVTable>,
         item_tree: &VRc<ItemTreeVTable, vtable::Dyn>,
         index: u32,
         item: Pin<VRef<ItemVTable>>,
     ) -> VisitChildrenResult,
     /// Destructor
-    drop: fn(VRefMut<ItemVisitorVTable>),
+    drop: extern "C-unwind" fn(VRefMut<ItemVisitorVTable>),
 }
 
 /// Type alias to `vtable::VRefMut<ItemVisitorVTable>`

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -42,7 +42,7 @@ impl From<IndexRange> for core::ops::Range<usize> {
 
 /// A ItemTree is representing an unit that is allocated together
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-#[vtable(no_extern)]
+#[vtable]
 #[repr(C)]
 pub struct ItemTreeVTable {
     /// Visit the children of the item at index `index`.
@@ -1049,7 +1049,7 @@ impl<'a> From<&'a [ItemTreeNode]> for ItemTreeNodeArray<'a> {
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-#[vtable(no_extern)]
+#[vtable]
 #[repr(C)]
 /// Object to be passed in visit_item_children method of the ItemTree.
 pub struct ItemVisitorVTable {

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -47,7 +47,7 @@ pub struct ItemTreeVTable {
     /// Visit the children of the item at index `index`.
     /// Note that the root item is at index 0, so passing 0 would visit the item under root (the children of root).
     /// If you want to visit the root item, you need to pass -1 as an index.
-    pub visit_children_item: extern "C" fn(
+    pub visit_children_item: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         index: isize,
         order: TraversalOrder,
@@ -55,17 +55,17 @@ pub struct ItemTreeVTable {
     ) -> VisitChildrenResult,
 
     /// Return a reference to an item using the given index
-    pub get_item_ref: extern "C" fn(
+    pub get_item_ref: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         index: u32,
     ) -> core::pin::Pin<VRef<ItemVTable>>,
 
     /// Return the range of indices below the dynamic `ItemTreeNode` at `index`
     pub get_subtree_range:
-        extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, index: u32) -> IndexRange,
+        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>, index: u32) -> IndexRange,
 
     /// Return the `ItemTreeRc` at `subindex` below the dynamic `ItemTreeNode` at `index`
-    pub get_subtree: extern "C" fn(
+    pub get_subtree: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         index: u32,
         subindex: usize,
@@ -75,7 +75,8 @@ pub struct ItemTreeVTable {
     /// Return the item tree that is defined by this `ItemTree`.
     /// The return value is an item weak because it can be null if there is no parent.
     /// And the return value is passed by &mut because ItemWeak has a destructor
-    pub get_item_tree: extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>) -> Slice<ItemTreeNode>,
+    pub get_item_tree:
+        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>) -> Slice<ItemTreeNode>,
 
     /// Return the node this ItemTree is a part of in the parent ItemTree.
     ///
@@ -83,34 +84,38 @@ pub struct ItemTreeVTable {
     /// And the return value is passed by &mut because ItemWeak has a destructor
     /// Note that the returned value will typically point to a repeater node, which is
     /// strictly speaking not an Item at all!
-    pub parent_node: extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, result: &mut ItemWeak),
+    pub parent_node:
+        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>, result: &mut ItemWeak),
 
     /// This embeds this ItemTree into the item tree of another ItemTree
     ///
     /// Returns `true` if this ItemTree was embedded into the `parent`
     /// at `parent_item_tree_index`.
-    pub embed_component: extern "C" fn(
+    pub embed_component: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         parent: &VWeak<ItemTreeVTable>,
         parent_item_tree_index: u32,
     ) -> bool,
 
     /// Return the index of the current subtree or usize::MAX if this is not a subtree
-    pub subtree_index: extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>) -> usize,
+    pub subtree_index: extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>) -> usize,
 
     /// Returns the layout info for the root of the ItemTree
-    pub layout_info: extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, Orientation) -> LayoutInfo,
+    pub layout_info:
+        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>, Orientation) -> LayoutInfo,
 
     /// Returns the item's geometry (relative to its parent item)
     pub item_geometry:
-        extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, item_index: u32) -> LogicalRect,
+        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>, item_index: u32) -> LogicalRect,
 
     /// Returns the accessible role for a given item
-    pub accessible_role:
-        extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, item_index: u32) -> AccessibleRole,
+    pub accessible_role: extern "C-unwind" fn(
+        core::pin::Pin<VRef<ItemTreeVTable>>,
+        item_index: u32,
+    ) -> AccessibleRole,
 
     /// Returns the accessible property via the `result`. Returns true if such a property exists.
-    pub accessible_string_property: extern "C" fn(
+    pub accessible_string_property: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         item_index: u32,
         what: AccessibleStringProperty,
@@ -118,27 +123,27 @@ pub struct ItemTreeVTable {
     ) -> bool,
 
     /// Executes an accessibility action.
-    pub accessibility_action: extern "C" fn(
+    pub accessibility_action: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         item_index: u32,
         action: &AccessibilityAction,
     ),
 
     /// Returns the supported accessibility actions.
-    pub supported_accessibility_actions: extern "C" fn(
+    pub supported_accessibility_actions: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         item_index: u32,
     ) -> SupportedAccessibilityAction,
 
     /// Add the `ElementName::id` entries of the given item
-    pub item_element_infos: extern "C" fn(
+    pub item_element_infos: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         item_index: u32,
         result: &mut SharedString,
     ) -> bool,
 
     /// Returns a Window, creating a fresh one if `do_create` is true.
-    pub window_adapter: extern "C" fn(
+    pub window_adapter: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         do_create: bool,
         result: &mut Option<WindowAdapterRc>,
@@ -1219,7 +1224,7 @@ pub(crate) mod ffi {
         index: isize,
         order: TraversalOrder,
         visitor: VRefMut<ItemVisitorVTable>,
-        visit_dynamic: extern "C" fn(
+        visit_dynamic: extern "C-unwind" fn(
             base: *const c_void,
             order: TraversalOrder,
             visitor: vtable::VRefMut<ItemVisitorVTable>,

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -118,7 +118,7 @@ pub struct ItemVTable {
     /// This function is called by the run-time after the memory for the item
     /// has been allocated and initialized. It will be called before any user specified
     /// bindings are set.
-    pub init: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>, my_item: &ItemRc),
+    pub init: extern "C-unwind" fn(core::pin::Pin<VRef<ItemVTable>>, my_item: &ItemRc),
 
     /// offset in bytes from the *const ItemImpl.
     /// isize::MAX  means None
@@ -127,7 +127,7 @@ pub struct ItemVTable {
     pub cached_rendering_data_offset: usize,
 
     /// We would need max/min/preferred size, and all layout info
-    pub layout_info: extern "C" fn(
+    pub layout_info: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         orientation: Orientation,
         window_adapter: &WindowAdapterRc,
@@ -138,7 +138,7 @@ pub struct ItemVTable {
     /// Then, depending on the return value, it is called for the children, and their children, then
     /// [`Self::input_event`] is called on the children, and finally [`Self::input_event`] is called
     /// on this item again.
-    pub input_event_filter_before_children: extern "C" fn(
+    pub input_event_filter_before_children: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
         window_adapter: &WindowAdapterRc,
@@ -146,28 +146,28 @@ pub struct ItemVTable {
     ) -> InputEventFilterResult,
 
     /// Handle input event for mouse and touch event
-    pub input_event: extern "C" fn(
+    pub input_event: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> InputEventResult,
 
-    pub focus_event: extern "C" fn(
+    pub focus_event: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &FocusEvent,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> FocusEventResult,
 
-    pub key_event: extern "C" fn(
+    pub key_event: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &KeyEvent,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> KeyEventResult,
 
-    pub render: extern "C" fn(
+    pub render: extern "C-unwind" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -112,7 +112,8 @@ pub enum RenderingResult {
 }
 
 /// Items are the nodes in the render tree.
-#[vtable]
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
+#[vtable(no_extern)]
 #[repr(C)]
 pub struct ItemVTable {
     /// This function is called by the run-time after the memory for the item

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -113,7 +113,7 @@ pub enum RenderingResult {
 
 /// Items are the nodes in the render tree.
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-#[vtable(no_extern)]
+#[vtable]
 #[repr(C)]
 pub struct ItemVTable {
     /// This function is called by the run-time after the memory for the item

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -22,15 +22,17 @@ use i_slint_core_macros::SlintElement;
 use vtable::{VRef, VRefMut};
 
 /// Interface for native menu and menubar
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 #[vtable::vtable]
 #[repr(C)]
 pub struct MenuVTable {
     /// destructor
-    drop: fn(VRefMut<MenuVTable>),
+    drop: extern "C-unwind" fn(VRefMut<MenuVTable>),
     /// Return the list of items for the sub menu (or the main menu of parent is None)
-    sub_menu: fn(VRef<MenuVTable>, Option<&MenuEntry>, &mut SharedVector<MenuEntry>),
+    sub_menu:
+        extern "C-unwind" fn(VRef<MenuVTable>, Option<&MenuEntry>, &mut SharedVector<MenuEntry>),
     /// Handler when the menu entry is activated
-    activate: fn(VRef<MenuVTable>, &MenuEntry),
+    activate: extern "C-unwind" fn(VRef<MenuVTable>, &MenuEntry),
 }
 
 struct ShadowTreeNode {

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -135,6 +135,7 @@ internal-json = ["dep:serde_json"]
 i-slint-compiler = { workspace = true }
 i-slint-common = { workspace = true }
 i-slint-core = { workspace = true, features = ["default", "rtti"] }
+i-slint-core-macros = { workspace = true }
 i-slint-backend-selector = { workspace = true, features = ["rtti"] }
 
 vtable = { workspace = true }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -705,7 +705,7 @@ impl ItemTreeDescription<'_> {
     }
 }
 
-extern "C" fn visit_children_item(
+extern "C-unwind" fn visit_children_item(
     component: ItemTreeRefPin,
     index: isize,
     order: TraversalOrder,
@@ -1845,7 +1845,10 @@ pub fn get_repeater_by_name<'a, 'id>(
     (rep_in_comp.offset.apply_pin(instance_ref.instance), rep_in_comp.item_tree_to_repeat.clone())
 }
 
-extern "C" fn layout_info(component: ItemTreeRefPin, orientation: Orientation) -> LayoutInfo {
+extern "C-unwind" fn layout_info(
+    component: ItemTreeRefPin,
+    orientation: Orientation,
+) -> LayoutInfo {
     generativity::make_guard!(guard);
     // This is fine since we can only be called with a component that with our vtable which is a ItemTreeDescription
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
@@ -1875,7 +1878,7 @@ extern "C" fn layout_info(component: ItemTreeRefPin, orientation: Orientation) -
     result
 }
 
-unsafe extern "C" fn get_item_ref(component: ItemTreeRefPin, index: u32) -> Pin<ItemRef> {
+unsafe extern "C-unwind" fn get_item_ref(component: ItemTreeRefPin, index: u32) -> Pin<ItemRef> {
     let tree = get_item_tree(component);
     match &tree[index as usize] {
         ItemTreeNode::Item { item_array_index, .. } => {
@@ -1890,7 +1893,7 @@ unsafe extern "C" fn get_item_ref(component: ItemTreeRefPin, index: u32) -> Pin<
     }
 }
 
-extern "C" fn get_subtree_range(component: ItemTreeRefPin, index: u32) -> IndexRange {
+extern "C-unwind" fn get_subtree_range(component: ItemTreeRefPin, index: u32) -> IndexRange {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     if index as usize >= instance_ref.description.repeater.len() {
@@ -1919,7 +1922,7 @@ extern "C" fn get_subtree_range(component: ItemTreeRefPin, index: u32) -> IndexR
     }
 }
 
-extern "C" fn get_subtree(
+extern "C-unwind" fn get_subtree(
     component: ItemTreeRefPin,
     index: u32,
     subtree_index: usize,
@@ -1957,14 +1960,14 @@ extern "C" fn get_subtree(
     }
 }
 
-extern "C" fn get_item_tree(component: ItemTreeRefPin) -> Slice<ItemTreeNode> {
+extern "C-unwind" fn get_item_tree(component: ItemTreeRefPin) -> Slice<ItemTreeNode> {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     let tree = instance_ref.description.item_tree.as_slice();
     unsafe { core::mem::transmute::<&[ItemTreeNode], &[ItemTreeNode]>(tree) }.into()
 }
 
-extern "C" fn subtree_index(component: ItemTreeRefPin) -> usize {
+extern "C-unwind" fn subtree_index(component: ItemTreeRefPin) -> usize {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     if let Ok(value) = instance_ref.description.get_property(component, SPECIAL_PROPERTY_INDEX) {
@@ -1974,7 +1977,7 @@ extern "C" fn subtree_index(component: ItemTreeRefPin) -> usize {
     }
 }
 
-unsafe extern "C" fn parent_node(component: ItemTreeRefPin, result: &mut ItemWeak) {
+unsafe extern "C-unwind" fn parent_node(component: ItemTreeRefPin, result: &mut ItemWeak) {
     generativity::make_guard!(guard);
     let instance_ref = InstanceRef::from_pin_ref(component, guard);
 
@@ -2013,7 +2016,7 @@ unsafe extern "C" fn parent_node(component: ItemTreeRefPin, result: &mut ItemWea
     }
 }
 
-unsafe extern "C" fn embed_component(
+unsafe extern "C-unwind" fn embed_component(
     component: ItemTreeRefPin,
     parent_component: &ItemTreeWeak,
     parent_item_tree_index: u32,
@@ -2043,7 +2046,7 @@ unsafe extern "C" fn embed_component(
     extra_data.embedding_position.set((parent_component.clone(), parent_item_tree_index)).is_ok()
 }
 
-extern "C" fn item_geometry(component: ItemTreeRefPin, item_index: u32) -> LogicalRect {
+extern "C-unwind" fn item_geometry(component: ItemTreeRefPin, item_index: u32) -> LogicalRect {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
 
@@ -2065,7 +2068,7 @@ extern "C" fn item_geometry(component: ItemTreeRefPin, item_index: u32) -> Logic
 
 // silence the warning despite `AccessibleRole` is a `#[non_exhaustive]` enum from another crate.
 #[allow(improper_ctypes_definitions)]
-extern "C" fn accessible_role(component: ItemTreeRefPin, item_index: u32) -> AccessibleRole {
+extern "C-unwind" fn accessible_role(component: ItemTreeRefPin, item_index: u32) -> AccessibleRole {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     let nr = instance_ref.description.original_elements[item_index as usize]
@@ -2083,7 +2086,7 @@ extern "C" fn accessible_role(component: ItemTreeRefPin, item_index: u32) -> Acc
     }
 }
 
-extern "C" fn accessible_string_property(
+extern "C-unwind" fn accessible_string_property(
     component: ItemTreeRefPin,
     item_index: u32,
     what: AccessibleStringProperty,
@@ -2112,7 +2115,7 @@ extern "C" fn accessible_string_property(
     }
 }
 
-extern "C" fn accessibility_action(
+extern "C-unwind" fn accessibility_action(
     component: ItemTreeRefPin,
     item_index: u32,
     action: &AccessibilityAction,
@@ -2147,7 +2150,7 @@ extern "C" fn accessibility_action(
     };
 }
 
-extern "C" fn supported_accessibility_actions(
+extern "C-unwind" fn supported_accessibility_actions(
     component: ItemTreeRefPin,
     item_index: u32,
 ) -> SupportedAccessibilityAction {
@@ -2169,7 +2172,7 @@ extern "C" fn supported_accessibility_actions(
     val
 }
 
-extern "C" fn item_element_infos(
+extern "C-unwind" fn item_element_infos(
     component: ItemTreeRefPin,
     item_index: u32,
     result: &mut SharedString,
@@ -2183,7 +2186,7 @@ extern "C" fn item_element_infos(
     true
 }
 
-extern "C" fn window_adapter(
+extern "C-unwind" fn window_adapter(
     component: ItemTreeRefPin,
     do_create: bool,
     result: &mut Option<WindowAdapterRc>,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -705,6 +705,7 @@ impl ItemTreeDescription<'_> {
     }
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn visit_children_item(
     component: ItemTreeRefPin,
     index: isize,
@@ -1845,6 +1846,7 @@ pub fn get_repeater_by_name<'a, 'id>(
     (rep_in_comp.offset.apply_pin(instance_ref.instance), rep_in_comp.item_tree_to_repeat.clone())
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn layout_info(
     component: ItemTreeRefPin,
     orientation: Orientation,
@@ -1878,6 +1880,7 @@ extern "C-unwind" fn layout_info(
     result
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 unsafe extern "C-unwind" fn get_item_ref(component: ItemTreeRefPin, index: u32) -> Pin<ItemRef> {
     let tree = get_item_tree(component);
     match &tree[index as usize] {
@@ -1893,6 +1896,7 @@ unsafe extern "C-unwind" fn get_item_ref(component: ItemTreeRefPin, index: u32) 
     }
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn get_subtree_range(component: ItemTreeRefPin, index: u32) -> IndexRange {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
@@ -1922,6 +1926,7 @@ extern "C-unwind" fn get_subtree_range(component: ItemTreeRefPin, index: u32) ->
     }
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn get_subtree(
     component: ItemTreeRefPin,
     index: u32,
@@ -1960,6 +1965,7 @@ extern "C-unwind" fn get_subtree(
     }
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn get_item_tree(component: ItemTreeRefPin) -> Slice<ItemTreeNode> {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
@@ -1967,6 +1973,7 @@ extern "C-unwind" fn get_item_tree(component: ItemTreeRefPin) -> Slice<ItemTreeN
     unsafe { core::mem::transmute::<&[ItemTreeNode], &[ItemTreeNode]>(tree) }.into()
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn subtree_index(component: ItemTreeRefPin) -> usize {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
@@ -1977,6 +1984,7 @@ extern "C-unwind" fn subtree_index(component: ItemTreeRefPin) -> usize {
     }
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 unsafe extern "C-unwind" fn parent_node(component: ItemTreeRefPin, result: &mut ItemWeak) {
     generativity::make_guard!(guard);
     let instance_ref = InstanceRef::from_pin_ref(component, guard);
@@ -2016,6 +2024,7 @@ unsafe extern "C-unwind" fn parent_node(component: ItemTreeRefPin, result: &mut 
     }
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 unsafe extern "C-unwind" fn embed_component(
     component: ItemTreeRefPin,
     parent_component: &ItemTreeWeak,
@@ -2046,6 +2055,7 @@ unsafe extern "C-unwind" fn embed_component(
     extra_data.embedding_position.set((parent_component.clone(), parent_item_tree_index)).is_ok()
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn item_geometry(component: ItemTreeRefPin, item_index: u32) -> LogicalRect {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
@@ -2068,6 +2078,7 @@ extern "C-unwind" fn item_geometry(component: ItemTreeRefPin, item_index: u32) -
 
 // silence the warning despite `AccessibleRole` is a `#[non_exhaustive]` enum from another crate.
 #[allow(improper_ctypes_definitions)]
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn accessible_role(component: ItemTreeRefPin, item_index: u32) -> AccessibleRole {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
@@ -2086,6 +2097,7 @@ extern "C-unwind" fn accessible_role(component: ItemTreeRefPin, item_index: u32)
     }
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn accessible_string_property(
     component: ItemTreeRefPin,
     item_index: u32,
@@ -2115,6 +2127,7 @@ extern "C-unwind" fn accessible_string_property(
     }
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn accessibility_action(
     component: ItemTreeRefPin,
     item_index: u32,
@@ -2150,6 +2163,7 @@ extern "C-unwind" fn accessibility_action(
     };
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn supported_accessibility_actions(
     component: ItemTreeRefPin,
     item_index: u32,
@@ -2172,6 +2186,7 @@ extern "C-unwind" fn supported_accessibility_actions(
     val
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn item_element_infos(
     component: ItemTreeRefPin,
     item_index: u32,
@@ -2186,6 +2201,7 @@ extern "C-unwind" fn item_element_infos(
     true
 }
 
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
 extern "C-unwind" fn window_adapter(
     component: ItemTreeRefPin,
     do_create: bool,
@@ -2200,14 +2216,22 @@ extern "C-unwind" fn window_adapter(
     }
 }
 
-unsafe extern "C" fn drop_in_place(component: vtable::VRefMut<ItemTreeVTable>) -> vtable::Layout {
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
+unsafe extern "C-unwind" fn drop_in_place(
+    component: vtable::VRefMut<ItemTreeVTable>,
+) -> vtable::Layout {
     let instance_ptr = component.as_ptr() as *mut Instance<'static>;
     let layout = (*instance_ptr).type_info().layout();
     dynamic_type::TypeInfo::drop_in_place(instance_ptr);
     layout.into()
 }
 
-unsafe extern "C" fn dealloc(_vtable: &ItemTreeVTable, ptr: *mut u8, layout: vtable::Layout) {
+#[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
+unsafe extern "C-unwind" fn dealloc(
+    _vtable: &ItemTreeVTable,
+    ptr: *mut u8,
+    layout: vtable::Layout,
+) {
     std::alloc::dealloc(ptr, layout.try_into().unwrap());
 }
 


### PR DESCRIPTION
When using rust, allow panics to cross the boundaries of our vtable traits. This avoids panic producing two backtrace with panic=unwind

This patch doesn't touch the ABI of out FFI interface, they stay extern "C", because if a panic or exception crosses these boundaries, we are in trouble. (Also, we have a panic=abort in our Cargo.toml anyway)
