### PR TITLE
Introducing Slint Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://github.com/slint-ui/slint/workflows/CI/badge.svg)](https://github.com/slint-ui/slint/actions)
 [![REUSE status](https://api.reuse.software/badge/github.com/slint-ui/slint)](https://api.reuse.software/info/github.com/slint-ui/slint)
 [![Discussions](https://img.shields.io/github/discussions/slint-ui/slint)](https://github.com/slint-ui/slint/discussions)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Slint%20Guru-006BFF)](https://gurubase.io/g/slint)
 
 Slint is a declarative GUI toolkit to build native user interfaces for embedded,
 desktop, and mobile applications written in Rust, C++, JavaScript, or Python. 


### PR DESCRIPTION
Hello Team,

This PR is a friendly notification that the [Slint Guru](https://gurubase.io/g/slint) has been added to Gurubase. The Slint Guru uses data from this repository and the [documentation](https://docs.slint.dev/latest/docs/slint/) to answer questions by leveraging the LLM.

Gurubase is a centralized, RAG-based learning and troubleshooting assistant platform. Each "Guru" is equipped with custom knowledge to answer user questions based on data collected for that tool. More information can be found in [this repo](https://github.com/getanteon/gurubase).

This PR updates the README to indicate that Slint users can now ask questions to Slint Guru. As shown in the [Used By](https://github.com/getanteon/gurubase?tab=readme-ov-file#used-by) section, over 100 open-source repositories currently showcase their Guru in their README.md.

By default, there are three possible actions:
1. If you dislike it, we can immediately disable Slint Guru in Gurubase and remove this PR.
2. If you like it but don’t want to add it to the README, we can remove this PR or include it in another place you prefer.
3. If you’re happy with it, we can keep it as is and merge the PR. You can then start managing Slint Guru as described [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru).

Although this PR is created by the Gurubase Notifier account, the team monitors it and will answer any questions you may have.

**Note:** If you consider this PR a time-waster, apologize for the inconvenience. Developers often request us to create a Guru for the tools they use. Once we create it, we notify the maintainers to inform them and seek their approval.
