### PR TITLE
C++: explicitly cast to float when generating gradiant stop

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3343,7 +3343,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             let mut stops_it = stops.iter().map(|(color, stop)| {
                 let color = compile_expression(color, ctx);
                 let position = compile_expression(stop, ctx);
-                format!("slint::private_api::GradientStop{{ {}, {}, }}", color, position)
+                format!("slint::private_api::GradientStop{{ {}, float({}), }}", color, position)
             });
             format!(
                 "[&] {{ const slint::private_api::GradientStop stops[] = {{ {} }}; return slint::Brush(slint::private_api::LinearGradientBrush({}, stops, {})); }}()",
@@ -3354,7 +3354,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             let mut stops_it = stops.iter().map(|(color, stop)| {
                 let color = compile_expression(color, ctx);
                 let position = compile_expression(stop, ctx);
-                format!("slint::private_api::GradientStop{{ {}, {}, }}", color, position)
+                format!("slint::private_api::GradientStop{{ {}, float({}), }}", color, position)
             });
             format!(
                 "[&] {{ const slint::private_api::GradientStop stops[] = {{ {} }}; return slint::Brush(slint::private_api::RadialGradientBrush(stops, {})); }}()",

--- a/tests/cases/types/gradients.slint
+++ b/tests/cases/types/gradients.slint
@@ -13,4 +13,20 @@ Test := Rectangle {
     }
 
     property <color> c: @linear-gradient(90deg,#e2e1e1,#c5c5c5);
+
+
+    Rectangle {
+        property <color> col1 : #f0f;
+        property <color> col2 : #0ff;
+        property <color> col3 : #ff0;
+        property <duration> time : 2s;
+        property <float> animated : 2 * Math.mod(animation-tick()/2s, 1);
+        property <float> animated2 : 2* Math.mod(animation-tick()/-2s, 1);
+        background:
+            self.animated <= 1 ? @linear-gradient(90deg, self.col1 self.animated * 0.1, self.col3 self.animated * 1, self.col1 self.animated2 * 1)
+            : self.animated <= 2 ? @linear-gradient(90deg, self.col1 self.animated2 * 0.1, self.col3 self.animated2 * 1, self.col1 self.animated * 1)
+            : @linear-gradient(90deg, self.col1 self.animated2 * 10, red self.animated2 * 150, self.col1 self.animated2 * 200);
+
+    }
+
 }


### PR DESCRIPTION
To avoid the error `error: narrowing conversion of`
