### PR TITLE
Fix window decoration on Linux with Wayland not being rendered accord…

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -573,7 +573,16 @@ impl WinitWindowAdapter {
         self.color_scheme
             .get_or_init(|| Box::pin(Property::new(ColorScheme::Unknown)))
             .as_ref()
-            .set(scheme)
+            .set(scheme);
+        // Inform winit about the selected color theme, so that the window decoration is drawn correctly.
+        #[cfg(not(use_winit_theme))]
+        if let Some(winit_window) = self.winit_window() {
+            winit_window.set_theme(match scheme {
+                ColorScheme::Unknown => None,
+                ColorScheme::Dark => Some(winit::window::Theme::Dark),
+                ColorScheme::Light => Some(winit::window::Theme::Light),
+            });
+        }
     }
 
     pub fn window_state_event(&self) {


### PR DESCRIPTION
…ing to the selected color scheme

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
