### PR TITLE
vscode extension: say that we support "ui" as an extension kind

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -33,6 +33,10 @@
   ],
   "main": "./out/extension.js",
   "browser": "./out/browser.js",
+  "extensionKind": [
+    "workspace",
+    "ui"
+  ],
   "contributes": {
     "languages": [
       {


### PR DESCRIPTION
According to the docs in https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location that seems to fit. Hoping that we would see the wasm preview in more cases such as live share
