### PR TITLE
nigel/docs-trailing-slash

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -12,6 +12,7 @@ import { BASE_PATH, BASE_URL } from "./src/utils/site-config";
 export default defineConfig({
     site: `${BASE_URL}${BASE_PATH}`,
     base: BASE_PATH,
+    trailingSlash: "always",
     markdown: {
         rehypePlugins: [
             [

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -52,7 +52,7 @@
                             </li>
                             <li id="pricing"><a href="https://slint.dev/pricing.html">Pricing</a></li>
                             <li id="blog"><a href="https://slint.dev/blog">Blog</a></li>
-                            <li id="docs"><a href="https://slint.dev/docs.html">Docs</a></li>
+                            <li id="docs"><a href="https://docs.slint.dev">Docs</a></li>
                             <li class="navi-item-has-children" id="resources"><a href="#">Resources</a>
                                 <ul>
                                     <li id="success"><a href="https://slint.dev/success">Success Stories</a></li>

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -1,153 +1,153 @@
 {
     "AnimationRef": {
-        "href": "reference/primitive-types#animation"
+        "href": "reference/primitive-types/#animation"
     },
     "AnimationTick": {
         "href": "reference/global-functions/builtinfunctions/#animation-tick---duration"
     },
     "angle": {
-        "href": "reference/primitive-types#angle"
+        "href": "reference/primitive-types/#angle"
     },
     "bool": {
-        "href": "reference/primitive-types#bool"
+        "href": "reference/primitive-types/#bool"
     },
     "brush": {
-        "href": "reference/primitive-types#brush"
+        "href": "reference/primitive-types/#brush"
     },
     "BorderRadiusRectangle": {
-        "href": "reference/elements/rectangle#border-radius-properties"
+        "href": "reference/elements/rectangle/#border-radius-properties"
     },
     "cache-rendering-hint": {
         "href": "reference/common/#cache-rendering-hint"
     },
     "ColorsRef": {
-        "href": "reference/colors-and-brushes"
+        "href": "reference/colors-and-brushes/"
     },
     "color": {
-        "href": "reference/primitive-types#color"
+        "href": "reference/primitive-types/#color"
     },
     "ComponentLibraries": {
         "href": "guide/language/coding/file/#component-libraries"
     },
     "CommonProperties": {
-        "href": "reference/common"
+        "href": "reference/common/"
     },
     "duration": {
-        "href": "reference/primitive-types#duration"
+        "href": "reference/primitive-types/#duration"
     },
     "DebugFn": {
-        "href": "reference/global-functions/builtinfunctions#debug"
+        "href": "reference/global-functions/builtinfunctions/#debug"
     },
     "easing": {
-        "href": "reference/primitive-types#easing"
+        "href": "reference/primitive-types/#easing"
     },
     "EnumType": {
-        "href": "reference/global-structs-enums"
+        "href": "reference/global-structs-enums/"
     },
     "Expressions": {
         "href": "guide/language/coding/expressions-and-statements/"
     },
     "float": {
-        "href": "reference/primitive-types#float"
+        "href": "reference/primitive-types/#float"
     },
     "FocusHandling": {
-        "href": "guide/development/focus"
+        "href": "guide/development/focus/"
     },
     "FontHandling": {
-        "href": "guide/development/fonts"
+        "href": "guide/development/fonts/"
     },
     "GridLayout": {
-        "href": "reference/layouts/gridlayout"
+        "href": "reference/layouts/gridlayout/"
     },
     "Globals": {
-        "href": "reference/global-structs-enums"
+        "href": "reference/global-structs-enums/"
     },
     "HorizontalBox": {
-        "href": "reference/std-widgets/layouts/horizontalbox"
+        "href": "reference/std-widgets/layouts/horizontalbox/"
     },
     "HorizontalLayout": {
-        "href": "reference/layouts/horizontallayout"
+        "href": "reference/layouts/horizontallayout/"
     },
     "Image": {
-        "href": "reference/elements/image"
+        "href": "reference/elements/image/"
     },
     "ImageType": {
-        "href": "reference/primitive-types#image"
+        "href": "reference/primitive-types/#image"
     },
     "int": {
-        "href": "reference/primitive-types#int"
+        "href": "reference/primitive-types/#int"
     },
     "KeyEvent": {
-        "href": "reference/keyboard-input/overview"
+        "href": "reference/keyboard-input/overview/"
     },
     "length": {
-        "href": "reference/primitive-types#length"
+        "href": "reference/primitive-types/#length"
     },
     "ListView": {
-        "href": "reference/std-widgets/views/listview"
+        "href": "reference/std-widgets/views/listview/"
     },
     "LineEdit": {
-        "href": "reference/std-widgets/views/lineedit"
+        "href": "reference/std-widgets/views/lineedit/"
     },
     "LinuxkmsBackend": {
-        "href": "guide/backends-and-renderers/backend_linuxkms"
+        "href": "guide/backends-and-renderers/backend_linuxkms/"
     },
     "Modules": {
         "href": "guide/language/coding/file/#modules"
     },
     "Models": {
-        "href": "guide/language/coding/repetition-and-data-models#models"
+        "href": "guide/language/coding/repetition-and-data-models/#models"
     },
     "NumericTypes": {
-        "href": "reference/primitive-types#numeric-types"
+        "href": "reference/primitive-types/#numeric-types"
     },
     "Path": {
-        "href": "reference/elements/path"
+        "href": "reference/elements/path/"
     },
     "percent": {
-        "href": "reference/primitive-types#percent"
+        "href": "reference/primitive-types/#percent"
     },
     "physicalLength": {
-        "href": "reference/primitive-types#physical-length"
+        "href": "reference/primitive-types/#physical-length"
     },
     "PopupWindow": {
-        "href": "reference/window/popupwindow"
+        "href": "reference/window/popupwindow/"
     },
     "ProgressIndicator": {
-        "href": "reference/std-widgets/basic-widgets/progressindicator"
+        "href": "reference/std-widgets/basic-widgets/progressindicator/"
     },
     "Purity": {
-        "href": "guide/language/concepts/reactivity"
+        "href": "guide/language/concepts/reactivity/"
     },
     "Rectangle": {
-        "href": "reference/elements/rectangle"
+        "href": "reference/elements/rectangle/"
     },
     "relativeFontSize": {
-        "href": "reference/primitive-types#relative-font-size"
+        "href": "reference/primitive-types/#relative-font-size"
     },
     "slintFile": {
-        "href": "guide/language/coding/file"
+        "href": "guide/language/coding/file/"
     },
     "ScrollView": {
-        "href": "reference/std-widgets/views/scrollview"
+        "href": "reference/std-widgets/views/scrollview/"
     },
     "StandardButton": {
-        "href": "reference/std-widgets/basic-widgets/standardbutton"
+        "href": "reference/std-widgets/basic-widgets/standardbutton/"
     },
     "StringType": {
-        "href": "reference/primitive-types#string"
+        "href": "reference/primitive-types/#string"
     },
     "StructType": {
-        "href": "reference/global-structs-enums"
+        "href": "reference/global-structs-enums/"
     },
     "StyleWidgets": {
-        "href": "reference/std-widgets/style"
+        "href": "reference/std-widgets/style/"
     },
     "Text": {
         "href": "reference/elements/text/"
     },
     "TextEdit": {
-        "href": "reference/std-widgets/views/textedit"
+        "href": "reference/std-widgets/views/textedit/"
     },
     "TextInput": {
         "href": "reference/keyboard-input/textinput/"
@@ -156,25 +156,25 @@
         "href": "reference/timer/"
     },
     "Types": {
-        "href": "reference/primitive-types"
+        "href": "reference/primitive-types/"
     },
     "VerticalBox": {
-        "href": "reference/std-widgets/layouts/verticalbox"
+        "href": "reference/std-widgets/layouts/verticalbox/"
     },
     "VerticalLayout": {
-        "href": "reference/layouts/verticallayout"
+        "href": "reference/layouts/verticallayout/"
     },
     "QtBackend": {
-        "href": "guide/backends-and-renderers/backend_qt"
+        "href": "guide/backends-and-renderers/backend_qt/"
     },
     "Window": {
-        "href": "reference/window/window"
+        "href": "reference/window/window/"
     },
     "WinitBackend": {
         "href": "guide/backends-and-renderers/backend_winit/"
     },
     "translations": {
-        "href": "guide/development/translations"
+        "href": "guide/development/translations/"
     },
     "backends_and_renderers": {
         "href": "guide/backends-and-renderers/backends_and_renderers/"


### PR DESCRIPTION
The docs were generated so links did not end with a trailing slash. e.g. `https://docs.slint.dev/latest/docs/slint/guide/tooling/vscode` but the website setup then redirects this to `https://docs.slint.dev/latest/docs/slint/guide/tooling/vscode/`. This now ensures the trailing slash is added.