### PR TITLE
Rename structs, enums and components

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -826,6 +826,12 @@ impl SyntaxNode {
             .find(|n| n.kind() == kind)
             .and_then(|x| x.as_token().map(|x| x.text().into()))
     }
+    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> {
+        let source_file = self.source_file.clone();
+        self.node
+            .descendants()
+            .map(move |node| SyntaxNode { node, source_file: source_file.clone() })
+    }
     pub fn kind(&self) -> SyntaxKind {
         self.node.kind()
     }

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -304,6 +304,22 @@ pub fn rename_component_from_definition(
     identifier: &syntax_nodes::DeclaredIdentifier,
     new_name: &str,
 ) -> crate::Result<lsp_types::WorkspaceEdit> {
+    rename_declared_identifier(document_cache, identifier, new_name, &change_local_element_type)
+}
+
+/// Helper function to rename a `DeclaredIdentifier`.
+fn rename_declared_identifier(
+    document_cache: &common::DocumentCache,
+    identifier: &syntax_nodes::DeclaredIdentifier,
+    new_name: &str,
+    fixup_local_use: &dyn Fn(
+        &common::DocumentCache,
+        &syntax_nodes::Document,
+        &str,
+        &str,
+        &mut Vec<common::SingleTextEdit>,
+    ),
+) -> crate::Result<lsp_types::WorkspaceEdit> {
     let source_file = identifier.source_file().expect("Identifier had no source file");
     let document = document_cache
         .get_document_for_source_file(source_file)
@@ -344,7 +360,7 @@ pub fn rename_component_from_definition(
     );
 
     // Change all local usages:
-    change_local_element_type(document_cache, document_node, &component_type, new_name, &mut edits);
+    fixup_local_use(document_cache, document_node, &component_type, new_name, &mut edits);
 
     // Change exports
     fix_exports(document_cache, document_node, &component_type, new_name, &mut edits);

--- a/tools/lsp/common/test.rs
+++ b/tools/lsp/common/test.rs
@@ -118,7 +118,7 @@ pub fn recompile_test_with_sources(
 
     eprintln!("Test source diagnostics:");
     for d in diagnostics.iter() {
-        eprintln!("    {d}");
+        eprintln!("    {:?}: {d}", d.level());
     }
     assert!(!diagnostics.has_errors());
     if !allow_warnings {


### PR DESCRIPTION
This adds renaming of structs... in a limited fashion though: You have to be in the declaration of the component/struct or enum you want to rename.

This PR handles significantly more corner cases than the old component renaming code we used to have and comes with a few more tests to cover those.

Up next and building on this code: Trigger renaming based on any use of any of these types.