### PR TITLE
Skia: Don't render with software by default on macOS/Windows

### DIFF
--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -260,7 +260,7 @@ impl super::Surface for D3DSurface {
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
-        if !matches!(requested_graphics_api, Some(RequestedGraphicsAPI::Direct3D)) {
+        if requested_graphics_api.map_or(false, |api| api != RequestedGraphicsAPI::Direct3D) {
             return Err(format!("Requested non-Direct3D rendering with Direct3D renderer").into());
         }
 

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -30,7 +30,7 @@ impl super::Surface for MetalSurface {
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
-        if !matches!(requested_graphics_api, Some(RequestedGraphicsAPI::Metal)) {
+        if requested_graphics_api.map_or(false, |api| api != RequestedGraphicsAPI::Metal) {
             return Err(format!("Requested non-Metal rendering with Metal renderer").into());
         }
 

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -164,7 +164,7 @@ impl super::Surface for VulkanSurface {
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
-        if !matches!(requested_graphics_api, Some(RequestedGraphicsAPI::Vulkan)) {
+        if requested_graphics_api.map_or(false, |api| api != RequestedGraphicsAPI::Vulkan) {
             return Err(format!("Requested non-Vulkan rendering with Vulkan renderer").into());
         }
         let library = VulkanLibrary::new()


### PR DESCRIPTION
On macOS we should default to the Meta renderer, similar `renderer-skia` defaults to D3D on Windows. Unfortunately commit 0d36f88152a8eb7f1eaa24f8599a68e6cea4b233 broke this by forgetting that None with the requested graphics API means: Go for with what we have, nothing special requested.

This also fixes the terminal output "Failed to initialize Skia GPU renderer: Requested non-Metal rendering with Metal renderer . Falling back to software rendering" (and similar on Windows).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
