### PR TITLE
add tree-sitter init for publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,8 @@ default-members = [
     'tools/viewer',
 ]
 
+exclude = ["editors/tree-sitter-slint"]
+
 resolver="2"
 
 [workspace.package]

--- a/editors/tree-sitter-slint/.editorconfig
+++ b/editors/tree-sitter-slint/.editorconfig
@@ -1,0 +1,46 @@
+root = true
+
+[*]
+charset = utf-8
+
+[*.{json,toml,yml,gyp}]
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.scm]
+indent_style = space
+indent_size = 2
+
+[*.{c,cc,h}]
+indent_style = space
+indent_size = 4
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.{py,pyi}]
+indent_style = space
+indent_size = 4
+
+[*.swift]
+indent_style = space
+indent_size = 4
+
+[*.go]
+indent_style = tab
+indent_size = 8
+
+[Makefile]
+indent_style = tab
+indent_size = 8
+
+[parser.c]
+indent_size = 2
+
+[{alloc,array,parser}.h]
+indent_size = 2

--- a/editors/tree-sitter-slint/.gitattributes
+++ b/editors/tree-sitter-slint/.gitattributes
@@ -1,0 +1,37 @@
+* text=auto eol=lf
+
+# Generated source files
+src/*.json linguist-generated
+src/parser.c linguist-generated
+src/tree_sitter/* linguist-generated
+
+# C bindings
+bindings/c/* linguist-generated
+CMakeLists.txt linguist-generated
+Makefile linguist-generated
+
+# Rust bindings
+bindings/rust/* linguist-generated
+Cargo.toml linguist-generated
+Cargo.lock linguist-generated
+
+# Node.js bindings
+bindings/node/* linguist-generated
+binding.gyp linguist-generated
+package.json linguist-generated
+package-lock.json linguist-generated
+
+# Python bindings
+bindings/python/** linguist-generated
+setup.py linguist-generated
+pyproject.toml linguist-generated
+
+# Go bindings
+bindings/go/* linguist-generated
+go.mod linguist-generated
+go.sum linguist-generated
+
+# Swift bindings
+bindings/swift/** linguist-generated
+Package.swift linguist-generated
+Package.resolved linguist-generated

--- a/editors/tree-sitter-slint/CMakeLists.txt
+++ b/editors/tree-sitter-slint/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(tree-sitter-slint
+        VERSION "0.23.0"
+        DESCRIPTION "A tree-sitter parser for Slint"
+        HOMEPAGE_URL "https://github.com/slint/slint-ui/tree/master/editors/tree-sitter-slint"
+        LANGUAGES C)
+
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+option(TREE_SITTER_REUSE_ALLOCATOR "Reuse the library allocator" OFF)
+
+set(TREE_SITTER_ABI_VERSION 14 CACHE STRING "Tree-sitter ABI version")
+if(NOT ${TREE_SITTER_ABI_VERSION} MATCHES "^[0-9]+$")
+    unset(TREE_SITTER_ABI_VERSION CACHE)
+    message(FATAL_ERROR "TREE_SITTER_ABI_VERSION must be an integer")
+endif()
+
+find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
+
+add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
+                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
+                   COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
+                            --abi=${TREE_SITTER_ABI_VERSION}
+                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                   COMMENT "Generating parser.c")
+
+add_library(tree-sitter-slint src/parser.c)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/scanner.c)
+  target_sources(tree-sitter-slint PRIVATE src/scanner.c)
+endif()
+target_include_directories(tree-sitter-slint PRIVATE src)
+
+target_compile_definitions(tree-sitter-slint PRIVATE
+                           $<$<BOOL:${TREE_SITTER_REUSE_ALLOCATOR}>:TREE_SITTER_REUSE_ALLOCATOR>
+                           $<$<CONFIG:Debug>:TREE_SITTER_DEBUG>)
+
+set_target_properties(tree-sitter-slint
+                      PROPERTIES
+                      C_STANDARD 11
+                      POSITION_INDEPENDENT_CODE ON
+                      SOVERSION "${TREE_SITTER_ABI_VERSION}.${PROJECT_VERSION_MAJOR}"
+                      DEFINE_SYMBOL "")
+
+configure_file(bindings/c/tree-sitter-slint.pc.in
+               "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-slint.pc" @ONLY)
+
+include(GNUInstallDirs)
+
+install(FILES bindings/c/tree-sitter-slint.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-slint.pc"
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
+install(TARGETS tree-sitter-slint
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+add_custom_target(ts-test "${TREE_SITTER_CLI}" test
+                  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                  COMMENT "tree-sitter test")

--- a/editors/tree-sitter-slint/Cargo.toml
+++ b/editors/tree-sitter-slint/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tree-sitter-slint"
+description = "A tree-sitter parser for Slint"
+version = "0.24.0"
+authors = ["Slint Developers <info@slint.dev>"]
+license = "MIT"
+readme = "README.md"
+keywords = ["incremental", "parsing", "tree-sitter", "slint"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/slint/slint-ui/tree/master/editors/tree-sitter-slint"
+edition = "2021"
+autoexamples = false
+
+build = "bindings/rust/build.rs"
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*", "tree-sitter.json"]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter-language = "0.1"
+
+[build-dependencies]
+cc = "1.1.22"
+
+[dev-dependencies]
+tree-sitter = "0.24.5"

--- a/editors/tree-sitter-slint/Package.swift
+++ b/editors/tree-sitter-slint/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterSlint",
+    products: [
+        .library(name: "TreeSitterSlint", targets: ["TreeSitterSlint"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.8.0"),
+    ],
+    targets: [
+        .target(
+            name: "TreeSitterSlint",
+            dependencies: [],
+            path: ".",
+            sources: [
+                "src/parser.c",
+                // NOTE: if your language has an external scanner, add it here.
+            ],
+            resources: [
+                .copy("queries")
+            ],
+            publicHeadersPath: "bindings/swift",
+            cSettings: [.headerSearchPath("src")]
+        ),
+        .testTarget(
+            name: "TreeSitterSlintTests",
+            dependencies: [
+                "SwiftTreeSitter",
+                "TreeSitterSlint",
+            ],
+            path: "bindings/swift/TreeSitterSlintTests"
+        )
+    ],
+    cLanguageStandard: .c11
+)

--- a/editors/tree-sitter-slint/go.mod
+++ b/editors/tree-sitter-slint/go.mod
@@ -1,0 +1,5 @@
+module github.com/slint/slint-ui/tree/master/editors/tree-sitter-slint
+
+go 1.22
+
+require github.com/tree-sitter/go-tree-sitter v0.24.0

--- a/editors/tree-sitter-slint/pyproject.toml
+++ b/editors/tree-sitter-slint/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tree-sitter-slint"
+description = "A tree-sitter parser for Slint"
+version = "0.23.0"
+keywords = ["incremental", "parsing", "tree-sitter", "slint"]
+classifiers = [
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Compilers",
+  "Topic :: Text Processing :: Linguistic",
+  "Typing :: Typed",
+]
+authors = [{ name = "Slint Developers", email = "info@slint.dev" }]
+requires-python = ">=3.9"
+license.text = "MIT"
+readme = "README.md"
+
+[project.urls]
+Homepage = "https://github.com/slint/slint-ui/tree/master/editors/tree-sitter-slint"
+
+[project.optional-dependencies]
+core = ["tree-sitter~=0.22"]
+
+[tool.cibuildwheel]
+build = "cp39-*"
+build-frontend = "build"

--- a/editors/tree-sitter-slint/setup.py
+++ b/editors/tree-sitter-slint/setup.py
@@ -1,0 +1,62 @@
+from os.path import isdir, join
+from platform import system
+
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build import build
+from wheel.bdist_wheel import bdist_wheel
+
+
+class Build(build):
+    def run(self):
+        if isdir("queries"):
+            dest = join(self.build_lib, "tree_sitter_slint", "queries")
+            self.copy_tree("queries", dest)
+        super().run()
+
+
+class BdistWheel(bdist_wheel):
+    def get_tag(self):
+        python, abi, platform = super().get_tag()
+        if python.startswith("cp"):
+            python, abi = "cp39", "abi3"
+        return python, abi, platform
+
+
+setup(
+    packages=find_packages("bindings/python"),
+    package_dir={"": "bindings/python"},
+    package_data={
+        "tree_sitter_slint": ["*.pyi", "py.typed"],
+        "tree_sitter_slint.queries": ["*.scm"],
+    },
+    ext_package="tree_sitter_slint",
+    ext_modules=[
+        Extension(
+            name="_binding",
+            sources=[
+                "bindings/python/tree_sitter_slint/binding.c",
+                "src/parser.c",
+                # NOTE: if your language uses an external scanner, add it here.
+            ],
+            extra_compile_args=[
+                "-std=c11",
+                "-fvisibility=hidden",
+            ] if system() != "Windows" else [
+                "/std:c11",
+                "/utf-8",
+            ],
+            define_macros=[
+                ("Py_LIMITED_API", "0x03090000"),
+                ("PY_SSIZE_T_CLEAN", None),
+                ("TREE_SITTER_HIDE_SYMBOLS", None),
+            ],
+            include_dirs=["src"],
+            py_limited_api=True,
+        )
+    ],
+    cmdclass={
+        "build": Build,
+        "bdist_wheel": BdistWheel
+    },
+    zip_safe=False
+)

--- a/editors/tree-sitter-slint/tree-sitter.json
+++ b/editors/tree-sitter-slint/tree-sitter.json
@@ -1,0 +1,36 @@
+{
+  "grammars": [
+    {
+      "name": "slint",
+      "camelcase": "Slint",
+      "scope": "source.slint",
+      "file-types": [
+        ".slint"
+      ],
+      "injection-regex": "^slint$"
+    }
+  ],
+  "metadata": {
+    "version": "0.23.0",
+    "license": "MIT",
+    "description": "A tree-sitter parser for Slint",
+    "authors": [
+      {
+        "name": "Slint Developers",
+        "email": "info@slint.dev",
+        "url": "https://slint.dev/"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/slint/slint-ui/tree/master/editors/tree-sitter-slint"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

I published a new version of this rust binding for the tree-sitter-slint crate. (I've also added @hunger as an owner). If you to include the tree-sitter generated bindings that are on by default with the `tree-sitter init` command this is the result. 

These things can be regenerated for publishing later so including this isn't strictly necessary but I think this would be good to include. 