### PR TITLE
Fix warning message for a property that name is used for function

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1005,7 +1005,7 @@ impl Element {
                 }
                 Type::Function { .. } => {
                     diag.push_error(
-                        format!("Cannot declare property '{}' when a callback with the same name exists", prop_name),
+                        format!("Cannot declare property '{}' when a function with the same name exists", prop_name),
                         &prop_decl.DeclaredIdentifier().child_token(SyntaxKind::Identifier).unwrap(),
                     );
                     continue;

--- a/internal/compiler/tests/syntax/functions/functions.slint
+++ b/internal/compiler/tests/syntax/functions/functions.slint
@@ -30,7 +30,7 @@ export Xxx := Rectangle {
 
     Abc {
         property <int> par;
-//                     ^error{Cannot declare property 'par' when a callback with the same name exists}
+//                     ^error{Cannot declare property 'par' when a function with the same name exists}
         callback par();
 //               ^error{Cannot declare callback 'par' when a function with the same name exists}
     }


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
