### PR TITLE
Update to Zephyr v4.0.0 so we can use the `zephyr,touch` chosen device tree entry

### DIFF
--- a/demos/printerdemo/zephyr/CMakeLists.txt
+++ b/demos/printerdemo/zephyr/CMakeLists.txt
@@ -18,10 +18,6 @@ else()
     message(FATAL_ERROR "Unsupported BOARD option specified: ${BOARD}")
 endif()
 
-if(SHIELD STREQUAL "rk055hdmipi4ma0")
-    set(EXTRA_DTC_OVERLAY_FILE "${CMAKE_CURRENT_LIST_DIR}/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay")
-endif()
-
 find_package(Zephyr)
 project(slint_zephyr_printer_demo_mcu LANGUAGES CXX)
 

--- a/demos/printerdemo/zephyr/boards/native_sim_64.overlay
+++ b/demos/printerdemo/zephyr/boards/native_sim_64.overlay
@@ -1,12 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-/{
-	aliases {
-		slint-input = &input_sdl_touch;
-	};
-};
-
 &sdl_dc {
 	height = <720>;
 	width = <1280>;

--- a/demos/printerdemo/zephyr/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
+++ b/demos/printerdemo/zephyr/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
@@ -1,8 +1,0 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: MIT
-
-/{
-	aliases {
-		slint-input = &gt911_rk055hdmipi4ma0;
-	};
-};

--- a/demos/printerdemo/zephyr/src/slint-zephyr.cpp
+++ b/demos/printerdemo/zephyr/src/slint-zephyr.cpp
@@ -419,8 +419,10 @@ void ZephyrPlatform::run_in_event_loop(Task event)
     k_sem_give(&SLINT_SEM);
 }
 
-void zephyr_process_input_event(struct input_event *event)
+void zephyr_process_input_event(struct input_event *event, void *user_data)
 {
+    ARG_UNUSED(user_data);
+
     static slint::LogicalPosition pos;
     static std::optional<slint::PointerEventButton> button;
 
@@ -481,7 +483,7 @@ void zephyr_process_input_event(struct input_event *event)
     }
 }
 
-INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_ALIAS(slint_input)), zephyr_process_input_event);
+INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_ALIAS(slint_input)), zephyr_process_input_event, NULL);
 
 void slint_zephyr_init(const struct device *display)
 {

--- a/demos/printerdemo/zephyr/src/slint-zephyr.cpp
+++ b/demos/printerdemo/zephyr/src/slint-zephyr.cpp
@@ -483,7 +483,7 @@ void zephyr_process_input_event(struct input_event *event, void *user_data)
     }
 }
 
-INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_ALIAS(slint_input)), zephyr_process_input_event, NULL);
+INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_CHOSEN(zephyr_touch)), zephyr_process_input_event, NULL);
 
 void slint_zephyr_init(const struct device *display)
 {

--- a/demos/printerdemo/zephyr/west.yaml
+++ b/demos/printerdemo/zephyr/west.yaml
@@ -9,5 +9,5 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: acc2b51959b68ff083e07f954f19739ef4b35a98
+      revision: v4.0.0
       import: true


### PR DESCRIPTION
This removes the need for a custom shield overlay, as the touch device supported by Zephyr (if one exists) is now chosen with a standard name in the device tree. This simplifies adding Slint/Zephyr support for other boards.