### PR TITLE
Workaround panic of autocompletion of import with unicode

### DIFF
--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -2012,7 +2012,7 @@ export component TestWindow inherits Window {
             "
   \t
 \t     \t
-                
+
 "
             .into(),
         );
@@ -2112,6 +2112,7 @@ export component MainWindow inherits Window {
         );
     }
 
+    #[cfg(any(feature = "preview-external", feature = "preview-engine"))]
     #[test]
     fn test_show_preview_code_lens() {
         // Empty slint document:
@@ -2120,8 +2121,8 @@ export component MainWindow inherits Window {
 component Internal { }
 
 export component Test {
-    
-}         
+
+}
 "#
             .into(),
         );

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -724,11 +724,12 @@ fn complete_path_in_string(
     text: &str,
     offset: TextSize,
 ) -> Option<Vec<CompletionItem>> {
-    if u32::from(offset) as usize > text.len() || offset == 0.into() {
+    let offset = u32::from(offset) as usize;
+    if offset > text.len() || offset == 0 || !text.is_char_boundary(offset) {
         return None;
     }
     let mut text = text.strip_prefix('\"')?;
-    text = &text[..(u32::from(offset) - 1) as usize];
+    text = &text[..(offset - 1)];
     let base = i_slint_compiler::typeloader::base_directory(base);
     let path = if let Some(last_slash) = text.rfind('/') {
         base.join(Path::new(&text[..last_slash]))


### PR DESCRIPTION
(As seen in the crash reporter)

Eg:
```
thread 'LanguageServer' panicked at tools/lsp/language/completion.rs:731:17:
byte index 4 is not a char boundary; it is inside '🍒' (bytes 2..6) of `./🍒🍓🍇"`
```

This can happen because offset might not be on a char boundary because of the utf-16 / utf-8 mismatch.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
