### PR TITLE
docs: Do not fail fatally when playwright can not install its browsers

### DIFF
--- a/xtask/src/slintdocs.rs
+++ b/xtask/src/slintdocs.rs
@@ -21,7 +21,9 @@ pub fn generate() -> Result<(), Box<dyn std::error::Error>> {
         let sh = Shell::new()?;
         let _p = sh.push_dir(&docs_source_dir);
         cmd!(sh, "pnpm install --frozen-lockfile --ignore-scripts").run()?;
-        cmd!(sh, "pnpm exec playwright install --with-deps").run()?;
+        // The following will fail on e.g. Fedora
+        cmd!(sh, "pnpm exec playwright install-deps").ignore_status().run()?;
+        cmd!(sh, "pnpm exec playwright install --with-deps").ignore_status().run()?;
         cmd!(sh, "pnpm run build").run()?;
     }
 


### PR DESCRIPTION
This is expected e.g. on Fedora :-/

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
