### PR TITLE
Update to Image 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ euclid = { version = "0.22.1", default-features = false }
 fontdb = { version = "0.22.0", default-features = false }
 fontdue = { version = "0.9.0" }
 glutin = { version = "0.32.0", default-features = false }
-image = { version = "0.24", default-features = false, features = [ "png", "jpeg" ] }
+image = { version = "0.25", default-features = false, features = [ "png", "jpeg" ] }
 itertools = { version = "0.14" }
 log = { version = "0.4.17" }
 resvg = { version= "0.44.0", default-features = false, features = ["text"] }

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -44,7 +44,7 @@ gettext = ["i-slint-core/gettext-rs"]
 accessibility = ["i-slint-backend-selector/accessibility"]
 system-testing = ["i-slint-backend-selector/system-testing"]
 
-std = ["image", "i-slint-core/default", "i-slint-backend-selector"]
+std = ["i-slint-core/default", "i-slint-core/image-default-formats", "i-slint-backend-selector"]
 freestanding = ["i-slint-core/libm", "i-slint-core/unsafe-single-threaded"]
 experimental = []
 
@@ -55,10 +55,8 @@ i-slint-backend-selector = { workspace = true, optional = true }
 i-slint-backend-testing = { workspace = true, optional = true, features = ["ffi"] }
 i-slint-renderer-skia = {  workspace = true, features = ["default", "x11", "wayland"], optional = true }
 i-slint-core = { workspace = true, features = ["ffi"] }
-slint-interpreter = { workspace = true, features = ["ffi", "compat-1-2"], optional = true }
+slint-interpreter = { workspace = true, features = ["ffi", "compat-1-10"], optional = true }
 raw-window-handle = { version = "0.6", optional = true }
-# Enable image-rs' default features to make all image formats to C++ users
-image = { workspace = true, optional = true, features = ["default"] }
 
 esp-backtrace = { version = "0.14.0", features = ["panic-handler", "println"], optional = true }
 esp-println = { version = "0.12.0", default-features = false, features = ["uart"], optional = true }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -25,16 +25,18 @@ default = [
   "backend-default",
   "renderer-femtovg",
   "renderer-software",
+  "image-default-formats",
   "accessibility",
-  "compat-1-2",
+  "compat-1-10",
 ]
 
 ## Mandatory feature:
-## This feature is required to keep the compatibility with Slint 1.2
+## This feature is required to keep the compatibility with Slint 1.10
 ## Newer patch version may put current functionality behind a new feature
 ## that would be enabled by default only if this feature was added.
 ## [More info in this blog post](https://slint.dev/blog/rust-adding-default-cargo-feature.html)
-"compat-1-2" = []
+"compat-1-10" = []
+"compat-1-2" = ["compat-1-10", "image-default-formats"]
 "compat-1-0" = ["compat-1-2", "renderer-software"]
 
 ## Enable use of the Rust standard library.
@@ -83,6 +85,10 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 ## [HasWindowHandle](raw_window_handle_06::HasWindowHandle) and
 ## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation.
 raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
+
+## Enable all formats from the `image` crate. To increase what is supported from [`Image::load_from_path`]
+## or in `@image-url`. Without this feature, only PNG and JPEG are supported.
+image-default-formats = ["i-slint-core/image-default-formats"]
 
 #! ### Backends
 

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -86,8 +86,10 @@ accessibility = ["i-slint-backend-selector/accessibility"]
 ## [HasDisplayHandle](raw_window_handle_06::HasDisplayHandle) implementation.
 raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/raw-window-handle-06"]
 
-## Enable all formats from the `image` crate. To increase what is supported from [`Image::load_from_path`]
-## or in `@image-url`. Without this feature, only PNG and JPEG are supported.
+## Enable the default image formats from the `image` crate, to support additional image formats in [`Image::load_from_path`]
+## and `@image-url`. When this feature is disabled, only PNG and JPEG are supported. When enabled,
+## the following image formats are supported:
+## AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
 image-default-formats = ["i-slint-core/image-default-formats"]
 
 #! ### Backends

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -202,9 +202,9 @@ each instance will have their own instance of associated globals singletons.
 
 extern crate alloc;
 
-#[cfg(not(feature = "compat-1-2"))]
+#[cfg(not(feature = "compat-1-10"))]
 compile_error!(
-    "The feature `compat-1-2` must be enabled to ensure \
+    "The feature `compat-1-10` must be enabled to ensure \
     forward compatibility with future version of this crate"
 );
 

--- a/api/rs/slint/mcu.md
+++ b/api/rs/slint/mcu.md
@@ -29,7 +29,7 @@ Start by adding a dependency to the `slint` and the `slint-build` crates to your
 Start with the `slint` crate like this:
 
 ```sh
-cargo add slint@1.9.0 --no-default-features --features "compat-1-2 unsafe-single-threaded libm renderer-software"
+cargo add slint@1.10.0 --no-default-features --features "compat-1-10 unsafe-single-threaded libm renderer-software"
 ```
 
 The default features of the `slint` crate are tailored towards hosted environments and includes the "std" feature. In bare metal environments,
@@ -37,7 +37,7 @@ you need to disable the default features.
 
 In the snippet above, three features are selected:
 
- * `compat-1-2`: We select this feature when disabling the default features. For a detailed explanation see our blog post ["Adding default cargo features without breaking Semantic Versioning"](https://slint.dev/blog/rust-adding-default-cargo-feature.html).
+ * `compat-1-10`: We select this feature when disabling the default features. For a detailed explanation see our blog post ["Adding default cargo features without breaking Semantic Versioning"](https://slint.dev/blog/rust-adding-default-cargo-feature.html).
  * `unsafe-single-threaded`: Slint internally uses Rust's [`thread_local!`](https://doc.rust-lang.org/std/macro.thread_local.html) macro to store global data.
    This macro is only available in the Rust Standard Library (std), but not in bare metal environments. As a fallback, the `unsafe-single-threaded`
    feature changes Slint to use unsafe static for storage. This way, you guarantee to use Slint API only from a single thread, and not from interrupt handlers.
@@ -52,7 +52,7 @@ This is the default when using the Rust 2021 Edition, but not if you use a works
 Then add the `slint-build` crate as a build dependency:
 
 ```sh
-cargo add --build slint-build@1.9.0
+cargo add --build slint-build@1.10.0
 ```
 
 For reference: These are the relevant parts of your `Cargo.toml` file,
@@ -68,11 +68,11 @@ edition = "2021"
 ## ... your other dependencies
 
 [dependencies.slint]
-version = "1.8.0"
+version = "1.10.0"
 default-features = false
-features = ["compat-1-2", "unsafe-single-threaded", "libm", "renderer-software"]
+features = ["compat-1-10", "unsafe-single-threaded", "libm", "renderer-software"]
 [build-dependencies]
-slint-build = "1.9.0"
+slint-build = "1.10.0"
 ```
 
 ## Changes to `build.rs`

--- a/api/wasm-interpreter/Cargo.toml
+++ b/api/wasm-interpreter/Cargo.toml
@@ -17,7 +17,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-slint-interpreter = { workspace = true, features = ["std", "backend-winit", "renderer-femtovg", "compat-1-2", "internal"] }
+slint-interpreter = { workspace = true, features = ["std", "backend-winit", "renderer-femtovg", "compat-1-10", "internal"] }
 send_wrapper = { workspace = true }
 
 vtable = { workspace = true }

--- a/demos/energy-monitor/Cargo.toml
+++ b/demos/energy-monitor/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-10"] }
 mcu-board-support = { path = "../../examples/mcu-board-support", optional = true }
 chrono = { version = "0.4.34", optional = true, default-features = false, features = ["clock", "std", "wasmbind"] }
 weer_api = { version = "0.1", optional = true }

--- a/demos/printerdemo_mcu/Cargo.toml
+++ b/demos/printerdemo_mcu/Cargo.toml
@@ -19,7 +19,7 @@ simulator = ["slint/renderer-software", "slint/backend-winit", "slint/std"]
 default = ["simulator"]
 
 [dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-10"] }
 mcu-board-support = { path = "../../examples/mcu-board-support" }
 
 [build-dependencies]

--- a/examples/bazel_build/MODULE.bazel
+++ b/examples/bazel_build/MODULE.bazel
@@ -39,7 +39,7 @@ crate = use_extension(
     "crate",
 )
 
-crate.spec(package = "slint", git = "https://github.com/slint-ui/slint", branch = "master", default_features = False, features = ["std","backend-winit", "renderer-skia-opengl", "compat-1-2"])
+crate.spec(package = "slint", git = "https://github.com/slint-ui/slint", branch = "master", default_features = False, features = ["std","backend-winit", "renderer-skia-opengl", "compat-1-10"])
 crate.spec(package = "slint-build", git = "https://github.com/slint-ui/slint", branch = "master")
 
 crate.annotation(

--- a/examples/carousel/rust/Cargo.toml
+++ b/examples/carousel/rust/Cargo.toml
@@ -15,7 +15,7 @@ path = "main.rs"
 name = "carousel"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-10"] }
 mcu-board-support = { path = "../../mcu-board-support", optional = true }
 
 [build-dependencies]

--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -25,7 +25,7 @@ esp32-s2-kaluga-1 = ["slint/unsafe-single-threaded", "esp-hal/esp32s2", "embedde
 esp32-s3-box = ["slint/unsafe-single-threaded", "esp-hal/esp32s3", "embedded-hal", "embedded-hal-bus", "esp-alloc", "esp-println/esp32s3", "esp-backtrace/esp32s3", "dep:mipidsi", "embedded-graphics-core", "slint/libm", "tt21100"]
 
 [dependencies]
-slint = { version = "=1.10.0", path = "../../api/rs/slint", default-features = false, features = ["compat-1-2", "renderer-software"] }
+slint = { version = "=1.10.0", path = "../../api/rs/slint", default-features = false, features = ["compat-1-10", "renderer-software"] }
 i-slint-core-macros = { version = "=1.10.0", path = "../../internal/core-macros" }
 
 derive_more = { workspace = true }

--- a/examples/uefi-demo/Cargo.toml
+++ b/examples/uefi-demo/Cargo.toml
@@ -18,7 +18,7 @@ uefi = { version = "0.33", features = ["panic_handler", "global_allocator"] }
 minipng = "=0.1.1"
 
 slint = { path = "../../api/rs/slint", default-features = false, features = [
-    "compat-1-2",
+    "compat-1-10",
     "renderer-software",
     "libm",
     "log",

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -37,6 +37,6 @@ image = { workspace = true, optional = true, features = ["png"] }
 pb-rs = { version = "0.10.0", optional = true, default-features = false }
 
 [dev-dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-10"] }
 i-slint-core-macros = { path = "../../core-macros" }
 i-slint-common = { path = "../../common" }

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -235,7 +235,7 @@ impl TestingClient {
                 buffer.as_bytes(),
                 buffer.width(),
                 buffer.height(),
-                image::ColorType::Rgba8,
+                image::ColorType::Rgba8.into(),
             )
             .map_err(|encode_err| {
                 format!("error encoding png image after screenshot: {encode_err}")

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -83,7 +83,7 @@ objc2-app-kit = { version = "0.2.2" }
 cfg_aliases = { workspace = true }
 
 [dev-dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "backend-winit", "renderer-software", "raw-window-handle-06"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-10", "backend-winit", "renderer-software", "raw-window-handle-06"] }
 
 [package.metadata.docs.rs]
 features = ["wayland", "renderer-software", "raw-window-handle-06"]

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -29,7 +29,7 @@ display-diagnostics = ["codemap", "codemap-diagnostic"]
 
 # Enabled the support to render images and font in the binary
 software-renderer = ["image", "dep:resvg", "fontdue", "i-slint-common/shared-fontdb", "dep:rayon"]
-embed-glyphs-as-sdf = ["dep:fdsm", "dep:ttf-parser-fdsm", "dep:nalgebra", "dep:image-fdsm", "dep:rayon"]
+embed-glyphs-as-sdf = ["dep:fdsm", "dep:ttf-parser-fdsm", "dep:nalgebra", "dep:rayon"]
 
 # Translation bundler
 bundle-translations = ["dep:polib"]
@@ -62,7 +62,6 @@ resvg = { workspace = true, optional = true }
 fontdue = { workspace = true, optional = true, features = ["parallel"] }
 fdsm = { version = "0.6.0", optional = true, features = ["ttf-parser"]}
 ttf-parser-fdsm = { package = "ttf-parser", version = "0.24.1", optional = true }
-image-fdsm = { package = "image", version = "0.25", optional = true, default-features = false }
 nalgebra = { version = "0.33.0", optional = true }
 rayon = { workspace = true, optional = true }
 # translations

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -521,7 +521,7 @@ fn generate_sdf_for_glyph(
 
     // Set up the resulting image and generate the distance field:
 
-    let mut sdf = image_fdsm::GrayImage::new(width, height);
+    let mut sdf = image::GrayImage::new(width, height);
     fdsm::generate::generate_sdf(&prepared_shape, range, &mut sdf);
     fdsm::render::correct_sign_sdf(
         &mut sdf,

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -36,6 +36,7 @@ software-renderer-systemfonts = ["shared-fontdb", "rustybuzz", "fontdue", "softw
 software-renderer = ["bytemuck"]
 
 image-decoders = ["dep:image", "dep:clru"]
+image-default-formats = ["image?/default-formats"]
 svg = ["dep:resvg", "shared-fontdb"]
 
 box-shadow-cache = []
@@ -107,7 +108,7 @@ web-sys = { workspace = true, features = [ "HtmlImageElement" ] }
 fontdb = { workspace = true, optional = true, default-features = true }
 
 [dev-dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-10"] }
 i-slint-backend-testing = { path="../backends/testing" }
 rustybuzz = { workspace = true }
 ttf-parser = { workspace = true }

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -20,17 +20,23 @@ path = "lib.rs"
 
 [features]
 
-default = ["backend-default", "renderer-femtovg", "renderer-software", "accessibility", "compat-1-2"]
+default = ["backend-default", "renderer-femtovg", "renderer-software", "accessibility", "image-default-formats", "compat-1-10"]
 
 ## Mandatory feature:
-## This feature is required to keep the compatibility with Slint 1.2
+## This feature is required to keep the compatibility with Slint 1.10
 ## Newer patch version may put current functionality behind a new feature
 ## that would be enabled by default only if this feature was added
-"compat-1-2" = []
+"compat-1-10" = []
+"compat-1-2" = ["compat-1-10", "image-default-formats"]
 "compat-1-0" = ["compat-1-2"]
 
 ## enable the [`print_diagnostics`] function to show diagnostic in the console output
 display-diagnostics = ["i-slint-compiler/display-diagnostics"]
+
+## Enable all formats from the `image` crate. To increase what is supported from [`Image::load_from_path`]
+## or in `@image-url`. Without this feature, only PNG and JPEG are supported.
+image-default-formats = ["i-slint-core/image-default-formats"]
+
 
 # (internal) export C++ FFI functions
 ffi = ["spin_on", "i-slint-core/ffi"]

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -33,8 +33,10 @@ default = ["backend-default", "renderer-femtovg", "renderer-software", "accessib
 ## enable the [`print_diagnostics`] function to show diagnostic in the console output
 display-diagnostics = ["i-slint-compiler/display-diagnostics"]
 
-## Enable all formats from the `image` crate. To increase what is supported from [`Image::load_from_path`]
-## or in `@image-url`. Without this feature, only PNG and JPEG are supported.
+## Enable the default image formats from the `image` crate, to support additional image formats in [`Image::load_from_path`]
+## and `@image-url`. When this feature is disabled, only PNG and JPEG are supported. When enabled,
+## the following image formats are supported:
+## AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
 image-default-formats = ["i-slint-core/image-default-formats"]
 
 

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -72,9 +72,9 @@ instance.run().unwrap();
 #![warn(missing_docs)]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 
-#[cfg(not(feature = "compat-1-2"))]
+#[cfg(not(feature = "compat-1-10"))]
 compile_error!(
-    "The feature `compat-1-2` must be enabled to ensure \
+    "The feature `compat-1-10` must be enabled to ensure \
     forward compatibility with future version of this crate"
 );
 

--- a/tests/driver/interpreter/Cargo.toml
+++ b/tests/driver/interpreter/Cargo.toml
@@ -18,7 +18,7 @@ path = "main.rs"
 name = "test-driver-interpreter"
 
 [dev-dependencies]
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-10"] }
 i-slint-backend-testing = { workspace = true }
 
 itertools = { workspace = true }

--- a/tests/driver/rust/Cargo.toml
+++ b/tests/driver/rust/Cargo.toml
@@ -23,7 +23,7 @@ build-time = ["i-slint-compiler", "spin_on"]
 [dependencies]
 slint = { workspace = true, features = ["std", "compat-1-2"] }
 i-slint-backend-testing = { workspace = true, features = ["internal"] }
-slint-interpreter = { workspace = true, features = ["std", "compat-1-2", "internal"] }
+slint-interpreter = { workspace = true, features = ["std", "compat-1-10", "internal"] }
 spin_on = { workspace = true }
 
 [build-dependencies]

--- a/tests/screenshots/Cargo.toml
+++ b/tests/screenshots/Cargo.toml
@@ -18,7 +18,7 @@ path = "main.rs"
 name = "test-driver-screenshot"
 
 [dependencies]
-slint = { workspace = true, features = ["std", "compat-1-2"] }
+slint = { workspace = true, features = ["std", "compat-1-10"] }
 i-slint-core = { workspace = true, features = ["default", "software-renderer"] }
 i-slint-backend-testing = { workspace = true }
 image = { workspace = true }

--- a/tools/docsnapper/Cargo.toml
+++ b/tools/docsnapper/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["viewer", "gui", "ui", "toolkit"]
 [dependencies]
 i-slint-compiler = { workspace = true }
 i-slint-core = { workspace = true }
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-10", "internal", "accessibility"] }
 i-slint-renderer-skia = { workspace = true, features = ["default", "wayland"] }
 
 clap = { workspace = true }

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -68,7 +68,7 @@ preview-lense = []
 ## to provide an implementation of the external preview API when building for WASM)
 preview-api = ["preview-external"]
 ## Build in the actual code to act as a preview for slint files.
-preview-engine = ["dep:slint", "dep:slint-interpreter", "dep:i-slint-core", "dep:i-slint-backend-selector", "dep:image", "dep:slint-build", "dep:i-slint-backend-winit", "dep:muda", "dep:objc2-foundation"]
+preview-engine = ["dep:slint", "dep:slint-interpreter", "dep:i-slint-core", "dep:i-slint-backend-selector", "dep:slint-build", "dep:i-slint-backend-winit", "dep:muda", "dep:objc2-foundation"]
 ## Build in the actual code to act as a preview for slint files. Does nothing in WASM!
 preview-builtin = ["preview-engine"]
 ## Support the external preview optionally used by e.g. the VSCode plugin
@@ -92,16 +92,13 @@ smol_str = { workspace = true }
 # for the preview-engine feature
 i-slint-backend-selector = { workspace = true, optional = true }
 i-slint-core = { workspace = true, features = ["std"], optional = true }
-slint = { workspace = true, features = ["compat-1-2"], optional = true }
-slint-interpreter = { workspace = true, features = ["compat-1-2", "highlight", "internal"], optional = true  }
+slint = { workspace = true, features = ["compat-1-10"], optional = true }
+slint-interpreter = { workspace = true, features = ["compat-1-10", "highlight", "internal", "image-default-formats"], optional = true  }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { workspace = true }
 crossbeam-channel = "0.5"  # must match the version used by lsp-server
 lsp-server = "0.7"
-
-# Enable image-rs' default features to make all image formats available for the preview
-image = { workspace = true, optional = true, features = ["default"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.5"

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -53,7 +53,7 @@ default = ["backend-default", "renderer-femtovg", "renderer-software"]
 [dependencies]
 i-slint-compiler = { workspace = true }
 i-slint-core = { workspace = true }
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-10", "internal", "accessibility", "image-default-formats"] }
 i-slint-backend-selector = { workspace = true }
 
 clap = { workspace = true }
@@ -66,9 +66,6 @@ spin_on = { workspace = true }
 env_logger = "0.11.0"
 itertools = { workspace = true }
 smol_str = { workspace = true }
-
-# Enable image-rs' default features to make all image formats available for preview
-image = { workspace = true, features = ["default"] }
 
 [[bin]]
 name = "slint-viewer"


### PR DESCRIPTION
Added image-default-formats with all the format supported by image by default, and enable that feature by default.
Also put that feature in compat-1-2 for compatibility with user that have used image 0.24 with enabled features.
Make a new compat-1-10 feature that does not enable default format by default

ChangeLog: upgraded image crate to 0.25, added a new cargo feature to enable all image formats. (that feature is enabled by default with compat-1-2, added compat-1-10 to disable it

Fixes https://github.com/slint-ui/slint/issues/7251
