### PR TITLE
doc: Shorten and edit the main page button text

### DIFF
--- a/docs/astro/src/content/docs/index.mdx
+++ b/docs/astro/src/content/docs/index.mdx
@@ -31,24 +31,24 @@ The documentation is split into several sections:
 <CardGrid>
 <LinkCard
   title="Guide"
-  description="This will get you up and running with the tooling for Slint development including the IDE integration via the Slint Language Server (LSP) and Slint Viewer.
+  description="Get up and running with the tooling for Slint development including the IDE integration via the Slint Language Server (LSP) and Slint Viewer.
   <br/><br/>
-  It then offers a guide explaining all the key concepts of Slint and how to understand and use the Slint language."
+  Learn all the key concepts of Slint to understand and use the Slint language."
   href={`${import.meta.env.BASE_URL}`}
 >
 </LinkCard>
 
 <LinkCard
   title="Reference"
-  description="This contains the API reference for all aspects of the Slint language. All the elements, properties, functions, callbacks and namespaces. It also contains the
-API reference for the `std-widgets` library. A set of cross platform components that can be used to build desktop applications."
+  description="Browse the API reference for all aspects of the Slint language: The elements, properties, functions, callbacks, namespaces, as well as
+the std-widgets library. A set of cross platform components that can be used to build desktop applications."
   href={`${import.meta.env.BASE_URL}/reference/primitive-types`}
 >
 </LinkCard>
 
 <LinkCard
   title="Tutorial"
-  description="For those that like to learn by example or want to see how to structure a simple application, this section contains a step-by-step tutorial that walks you
+  description="Learn by example and see how to structure a simple application via a step-by-step tutorial that walks you
 through the creation of a simple memory game example."
 href={`${import.meta.env.BASE_URL}/tutorial/quickstart/`}
 >
@@ -56,7 +56,7 @@ href={`${import.meta.env.BASE_URL}/tutorial/quickstart/`}
 
 <LinkCard
   title="Language Integrations"
-  description="This details the API for the Rust, C++, and JS-Runtime versions of Slint."
+  description="API reference for the Rust, C++, and JavaScript versions of Slint."
 href={`${import.meta.env.BASE_URL}/language-integrations/`}
 >
 </LinkCard>


### PR DESCRIPTION
This is attempt to make it easier to read by using less words and by starting each card with a verb (to make it actionable). Also removed the backticks for std-widgets, as it seems that LinkCard doesn't support inline markdown formatting.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
