### PR TITLE
Make the printerdemo and printerdemo_mcu PrinterQueueItem compatible with each other

### DIFF
--- a/demos/printerdemo_mcu/esp-idf/main/main.cpp
+++ b/demos/printerdemo_mcu/esp-idf/main/main.cpp
@@ -74,7 +74,7 @@ extern "C" void app_main(void)
         char time_buf[100] = { 0 };
         std::strftime(time_buf, sizeof(time_buf), "%H:%M:%S %d/%m/%Y", std::localtime(&now));
         PrinterQueueItem item;
-        item.status = JobStatus::Waiting;
+        item.status = "waiting";
         item.progress = 0;
         item.title = std::move(name);
         item.owner = "joe@example.com";
@@ -94,7 +94,7 @@ extern "C" void app_main(void)
             if (top_item.progress > 100) {
                 printer_queue->erase(0);
             } else {
-                top_item.status = JobStatus::Printing;
+                top_item.status = "printing";
                 printer_queue->set_row_data(0, top_item);
             }
         }

--- a/demos/printerdemo_mcu/main.rs
+++ b/demos/printerdemo_mcu/main.rs
@@ -21,7 +21,7 @@ struct PrinterQueueData {
 impl PrinterQueueData {
     fn push_job(&self, title: slint::SharedString) {
         self.data.push(PrinterQueueItem {
-            status: JobStatus::Waiting,
+            status: "waiting".into(),
             progress: 0,
             title,
             owner: env!("CARGO_PKG_AUTHORS").into(),
@@ -78,7 +78,7 @@ fn main() -> ! {
                 if printer_queue.data.row_count() > 0 {
                     let mut top_item = printer_queue.data.row_data(0).unwrap();
                     top_item.progress += 1;
-                    top_item.status = JobStatus::Printing;
+                    top_item.status = "printing".into();
                     if top_item.progress > 100 {
                         printer_queue.data.remove(0);
                         if printer_queue.data.row_count() == 0 {

--- a/demos/printerdemo_mcu/ui/printer_queue.slint
+++ b/demos/printerdemo_mcu/ui/printer_queue.slint
@@ -3,13 +3,8 @@
 
 import { DemoPalette, PushButton } from "./common.slint";
 
-enum JobStatus {
-    Waiting,
-    Printing
-}
-
 export struct PrinterQueueItem  {
-    status: JobStatus,
+    status: string,
     progress: int,
     title: string,
     owner: string,
@@ -20,19 +15,19 @@ export struct PrinterQueueItem  {
 
 export global PrinterQueue  {
     in property <[PrinterQueueItem]> printer-queue: [
-        { status: JobStatus.Printing, progress: 63, title: "Slint-Demo.jpeg", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
-        { status: JobStatus.Waiting, title: "Adressliste.docx", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
-        { status: JobStatus.Waiting, title: "210106-FinalPresentation.pdf", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
+        { status: "printing", progress: 63, title: "Slint-Demo.jpeg", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
+        { status: "waiting", title: "Adressliste.docx", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
+        { status: "waiting", title: "210106-FinalPresentation.pdf", owner: "info@slint.dev", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
     ];
 
     callback start-job(string);
     callback cancel-job(int);
     callback pause-job(int);
 
-    public pure function statusString(status: JobStatus) -> string {
-        if (status == JobStatus.Printing) {
+    public pure function statusString(status: string) -> string {
+        if (status == "printing") {
             "PRINTING"
-        } else if (status == JobStatus.Waiting) {
+        } else if (status == "waiting") {
             "WAITING..."
         } else {
             "Unknown job status"
@@ -186,7 +181,7 @@ component NarrowPrintQueueElement inherits Rectangle {
                 Text {
                     // TODO: text-transform: uppercase
                     text: {
-                        if (root.queue-item.status == JobStatus.Printing) {
+                        if (root.queue-item.status == "printing") {
                         "\{root.queue-item.progress}% - \{PrinterQueue.statusString(root.queue-item.status)}"
                         } else {
                             PrinterQueue.statusString(root.queue-item.status)


### PR DESCRIPTION
printerdemo_mcu PrinterQueueItem uses a status string instead of the JobStatus enum.

This makes the PrinterQueue code compatible with the printerdemo code, allowing us to switch between mcu and non-mcu versions of this demo, depending on what will fit on a device.

A string is used, rather than porting the non-mcu demo to an enum, because the non-mcu demo needs to work with the cpp_interpreted demo. Currently, the interpreter does not have support for enumerations (#4777).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
