### PR TITLE
Fix for download links for C++ binary packages in release notes

### DIFF
--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -8,8 +8,8 @@ For C++ developers, this release contains the following pre-packed builds of Sli
 
 | Desktop Operating System | Compiler | Architecture | Download |
 |--------------------------|----------|--------------|----------|
-| Linux                    | gcc      | x86-64       | [Slint-cpp-{download_version}-Linux-x86_64.tar.gz](https://github.com/slint-ui/slint/releases/download/{download_version}/Slint-cpp-{download_version}-Linux-x86_64.tar.gz) |
-| Windows                  | MSVC     | x86-64       | [Slint-cpp-{download_version}-win64-MSVC.exe](https://github.com/slint-ui/slint/releases/download/{download_version}/Slint-cpp-{download_version}-win64-MSVC.exe) |
+| Linux                    | gcc      | x86-64       | [Slint-cpp-{version}-Linux-x86_64.tar.gz](https://github.com/slint-ui/slint/releases/download/{download_version}/Slint-cpp-{version}-Linux-x86_64.tar.gz) |
+| Windows                  | MSVC     | x86-64       | [Slint-cpp-{version}-win64-MSVC.exe](https://github.com/slint-ui/slint/releases/download/{download_version}/Slint-cpp-{version}-win64-MSVC.exe) |
 
 | Templates for Microcontroller Evaluation Board | Download |
 |----------------------------------|----------|


### PR DESCRIPTION
The {download_version} variable is either "nightly" or "vX.Y.Z", but the C++ binary packages dont have the "v" prefix. So use the plain version variable for the file name infix in the link.

Fixes #7242

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
