### PR TITLE
Add a warning when a component/type name overwrite another

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -403,6 +403,7 @@ fn duplicate_sub_component(
         popup_windows: Default::default(),
         timers: component_to_duplicate.timers.clone(),
         exported_global_names: component_to_duplicate.exported_global_names.clone(),
+        used: component_to_duplicate.used.clone(),
         private_properties: Default::default(),
         inherits_popup_window: core::cell::Cell::new(false),
     };

--- a/internal/compiler/tests/syntax/lookup/name_reuse.slint
+++ b/internal/compiler/tests/syntax/lookup/name_reuse.slint
@@ -1,0 +1,47 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Foo /* Foo 1 */ { }
+
+export component FooBaz {
+    Foo /* <- TEST_ME_1 */ { }
+}
+
+component Foo /* Foo 2 */ { }
+//        ^warning{Component 'Foo' is replacing a previously defined component with the same name}
+
+export component Baz {
+    Foo /* <- TEST_ME_2 */ { }
+}
+
+
+struct Type1 { xxx: int }
+enum Type2 { AAA, BBB }
+
+  component Test1 {}
+//^warning{Component is neither used nor exported}
+
+export component Test1 {
+//               ^warning{Component 'Test1' is replacing a previously defined component with the same name}
+    property <Type1> t1: { xxx: 42 };
+    property <Type2> t2: Type2.AAA;
+//                       ^error{Cannot access id 'Type2'} // because in the lookup phase it was already erased
+
+    init => {
+        debug(Type1.CCC);         // This is allowed because the resolving phase has full view on the document
+        debug(Type2.AAA);
+//            ^error{Cannot access id 'Type2'}
+    }
+}
+
+struct Type2 { yyy: int }
+//     ^warning{Struct 'Type2' is replacing a previously defined type with the same name}
+enum Type1 { CCC, DDD }
+//   ^warning{Enum 'Type1' is replacing a previously defined type with the same name}
+export component Test2 {
+    property <Type1> t1: Type1.DDD;
+    property <Type2> t2: { yyy: 42 };
+    property <Type1> error: Type2.AAA;
+    //                      ^error{Cannot access id 'Type2'}
+}
+

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -350,6 +350,7 @@ impl Snapshotter {
                 exported_global_names: RefCell::new(
                     component.exported_global_names.borrow().clone(),
                 ),
+                used: component.used.clone(),
                 init_code: RefCell::new(component.init_code.borrow().clone()),
                 inherits_popup_window: std::cell::Cell::new(component.inherits_popup_window.get()),
                 optimized_elements,
@@ -1455,7 +1456,7 @@ impl TypeLoader {
                 itertools::Either::Right(ty) => registry_to_populate
                     .borrow_mut()
                     .insert_type_with_name(ty, import_name.internal_name),
-            }
+            };
         }
     }
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -356,12 +356,17 @@ impl TypeRegister {
         }
     }
 
-    /// FIXME: same as 'add' ?
-    pub fn insert_type(&mut self, t: Type) {
-        self.types.insert(t.to_smolstr(), t);
+    /// Insert a type into the type register with its builtin type name.
+    ///
+    /// Returns false if a it replaced an existing type.
+    pub fn insert_type(&mut self, t: Type) -> bool {
+        self.types.insert(t.to_smolstr(), t).is_none()
     }
-    pub fn insert_type_with_name(&mut self, t: Type, name: SmolStr) {
-        self.types.insert(name, t);
+    /// Insert a type into the type register with a specified name.
+    ///
+    /// Returns false if a it replaced an existing type.
+    pub fn insert_type_with_name(&mut self, t: Type, name: SmolStr) -> bool {
+        self.types.insert(name, t).is_none()
     }
 
     fn builtin_internal() -> Self {
@@ -642,12 +647,18 @@ impl TypeRegister {
         self.lookup(qualified[0].as_ref())
     }
 
-    pub fn add(&mut self, comp: Rc<Component>) {
-        self.add_with_name(comp.id.clone(), comp);
+    /// Add the component with it's defined name
+    ///
+    /// Returns false if there was already an element with the same name
+    pub fn add(&mut self, comp: Rc<Component>) -> bool {
+        self.add_with_name(comp.id.clone(), comp)
     }
 
-    pub fn add_with_name(&mut self, name: SmolStr, comp: Rc<Component>) {
-        self.elements.insert(name, ElementType::Component(comp));
+    /// Add the component with a specified name
+    ///
+    /// Returns false if there was already an element with the same name
+    pub fn add_with_name(&mut self, name: SmolStr, comp: Rc<Component>) -> bool {
+        self.elements.insert(name, ElementType::Component(comp)).is_none()
     }
 
     pub fn add_builtin(&mut self, builtin: Rc<BuiltinElement>) {


### PR DESCRIPTION
Also fix the unused component warning when that happens Fixes #7176

ChangeLog: Warning when a type name overwrite another
