### PR TITLE
Fix runtime panic with colpan or rowspan set to zero

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -311,14 +311,15 @@ mod grid_internal {
         spacing: Coord,
         size: Option<Coord>,
     ) -> Vec<LayoutData> {
-        let mut num = 0;
+        let mut num = 0usize;
         for cell in data {
-            num = num.max(cell.col_or_row + cell.span);
+            num = num.max(cell.col_or_row as usize + cell.span.max(1) as usize);
         }
         if num < 1 {
             return Default::default();
         }
-        let mut layout_data = alloc::vec![grid_internal::LayoutData { stretch: 1., ..Default::default() }; num as usize];
+        let mut layout_data =
+            alloc::vec![grid_internal::LayoutData { stretch: 1., ..Default::default() }; num];
         let mut has_spans = false;
         for cell in data {
             let constraint = &cell.constraint;

--- a/tests/cases/layout/grid_span.slint
+++ b/tests/cases/layout/grid_span.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+component TestCase inherits Window {
     width: 400phx;
     height: 400phx;
 
@@ -44,12 +44,17 @@ TestCase := Window {
             horizontal_stretch: 10;
             vertical_stretch: 10;
         }
+        zero2 := Rectangle {
+            col: 5;
+            colspan: 0;
+        }
     }
 
-    property <bool> test: {
+    out property <bool> test: {
         rr.x == 50phx && rr.y == 50phx && rr.width == 30phx && rr.height == (200phx - 10phx) / 2 &&
         rb.width == 40phx && rg.width == 20phx && rg.height == (400phx - 200phx - 100phx - 20phx) / 2 &&
-        zero.height == 0 && zero.width == rb.width && zero.x == rb.x && zero.y == rg.y
+        zero.height == 0 && zero.width == rb.width && zero.x == rb.x && zero.y == rg.y &&
+        zero2.height == rg.height && zero2.width == 0 && zero2.x > rb.x && zero2.y == rg.y
 
     }
 

--- a/tests/cases/layout/grid_span.slint
+++ b/tests/cases/layout/grid_span.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-component TestCase inherits Window {
+export component TestCase inherits Window {
     width: 400phx;
     height: 400phx;
 


### PR DESCRIPTION

Fix panic:
```
panicked at internal/core/layout.rs:459:33:
index out of bounds: the len is 2 but the index is 2
```


