### PR TITLE
Fix Bazel build

### DIFF
--- a/internal/core-macros/slint_doc.rs
+++ b/internal/core-macros/slint_doc.rs
@@ -24,10 +24,11 @@ impl syn::visit_mut::VisitMut for Visitor {
 
 impl Visitor {
     pub fn new() -> Self {
-        let link_path = concat!(env!("CARGO_MANIFEST_DIR"), "/link-data.json");
-        let link_data = std::fs::read_to_string(link_path).expect("Failed to read {link_path}");
-        let link_data: serde_json::Value =
-            serde_json::from_str(&link_data).expect("Failed to parse link-data.json");
+        let link_data: serde_json::Value = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/link-data.json"
+        )))
+        .expect("Failed to parse link-data.json");
         Self(link_data, false)
     }
 


### PR DESCRIPTION
Include link-data.json as core-macros build time, so that later at run-time the extracted sources don't have to be around anymore.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
