### PR TITLE
Remove type-check from api/node

### DIFF
--- a/api/node/package.json
+++ b/api/node/package.json
@@ -47,8 +47,7 @@
     "format:fix": "biome format --write",
     "lint": "biome lint",
     "lint:fix": "biome lint --fix",
-    "test": "ava",
-    "type-check": "tsc --noEmit"
+    "test": "ava"
   },
   "ava": {
     "extensions": {


### PR DESCRIPTION
tsc is already invoked during the CI compile step, where it checks type.

For the tsc invocation to work, we need to build the Rust module first, which slows down the fmt_lint_typecheck CI job.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
