### PR TITLE
Fix purity check for `focus()` on custom component

### DIFF
--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -289,9 +289,9 @@ pub fn run_import_passes(
 ) {
     infer_aliases_types::resolve_aliases(doc, diag);
     resolving::resolve_expressions(doc, type_loader, diag);
+    purity_check::purity_check(doc, diag);
     focus_handling::replace_forward_focus_bindings_with_focus_functions(doc, diag);
     check_expressions::check_expressions(doc, diag);
-    purity_check::purity_check(doc, diag);
     check_rotation::check_rotation(doc, diag);
     unique_id::check_unique_id(doc, diag);
 }

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -58,6 +58,7 @@ pub fn replace_forward_focus_bindings_with_focus_functions(
                                 arg_names: vec![],
                             })),
                             visibility: PropertyVisibility::Public,
+                            pure: Some(false),
                             ..Default::default()
                         },
                     );

--- a/internal/compiler/tests/syntax/fuzzing/6979.slint
+++ b/internal/compiler/tests/syntax/fuzzing/6979.slint
@@ -1,0 +1,16 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component SubElement {
+    forward_focus: input;
+    input := TextInput { }
+}
+
+export component TestCase {
+    pure callback focus_input2();
+    focus_input2 => {
+        input2.focus();
+//             ^error{Call of impure function}
+    }
+    input2 := SubElement { }
+}


### PR DESCRIPTION
Do the purity check before doing the transformation of the `focus()` function, so the source location of the error is the most accurate

Fixes #6979
