### PR TITLE
Fix the hello world slint macro example

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -44,7 +44,7 @@ This method combines your Rust code with the `.slint` design markup in one file,
 
 ```rust
 slint::slint!{
-    export component HelloWorld {
+    export component HelloWorld inherits Window {
         Text {
             text: "hello world";
             color: green;


### PR DESCRIPTION
The slint VS Code plugin is otherwise reporting the warning: Exported component 'HelloWorld' doesn't inherit Window. This is deprecated

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
