### PR TITLE
Make configuration more reliable right after starting VSCode

### DIFF
--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -231,6 +231,14 @@ impl DocumentCache {
         self.type_loader.global_type_registry.borrow()
     }
 
+    fn invalidate_everything(&mut self) {
+        let all_files = self.type_loader.all_files().cloned().collect::<Vec<_>>();
+
+        for path in all_files {
+            self.type_loader.invalidate_document(&path);
+        }
+    }
+
     pub async fn reconfigure(
         &mut self,
         style: Option<String>,
@@ -256,6 +264,8 @@ impl DocumentCache {
         if let Some(lp) = library_paths {
             self.type_loader.compiler_config.library_paths = lp;
         }
+
+        self.invalidate_everything();
 
         self.preload_builtins().await;
 

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -239,7 +239,7 @@ fn test_goto_definition_multi_files() {
         Some(43),
         &mut dc,
     ));
-    let diag = common::convert_diagnostics(&extra_files, diag);
+    let diag = crate::language::convert_diagnostics(&extra_files, diag);
     for (u, ds) in diag {
         assert_eq!(ds, vec![], "errors in {u}");
     }

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -232,16 +232,18 @@ fn test_goto_definition_multi_files() {
     "#,
         url1 = url1.to_file_path().unwrap().display()
     );
-    let diags = spin_on::spin_on(crate::language::reload_document_impl(
+    let (extra_files, diag) = spin_on::spin_on(crate::language::reload_document_impl(
         None,
         source2.clone(),
         url2.clone(),
         Some(43),
         &mut dc,
     ));
-    for (u, ds) in diags {
+    let diag = common::convert_diagnostics(&extra_files, diag);
+    for (u, ds) in diag {
         assert_eq!(ds, vec![], "errors in {u}");
     }
+
     let doc2 = dc.get_document(&url2).unwrap().node.clone().unwrap();
 
     let offset: TextSize = (source2.find("h := Hello").unwrap() as u32).into();

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -7,9 +7,14 @@ use lsp_types::{Diagnostic, Url};
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::rc::Rc;
 
 use crate::common;
+use crate::language::convert_diagnostics;
 use crate::language::reload_document_impl;
+
+use super::Context;
 
 /// Create an empty `DocumentCache`
 pub fn empty_document_cache() -> common::DocumentCache {
@@ -40,8 +45,10 @@ pub fn loaded_document_cache_with_file_name(
         format!("/foo/{file_name}")
     };
     let url = Url::from_file_path(dummy_absolute_path).unwrap();
-    let diag =
+    let (extra_files, diag) =
         spin_on::spin_on(reload_document_impl(None, content, url.clone(), Some(42), &mut dc));
+
+    let diag = convert_diagnostics(&extra_files, diag);
     (dc, url, diag)
 }
 
@@ -104,48 +111,56 @@ component MainWindow inherits Window {
             "#.to_string())
 }
 
+#[track_caller]
+fn load(
+    ctx: Option<&Rc<Context>>,
+    document_cache: &mut common::DocumentCache,
+    path: &Path,
+    content: &str,
+) -> (Url, HashMap<Url, Vec<lsp_types::Diagnostic>>) {
+    let url = Url::from_file_path(path).unwrap();
+
+    let (main_file, diag) = spin_on::spin_on(reload_document_impl(
+        ctx,
+        content.into(),
+        url.clone(),
+        Some(1),
+        document_cache,
+    ));
+
+    (url, convert_diagnostics(&main_file, diag))
+}
+
 #[test]
 fn accurate_diagnostics_in_dependencies() {
     // Test for issue 5797
     let mut dc = empty_document_cache();
 
-    let bar_ctn = r#" export component Bar { property <int> hi; } "#;
-    let bar_url =
-        Url::from_file_path(std::env::current_dir().unwrap().join("xxx/bar.slint")).unwrap();
-    let diag = spin_on::spin_on(reload_document_impl(
+    let (bar_url, diag) = load(
         None,
-        bar_ctn.into(),
-        bar_url.clone(),
-        Some(1),
         &mut dc,
-    ));
+        &std::env::current_dir().unwrap().join("xxx/bar.slint"),
+        r#" export component Bar { property <int> hi; } "#,
+    );
     assert_eq!(diag, HashMap::from_iter([(bar_url.clone(), vec![])]));
 
-    let reexport_ctn = r#"import { Bar } from "bar.slint"; export component Foo inherits Bar { in property <string> reexport; }"#;
-    let reexport_url =
-        Url::from_file_path(std::env::current_dir().unwrap().join("xxx/reexport.slint")).unwrap();
-    let diag = spin_on::spin_on(reload_document_impl(
+    let (reexport_url, diag) = load(
         None,
-        reexport_ctn.into(),
-        reexport_url.clone(),
-        Some(1),
         &mut dc,
-    ));
+        &std::env::current_dir().unwrap().join("xxx/reexport.slint"),
+        r#"import { Bar } from "bar.slint"; export component Foo inherits Bar { in property <string> reexport; }"#,
+    );
     assert_eq!(
         diag,
         HashMap::from_iter([(reexport_url.clone(), vec![]), (bar_url.clone(), vec![])])
     );
 
-    let foo_ctn = r#"import { Foo } from "reexport.slint"; export component MainWindow inherits Window { Foo { hello: 45; } }"#;
-    let foo_url =
-        Url::from_file_path(std::env::current_dir().unwrap().join("xxx/foo.slint")).unwrap();
-    let diag = spin_on::spin_on(reload_document_impl(
+    let (foo_url, diag) = load(
         None,
-        foo_ctn.into(),
-        foo_url.clone(),
-        Some(1),
         &mut dc,
-    ));
+        &std::env::current_dir().unwrap().join("xxx/foo.slint"),
+        r#"import { Foo } from "reexport.slint"; export component MainWindow inherits Window { Foo { hello: 45; } }"#,
+    );
     //assert_eq!(diag.len(), 3);
     assert_eq!(diag[&reexport_url], vec![]);
     //assert_eq!(diag[&bar_url], vec![]);
@@ -161,14 +176,12 @@ fn accurate_diagnostics_in_dependencies() {
         open_urls: RefCell::new(HashSet::from_iter([foo_url.clone(), bar_url.clone()])),
     }));
 
-    let bar_ctn = r#" export component Bar { in property <int> hello; } "#;
-    let diag = spin_on::spin_on(reload_document_impl(
+    let (bar_url, diag) = load(
         ctx.as_ref(),
-        bar_ctn.into(),
-        bar_url.clone(),
-        Some(1),
         &mut dc,
-    ));
+        &std::env::current_dir().unwrap().join("xxx/bar.slint"),
+        r#" export component Bar { in property <int> hello; } "#,
+    );
     assert_eq!(diag.len(), 3);
     assert_eq!(
         diag,
@@ -186,23 +199,19 @@ fn accurate_diagnostics_in_dependencies() {
     .expect("foo.slint should still be loaded");
     assert!(matches!(sym, lsp_types::DocumentSymbolResponse::Nested(result) if result.len() >= 1));
 
-    let foo_ctn = r#"import { Foo } from "reexport.slint"; export component MainWindow inherits Window { Foo { hi: 45; } }"#;
-    let diag = spin_on::spin_on(reload_document_impl(
+    let (foo_url, diag) = load(
         ctx.as_ref(),
-        foo_ctn.into(),
-        foo_url.clone(),
-        Some(1),
         &mut dc,
-    ));
+        &std::env::current_dir().unwrap().join("xxx/foo.slint"),
+        r#"import { Foo } from "reexport.slint"; export component MainWindow inherits Window { Foo { hi: 45; } }"#,
+    );
     assert!(diag[&foo_url][0].message.contains("hi"));
 
-    let foo_ctn = r#"import { Foo } from "reexport.slint"; export component MainWindow inherits Window { Foo { hello: 12; } }"#;
-    let diag = spin_on::spin_on(reload_document_impl(
+    let (foo_url, diag) = load(
         ctx.as_ref(),
-        foo_ctn.into(),
-        foo_url.clone(),
-        Some(1),
         &mut dc,
-    ));
+        &std::env::current_dir().unwrap().join("xxx/foo.slint"),
+        r#"import { Foo } from "reexport.slint"; export component MainWindow inherits Window { Foo { hello: 12; } }"#,
+    );
     assert_eq!(diag[&foo_url], vec![]);
 }


### PR DESCRIPTION
We got reports that you need to tweak the configuration for it to become applied right after starting VSCode. This effects mostly the library_path and Include_path options that need to get applied to the code when building in LS or live-preview.

I ran into several issues:

 * The content cache was not initialized yet when the LSP sent the configuration
 * The LSP did not invalidate any files on configuration changes, so it never noticed that the include/library paths were changed (and thus did not send the new files on to the live preview.
 * The live preview raced against itself trying to render with the updated configuration but the old data. I added an explicit "commit configuration" step now to avoid that.

This greatly improves the reliability of configuration with the live preview and LS for me on first start of VSCode or when switching between WASM and binary preview.

Note: The WASM preview does not work with library_path at all for me: The compiler uses file existence tests, which always fail in WASM AFAICT.