### PR TITLE
Enable muda macOS menubar on macOS

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -346,17 +346,7 @@ impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
                     .err();
             }
             WindowEvent::Focused(have_focus) => {
-                let have_focus = have_focus || window.input_method_focused();
-                // We don't render popups as separate windows yet, so treat
-                // focus to be the same as being active.
-                if have_focus != runtime_window.active() {
-                    self.loop_error = window
-                        .window()
-                        .try_dispatch_event(corelib::platform::WindowEvent::WindowActiveChanged(
-                            have_focus,
-                        ))
-                        .err();
-                }
+                self.loop_error = window.activation_changed(have_focus).err();
             }
 
             WindowEvent::KeyboardInput { event, is_synthetic, .. } => {

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -235,8 +235,16 @@ impl BackendBuilder {
     /// slint::platform::set_platform(Box::new(backend));
     /// ```
     pub fn build(self) -> Result<Backend, PlatformError> {
-        let event_loop_builder =
-            self.event_loop_builder.unwrap_or_else(winit::event_loop::EventLoop::with_user_event);
+        let event_loop_builder = self.event_loop_builder.unwrap_or_else(|| {
+            #[allow(unused_mut)]
+            let mut default_builder = winit::event_loop::EventLoop::with_user_event();
+            #[cfg(all(feature = "muda", target_os = "macos"))]
+            winit::platform::macos::EventLoopBuilderExtMacOS::with_default_menu(
+                &mut default_builder,
+                false,
+            );
+            default_builder
+        });
 
         // Initialize the winit event loop and propagate errors if for example `DISPLAY` or `WAYLAND_DISPLAY` isn't set.
 


### PR DESCRIPTION
Hide the winit menu bar and provide a fallback if the app doesn't provide one. Also, activate per window to fix support for multiple windows.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
