### PR TITLE
Support default-font-* properties in Live-Preview

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -170,6 +170,16 @@ inline float layout_cache_access(const SharedVector<float> &cache, int offset, i
     size_t idx = size_t(cache[offset]) + repeater_index * 2;
     return idx < cache.size() ? cache[idx] : 0;
 }
+
+template<typename VT, typename ItemType>
+inline cbindgen_private::LayoutInfo
+item_layout_info(VT *itemvtable, ItemType *item_ptr, cbindgen_private::Orientation orientation,
+                 WindowAdapterRc *window_adapter, const ItemTreeRc &component_rc,
+                 uint32_t item_index)
+{
+    cbindgen_private::ItemRc item_rc { component_rc, item_index };
+    return itemvtable->layout_info({ itemvtable, item_ptr }, orientation, window_adapter, &item_rc);
+}
 } // namespace private_api
 
 namespace private_api {

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -448,7 +448,7 @@ extern "system" fn Java_SlintAndroidJavaHelper_moveCursorHandle(
                     let adaptor = adaptor.clone() as Rc<dyn WindowAdapter>;
                     let size = text_input
                         .as_pin_ref()
-                        .font_request(&adaptor)
+                        .font_request(&focus_item)
                         .pixel_size
                         .unwrap_or_default()
                         .get();
@@ -457,7 +457,11 @@ extern "system" fn Java_SlintAndroidJavaHelper_moveCursorHandle(
                             pos_x as f32 / scale_factor,
                             pos_y as f32 / scale_factor - size / 2.,
                         ) - focus_item.map_to_window(focus_item.geometry().origin).to_vector();
-                    let text_pos = text_input.as_pin_ref().byte_offset_for_position(pos, &adaptor);
+                    let text_pos = text_input.as_pin_ref().byte_offset_for_position(
+                        pos,
+                        &adaptor,
+                        &focus_item,
+                    );
 
                     let cur_pos = if id == 0 {
                         text_input.anchor_position_byte_offset.set(text_pos as i32);

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -202,6 +202,7 @@ impl Item for NativeButton {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let standard_button_kind = self.actual_standard_button_kind();
         let mut text: qttypes::QString = self.actual_text(standard_button_kind);

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -35,6 +35,7 @@ impl Item for NativeCheckBox {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.text().as_str().into();
         let widget: NonNull<()> = SlintTypeErasedWidgetPtr::qwidget_ptr(&self.widget_ptr);

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -32,6 +32,7 @@ impl Item for NativeComboBox {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let widget: NonNull<()> = SlintTypeErasedWidgetPtr::qwidget_ptr(&self.widget_ptr);
         let size = cpp!(unsafe [widget as "QWidget*"] -> qttypes::QSize as "QSize" {
@@ -185,6 +186,7 @@ impl Item for NativeComboBoxPopup {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         Default::default()
     }

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -146,6 +146,7 @@ impl Item for NativeGroupBox {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
 

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -76,6 +76,7 @@ impl Item for NativeLineEdit {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let min = match orientation {
             Orientation::Horizontal => self.native_padding_left() + self.native_padding_right(),

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -37,6 +37,7 @@ impl Item for NativeStandardListViewItem {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let index: i32 = self.index();
         let item = self.item();

--- a/internal/backends/qt/qt_widgets/progress_indicator.rs
+++ b/internal/backends/qt/qt_widgets/progress_indicator.rs
@@ -30,6 +30,7 @@ impl Item for NativeProgressIndicator {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let indeterminate = self.indeterminate();
         let progress =

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -93,6 +93,7 @@ impl Item for NativeScrollView {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let min = match orientation {
             Orientation::Horizontal => self.native_padding_left() + self.native_padding_right(),

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -78,6 +78,7 @@ impl Item for NativeSlider {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let enabled = self.enabled();
         // Slint slider supports floating point ranges, while Qt uses integer. To support (0..1) ranges

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -73,6 +73,7 @@ impl Item for NativeSpinBox {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         //let value: i32 = self.value();
         let data = self.data();

--- a/internal/backends/qt/qt_widgets/tableheadersection.rs
+++ b/internal/backends/qt/qt_widgets/tableheadersection.rs
@@ -29,6 +29,7 @@ impl Item for NativeTableHeaderSection {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let index: i32 = self.index();
         let item = self.item();

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -178,6 +178,7 @@ impl Item for NativeTabWidget {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let (content_size, tabbar_size) = match orientation {
             Orientation::Horizontal => (
@@ -368,6 +369,7 @@ impl Item for NativeTab {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let text: qttypes::QString = self.title().as_str().into();
         let icon: qttypes::QPixmap =

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -16,6 +16,7 @@ use i_slint_core::item_rendering::{
     CachedRenderingData, ItemCache, ItemRenderer, RenderBorderRectangle, RenderImage,
     RenderRectangle, RenderText,
 };
+use i_slint_core::item_tree::ParentItemTraversalMode;
 use i_slint_core::item_tree::{ItemTreeRc, ItemTreeRef};
 use i_slint_core::items::{
     self, ColorScheme, FillRule, ImageRendering, ItemRc, ItemRef, Layer, LineCap, MouseCursor,
@@ -2431,7 +2432,7 @@ fn accessible_item(item: Option<ItemRc>) -> Option<ItemRc> {
         if c.is_accessible() {
             return Some(c);
         } else {
-            current = c.parent_item();
+            current = c.parent_item(ParentItemTraversalMode::StopAtPopups);
         }
     }
     None

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -695,14 +695,14 @@ impl ItemRenderer for QtItemRenderer<'_> {
     fn draw_text(
         &mut self,
         text: Pin<&dyn RenderText>,
-        _: &ItemRc,
+        self_rc: &ItemRc,
         size: LogicalSize,
         _: &CachedRenderingData,
     ) {
         let rect: qttypes::QRectF = check_geometry!(size);
         let fill_brush: qttypes::QBrush = into_qbrush(text.color(), rect.width, rect.height);
         let mut string: qttypes::QString = text.text().as_str().into();
-        let font: QFont = get_font(text.font_request(WindowInner::from_pub(self.window)));
+        let font: QFont = get_font(text.font_request(self_rc));
         let (horizontal_alignment, vertical_alignment) = text.alignment();
         let alignment = match horizontal_alignment {
             TextHorizontalAlignment::Left => key_generated::Qt_AlignmentFlag_AlignLeft,
@@ -872,14 +872,13 @@ impl ItemRenderer for QtItemRenderer<'_> {
     fn draw_text_input(
         &mut self,
         text_input: Pin<&items::TextInput>,
-        _: &ItemRc,
+        self_rc: &ItemRc,
         size: LogicalSize,
     ) {
         let rect: qttypes::QRectF = check_geometry!(size);
         let fill_brush: qttypes::QBrush = into_qbrush(text_input.color(), rect.width, rect.height);
 
-        let font: QFont =
-            get_font(text_input.font_request(&WindowInner::from_pub(self.window).window_adapter()));
+        let font: QFont = get_font(text_input.font_request(self_rc));
         let flags = match text_input.horizontal_alignment() {
             TextHorizontalAlignment::Left => key_generated::Qt_AlignmentFlag_AlignLeft,
             TextHorizontalAlignment::Center => key_generated::Qt_AlignmentFlag_AlignHCenter,

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -4,7 +4,7 @@
 use core::ops::ControlFlow;
 use i_slint_core::accessibility::{AccessibilityAction, AccessibleStringProperty};
 use i_slint_core::api::{ComponentHandle, LogicalPosition};
-use i_slint_core::item_tree::{ItemTreeRc, ItemWeak};
+use i_slint_core::item_tree::{ItemTreeRc, ItemWeak, ParentItemTraversalMode};
 use i_slint_core::items::{ItemRc, Opacity};
 use i_slint_core::window::WindowInner;
 use i_slint_core::SharedString;
@@ -760,7 +760,7 @@ impl ElementHandle {
             .upgrade()
             .map(|mut item| {
                 let mut opacity = 1.0;
-                while let Some(parent) = item.parent_item() {
+                while let Some(parent) = item.parent_item(ParentItemTraversalMode::StopAtPopups) {
                     if let Some(opacity_item) =
                         i_slint_core::items::ItemRef::downcast_pin::<Opacity>(item.borrow())
                     {

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -175,10 +175,16 @@ impl RendererSealed for TestingWindow {
 
     fn font_metrics(
         &self,
-        _font_request: i_slint_core::graphics::FontRequest,
+        font_request: i_slint_core::graphics::FontRequest,
         _scale_factor: ScaleFactor,
     ) -> i_slint_core::items::FontMetrics {
-        i_slint_core::items::FontMetrics { ascent: 7., descent: 3., x_height: 3., cap_height: 7. }
+        let pixel_size = font_request.pixel_size.unwrap_or(LogicalLength::new(10.));
+        i_slint_core::items::FontMetrics {
+            ascent: pixel_size.get() * 0.7,
+            descent: pixel_size.get() * 0.3,
+            x_height: 3.,
+            cap_height: 7.,
+        }
     }
 
     fn text_input_byte_offset_for_position(

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -11,7 +11,7 @@ use i_slint_core::accessibility::{
     AccessibilityAction, AccessibleStringProperty, SupportedAccessibilityAction,
 };
 use i_slint_core::api::Window;
-use i_slint_core::item_tree::{ItemTreeRc, ItemTreeRef, ItemTreeWeak};
+use i_slint_core::item_tree::{ItemTreeRc, ItemTreeRef, ItemTreeWeak, ParentItemTraversalMode};
 use i_slint_core::items::{ItemRc, WindowItem};
 use i_slint_core::lengths::{LogicalPoint, ScaleFactor};
 use i_slint_core::window::{PopupWindowLocation, WindowInner};
@@ -251,7 +251,7 @@ impl AccessKitAdapter {
 
 fn accessible_parent_for_item_rc(mut item: ItemRc) -> ItemRc {
     while !item.is_accessible() {
-        if let Some(parent) = item.parent_item() {
+        if let Some(parent) = item.parent_item(ParentItemTraversalMode::StopAtPopups) {
             item = parent;
         } else {
             break;
@@ -647,7 +647,7 @@ impl NodeCollection {
         {
             node.set_position_in_set(position_in_set);
             let mut item = item.clone();
-            while let Some(parent) = item.parent_item() {
+            while let Some(parent) = item.parent_item(ParentItemTraversalMode::StopAtPopups) {
                 if !parent.is_accessible() {
                     item = parent;
                     continue;

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3916,13 +3916,15 @@ fn compile_builtin_function_call(
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
             if let [llr::Expression::PropertyReference(pr)] = arguments {
                 let native = native_prop_info(pr, ctx).0;
+                let item_rc = access_item_rc(pr, ctx);
                 format!(
-                    "{vt}->layout_info({{{vt}, const_cast<slint::cbindgen_private::{ty}*>(&{i})}}, {o}, &{window})",
+                    "slint::private_api::item_layout_info({vt}, const_cast<slint::cbindgen_private::{ty}*>(&{i}), {o}, &{window}, {item_rc})",
                     vt = native.cpp_vtable_getter,
                     ty = native.class_name,
                     o = to_cpp_orientation(orient),
                     i = access_member(pr, ctx),
-                    window = access_window_field(ctx)
+                    window = access_window_field(ctx),
+                    item_rc = item_rc
                 )
             } else {
                 panic!("internal error: invalid args to ImplicitLayoutInfo {arguments:?}")

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2909,10 +2909,11 @@ fn compile_builtin_function_call(
         BuiltinFunction::ItemFontMetrics => {
             if let [Expression::PropertyReference(pr)] = arguments {
                 let item = access_member(pr, ctx);
+                let item_rc = access_item_rc(pr, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
                 item.then(|item| {
                     quote!(
-                        #item.font_metrics(#window_adapter_tokens)
+                        #item.font_metrics(#window_adapter_tokens, #item_rc)
                     )
                 })
             } else {
@@ -2924,8 +2925,9 @@ fn compile_builtin_function_call(
                 let item = access_member(pr, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
                 item.then(|item| {
+                    let item_rc = access_item_rc(pr, ctx);
                     quote!(
-                        sp::Item::layout_info(#item, #orient, #window_adapter_tokens)
+                        sp::Item::layout_info(#item, #orient, #window_adapter_tokens, &#item_rc)
                     )
                 })
             } else {

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -165,59 +165,6 @@ impl FontRequest {
     }
 }
 
-impl FontRequest {
-    /// Creates a new FontRequest that uses the provide local font properties. If they're not set, i.e.
-    /// the family is an empty string, or the weight is zero, the corresponding properties are fetched
-    /// from the next parent WindowItem.
-    pub fn new_resolved(
-        self_rc: &crate::items::ItemRc,
-        local_font_family: SharedString,
-        local_font_weight: i32,
-        local_font_size: LogicalLength,
-        local_letter_spacing: LogicalLength,
-        local_italic: bool,
-    ) -> Self {
-        let Some(window_item_rc) = self_rc.window_item() else {
-            return Self::default();
-        };
-
-        FontRequest {
-            family: {
-                if !local_font_family.is_empty() {
-                    Some(local_font_family)
-                } else {
-                    crate::items::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        crate::items::WindowItem::font_family,
-                    )
-                }
-            },
-            weight: {
-                if local_font_weight == 0 {
-                    crate::items::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        crate::items::WindowItem::font_weight,
-                    )
-                } else {
-                    Some(local_font_weight)
-                }
-            },
-            pixel_size: {
-                if local_font_size.get() == 0 as Coord {
-                    crate::items::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        crate::items::WindowItem::font_size,
-                    )
-                } else {
-                    Some(local_font_size)
-                }
-            },
-            letter_spacing: Some(local_letter_spacing),
-            italic: local_italic,
-        }
-    }
-}
-
 /// Internal enum to specify which version of OpenGL to request
 /// from the windowing system.
 #[derive(Debug, Clone, PartialEq)]

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -165,6 +165,59 @@ impl FontRequest {
     }
 }
 
+impl FontRequest {
+    /// Creates a new FontRequest that uses the provide local font properties. If they're not set, i.e.
+    /// the family is an empty string, or the weight is zero, the corresponding properties are fetched
+    /// from the next parent WindowItem.
+    pub fn new_resolved(
+        self_rc: &crate::items::ItemRc,
+        local_font_family: SharedString,
+        local_font_weight: i32,
+        local_font_size: LogicalLength,
+        local_letter_spacing: LogicalLength,
+        local_italic: bool,
+    ) -> Self {
+        let Some(window_item_rc) = self_rc.window_item() else {
+            return Self::default();
+        };
+
+        FontRequest {
+            family: {
+                if !local_font_family.is_empty() {
+                    Some(local_font_family)
+                } else {
+                    crate::items::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        crate::items::WindowItem::font_family,
+                    )
+                }
+            },
+            weight: {
+                if local_font_weight == 0 {
+                    crate::items::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        crate::items::WindowItem::font_weight,
+                    )
+                } else {
+                    Some(local_font_weight)
+                }
+            },
+            pixel_size: {
+                if local_font_size.get() == 0 as Coord {
+                    crate::items::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        crate::items::WindowItem::font_size,
+                    )
+                } else {
+                    Some(local_font_size)
+                }
+            },
+            letter_spacing: Some(local_letter_spacing),
+            italic: local_italic,
+        }
+    }
+}
+
 /// Internal enum to specify which version of OpenGL to request
 /// from the windowing system.
 #[derive(Debug, Clone, PartialEq)]

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -315,7 +315,7 @@ pub trait RenderImage {
 pub trait RenderText {
     fn target_size(self: Pin<&Self>) -> LogicalSize;
     fn text(self: Pin<&Self>) -> SharedString;
-    fn font_request(self: Pin<&Self>, window: &WindowInner) -> FontRequest;
+    fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest;
     fn color(self: Pin<&Self>) -> Brush;
     fn alignment(self: Pin<&Self>) -> (TextHorizontalAlignment, TextVerticalAlignment);
     fn wrap(self: Pin<&Self>) -> TextWrap;
@@ -325,12 +325,13 @@ pub trait RenderText {
 
     fn text_bounding_rect(
         self: Pin<&Self>,
+        self_rc: &ItemRc,
         window_adapter: &Rc<dyn WindowAdapter>,
         mut geometry: euclid::Rect<f32, crate::lengths::LogicalPx>,
     ) -> euclid::Rect<f32, crate::lengths::LogicalPx> {
         let window_inner = WindowInner::from_pub(window_adapter.window());
         let text_string = self.text();
-        let font_request = self.font_request(window_inner);
+        let font_request = self.font_request(self_rc);
         let scale_factor = crate::lengths::ScaleFactor::new(window_inner.scale_factor());
         let max_width = geometry.size.width_length();
         geometry.size = geometry.size.max(

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -745,6 +745,14 @@ impl ItemRc {
         result
     }
 
+    pub fn window_item(&self) -> Option<VRcMapped<ItemTreeVTable, crate::items::WindowItem>> {
+        let root_item_in_local_item_tree = ItemRc::new(self.item_tree.clone(), 0);
+
+        root_item_in_local_item_tree.downcast::<crate::items::WindowItem>().or_else(|| {
+            root_item_in_local_item_tree.parent_item().and_then(|parent| parent.window_item())
+        })
+    }
+
     /// Visit the children of this element and call the visitor to each of them, until the visitor returns [`ControlFlow::Break`].
     /// When the visitor breaks, the function returns the value. If it doesn't break, the function returns None.
     fn visit_descendants_impl<R>(

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -250,6 +250,11 @@ fn step_into_node(
     }
 }
 
+pub enum ParentItemTraversalMode {
+    FindAllParents,
+    StopAtPopups,
+}
+
 /// A ItemRc is holding a reference to a ItemTree containing the item, and the index of this item
 #[repr(C)]
 #[derive(Clone, Debug)]
@@ -301,7 +306,7 @@ impl ItemRc {
     /// Return the parent Item in the item tree.
     ///
     /// If the item is a the root on its Window or PopupWindow, then the parent is None.
-    pub fn parent_item(&self) -> Option<ItemRc> {
+    pub fn parent_item(&self, find_mode: ParentItemTraversalMode) -> Option<ItemRc> {
         let comp_ref_pin = vtable::VRc::borrow_pin(&self.item_tree);
         let item_tree = crate::item_tree::ItemTreeNodeArray::new(&comp_ref_pin);
 
@@ -322,7 +327,10 @@ impl ItemRc {
         } else {
             // the Item was most likely a PopupWindow and we don't want to return the item for the purpose of this call
             // (eg, focus/geometry/...)
-            None
+            match find_mode {
+                ParentItemTraversalMode::FindAllParents => r.upgrade(),
+                ParentItemTraversalMode::StopAtPopups => None,
+            }
         }
     }
 
@@ -342,15 +350,16 @@ impl ItemRc {
     /// Returns the clip rect that applies to this item (in window coordinates) as well as the
     /// item's (unclipped) geometry (also in window coordinates).
     fn absolute_clip_rect_and_geometry(&self) -> (LogicalRect, LogicalRect) {
-        let (mut clip, parent_geometry) = self.parent_item().map_or_else(
-            || {
-                (
-                    LogicalRect::from_size((crate::Coord::MAX, crate::Coord::MAX).into()),
-                    Default::default(),
-                )
-            },
-            |parent| parent.absolute_clip_rect_and_geometry(),
-        );
+        let (mut clip, parent_geometry) =
+            self.parent_item(ParentItemTraversalMode::StopAtPopups).map_or_else(
+                || {
+                    (
+                        LogicalRect::from_size((crate::Coord::MAX, crate::Coord::MAX).into()),
+                        Default::default(),
+                    )
+                },
+                |parent| parent.absolute_clip_rect_and_geometry(),
+            );
 
         let geometry = self.geometry().translate(parent_geometry.origin.to_vector());
 
@@ -451,7 +460,7 @@ impl ItemRc {
     pub fn map_to_window(&self, p: LogicalPoint) -> LogicalPoint {
         let mut current = self.clone();
         let mut result = p;
-        while let Some(parent) = current.parent_item() {
+        while let Some(parent) = current.parent_item(ParentItemTraversalMode::StopAtPopups) {
             let geometry = parent.geometry();
             result += geometry.origin.to_vector();
             current = parent.clone();
@@ -471,7 +480,7 @@ impl ItemRc {
         if current.is_root_item_of(item_tree) {
             return result;
         }
-        while let Some(parent) = current.parent_item() {
+        while let Some(parent) = current.parent_item(ParentItemTraversalMode::StopAtPopups) {
             if parent.is_root_item_of(item_tree) {
                 break;
             }
@@ -745,12 +754,16 @@ impl ItemRc {
         result
     }
 
-    pub fn window_item(&self) -> Option<VRcMapped<ItemTreeVTable, crate::items::WindowItem>> {
+    pub fn window_item(&self) -> Option<Self> {
         let root_item_in_local_item_tree = ItemRc::new(self.item_tree.clone(), 0);
 
-        root_item_in_local_item_tree.downcast::<crate::items::WindowItem>().or_else(|| {
-            root_item_in_local_item_tree.parent_item().and_then(|parent| parent.window_item())
-        })
+        if root_item_in_local_item_tree.downcast::<crate::items::WindowItem>().is_some() {
+            Some(root_item_in_local_item_tree)
+        } else {
+            root_item_in_local_item_tree
+                .parent_item(ParentItemTraversalMode::FindAllParents)
+                .and_then(|parent| parent.window_item())
+        }
     }
 
     /// Visit the children of this element and call the visitor to each of them, until the visitor returns [`ControlFlow::Break`].
@@ -1466,11 +1479,11 @@ mod tests {
         assert!(fc.first_child().is_none());
         assert!(fc.last_child().is_none());
         assert!(fc.previous_sibling().is_none());
-        assert_eq!(fc.parent_item().unwrap(), item);
+        assert_eq!(fc.parent_item(ParentItemTraversalMode::StopAtPopups).unwrap(), item);
 
         // Examine item between first and last child:
         assert_eq!(fcn, lcp);
-        assert_eq!(lcp.parent_item().unwrap(), item);
+        assert_eq!(lcp.parent_item(ParentItemTraversalMode::StopAtPopups).unwrap(), item);
         assert_eq!(fcn.previous_sibling().unwrap(), fc);
         assert_eq!(fcn.next_sibling().unwrap(), lc);
 
@@ -1478,7 +1491,7 @@ mod tests {
         assert!(lc.first_child().is_none());
         assert!(lc.last_child().is_none());
         assert!(lc.next_sibling().is_none());
-        assert_eq!(lc.parent_item().unwrap(), item);
+        assert_eq!(lc.parent_item(ParentItemTraversalMode::StopAtPopups).unwrap(), item);
     }
 
     #[test]

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -328,7 +328,7 @@ impl ItemRc {
             // the Item was most likely a PopupWindow and we don't want to return the item for the purpose of this call
             // (eg, focus/geometry/...)
             match find_mode {
-                ParentItemTraversalMode::FindAllParents => r.upgrade(),
+                ParentItemTraversalMode::FindAllParents => Some(parent),
                 ParentItemTraversalMode::StopAtPopups => None,
             }
         }

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -754,18 +754,6 @@ impl ItemRc {
         result
     }
 
-    pub fn window_item(&self) -> Option<Self> {
-        let root_item_in_local_item_tree = ItemRc::new(self.item_tree.clone(), 0);
-
-        if root_item_in_local_item_tree.downcast::<crate::items::WindowItem>().is_some() {
-            Some(root_item_in_local_item_tree)
-        } else {
-            root_item_in_local_item_tree
-                .parent_item(ParentItemTraversalMode::FindAllParents)
-                .and_then(|parent| parent.window_item())
-        }
-    }
-
     /// Visit the children of this element and call the visitor to each of them, until the visitor returns [`ControlFlow::Break`].
     /// When the visitor breaks, the function returns the value. If it doesn't break, the function returns None.
     fn visit_descendants_impl<R>(

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1204,6 +1204,27 @@ impl WindowItem {
             Some(font_weight)
         }
     }
+
+    pub fn resolve_font_property<T>(
+        self_rc: &ItemRc,
+        property_fn: impl Fn(Pin<&Self>) -> Option<T>,
+    ) -> Option<T> {
+        let mut window_item_rc = self_rc.clone();
+        loop {
+            let window_item = window_item_rc.downcast::<Self>()?;
+            if let Some(result) = property_fn(window_item.as_pin_ref()) {
+                return Some(result);
+            }
+
+            match window_item_rc
+                .parent_item(crate::item_tree::ParentItemTraversalMode::FindAllParents)
+                .and_then(|p| p.window_item())
+            {
+                Some(item) => window_item_rc = item,
+                None => return None,
+            }
+        }
+    }
 }
 
 impl ItemConsts for WindowItem {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -26,7 +26,7 @@ use crate::input::{
     KeyEventType, MouseEvent,
 };
 use crate::item_rendering::{CachedRenderingData, RenderBorderRectangle, RenderRectangle};
-pub use crate::item_tree::ItemRc;
+pub use crate::item_tree::{ItemRc, ItemTreeVTable};
 use crate::layout::LayoutInfo;
 use crate::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalRect, LogicalSize, LogicalVector, PointLengths,
@@ -130,6 +130,7 @@ pub struct ItemVTable {
         core::pin::Pin<VRef<ItemVTable>>,
         orientation: Orientation,
         window_adapter: &WindowAdapterRc,
+        self_rc: &ItemRc,
     ) -> LayoutInfo,
 
     /// Event handler for mouse and touch event. This function is called before being called on children.
@@ -201,6 +202,7 @@ impl Item for Empty {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -292,6 +294,7 @@ impl Item for Rectangle {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -392,6 +395,7 @@ impl Item for BasicBorderRectangle {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -505,6 +509,7 @@ impl Item for BorderRectangle {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -633,6 +638,7 @@ impl Item for Clip {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -744,6 +750,7 @@ impl Item for Opacity {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -861,6 +868,7 @@ impl Item for Layer {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -953,6 +961,7 @@ impl Item for Rotate {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -1097,6 +1106,7 @@ impl Item for WindowItem {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -1227,6 +1237,7 @@ impl Item for ContextMenu {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo::default()
     }
@@ -1404,6 +1415,7 @@ impl Item for BoxShadow {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -167,6 +167,7 @@ impl Item for ComponentContainer {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         self.ensure_updated();
         if let Some(rc) = self.item_tree.borrow().clone() {

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -65,6 +65,7 @@ impl Item for Flickable {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -49,6 +49,7 @@ impl Item for ImageItem {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         let natural_size = self.source().size();
         LayoutInfo {
@@ -195,6 +196,7 @@ impl Item for ClippedImage {
         self: Pin<&Self>,
         orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo {
             preferred: match orientation {

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -60,6 +60,7 @@ impl Item for TouchArea {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -272,6 +273,7 @@ impl Item for FocusScope {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }
@@ -408,6 +410,7 @@ impl Item for SwipeGestureHandler {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -58,6 +58,7 @@ impl Item for Path {
         self: Pin<&Self>,
         _orientation: Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> LayoutInfo {
         LayoutInfo { stretch: 1., ..LayoutInfo::default() }
     }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -70,9 +70,11 @@ impl Item for ComplexText {
         self: Pin<&Self>,
         orientation: Orientation,
         window_adapter: &Rc<dyn WindowAdapter>,
+        self_rc: &ItemRc,
     ) -> LayoutInfo {
         text_layout_info(
             self,
+            &self_rc,
             window_adapter,
             orientation,
             Self::FIELD_OFFSETS.width.apply_pin(self),
@@ -128,10 +130,10 @@ impl Item for ComplexText {
     fn bounding_rect(
         self: core::pin::Pin<&Self>,
         window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
+        self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
-        self.text_bounding_rect(window_adapter, geometry.cast()).cast()
+        self.text_bounding_rect(self_rc, window_adapter, geometry.cast()).cast()
     }
 
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
@@ -155,8 +157,8 @@ impl RenderText for ComplexText {
         self.text()
     }
 
-    fn font_request(self: Pin<&Self>, window: &WindowInner) -> FontRequest {
-        let window_item = window.window_item();
+    fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
+        let window_item = self_rc.window_item();
 
         FontRequest {
             family: {
@@ -216,10 +218,14 @@ impl RenderText for ComplexText {
 }
 
 impl ComplexText {
-    pub fn font_metrics(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>) -> FontMetrics {
+    pub fn font_metrics(
+        self: Pin<&Self>,
+        window_adapter: &Rc<dyn WindowAdapter>,
+        self_rc: &ItemRc,
+    ) -> FontMetrics {
         let window_inner = WindowInner::from_pub(window_adapter.window());
         let scale_factor = ScaleFactor::new(window_inner.scale_factor());
-        let font_request = self.font_request(window_inner);
+        let font_request = self.font_request(self_rc);
         window_adapter.renderer().font_metrics(font_request, scale_factor)
     }
 }
@@ -248,9 +254,11 @@ impl Item for SimpleText {
         self: Pin<&Self>,
         orientation: Orientation,
         window_adapter: &Rc<dyn WindowAdapter>,
+        self_rc: &ItemRc,
     ) -> LayoutInfo {
         text_layout_info(
             self,
+            &self_rc,
             window_adapter,
             orientation,
             Self::FIELD_OFFSETS.width.apply_pin(self),
@@ -306,10 +314,10 @@ impl Item for SimpleText {
     fn bounding_rect(
         self: core::pin::Pin<&Self>,
         window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
+        self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
-        self.text_bounding_rect(window_adapter, geometry.cast()).cast()
+        self.text_bounding_rect(self_rc, window_adapter, geometry.cast()).cast()
     }
 
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
@@ -333,8 +341,8 @@ impl RenderText for SimpleText {
         self.text()
     }
 
-    fn font_request(self: Pin<&Self>, window: &WindowInner) -> FontRequest {
-        let window_item = window.window_item();
+    fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
+        let window_item = self_rc.window_item();
 
         FontRequest {
             family: window_item.as_ref().and_then(|item| item.as_pin_ref().font_family()),
@@ -387,23 +395,28 @@ impl RenderText for SimpleText {
 }
 
 impl SimpleText {
-    pub fn font_metrics(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>) -> FontMetrics {
+    pub fn font_metrics(
+        self: Pin<&Self>,
+        window_adapter: &Rc<dyn WindowAdapter>,
+        self_rc: &ItemRc,
+    ) -> FontMetrics {
         let window_inner = WindowInner::from_pub(window_adapter.window());
         let scale_factor = ScaleFactor::new(window_inner.scale_factor());
-        let font_request = self.font_request(window_inner);
+        let font_request = self.font_request(self_rc);
         window_adapter.renderer().font_metrics(font_request, scale_factor)
     }
 }
 
 fn text_layout_info(
     text: Pin<&dyn RenderText>,
+    self_rc: &ItemRc,
     window_adapter: &Rc<dyn WindowAdapter>,
     orientation: Orientation,
     width: Pin<&Property<LogicalLength>>,
 ) -> LayoutInfo {
     let window_inner = WindowInner::from_pub(window_adapter.window());
     let text_string = text.text();
-    let font_request = text.font_request(window_inner);
+    let font_request = text.font_request(self_rc);
     let scale_factor = ScaleFactor::new(window_inner.scale_factor());
     let implicit_size = |max_width, text_wrap| {
         window_adapter.renderer().text_size(
@@ -545,11 +558,12 @@ impl Item for TextInput {
         self: Pin<&Self>,
         orientation: Orientation,
         window_adapter: &Rc<dyn WindowAdapter>,
+        self_rc: &ItemRc,
     ) -> LayoutInfo {
         let text = self.text();
         let implicit_size = |max_width, text_wrap| {
             window_adapter.renderer().text_size(
-                self.font_request(window_adapter),
+                self.font_request(&self_rc),
                 {
                     if text.is_empty() {
                         "*"
@@ -615,7 +629,8 @@ impl Item for TextInput {
         }
         match event {
             MouseEvent::Pressed { position, button: PointerEventButton::Left, click_count } => {
-                let clicked_offset = self.byte_offset_for_position(position, window_adapter) as i32;
+                let clicked_offset =
+                    self.byte_offset_for_position(position, window_adapter, self_rc) as i32;
                 self.as_ref().pressed.set((click_count % 3) + 1);
 
                 if !window_adapter.window().0.modifiers.get().shift() {
@@ -651,7 +666,8 @@ impl Item for TextInput {
                 self.ensure_focus_and_ime(window_adapter, self_rc);
             }
             MouseEvent::Released { position, button: PointerEventButton::Middle, .. } => {
-                let clicked_offset = self.byte_offset_for_position(position, window_adapter) as i32;
+                let clicked_offset =
+                    self.byte_offset_for_position(position, window_adapter, self_rc) as i32;
                 self.as_ref().anchor_position_byte_offset.set(clicked_offset);
                 self.set_cursor_position(
                     clicked_offset,
@@ -676,7 +692,7 @@ impl Item for TextInput {
                 let pressed = self.as_ref().pressed.get();
                 if pressed > 0 {
                     let clicked_offset =
-                        self.byte_offset_for_position(position, window_adapter) as i32;
+                        self.byte_offset_for_position(position, window_adapter, self_rc) as i32;
                     self.set_cursor_position(
                         clicked_offset,
                         true,
@@ -987,12 +1003,12 @@ impl Item for TextInput {
     fn bounding_rect(
         self: core::pin::Pin<&Self>,
         window_adapter: &Rc<dyn WindowAdapter>,
-        _self_rc: &ItemRc,
+        self_rc: &ItemRc,
         mut geometry: LogicalRect,
     ) -> LogicalRect {
         let window_inner = WindowInner::from_pub(window_adapter.window());
         let text_string = self.text();
-        let font_request = self.font_request(window_adapter);
+        let font_request = self.font_request(self_rc);
         let scale_factor = crate::lengths::ScaleFactor::new(window_inner.scale_factor());
         let max_width = geometry.size.width_length();
         geometry.size = geometry.size.max(window_adapter.renderer().text_size(
@@ -1208,7 +1224,7 @@ impl TextInput {
         let font_height = window_adapter
             .renderer()
             .text_size(
-                self.font_request(window_adapter),
+                self.font_request(self_rc),
                 " ",
                 None,
                 ScaleFactor::new(window_adapter.window().scale_factor()),
@@ -1240,22 +1256,24 @@ impl TextInput {
             TextCursorDirection::NextLine => {
                 reset_preferred_x_pos = false;
 
-                let cursor_rect = self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter);
+                let cursor_rect =
+                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
                 let mut cursor_xy_pos = cursor_rect.center();
 
                 cursor_xy_pos.y += font_height;
                 cursor_xy_pos.x = self.preferred_x_pos.get();
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter)
+                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
             }
             TextCursorDirection::PreviousLine => {
                 reset_preferred_x_pos = false;
 
-                let cursor_rect = self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter);
+                let cursor_rect =
+                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
                 let mut cursor_xy_pos = cursor_rect.center();
 
                 cursor_xy_pos.y -= font_height;
                 cursor_xy_pos.x = self.preferred_x_pos.get();
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter)
+                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
             }
             TextCursorDirection::PreviousCharacter => {
                 let mut i = last_cursor_pos;
@@ -1272,18 +1290,20 @@ impl TextInput {
                 prev_word_boundary(&text, last_cursor_pos.saturating_sub(1))
             }
             TextCursorDirection::StartOfLine => {
-                let cursor_rect = self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter);
+                let cursor_rect =
+                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
                 let mut cursor_xy_pos = cursor_rect.center();
 
                 cursor_xy_pos.x = 0 as Coord;
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter)
+                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
             }
             TextCursorDirection::EndOfLine => {
-                let cursor_rect = self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter);
+                let cursor_rect =
+                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
                 let mut cursor_xy_pos = cursor_rect.center();
 
                 cursor_xy_pos.x = Coord::MAX;
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter)
+                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
             }
             TextCursorDirection::StartOfParagraph => {
                 prev_paragraph_boundary(&text, last_cursor_pos.saturating_sub(1))
@@ -1299,11 +1319,12 @@ impl TextInput {
                     return false;
                 }
                 reset_preferred_x_pos = false;
-                let cursor_rect = self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter);
+                let cursor_rect =
+                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
                 let mut cursor_xy_pos = cursor_rect.center();
                 cursor_xy_pos.y -= offset;
                 cursor_xy_pos.x = self.preferred_x_pos.get();
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter)
+                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
             }
             TextCursorDirection::PageDown => {
                 let offset = self.page_height().get() - font_height;
@@ -1311,11 +1332,12 @@ impl TextInput {
                     return false;
                 }
                 reset_preferred_x_pos = false;
-                let cursor_rect = self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter);
+                let cursor_rect =
+                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
                 let mut cursor_xy_pos = cursor_rect.center();
                 cursor_xy_pos.y += offset;
                 cursor_xy_pos.x = self.preferred_x_pos.get();
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter)
+                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
             }
         };
 
@@ -1350,8 +1372,9 @@ impl TextInput {
     ) {
         self.cursor_position_byte_offset.set(new_position);
         if new_position >= 0 {
-            let pos =
-                self.cursor_rect_for_byte_offset(new_position as usize, window_adapter).origin;
+            let pos = self
+                .cursor_rect_for_byte_offset(new_position as usize, window_adapter, self_rc)
+                .origin;
             if reset_preferred_x_pos {
                 self.preferred_x_pos.set(pos.x);
             }
@@ -1460,14 +1483,15 @@ impl TextInput {
         WindowInner::from_pub(window_adapter.window()).last_ime_text.replace(text.clone());
         let cursor_position = self.cursor_position(&text);
         let anchor_position = self.anchor_position(&text);
-        let cursor_relative = self.cursor_rect_for_byte_offset(cursor_position, window_adapter);
+        let cursor_relative =
+            self.cursor_rect_for_byte_offset(cursor_position, window_adapter, self_rc);
         let geometry = self_rc.geometry();
         let origin = self_rc.map_to_window(geometry.origin).to_vector();
         let cursor_rect_origin =
             crate::api::LogicalPosition::from_euclid(cursor_relative.origin + origin);
         let cursor_rect_size = crate::api::LogicalSize::from_euclid(cursor_relative.size);
         let anchor_point = crate::api::LogicalPosition::from_euclid(
-            self.cursor_rect_for_byte_offset(anchor_position, window_adapter).origin
+            self.cursor_rect_for_byte_offset(anchor_position, window_adapter, self_rc).origin
                 + origin
                 + cursor_relative.size,
         );
@@ -1679,8 +1703,8 @@ impl TextInput {
         }
     }
 
-    pub fn font_request(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>) -> FontRequest {
-        let window_item = WindowInner::from_pub(window_adapter.window()).window_item();
+    pub fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
+        let window_item = self_rc.window_item();
 
         FontRequest {
             family: {
@@ -1781,11 +1805,12 @@ impl TextInput {
         self: Pin<&Self>,
         byte_offset: usize,
         window_adapter: &Rc<dyn WindowAdapter>,
+        self_rc: &ItemRc,
     ) -> LogicalRect {
         window_adapter.renderer().text_input_cursor_rect_for_byte_offset(
             self,
             byte_offset,
-            self.font_request(window_adapter),
+            self.font_request(self_rc),
             ScaleFactor::new(window_adapter.window().scale_factor()),
         )
     }
@@ -1794,11 +1819,12 @@ impl TextInput {
         self: Pin<&Self>,
         pos: LogicalPoint,
         window_adapter: &Rc<dyn WindowAdapter>,
+        self_rc: &ItemRc,
     ) -> usize {
         window_adapter.renderer().text_input_byte_offset_for_position(
             self,
             pos,
-            self.font_request(window_adapter),
+            self.font_request(self_rc),
             ScaleFactor::new(window_adapter.window().scale_factor()),
         )
     }
@@ -1948,10 +1974,14 @@ impl TextInput {
         self.undo_items.set(undo_items);
     }
 
-    pub fn font_metrics(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>) -> FontMetrics {
+    pub fn font_metrics(
+        self: Pin<&Self>,
+        window_adapter: &Rc<dyn WindowAdapter>,
+        self_rc: &ItemRc,
+    ) -> FontMetrics {
         let window_inner = WindowInner::from_pub(window_adapter.window());
         let scale_factor = ScaleFactor::new(window_inner.scale_factor());
-        let font_request = self.font_request(window_adapter);
+        let font_request = self.font_request(self_rc);
         window_adapter.renderer().font_metrics(font_request, scale_factor)
     }
 
@@ -2096,13 +2126,14 @@ pub unsafe extern "C" fn slint_textinput_paste(
 pub fn slint_text_item_fontmetrics(
     window_adapter: &Rc<dyn WindowAdapter>,
     item_ref: Pin<ItemRef<'_>>,
+    self_rc: &ItemRc,
 ) -> FontMetrics {
     if let Some(simple_text) = ItemRef::downcast_pin::<SimpleText>(item_ref) {
-        simple_text.font_metrics(window_adapter)
+        simple_text.font_metrics(window_adapter, self_rc)
     } else if let Some(complex_text) = ItemRef::downcast_pin::<ComplexText>(item_ref) {
-        complex_text.font_metrics(window_adapter)
+        complex_text.font_metrics(window_adapter, self_rc)
     } else if let Some(text_input) = ItemRef::downcast_pin::<TextInput>(item_ref) {
-        text_input.font_metrics(window_adapter)
+        text_input.font_metrics(window_adapter, self_rc)
     } else {
         Default::default()
     }
@@ -2118,5 +2149,5 @@ pub unsafe extern "C" fn slint_cpp_text_item_fontmetrics(
     let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
     let self_rc = ItemRc::new(self_component.clone(), self_index);
     let self_ref = self_rc.borrow();
-    slint_text_item_fontmetrics(window_adapter, self_ref)
+    slint_text_item_fontmetrics(window_adapter, self_ref, &self_rc)
 }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -158,47 +158,14 @@ impl RenderText for ComplexText {
     }
 
     fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
-        let Some(window_item_rc) = self_rc.window_item() else {
-            return Default::default();
-        };
-
-        FontRequest {
-            family: {
-                let maybe_family = self.font_family();
-                if !maybe_family.is_empty() {
-                    Some(maybe_family)
-                } else {
-                    super::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        super::WindowItem::font_family,
-                    )
-                }
-            },
-            weight: {
-                let weight = self.font_weight();
-                if weight == 0 {
-                    super::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        super::WindowItem::font_weight,
-                    )
-                } else {
-                    Some(weight)
-                }
-            },
-            pixel_size: {
-                let font_size = self.font_size();
-                if font_size.get() == 0 as Coord {
-                    super::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        super::WindowItem::font_size,
-                    )
-                } else {
-                    Some(font_size)
-                }
-            },
-            letter_spacing: Some(self.letter_spacing()),
-            italic: self.font_italic(),
-        }
+        FontRequest::new_resolved(
+            self_rc,
+            self.font_family(),
+            self.font_weight(),
+            self.font_size(),
+            self.letter_spacing(),
+            self.font_italic(),
+        )
     }
 
     fn color(self: Pin<&Self>) -> Brush {
@@ -353,40 +320,14 @@ impl RenderText for SimpleText {
     }
 
     fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
-        let Some(window_item_rc) = self_rc.window_item() else {
-            return Default::default();
-        };
-
-        FontRequest {
-            family: super::WindowItem::resolve_font_property(
-                &window_item_rc,
-                super::WindowItem::font_family,
-            ),
-            weight: {
-                let weight = self.font_weight();
-                if weight == 0 {
-                    super::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        super::WindowItem::font_weight,
-                    )
-                } else {
-                    Some(weight)
-                }
-            },
-            pixel_size: {
-                let font_size = self.font_size();
-                if font_size.get() == 0 as Coord {
-                    super::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        super::WindowItem::font_size,
-                    )
-                } else {
-                    Some(font_size)
-                }
-            },
-            letter_spacing: None,
-            italic: false,
-        }
+        FontRequest::new_resolved(
+            self_rc,
+            SharedString::default(),
+            self.font_weight(),
+            self.font_size(),
+            self.letter_spacing(),
+            false,
+        )
     }
 
     fn color(self: Pin<&Self>) -> Brush {
@@ -1726,47 +1667,14 @@ impl TextInput {
     }
 
     pub fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
-        let Some(window_item_rc) = self_rc.window_item() else {
-            return Default::default();
-        };
-
-        FontRequest {
-            family: {
-                let maybe_family = self.font_family();
-                if !maybe_family.is_empty() {
-                    Some(maybe_family)
-                } else {
-                    super::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        super::WindowItem::font_family,
-                    )
-                }
-            },
-            weight: {
-                let weight = self.font_weight();
-                if weight == 0 {
-                    super::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        super::WindowItem::font_weight,
-                    )
-                } else {
-                    Some(weight)
-                }
-            },
-            pixel_size: {
-                let font_size = self.font_size();
-                if font_size.get() == 0 as Coord {
-                    super::WindowItem::resolve_font_property(
-                        &window_item_rc,
-                        super::WindowItem::font_size,
-                    )
-                } else {
-                    Some(font_size)
-                }
-            },
-            letter_spacing: Some(self.letter_spacing()),
-            italic: self.font_italic(),
-        }
+        FontRequest::new_resolved(
+            self_rc,
+            self.font_family(),
+            self.font_weight(),
+            self.font_size(),
+            self.letter_spacing(),
+            self.font_italic(),
+        )
     }
 
     /// Returns a [`TextInputVisualRepresentation`] struct that contains all the fields necessary for rendering the text input,

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -158,7 +158,9 @@ impl RenderText for ComplexText {
     }
 
     fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
-        let window_item = self_rc.window_item();
+        let Some(window_item_rc) = self_rc.window_item() else {
+            return Default::default();
+        };
 
         FontRequest {
             family: {
@@ -166,13 +168,19 @@ impl RenderText for ComplexText {
                 if !maybe_family.is_empty() {
                     Some(maybe_family)
                 } else {
-                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_family())
+                    super::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        super::WindowItem::font_family,
+                    )
                 }
             },
             weight: {
                 let weight = self.font_weight();
                 if weight == 0 {
-                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_weight())
+                    super::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        super::WindowItem::font_weight,
+                    )
                 } else {
                     Some(weight)
                 }
@@ -180,7 +188,10 @@ impl RenderText for ComplexText {
             pixel_size: {
                 let font_size = self.font_size();
                 if font_size.get() == 0 as Coord {
-                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_size())
+                    super::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        super::WindowItem::font_size,
+                    )
                 } else {
                     Some(font_size)
                 }
@@ -342,14 +353,22 @@ impl RenderText for SimpleText {
     }
 
     fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
-        let window_item = self_rc.window_item();
+        let Some(window_item_rc) = self_rc.window_item() else {
+            return Default::default();
+        };
 
         FontRequest {
-            family: window_item.as_ref().and_then(|item| item.as_pin_ref().font_family()),
+            family: super::WindowItem::resolve_font_property(
+                &window_item_rc,
+                super::WindowItem::font_family,
+            ),
             weight: {
                 let weight = self.font_weight();
                 if weight == 0 {
-                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_weight())
+                    super::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        super::WindowItem::font_weight,
+                    )
                 } else {
                     Some(weight)
                 }
@@ -357,7 +376,10 @@ impl RenderText for SimpleText {
             pixel_size: {
                 let font_size = self.font_size();
                 if font_size.get() == 0 as Coord {
-                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_size())
+                    super::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        super::WindowItem::font_size,
+                    )
                 } else {
                     Some(font_size)
                 }
@@ -1704,7 +1726,9 @@ impl TextInput {
     }
 
     pub fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
-        let window_item = self_rc.window_item();
+        let Some(window_item_rc) = self_rc.window_item() else {
+            return Default::default();
+        };
 
         FontRequest {
             family: {
@@ -1712,13 +1736,19 @@ impl TextInput {
                 if !maybe_family.is_empty() {
                     Some(maybe_family)
                 } else {
-                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_family())
+                    super::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        super::WindowItem::font_family,
+                    )
                 }
             },
             weight: {
                 let weight = self.font_weight();
                 if weight == 0 {
-                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_weight())
+                    super::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        super::WindowItem::font_weight,
+                    )
                 } else {
                     Some(weight)
                 }
@@ -1726,7 +1756,10 @@ impl TextInput {
             pixel_size: {
                 let font_size = self.font_size();
                 if font_size.get() == 0 as Coord {
-                    window_item.as_ref().and_then(|item| item.as_pin_ref().font_size())
+                    super::WindowItem::resolve_font_property(
+                        &window_item_rc,
+                        super::WindowItem::font_size,
+                    )
                 } else {
                     Some(font_size)
                 }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -11,7 +11,7 @@ use super::{
     EventResult, FontMetrics, InputType, Item, ItemConsts, ItemRc, ItemRef, KeyEventArg,
     KeyEventResult, KeyEventType, PointArg, PointerEventButton, RenderingResult,
     TextHorizontalAlignment, TextOverflow, TextStrokeStyle, TextVerticalAlignment, TextWrap,
-    VoidArg,
+    VoidArg, WindowItem,
 };
 use crate::graphics::{Brush, Color, FontRequest};
 use crate::input::{
@@ -158,7 +158,7 @@ impl RenderText for ComplexText {
     }
 
     fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
-        FontRequest::new_resolved(
+        WindowItem::resolved_font_request(
             self_rc,
             self.font_family(),
             self.font_weight(),
@@ -320,7 +320,7 @@ impl RenderText for SimpleText {
     }
 
     fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
-        FontRequest::new_resolved(
+        WindowItem::resolved_font_request(
             self_rc,
             SharedString::default(),
             self.font_weight(),
@@ -1667,7 +1667,7 @@ impl TextInput {
     }
 
     pub fn font_request(self: Pin<&Self>, self_rc: &ItemRc) -> FontRequest {
-        FontRequest::new_resolved(
+        WindowItem::resolved_font_request(
             self_rc,
             self.font_family(),
             self.font_weight(),

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -154,6 +154,7 @@ impl crate::items::Item for MenuItem {
         self: Pin<&Self>,
         _orientation: crate::items::Orientation,
         _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
     ) -> crate::layout::LayoutInfo {
         Default::default()
     }

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -2104,7 +2104,7 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'_, T
     fn draw_text(
         &mut self,
         text: Pin<&dyn crate::item_rendering::RenderText>,
-        _: &ItemRc,
+        self_rc: &ItemRc,
         size: LogicalSize,
         _cache: &CachedRenderingData,
     ) {
@@ -2117,7 +2117,7 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'_, T
             return;
         }
 
-        let font_request = text.font_request(self.window);
+        let font_request = text.font_request(self_rc);
 
         let color = self.alpha_color(text.color().color());
         let max_size = (geom.size.cast() * self.scale_factor).cast();
@@ -2179,7 +2179,7 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'_, T
     fn draw_text_input(
         &mut self,
         text_input: Pin<&crate::items::TextInput>,
-        _: &ItemRc,
+        self_rc: &ItemRc,
         size: LogicalSize,
     ) {
         let geom = LogicalRect::from(size);
@@ -2187,7 +2187,7 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'_, T
             return;
         }
 
-        let font_request = text_input.font_request(&self.window.window_adapter());
+        let font_request = text_input.font_request(self_rc);
         let max_size = (geom.size.cast() * self.scale_factor).cast();
 
         // Clip glyphs not only against the global clip but also against the Text's geometry to avoid drawing outside

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -14,7 +14,10 @@ use crate::input::{
     key_codes, ClickState, FocusEvent, InternalKeyboardModifierState, KeyEvent, KeyEventType,
     MouseEvent, MouseInputState, TextCursorBlinker,
 };
-use crate::item_tree::{ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeVTable, ItemTreeWeak, ItemWeak};
+use crate::item_tree::{
+    ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeVTable, ItemTreeWeak, ItemWeak,
+    ParentItemTraversalMode,
+};
 use crate::items::{ColorScheme, InputType, ItemRef, MouseCursor, PopupClosePolicy};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, SizeLengths};
 use crate::menus::MenuVTable;
@@ -682,7 +685,7 @@ impl WindowInner {
                             .map_to_item_tree(Default::default(), &self.component())
                             .to_vector(),
                     );
-                    menubar_item.parent_item()
+                    menubar_item.parent_item(ParentItemTraversalMode::StopAtPopups)
                 }
             };
 
@@ -766,7 +769,7 @@ impl WindowInner {
                 crate::properties::ChangeTracker::run_change_handlers();
                 return;
             }
-            item = focus_item.parent_item();
+            item = focus_item.parent_item(ParentItemTraversalMode::StopAtPopups);
         }
 
         // Make Tab/Backtab handle keyboard focus

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -9,7 +9,7 @@ use i_slint_compiler::langtype::Type;
 use i_slint_compiler::layout::{Layout, LayoutConstraints, LayoutGeometry, Orientation};
 use i_slint_compiler::namedreference::NamedReference;
 use i_slint_compiler::object_tree::ElementRc;
-use i_slint_core::items::DialogButtonRole;
+use i_slint_core::items::{DialogButtonRole, ItemRc};
 use i_slint_core::layout::{self as core_layout};
 use i_slint_core::model::RepeatedItemTree;
 use i_slint_core::slice::Slice;
@@ -310,10 +310,14 @@ pub(crate) fn get_layout_info(
             .items
             .get(elem.id.as_str())
             .unwrap_or_else(|| panic!("Internal error: Item {} not found", elem.id));
+        let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
+
         unsafe {
-            item.item_from_item_tree(component.as_ptr())
-                .as_ref()
-                .layout_info(to_runtime(orientation), window_adapter)
+            item.item_from_item_tree(component.as_ptr()).as_ref().layout_info(
+                to_runtime(orientation),
+                window_adapter,
+                &ItemRc::new(vtable::VRc::into_dyn(item_comp), item.item_index()),
+            )
         }
     }
 }

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -23,7 +23,6 @@ use i_slint_core::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector,
     RectLengths, ScaleFactor, SizeLengths,
 };
-use i_slint_core::window::WindowInner;
 use i_slint_core::{Brush, Color, ImageInner, SharedString};
 
 use super::images::{Texture, TextureCacheKey};
@@ -310,7 +309,7 @@ impl ItemRenderer for GLItemRenderer<'_> {
     fn draw_text(
         &mut self,
         text: Pin<&dyn RenderText>,
-        _: &ItemRc,
+        self_rc: &ItemRc,
         size: LogicalSize,
         _cache: &CachedRenderingData,
     ) {
@@ -328,11 +327,7 @@ impl ItemRenderer for GLItemRenderer<'_> {
         let string = text.text();
         let string = string.as_str();
         let font = fonts::FONT_CACHE.with(|cache| {
-            cache.borrow_mut().font(
-                text.font_request(WindowInner::from_pub(self.window)),
-                self.scale_factor,
-                &text.text(),
-            )
+            cache.borrow_mut().font(text.font_request(self_rc), self.scale_factor, &text.text())
         });
 
         let text_path = rect_to_path((size * self.scale_factor).into());
@@ -396,7 +391,7 @@ impl ItemRenderer for GLItemRenderer<'_> {
     fn draw_text_input(
         &mut self,
         text_input: Pin<&items::TextInput>,
-        _: &ItemRc,
+        self_rc: &ItemRc,
         size: LogicalSize,
     ) {
         let width = size.width_length() * self.scale_factor;
@@ -411,7 +406,7 @@ impl ItemRenderer for GLItemRenderer<'_> {
 
         let font = fonts::FONT_CACHE.with(|cache| {
             cache.borrow_mut().font(
-                text_input.font_request(&WindowInner::from_pub(self.window).window_adapter()),
+                text_input.font_request(self_rc),
                 self.scale_factor,
                 &text_input.text(),
             )

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -498,7 +498,7 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
     fn draw_text(
         &mut self,
         text: Pin<&dyn RenderText>,
-        _self_rc: &i_slint_core::items::ItemRc,
+        self_rc: &i_slint_core::items::ItemRc,
         size: LogicalSize,
         _cache: &CachedRenderingData,
     ) {
@@ -511,7 +511,7 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
 
         let string = text.text();
         let string = string.as_str();
-        let font_request = text.font_request(WindowInner::from_pub(self.window));
+        let font_request = text.font_request(self_rc);
 
         let paint = match self.brush_to_paint(text.color(), max_width, max_height) {
             Some(paint) => paint,
@@ -597,7 +597,7 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
     fn draw_text_input(
         &mut self,
         text_input: Pin<&i_slint_core::items::TextInput>,
-        _self_rc: &i_slint_core::items::ItemRc,
+        self_rc: &i_slint_core::items::ItemRc,
         size: LogicalSize,
     ) {
         let max_width = size.width_length() * self.scale_factor;
@@ -607,8 +607,7 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
             return;
         }
 
-        let font_request =
-            text_input.font_request(&WindowInner::from_pub(self.window).window_adapter());
+        let font_request = text_input.font_request(self_rc);
 
         let visual_representation = text_input.visual_representation(None);
         let paint =

--- a/tests/cases/text/font_size_propagation.slint
+++ b/tests/cases/text/font_size_propagation.slint
@@ -31,6 +31,23 @@ let factory = slint::ComponentFactory::new(move |ctx| {
                 t := Text {
                     text: "Hello 🌍";
                 }
+
+                out property <length> popup-text-size: 0px;
+
+                popup := PopupWindow {
+                    popup-text := Text {
+                        text: "Ok 🌍";
+                    }
+                    init => {
+                        popup-text-size = popup-text.font-metrics.ascent + popup-text.font-metrics.descent;
+                    }
+                }
+
+                TouchArea {
+                    clicked => {
+                        popup.show();
+                    }
+                }
             }"#.into(),
         std::path::PathBuf::from("embedded.slint"),
      )).component("Inner").unwrap();
@@ -43,6 +60,11 @@ let factory = slint::ComponentFactory::new(move |ctx| {
 let instance = TestCase::new().unwrap();
 instance.set_component_factory(factory.clone());
 assert_eq!(instance.get_pref_height(), 34.);
+let popup_text_size = inner_instance.borrow().as_ref().expect("should have been created").get_property("popup-text-size").unwrap();
+assert_eq!(popup_text_size, slint_interpreter::Value::from(0.));
+slint_testing::send_mouse_click(&instance, 5., 5.);
+let popup_text_size = inner_instance.borrow().as_ref().expect("should have been created").get_property("popup-text-size").unwrap();
+assert_eq!(popup_text_size, slint_interpreter::Value::from(34.));
 ```
 
 

--- a/tests/cases/text/font_size_propagation.slint
+++ b/tests/cases/text/font_size_propagation.slint
@@ -1,0 +1,49 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//ignore: cpp,js
+
+export component TestCase inherits Window {
+    default-font-size: 24px;
+    HorizontalLayout {
+        cont := ComponentContainer { }
+    }
+
+    in property <component-factory> component-factory <=> cont.component-factory;
+    out property <length> pref-height: root.preferred-height;
+}
+
+/*
+
+
+
+```rust
+
+use slint::ComponentHandle;
+let inner_instance = std::rc::Rc::<core::cell::RefCell<Option<slint_interpreter::ComponentInstance>>>::default();
+let inner_instance_clone = inner_instance.clone();
+let factory = slint::ComponentFactory::new(move |ctx| {
+    let compiler = slint_interpreter::Compiler::new();
+    let e = spin_on::spin_on(compiler.build_from_source(
+        r#"export component Inner inherits Window {
+                default-font-size: 34px;
+                preferred-height: t.font-metrics.ascent + t.font-metrics.descent;
+                t := Text {
+                    text: "Hello 🌍";
+                }
+            }"#.into(),
+        std::path::PathBuf::from("embedded.slint"),
+     )).component("Inner").unwrap();
+
+    let inner = e.create_embedded(ctx).unwrap();
+    inner_instance_clone.replace(Some(inner.clone_strong()));
+    Some(inner)
+});
+
+let instance = TestCase::new().unwrap();
+instance.set_component_factory(factory.clone());
+assert_eq!(instance.get_pref_height(), 34.);
+```
+
+
+*/

--- a/tests/cases/text/metrics.slint
+++ b/tests/cases/text/metrics.slint
@@ -6,6 +6,10 @@ component Text2 inherits  Text {}
 export component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
+    /// The style provides the default font size. Some tests in the CI run with the Qt style, some with our built-in styles.
+    /// The built-in styles don't provide a default font size, so the testing backend provides the last resort fallback.
+    /// To provide a consistent test environment, don't use the style's default font size.
+    default-font-size: 10px;
     simple-text := Text { }
 
     complex-text := Text {


### PR DESCRIPTION
... by changing the resolution for the `WindowItem` to traverse the item tree from the current item, instead of going to the window.

This doesn't quite fix #4298 because `rem` resolution is still missing. That requires the built-in default font size function to be fixed as well, which is non-trivial.

cc #4298

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
