### PR TITLE
LSP: Show the image when hovering an @image-url

### DIFF
--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -44,7 +44,7 @@ pub fn goto_definition(
             // FIXME: this goes to the enum definition instead of the value definition.
             goto_node(&*v.enumeration.node.as_ref()?)
         }
-        TokenInfo::FileName(f) => {
+        TokenInfo::FileName(f) | TokenInfo::Image(f) => {
             if let Some(doc) = document_cache.get_document_by_path(&f) {
                 let doc_node = doc.node.clone()?;
                 goto_node(&doc_node)
@@ -192,6 +192,7 @@ export component Test {
     // Jump to test.png image url
     let offset: TextSize = (source.find("\"test.png\"").unwrap() as u32).into();
     let token = crate::language::token_at_offset(&doc, offset + TextSize::new(1)).unwrap();
+
     assert_eq!(token.text(), "\"test.png\"");
     let def = goto_definition(&mut dc, token).unwrap();
     let link = first_link(&def);

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -42,6 +42,10 @@ pub fn get_tooltip(document_cache: &mut DocumentCache, token: SyntaxToken) -> Op
             kind: lsp_types::MarkupKind::Markdown,
             value: format!("`{}`", path.to_string_lossy()),
         },
+        TokenInfo::Image(path) => MarkupContent {
+            kind: lsp_types::MarkupKind::Markdown,
+            value: format!("![Image]({})", path.to_string_lossy()),
+        },
         // Todo: this can happen when there is some syntax error
         TokenInfo::LocalProperty(_) | TokenInfo::LocalCallback(_) => return None,
         TokenInfo::IncompleteNamedReference(el, name) => from_property_in_type(&el, &name)?,
@@ -269,7 +273,7 @@ export component Test {
             uri.join("test.png").unwrap().to_file_path().unwrap().to_string_lossy().to_string();
         assert_tooltip(
             get_tooltip(&mut dc, find_tk("@image-url(", 15.into())),
-            &format!("`{target_path}`"),
+            &format!("![Image]({target_path})"),
         );
 
         // enums

--- a/tools/lsp/language/token_info.rs
+++ b/tools/lsp/language/token_info.rs
@@ -20,6 +20,7 @@ pub enum TokenInfo {
     NamedReference(NamedReference),
     EnumerationValue(EnumerationValue),
     FileName(std::path::PathBuf),
+    Image(std::path::PathBuf),
     LocalProperty(syntax_nodes::PropertyDeclaration),
     LocalCallback(syntax_nodes::CallbackDeclaration),
     /// This is like a NamedReference, but the element doesn't have an ElementRc because
@@ -33,7 +34,7 @@ pub fn token_info(document_cache: &mut DocumentCache, token: SyntaxToken) -> Opt
         let path = i_slint_compiler::literals::unescape_string(token.text())?;
         let path = token.source_file.path().parent().map(|p| p.to_path_buf())?.join(path);
 
-        return Some(TokenInfo::FileName(path));
+        return Some(TokenInfo::Image(path));
     }
 
     loop {


### PR DESCRIPTION
Do not show the file name when hovering the string constant inside a @image-url, show the image instead.
