### PR TITLE
Document `TouchArea`'s `enabled` property

### DIFF
--- a/docs/astro/src/content/docs/reference/gestures/toucharea.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/toucharea.mdx
@@ -45,6 +45,12 @@ When not part of a layout, its width or height default to 100% of the parent ele
 <SlintProperty propName="enabled" typeName="bool" defaultValue="true">
 When disabled, the `TouchArea` doesn't recognize any touch or mouse events and they are
 passed through to elements underneath.
+
+:::note{Note}
+When `enabled` is set to false while the `TouchArea` is pressed, `pointer-event` will be
+invoked with `PointerEventKind.Cancel`, and the `pressed` and `has-hover` properties will
+be reset to `false`.
+:::
 </SlintProperty>
 
 ### has-hover

--- a/docs/astro/src/content/docs/reference/gestures/toucharea.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/toucharea.mdx
@@ -41,6 +41,12 @@ When not part of a layout, its width or height default to 100% of the parent ele
 
 ## Properties
 
+### enabled
+<SlintProperty propName="enabled" typeName="bool" defaultValue="true">
+When disabled, the `TouchArea` doesn't recognize any touch or mouse events and they are
+passed through to elements underneath.
+</SlintProperty>
+
 ### has-hover
 <SlintProperty propName="has-hover" typeName="bool" propertyVisibility="out">
 Set to true when the mouse is over the `TouchArea` area.

--- a/docs/astro/src/content/docs/reference/gestures/toucharea.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/toucharea.mdx
@@ -7,6 +7,7 @@ import SlintProperty  from '/src/components/SlintProperty.astro';
 import PointerEvent from '/src/content/collections/structs/PointerEvent.md';
 import PointerScrollEvent from '/src/content/collections/structs/PointerScrollEvent.md';
 import EventResult from '/src/content/collections/enums/EventResult.md';
+import CodeSnippetMD from '/src/components/CodeSnippetMD.astro';
 
 
 ```slint playground
@@ -45,6 +46,30 @@ When not part of a layout, its width or height default to 100% of the parent ele
 <SlintProperty propName="enabled" typeName="bool" defaultValue="true">
 When disabled, the `TouchArea` doesn't recognize any touch or mouse events and they are
 passed through to elements underneath.
+
+<CodeSnippetMD imagePath="/src/assets/generated/basic-syntax.png" scale="2"  imageWidth="200" imageHeight="100" imageAlt='Basic syntax'>
+```slint playground
+import { Button, CheckBox } from "std-widgets.slint";
+
+export component Example inherits Window {
+    width: 200px; height: 100px;
+
+    VerticalLayout {
+        Rectangle {
+            Button {
+                text: "Try to press me";
+            }
+            TouchArea {
+                enabled: event-blocker.checked;
+            }
+        }
+        event-blocker := CheckBox {
+            text: "Block Access";
+        }
+    }   
+}
+```
+</CodeSnippetMD>
 
 :::note{Note}
 When `enabled` is set to false while the `TouchArea` is pressed, `pointer-event` will be


### PR DESCRIPTION
I'm surprised this wasn't documented...

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
