### PR TITLE
Improve accessibility of tab widgets

### DIFF
--- a/examples/gallery/ui/pages/page.slint
+++ b/examples/gallery/ui/pages/page.slint
@@ -10,6 +10,8 @@ export component Page inherits VerticalBox {
     in property<string> description: "description";
     in property<bool> show-enable-switch: true;
 
+    accessible-role: tab-panel;
+
     HorizontalBox {
         Text {
             font-size: 20px;

--- a/examples/gallery/ui/pages/page.slint
+++ b/examples/gallery/ui/pages/page.slint
@@ -11,6 +11,7 @@ export component Page inherits VerticalBox {
     in property<bool> show-enable-switch: true;
 
     accessible-role: tab-panel;
+    accessible-label: root.title;
 
     HorizontalBox {
         Text {

--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -15,6 +15,7 @@ component SideBarItem inherits Rectangle {
     accessible-role: tab;
     accessible-label: root.text;
     accessible-item-index: root.tab-index;
+    accessible-item-selectable: true;
 
     states [
         pressed when touch.pressed : {

--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -4,6 +4,7 @@
 import { HorizontalBox, VerticalBox, Palette } from "std-widgets.slint";
 
 component SideBarItem inherits Rectangle {
+    in property <int> tab-index;
     in property <bool> selected;
     in property <bool> has-focus;
     in-out property <string> text <=> label.text;
@@ -13,6 +14,7 @@ component SideBarItem inherits Rectangle {
     min-height: l.preferred-height;
     accessible-role: tab;
     accessible-label: root.text;
+    accessible-item-index: root.tab-index;
 
     states [
         pressed when touch.pressed : {
@@ -116,6 +118,7 @@ export component SideBar inherits Rectangle {
             for item[index] in root.model : SideBarItem {
                 clicked => { root.current-item = index; }
 
+                tab-index: index;
                 has-focus: index == root.current-focused;
                 text: item;
                 selected: index == root.current-item;

--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -11,6 +11,8 @@ component SideBarItem inherits Rectangle {
     callback clicked <=> touch.clicked;
 
     min-height: l.preferred-height;
+    accessible-role: tab;
+    accessible-label: root.text;
 
     states [
         pressed when touch.pressed : {
@@ -40,7 +42,8 @@ component SideBarItem inherits Rectangle {
 
         label := Text {
             vertical-alignment: center;
-         }
+            accessible-role: none;
+        }
     }
 
     touch := TouchArea {
@@ -57,8 +60,9 @@ export component SideBar inherits Rectangle {
 
     width: 180px;
     forward-focus: fs;
-    accessible-role: tab;
+    accessible-role: tab-list;
     accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current-item;
+    accessible-label: root.title;
 
     Rectangle {
         background: Palette.background.darker(0.2);

--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -63,6 +63,7 @@ export component SideBar inherits Rectangle {
     accessible-role: tab-list;
     accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current-item;
     accessible-label: root.title;
+    accessible-item-count: root.model.length;
 
     Rectangle {
         background: Palette.background.darker(0.2);

--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -16,6 +16,7 @@ component SideBarItem inherits Rectangle {
     accessible-label: root.text;
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
+    accessible-item-selected: root.selected;
 
     states [
         pressed when touch.pressed : {

--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -17,6 +17,7 @@ component SideBarItem inherits Rectangle {
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
     accessible-item-selected: root.selected;
+    accessible-action-default => { self.clicked(); }
 
     states [
         pressed when touch.pressed : {

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -321,6 +321,7 @@ cpp! {{
                     i_slint_core::items::AccessibleRole::TextInput => QAccessible_Role_EditableText,
                     i_slint_core::items::AccessibleRole::Switch => QAccessible_Role_CheckBox,
                     i_slint_core::items::AccessibleRole::ListItem => QAccessible_Role_ListItem,
+                    i_slint_core::items::AccessibleRole::TabPanel => QAccessible_Role_Pane,
                     _ => QAccessible_Role_NoRole,
                 }
             });

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -97,6 +97,7 @@ enum AccessibleRole {
     TextInput = 13;
     Switch = 14;
     ListItem = 15;
+    TabPanel = 16;
 }
 
 message ElementQueryInstruction {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -528,6 +528,7 @@ fn convert_to_proto_accessible_role(
         i_slint_core::items::AccessibleRole::TextInput => proto::AccessibleRole::TextInput,
         i_slint_core::items::AccessibleRole::Switch => proto::AccessibleRole::Switch,
         i_slint_core::items::AccessibleRole::ListItem => proto::AccessibleRole::ListItem,
+        i_slint_core::items::AccessibleRole::TabPanel => proto::AccessibleRole::TabPanel,
         _ => return None,
     })
 }
@@ -554,6 +555,7 @@ fn convert_from_proto_accessible_role(
         proto::AccessibleRole::TextInput => i_slint_core::items::AccessibleRole::TextInput,
         proto::AccessibleRole::Switch => i_slint_core::items::AccessibleRole::Switch,
         proto::AccessibleRole::ListItem => i_slint_core::items::AccessibleRole::ListItem,
+        proto::AccessibleRole::TabPanel => i_slint_core::items::AccessibleRole::TabPanel,
     })
 }
 

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -484,6 +484,10 @@ impl NodeCollection {
             node.set_disabled();
         }
 
+        if !item.is_visible() {
+            node.set_hidden();
+        }
+
         let geometry = item.geometry();
         let absolute_origin = item.map_to_window(geometry.origin) + window_position.to_vector();
         let physical_origin = (absolute_origin * scale_factor).cast::<f64>();

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -448,6 +448,7 @@ impl NodeCollection {
                     i_slint_core::items::AccessibleRole::Spinbox => Role::SpinButton,
                     i_slint_core::items::AccessibleRole::Tab => Role::Tab,
                     i_slint_core::items::AccessibleRole::TabList => Role::TabList,
+                    i_slint_core::items::AccessibleRole::TabPanel => Role::TabPanel,
                     i_slint_core::items::AccessibleRole::Text => Role::Label,
                     i_slint_core::items::AccessibleRole::Table => Role::Table,
                     i_slint_core::items::AccessibleRole::Tree => Role::Tree,

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -360,6 +360,8 @@ macro_rules! for_each_enums {
                 Tab,
                 /// The element is similar to the tab bar in a `TabWidget`.
                 TabList,
+                /// The element is a container for tab content.
+                TabPanel,
                 /// The role for a `Text` element. It's automatically applied.
                 Text,
                 /// The role for a `TableView` or behaves like one.

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -110,6 +110,21 @@ fn process_tabwidget(
                 &old.into_inner(),
             );
         }
+        let role = crate::typeregister::BUILTIN
+            .with(|e| e.enums.AccessibleRole.clone())
+            .try_value_from_string("tab-panel")
+            .unwrap();
+        let old = child.borrow_mut().bindings.insert(
+            SmolStr::new_static("accessible-role"),
+            RefCell::new(Expression::EnumerationValue(role).into()),
+        );
+        if let Some(old) = old {
+            diag.push_error(
+                "The property 'accessible-role' cannot be set for Tabs inside a TabWidget"
+                    .to_owned(),
+                &old.into_inner(),
+            );
+        }
 
         let mut tab = Element {
             id: format_smolstr!("{}-tab{}", elem.borrow().id, index),

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -125,6 +125,17 @@ fn process_tabwidget(
                 &old.into_inner(),
             );
         }
+        let title_ref = RefCell::new(
+            Expression::PropertyReference(NamedReference::new(child, "title".into())).into(),
+        );
+        let old = child.borrow_mut().bindings.insert("accessible-label".into(), title_ref);
+        if let Some(old) = old {
+            diag.push_error(
+                "The property 'accessible-label' cannot be set for Tabs inside a TabWidget"
+                    .to_owned(),
+                &old.into_inner(),
+            );
+        }
 
         let mut tab = Element {
             id: format_smolstr!("{}-tab{}", elem.borrow().id, index),

--- a/internal/compiler/tests/syntax/elements/tabwidget2.slint
+++ b/internal/compiler/tests/syntax/elements/tabwidget2.slint
@@ -30,5 +30,10 @@ export Test2 := Rectangle {
 //                           ^error{The property 'accessible-role' cannot be set for Tabs inside a TabWidget}
             Rectangle { }
         }
+        Tab {
+            accessible-label: "Tab Panel";
+//                            ^error{The property 'accessible-label' cannot be set for Tabs inside a TabWidget}
+            Rectangle { }
+        }
     }
 }

--- a/internal/compiler/tests/syntax/elements/tabwidget2.slint
+++ b/internal/compiler/tests/syntax/elements/tabwidget2.slint
@@ -24,5 +24,11 @@ export Test2 := Rectangle {
 //                  ^error{dynamic tabs \('if' or 'for'\) are currently not supported}
             title: "hello";
         }
+
+        Tab {
+            accessible-role: tab-panel;
+//                           ^error{The property 'accessible-role' cannot be set for Tabs inside a TabWidget}
+            Rectangle { }
+        }
     }
 }

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -140,6 +140,7 @@ export component TabBarImpl inherits TabBarBase {
 
     accessible-role: tab-list;
     accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current;
+    accessible-item-count: root.num-tabs;
     preferred-height: 44px;
 
     Flickable {

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -55,6 +55,7 @@ export component TabImpl inherits Rectangle {
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
     accessible-item-selected: root.is-current;
+    accessible-action-default => { touch-area.clicked(); }
 
     Rectangle {
         y: 0;

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -128,6 +128,7 @@ export component TabImpl inherits Rectangle {
             font-size: CosmicFontSettings.body.font-size;
             font-weight: root.is-current ? CosmicFontSettings.body-strong.font-weight : CosmicFontSettings.body.font-weight;
             color: root.is-current ? CosmicPalette.accent-background : CosmicPalette.control-foreground;
+            accessible-role: none;
         }
     }
 }

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -52,6 +52,7 @@ export component TabImpl inherits Rectangle {
     accessible-role: tab;
     accessible-enabled: root.enabled;
     accessible-label: root.title;
+    accessible-item-index: root.tab-index;
 
     Rectangle {
         y: 0;

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -54,6 +54,7 @@ export component TabImpl inherits Rectangle {
     accessible-label: root.title;
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
+    accessible-item-selected: root.is-current;
 
     Rectangle {
         y: 0;

--- a/internal/compiler/widgets/cosmic/tabwidget.slint
+++ b/internal/compiler/widgets/cosmic/tabwidget.slint
@@ -53,6 +53,7 @@ export component TabImpl inherits Rectangle {
     accessible-enabled: root.enabled;
     accessible-label: root.title;
     accessible-item-index: root.tab-index;
+    accessible-item-selectable: true;
 
     Rectangle {
         y: 0;

--- a/internal/compiler/widgets/cupertino/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino/tabwidget.slint
@@ -50,6 +50,7 @@ export component TabImpl inherits Rectangle {
     accessible-role: tab;
     accessible-enabled: root.enabled;
     accessible-label: root.title;
+    accessible-item-index: root.tab-index;
 
     if (root.is-current || i-touch-area.pressed): Rectangle {
         width: 100%;

--- a/internal/compiler/widgets/cupertino/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino/tabwidget.slint
@@ -53,6 +53,7 @@ export component TabImpl inherits Rectangle {
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
     accessible-item-selected: root.is-current;
+    accessible-action-default => { i-touch-area.clicked(); }
 
     if (root.is-current || i-touch-area.pressed): Rectangle {
         width: 100%;

--- a/internal/compiler/widgets/cupertino/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino/tabwidget.slint
@@ -94,6 +94,7 @@ export component TabImpl inherits Rectangle {
             font-size: CupertinoFontSettings.body-strong.font-size;
             font-weight: CupertinoFontSettings.body-strong.font-weight;
             color: CupertinoPalette.foreground;
+            accessible-role: none;
         }
     }
 }

--- a/internal/compiler/widgets/cupertino/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino/tabwidget.slint
@@ -51,6 +51,7 @@ export component TabImpl inherits Rectangle {
     accessible-enabled: root.enabled;
     accessible-label: root.title;
     accessible-item-index: root.tab-index;
+    accessible-item-selectable: true;
 
     if (root.is-current || i-touch-area.pressed): Rectangle {
         width: 100%;

--- a/internal/compiler/widgets/cupertino/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino/tabwidget.slint
@@ -52,6 +52,7 @@ export component TabImpl inherits Rectangle {
     accessible-label: root.title;
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
+    accessible-item-selected: root.is-current;
 
     if (root.is-current || i-touch-area.pressed): Rectangle {
         width: 100%;

--- a/internal/compiler/widgets/cupertino/tabwidget.slint
+++ b/internal/compiler/widgets/cupertino/tabwidget.slint
@@ -106,6 +106,7 @@ export component TabBarImpl inherits TabBarBase {
 
     accessible-role: tab-list;
     accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current;
+    accessible-item-count: root.num-tabs;
 
     Rectangle {
         border-radius: 7px;

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -50,6 +50,7 @@ export component TabImpl inherits Rectangle {
     accessible-role: tab;
     accessible-enabled: root.enabled;
     accessible-label: root.title;
+    accessible-item-index: root.tab-index;
 
     Rectangle {
         clip: true;

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -85,6 +85,7 @@ export component TabImpl inherits Rectangle {
             font-size: root.is-current ? FluentFontSettings.body-strong.font-size : FluentFontSettings.body.font-size;
             font-weight: root.is-current ? FluentFontSettings.body-strong.font-weight : FluentFontSettings.body.font-weight;
             color: root.is-current ? FluentPalette.control-foreground : FluentPalette.text-secondary;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -122,6 +122,7 @@ export component TabBarImpl inherits TabBarBase {
    
     accessible-role: tab-list;
     accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current;
+    accessible-item-count: root.num-tabs;
 
     i-focus-scope := FocusScope {
         property <int> focused-tab: 0;

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -52,6 +52,7 @@ export component TabImpl inherits Rectangle {
     accessible-label: root.title;
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
+    accessible-item-selected: root.is-current;
 
     Rectangle {
         clip: true;

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -51,6 +51,7 @@ export component TabImpl inherits Rectangle {
     accessible-enabled: root.enabled;
     accessible-label: root.title;
     accessible-item-index: root.tab-index;
+    accessible-item-selectable: true;
 
     Rectangle {
         clip: true;

--- a/internal/compiler/widgets/fluent/tabwidget.slint
+++ b/internal/compiler/widgets/fluent/tabwidget.slint
@@ -53,6 +53,7 @@ export component TabImpl inherits Rectangle {
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
     accessible-item-selected: root.is-current;
+    accessible-action-default => { i-touch-area.clicked(); }
 
     Rectangle {
         clip: true;

--- a/internal/compiler/widgets/material/tabwidget.slint
+++ b/internal/compiler/widgets/material/tabwidget.slint
@@ -50,6 +50,7 @@ export component TabImpl inherits Rectangle {
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
     accessible-item-selected: root.active;
+    accessible-action-default => { i-touch-area.clicked(); }
 
     i-container := Rectangle {
         background: MaterialPalette.alternate-background;

--- a/internal/compiler/widgets/material/tabwidget.slint
+++ b/internal/compiler/widgets/material/tabwidget.slint
@@ -76,6 +76,7 @@ export component TabImpl inherits Rectangle {
             //font-family: MaterialFontSettings.title-small.font;
             font-size: MaterialFontSettings.title-small.font-size;
             font-weight: MaterialFontSettings.title-small.font-weight;
+            accessible-role: none;
 
             animate color {
                 duration: 250ms;

--- a/internal/compiler/widgets/material/tabwidget.slint
+++ b/internal/compiler/widgets/material/tabwidget.slint
@@ -49,6 +49,7 @@ export component TabImpl inherits Rectangle {
     accessible-label: root.title;
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
+    accessible-item-selected: root.active;
 
     i-container := Rectangle {
         background: MaterialPalette.alternate-background;

--- a/internal/compiler/widgets/material/tabwidget.slint
+++ b/internal/compiler/widgets/material/tabwidget.slint
@@ -114,6 +114,7 @@ export component TabBarImpl inherits TabBarBase {
 
     accessible-role: tab-list;
     accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current;
+    accessible-item-count: root.num-tabs;
 
     Flickable {
         HorizontalLayout {            

--- a/internal/compiler/widgets/material/tabwidget.slint
+++ b/internal/compiler/widgets/material/tabwidget.slint
@@ -48,6 +48,7 @@ export component TabImpl inherits Rectangle {
     accessible-enabled: root.enabled;
     accessible-label: root.title;
     accessible-item-index: root.tab-index;
+    accessible-item-selectable: true;
 
     i-container := Rectangle {
         background: MaterialPalette.alternate-background;

--- a/internal/compiler/widgets/material/tabwidget.slint
+++ b/internal/compiler/widgets/material/tabwidget.slint
@@ -47,6 +47,7 @@ export component TabImpl inherits Rectangle {
     accessible-role: tab;
     accessible-enabled: root.enabled;
     accessible-label: root.title;
+    accessible-item-index: root.tab-index;
 
     i-container := Rectangle {
         background: MaterialPalette.alternate-background;

--- a/internal/compiler/widgets/qt/tabwidget.slint
+++ b/internal/compiler/widgets/qt/tabwidget.slint
@@ -9,6 +9,7 @@ export component TabImpl inherits NativeTab {
     accessible-role: tab;
     accessible-enabled: root.enabled;
     accessible-label <=> root.title;
+    accessible-item-index: root.tab-index;
 }
 
 export component TabBarImpl inherits TabBarBase {

--- a/internal/compiler/widgets/qt/tabwidget.slint
+++ b/internal/compiler/widgets/qt/tabwidget.slint
@@ -11,6 +11,7 @@ export component TabImpl inherits NativeTab {
     accessible-label <=> root.title;
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
+    accessible-item-selected: root.tab-index == root.current;
 }
 
 export component TabBarImpl inherits TabBarBase {

--- a/internal/compiler/widgets/qt/tabwidget.slint
+++ b/internal/compiler/widgets/qt/tabwidget.slint
@@ -10,6 +10,7 @@ export component TabImpl inherits NativeTab {
     accessible-enabled: root.enabled;
     accessible-label <=> root.title;
     accessible-item-index: root.tab-index;
+    accessible-item-selectable: true;
 }
 
 export component TabBarImpl inherits TabBarBase {

--- a/internal/compiler/widgets/qt/tabwidget.slint
+++ b/internal/compiler/widgets/qt/tabwidget.slint
@@ -12,6 +12,10 @@ export component TabImpl inherits NativeTab {
     accessible-item-index: root.tab-index;
     accessible-item-selectable: true;
     accessible-item-selected: root.tab-index == root.current;
+    accessible-action-default => {
+        root.current = root.tab-index;
+        root.current-focused = root.tab-index;
+    }
 }
 
 export component TabBarImpl inherits TabBarBase {

--- a/internal/compiler/widgets/qt/tabwidget.slint
+++ b/internal/compiler/widgets/qt/tabwidget.slint
@@ -18,6 +18,7 @@ export component TabBarImpl inherits TabBarBase {
 
     accessible-role: tab-list;
     accessible-delegate-focus: root.current;
+    accessible-item-count: root.num-tabs;
 
     Rectangle {
         // The breeze style draws outside of the tab bar, which is clip by default with Qt

--- a/tests/cases/widgets/tabwidget.slint
+++ b/tests/cases/widgets/tabwidget.slint
@@ -91,5 +91,24 @@ assert_eq!(tab2.accessible_item_selected(), Some(false));
 assert_eq!(tab3.accessible_item_index(), Some(2));
 assert_eq!(tab3.accessible_item_selectable(), Some(true));
 assert_eq!(tab3.accessible_item_selected(), Some(false));
+
+// The accessible default action of tabs change the active tab panel
+tab2.invoke_accessible_default_action();
+assert_eq!(tab2.accessible_item_selectable(), Some(true));
+assert_eq!(tab2.accessible_item_selected(), Some(true));
+assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "Second Tab").count(), 2);
+
+assert_eq!(tab1.accessible_item_selectable(), Some(true));
+assert_eq!(tab1.accessible_item_selected(), Some(false));
+assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "First Tab").count(), 1);
+
+tab3.invoke_accessible_default_action();
+assert_eq!(tab3.accessible_item_selectable(), Some(true));
+assert_eq!(tab3.accessible_item_selected(), Some(true));
+assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "Third Tab").count(), 2);
+
+assert_eq!(tab2.accessible_item_selectable(), Some(true));
+assert_eq!(tab2.accessible_item_selected(), Some(false));
+assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "Second Tab").count(), 1);
 ```
 */

--- a/tests/cases/widgets/tabwidget.slint
+++ b/tests/cases/widgets/tabwidget.slint
@@ -65,12 +65,20 @@ assert_eq!(tabbar.accessible_item_count(), Some(3));
 
 let mut tab1_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "First Tab");
 let tab1 = tab1_search.next().unwrap();
+// First tab panel is visible and has the same accessible label
+assert!(tab1_search.next().is_some());
+assert!(tab1_search.next().is_none());
 
 let mut tab2_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Second Tab");
 let tab2 = tab2_search.next().unwrap();
+// Second tab panel is not active at first, so it is hidden.
+assert!(tab2_search.next().is_none());
 
 let mut tab3_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Third Tab");
 let tab3 = tab3_search.next().unwrap();
+// Third tab panel is not active at first, so it is hidden.
+assert!(tab3_search.next().is_none());
+
 
 assert_eq!(tab1.accessible_item_index(), Some(0));
 assert_eq!(tab1.accessible_item_selectable(), Some(true));

--- a/tests/cases/widgets/tabwidget.slint
+++ b/tests/cases/widgets/tabwidget.slint
@@ -1,0 +1,71 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Button, GroupBox, TabWidget, VerticalBox } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    TabWidget {
+        Tab {
+            title: "First Tab";
+
+            VerticalBox {
+                alignment: start;
+
+                GroupBox {
+                    title: "Content of first tab";
+
+                    Button {
+                        text: "Button 1";
+                    }
+                }
+            }
+        }
+
+        Tab {
+            title: "Second Tab";
+
+            VerticalBox {
+                alignment: start;
+
+                GroupBox {
+                    title: "Content of second tab";
+
+                    Button {
+                        text: "Button 2";
+                    }
+                }
+            }
+        }
+
+        Tab {
+            title: "Third Tab";
+
+            VerticalBox {
+                alignment: start;
+
+                GroupBox {
+                    title: "Content of third tab";
+
+                    Button {
+                        text: "Button 3";
+                    }
+                }
+            }
+        }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+let mut tab1_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "First Tab");
+let _tab1 = tab1_search.next().unwrap();
+
+let mut tab2_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Second Tab");
+let _tab2 = tab2_search.next().unwrap();
+
+let mut tab3_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Third Tab");
+let _tab3 = tab3_search.next().unwrap();
+```
+*/

--- a/tests/cases/widgets/tabwidget.slint
+++ b/tests/cases/widgets/tabwidget.slint
@@ -73,7 +73,12 @@ let mut tab3_search = slint_testing::ElementHandle::find_by_accessible_label(&in
 let tab3 = tab3_search.next().unwrap();
 
 assert_eq!(tab1.accessible_item_index(), Some(0));
+assert_eq!(tab1.accessible_item_selectable(), Some(true));
+
 assert_eq!(tab2.accessible_item_index(), Some(1));
+assert_eq!(tab2.accessible_item_selectable(), Some(true));
+
 assert_eq!(tab3.accessible_item_index(), Some(2));
+assert_eq!(tab3.accessible_item_selectable(), Some(true));
 ```
 */

--- a/tests/cases/widgets/tabwidget.slint
+++ b/tests/cases/widgets/tabwidget.slint
@@ -74,11 +74,14 @@ let tab3 = tab3_search.next().unwrap();
 
 assert_eq!(tab1.accessible_item_index(), Some(0));
 assert_eq!(tab1.accessible_item_selectable(), Some(true));
+assert_eq!(tab1.accessible_item_selected(), Some(true));
 
 assert_eq!(tab2.accessible_item_index(), Some(1));
 assert_eq!(tab2.accessible_item_selectable(), Some(true));
+assert_eq!(tab2.accessible_item_selected(), Some(false));
 
 assert_eq!(tab3.accessible_item_index(), Some(2));
 assert_eq!(tab3.accessible_item_selectable(), Some(true));
+assert_eq!(tab3.accessible_item_selected(), Some(false));
 ```
 */

--- a/tests/cases/widgets/tabwidget.slint
+++ b/tests/cases/widgets/tabwidget.slint
@@ -64,12 +64,16 @@ let tabbar = tabbar_search.next().unwrap();
 assert_eq!(tabbar.accessible_item_count(), Some(3));
 
 let mut tab1_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "First Tab");
-let _tab1 = tab1_search.next().unwrap();
+let tab1 = tab1_search.next().unwrap();
 
 let mut tab2_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Second Tab");
-let _tab2 = tab2_search.next().unwrap();
+let tab2 = tab2_search.next().unwrap();
 
 let mut tab3_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Third Tab");
-let _tab3 = tab3_search.next().unwrap();
+let tab3 = tab3_search.next().unwrap();
+
+assert_eq!(tab1.accessible_item_index(), Some(0));
+assert_eq!(tab2.accessible_item_index(), Some(1));
+assert_eq!(tab3.accessible_item_index(), Some(2));
 ```
 */

--- a/tests/cases/widgets/tabwidget.slint
+++ b/tests/cases/widgets/tabwidget.slint
@@ -59,6 +59,10 @@ export component TestCase inherits Window {
 ```rust
 let instance = TestCase::new().unwrap();
 
+let mut tabbar_search = slint_testing::ElementHandle::find_by_element_id(&instance, "TabBarImpl::root");
+let tabbar = tabbar_search.next().unwrap();
+assert_eq!(tabbar.accessible_item_count(), Some(3));
+
 let mut tab1_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "First Tab");
 let _tab1 = tab1_search.next().unwrap();
 


### PR DESCRIPTION
<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

This PR greatly improve the accessibility of the `TabWidget` as well as the other tab widget implementation in the gallery example.

There is one annoying issue left with the gallery example: since the sidebar also contain a label at the top, this label is the first element to get focus as far as AccessKit is concerned. I think this is due to the fact that `accessible-delegate-focus` does not ignore non-focusable items when building AccessKit tree updates. It is not strictly linked to tab widgets so I'm not including the fix in this PR.

Suggested Changelog entries:
- Improve overall accessibility of tab widgets
- Add `AccessibleRole::TabPanel`
