### PR TITLE
ListView focus fixes

### DIFF
--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -330,8 +330,13 @@ impl ItemRc {
     /// false for `Clip` elements with the `clip` property evaluating to true.
     pub fn is_visible(&self) -> bool {
         let (clip, geometry) = self.absolute_clip_rect_and_geometry();
-        let intersection = geometry.intersection(&clip).unwrap_or_default();
-        !intersection.is_empty() || (geometry.is_empty() && clip.contains(geometry.center()))
+        let clip = clip.to_box2d();
+        let geometry = geometry.to_box2d();
+        !clip.is_empty()
+            && clip.max.x >= geometry.min.x
+            && clip.max.y >= geometry.min.y
+            && clip.min.x <= geometry.max.x
+            && clip.min.y <= geometry.max.y
     }
 
     /// Returns the clip rect that applies to this item (in window coordinates) as well as the

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1251,7 +1251,7 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
         let inner = self.0.inner.borrow();
         inner
             .instances
-            .get(index - inner.offset)
+            .get(index.checked_sub(inner.offset)?)
             .map(|c| c.1.clone().expect("That was updated before!"))
     }
 

--- a/tests/cases/focus/listview-hidden.slint
+++ b/tests/cases/focus/listview-hidden.slint
@@ -1,0 +1,93 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue #7341
+// Check that changing focus while the current item is hidden does not panic
+
+import { LineEdit, StandardListView } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+
+    forward-focus: l1;
+    out property l1-has-focus <=> l1.has-focus;
+    out property l2-has-focus <=> l2.has-focus;
+    out property lv-has-focus <=> lv.has-focus;
+    out property current-item <=> lv.current-item;
+    out property viewport-y <=> lv.viewport-y;
+    out property <length> item-height: lv.viewport-height / lv.model.length;
+
+
+    VerticalLayout {
+        l1 := LineEdit {}
+        lv := StandardListView {
+            model: [ { text: "a"}, { text: "b"}, { text: "c"}, { text: "d"}, { text: "e"}, { text: "f"}, { text: "g"}, { text: "h"}, { text: "i"}, { text: "j"}, { text: "k"}, { text: "l"}, { text: "m"}, { text: "n"}, { text: "o"}, { text: "p"}, { text: "q"}, { text: "r"}, { text: "s"}, { text: "t"}, { text: "u"}, { text: "v"}, { text: "w"}, { text: "x"}, { text: "y"}, { text: "z"} ];
+           current-item-changed(current-item) => {
+               debug("current-item-changed", current-item);
+           }
+        }
+        l2 := LineEdit {}
+    }
+
+}
+
+/*
+```rust
+use slint::{LogicalPosition, SharedString};
+use slint::platform::{Key, WindowEvent};
+let instance = TestCase::new().unwrap();
+assert!(instance.get_l1_has_focus());
+assert!(!instance.get_lv_has_focus());
+assert!(!instance.get_l2_has_focus());
+assert_eq!(instance.get_current_item(), -1);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert!(!instance.get_l1_has_focus());
+assert!(instance.get_lv_has_focus());
+assert!(!instance.get_l2_has_focus());
+assert_eq!(instance.get_current_item(), 0);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
+assert_eq!(instance.get_current_item(), 1);
+
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert!(!instance.get_l1_has_focus());
+assert!(!instance.get_lv_has_focus());
+assert!(instance.get_l2_has_focus());
+assert_eq!(instance.get_current_item(), 1);
+
+let delta_y = -600.0;
+
+assert_eq!(instance.get_viewport_y(), 0.0);
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(150.0, 150.0), delta_x: -0.0, delta_y });
+assert_eq!(instance.get_viewport_y(), delta_y);
+assert_eq!(instance.get_current_item(), 1);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Backtab));
+assert!(!instance.get_l1_has_focus());
+assert!(instance.get_lv_has_focus());
+assert!(!instance.get_l2_has_focus());
+assert_eq!(instance.get_current_item(), 1);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Backtab));
+assert!(instance.get_l1_has_focus());
+assert!(!instance.get_lv_has_focus());
+assert!(!instance.get_l2_has_focus());
+assert_eq!(instance.get_current_item(), 1);
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert!(!instance.get_l1_has_focus());
+assert!(instance.get_lv_has_focus());
+assert!(!instance.get_l2_has_focus());
+assert_eq!(instance.get_current_item(), 1);
+
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::UpArrow));
+let mut x = (-delta_y / instance.get_item_height()).round() as i32 - 1;
+assert_eq!(instance.get_current_item(), x);
+while x > 0 {
+    slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::UpArrow));
+    x -= 1;
+    assert_eq!(instance.get_current_item(), x);
+}
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::UpArrow));
+assert_eq!(instance.get_current_item(), 0);
+```
+
+
+
+*/


### PR DESCRIPTION
 - Fix StandardListView not always getting the focus. Because the geometry of the FocusScope might be empty but its position is still in the non-clipped area, but not its center.

 - Fix panic when accessing "negative" items if there are hidden elements in the ListView (#7341)

Fixes #7341
