### PR TITLE
Add property to toggle anti-aliasing on Path elements

### DIFF
--- a/docs/astro/src/content/docs/reference/elements/path.mdx
+++ b/docs/astro/src/content/docs/reference/elements/path.mdx
@@ -79,7 +79,7 @@ clipped at the boundaries of the view box.
 
 ### anti-alias
 <SlintProperty propName="anti-alias" typeName="bool" defaultValue="true"/>
- By default, the fill and stroke of a path is rendered with anti-aliasing, for best quality. Some GPU's
+ By default, the fill and stroke of a path is rendered with anti-aliasing, for best quality. Some GPUs
  have performance issues when rendering with anti-aliasing and animation. Setting the value to `false`
  might improve the frame-rate at the expense of a smoother looking path.
 

--- a/docs/astro/src/content/docs/reference/elements/path.mdx
+++ b/docs/astro/src/content/docs/reference/elements/path.mdx
@@ -79,9 +79,9 @@ clipped at the boundaries of the view box.
 
 ### anti-alias
 <SlintProperty propName="anti-alias" typeName="bool" defaultValue="true"/>
- By default, the fill and stroke of a path is rendered with anti-aliasing, for best quality. Certain
- GPUs have been observed to significantly degrade performance when rendering anti-aliased paths in
- some scenes. If you're experiencing this, try setting this to `false`.
+ By default, the fill and stroke of a path is rendered with anti-aliasing, for best quality. Some GPU's
+ have performance issues when rendering with anti-aliasing and animation. Setting the value to `false`
+ might improve the frame-rate at the expense of a smoother looking path.
 
 ## Path Using SVG Commands
 

--- a/docs/astro/src/content/docs/reference/elements/path.mdx
+++ b/docs/astro/src/content/docs/reference/elements/path.mdx
@@ -77,6 +77,12 @@ ignored and instead the bounding rectangle of all path elements is used to defin
 outside of it, they are still rendered. When this property is set to `true`, then rendering will be
 clipped at the boundaries of the view box.
 
+### anti-alias
+<SlintProperty propName="anti-alias" typeName="bool" defaultValue="true"/>
+ By default, the fill and stroke of a path is rendered with anti-aliasing, for best quality. Certain
+ GPUs have been observed to significantly degrade performance when rendering anti-aliased paths in
+ some scenes. If you're experiencing this, try setting this to `false`.
+
 ## Path Using SVG Commands
 
 SVG is a popular file format for defining scalable graphics, which are often composed of paths. In SVG

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1018,6 +1018,8 @@ impl ItemRenderer for QtItemRenderer<'_> {
             }
         }
 
+        let anti_alias: bool = path.anti_alias();
+
         let painter: &mut QPainterPtr = &mut self.painter;
         cpp! { unsafe [
                 painter as "QPainterPtr*",
@@ -1025,12 +1027,14 @@ impl ItemRenderer for QtItemRenderer<'_> {
                 mut painter_path as "QPainterPath",
                 fill_brush as "QBrush",
                 stroke_brush as "QBrush",
-                stroke_width as "float"] {
+                stroke_width as "float",
+                anti_alias as "bool"] {
             (*painter)->save();
             auto cleanup = qScopeGuard([&] { (*painter)->restore(); });
             (*painter)->translate(pos);
             (*painter)->setPen(stroke_width > 0 ? QPen(stroke_brush, stroke_width) : Qt::NoPen);
             (*painter)->setBrush(fill_brush);
+            (*painter)->setRenderHint(QPainter::Antialiasing, anti_alias);
             (*painter)->drawPath(painter_path);
         }}
     }

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -406,6 +406,7 @@ export component Path {
     in property <float> viewbox-width;
     in property <float> viewbox-height;
     in property <bool> clip;
+    in property <bool> anti-alias: true;
 
     //-disallow_global_types_as_child_elements
     MoveTo { }

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -45,6 +45,7 @@ pub struct Path {
     pub viewbox_width: Property<f32>,
     pub viewbox_height: Property<f32>,
     pub clip: Property<bool>,
+    pub anti_alias: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
 }
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -624,16 +624,20 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
             }
         }
 
+        let anti_alias = path.anti_alias();
+
         let fill_paint = self.brush_to_paint(path.fill(), &femtovg_path).map(|mut fill_paint| {
             fill_paint.set_fill_rule(match path.fill_rule() {
                 FillRule::Nonzero => femtovg::FillRule::NonZero,
                 FillRule::Evenodd => femtovg::FillRule::EvenOdd,
             });
+            fill_paint.set_anti_alias(anti_alias);
             fill_paint
         });
 
         let border_paint = self.brush_to_paint(path.stroke(), &femtovg_path).map(|mut paint| {
             paint.set_line_width((path.stroke_width() * self.scale_factor).get());
+            paint.set_anti_alias(anti_alias);
             paint
         });
 

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -727,16 +727,18 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
 
         self.canvas.translate((physical_offset.x, physical_offset.y));
 
+        let anti_alias = path.anti_alias();
+
         if let Some(mut fill_paint) =
             self.brush_to_paint(path.fill(), geometry.width_length(), geometry.height_length())
         {
-            fill_paint.set_anti_alias(true);
+            fill_paint.set_anti_alias(anti_alias);
             self.canvas.draw_path(&skpath, &fill_paint);
         }
         if let Some(mut border_paint) =
             self.brush_to_paint(path.stroke(), geometry.width_length(), geometry.height_length())
         {
-            border_paint.set_anti_alias(true);
+            border_paint.set_anti_alias(anti_alias);
             border_paint.set_stroke_width((path.stroke_width() * self.scale_factor).get());
             border_paint.set_stroke(true);
             self.canvas.draw_path(&skpath, &border_paint);


### PR DESCRIPTION
This enables working around bugs in GPU drivers. Especially the GC7000UL
plus its driver on imx8mp has been observed to sometimes horribly degrade in performance when Skia renders anti-aliased paths (when a function like `gcoSURF_BlitCPU` shows up at the top of `perf` that's a bad sign).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
