### PR TITLE
Fix panic in FemtoVG and Skia renderers with certain drop shadows

### DIFF
--- a/internal/core/graphics/boxshadowcache.rs
+++ b/internal/core/graphics/boxshadowcache.rs
@@ -82,7 +82,7 @@ impl BoxShadowOptions {
 }
 
 /// Cache to hold box textures for given box shadow options.
-pub struct BoxShadowCache<ImageType>(RefCell<BTreeMap<BoxShadowOptions, ImageType>>);
+pub struct BoxShadowCache<ImageType>(RefCell<BTreeMap<BoxShadowOptions, Option<ImageType>>>);
 
 impl<ImageType> Default for BoxShadowCache<ImageType> {
     fn default() -> Self {
@@ -98,7 +98,7 @@ impl<ImageType: Clone> BoxShadowCache<ImageType> {
         item_cache: &crate::item_rendering::ItemCache<Option<ImageType>>,
         box_shadow: std::pin::Pin<&crate::items::BoxShadow>,
         scale_factor: ScaleFactor,
-        shadow_render_fn: impl FnOnce(&BoxShadowOptions) -> ImageType,
+        shadow_render_fn: impl FnOnce(&BoxShadowOptions) -> Option<ImageType>,
     ) -> Option<ImageType> {
         item_cache.get_or_update_cache_entry(item_rc, || {
             let shadow_options = BoxShadowOptions::new(item_rc, box_shadow, scale_factor)?;
@@ -107,7 +107,6 @@ impl<ImageType: Clone> BoxShadowCache<ImageType> {
                 .entry(shadow_options.clone())
                 .or_insert_with(|| shadow_render_fn(&shadow_options))
                 .clone()
-                .into()
         })
     }
 }

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -693,8 +693,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
                     &self.canvas,
                     shadow_image_width,
                     shadow_image_height,
-                )
-                .expect("unable to create box shadow texture");
+                )?;
 
                 {
                     let mut canvas = self.canvas.borrow_mut();
@@ -756,7 +755,7 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
                     canvas.set_render_target(self.current_render_target());
                 }
 
-                ItemGraphicsCacheEntry::Texture(shadow_image)
+                Some(ItemGraphicsCacheEntry::Texture(shadow_image))
             },
         );
 

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -795,11 +795,11 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
                     None,
                 ));
 
-                let mut surface = self.canvas.new_surface(&image_info, None).unwrap();
+                let mut surface = self.canvas.new_surface(&image_info, None)?;
                 let canvas = surface.canvas();
                 canvas.clear(skia_safe::Color::TRANSPARENT);
                 canvas.draw_rrect(rounded_rect, &paint);
-                surface.image_snapshot()
+                Some(surface.image_snapshot())
             },
         );
 


### PR DESCRIPTION
If the effectively drop shadow size would be zero, the FemtoVG and Skia item renderers would panic. The following test-case reproduces this:

```slint
export component Test inherits Window {
    Rectangle {
        drop-shadow-color: black;
        drop-shadow-offset-x: 1px;
        drop-shadow-blur: -0.5px;
        width: 0.5px;
        height: 0.5px;
        background: blue;
    }
}
```

ChangeLog: [Renderers] Fix panic with FemtoVG and Skia renderers for certain drop shadows.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
