### PR TITLE
More robust BASE_URL support for docs

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -125,6 +125,13 @@ jobs:
             - name: Publish Test Summary Results
               working-directory: docs/astro
               run: npx github-actions-ctrf playwright-report/ctrf-report.json
+            - name: Upload test results
+              if: always()
+              uses: actions/upload-artifact@v3
+              with:
+                name: playwright-test-report
+                path: docs/astro/playwright-report/
+                retention-days: 30
 
             - name: "Node docs"
               run: pnpm run docs

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -104,12 +104,11 @@ jobs:
               working-directory: docs/astro
               continue-on-error: true
               run: pnpm format
-#            - name: Update URL for sitemap in astro.config.mjs
+            - name: Update URL for sitemap in site-config.ts
 #              if: ${{ env.RELEASE_INPUT == 'true' }}
-#              run: |
-#                sed -i 's|"https://snapshots.slint.dev/master/docs/slint/"|"https://releases.slint.dev/${{ steps.version.outputs.VERSION }}/docs/slint/"|' docs/astro/astro.config.mjs
-#                sed -i 's|"/master/docs/slint"|"/${{ steps.version.outputs.VERSION }}/docs/slint"|' docs/astro/astro.config.mjs
-#                sed -i 's|href="/master/docs/slint|href="/${{ steps.version.outputs.VERSION }}/docs/slint|' docs/astro/src/content/docs/index.mdx
+              run: |
+                sed -i 's|BASE_URL = "https://snapshots.slint.dev"|BASE_URL = "https://releases.slint.dev"|' docs/astro/src/utils/site-config.ts
+                sed -i 's|BASE_PATH = "/master/docs/slint"|BASE_PATH = "/${{ steps.version.outputs.VERSION }}/docs/slint"|' docs/astro/src/utils/site-config.ts
             - name: "Slint Language Documentation"
               run: cargo xtask slintdocs
             - name: Spellcheck

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -116,15 +116,15 @@ jobs:
               working-directory: docs/astro
               run: pnpm spellcheck
             # Test docs
-#            - name: Install Playwright
-#              working-directory: docs/astro
-#              run: pnpm exec playwright install --with-deps
-#            - name: Run Playwright tests
-#              working-directory: docs/astro
-#              run: pnpm exec playwright test
-#            - name: Publish Test Summary Results
-#              working-directory: docs/astro
-#              run: npx github-actions-ctrf playwright-report/ctrf-report.json
+            - name: Install Playwright
+              working-directory: docs/astro
+              run: pnpm exec playwright install --with-deps
+            - name: Run Playwright tests
+              working-directory: docs/astro
+              run: pnpm exec playwright test
+            - name: Publish Test Summary Results
+              working-directory: docs/astro
+              run: npx github-actions-ctrf playwright-report/ctrf-report.json
 
             - name: "Node docs"
               run: pnpm run docs

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -11,7 +11,7 @@ import { BASE_PATH } from "./src/utils/site-config";
 // https://astro.build/config
 export default defineConfig({
     site: `https://releases.slint.dev${BASE_PATH}`,
-    base: `${BASE_PATH}`,
+    base: BASE_PATH,
     markdown: {
         rehypePlugins: [
             [

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -6,11 +6,11 @@ import starlight from "@astrojs/starlight";
 import starlightLinksValidator from "starlight-links-validator";
 import rehypeExternalLinks from "rehype-external-links";
 import starlightSidebarTopics from "starlight-sidebar-topics";
-import { BASE_PATH } from "./src/utils/site-config";
+import { BASE_PATH, BASE_URL } from "./src/utils/site-config";
 
 // https://astro.build/config
 export default defineConfig({
-    site: `https://releases.slint.dev${BASE_PATH}`,
+    site: `${BASE_URL}${BASE_PATH}`,
     base: BASE_PATH,
     markdown: {
         rehypePlugins: [

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -6,11 +6,12 @@ import starlight from "@astrojs/starlight";
 import starlightLinksValidator from "starlight-links-validator";
 import rehypeExternalLinks from "rehype-external-links";
 import starlightSidebarTopics from "starlight-sidebar-topics";
+import { BASE_PATH } from "./src/utils/site-config";
 
 // https://astro.build/config
 export default defineConfig({
-    site: "https://releases.slint.dev/1.9.0/docs/slint/",
-    base: "/1.9.0/docs/slint",
+    site: `https://releases.slint.dev${BASE_PATH}`,
+    base: `${BASE_PATH}`,
     markdown: {
         rehypePlugins: [
             [

--- a/docs/astro/playwright.config.ts
+++ b/docs/astro/playwright.config.ts
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 import { defineConfig, devices } from "@playwright/test";
+import { BASE_PATH } from "./src/utils/site-config";
 
 /**
  * Read environment variables from file.
@@ -37,7 +38,7 @@ export default defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: "http://127.0.0.1:4321/master/docs/slint/",
+        baseURL: `http://localhost:4321${BASE_PATH}`,
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: "on-first-retry",
@@ -83,7 +84,7 @@ export default defineConfig({
     /* Run your local dev server before starting the tests */
     webServer: {
         command: "pnpm run preview",
-        url: "http://localhost:4321/master/docs/slint",
+        url: `http://localhost:4321${BASE_PATH}`,
         reuseExistingServer: !process.env.CI,
         timeout: 120 * 1000,
     },

--- a/docs/astro/src/utils/site-config.ts
+++ b/docs/astro/src/utils/site-config.ts
@@ -1,1 +1,5 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+export const BASE_URL = "https://snapshots.slint.dev";
 export const BASE_PATH = "/1.9.0/docs/slint/";

--- a/docs/astro/src/utils/site-config.ts
+++ b/docs/astro/src/utils/site-config.ts
@@ -1,0 +1,1 @@
+export const BASE_PATH = "/1.9.0/docs/slint/";

--- a/docs/astro/tests/link-test.spec.ts
+++ b/docs/astro/tests/link-test.spec.ts
@@ -4,20 +4,33 @@ import { test, expect } from "@playwright/test";
 import { linkMap } from "../src/utils/utils";
 
 test("Test all links", async ({ page }) => {
-    const baseUrl = "http://localhost:4321/master/docs/slint";
+    for (const [key, value] of Object.entries(linkMap)) {
+        const href = value.href.replace(/^\//, "");
 
-    for (const [_key, value] of Object.entries(linkMap)) {
-        const fullUrl = `${baseUrl}${value.href}`;
-
-        try {
-            const response = await page.request.get(fullUrl);
-            expect
-                .soft(response.ok(), `${fullUrl} has no green status code`)
-                .toBeTruthy();
-        } catch {
-            expect
-                .soft(null, `${fullUrl} has no green status code`)
-                .toBeTruthy();
+        // Skip testing anchor links (internal page references)
+        if (href.includes("#")) {
+            // Optionally test if the base page exists
+            const basePath = href.split("#")[0];
+            if (basePath) {
+                const response = await page.goto(basePath);
+                expect(
+                    response?.status(),
+                    `Link ${key} (${basePath}) returned ${response?.status()}`,
+                ).toBe(200);
+            }
+            continue;
         }
+
+        const response = await page.goto(href);
+        expect(
+            response?.status(),
+            `Link ${key} (${href}) returned ${response?.status()}`,
+        ).toBe(200);
+
+        // Optionally verify we didn't get to an error page
+        const title = await page.title();
+        expect(title, `Page ${href} has error title: ${title}`).not.toContain(
+            "404",
+        );
     }
 });

--- a/docs/astro/tests/link-test.spec.ts
+++ b/docs/astro/tests/link-test.spec.ts
@@ -13,19 +13,21 @@ test("Test all links", async ({ page }) => {
             const basePath = href.split("#")[0];
             if (basePath) {
                 const response = await page.goto(basePath);
+                const status = response?.status();
                 expect(
-                    response?.status(),
-                    `Link ${key} (${basePath}) returned ${response?.status()}`,
-                ).toBe(200);
+                    [200, 304].includes(status!),
+                    `Link ${key} (${basePath}) returned ${status}`,
+                ).toBeTruthy();
             }
             continue;
         }
 
         const response = await page.goto(href);
+        const status = response?.status();
         expect(
-            response?.status(),
-            `Link ${key} (${href}) returned ${response?.status()}`,
-        ).toBe(200);
+            [200, 304].includes(status!),
+            `Link ${key} (${href}) returned ${status}`,
+        ).toBeTruthy();
 
         // Optionally verify we didn't get to an error page
         const title = await page.title();

--- a/docs/astro/tests/smoke-test.spec.ts
+++ b/docs/astro/tests/smoke-test.spec.ts
@@ -3,7 +3,7 @@
 import { test, expect } from "@playwright/test";
 
 test("smoke test", async ({ page }) => {
-    await page.goto("http://localhost:4321/master/docs/slint");
+    await page.goto("");
     await expect(page.locator('[id="_top"]')).toContainText("Welcome to Slint");
     await page
         .getByLabel("Main")


### PR DESCRIPTION
The CI should edit the base_url in site-config file. This way the playwright tests won't break as after this change both Astro/Starlight and Playwright use the same single BASE_URL variable.

We should update the CI too? Also tweak the way playwright reports issues in CI. At least upload the report as an archive so there is something to look at to give a clue what happens after a total test run fail.