### PR TITLE
Keep focus of child of clipped item that are themselves not clipped

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -685,15 +685,16 @@ impl WindowInner {
         event.modifiers = self.modifiers.get().into();
 
         let mut item = self.focus_item.borrow().clone().upgrade();
+
+        if item.as_ref().is_some_and(|i| !i.is_visible()) {
+            // Reset the focus... not great, but better than keeping it.
+            self.take_focus_item();
+            item = None;
+        }
+
         while let Some(focus_item) = item {
-            if !focus_item.is_visible() {
-                // Reset the focus... not great, but better than keeping it.
-                self.take_focus_item();
-            } else if focus_item.borrow().as_ref().key_event(
-                &event,
-                &self.window_adapter(),
-                &focus_item,
-            ) == crate::input::KeyEventResult::EventAccepted
+            if focus_item.borrow().as_ref().key_event(&event, &self.window_adapter(), &focus_item)
+                == crate::input::KeyEventResult::EventAccepted
             {
                 crate::properties::ChangeTracker::run_change_handlers();
                 return;

--- a/tests/cases/focus/7058_scrolled_clip.slint
+++ b/tests/cases/focus/7058_scrolled_clip.slint
@@ -1,0 +1,40 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+
+import { Button, TextEdit } from "std-widgets.slint";
+export component TestCase inherits Window {
+    preferred-height: 768px;
+    preferred-width: 1024px;
+    forward-focus: te;
+    VerticalLayout {
+        y: -1 * root.height;
+        width: root.width;
+        Rectangle {
+            height: root.height;
+        }
+        te := TextEdit {
+            height: root.height;
+
+        }
+    }
+    out property <string> text <=> te.text;
+    out property <bool> has-focus <=> te.has-focus;
+}
+
+
+/*
+
+
+```rust
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_has_focus(), true);
+slint_testing::send_keyboard_string_sequence(&instance, "X");
+slint_testing::send_keyboard_string_sequence(&instance, "Y");
+slint_testing::send_keyboard_string_sequence(&instance, "Z");
+assert_eq!(instance.get_text(), "XYZ");
+assert_eq!(instance.get_has_focus(), true);
+```
+
+*/


### PR DESCRIPTION
If a clipped item has a child outside of its bounds that is not clipped, we shouldn't remove the focus.

Fixes #7058
