### PR TITLE
Tweak API references links

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -256,21 +256,16 @@ export default defineConfig({
                                         attrs: { target: "_blank" },
                                     },
                                     {
-                                        label: "Python ↗",
-                                        badge: {
-                                            text: "beta",
-                                            variant: "caution",
-                                        },
-                                        link: "https://pypi.org/project/slint/",
-                                        attrs: { target: "_blank" },
-                                    },
-                                    {
                                         label: "Rust ↗",
                                         link: "https://docs.slint.dev/latest/docs/rust/slint/",
                                         attrs: { target: "_blank" },
                                     },
                                     {
                                         label: "TypeScript ↗",
+                                        badge: {
+                                            text: "beta",
+                                            variant: "caution",
+                                        },
                                         link: "https://docs.slint.dev/latest/docs/node/",
                                         attrs: { target: "_blank" },
                                     },

--- a/docs/src/content/docs/platforms/index.mdx
+++ b/docs/src/content/docs/platforms/index.mdx
@@ -13,13 +13,10 @@ Slint provides first class integrations to various programming languages allowin
   <IconLinkCard title="C++" href="https://docs.slint.dev/latest/docs/cpp/" icon="seti:cpp">
     Browse C++ API docs
   </IconLinkCard>
-  <IconLinkCard title="Python (beta)" href="https://pypi.org/project/slint/" icon="seti:python">
-    Browse Python API docs.
-  </IconLinkCard>
   <IconLinkCard title="Rust" href="https://docs.slint.dev/latest/docs/rust/slint/" icon="seti:rust">
     Browse Rust API docs
   </IconLinkCard>
-  <IconLinkCard title="TypeScript" href="https://docs.slint.dev/latest/docs/node/" icon="seti:typescript">
+  <IconLinkCard title="TypeScript (beta)" href="https://docs.slint.dev/latest/docs/node/" icon="seti:typescript">
     Browse TypeScript / JavaScript API docs.
   </IconLinkCard>
 </CardGrid>


### PR DESCRIPTION
- Remove Python as we don't have API docs yet
- Add the beta label to the JS integration (see #4471)

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
