### PR TITLE
Docs: fix the path for the `syntax tests`

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@ This documents describe the testing infrastructure of Slint
 
 The syntax tests are testing that the compiler show the right error messages in case of error.
 
-The syntax tests are located in `slint_compiler/tests/syntax/` and it's driven by the
+The syntax tests are located in [internal/compiler/tests/syntax/](../internal/compiler/tests/syntax/) and it's driven by the
 [`syntax_tests.rs`](../internal/compiler/tests/syntax_tests.rs) file. More info in the comments of that file.
 
 In summary, each .slint files have comments with `^error` like so:


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
