### PR TITLE
Remove an unused import to fix a warning

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -13,8 +13,6 @@ use std::rc::Weak;
 #[cfg(target_arch = "wasm32")]
 use winit::platform::web::WindowExtWebSys;
 #[cfg(target_family = "windows")]
-use winit::platform::windows::WindowAttributesExtWindows;
-#[cfg(target_family = "windows")]
 use winit::platform::windows::WindowExtWindows;
 
 use crate::renderer::WinitCompatibleRenderer;


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

I don't know why this warning was not caught by the CI, but it has been bothering me for quite a while.