### PR TITLE
Experimental support for Linux ARMv7/ARMv8 binary C++ packages

### DIFF
--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -187,6 +187,35 @@ jobs:
                   name: cpp_mcu_bin-${{ matrix.idf_target }}
                   path: ${{ runner.workspace }}/cppbuild/Slint-cpp-*
 
+    cmake_package_arm_linux:
+        env:
+            CARGO_INCREMENTAL: false
+        strategy:
+            matrix:
+                gcc_target: [aarch64-linux-gnu, arm-linux-gnueabihf]
+                include:
+                  - gcc_target: aarch64-linux-gnu
+                    rust_target: aarch64-unknown-linux-gnu
+                  - gcc_target: arm-linux-gnueabihf
+                    rust_target: armv7-unknown-linux-gnueabihf
+
+        runs-on: ubuntu-20.04
+        container: ghcr.io/slint-ui/slint/${{ matrix.rust_target }}-cpp
+        steps:
+            - uses: actions/checkout@v4
+            - name: CMake configure
+              run: cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRust_CARGO_TARGET=${{ matrix.rust_target}} -DCMAKE_C_COMPILER=${{ matrix.gcc_target }}-gcc -DCMAKE_CXX_COMPILER=${{ matrix.gcc_target }}-g++  -DSLINT_COMPILER=download ${{ env.SLINT_BINARY_FEATURES }} ${{ inputs.extra_cmake_flags }}
+            - name: CMake build
+              run: cmake --build build --parallel
+            - name: CMake package                                      
+              working-directory: build
+              run: cpack -G TGZ
+            - name: "Upload C++ packages"
+              uses: actions/upload-artifact@v4
+              with:
+                  name: cpp_bin-${{ matrix.rust_target }}
+                  path: build/Slint-cpp-*
+
     cmake_slint_compiler:
         env:
             CARGO_INCREMENTAL: false

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -199,7 +199,7 @@ jobs:
                   - gcc_target: arm-linux-gnueabihf
                     rust_target: armv7-unknown-linux-gnueabihf
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         container: ghcr.io/slint-ui/slint/${{ matrix.rust_target }}-cpp
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -196,15 +196,17 @@ jobs:
                 include:
                   - gcc_target: aarch64-linux-gnu
                     rust_target: aarch64-unknown-linux-gnu
+                    cmake_system_processor: arm64
                   - gcc_target: arm-linux-gnueabihf
                     rust_target: armv7-unknown-linux-gnueabihf
+                    cmake_system_processor: armhf
 
         runs-on: ubuntu-22.04
         container: ghcr.io/slint-ui/slint/${{ matrix.rust_target }}-cpp
         steps:
             - uses: actions/checkout@v4
             - name: CMake configure
-              run: cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRust_CARGO_TARGET=${{ matrix.rust_target}} -DCMAKE_C_COMPILER=${{ matrix.gcc_target }}-gcc -DCMAKE_CXX_COMPILER=${{ matrix.gcc_target }}-g++  -DSLINT_COMPILER=download ${{ env.SLINT_BINARY_FEATURES }} ${{ inputs.extra_cmake_flags }}
+              run: cmake -B build -S . -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=${{ matrix.cmake_system_processor }} -DRust_CARGO_TARGET=${{ matrix.rust_target}} -DCMAKE_C_COMPILER=${{ matrix.gcc_target }}-gcc -DCMAKE_CXX_COMPILER=${{ matrix.gcc_target }}-g++  -DSLINT_COMPILER=download ${{ env.SLINT_BINARY_FEATURES }} ${{ inputs.extra_cmake_flags }}
             - name: CMake build
               run: cmake --build build --parallel
             - name: CMake package                                      

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -482,11 +482,11 @@ else()
 endif()
 
 if (NOT Rust_CARGO_TARGET STREQUAL Rust_CARGO_HOST_TARGET)
-    # If the package contains host dependent content (the slint-compiler), append the target suffix, otherwise
-    # strip the host suffix
+    # If the package contains host dependent content (the slint-compiler), append the target suffix.
+    # For cross-builds that target bare-metal, strip the host suffix
     if (TARGET Slint::slint-compiler)
         string(APPEND CPACK_SYSTEM_NAME "-${Rust_CARGO_TARGET}")
-    else()
+    elseif(SLINT_FEATURE_FREESTANDING)
         set(CPACK_SYSTEM_NAME "${Rust_CARGO_TARGET}")
     endif()
 endif()


### PR DESCRIPTION
Build them in the same container(*) as we're building Rust binaries with cross.

(*) It's not exactly the same container, it's the cross one _plus_ cmake added.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
