### PR TITLE
live-preview: Move library closer to the 1.9 Reference docs

### DIFF
--- a/tools/lsp/common/component_catalog.rs
+++ b/tools/lsp/common/component_catalog.rs
@@ -22,9 +22,23 @@ fn builtin_component_info(name: &str) -> ComponentInformation {
         _ => vec![],
     };
 
+    let component = {
+        if ["Flickable", "SwipeGestureHandler", "TouchArea"].contains(&name) {
+            "Gestures"
+        } else if ["FocusScope", "TextInput"].contains(&name) {
+            "Keyboard Input"
+        } else if name.ends_with("Layout") {
+            "Basic Layouts"
+        } else if ["Dialog", "PopupWindow", "Window"].contains(&name) {
+            "Window"
+        } else {
+            "Basic Elements"
+        }
+    };
+
     ComponentInformation {
         name: name.to_string(),
-        category: "Builtin Elements".to_string(),
+        category: component.to_string(),
         is_global: false,
         is_builtin: true,
         is_std_widget: false,
@@ -57,7 +71,7 @@ fn std_widgets_info(name: &str, is_global: bool) -> ComponentInformation {
 
     ComponentInformation {
         name: name.to_string(),
-        category: "Widgets".to_string(),
+        category: "Std-Widgets".to_string(),
         is_global,
         is_builtin: false,
         is_std_widget: true,
@@ -112,10 +126,9 @@ fn file_local_component_info(
 pub fn builtin_components(document_cache: &DocumentCache, result: &mut Vec<ComponentInformation>) {
     let registry = document_cache.global_type_registry();
     result.extend(registry.all_elements().iter().filter_map(|(name, ty)| match ty {
-        ElementType::Builtin(b)
-            if !b.is_internal && !b.is_non_item_type && name != "Dialog" && name != "Window" =>
-        {
-            Some(builtin_component_info(name))
+        ElementType::Builtin(b) if !b.is_internal && !b.is_non_item_type => {
+            let info = builtin_component_info(name);
+            (info.category != "Window").then_some(info)
         }
         _ => None,
     }));


### PR DESCRIPTION
I can not exactly mirror the Reference manual as the library is hard-coded to one level of depth, while the docs use two levels.

This patch takes the "lower" level of the docs ("Basic Layouts", ...), but groups all widgets below "Std Widgets" (the "upper" level of the docs layout). This is because we see many projects that avoid our widgets, so I wanted those users to be able to collapse all widgets with one click.

One additional refinement in this patch is that all widgets will always be sorted after all builtin categories and that none of the builtin Windows will get shown in the library as those are not really editable in the live preview anyway.
