### PR TITLE
LSP: Document symbol: make sure the selectionRange is contained in the full range

### DIFF
--- a/internal/compiler/tests/syntax/parse_error/sub.slint
+++ b/internal/compiler/tests/syntax/parse_error/sub.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Foo {
+    foo := {}
+    //     ^error{Syntax error: expected Identifier}
+
+    Image {}
+
+    bar :=
+  }
+//^error{Syntax error: expected Identifier}
+
+component Bar inherits {
+//                     ^error{Syntax error: expected Identifier}
+    if true : {}
+//            ^error{Syntax error: expected Identifier}
+}

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -34,10 +34,8 @@ pub fn node_to_url_and_lsp_range(node: &SyntaxNode) -> Option<(lsp_types::Url, l
 }
 
 /// Map a `node` to the `Range` of characters covered by the `node`
-///
-/// This will exclude trailing whitespaces.
 pub fn node_to_lsp_range(node: &SyntaxNode) -> lsp_types::Range {
-    let range = node_range_without_trailing_ws(node);
+    let range = node.text_range();
     text_range_to_lsp_range(&node.source_file, range)
 }
 


### PR DESCRIPTION
Otherwise we get a lot of error in vscode such as:

```
Error: selectionRange must be contained in fullRange
	at Gd.validate (file:///snap/code/178/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:109:33728)
	at new Gd (file:///snap/code/178/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:109:33936)
	at Ke (/home/olivier/.vscode/extensions/slint.slint-nightly-2025.1.109/out/extension.js:35:72279)
	at Ke (/home/olivier/.vscode/extensions/slint.slint-nightly-2025.1.109/out/extension.js:35:72456)
	at o (/home/olivier/.vscode/extensions/slint.slint-nightly-2025.1.109/out/extension.js:35:46654)
	at Object.$P [as map] (/home/olivier/.vscode/extensions/slint.slint-nightly-2025.1.109/out/extension.js:35:46740)
	at Object.Se [as asDocumentSymbols] (/home/olivier/.vscode/extensions/slint.slint-nightly-2025.1.109/out/extension.js:35:72246)
	at c (/home/olivier/.vscode/extensions/slint.slint-nightly-2025.1.109/out/extension.js:39:56055)
	at async uI.provideDocumentSymbols (file:///snap/code/178/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:138:126457)
[Error - 11:41:30 AM] Request textDocument/documentSymbol failed.
```

We shouldn't need to trim the whitespace from the node range.
Because the selected range might be the end of the range and it might
end up being trimmed.

In normal cases, whitespace are not part of the Node anyway


Also improve a bit the parsing error when element base is missing.