### PR TITLE
Fix panic in the compiler when having a changed callback over a property that is not materlialized

### DIFF
--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -121,7 +121,7 @@ fn should_materialize(
 
 /// Returns true if the property is declared in this element or parent
 /// (as opposed to being implicitly declared)
-fn has_declared_property(elem: &Element, prop: &str) -> bool {
+pub fn has_declared_property(elem: &Element, prop: &str) -> bool {
     if elem.property_declarations.contains_key(prop) {
         return true;
     }

--- a/internal/compiler/passes/remove_unused_properties.rs
+++ b/internal/compiler/passes/remove_unused_properties.rs
@@ -28,6 +28,12 @@ pub fn remove_unused_properties(doc: &Document) {
                     elem.property_analysis.borrow_mut().remove(x);
                     elem.bindings.remove(x);
                 }
+                // Remove changed callbacks over properties that are not materialized as they are not used
+                let mut change_callbacks = std::mem::take(&mut elem.change_callbacks);
+                change_callbacks.retain(|prop, _| {
+                    super::materialize_fake_properties::has_declared_property(&elem, prop)
+                });
+                elem.change_callbacks = change_callbacks;
             },
         );
     }

--- a/tests/cases/crashes/issue_7316_changed_visibility.slint
+++ b/tests/cases/crashes/issue_7316_changed_visibility.slint
@@ -1,0 +1,13 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component PostAction inherits Rectangle {
+    changed visible => {
+    }
+}
+
+
+
+export component TestCase inherits Window {
+    PostAction {}
+}


### PR DESCRIPTION
Fixes #7316

