### PR TITLE
Fix panic in accesskit when focus change occurs before initial tree u…

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -100,7 +100,10 @@ impl AccessKitAdapter {
                 None
             }
             accesskit_winit::WindowEvent::ActionRequested(r) => self.handle_request(r),
-            accesskit_winit::WindowEvent::AccessibilityDeactivated => None,
+            accesskit_winit::WindowEvent::AccessibilityDeactivated => {
+                self.initial_tree_sent = false;
+                None
+            }
         }
     }
 


### PR DESCRIPTION
…pdate

This is a prospective fix to avoid sending `tree: None` as the first tree update.

Fixes #6015

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
