### PR TITLE
Remove draw_rect() shortcut in ItemRenderer trait

### DIFF
--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -292,6 +292,24 @@ pub trait RenderBorderRectangle {
     fn border_color(self: Pin<&Self>) -> Brush;
 }
 
+impl RenderBorderRectangle for Brush {
+    fn background(self: Pin<&Self>) -> Brush {
+        self.get_ref().clone()
+    }
+
+    fn border_width(self: Pin<&Self>) -> LogicalLength {
+        Default::default()
+    }
+
+    fn border_radius(self: Pin<&Self>) -> LogicalBorderRadius {
+        Default::default()
+    }
+
+    fn border_color(self: Pin<&Self>) -> Brush {
+        Default::default()
+    }
+}
+
 /// Trait for an item that represents an Image towards the renderer
 #[allow(missing_docs)]
 pub trait RenderImage {
@@ -450,12 +468,6 @@ pub trait ItemRenderer {
     fn draw_string(&mut self, string: &str, color: crate::Color);
 
     fn draw_image_direct(&mut self, image: crate::graphics::Image);
-
-    /// Fills a rectangle at (0,0) with the given size. This is used for example by the Skia renderer to
-    /// handle window backgrounds with a brush (gradient).
-    fn draw_rect(&mut self, _size: LogicalSize, _brush: Brush) {
-        unimplemented!()
-    }
 
     /// This is called before it is being rendered (before the draw_* function).
     /// Returns
@@ -908,10 +920,6 @@ impl<'a, T: ItemRenderer> ItemRenderer for PartialRenderer<'a, T> {
 
     fn draw_image_direct(&mut self, image: crate::graphics::image::Image) {
         self.actual_renderer.draw_image_direct(image)
-    }
-
-    fn draw_rect(&mut self, size: LogicalSize, brush: Brush) {
-        self.actual_renderer.draw_rect(size, brush);
     }
 
     fn window(&self) -> &crate::window::WindowInner {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1216,6 +1216,18 @@ impl WindowInner {
         })
     }
 
+    /// Returns the window item that is the first item in the component.
+    pub fn window_item_rc(&self) -> Option<ItemRc> {
+        self.try_component().and_then(|component_rc| {
+            let window_item_rc = ItemRc::new(component_rc, 0);
+            if window_item_rc.downcast::<crate::items::WindowItem>().is_some() {
+                Some(window_item_rc)
+            } else {
+                None
+            }
+        })
+    }
+
     /// Sets the size of the window item. This method is typically called in response to receiving a
     /// window resize event from the windowing system.
     pub(crate) fn set_window_item_geometry(&self, size: crate::lengths::LogicalSize) {

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -176,9 +176,10 @@ impl<'a> GLItemRenderer<'a> {
     pub fn global_alpha_transparent(&self) -> bool {
         self.state.last().unwrap().global_alpha == 0.0
     }
+}
 
-    /// Draws a `Rectangle` using the `GLItemRenderer`.
-    pub fn draw_rect(&mut self, size: LogicalSize, brush: Brush) {
+impl<'a> ItemRenderer for GLItemRenderer<'a> {
+    fn draw_rectangle(&mut self, rect: Pin<&items::Rectangle>, _: &ItemRc, size: LogicalSize) {
         let geometry = PhysicalRect::from(size * self.scale_factor);
         if geometry.is_empty() {
             return;
@@ -186,6 +187,7 @@ impl<'a> GLItemRenderer<'a> {
         if self.global_alpha_transparent() {
             return;
         }
+        let brush = rect.background();
         // TODO: cache path in item to avoid re-tesselation
         let path = rect_to_path(geometry);
         let paint = match self.brush_to_paint(brush, &path) {
@@ -196,12 +198,6 @@ impl<'a> GLItemRenderer<'a> {
         // the extra stroke triangle strip around the edges
         .with_anti_alias(false);
         self.canvas.borrow_mut().fill_path(&path, &paint);
-    }
-}
-
-impl<'a> ItemRenderer for GLItemRenderer<'a> {
-    fn draw_rectangle(&mut self, rect: Pin<&items::Rectangle>, _: &ItemRc, size: LogicalSize) {
-        self.draw_rect(size, rect.background());
     }
 
     fn draw_border_rectangle(

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -264,11 +264,17 @@ impl FemtoVGRenderer {
                 match window_background_brush {
                     Some(Brush::SolidColor(..)) | None => {}
                     Some(brush) => {
-                        item_renderer.draw_rect(
+                        let window_item_rc = window_inner.window_item_rc().unwrap();
+                        let window_item =
+                            window_item_rc.downcast::<i_slint_core::items::WindowItem>().unwrap();
+                        let pinned_brush = std::pin::pin!(brush);
+                        item_renderer.draw_border_rectangle(
+                            pinned_brush,
+                            &window_item_rc,
                             i_slint_core::lengths::logical_size_from_api(
                                 window.size().to_logical(window_inner.scale_factor()),
                             ),
-                            brush,
+                            &window_item.cached_rendering_data,
                         );
                     }
                 }

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -449,11 +449,17 @@ impl SkiaRenderer {
                 }
                 None => {}
                 Some(brush @ _) => {
-                    item_renderer.draw_rect(
+                    let window_item_rc = window_inner.window_item_rc().unwrap();
+                    let window_item =
+                        window_item_rc.downcast::<i_slint_core::items::WindowItem>().unwrap();
+                    let pinned_brush = std::pin::pin!(brush);
+                    item_renderer.draw_border_rectangle(
+                        pinned_brush,
+                        &window_item_rc,
                         i_slint_core::lengths::logical_size_from_api(
                             window.size().to_logical(window_inner.scale_factor()),
                         ),
-                        brush,
+                        &window_item.cached_rendering_data,
                     );
                 }
             }


### PR DESCRIPTION
As discussed during API Review, reducing the API surface.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
