### PR TITLE
gstreamer-player: Make the EGL integration easier to re-use

### DIFF
--- a/examples/gstreamer-player/Cargo.toml
+++ b/examples/gstreamer-player/Cargo.toml
@@ -31,4 +31,5 @@ glutin_egl_sys = "0.7.1"
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }
+cfg_aliases = { workspace = true }
 

--- a/examples/gstreamer-player/build.rs
+++ b/examples/gstreamer-player/build.rs
@@ -1,6 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
+use cfg_aliases::cfg_aliases;
+
 fn main() {
     slint_build::compile("scene.slint").unwrap();
+    cfg_aliases! {
+       slint_gstreamer_egl: { target_os = "linux" },
+    }
 }


### PR DESCRIPTION
By not requiring a pipeline and having a lower-level SlintOpenGLSink type, it's easier to re-use this code in application code that for example doesn't use playbin.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
