### PR TITLE
compiler: Warn user when immediately converting gradient macro to color

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1107,6 +1107,14 @@ impl Expression {
             self
         } else if ty.can_convert(&target_type) {
             let from = match (ty, &target_type) {
+                (Type::Brush, Type::Color) => match self {
+                    Expression::LinearGradient { .. } | Expression::RadialGradient { .. } => {
+                        let message = format!("Narrowing conversion from {0} to {1}. This can lead to unexpected behavior because the {0} is a gradient", Type::Brush, Type::Color);
+                        diag.push_warning(message, node);
+                        self
+                    }
+                    _ => self,
+                },
                 (Type::Percent, Type::Float32) => Expression::BinaryExpression {
                     lhs: Box::new(self),
                     rhs: Box::new(Expression::NumberLiteral(0.01, Unit::None)),

--- a/internal/compiler/tests/syntax/basic/linear-gradient.slint
+++ b/internal/compiler/tests/syntax/basic/linear-gradient.slint
@@ -29,4 +29,6 @@ export X := Rectangle {
 //                                                             ^error{Unknown unqualified identifier 'r'}
     property <brush> g15: @linear-gradient(90deg, brown o, green); // #3241
 //                                                      ^error{Unknown unqualified identifier 'o'}
+    property<color> g16: @linear-gradient(0deg, red, green, blue); // #6819
+//                       ^warning{Narrowing conversion from brush to color. This can lead to unexpected behavior because the brush is a gradient}
 }

--- a/internal/compiler/tests/syntax/basic/radial-gradient.slint
+++ b/internal/compiler/tests/syntax/basic/radial-gradient.slint
@@ -25,4 +25,7 @@ export X := Rectangle {
     property<brush> g11: @radial-gradient(circle,);
 
     property<brush> g12: @radial-gradient(circle);
+
+    property<color> g13: @radial-gradient(circle, red, green, blue); // #6819
+//                       ^warning{Narrowing conversion from brush to color. This can lead to unexpected behavior because the brush is a gradient}
 }


### PR DESCRIPTION
Fixes #6819

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
