### PR TITLE
Skia: Report the buffer age when rendering with metal

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -62,7 +62,7 @@ skia-safe = { version = "0.78.0", features = ["d3d"] }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc2 = { version = "0.5.2" }
-objc2-metal = { version = "0.2.2", features = ["MTLCommandQueue", "MTLCommandBuffer"] }
+objc2-metal = { version = "0.2.2", features = ["MTLCommandQueue", "MTLCommandBuffer", "MTLResource", "MTLTexture", "MTLTypes"] }
 objc2-foundation = { version = "0.2.2"}
 objc2-quartz-core = { version = "0.2.2" }
 objc2-app-kit = { version = "0.2.2" }


### PR DESCRIPTION
This makes it possible to debug partial rendering with macOS easily.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
