### PR TITLE
Fix error message when a property named color is override

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1013,7 +1013,7 @@ impl Element {
                 Type::Invalid => {} // Ok to proceed with a new declaration
                 _ => {
                     diag.push_error(
-                        format!("Cannot override property '{}'", prop_name),
+                        format!("Cannot override property '{}'", unresolved_prop_name),
                         &prop_decl
                             .DeclaredIdentifier()
                             .child_token(SyntaxKind::Identifier)

--- a/internal/compiler/tests/syntax/basic/property_declaration.slint
+++ b/internal/compiler/tests/syntax/basic/property_declaration.slint
@@ -25,4 +25,7 @@ export Test := Comp {
 
     property<bool> pressed;
 //                 ^error{Cannot declare property 'pressed' when a callback with the same name exists}
+
+    property<color> color;
+//                  ^error{Cannot override property 'color'}
 }


### PR DESCRIPTION
It said `Cannot override property 'background'` because color is defined as below

```slint
property <color> color <=> background;
```

For the warning, the name should not be resolved.

Fixes #6324

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
