### PR TITLE
Introduce link-data.json in the C++ docs to reduce risk of dead links

### DIFF
--- a/api/cpp/docs/cmake.md
+++ b/api/cpp/docs/cmake.md
@@ -130,7 +130,7 @@ any built-in backends, and instead develop your own backend by implementing Slin
 abstraction and window adapter interfaces.
 
 For more information about the available backends, their system requirements, and configuration
-options, see the [Backend & Renderers Documentation](slint-reference:src/advanced/backends_and_renderers.html).
+options, see the {{ '[Backend & Renderers Documentation]({})'.format(slint_href_backends_and_renderers) }}.
 
 By default Slint will include both the Qt and
 [winit](https://crates.io/crates/winit) back-ends -- if both are detected at

--- a/api/cpp/docs/cmake_reference.md
+++ b/api/cpp/docs/cmake_reference.md
@@ -13,7 +13,7 @@ and extend the include directories of your target so that the generated file is 
 
 The optional `NAMESPACE` argument will put the generated components in the given C++ namespace.
 
-Use the `LIBRARY_PATHS` argument to specify the name and paths to [component libraries](slint-reference:src/language/syntax/modules#component-libraries),
+Use the `LIBRARY_PATHS` argument to specify the name and paths to {{ '[component libraries]({})'.format(slint_href_ComponentLibraries) }},
 separated by an equals sign (`=`).
 
 Given a file called `the_window.slint`, the following example will create a file called `the_window.h` that can
@@ -38,7 +38,7 @@ only one single `.h` file.
 
 ## Resource Embedding
 
-By default, images from [`@image-url()`](slint-reference:src/language/syntax/types#images) or fonts that your Slint files reference are loaded from disk at run-time. This minimises build times, but requires that the directory structure with the files remains stable. If you want to build a program that runs anywhere, then you can configure the Slint compiler to embed such sources into the binary.
+By default, images from {{ '[`@image-url()`]({})'.format(slint_href_ImageType) }} or fonts that your Slint files reference are loaded from disk at run-time. This minimises build times, but requires that the directory structure with the files remains stable. If you want to build a program that runs anywhere, then you can configure the Slint compiler to embed such sources into the binary.
 
 Set the `SLINT_EMBED_RESOURCES` target property on your CMake target to one of the following values:
 

--- a/api/cpp/docs/conf.py
+++ b/api/cpp/docs/conf.py
@@ -13,10 +13,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import textwrap
+import os
+import json
 
 
 # -- Project information -----------------------------------------------------
@@ -109,7 +110,7 @@ html_show_sourcelink = False
 html_logo = "https://slint.dev/logo/slint-logo-small-light.svg"
 
 myst_enable_extensions = [
-    "html_image", "colon_fence"
+    "html_image", "colon_fence", "substitution"
 ]
 
 # Annotate h1/h2 elements with anchors
@@ -120,13 +121,19 @@ myst_url_schemes = {
     'http': None, 'https': None, 'mailto': None,
 }
 
-rst_epilog = """
-.. |ListView| replace:: :code:`ListView`
-.. _ListView: ../../slint/src/language/widgets/listview
-.. |Repetition| replace:: :code:`for` - :code:`in`
-.. _Repetition: ../../slint/src/reference/repetitions.html
-"""
+rst_epilog = ""
 
+myst_substitutions = {}
+
+with open(os.path.join(os.path.dirname(__file__), "..", "..", "internal", "core-macros", "link-data.json")) as link_data:
+    links = json.load(link_data)
+
+for key in links.keys():
+    href = links[key]["href"]
+    url = f"https://slint.dev/releases/{version}/docs/slint{href}"
+    myst_substitutions[f"slint_href_{key}"] = url
+    rst_epilog += f".. |{key}| replace:: :code:`{key}`\n"
+    rst_epilog += f".. _{key}: {url}\n"
 
 def setup(app):
     app.add_css_file("theme_tweak.css")

--- a/api/cpp/docs/generated_code.md
+++ b/api/cpp/docs/generated_code.md
@@ -35,8 +35,8 @@ actual instance and keeps it alive as long as at least one
 {cpp:class}`slint::ComponentHandle` is in scope, similar to `std::shared_ptr<T>`.
 
 For more complex user interfaces it's common to supply data in the form of an
-abstract data model, that's used with <a href="../slint/src/reference/repetitions.html">`for` - `in`</a>
-repetitions or <a href="../slint/src/language/widgets/listview">`ListView`</a> elements in the
+abstract data model, that's used with {{ '[`for` - `in`]({})'.format(slint_href_Models) }}
+repetitions or {{ '[ListView]({})'.format(slint_href_ListView) }} elements in the
 `.slint` language. All models in C++ are sub-classes of the
 {cpp:class}`slint::Model` and you can sub-class it yourself. For convenience,
 the {cpp:class}`slint::VectorModel` provides an implementation that's backed

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -316,7 +316,7 @@ long int model_length(const std::shared_ptr<M> &model)
 } // namespace private_api
 
 /// \rst
-/// A Model is providing Data for |Repetition|_ repetitions or |ListView|_ elements of the
+/// A Model is providing Data for Slint |Models|_ or |ListView|_ elements of the
 /// :code:`.slint` language
 /// \endrst
 template<typename ModelData>

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -26,6 +26,9 @@
     "color": {
         "href": "/reference/primitive-types#color"
     },
+    "ComponentLibraries": {
+        "href": "/guide/language/coding/file/#component-libraries"
+    },
     "CommonProperties": {
         "href": "/reference/common"
     },


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
