### PR TITLE
Printer demo touch improvements

### DIFF
--- a/demos/printerdemo/ui/common.slint
+++ b/demos/printerdemo/ui/common.slint
@@ -106,8 +106,9 @@ export component Page inherits Rectangle {
         TouchArea {
             clicked => { root.back() }
 
-            x:0;
-            width: 150%;
+            x: -14px;
+            height: 200%;
+            width: self.height;
         }
     }
 

--- a/demos/printerdemo/ui/printerdemo.slint
+++ b/demos/printerdemo/ui/printerdemo.slint
@@ -16,6 +16,7 @@ import "./fonts/NotoSans-Bold.ttf";
 component SideBarIcon inherits Rectangle {
     in-out property <bool> active;
     in-out property <image> icon <=> i.source;
+    in-out property <brush> icon-colorize <=> i.colorize;
 
     callback activate;
     width: DemoPalette.side-bar-width;
@@ -176,18 +177,10 @@ export component MainWindow inherits Window {
                 DemoPalette.dark-mode = !DemoPalette.dark-mode;
             }
 
-            y: sidebar.icon-y(4);
-            x: 16px;
-            height: 35px;
-            width: 30px;
+            icon: DemoPalette.dark-mode ? @image-url("images/moon_full.svg") : @image-url("images/moon.svg");
+            icon-colorize: DemoPalette.dark-mode ? #F1FF98 : DemoPalette.inactive-page-icon-color;
 
-            Image {
-                colorize: DemoPalette.dark-mode ? #F1FF98 : DemoPalette.inactive-page-icon-color;
-                source: DemoPalette.dark-mode ? @image-url("images/moon_full.svg") : @image-url("images/moon.svg");
-                image-fit: contain;
-                width: 100%;
-                height: 100%;
-            }
+            y: sidebar.icon-y(4) - 17px;
         }
     }
 }


### PR DESCRIPTION
Fix a couple of TouchAreas that were difficult to interact with.

1. The back button arrow TouchArea was a bit on the small side;
2. The night-mode button was especially hard to hit compared to the other sidebar buttons:

The old touch areas, highlighted in red:
<img width="1011" alt="Screenshot 2025-01-09 at 14 37 48" src="https://github.com/user-attachments/assets/77e3e0f5-0f58-4e85-95cb-e6d853c9c434" />

The new touch areas:
<img width="1011" alt="Screenshot 2025-01-09 at 14 30 16" src="https://github.com/user-attachments/assets/d8ec4dfc-823c-43d8-88b1-f0f57c5e967e" />
