### PR TITLE
Don't panic in the generated rust `ComponentHandle::window()`

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1763,6 +1763,10 @@ fn generate_item_tree(
     // And in PopupWindow this is also called by the runtime
     if parent_ctx.is_none() {
         create_code.push("self->user_init();".to_string());
+        if !is_popup_menu {
+            // initialize the Window in this point to be consistent with Rust
+            create_code.push("self->window();".to_string())
+        }
     }
 
     create_code

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -291,6 +291,8 @@ fn generate_public_component(
                 #init_bundle_translations
                 inner.globals.get().unwrap().init();
                 #inner_component_id::user_init(sp::VRc::map(inner.clone(), |x| x));
+                // ensure that the window exist as this point so further call to window() don't panic
+                inner.globals.get().unwrap().window_adapter_ref()?;
                 core::result::Result::Ok(Self(inner))
             }
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -964,9 +964,10 @@ impl ComponentDefinition {
     /// Creates a new instance of the component and returns a shared handle to it.
     pub fn create(&self) -> Result<ComponentInstance, PlatformError> {
         generativity::make_guard!(guard);
-        Ok(ComponentInstance {
-            inner: self.inner.unerase(guard).clone().create(Default::default())?,
-        })
+        let instance = self.inner.unerase(guard).clone().create(Default::default())?;
+        // Make sure the window adapter is created so call to `window()` do not panic later.
+        instance.window_adapter_ref()?;
+        Ok(ComponentInstance { inner: instance })
     }
 
     /// Creates a new instance of the component and returns a shared handle to it.


### PR DESCRIPTION
It can panic if lazily constructing the window adapter. Make sure it is actually not lazily constructed, we don't need lazy constructor when not embedding anyway.
