### PR TITLE
Replace ashpd dependency with just zbus

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -73,7 +73,8 @@ accesskit_winit = { version = "0.23", optional = true }
 copypasta = { version = "0.10", default-features = false }
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-ashpd = { version = "0.9.2" }
+# Use same version and executor as accesskit
+zbus = { version = "4.4.0", default-features = false, features = ["async-io"] }
 futures = { version = "0.3.31" }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -79,6 +79,8 @@ mod renderer {
 mod accesskit;
 #[cfg(muda)]
 mod muda;
+#[cfg(not(use_winit_theme))]
+mod xdg_color_scheme;
 
 #[cfg(target_arch = "wasm32")]
 pub(crate) mod wasm_input_helper;

--- a/internal/backends/winit/xdg_color_scheme.rs
+++ b/internal/backends/winit/xdg_color_scheme.rs
@@ -1,0 +1,55 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use std::rc::Weak;
+
+use i_slint_core::items::ColorScheme;
+
+use crate::WinitWindowAdapter;
+
+fn xdg_color_scheme_to_slint(value: zbus::zvariant::OwnedValue) -> ColorScheme {
+    match value.downcast_ref::<u32>() {
+        Ok(1) => ColorScheme::Dark,
+        Ok(2) => ColorScheme::Light,
+        _ => ColorScheme::Unknown,
+    }
+}
+
+pub async fn watch(window_weak: Weak<WinitWindowAdapter>) -> zbus::Result<()> {
+    let connection = zbus::Connection::session().await?;
+    let settings_proxy: zbus::Proxy = zbus::proxy::Builder::new(&connection)
+        .interface("org.freedesktop.portal.Settings")?
+        .path("/org/freedesktop/portal/desktop")?
+        .destination("org.freedesktop.portal.Desktop")?
+        .build()
+        .await?;
+
+    let initial_value: zbus::zvariant::OwnedValue =
+        settings_proxy.call("Read", &("org.freedesktop.appearance", "color-scheme")).await?;
+
+    if let Some(window) = window_weak.upgrade() {
+        window.set_color_scheme(xdg_color_scheme_to_slint(initial_value));
+    }
+
+    use futures::stream::StreamExt;
+
+    let mut color_scheme_stream = settings_proxy
+        .receive_signal_with_args(
+            "SettingChanged",
+            &[(0, "org.freedesktop.appearance"), (1, "color-scheme")],
+        )
+        .await?
+        .map(|message| {
+            let (_, _, scheme): (String, String, zbus::zvariant::OwnedValue) =
+                message.body().deserialize().ok()?;
+            Some(scheme)
+        });
+
+    while let Some(Some(new_scheme)) = color_scheme_stream.next().await {
+        if let Some(window) = window_weak.upgrade() {
+            window.set_color_scheme(xdg_color_scheme_to_slint(new_scheme));
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This makes our dependency tree lighter and zbus is an already existing dependency (through accesskit).

cc #7276

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
