### PR TITLE
Minor dependency cleanup

### DIFF
--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -22,7 +22,6 @@ default = []
 
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "rust", "display-diagnostics", "software-renderer", "bundle-translations"] }
-i-slint-core-macros = { workspace = true }
 
 spin_on = { workspace = true }
 toml_edit = { workspace = true }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["gui", "development-tools", "no-std"]
 path = "lib.rs"
 
 [features]
-ffi = [] # Expose C ABI
+ffi = ["dep:static_assertions"] # Expose C ABI
 libm = ["num-traits/libm", "euclid/libm"]
 # Allow the viewer to query at runtime information about item types
 rtti = []
@@ -72,7 +72,7 @@ rgb = "0.8.27"
 scoped-tls-hkt = { version = "0.1", optional = true }
 scopeguard =  { version = "1.1.0", default-features = false }
 slab = { version = "0.4.3", default-features = false }
-static_assertions = "1.1"
+static_assertions = { version = "1.1", optional = true }
 strum = { workspace = true }
 unicode-segmentation = { workspace = true }
 unicode-linebreak = { version = "0.1.5", optional = true }


### PR DESCRIPTION
- static_assertions is only needed with ffi.
- i-slint-core-macro is not needed in the build crate.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
