### PR TITLE
Doc: specify package to build Rust API

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -236,7 +236,7 @@ See [astro/README.md](astro/README.md)
 Run the following command to generate the documentation using rustdoc in the `target/doc/` sub-folder:
 
 ```sh
-RUSTDOCFLAGS="--html-in-header=$PWD/docs/astro/src/utils/slint-docs-preview.html --html-in-header=$PWD/docs/astro/src/utils/slint-docs-highlight.html" cargo doc --no-deps --features slint/document-features,slint/log
+RUSTDOCFLAGS="--html-in-header=$PWD/docs/astro/src/utils/slint-docs-preview.html --html-in-header=$PWD/docs/astro/src/utils/slint-docs-highlight.html" cargo doc --package slint --no-deps --features slint/document-features,slint/log
 ```
 
 Note: `--html-in-header` arguments passed to rustdoc via `RUSTDOCFLAGS` are used to enable syntax highlighting and live-preview for Slint example snippets.


### PR DESCRIPTION
When `cargo doc` generates multiple docs, it reports the last one(carousel) and --open opens it.
```
Generated .../target/doc/carousel/index.html and 26 other files
```

Specifing the package solves the issue and improves developer experience.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
