### PR TITLE
live-preview: Do not update the preview when build fails

### DIFF
--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -142,27 +142,6 @@ pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, Platfor
     Ok(ui)
 }
 
-pub fn convert_diagnostics(diagnostics: &[slint_interpreter::Diagnostic]) -> Vec<Diagnostics> {
-    diagnostics
-        .iter()
-        .filter(|d| d.level() == DiagnosticLevel::Error)
-        .map(|d| {
-            let (line, column) = d.line_column();
-
-            Diagnostics {
-                level: format!("{:?}", d.level()).into(),
-                message: d.message().into(),
-                url: d
-                    .source_file()
-                    .map(|p| p.to_string_lossy().to_string().into())
-                    .unwrap_or_default(),
-                line: line as i32,
-                column: column as i32,
-            }
-        })
-        .collect::<Vec<_>>()
-}
-
 fn extract_definition_location(ci: &ComponentInformation) -> (SharedString, SharedString) {
     let Some(url) = ci.defined_at.as_ref().map(|da| da.url()) else {
         return (Default::default(), Default::default());
@@ -177,6 +156,21 @@ fn extract_definition_location(ci: &ComponentInformation) -> (SharedString, Shar
 pub fn ui_set_uses_widgets(ui: &PreviewUi, uses_widgets: bool) {
     let api = ui.global::<Api>();
     api.set_uses_widgets(uses_widgets);
+}
+
+pub fn set_diagnostics(ui: &PreviewUi, diagnostics: &[slint_interpreter::Diagnostic]) {
+    let summary = diagnostics.iter().fold(DiagnosticSummary::NothingDetected, |acc, d| {
+        match (acc, d.level()) {
+            (_, DiagnosticLevel::Error) => DiagnosticSummary::Errors,
+            (DiagnosticSummary::Errors, DiagnosticLevel::Warning) => DiagnosticSummary::Errors,
+            (_, DiagnosticLevel::Warning) => DiagnosticSummary::Warnings,
+            // DiagnosticLevel is non-exhaustive:
+            (acc, _) => acc,
+        }
+    });
+
+    let api = ui.global::<Api>();
+    api.set_diagnostic_summary(summary);
 }
 
 pub fn ui_set_known_components(

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -22,12 +22,10 @@ export struct ComponentListItem {
 }
 
 /// Some `Diagnostics` as raised by the compiler
-export struct Diagnostics {
-    level: string,
-    message: string,
-    url: string,
-    line: int,
-    column: int,
+export enum DiagnosticSummary {
+    NothingDetected,
+    Warnings,
+    Errors,
 }
 
 /// What kind of layout we are working with
@@ -180,9 +178,8 @@ export global Api {
     // The component currently viewed
     out property <ComponentItem> visible-component;
 
-    // ## Diagnostics and other Status messages
-    // Compiler diagnostics
-    in property <[Diagnostics]> diagnostics;
+    // ## Kinds of diagnostics seen in the last compiler run
+    in property <DiagnosticSummary> diagnostic-summary;
     // status message text
     in property <string> status-text;
 

--- a/tools/lsp/ui/components/expandable-listview.slint
+++ b/tools/lsp/ui/components/expandable-listview.slint
@@ -118,6 +118,8 @@ component ItemTemplate {
 
 export component ExpandableListView inherits ScrollView {
     in property <[ComponentListItem]> known-components;
+
+    in property <bool> preview-is-current;
     in property <length> preview-area-position-x;
     in property <length> preview-area-position-y;
     in property <length> preview-area-width;
@@ -153,7 +155,7 @@ export component ExpandableListView inherits ScrollView {
                             drop-x >= 0 && drop-x <= root.preview-area-width && drop-y >= 0 && drop-y <= root.preview-area-height;
                     property <ComponentItem> data: ci;
 
-                    can-drop-here: !self.data.is-currently-shown && root.can-drop(self.data.index, drop-x, drop-y, on-drop-area);
+                    can-drop-here: root.preview-is-current && !self.data.is-currently-shown && root.can-drop(self.data.index, drop-x, drop-y, on-drop-area);
                     enabled: root.preview-visible;
                     text: ci.name;
                     offset: header-item.offset;

--- a/tools/lsp/ui/components/out-of-date-box.slint
+++ b/tools/lsp/ui/components/out-of-date-box.slint
@@ -1,0 +1,24 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Palette } from "std-widgets.slint";
+export component OutOfDateBox {
+    Rectangle {
+        background: Palette.accent-background;
+
+        border-radius: self.height / 2;
+
+        HorizontalLayout {
+            padding-top: 5px;
+            padding-bottom: 5px;
+            padding-left: 15px;
+            padding-right: 15px;
+
+            Text {
+                color: Palette.accent-foreground;
+                text: "Preview is out of date";
+                vertical-alignment: center;
+            }
+        }
+    }
+}

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -4,15 +4,15 @@
 // cSpell: ignore Heade
 
 import { Button, ComboBox, ListView, ScrollView, VerticalBox, Palette } from "std-widgets.slint";
-import { Api, ComponentItem } from "api.slint";
+import { Api, ComponentItem, DiagnosticSummary } from "api.slint";
 
-import { DiagnosticsOverlay } from "./components/diagnostics-overlay.slint";
 import { EditorSpaceSettings, Icons } from "./components/styling.slint";
 import { StatusLine } from "./components/status-line.slint";
 import { HeaderView } from "./views/header-view.slint";
 import { LibraryView } from "./views/library-view.slint";
 import { DrawAreaMode, PreviewView } from "./views/preview-view.slint";
 import { PropertyView } from "./views/property-view.slint";
+import { OutOfDateBox } from "components/out-of-date-box.slint";
 
 export { Api }
 
@@ -41,15 +41,6 @@ export component PreviewUi inherits Window {
                 }
             }
 
-            // Diagnostics overlay:
-            DiagnosticsOverlay {
-                width: 100%;
-                height: 100%;
-                diagnostics <=> Api.diagnostics;
-                show-document(url, line, column) => {
-                    Api.show-document(url, line, column);
-                }
-            }
         }
         if Api.show-preview-ui: Rectangle {
             VerticalLayout {
@@ -70,6 +61,7 @@ export component PreviewUi inherits Window {
                         checkable: true;
                         checked <=> preview.select-mode;
                         primary: preview.select-mode;
+                        enabled: Api.diagnostic-summary != DiagnosticSummary.Errors;
                     }
                 }
 
@@ -108,5 +100,10 @@ export component PreviewUi inherits Window {
                 StatusLine { }
             }
         }
+    }
+
+    if Api.diagnostic-summary == DiagnosticSummary.Errors: OutOfDateBox {
+        x: (parent.width - self.width) / 2;
+        y: (parent.height / 10);
     }
 }

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -61,7 +61,7 @@ export component PreviewUi inherits Window {
                         checkable: true;
                         checked <=> preview.select-mode;
                         primary: preview.select-mode;
-                        enabled: Api.diagnostic-summary != DiagnosticSummary.Errors;
+                        enabled: preview.preview-is-current;
                     }
                 }
 
@@ -77,7 +77,8 @@ export component PreviewUi inherits Window {
                         preview-area-position-y: preview.preview-area-position-y;
                         preview-area-width: preview.preview-area-width;
                         preview-area-height: preview.preview-area-height;
-                        visible-component <=> root.visible-component;
+
+                        visible-component: root.visible-component;
 
                         can-drop(index, x, y, on-drop-area) => {
                             Api.can-drop(index, x, y, on-drop-area);
@@ -96,7 +97,9 @@ export component PreviewUi inherits Window {
                         visible-component <=> root.visible-component;
                     }
 
-                    if  root.show-right-sidebar: PropertyView { }
+                    if  root.show-right-sidebar: PropertyView {
+                        enabled: preview.preview-is-current;
+                    }
                 }
 
                 StatusLine { }

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -71,6 +71,8 @@ export component PreviewUi inherits Window {
 
                     if  root.show-left-sidebar: LibraryView {
                         known-components: Api.known-components;
+
+                        preview-area-is-current: preview.preview-is-current;
                         preview-area-position-x: preview.preview-area-position-x;
                         preview-area-position-y: preview.preview-area-position-y;
                         preview-area-width: preview.preview-area-width;

--- a/tools/lsp/ui/views/library-view.slint
+++ b/tools/lsp/ui/views/library-view.slint
@@ -4,15 +4,18 @@
 import { Group, GroupHeader } from "../components/group.slint";
 import { ExpandableListView } from "../components/expandable-listview.slint";
 import { Icons, EditorSizeSettings } from "../components/styling.slint";
-import { ComponentListItem, ComponentItem } from "../api.slint";
+import { Api, ComponentListItem, ComponentItem, DiagnosticSummary } from "../api.slint";
 import { IconButton } from "../components/icon-button.slint";
 
 export component LibraryView {
     in property <[ComponentListItem]> known-components <=> component-list-view.known-components;
+
+    in property <bool> preview-area-is-current <=> component-list-view.preview-is-current;
     in property <length> preview-area-position-x <=> component-list-view.preview-area-position-x;
     in property <length> preview-area-position-y <=> component-list-view.preview-area-position-y;
     in property <length> preview-area-width <=> component-list-view.preview-area-width;
     in property <length> preview-area-height <=> component-list-view.preview-area-height;
+
     in-out property <ComponentItem> visible-component <=> component-list-view.visible-component;
 
     pure callback can-drop <=> component-list-view.can-drop;

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -190,7 +190,7 @@ component SelectionFrame {
 export component PreviewView {
     property <[Selection]> selections <=> Api.selections;
     in property <ComponentItem> visible-component;
-    property <bool> preview-is-current: Api.diagnostic-summary != DiagnosticSummary.Errors;
+    in-out property <bool> preview-is-current: Api.diagnostic-summary != DiagnosticSummary.Errors;
     property <DropMark> drop-mark <=> Api.drop-mark;
     property <component-factory> preview-area <=> Api.preview-area;
     in-out property <bool> select-mode: false;

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -4,8 +4,7 @@
 // cSpell: ignore resizer
 
 import { Button, ComboBox, HorizontalBox, LineEdit, ListView, Palette, ScrollView, VerticalBox } from "std-widgets.slint";
-import { Api, ComponentItem, Diagnostics, DropMark, LayoutKind, Selection } from "../api.slint";
-import { DiagnosticsOverlay } from "../components/diagnostics-overlay.slint";
+import { Api, ComponentItem, DiagnosticSummary, DropMark, LayoutKind, Selection } from "../api.slint";
 import { Resizer } from "../components/resizer.slint";
 import { Group, GroupHeader } from "../components/group.slint";
 import { SelectionPopup } from "../components/selection-popup.slint";
@@ -26,7 +25,7 @@ export enum DrawAreaMode {
     uninitialized,
     viewing,
     selecting,
-    error,
+    outdated,
 }
 
 component SelectionFrame {
@@ -189,14 +188,14 @@ component SelectionFrame {
 }
 
 export component PreviewView {
-    property <[Diagnostics]> diagnostics <=> Api.diagnostics;
     property <[Selection]> selections <=> Api.selections;
     in property <ComponentItem> visible-component;
+    property <bool> preview-is-current: Api.diagnostic-summary != DiagnosticSummary.Errors;
     property <DropMark> drop-mark <=> Api.drop-mark;
     property <component-factory> preview-area <=> Api.preview-area;
     in-out property <bool> select-mode: false;
 
-    out property <bool> preview-visible: preview-area-container.has-component && !diagnostics.diagnostics-open;
+    out property <bool> preview-visible: preview-area-container.has-component;
     out property <DrawAreaMode> mode: uninitialized;
 
     out property <length> preview-area-position-x: preview-area-container.absolute-position.x;
@@ -425,28 +424,17 @@ export component PreviewView {
         }
     }
 
-    // Diagnostics overlay:
-    diagnostics := DiagnosticsOverlay {
-        width: 100%;
-        height: 100%;
-        diagnostics <=> root.diagnostics;
-
-        show-document(url, line, column) => {
-            Api.show-document(url, line, column);
-        }
-    }
-
     states [
         uninitialized when !preview-area-container.has-component: {
             root.mode: DrawAreaMode.uninitialized;
         }
-        error when diagnostics.diagnostics-open && preview-area-container.has-component: {
-            root.mode: DrawAreaMode.error;
+        error when !root.preview-is-current && preview-area-container.has-component: {
+            root.mode: DrawAreaMode.outdated;
         }
-        selecting when root.select-mode && !diagnostics.diagnostics-open && preview-area-container.has-component: {
+        selecting when root.select-mode && root.preview-is-current && preview-area-container.has-component: {
             root.mode: DrawAreaMode.selecting;
         }
-        viewing when !root.select-mode && !diagnostics.diagnostics-open && preview-area-container.has-component: {
+        viewing when !root.select-mode && root.preview-is-current && preview-area-container.has-component: {
             root.mode: DrawAreaMode.viewing;
         }
     ]

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -190,7 +190,9 @@ component SelectionFrame {
 export component PreviewView {
     property <[Selection]> selections <=> Api.selections;
     in property <ComponentItem> visible-component;
-    in-out property <bool> preview-is-current: Api.diagnostic-summary != DiagnosticSummary.Errors;
+    property <DiagnosticSummary> diagnostic-summary <=> Api.diagnostic-summary;
+    out property <bool> preview-is-current: self.diagnostic-summary != DiagnosticSummary.Errors;
+
     property <DropMark> drop-mark <=> Api.drop-mark;
     property <component-factory> preview-area <=> Api.preview-area;
     in-out property <bool> select-mode: false;
@@ -205,6 +207,17 @@ export component PreviewView {
 
     preferred-height: max(max(preview-area-container.preferred-height, preview-area-container.min-height) + 2 * scroll-view.border, 10 * scroll-view.border);
     preferred-width: max(max(preview-area-container.preferred-width, preview-area-container.min-width) + 2 * scroll-view.border, 10 * scroll-view.border);
+
+    changed diagnostic-summary => {
+        if self.diagnostic-summary == DiagnosticSummary.NothingDetected {
+            StatusLineApi.help-text = @tr("");
+        } else if self.diagnostic-summary == DiagnosticSummary.Warnings {
+            StatusLineApi.help-text = @tr("Check your text editor for warnings");
+        }
+        if self.diagnostic-summary == DiagnosticSummary.Errors {
+            StatusLineApi.help-text = @tr("Check your text editor for errors");
+        }
+    }
 
     scroll-view := ScrollView {
         out property <length> border: 30px;

--- a/tools/lsp/ui/views/property-view.slint
+++ b/tools/lsp/ui/views/property-view.slint
@@ -62,16 +62,17 @@ component NameLabel inherits HorizontalLayout {
 }
 
 component ResettingLineEdit {
-    property <length> border: 3px;
     in property <string> default-text;
     in-out property <bool> can-compile: true;
 
-    in property <bool> enabled <=> le.enabled;
+    in property <bool> enabled;
     in property <InputType> input-type <=> le.input-type;
     in property <TextHorizontalAlignment> horizontal-alignment <=> le.horizontal-alignment;
     in property <string> placeholder-text <=> le.placeholder-text;
     out property <bool> has-focus <=> le.has-focus;
     in-out property <string> text <=> le.text;
+
+    property <length> border: 3px;
 
     callback accepted <=> le.accepted;
     callback edited <=> le.edited;
@@ -85,6 +86,8 @@ component ResettingLineEdit {
     max-height <=> le.max-height;
 
     le := LineEdit {
+        enabled: root.enabled;
+        
         width: 100%;
         height: 100%;
         x: 0px;
@@ -120,6 +123,7 @@ component ResettingLineEdit {
 }
 
 component CodeWidget inherits VerticalLayout {
+    in property <bool> enabled;
     in property <ElementInformation> element-information;
     in property <PropertyInformation> property-information;
 
@@ -145,11 +149,13 @@ component CodeWidget inherits VerticalLayout {
     if property-information.value.code != "": HorizontalLayout {
         spacing: EditorSpaceSettings.default-spacing;
         ResetButton {
+            enabled: root.enabled;
             element-information <=> element-information;
             property-information: property-information;
         }
 
         CodeButton {
+            enabled: root.enabled;
             element-information <=> element-information;
             property-information: property-information;
         }
@@ -160,8 +166,6 @@ component ChildIndicator {
     out property <bool> open: false;
 
     x: -1.0 * EditorSpaceSettings.group-indent * 2;
-
-
 
     Rectangle {
         width: 100%;
@@ -187,6 +191,7 @@ component ChildIndicator {
 component SecondaryContent inherits Rectangle {
     in property <ElementInformation> element-information;
     in property <PropertyInformation> property-information;
+    in property <bool> enabled;
 
     in property <bool> open: false;
 
@@ -214,12 +219,14 @@ component SecondaryContent inherits Rectangle {
             HorizontalLayout {
                 spacing: EditorSpaceSettings.default-spacing;
                 ResetButton {
+                    enabled: root.enabled;
                     element-information <=> element-information;
                     property-information: property-information;
                     clicked() => { root.reset(); }
                 }
 
                 CodeButton {
+                    enabled: root.enabled;
                     element-information <=> element-information;
                     property-information: property-information;
                 }
@@ -229,6 +236,7 @@ component SecondaryContent inherits Rectangle {
 }
 
 component FloatWidget inherits VerticalLayout {
+    in property <bool> enabled;
     in property <ElementInformation> element-information;
     in property <PropertyInformation> property-information;
 
@@ -268,6 +276,7 @@ component FloatWidget inherits VerticalLayout {
         height: 2rem;
 
         number := ResettingLineEdit {
+            enabled: root.enabled;
             horizontal-alignment: right;
             min-width: EditorSizeSettings.float-size;
             horizontal-stretch: 0;
@@ -290,6 +299,8 @@ component FloatWidget inherits VerticalLayout {
         }
 
         if property-information.value.visual-items.length > 1: ComboBox {
+            enabled: root.enabled;
+
             horizontal-stretch: 0;
 
             min-width: EditorSizeSettings.length-combo;
@@ -312,12 +323,13 @@ component FloatWidget inherits VerticalLayout {
 }
 
 component StringWidget {
+    in property <bool> enabled;
     in property <ElementInformation> element-information;
     in property <PropertyInformation> property-information;
 
     property <bool> open: false;
 
-    childIndicator := ChildIndicator {
+           childIndicator := ChildIndicator {
         y: content.y + EditorSpaceSettings.default-spacing/2;
     }
 
@@ -331,45 +343,50 @@ component StringWidget {
             spacing: EditorSpaceSettings.default-spacing;
             height: 2rem;
             ResettingLineEdit {
+                enabled: root.enabled;
                 default-text: property-information.value.value-string;
                 edited(text) => {
                     self.can-compile = Api.test-string-binding(
-                 root.element-information.source-uri,
-                 root.element-information.source-version,
-                 root.element-information.range.start,
-                 property-information.name,
-                 text,
-                 property-information.value.is-translatable,
-                 property-information.value.tr-context,
-                 property-information.value.tr-plural,
-                 property-information.value.tr-plural-expression,
-             );
+                        root.element-information.source-uri,
+                        root.element-information.source-version,
+                        root.element-information.range.start,
+                        property-information.name,
+                        text,
+                        property-information.value.is-translatable,
+                        property-information.value.tr-context,
+                        property-information.value.tr-plural,
+                        property-information.value.tr-plural-expression,
+                    );
                 }
                 accepted(text) => {
                     Api.set-string-binding(
-                 root.element-information.source-uri,
-                 root.element-information.source-version,
-                 root.element-information.range.start,
-                 property-information.name,
-                 text,
-                 property-information.value.is-translatable,
-                 property-information.value.tr-context,
-                 property-information.value.tr-plural,
-                 property-information.value.tr-plural-expression,
-             );
+                        root.element-information.source-uri,
+                        root.element-information.source-version,
+                        root.element-information.range.start,
+                        property-information.name,
+                        text,
+                        property-information.value.is-translatable,
+                        property-information.value.tr-context,
+                        property-information.value.tr-plural,
+                        property-information.value.tr-plural-expression,
+                    );
                 }
             }
         }
 
         sub := SecondaryContent {
+            enabled: root.enabled;
             element-information: element-information;
             property-information: property-information;
             open: childIndicator.open;
+
             CheckBox {
+                enabled: root.enabled;
                 text: "Translatable";
             }
 
             CheckBox {
+                enabled: root.enabled;
                 text: "Disambiguate";
             }
         }
@@ -377,10 +394,11 @@ component StringWidget {
 }
 
 component ColorLineEdit inherits HorizontalLayout {
+    in property <bool> enabled;
     in property <string> channel: "R";
     in-out property <int> value;
 
-    alignment: stretch;
+          alignment: stretch;
     spacing: EditorSpaceSettings.default-spacing;
 
     Text {
@@ -390,6 +408,7 @@ component ColorLineEdit inherits HorizontalLayout {
     }
 
     slide-value := Slider {
+        enabled: root.enabled;
         minimum: 0;
         maximum: 255;
         value: root.value;
@@ -400,6 +419,7 @@ component ColorLineEdit inherits HorizontalLayout {
     }
 
     num-value := ResettingLineEdit {
+        enabled: root.enabled;
         input-type: number;
         width: 5rem;
         default-text: root.value;
@@ -411,6 +431,7 @@ component ColorLineEdit inherits HorizontalLayout {
 }
 
 component ColorWidget inherits Rectangle {
+    in property <bool> enabled;
     in property <ElementInformation> element-information;
     in property <PropertyInformation> property-information;
 
@@ -435,6 +456,7 @@ component ColorWidget inherits Rectangle {
             alignment: stretch;
 
             ResettingLineEdit {
+                enabled: root.enabled;
                 default-text: root.current-color-data.text;
 
                 edited(text) => {
@@ -452,12 +474,12 @@ component ColorWidget inherits Rectangle {
 
                 accepted(text) => {
                     Api.set-code-binding(
-                    root.element-information.source-uri,
-                    root.element-information.source-version,
-                    root.element-information.range.start,
-                    root.property-information.name,
-                    text,
-                );
+                        root.element-information.source-uri,
+                        root.element-information.source-version,
+                        root.element-information.range.start,
+                        root.property-information.name,
+                        text,
+                    );
                 }
             }
 
@@ -472,6 +494,8 @@ component ColorWidget inherits Rectangle {
         sub := SecondaryContent {
             out property <color> slider-color: Api.rgba-to-color(r.value, g.value, b.value, a.value);
 
+            enabled: root.enabled;
+
             changed slider-color => {
                 root.current-color = slider-color;
             }
@@ -480,21 +504,25 @@ component ColorWidget inherits Rectangle {
 
 
             r := ColorLineEdit {
+                enabled: root.enabled;
                 value: root.current-color-data.r;
                 channel: "R";
             }
 
             g := ColorLineEdit {
+                enabled: root.enabled;
                 value: root.current-color-data.g;
                 channel: "G";
             }
 
             b := ColorLineEdit {
+                enabled: root.enabled;
                 value: root.current-color-data.b;
                 channel: "B";
             }
 
             a := ColorLineEdit {
+                enabled: root.enabled;
                 value: root.current-color-data.a;
                 channel: "A";
             }
@@ -507,6 +535,7 @@ component ColorWidget inherits Rectangle {
 }
 
 component IntegerWidget inherits VerticalLayout {
+    in property <bool> enabled;
     in property <ElementInformation> element-information;
     in property <PropertyInformation> property-information;
 
@@ -519,6 +548,7 @@ component IntegerWidget inherits VerticalLayout {
         height: 2rem;
         spacing: EditorSpaceSettings.default-spacing;
         ResettingLineEdit {
+            enabled: root.enabled;
             horizontal-alignment: right;
             input-type: number;
 
@@ -526,28 +556,29 @@ component IntegerWidget inherits VerticalLayout {
 
             edited(text) => {
                 self.can-compile = Api.test-code-binding(
-            element-information.source-uri,
-            element-information.source-version,
-            element-information.range.start,
-            property-information.name,
-            text,
-        );
+                    element-information.source-uri,
+                    element-information.source-version,
+                    element-information.range.start,
+                    property-information.name,
+                    text,
+                );
             }
 
             accepted(text) => {
                 Api.set-code-binding(
-            element-information.source-uri,
-            element-information.source-version,
-            element-information.range.start,
-            property-information.name,
-            text,
-        );
+                    element-information.source-uri,
+                    element-information.source-version,
+                    element-information.range.start,
+                    property-information.name,
+                    text,
+                );
             }
         }
     }
 }
 
 component EnumWidget inherits VerticalLayout {
+    in property <bool> enabled;
     in property <ElementInformation> element-information;
     in property <PropertyInformation> property-information;
 
@@ -558,6 +589,7 @@ component EnumWidget inherits VerticalLayout {
 
     HorizontalLayout {
         ComboBox {
+            enabled: root.enabled;
             current-index: property-information.value.value-int;
 
             model: property-information.value.visual-items;
@@ -576,6 +608,7 @@ component EnumWidget inherits VerticalLayout {
 }
 
 component BooleanWidget inherits VerticalLayout {
+    in property <bool> enabled;
     in property <ElementInformation> element-information;
     in property <PropertyInformation> property-information;
 
@@ -595,97 +628,19 @@ component BooleanWidget inherits VerticalLayout {
                 alignment: start;
                 padding-left: EditorSpaceSettings.default-padding;
                 spacing: EditorSpaceSettings.default-spacing;
-                checkbox:=CheckBox {
+                checkbox := CheckBox {
+                    enabled: root.enabled;
                     checked: property-information.value.value_bool;
                     text: self.checked ? "True" : "False";
 
                     toggled() => {
                         Api.set-code-binding(
-            element-information.source-uri,
-            element-information.source-version,
-            element-information.range.start,
-            property-information.name,
-            self.checked ? "true" : "false",
-        );
-                    }
-                }
-
-            }
-        }
-    }
-}
-
-export component ExpandableProperty inherits Rectangle {
-    callback toggled;
-    in-out property <bool> checked:false;
-    property <duration> dur:300ms;
-    in-out property <color> headerBG: Palette.alternate-background;
-    in-out property <bool> enabled:true;
-    in property <string> title: "Title";
-    clip: true;
-    height: header.height + EditorSpaceSettings.default-spacing + (root.checked ? content.preferred-height : 0px);
-    animate height {
-        duration: dur;
-        easing: ease-out;
-    }
-
-    VerticalLayout {
-        x: 0;
-        spacing: EditorSpaceSettings.default-spacing;
-        Rectangle {
-            height: 5px;
-        }
-
-        touch-area := TouchArea {
-            clicked => {
-                if (root.enabled) {
-                    root.checked = !root.checked;
-                    root.toggled();
-                }
-            }
-
-            state-layer := StateLayer {
-                width: 100%;
-                height: 100%;
-                has-hover: touch-area.has-hover;
-                pressed: touch-area.pressed;
-            }
-
-            header := Rectangle {
-                width: 100%;
-                height: 30px;
-                background: headerBG;
-            }
-
-            HorizontalLayout {
-                x: 0;
-                y: 0;
-                width: 100%;
-                alignment: stretch;
-
-                accordionIcon := Image {
-                    width: EditorSpaceSettings.group-indent;
-                    source: Icons.add;
-                    colorize: Palette.foreground;
-                    vertical-alignment: top;
-                    visible: state-layer.has-hover;
-                    rotation-angle: root.checked ? 180deg : 0deg;
-                    animate rotation-angle {
-                        duration: dur / 2;
-                        easing: ease-in;
-                    }
-                }
-
-                content := Rectangle {
-                    background: headerBG;
-                    height: root.checked ? self.preferred-height : 10px;
-                    animate height {
-                        duration: dur;
-                        easing: ease-out;
-                    }
-                    VerticalLayout {
-                        width: 100%;
-                        @children
+                            element-information.source-uri,
+                            element-information.source-version,
+                            element-information.range.start,
+                            property-information.name,
+                            self.checked ? "true" : "false",
+                        );
                     }
                 }
             }
@@ -694,12 +649,14 @@ export component ExpandableProperty inherits Rectangle {
 }
 
 component ExpandableGroup {
+    in property <bool> enabled;
     in property <ElementInformation> element-information;
     in property <string> text;
     in property <[PropertyInformation]> properties;
     in property <length> panel-width;
 
     property <bool> open: true;
+
     group-layer := Rectangle {
 
         content-layer := VerticalLayout {
@@ -757,31 +714,38 @@ component ExpandableGroup {
                         alignment: stretch;
 
                         if property.value.kind == PropertyValueKind.boolean: BooleanWidget {
+                            enabled: root.enabled;
                             element-information <=> root.element-information;
                             property-information: property;
                         }
                         if (property.value.kind == PropertyValueKind.color) || (property.value.kind == PropertyValueKind.brush): ColorWidget {
+                            enabled: root.enabled;
                             element-information <=> root.element-information;
                             property-information: property;
                         }
 
                         if property.value.kind == PropertyValueKind.code: CodeWidget {
+                            enabled: root.enabled;
                             element-information <=> root.element-information;
                             property-information: property;
                         }
                         if property.value.kind == PropertyValueKind.enum:  EnumWidget {
+                            enabled: root.enabled;
                             element-information <=> root.element-information;
                             property-information: property;
                         }
                         if property.value.kind == PropertyValueKind.integer: IntegerWidget {
+                            enabled: root.enabled;
                             element-information <=> root.element-information;
                             property-information: property;
                         }
                         if property.value.kind == PropertyValueKind.string: StringWidget {
+                            enabled: root.enabled;
                             element-information <=> root.element-information;
                             property-information: property;
                         }
                         if property.value.kind == PropertyValueKind.float: FloatWidget {
+                            enabled: root.enabled;
                             element-information <=> root.element-information;
                             property-information: property;
                         }
@@ -793,6 +757,8 @@ component ExpandableGroup {
 }
 
 export component PropertyView {
+    in property <bool> enabled;
+
     property <ElementInformation> current-element <=> Api.current-element;
     property <[PropertyGroup]> properties <=> Api.properties;
 
@@ -820,6 +786,8 @@ export component PropertyView {
                 alignment: start;
 
                 for group in root.properties: ExpandableGroup {
+                    enabled: root.enabled;
+
                     text: group.group-name;
                     panel-width: content-layer.width;
                     element-information <=> root.current-element;


### PR DESCRIPTION
This leaves the previous state visible.

* The diagnostics are removed. You need to fix those in your editor anyway, so we report them there.
* Use the statusbar to point to the editor in case of errors or warnings.
* Have a small popup to show the preview is outdated
* Disable dropping things into an outdated preview
* Disable the property editor when the preview is outdated
* Disable selection/editing when the preview is outdated
