### PR TITLE
Docs: Fix <title> tag having docs version

### DIFF
--- a/.github/workflows/upgrade_version.yaml
+++ b/.github/workflows/upgrade_version.yaml
@@ -27,7 +27,6 @@ jobs:
 
                   # The version is also in these files
                   sed -i "s/^version = \"[0-9]*\.[0-9]*\.[0-9]*\(.*\)\"/version = \"${{ github.event.inputs.new_version }}\1\"/" api/cpp/docs/conf.py api/python/pyproject.toml
-                  sed -i 's/title: "[0-9]*\.[0-9]*\.[0-9]*"/title: "${{ github.event.inputs.new_version }}"/' docs/astro/astro.config.mjs
 
                   # Version in package.json files
                   git ls-files | grep package.json | xargs sed -i 's/"version": ".*"/"version": "${{ github.event.inputs.new_version }}"/'

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -31,10 +31,9 @@ export default defineConfig({
     },
     integrations: [
         starlight({
-            title: "1.10.0",
+            title: "Slint Docs",
             logo: {
-                light: "./src/assets/slint-logo-simple-light.webp",
-                dark: "./src/assets/slint-logo-simple-dark.webp",
+                src: "./src/assets/slint-logo-small-light.svg",
             },
             customCss: ["./src/styles/custom.css", "./src/styles/theme.css"],
 

--- a/docs/astro/src/styles/custom.css
+++ b/docs/astro/src/styles/custom.css
@@ -102,8 +102,8 @@
 
 .site-title {
     font-size: 1.3rem;
-    text-transform: uppercase;
     color: #fff;
+    margin-top: -4px;
 }
 
 span {


### PR DESCRIPTION
The version was being set not just as a visual title, but also as part of the meta tag for every page on the docs site. Which will then change for each release as the version number changes.

Other sites have a static label here that is indepedent of the version e.g. Slint UI or Slint docs. 'Slint Docs' is now used.