### PR TITLE
Clean up unicode-segmentation dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ web-sys = { version = "0.3.72", default-features = false }
 smol_str = { version = "0.3.1" }
 rayon = { version = "1.10.0", default-features = false }
 raw-window-handle-06 = { package = "raw-window-handle", version = "0.6", features = ["alloc"] }
+unicode-segmentation = { version = "1.12.0" }
 
 [profile.release]
 lto = true

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -73,7 +73,7 @@ scopeguard =  { version = "1.1.0", default-features = false }
 slab = { version = "0.4.3", default-features = false }
 static_assertions = "1.1"
 strum = { workspace = true }
-unicode-segmentation = "1.12.0"
+unicode-segmentation = { workspace = true }
 unicode-linebreak = { version = "0.1.5", optional = true }
 unicode-script = { version = "0.5.7", optional = true }
 integer-sqrt = { version = "0.1.5" }

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -38,7 +38,7 @@ imgref = { version = "1.6.1" }
 rgb = { version = "0.8.27" }
 
 glow = { version = "0.15" }
-unicode-segmentation = { version = "1.8.0" }
+unicode-segmentation = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["dwrite"] }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -44,7 +44,7 @@ raw-window-handle = { version = "0.6", features = ["std"] }
 
 skia-safe = { version = "0.78.0", features = ["textlayout", "gl"] }
 glow = { version = "0.13" }
-unicode-segmentation = { version = "1.8.0" }
+unicode-segmentation = { workspace = true }
 
 ash = { version = "^0.37.2", optional = true }
 vulkano = { version = "0.34.0", optional = true, default-features = false }


### PR DESCRIPTION
Use a workspace dependency.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
