### PR TITLE
docs:handle the console on Windows

### DIFF
--- a/docs/src/content/docs/platforms/desktop.mdx
+++ b/docs/src/content/docs/platforms/desktop.mdx
@@ -4,6 +4,8 @@ title: Desktop
 description: Desktop platforms on which Slint has been tested
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 Generally, Slint runs on Windows, macOS, and popular Linux distributions. The following tables
 cover versions that we specifically test. The general objective is to support the operating systems that
 are supported by their vendors at the time of a Slint version release.
@@ -14,6 +16,85 @@ are supported by their vendors at the time of a Slint version release.
 | ---------------- | ------------ |
 | Windows 10       | x86-64       |
 | Windows 11       | x86-64       |
+
+### Handle the console window
+
+When you run an application built by slint, a console window would show, by default ( see [/SUBSYSTEM (Specify Subsystem)](https://learn.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-170)).
+
+You could disable the console by specify window subsystem.
+
+<Tabs syncKey="dev-language">
+<TabItem label="Rust">
+
+Add the code to the top of .rs file which contains `fn main()`.
+
+```rust
+#![windows_subsystem = "windows"]
+```
+
+Or if you want to keep console output in debug mode:
+
+```rust
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+```
+</TabItem>
+<TabItem label="C++">
+
+Add link flag `/SUBSYSTEM:WINDOWS`. If you are using Visual Studio, follow the steps:
+
+1. Open the project's Property Pages dialog box. For details, see Set C++ compiler and build properties in Visual Studio.
+
+2. Select the Configuration Properties > Linker > System property page.
+
+3. Modify the SubSystem property, select "Window(/SUBSYSTEM:WINDOWS)".
+
+</TabItem>
+<TabItem label="Node.js">
+
+TODO: Add node.js
+</TabItem>
+</Tabs>
+
+Set subsystem to "windows" would lost stdout if you run the application from command line. If you want to deal with CLI, consider use `FreeConsole()` instead of flag subsystem.
+
+Here is a Rust example. The parent process should be "explorer.exe" if you run the application from desktop, or folder window, so we could free the console as we dont want to see it.
+
+```rust
+fn get_parent_process_name() -> Option<String> {
+    use sysinfo::{ProcessExt, System, SystemExt};
+
+    let current_pid = sysinfo::get_current_pid().unwrap();
+    let mut sys = System::new();
+    if sys.refresh_process(current_pid) {
+        if let Some(process) = sys.process(current_pid) {
+            if let Some(parent_pid) = process.parent() {
+                sys.refresh_process(parent_pid);
+                if let Some(parent_process) = sys.process(parent_pid) {
+                    return Some(parent_process.name().to_lowercase());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn main() {
+    let parent_process = get_parent_process_name();
+    let run_without_console = match &parent_process {
+        Some(s) if s == "explorer.exe" => true,
+        _ => false,
+    };
+
+    if run_without_console {
+        unsafe {
+            winapi::um::wincon::FreeConsole();
+        }
+    }
+}
+```
+
+See more details at [#3235](https://github.com/slint-ui/slint/issues/3235)
 
 ## macOS
 

--- a/docs/src/content/docs/platforms/desktop.mdx
+++ b/docs/src/content/docs/platforms/desktop.mdx
@@ -21,12 +21,12 @@ are supported by their vendors at the time of a Slint version release.
 
 When you run an application built by slint, a console window would show, by default ( see [/SUBSYSTEM (Specify Subsystem)](https://learn.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-170)).
 
-You could disable the console by specify window subsystem.
+You could disable the console by specify `WINDOWS` subsystem.
 
 <Tabs syncKey="dev-language">
 <TabItem label="Rust">
 
-Add the code to the top of .rs file which contains `fn main()`.
+Add the code to the top of .rs file which contains `fn main()`:
 
 ```rust
 #![windows_subsystem = "windows"]
@@ -40,13 +40,13 @@ Or if you want to keep console output in debug mode:
 </TabItem>
 <TabItem label="C++">
 
-Add link flag `/SUBSYSTEM:WINDOWS`. If you are using Visual Studio, follow the steps:
 
-1. Open the project's Property Pages dialog box. For details, see Set C++ compiler and build properties in Visual Studio.
+Select the `WINDOWS` subsystem by setting the [`WIN32_EXECUTABLE`](https://cmake.org/cmake/help/latest/prop_tgt/WIN32_EXECUTABLE.html#prop_tgt:WIN32_EXECUTABLE) target property on your executable target:
 
-2. Select the Configuration Properties > Linker > System property page.
-
-3. Modify the SubSystem property, select "Window(/SUBSYSTEM:WINDOWS)".
+```cmake
+add_executable(my_program ...)
+set_property(TARGET my_program APPEND PROPERTY WIN32_EXECUTABLE TRUE)
+```
 
 </TabItem>
 <TabItem label="Node.js">

--- a/docs/src/content/docs/platforms/desktop.mdx
+++ b/docs/src/content/docs/platforms/desktop.mdx
@@ -55,9 +55,9 @@ TODO: Add node.js
 </TabItem>
 </Tabs>
 
-Set subsystem to "windows" would lost stdout if you run the application from command line. If you want to deal with CLI, consider use `FreeConsole()` instead of flag subsystem.
+When running the application from the command line, if the subsystem is set to windows it will no longer output stdout. To get it back consider using `FreeConsole()`.
 
-Here is a Rust example. The parent process should be "explorer.exe" if you run the application from desktop, or folder window, so we could free the console as we dont want to see it.
+Here is a Rust example. It checks if the parent process is "explorer.exe" to ensure the console window is closed when opening the app via the normal windows GUI.
 
 ```rust
 fn get_parent_process_name() -> Option<String> {


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
Closes #3235. I left the Node.js example with TODO while I am not familiar with it.
