### PR TITLE
Speed up the home automation's lock screen

### DIFF
--- a/demos/home-automation/ui/components/mainView/mainScreen.slint
+++ b/demos/home-automation/ui/components/mainView/mainScreen.slint
@@ -97,6 +97,7 @@ export component MainScreen inherits Rectangle {
             y: 0;
             width: root.width;
             height: root.height;
+            cache-rendering-hint: door-component-loaded;
 
             navigation := Rectangle {
                 filterShadow := Rectangle {


### PR DESCRIPTION
Don't redraw the entire scene underneath every time the LEDs are animated. Instead, cache it into one large layer. The scene is reasonabley complex that this justifies the expense of the additional memory throughput.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
