### PR TITLE
LinuxKMS: Fix support for triple buffering with DRM

### DIFF
--- a/internal/backends/linuxkms/calloop_backend.rs
+++ b/internal/backends/linuxkms/calloop_backend.rs
@@ -261,7 +261,6 @@ impl i_slint_core::platform::Platform for Backend {
             }
 
             if let Some(adapter) = self.window.borrow().as_ref() {
-                adapter.register_event_loop(event_loop.handle())?;
                 adapter.clone().render_if_needed(mouse_position_property.as_ref())?;
             };
 

--- a/internal/backends/linuxkms/display/gbmdisplay.rs
+++ b/internal/backends/linuxkms/display/gbmdisplay.rs
@@ -44,8 +44,6 @@ impl GbmDisplay {
             )
             .map_err(|e| format!("Error creating gbm surface: {e}"))?;
 
-        drm_output.set_renderer_is_triple_buffered(true);
-
         Ok(GbmDisplay { drm_output, gbm_surface, gbm_device, surface_format })
     }
 
@@ -74,17 +72,7 @@ impl GbmDisplay {
 }
 
 impl super::Presenter for GbmDisplay {
-    fn register_page_flip_handler(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<(), PlatformError> {
-        self.drm_output.register_page_flip_handler(event_loop_handle)
-    }
-
-    fn present_with_next_frame_callback(
-        &self,
-        ready_for_next_animation_frame: Box<dyn FnOnce()>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    fn present(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let mut front_buffer = unsafe {
             self.gbm_surface
                 .lock_front_buffer()
@@ -114,11 +102,7 @@ impl super::Presenter for GbmDisplay {
             })
             .map_err(|e| format!("Error setting userdata on gbm surface front buffer: {e}"))?;
 
-        self.drm_output.present(front_buffer, fb, ready_for_next_animation_frame)
-    }
-
-    fn is_ready_to_present(&self) -> bool {
-        self.drm_output.is_ready_to_present()
+        self.drm_output.present(front_buffer, fb)
     }
 }
 

--- a/internal/backends/linuxkms/display/gbmdisplay.rs
+++ b/internal/backends/linuxkms/display/gbmdisplay.rs
@@ -44,6 +44,8 @@ impl GbmDisplay {
             )
             .map_err(|e| format!("Error creating gbm surface: {e}"))?;
 
+        drm_output.set_renderer_is_triple_buffered(true);
+
         Ok(GbmDisplay { drm_output, gbm_surface, gbm_device, surface_format })
     }
 

--- a/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
+++ b/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
@@ -20,7 +20,6 @@ impl DumbBufferDisplay {
         device_opener: &crate::DeviceOpener,
     ) -> Result<Rc<dyn super::SoftwareBufferDisplay>, PlatformError> {
         let drm_output = DrmOutput::new(device_opener)?;
-        drm_output.set_renderer_is_triple_buffered(true);
 
         //eprintln!("mode {}/{}", width, height);
 
@@ -76,17 +75,7 @@ impl super::SoftwareBufferDisplay for DumbBufferDisplay {
 }
 
 impl crate::display::Presenter for DumbBufferDisplay {
-    fn register_page_flip_handler(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<(), PlatformError> {
-        self.drm_output.register_page_flip_handler(event_loop_handle)
-    }
-
-    fn present_with_next_frame_callback(
-        &self,
-        ready_for_next_animation_frame: Box<dyn FnOnce()>,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    fn present(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.drm_output.wait_for_page_flip();
 
         self.back_buffer.swap(&self.front_buffer);
@@ -104,13 +93,8 @@ impl crate::display::Presenter for DumbBufferDisplay {
         self.drm_output.present(
             self.in_flight_buffer.borrow().buffer_handle,
             self.in_flight_buffer.borrow().fb_handle,
-            ready_for_next_animation_frame,
         )?;
         Ok(())
-    }
-
-    fn is_ready_to_present(&self) -> bool {
-        self.drm_output.is_ready_to_present()
     }
 }
 

--- a/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
+++ b/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
@@ -12,7 +12,7 @@ pub struct LinuxFBDisplay {
     back_buffer: RefCell<Box<[u8]>>,
     width: u32,
     height: u32,
-    presenter: Rc<crate::display::timeranimations::TimerBasedAnimationDriver>,
+    presenter: Rc<crate::display::noop_presenter::NoopPresenter>,
     first_frame: Cell<bool>,
     format: drm::buffer::DrmFourcc,
 }
@@ -98,7 +98,7 @@ impl LinuxFBDisplay {
             back_buffer,
             width,
             height,
-            presenter: crate::display::timeranimations::TimerBasedAnimationDriver::new(),
+            presenter: crate::display::noop_presenter::NoopPresenter::new(),
             first_frame: Cell::new(true),
             format,
         }))

--- a/internal/backends/linuxkms/display/vulkandisplay.rs
+++ b/internal/backends/linuxkms/display/vulkandisplay.rs
@@ -173,6 +173,6 @@ pub fn create_vulkan_display() -> Result<VulkanDisplay, PlatformError> {
         queue_family_index,
         surface: vulkan_surface,
         size,
-        presenter: crate::display::timeranimations::TimerBasedAnimationDriver::new(),
+        presenter: crate::display::noop_presenter::NoopPresenter::new(),
     })
 }

--- a/internal/backends/linuxkms/renderer/femtovg.rs
+++ b/internal/backends/linuxkms/renderer/femtovg.rs
@@ -177,15 +177,10 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for FemtoVGRendererAdapt
         &self.renderer
     }
 
-    fn is_ready_to_present(&self) -> bool {
-        self.gbm_display.is_ready_to_present()
-    }
-
     fn render_and_present(
         &self,
         rotation: RenderingRotation,
         draw_mouse_cursor_callback: &dyn Fn(&mut dyn ItemRenderer),
-        ready_for_next_animation_frame: Box<dyn FnOnce()>,
     ) -> Result<(), PlatformError> {
         let size = self.size();
         self.renderer.render_transformed_with_post_callback(
@@ -196,18 +191,11 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for FemtoVGRendererAdapt
                 draw_mouse_cursor_callback(item_renderer);
             }),
         )?;
-        self.gbm_display.present_with_next_frame_callback(ready_for_next_animation_frame)?;
+        self.gbm_display.present()?;
         Ok(())
     }
     fn size(&self) -> i_slint_core::api::PhysicalSize {
         let (width, height) = self.gbm_display.drm_output.size();
         i_slint_core::api::PhysicalSize::new(width, height)
-    }
-
-    fn register_page_flip_handler(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<(), PlatformError> {
-        self.gbm_display.clone().register_page_flip_handler(event_loop_handle)
     }
 }

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -140,15 +140,10 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SkiaRendererAdapter 
         &self.renderer
     }
 
-    fn is_ready_to_present(&self) -> bool {
-        self.presenter.is_ready_to_present()
-    }
-
     fn render_and_present(
         &self,
         rotation: RenderingRotation,
         draw_mouse_cursor_callback: &dyn Fn(&mut dyn ItemRenderer),
-        ready_for_next_animation_frame: Box<dyn FnOnce()>,
     ) -> Result<(), PlatformError> {
         self.renderer.render_transformed_with_post_callback(
             rotation.degrees(),
@@ -158,18 +153,11 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SkiaRendererAdapter 
                 draw_mouse_cursor_callback(item_renderer);
             }),
         )?;
-        self.presenter.present_with_next_frame_callback(ready_for_next_animation_frame)?;
+        self.presenter.present()?;
         Ok(())
     }
     fn size(&self) -> i_slint_core::api::PhysicalSize {
         self.size
-    }
-
-    fn register_page_flip_handler(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<(), PlatformError> {
-        self.presenter.clone().register_page_flip_handler(event_loop_handle)
     }
 }
 struct DrmDumbBufferAccess {

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -70,9 +70,17 @@ impl SkiaRendererAdapter {
             renderer: i_slint_renderer_skia::SkiaRenderer::new_with_surface(Box::new(
                 skia_gl_surface,
             )),
-            presenter: display,
+            presenter: display.clone(),
             size,
         });
+
+        renderer.renderer.set_pre_present_callback(Some(Box::new({
+            move || {
+                // Make sure the in-flight font-buffer from the previous swap_buffers call has been
+                // posted to the screen.
+                display.drm_output.wait_for_page_flip();
+            }
+        })));
 
         eprintln!("Using Skia OpenGL renderer");
 

--- a/internal/backends/linuxkms/renderer/sw.rs
+++ b/internal/backends/linuxkms/renderer/sw.rs
@@ -90,15 +90,10 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SoftwareRendererAdap
         &self.renderer
     }
 
-    fn is_ready_to_present(&self) -> bool {
-        self.presenter.is_ready_to_present()
-    }
-
     fn render_and_present(
         &self,
         rotation: RenderingRotation,
         _draw_mouse_cursor_callback: &dyn Fn(&mut dyn i_slint_core::item_rendering::ItemRenderer),
-        ready_for_next_animation_frame: Box<dyn FnOnce()>,
     ) -> Result<(), PlatformError> {
         self.display.map_back_buffer(&mut |pixels, age, format| {
             self.renderer.set_repaint_buffer_type(match age {
@@ -143,18 +138,11 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SoftwareRendererAdap
 
             Ok(())
         })?;
-        self.presenter.present_with_next_frame_callback(ready_for_next_animation_frame)?;
+        self.presenter.present()?;
         Ok(())
     }
 
     fn size(&self) -> i_slint_core::api::PhysicalSize {
         self.size
-    }
-
-    fn register_page_flip_handler(
-        &self,
-        event_loop_handle: crate::calloop_backend::EventLoopHandle,
-    ) -> Result<(), PlatformError> {
-        self.presenter.register_page_flip_handler(event_loop_handle)
     }
 }


### PR DESCRIPTION
This simplifies code and (more importantly) avoids getting accidentally frame-locked into 30 FPS when rendering takes slightly longer than 16ms.

Fixes #6951