### PR TITLE
Fix panic when inlining 0 children in a `Row`

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -147,7 +147,7 @@ fn inline_element(
                 } else if Rc::ptr_eq(elem, &root_component.root_element) {
                     *cip = Some((insertion_element.clone(), *index + old_count, cip_node.clone()));
                 };
-            } else {
+            } else if old_count > 0 {
                 // @children was into a PopupWindow
                 debug_assert!(inlined_component.popup_windows.borrow().iter().any(|p| Rc::ptr_eq(
                     &p.component,

--- a/tests/cases/children/children_in_row.slint
+++ b/tests/cases/children/children_in_row.slint
@@ -1,0 +1,40 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue 7284
+
+component HeaderScreen {
+    GridLayout {
+        Row {
+            @children
+        }
+    }
+}
+
+component Intermediate {
+    HeaderScreen {
+        @children
+    }
+}
+
+export component TestCase inherits Window {
+    h := HeaderScreen {  }
+    i := Intermediate { }
+    i2 := Intermediate { Rectangle { height: 32px; } }
+
+    out property <bool> test: h.preferred-height == 0 && i.preferred-height == 0 && i2.preferred-height == 32px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/


### PR DESCRIPTION
The first inlining pass should inline any element that has children. Row is going to be optimized out before the second inlining pass. In that pass, we shouldn't care if there is no children while inlining in a `@children`

Fixes #7284
