### PR TITLE
doc: Fix language of return value handling of key callbacks for Focus…

### DIFF
--- a/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
+++ b/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
@@ -59,11 +59,11 @@ Call this function to remove keyboard focus from this `FocusScope` if it current
 
 ### key-pressed(KeyEvent) -> EventResult
 Invoked when a key is pressed, the argument is a <Link type="KeyEvent" /> struct. The returned `EventResult` 
-indicates whether to accept or ignore the event. Ignored events are forwarded to the parent element.
+indicates whether to accept or reject the event. Rejected events are forwarded to the parent element.
 
 ### key-released(KeyEvent) -> EventResult
 Invoked when a key is released, the argument is a <Link type="KeyEvent" /> struct. The returned `EventResult` 
-indicates whether to accept or ignore the event. Ignored events are forwarded to the parent element.
+indicates whether to accept or reject the event. Rejected events are forwarded to the parent element.
 
 ### focus-changed-event()
 Invoked when the focus on the `FocusScope` has changed.


### PR DESCRIPTION
…Scope

We use reject instead of ignore.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
