### PR TITLE
lsp: Better hover information for images in text only editors

### DIFF
--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -44,7 +44,7 @@ pub fn get_tooltip(document_cache: &mut DocumentCache, token: SyntaxToken) -> Op
         },
         TokenInfo::Image(path) => MarkupContent {
             kind: lsp_types::MarkupKind::Markdown,
-            value: format!("![Image]({})", path.to_string_lossy()),
+            value: format!("![{0}]({0})", path.to_string_lossy()),
         },
         // Todo: this can happen when there is some syntax error
         TokenInfo::LocalProperty(_) | TokenInfo::LocalCallback(_) => return None,
@@ -273,7 +273,7 @@ export component Test {
             uri.join("test.png").unwrap().to_file_path().unwrap().to_string_lossy().to_string();
         assert_tooltip(
             get_tooltip(&mut dc, find_tk("@image-url(", 15.into())),
-            &format!("![Image]({target_path})"),
+            &format!("![{target_path}]({target_path})"),
         );
 
         // enums


### PR DESCRIPTION
Whow the path when the editor can not render the image itself.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
