### PR TITLE
Implement full-screen property for slint Window item

### DIFF
--- a/docs/astro/src/content/docs/reference/window/window.mdx
+++ b/docs/astro/src/content/docs/reference/window/window.mdx
@@ -18,6 +18,11 @@ or smaller. The initial width can be controlled with the `preferred-width` prope
 Whether the window should be placed above all other windows on window managers supporting it.
 </SlintProperty>
 
+### full-screen
+<SlintProperty propName="full-screen" typeName="bool" defaultValue="true if 'SLINT_FULLSCREEN' environment variable is set, otherwise false ">
+Whether to display the Window in full-screen mode. In full-screen mode the Window will occupy the entire screen, it will not be resizable, and it will not display the title bar.
+</SlintProperty>
+
 ### background
 <SlintProperty propName="background" typeName="brush" defaultValue="depends on the style">
 The background brush of the `Window`.

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -871,6 +871,7 @@ impl WindowAdapter for WinitWindowAdapter {
             } else {
                 winit_window_or_none.set_fullscreen(None);
             }
+            self.fullscreen.set(m);
         }
 
         let m = properties.is_maximized();

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -217,6 +217,7 @@ component WindowItem {
     in property <bool> no-frame;
     in property <length> resize-border-width;
     in property <bool> always-on-top;
+    in-out property <bool> full-screen;
     in property <string> default-font-family;
     in-out property <length> default-font-size; // <=> StyleMetrics.default-font-size  set in apply_default_properties_from_style
     in property <int> default-font-weight;

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -955,6 +955,7 @@ pub struct WindowItem {
     pub no_frame: Property<bool>,
     pub resize_border_width: Property<LogicalLength>,
     pub always_on_top: Property<bool>,
+    pub full_screen: Property<bool>,
     pub icon: Property<crate::graphics::Image>,
     pub default_font_family: Property<SharedString>,
     pub default_font_size: Property<LogicalLength>,
@@ -963,7 +964,10 @@ pub struct WindowItem {
 }
 
 impl Item for WindowItem {
-    fn init(self: Pin<&Self>, _self_rc: &ItemRc) {}
+    fn init(self: Pin<&Self>, _self_rc: &ItemRc) {
+        #[cfg(feature = "std")]
+        self.full_screen.set(std::env::var("SLINT_FULLSCREEN").is_ok());
+    }
 
     fn layout_info(
         self: Pin<&Self>,

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -332,7 +332,7 @@ impl<'a> WindowProperties<'a> {
 
     /// Returns true if the window should be shown fullscreen; false otherwise.
     pub fn is_fullscreen(&self) -> bool {
-        self.0.fullscreen.get()
+        self.0.is_fullscreen()
     }
 
     /// true if the window is in a maximized state, otherwise false
@@ -430,7 +430,6 @@ pub struct WindowInner {
     cursor_blinker: RefCell<pin_weak::rc::PinWeak<crate::input::TextCursorBlinker>>,
 
     pinned_fields: Pin<Box<WindowPinnedFields>>,
-    fullscreen: Cell<bool>,
     maximized: Cell<bool>,
     minimized: Cell<bool>,
 
@@ -488,10 +487,6 @@ impl WindowInner {
                     "i_slint_core::Window::text_input_focused",
                 ),
             }),
-            #[cfg(feature = "std")]
-            fullscreen: Cell::new(std::env::var("SLINT_FULLSCREEN").is_ok()),
-            #[cfg(not(feature = "std"))]
-            fullscreen: Cell::new(false),
             maximized: Cell::new(false),
             minimized: Cell::new(false),
             focus_item: Default::default(),
@@ -1232,13 +1227,19 @@ impl WindowInner {
 
     /// Returns if the window is currently maximized
     pub fn is_fullscreen(&self) -> bool {
-        self.fullscreen.get()
+        if let Some(window_item) = self.window_item() {
+            window_item.as_pin_ref().full_screen()
+        } else {
+            false
+        }
     }
 
     /// Set or unset the window to display fullscreen.
     pub fn set_fullscreen(&self, enabled: bool) {
-        self.fullscreen.set(enabled);
-        self.update_window_properties()
+        if let Some(window_item) = self.window_item() {
+            window_item.as_pin_ref().full_screen.set(enabled);
+            self.update_window_properties()
+        }
     }
 
     /// Returns if the window is currently maximized


### PR DESCRIPTION
Make it possible to programatically to switch to full-screen mode via a new property in the Windows item.
The SLINT_FULLSCREEN environment variable will default set this property to true. However settings this property in the slint code will override the SLINT_FULLSCREEN.

Fixes #6665

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
