### PR TITLE
Bump 'ashpd' version to '0.10.2'

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -70,7 +70,7 @@ accesskit_winit = { version = "0.23", optional = true }
 copypasta = { version = "0.10", default-features = false }
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-ashpd = { version = "0.9.2" }
+ashpd = { version = "0.10.2" }
 futures = { version = "0.3.31" }
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
I've been trying out Slint for a bit, and I think it's really neat!  One of my concerns is the size of the dependency tree, even for really minimal builds (e.g. disabling accessibility and only using the `winit` backend and `femtovg` renderer gives ~500 transitive dependencies).

'ashpd' version 0.9 relies on 'async-io' by default, which pulls in a lot of extra crates.  'ashpd' 0.10 switches to 'tokio' by default.  I hope this cuts down the size of Slint's dependency tree.  From what I can tell, everything still builds just fine.  I haven't been able to run tests because rustc hits OOM when trying to compile them.