### PR TITLE
Re-enable tests of the doc snippets

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/file.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/file.mdx
@@ -134,7 +134,7 @@ as self closing tags.
 Slint simply has a single way to declare an item the `element-name` followed by a set of curly braces `{}` that contain
 the properties of the element.
 
-```slint del="Text {};"
+```slint no-test del="Text {};"
 // valid
 Text {}
 

--- a/docs/astro/src/content/docs/guide/language/coding/globals.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/globals.mdx
@@ -27,7 +27,7 @@ Export a global to make it accessible from other files (see <Link type="Modules"
 the file also exporting the main application component to make it visible
 to native code in the business logic.
 
-```slint no-test
+```slint
 export global Logic  {
     in-out property <int> the-value;
     pure callback magic-operation(int) -> int;

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -132,7 +132,7 @@ export component Example inherits Window {
 
         // Check the size to find out if the image is empty.
         if some_image.width > 0 : Image {
-            source: some_image
+            source: some_image;
         }
     }
 }

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/button.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/button.mdx
@@ -17,8 +17,8 @@ export component Example inherits Window {
         }
         Button {
             text: "Click Me";
-            clicked => { 
-                label.text = " Button clicked"; 
+            clicked => {
+                label.text = " Button clicked";
             }
         }
     }
@@ -36,7 +36,7 @@ A simple button. Common types of buttons can also be created with <Link type="St
 <SlintProperty propName="checkable" typeName="bool" defaultValue="false">
 Shows whether the button can be checked or not. This enables the `checked` property to possibly become true.
 
-```slint no-test "checkable: true;"
+```slint "checkable: true;"
 Button {
     text: "Checkable Button";
     checkable: true;
@@ -73,7 +73,7 @@ Set to true when the button is pressed.
 <SlintProperty propName="text" typeName="string">
 The text written in the button.
 
-```slint no-test 'text: "Button with text";'
+```slint 'text: "Button with text";'
 Button {
     text: "Button with text";
 }
@@ -96,7 +96,7 @@ If set to true, the icon will be colorized to the same color as the Button's tex
 
 Invoked when clicked: A finger or the left mouse button is pressed, then released on this element.
 
-```slint no-test {3-5}
+```slint {3-5}
 Button {
     text: "Click me";
     clicked() => {

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/checkbox.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/checkbox.mdx
@@ -31,7 +31,7 @@ Use a `CheckBox` to let the user select or deselect values, for example in a lis
 ### checked
 <SlintProperty propName="checked" typeName="bool" defaultValue="false" propertyVisibility="in-out">
 Whether the checkbox is checked or not.
-```slint no-test "checked: true;"
+```slint "checked: true;"
 CheckBox {
     text: self.checked ? "Checked" : "Not checked";
     checked: true;
@@ -52,7 +52,7 @@ Set to true when the checkbox has keyboard focus.
 ### text
 <SlintProperty propName="text" typeName="string">
 The text written next to the checkbox.
-```slint no-test 'text: "CheckBox with text";'
+```slint 'text: "CheckBox with text";'
 CheckBox {
     text: "CheckBox with text";
 }
@@ -64,7 +64,7 @@ CheckBox {
 ### toggled()
 The checkbox value changed
 
-```slint no-test {3-5}
+```slint {3-5}
 CheckBox {
     text: "CheckBox";
     toggled() => {

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/combobox.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/combobox.mdx
@@ -31,7 +31,7 @@ A button that, when clicked, opens a popup to select a value.
 ### current-index
 <SlintProperty propName="current-index" typeName="int" defaultValue="-1" propertyVisibility="in-out">
 The index of the selected value (-1 if no value is selected)
-```slint no-test "current-index: 1;"
+```slint "current-index: 1;"
 ComboBox {
     model: ["first", "second", "third"];
     current-index: 1;
@@ -57,7 +57,7 @@ Set to true when the combobox has keyboard focus.
 ### model
 <SlintProperty propName="model" typeName="[string]" defaultValue="[]">
 The list of possible values
-```slint no-test 'model: ["first", "second", "third"];'
+```slint 'model: ["first", "second", "third"];'
 ComboBox {
     model: ["first", "second", "third"];
 }
@@ -70,7 +70,7 @@ ComboBox {
 ### selected(string)
 A value was selected from the combo box. The argument is the currently selected value.
 
-```slint no-test {3-5}
+```slint {3-5}
 ComboBox {
     model: ["first", "second", "third"];
     selected(value) => {

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/progressindicator.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/progressindicator.mdx
@@ -35,7 +35,7 @@ Set to true if the progress of the operation cannot be determined by value.
 ### progress
 <SlintProperty propName="progress" typeName="float" defaultValue="0">
 Percentage of completion, as value between 0 and 1. Values less than 0 or greater than 1 are capped.
-```slint no-test "progress: 0.5;"
+```slint "progress: 0.5;"
 ProgressIndicator {
     progress: 0.5;
 }

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/slider.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/slider.mdx
@@ -40,7 +40,7 @@ Set to true when the slider currently has the focus
 ### value
 <SlintProperty propName="value" typeName="float" defaultValue="0" propertyVisibility="in-out">
 The value. Defaults to the minimum.
-```slint no-test "value: 50;"
+```slint "value: 50;"
 Slider {
     value: 50;
 }
@@ -50,7 +50,7 @@ Slider {
 ### step
 <SlintProperty propName="step" typeName="float" defaultValue="1">
 The change step when pressing arrow key.
-```slint no-test "step: 1;"
+```slint "step: 1;"
 Slider {
     step: 1;
 }
@@ -60,7 +60,7 @@ Slider {
 ### minimum
 <SlintProperty propName="minimum" typeName="float" defaultValue="0">
 The minimum value.
-```slint no-test "minimum: 10;"
+```slint "minimum: 10;"
 Slider {
     minimum: 10;
     value: 11;
@@ -71,7 +71,7 @@ Slider {
 ### maximum
 <SlintProperty propName="maximum" typeName="float" defaultValue="100">
 The maximum value.
-```slint no-test "maximum: 10;"
+```slint "maximum: 10;"
 Slider {
     maximum: 10;
     value: 9;
@@ -89,7 +89,7 @@ If set to true the Slider is displayed vertical.
 ### changed(float)
 The value was changed
 
-```slint no-test {2-4}
+```slint {2-4}
 Slider {
     changed(value) => {
         debug("New value: ", value);
@@ -100,7 +100,7 @@ Slider {
 ### released(float)
 Invoked when the user completed changing the slider's value, i.e. when the press on the knob was released or the arrow keys lifted.
 
-```slint no-test {2-4}
+```slint {2-4}
 Slider {
     released(position) => {
         debug("Released at position: ", position);

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinbox.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinbox.mdx
@@ -20,7 +20,7 @@ export component Example inherits Window {
         SpinBox {
             value: 42;
         }
-    }  
+    }
 }
 ```
 </CodeSnippetMD>
@@ -40,7 +40,7 @@ Set to true when the spinbox currently has the focus.
 ### value
 <SlintProperty propName="value" typeName="int" defaultValue="0" propertyVisibility="in-out">
 The value. Defaults to the minimum.
-```slint no-test "value: 50;"
+```slint "value: 50;"
 SpinBox {
     value: 50;
 }
@@ -50,7 +50,7 @@ SpinBox {
 ### minimum
 <SlintProperty propName="minimum" typeName="int" defaultValue="0">
 The minimum value.
-```slint no-test "minimum: 10;"
+```slint "minimum: 10;"
 SpinBox {
     minimum: 10;
     value: 11;
@@ -61,7 +61,7 @@ SpinBox {
 ### maximum
 <SlintProperty propName="maximum" typeName="int" defaultValue="100">
 The maximum value.
-```slint no-test "maximum: 10;"
+```slint "maximum: 10;"
 SpinBox {
     maximum: 10;
     value: 9;
@@ -81,12 +81,12 @@ The horizontal alignment of the text.
 
 ## Callbacks
 
-### changed(int)
+### edited(int)
 Emitted when the value has changed because the user modified it
 
-```slint no-test {2-4}
+```slint {2-4}
 SpinBox {
-    changed(value) => {
+    edited(value) => {
         debug("New value: ", value);
     }
 }

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinner.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinner.mdx
@@ -36,7 +36,7 @@ Set to true if the progress of the operation cannot be determined by value.
 <SlintProperty typeName="float" propName="progress" default="0" >
 Percentage of completion, as value between 0 and 1. Values less than 0 or greater than 1 are capped.
 
-```slint no-test "progress: 0.5;"
+```slint "progress: 0.5;"
 Spinner {
     progress: 0.5;
 }

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/standardbutton.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/standardbutton.mdx
@@ -39,7 +39,7 @@ Set to true when the button currently has the focus
 <SlintProperty typeName="enum" propName="kind" default="ok" enumName="StandardButtonKind" >
 The kind of button, one of `ok` `cancel`, `apply`, `close`, `reset`, `help`, `yes`, `no,` `abort`, `retry` or `ignore`
 
-```slint no-test "kind: ok;"
+```slint "kind: ok;"
 StandardButton {
     kind: ok;
 }
@@ -57,7 +57,7 @@ Set to true when the button is pressed.
 
 Invoked when clicked: A finger or the left mouse button is pressed, then released on this element.
 
-```slint no-test {2-4}
+```slint {2-4}
 StandardButton {
     clicked() => {
         debug("Button clicked");

--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/switch.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/switch.mdx
@@ -29,7 +29,7 @@ A `Switch` is a representation of a physical switch that allows users to turn th
 <SlintProperty typeName="bool" propName="checked" default="false" propertyVisibility="in-out">
 Whether the switch is checked or not.
 
-```slint no-test "checked: true;"
+```slint "checked: true;"
 Switch {
     text: self.checked ? "Checked" : "Not checked";
     checked: true;
@@ -51,7 +51,7 @@ Set to true when the switch has keyboard focus
 <SlintProperty typeName="string" propName="text" >
 The text written next to the switch.
 
-```slint no-test 'text: "CheckBox with text";'
+```slint 'text: "CheckBox with text";'
 Switch {
     text: "Switch with text";
 }
@@ -63,7 +63,7 @@ Switch {
 ### toggled()
 The switch value changed
 
-```slint no-test {3-5}
+```slint {3-5}
 Switch {
     text: "Switch";
     toggled() => {

--- a/docs/astro/src/content/docs/reference/std-widgets/misc/datepicker.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/misc/datepicker.mdx
@@ -50,7 +50,7 @@ The text that is displayed at the top of the picker.
 ### date
 <SlintProperty propName="date" typeName="struct" structName="Date">
 Set the initial displayed date.
-```slint no-test "date: { year: 2024, month: 11 };"
+```slint "date: { year: 2024, month: 11 };"
 DatePickerPopup {
     date: { year: 2024, month: 11 };
 }
@@ -62,7 +62,7 @@ DatePickerPopup {
 ### canceled()
 Invoked when the cancel button is clicked.
 
-```slint no-test {2-4}
+```slint {2-4}
 date-picker := DatePickerPopup {
     canceled() => {
         date-picker.close();
@@ -73,7 +73,7 @@ date-picker := DatePickerPopup {
 ### accepted(Date)
 Invoked when the ok button is clicked.
 
-```slint no-test {2-5}
+```slint {2-5}
 date-picker := DatePickerPopup {
     accepted(date) => {
         debug("Selected date: ", date);

--- a/docs/astro/src/content/docs/reference/std-widgets/misc/timepicker.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/misc/timepicker.mdx
@@ -60,7 +60,7 @@ The text that is displayed at the top of the picker.
 <SlintProperty propName="time" typeName="struct" structName="Time" >
 Set the initial displayed time.
 
-```slint no-test "time: { hour: 12, minute: 24 };"
+```slint "time: { hour: 12, minute: 24 };"
 TimePickerPopup {
     time: { hour: 12, minute: 24 };
 }
@@ -72,7 +72,7 @@ TimePickerPopup {
 ### canceled()
 The cancel button was clicked.
 
-```slint no-test {2-4}
+```slint {2-4}
 time-picker := TimePickerPopup {
     canceled() => {
         time-picker.close();
@@ -83,7 +83,7 @@ time-picker := TimePickerPopup {
 ### accepted(Time)
 The ok button was clicked.
 
-```slint no-test {2-5}
+```slint {2-5}
 time-picker := TimePickerPopup {
     accepted(time) => {
         debug("Selected time: ", time);

--- a/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
@@ -52,7 +52,7 @@ The horizontal alignment of the text.
 ### input-type
 <SlintProperty propName="input-type" typeName="enum" enumName="InputType" defaultValue="text">
 The way to allow special input viewing properties such as password fields.
-```slint no-test "input-type: password;"
+```slint "input-type: password;"
 LineEdit {
     input-type: password;
 }
@@ -73,7 +73,7 @@ enabled as well as editing text programmatically.
 ### text
 <SlintProperty propName="text" typeName="string" defaultValue='""' propertyVisibility="in-out">
 The text being edited
-```slint no-test 'text: "Initial text";'
+```slint 'text: "Initial text";'
 LineEdit {
     text: "Initial text";
 }
@@ -111,7 +111,7 @@ Pastes the text content of the clipboard at the cursor position.
 ### accepted(string)
 Invoked when the enter key is pressed.
 
-```slint no-test {2-4}
+```slint {2-4}
 LineEdit {
     accepted(text) => {
         debug("Accepted: ", text);
@@ -122,7 +122,7 @@ LineEdit {
 ### edited(string)
 Emitted when the text has changed because the user modified it
 
-```slint no-test {2-4}
+```slint {2-4}
 LineEdit {
     edited(text) => {
         debug("Text edited: ", text);

--- a/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
@@ -93,7 +93,7 @@ The horizontal scroll bar visibility policy. The default value is `ScrollBarPoli
 ### scrolled()
 Invoked when `viewport-x` or `viewport-y` is changed by a user action (dragging, scrolling).
 
-```slint no-test {11-14}
+```slint {11-14}
 ScrollView {
     width: 200px;
     height: 200px;

--- a/docs/astro/src/content/docs/reference/std-widgets/views/standardlistview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/standardlistview.mdx
@@ -42,7 +42,7 @@ The index of the currently active item. -1 mean none is selected, which is the d
 <SlintProperty typeName="struct" structName="StandardListViewItem" propName="model" default="[]">
 The model.
 
-```slint no-test 'model: [{ text: "Blue" }, { text: "Red" }, { text: "Green" }];'
+```slint 'model: [{ text: "Blue" }, { text: "Red" }, { text: "Green" }];'
 StandardListView {
     model: [{ text: "Blue" }, { text: "Red" }, { text: "Green" }];
 }
@@ -59,7 +59,7 @@ Sets the current item by the specified index and brings it into view.
 ### current-item-changed(int)
 Emitted when the current item has changed because the user modified it
 
-```slint no-test {3-5}
+```slint {3-5}
 StandardListView {
     model: [{ text: "Blue" }, { text: "Red" }, { text: "Green" }];
     current-item-changed(index) => {

--- a/docs/astro/src/content/docs/reference/std-widgets/views/standardtableview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/standardtableview.mdx
@@ -19,7 +19,7 @@ import { StandardTableView } from "std-widgets.slint";
 export component Example inherits Window {
     width: 230px;
     height: 200px;
-    
+
     StandardTableView {
         width: 230px;
         height: 200px;
@@ -58,10 +58,10 @@ Indicates the sorted column. -1 mean no column is sorted.
 <SlintProperty typeName="[struct]" structName="TableColumn" propName="columns" default="[]" propertyVisibility="in-out">
 Defines the model of the table columns.
 
-```slint no-test 'columns: [{ title: "Header 1" }, { title: "Header 2" }];'
+```slint 'columns: [{ title: "Header 1" }, { title: "Header 2" }];'
 StandardTableView {
     columns: [{ title: "Header 1" }, { title: "Header 2" }];
-    rows: [{ text: "Item 1" }, { text: "Item 2" }];
+    rows: [[{ text: "Item 1" }, { text: "Item 2" }]];
 }
 ```
 </SlintProperty>
@@ -70,10 +70,10 @@ StandardTableView {
 <SlintProperty typeName="[[struct]]" structName="StandardListViewItem" propName="rows" default="[]" propertyVisibility="in-out">
 Defines the model of table rows.
 
-```slint no-test 'rows: [{ text: "Item 1" }, { text: "Item 2" }];'
+```slint 'rows: [{ text: "Item 1" }, { text: "Item 2" }];'
 StandardTableView {
     columns: [{ title: "Header 1" }, { title: "Header 2" }];
-    rows: [{ text: "Item 1" }, { text: "Item 2" }];
+    rows: [[{ text: "Item 1" }, { text: "Item 2" }]];
 }
 ```
 </SlintProperty>
@@ -97,12 +97,12 @@ Emitted on any mouse pointer event similar to `TouchArea`. Arguments are row ind
 ### current-row-changed(int)
 Emitted when the current row has changed because the user modified it
 
-```slint no-test {5-7}
+```slint {5-7}
 StandardTableView {
     columns: [{ title: "Header 1" }, { title: "Header 2" }];
-    rows: [{ text: "Item 1" }, { text: "Item 2" }];
+    rows: [[{ text: "Item 1" }, { text: "Item 2" }]];
 
-    current-row-changed(index) {
+    current-row-changed(index) => {
         debug("Current row: ", index);
     }
 }

--- a/docs/astro/src/content/docs/reference/std-widgets/views/tabwidget.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/tabwidget.mdx
@@ -36,7 +36,7 @@ a time.
 <SlintProperty typeName="int" propName="current-index" default="0">
 The index of the currently visible tab.
 
-```slint no-test "current-index: 1;"
+```slint "current-index: 1;"
 TabWidget {
     current-index: 1;
     
@@ -56,7 +56,7 @@ TabWidget {
 <SlintProperty typeName="string" propName="title">
 The text written on the tab.
 
-```slint no-test 'title: "First";'
+```slint 'title: "First";'
 TabWidget {
     Tab {
         title: "First";

--- a/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
@@ -39,7 +39,7 @@ The size of the font of the input text.
 <SlintProperty propName="text" typeName="string" propertyVisibility="in-out" >
 The text being edited
 
-```slint no-test 'text: "Initial text";'
+```slint 'text: "Initial text";'
 TextEdit {
     text: "Initial text";
 }
@@ -89,10 +89,10 @@ The horizontal alignment of the text.
 
 Emitted when the text has changed because the user modified it
 
-```slint no-test {2-4}
+```slint {2-4}
 TextEdit {
-    accepted(text) => {
-        debug("Accepted: ", text);
+    edited(text) => {
+        debug("Edited: ", text);
     }
 }
 ```

--- a/docs/astro/src/content/docs/reference/timer.mdx
+++ b/docs/astro/src/content/docs/reference/timer.mdx
@@ -65,7 +65,7 @@ Timer {
 ### interval
 <SlintProperty propName="interval" typeName="duration">
 The interval between timer ticks. This property is mandatory.
-```slint no-test "interval: 250ms;"
+```slint "interval: 250ms;"
 Timer {
     property <int> count: 0;
     interval: 250ms;
@@ -80,7 +80,7 @@ Timer {
 ### running
 <SlintProperty propName="running" typeName="bool" defaultValue="true">
 `true` if the timer is running.
-```slint no-test "running: false; // timer is not running"
+```slint "running: false; // timer is not running"
 Timer {
     property <int> count: 0;
     interval: 250ms;
@@ -96,7 +96,7 @@ Timer {
 
 ### triggered()
 Invoked every time the timer ticks (every `interval`).
-```slint no-test {4-6}
+```slint {4-6}
 Timer {
     property <int> count: 0;
     interval: 250ms;

--- a/tests/doctests/build.rs
+++ b/tests/doctests/build.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().map_or(true, |e| e != "md") {
+        if path.extension().map_or(true, |e| e != "md" && e != "mdx") {
             continue;
         }
 
@@ -48,9 +48,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             // Permit `slint,no-preview` and `slint,no-auto-preview` but skip `slint,ignore` and others.
             rest = match rest.split_once('\n') {
-                Some((",no-preview", rest)) | Some((",no-auto-preview", rest)) => rest,
-                Some(("", rest)) => rest,
-                Some((" no-test", ..)) => continue,
+                Some((",ignore", _)) => continue,
+                Some((x, _)) if x.contains("no-test") => continue,
+                Some((_, rest)) => rest,
                 _ => continue,
             };
 


### PR DESCRIPTION
Since the file were moved to `.mdx` they were no longer tested. Adapt the code so it can test things that needs to be wrapped. Fix a bunch of mistake in the docs such as simple syntax error to documented callback that did not exist like SpinBox::changed

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
