### PR TITLE
core: Improve forward/backward cursor movement in TextInput

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -996,6 +996,7 @@ impl core::convert::TryFrom<char> for TextCursorDirection {
     }
 }
 
+#[derive(PartialEq)]
 enum AnchorMode {
     KeepAnchor,
     MoveAnchor,
@@ -1136,6 +1137,7 @@ impl TextInput {
             return false;
         }
 
+        let (anchor, cursor) = self.selection_anchor_and_cursor();
         let last_cursor_pos = self.cursor_position(&text);
 
         let mut grapheme_cursor =
@@ -1156,10 +1158,22 @@ impl TextInput {
 
         let new_cursor_pos = match direction {
             TextCursorDirection::Forward => {
-                grapheme_cursor.next_boundary(&text, 0).ok().flatten().unwrap_or_else(|| text.len())
+                if anchor == cursor || anchor_mode == AnchorMode::KeepAnchor {
+                    grapheme_cursor
+                        .next_boundary(&text, 0)
+                        .ok()
+                        .flatten()
+                        .unwrap_or_else(|| text.len())
+                } else {
+                    cursor
+                }
             }
             TextCursorDirection::Backward => {
-                grapheme_cursor.prev_boundary(&text, 0).ok().flatten().unwrap_or(0)
+                if anchor == cursor || anchor_mode == AnchorMode::KeepAnchor {
+                    grapheme_cursor.prev_boundary(&text, 0).ok().flatten().unwrap_or(0)
+                } else {
+                    anchor
+                }
             }
             TextCursorDirection::NextLine => {
                 reset_preferred_x_pos = false;

--- a/tests/cases/text/cursor_move.slint
+++ b/tests/cases/text/cursor_move.slint
@@ -80,15 +80,78 @@ assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 2);
 assert_eq!(instance.get_test_anchor_pos(), 0);
 
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
 assert!(!instance.get_has_selection());
+assert_eq!(instance.get_test_cursor_pos(), 2);
+assert_eq!(instance.get_test_anchor_pos(), 2);
 
 send_move_mod_shift_modifier(&instance, true);
 slint_testing::send_keyboard_string_sequence(&instance, &UP_CODE.to_string());
 send_move_mod_shift_modifier(&instance, false);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 0);
-assert_eq!(instance.get_test_anchor_pos(), 1);
+assert_eq!(instance.get_test_anchor_pos(), 2);
+
+// Select all and start over
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &"a");
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
+slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+assert!(!instance.get_has_selection());
+assert_eq!(instance.get_test_text(), "");
+
+slint_testing::send_keyboard_string_sequence(&instance, "abcdefghi");
+assert_eq!(instance.get_test_text(), "abcdefghi");
+slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+assert!(instance.get_has_selection());
+assert_eq!(instance.get_test_cursor_pos(), 4);
+assert_eq!(instance.get_test_anchor_pos(), 6);
+
+slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+assert!(!instance.get_has_selection());
+assert_eq!(instance.get_test_cursor_pos(), 6);
+
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+assert!(instance.get_has_selection());
+assert_eq!(instance.get_test_cursor_pos(), 4);
+assert_eq!(instance.get_test_anchor_pos(), 6);
+
+slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+assert!(!instance.get_has_selection());
+assert_eq!(instance.get_test_cursor_pos(), 4);
+
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+assert!(instance.get_has_selection());
+assert_eq!(instance.get_test_cursor_pos(), 6);
+assert_eq!(instance.get_test_anchor_pos(), 4);
+
+slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+assert!(!instance.get_has_selection());
+assert_eq!(instance.get_test_cursor_pos(), 4);
+
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+assert!(instance.get_has_selection());
+assert_eq!(instance.get_test_cursor_pos(), 6);
+assert_eq!(instance.get_test_anchor_pos(), 4);
+
+slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+assert!(!instance.get_has_selection());
+assert_eq!(instance.get_test_cursor_pos(), 6);
 
 // Select all and start over
 slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);


### PR DESCRIPTION
When a TextInput has a selection and a forward or backward movement is performed (i.e. pressing Left or Right) without keeping the anchor (i.e. Shift is not pressed), the selection collapses either to the beginning or end of the selection based on the movement direction.

ChangeLog: Improved deselection behavior when pressing Left/Right in TextInput

Fixes #6511

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
