### PR TITLE
Setting `TypeRegister::enable_experimental` on the start of `compile_syntax_node()`

### DIFF
--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -294,12 +294,16 @@ pub async fn compile_syntax_node(
     mut diagnostics: diagnostics::BuildDiagnostics,
     #[allow(unused_mut)] mut compiler_config: CompilerConfiguration,
 ) -> (object_tree::Document, diagnostics::BuildDiagnostics, typeloader::TypeLoader) {
+    let enable_experimental = compiler_config.enable_experimental;
     let mut loader = prepare_for_compile(&mut diagnostics, compiler_config);
 
     let doc_node: parser::syntax_nodes::Document = doc_node.into();
 
     let type_registry =
         Rc::new(RefCell::new(typeregister::TypeRegister::new(&loader.global_type_registry)));
+    if enable_experimental {
+        type_registry.borrow_mut().expose_internal_types = true;
+    }
     let (foreign_imports, reexports) =
         loader.load_dependencies_recursively(&doc_node, &mut diagnostics, &type_registry).await;
 


### PR DESCRIPTION
Slint has many nifty experimental features coming (like menu bars) that need to be enabled when compiling by setting.  While I was able to use this technique to experiment with menu bars, context menus did not function.  After some debugging, it appears that that the way that way experimental features is enabled is by modifying the `TypeRegister` object in a few ad hoc ways, along these lines:

````
dependency_registry.borrow_mut().expose_internal_types =
            is_builtin || state.borrow().tl.compiler_config.enable_experimental;
````

I do not quite understand why these enablements seem to be sufficient for `MenuBar` but not `ContextMenu` but in any case adding analogous logic to `compile_syntax_node()` does the trick.

All this said, the ideal solution seems (to me) to likely be adding a parameter to `TypeRegister::new()`, but that would be a much more intrusive change.