### PR TITLE
Improve documentation for building slintdocs

### DIFF
--- a/docs/astro/README.md
+++ b/docs/astro/README.md
@@ -62,13 +62,14 @@ pnpm run build
 This will build the site and place it in `dist/`.
 
 ## Live edit the docs
-To run the live hot reloading dev server run:
+To run the live hot reloading dev server run in the astro directory:
 
 ```bash
+cd docs/astro/
 pnpm start
 ```
 
-This will start the dev server at [`localhost:4321/master/docs/slint`](http://localhost:4321/master/docs/slint).
+This will start the dev server at [`localhost:4321/docs/`](http://localhost:4321/docs/).
 
 
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -229,18 +229,7 @@ The quickstart guide is part of the DSL documentation.
 
 ### Quickstart and DSL docs
 
-The quickstart and DSL docs are written in markdown and built with Sphinx, using the myst parser extension.
-
-**Prerequisites**:
-
-- [pipenv](https://pipenv.pypa.io/en/latest/)
-- [Python](https://www.python.org/downloads/)
-
-Use the following command line to build the documentation using `rustdoc` to the `target/slintdocs/html` folder:
-
-```shell
-cargo xtask slintdocs --show-warnings
-```
+See [astro/README.md](astro/README.md)
 
 ### Rust API docs
 


### PR DESCRIPTION
- Updated Quickstart and DSL docs in building.md to redirect to astro/README.md due to outdated information
- Fixed issues in astro/README.md that prevented it from working out of the box

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
