### PR TITLE
Live-Preview: Add option to disable reload while typing

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -152,6 +152,11 @@
             }
           },
           "description": "Map of paths in which the `import` statement for `@library` imports are looked up"
+        },
+        "slint.preview.reloadOnType": {
+          "type": "boolean",
+          "default": true,
+          "description": "Reload the preview while typing in a file."
         }
       }
     },

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -462,6 +462,7 @@ pub struct PreviewConfig {
     pub style: String,
     pub include_paths: Vec<PathBuf>,
     pub library_paths: HashMap<String, PathBuf>,
+    pub reload_on_type: bool,
 }
 
 /// The Component to preview

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -457,7 +457,7 @@ async fn handle_notification(req: lsp_server::Notification, ctx: &Rc<Context>) -
             let params: DidCloseTextDocumentParams = serde_json::from_value(req.params)?;
             close_document(ctx, params.text_document.uri).await
         }
-        DidChangeTextDocument::METHOD if ctx.preview_config.borrow().reload_on_type => {
+        DidChangeTextDocument::METHOD => {
             let mut params: DidChangeTextDocumentParams = serde_json::from_value(req.params)?;
             reload_document(
                 ctx,
@@ -465,6 +465,7 @@ async fn handle_notification(req: lsp_server::Notification, ctx: &Rc<Context>) -
                 params.text_document.uri,
                 Some(params.text_document.version),
                 &mut ctx.document_cache.borrow_mut(),
+                ctx.preview_config.borrow().reload_on_type,
             )
             .await
         }
@@ -476,6 +477,7 @@ async fn handle_notification(req: lsp_server::Notification, ctx: &Rc<Context>) -
                 params.text_document.uri,
                 None,
                 &mut ctx.document_cache.borrow_mut(),
+                true,
             )
             .await
         }


### PR DESCRIPTION
Add a slint.preview.reloadOnType setting that can be set to false to reload the preview only when saving a file.

cc #6357

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
