### PR TITLE
Tool packages: Don't enable the Qt backend

### DIFF
--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -95,16 +95,11 @@ jobs:
             - uses: ./.github/actions/setup-rust
               with:
                   target: x86_64-unknown-linux-gnu
-            - name: Install Qt
-              uses: jurplel/install-qt-action@v4
-              with:
-                  version: 6.2.2
-                  cache: true
             - uses: baptiste0928/cargo-install@v3
               with:
                   crate: cargo-about
             - name: Build
-              run: cargo build --verbose --no-default-features --features backend-qt,${{ github.event.inputs.features || inputs.features }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
+              run: cargo build --verbose --no-default-features --features ${{ github.event.inputs.features || inputs.features }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
             - name: Create artifact directory
               run: |
                   mkdir -p slint-${{ github.event.inputs.program || inputs.program }}


### PR DESCRIPTION
Don't link against Qt in our binary because it might not be binary compatible with all distributions.
Eg, archlinux shows this error:
`error due to GNU_PROPERTY_1_NEEDED_INDIRECT_EXTERN_ACCESS`

We also don't enable the Qt backend in our vscode extension

Fixes #7174

