### PR TITLE
API to enable creating winit Windows with Slint's event loop

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -596,6 +596,13 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
 
 impl private::WinitWindowAccessorSealed for i_slint_core::api::Window {}
 
+/// Creates a non Slint aware window with winit
+pub fn create_winit_window(
+    window_attributes: winit::window::WindowAttributes,
+) -> Result<winit::window::Window, winit::error::OsError> {
+    event_loop::with_window_target(|eli| Ok(eli.create_window(window_attributes))).unwrap()
+}
+
 #[cfg(test)]
 mod testui {
     slint::slint! {


### PR DESCRIPTION
In `winit`, it is not possible to instantiate a new window without access to the `winit` event loop, which Slint manages.  With this change, there is now a `create_winit_window` call on Slint's winit` back end that will enable creating `winit` windows using existing functionality.

Of course, the utility of these windows is limited without access to `winit` event handling, but there are applications for which simply creating a window and instructing an external program to write into it (by passing the `HWND` on Windows or the `XId` on X11) is useful.