### PR TITLE
Improve keyboard navigation of `StandardListView`

### DIFF
--- a/internal/compiler/widgets/common/listview.slint
+++ b/internal/compiler/widgets/common/listview.slint
@@ -24,7 +24,6 @@ component StandardListViewBase inherits ListView {
 
         current-item = index;
         focus-item = index;
-        first-selection = true;
         current-item-changed(current-item);
     }
 
@@ -33,7 +32,7 @@ component StandardListViewBase inherits ListView {
     private property <length> into-view-item-y: root.item-y(root.into-view-item);
     private property <length> current-item-y: root.item-y(root.focus-item);
     private property <int> focus-item: 0;
-    private property <bool> first-selection: false;
+    private property <bool> has-item-been-selected: false;
 
     accessible-delegate-focus: root.focus-item;
     accessible-item-count: root.model.length;
@@ -71,11 +70,7 @@ component StandardListViewBase inherits ListView {
     }
 
     protected function focus-down() {
-        if (root.first-selection) {
-            root.set-focus-item(root.focus-item + 1);
-        } else {
-            root.select-focus-item();
-        }
+        root.set-focus-item(root.focus-item + 1);
     }
 
     protected function focus-last() {
@@ -87,7 +82,10 @@ component StandardListViewBase inherits ListView {
     }
 
     protected function focus-current-item() {
-        root.focus-item = max(0, root.current-item);
+        if root.current-item == -1 && !root.has-item-been-selected && root.model.length > 0 {
+            root.current-item = 0;
+        }
+        root.has-item-been-selected = true;
 
         if (root.current-item-y + root.item-height < 0
             || root.current-item-y > root.height) {

--- a/internal/compiler/widgets/common/listview.slint
+++ b/internal/compiler/widgets/common/listview.slint
@@ -24,6 +24,7 @@ component StandardListViewBase inherits ListView {
 
         current-item = index;
         focus-item = index;
+        first-selection = true;
         current-item-changed(current-item);
     }
 
@@ -32,6 +33,7 @@ component StandardListViewBase inherits ListView {
     private property <length> into-view-item-y: root.item-y(root.into-view-item);
     private property <length> current-item-y: root.item-y(root.focus-item);
     private property <int> focus-item: 0;
+    private property <bool> first-selection: false;
 
     accessible-delegate-focus: root.focus-item;
     accessible-item-count: root.model.length;
@@ -64,8 +66,20 @@ component StandardListViewBase inherits ListView {
         root.set-focus-item(root.focus-item - 1);
     }
 
+    protected function focus-first() {
+        root.set-focus-item(0);
+    }
+
     protected function focus-down() {
-       root.set-focus-item(root.focus-item + 1);
+        if (root.first-selection) {
+            root.set-focus-item(root.focus-item + 1);
+        } else {
+            root.select-focus-item();
+        }
+    }
+
+    protected function focus-last() {
+        root.set-focus-item(root.model.length - 1);
     }
 
     protected function select-focus-item() {
@@ -78,6 +92,14 @@ component StandardListViewBase inherits ListView {
         if (root.current-item-y + root.item-height < 0
             || root.current-item-y > root.height) {
                 root.focus-item = root.first-visible-item();
+        }
+    }
+
+    protected function toggle-focus-item-selection() {
+        if (root.current-item == root.focus-item) {
+            root.current-item = -1;
+        } else {
+            root.select-focus-item();
         }
     }
 
@@ -127,12 +149,34 @@ export component StandardListView inherits StandardListViewBase {
         key-pressed(event) => {
             if (event.text == Key.UpArrow) {
                 root.focus-up();
+                if (!event.modifiers.control) {
+                    root.select-focus-item();
+                }
+                return accept;
+            } else if (event.text == Key.Home) {
+                root.focus-first();
+                if (!event.modifiers.control) {
+                    root.select-focus-item();
+                }
                 return accept;
             } else if (event.text == Key.DownArrow) {
                 root.focus-down();
+                if (!event.modifiers.control) {
+                    root.select-focus-item();
+                }
                 return accept;
-            }else if (event.text == Key.Return) {
-                root.select-focus-item();
+            } else if (event.text == Key.End) {
+                root.focus-last();
+                if (!event.modifiers.control) {
+                    root.select-focus-item();
+                }
+                return accept;
+            } else if (event.text == Key.Space) {
+                if (event.modifiers.control) {
+                    root.toggle-focus-item-selection();
+                } else {
+                    root.select-focus-item();
+                }
                 return accept;
             }
             reject

--- a/internal/compiler/widgets/common/listview.slint
+++ b/internal/compiler/widgets/common/listview.slint
@@ -41,8 +41,16 @@ component StandardListViewBase inherits ListView {
         return min(root.model.length - 1, max(0, round(-root.viewport-y / root.item-height)));
     }
 
+    pure function last-visible-item() -> int {
+        return min(root.model.length - 1, max(0, round((-root.viewport-y + root.height - root.item-height) / root.item-height)));
+    }
+
     pure function item-y(index: int) -> length {
         return root.viewport-y + index * root.item-height;
+    }
+
+    pure function item-at-y(y: length) -> int {
+        return min(root.model.length - 1, max(0, round(y / root.item-height)));
     }
 
     function bring-into-view(index: int) {
@@ -65,12 +73,28 @@ component StandardListViewBase inherits ListView {
         root.set-focus-item(root.focus-item - 1);
     }
 
+    protected function focus-page-up() {
+        if root.focus-item != root.first-visible-item() {
+            root.set-focus-item(root.first-visible-item())
+        } else {
+            root.set-focus-item(root.item-at-y(root.item-y(root.first-visible-item()) - root.height));
+        }
+    }
+
     protected function focus-first() {
         root.set-focus-item(0);
     }
 
     protected function focus-down() {
         root.set-focus-item(root.focus-item + 1);
+    }
+
+    protected function focus-page-down() {
+        if root.focus-item != root.last-visible-item() {
+            root.set-focus-item(root.last-visible-item())
+        } else {
+            root.set-focus-item(root.item-at-y(root.item-y(root.last-visible-item()) + root.height));
+        }
     }
 
     protected function focus-last() {
@@ -83,7 +107,7 @@ component StandardListViewBase inherits ListView {
 
     protected function focus-current-item() {
         if root.current-item == -1 && !root.has-item-been-selected && root.model.length > 0 {
-            root.current-item = 0;
+            root.set-current-item(0);
         }
         root.has-item-been-selected = true;
 
@@ -151,6 +175,12 @@ export component StandardListView inherits StandardListViewBase {
                     root.select-focus-item();
                 }
                 return accept;
+            } else if (event.text == Key.PageUp) {
+                root.focus-page-up();
+                if (!event.modifiers.control) {
+                    root.select-focus-item();
+                }
+                return accept;
             } else if (event.text == Key.Home) {
                 root.focus-first();
                 if (!event.modifiers.control) {
@@ -159,6 +189,12 @@ export component StandardListView inherits StandardListViewBase {
                 return accept;
             } else if (event.text == Key.DownArrow) {
                 root.focus-down();
+                if (!event.modifiers.control) {
+                    root.select-focus-item();
+                }
+                return accept;
+            } else if (event.text == Key.PageDown) {
+                root.focus-page-down();
                 if (!event.modifiers.control) {
                     root.select-focus-item();
                 }

--- a/tests/cases/widgets/listview.slint
+++ b/tests/cases/widgets/listview.slint
@@ -3,7 +3,7 @@
 
 import { StandardListView } from "std-widgets.slint";
 
-TestCase := Rectangle {
+export component TestCase inherits Window {
     callback set-current-item(int);
 
     out property <int> count: list.model.length;
@@ -15,6 +15,7 @@ TestCase := Rectangle {
         { text: "Item 3" },
     ];
     in-out property <int> current-item <=> list.current-item;
+    out property has-focus <=> list.has-focus;
 
     list := StandardListView {
         model: root.model;
@@ -33,6 +34,9 @@ TestCase := Rectangle {
 /*
 
 ```rust
+use slint::platform::Key;
+use slint::SharedString;
+
 let instance = TestCase::new().unwrap();
 assert_eq!(instance.get_count(), 3);
 assert_eq!(instance.get_current_item(), -1);
@@ -47,5 +51,78 @@ instance.invoke_set_current_item(1);
 assert_eq!(instance.get_callback_current_item(), -1);
 assert_eq!(instance.get_current_item(), 1);
 
+instance.invoke_set_current_item(0);
+assert_eq!(instance.get_has_focus(), false);
+
+// Focus the listview
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Tab));
+assert_eq!(instance.get_has_focus(), true);
+assert_eq!(instance.get_current_item(), 0);
+
+// Up and Down arrow keys move the selection
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::UpArrow));
+assert_eq!(instance.get_current_item(), 0);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
+assert_eq!(instance.get_current_item(), 1);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
+assert_eq!(instance.get_current_item(), 2);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
+assert_eq!(instance.get_current_item(), 2);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::UpArrow));
+assert_eq!(instance.get_current_item(), 1);
+
+// Pressing the Home key selects the first item
+instance.invoke_set_current_item(2);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Home));
+assert_eq!(instance.get_current_item(), 0);
+
+// Pressing the End key selects the last item
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::End));
+assert_eq!(instance.get_current_item(), 2);
+
+// Pressing the space bar on the selected item does not deselect it
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Space));
+assert_eq!(instance.get_current_item(), 2);
+
+// Control+Space deselects the currently focused item
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Space));
+assert_eq!(instance.get_current_item(), -1);
+
+// Control+Space selects the currently focused item
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Space));
+assert_eq!(instance.get_current_item(), 2);
+
+// Control+UpArrow moves the focus up one item but not the selection
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::UpArrow));
+assert_eq!(instance.get_current_item(), 2);
+
+// Pressing the space bar selects the currently focused item if it is not
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Space));
+assert_eq!(instance.get_current_item(), 1);
+
+// Control+DownArrow moves the focus down one item but not the selection
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
+assert_eq!(instance.get_current_item(), 1);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Space));
+assert_eq!(instance.get_current_item(), 2);
+
+// Control+Home moves the focus to the first item but not the selection
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Home));
+assert_eq!(instance.get_current_item(), 2);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Space));
+assert_eq!(instance.get_current_item(), 0);
+
+// Control+End moves the focus to the last item but not the selection
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::End));
+assert_eq!(instance.get_current_item(), 0);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Space));
+assert_eq!(instance.get_current_item(), 2);
 ```
+
 */


### PR DESCRIPTION
Implements keyboard navigation inside `StandardListView` widgets. The reference is [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role). The only deviation is around this:

> When a list is tabbed to, the first item in the list will be selected if nothing else already is.

Native platforms typically don't select the first item when a list view is tabbed into if no item was previously selected, and use of the down arrow won't move the focus and selection down on first key press.

`PageUp` and `PageDown` will have to be implemented at some point. They are used to move the focus and select the first or last item currently visible, and will scroll until bounds are reached if pressed multiple times.

I am also aware that Slint widgets are activated when the `Return` key is pressed, but the space bar is more widely used for this task. Some widgets such as buttons will accept both on some platforms, but list view items usually don't.