### PR TITLE
1.9 docs: Show snippet language

### DIFF
--- a/docs/ec.config.mjs
+++ b/docs/ec.config.mjs
@@ -44,12 +44,12 @@ function sideBorder() {
 }
 
 function remapLanguageIdentifiers(lang) {
-    switch(lang){
+    switch (lang) {
         case "cpp": {
-            return "C++"
+            return "C++";
         }
         case "sh": {
-            return "bash"
+            return "bash";
         }
         default: {
             return lang;
@@ -85,7 +85,9 @@ function languageLabel() {
                     context.renderData.blockAst.children[1].properties
                         .dataLanguage;
 
-                const label = h("div.language-label", {}, [remapLanguageIdentifiers(language)]);
+                const label = h("div.language-label", {}, [
+                    remapLanguageIdentifiers(language),
+                ]);
 
                 const ast = context.renderData.blockAst;
                 ast.children.push(label);

--- a/docs/ec.config.mjs
+++ b/docs/ec.config.mjs
@@ -43,6 +43,59 @@ function sideBorder() {
     });
 }
 
+function remapLanguageIdentifiers(lang) {
+    switch(lang){
+        case "cpp": {
+            return "C++"
+        }
+        case "sh": {
+            return "bash"
+        }
+        default: {
+            return lang;
+        }
+    }
+}
+
+function languageLabel() {
+    return definePlugin({
+        name: "Adds language label to code blocks",
+        baseStyles: `
+        .language-label {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            position: absolute;
+            inset-block-start: calc(var(--ec-brdWd) + var(--button-spacing));
+            inset-inline-end: calc(var(--ec-brdWd) + var(--ec-uiPadInl) );
+            direction: ltr;
+            font-size: 0.8rem;
+            color: #767676;
+            opacity: 1;
+            transition: opacity 0.3s;
+        }
+        div.expressive-code:hover .language-label,
+        .expressive-code:hover .language-label {
+            opacity: 0;
+        }
+        `,
+        hooks: {
+            postprocessRenderedBlock: async (context) => {
+                const language =
+                    context.renderData.blockAst.children[1].properties
+                        .dataLanguage;
+
+                const label = h("div.language-label", {}, [remapLanguageIdentifiers(language)]);
+
+                const ast = context.renderData.blockAst;
+                ast.children.push(label);
+
+                context.renderData.blockAst = ast;
+            },
+        },
+    });
+}
+
 function workersPlaygroundButton() {
     return definePlugin({
         name: "Adds 'Run in SlintPad' button to slint codeblocks",
@@ -114,7 +167,7 @@ function workersPlaygroundButton() {
 }
 
 export default {
-    plugins: [workersPlaygroundButton(), sideBorder()],
+    plugins: [workersPlaygroundButton(), sideBorder(), languageLabel()],
     themes: ["dark-plus", "light-plus"],
     styleOverrides: {
         borderRadius: "0.4rem",

--- a/docs/src/content/docs/guide/development/localization.md
+++ b/docs/src/content/docs/guide/development/localization.md
@@ -8,8 +8,6 @@ description: Localization
 
 Slint's translation infrastructure makes your application available in different languages.
 
-## Overview
-
 :::tip[Prerequisite]
 Install the `slint-tr-extractor` tool to extract translatable strings from `.slint` files:
 ```sh

--- a/docs/src/content/docs/tutorial/from_one_to_multiple_tiles.mdx
+++ b/docs/src/content/docs/tutorial/from_one_to_multiple_tiles.mdx
@@ -28,7 +28,7 @@ First, add the tile data structure definition at the top of the `ui/app-window.s
 
 import multipleTiles from '../../code/main_multiple_tiles.rs?raw'
 
-<Code code={extractLines(multipleTiles, 11, 15)} lang="rust" />
+<Code code={extractLines(multipleTiles, 11, 15)} lang="slint" />
 
 
 Next, replace the _export component <span class="hljs-title">MainWindow</span> inherits Window \{ ... \} section at the bottom of the `ui/app-window.slint` file with the following:

--- a/docs/src/content/docs/tutorial/memory_tile.mdx
+++ b/docs/src/content/docs/tutorial/memory_tile.mdx
@@ -22,7 +22,7 @@ Copy the following code into `ui/app-window.slint` file, replacing the current c
 
 import memoryTile from '../../code/memory_tile.slint?raw'
 
-<Code code={extractLines(memoryTile, 5, 19)} lang="slint" title="memory-tile.slint" />
+<Code code={extractLines(memoryTile, 5, 19)} lang="slint" />
 
 This exports the <span class="hljs-title">MainWindow</span> component so that the game logic code can access it later.
 
@@ -35,7 +35,7 @@ You need to install this icon and others you use later first. You can download a
 If you are on Linux or macOS, download and extract it with the following commands:
 
 <Tabs syncKey="dev-platform">
-<TabItem label="Windows">
+<TabItem label="Windows" icon="seti:windows">
 
 If you are on Windows, use the following commands:
 
@@ -47,7 +47,7 @@ cd ..
 ```
 This unpacks an `icons` directory containing several icons.
 </TabItem>
-<TabItem label="macOS">
+<TabItem label="macOS" icon="apple">
 ```sh title="Terminal"
 cd ui
 curl -O https://slint.dev/blog/memory-game-tutorial/icons.zip
@@ -75,12 +75,12 @@ This unpacks an `icons` directory containing several icons.
 Compiling the program with `cmake --build build` and running with the `./build/my_application` opens a window that shows the icon of a bus on a blue background.
 
 </TabItem>
-<TabItem label="NodeJS" icon="seti:javascript">
+<TabItem label="NodeJS">
 
 Running the program with `npm start` opens a window that shows the icon of a bus on a blue background.
 
 </TabItem>
-<TabItem label="Rust" icon="seti:rust">
+<TabItem label="Rust">
 
 Running the program with `cargo run` opens a window that shows the icon of a bus on a blue background.
 


### PR DESCRIPTION
The docs don't just have Slint language files. They have Rust, Cpp, Javascript, bash, etc files. This change shows a little language hint to make it clear what the language is.

It fades away on hover to be replaced by the copy/paste or slint pad icons.
<img width="658" alt="image" src="https://github.com/user-attachments/assets/f0239a6f-819b-44b4-a3fc-2f425f0942e5">
