### PR TITLE
Fix layouting of huge ListView with millions of items

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -1190,13 +1190,13 @@ public:
     void ensure_updated_listview(const Parent *parent,
                                  const private_api::Property<float> *viewport_width,
                                  const private_api::Property<float> *viewport_height,
-                                 [[maybe_unused]] const private_api::Property<float> *viewport_y,
+                                 const private_api::Property<float> *viewport_y,
                                  float listview_width, [[maybe_unused]] float listview_height) const
     {
         // TODO: the rust code in model.rs try to only allocate as many items as visible items
         ensure_updated(parent);
 
-        float h = compute_layout_listview(viewport_width, listview_width);
+        float h = compute_layout_listview(viewport_width, listview_width, viewport_y->get());
         viewport_height->set(h);
     }
 
@@ -1234,9 +1234,9 @@ public:
     }
 
     float compute_layout_listview(const private_api::Property<float> *viewport_width,
-                                  float listview_width) const
+                                  float listview_width, float viewport_y) const
     {
-        float offset = 0;
+        float offset = viewport_y;
         viewport_width->set(listview_width);
         if (!inner)
             return offset;

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -85,8 +85,6 @@ fn create_repeater_components(component: &Rc<Component>) {
                     RefCell::new(Expression::PropertyReference(listview.listview_width).into()),
                 );
             }
-
-            NamedReference::new(&comp.root_element, SmolStr::new_static("y")).mark_as_set();
         }
 
         let weak = Rc::downgrade(&comp);

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1073,6 +1073,7 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
             (inner.offset, first_item_y + vp_y)
         };
 
+        let mut loop_count = 0;
         loop {
             // If there is a gap before the new_offset and the beginning of the visible viewport,
             // try to fill it with items. First look at items that are before new_offset in the
@@ -1154,15 +1155,12 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
                 inner.instances.push((RepeatedInstanceState::Clean, Some(new_instance)));
                 idx += 1;
             }
-            if y < listview_height && vp_y < zero {
+            if y < listview_height && vp_y < zero && loop_count < 3 {
                 assert!(idx >= row_count);
                 // we reached the end of the model, and we still have room. scroll a bit up.
-                let new_vp_y = vp_y + (listview_height - y);
-                // check that we actually did scroll (for very large lists we can exceed the precision of f32 and have an infinite loop)
-                if new_vp_y != vp_y {
-                    vp_y = new_vp_y;
-                    continue;
-                }
+                vp_y += listview_height - y;
+                loop_count += 1;
+                continue;
             }
 
             // Let's cleanup the instances that are not shown.

--- a/tests/cases/elements/listview-millions.slint
+++ b/tests/cases/elements/listview-millions.slint
@@ -1,0 +1,130 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// As of now, the C++ optimization doesn't optimize hidden item of Listview so this test would take forever
+//ignore:cpp
+
+import { ListView } from "std-widgets.slint";
+export component TestCase inherits Window {
+    preferred-width: 300px;
+    preferred-height: 300px;
+
+    in-out property <string> result;
+    callback clicked(int);
+    in-out property <length> viewport-y <=> lv.viewport-y;
+
+    lv := ListView {
+        for _[num] in 2130000000: Rectangle {
+            height: 20px;
+            border-width: 1px;
+            border-color: red;
+            Text { text: num; }
+            TouchArea {
+                clicked => { result = "|"+num; root.clicked(num) }
+            }
+        }
+    }
+}
+
+
+/*
+
+
+```rust
+let instance = TestCase::new().unwrap();
+let clicked = std::rc::Rc::new(std::cell::RefCell::new(Vec::<i32>::new()));
+let clicked2 = clicked.clone();
+instance.on_clicked(move |x| clicked2.borrow_mut().push(x) );
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert_eq!(clicked.borrow().as_slice(), &[12]);
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert_eq!(clicked.borrow().as_slice(), &[12, 13, 11]);
+
+instance.set_viewport_y(-20. * 1000.);
+clicked.borrow_mut().clear();
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert_eq!(clicked.borrow().as_slice(), &[1012]);
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert_eq!(clicked.borrow().as_slice(), &[1012, 1013, 1011]);
+
+instance.set_viewport_y(-20. * 100000.);
+clicked.borrow_mut().clear();
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert_eq!(clicked.borrow().as_slice(), &[100012]);
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert_eq!(clicked.borrow().as_slice(), &[100012, 100013, 100011]);
+
+instance.set_viewport_y(-20. * 10000000.);
+clicked.borrow_mut().clear();
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert_eq!(clicked.borrow().as_slice(), &[10000012]);
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert_eq!(clicked.borrow().as_slice(), &[10000012, 10000013, 10000011]);
+
+instance.set_viewport_y(-20. * 210000000.);
+clicked.borrow_mut().clear();
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert_eq!(clicked.borrow().as_slice(), &[210000012]);
+slint_testing::send_mouse_click(&instance, 5., 263.);
+slint_testing::send_mouse_click(&instance, 5., 239.);
+assert_eq!(clicked.borrow().as_slice(), &[210000012, 210000013, 210000011]);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+auto clicked = std::make_shared<std::vector<int>>();
+instance.on_clicked([clicked](int x) { clicked->push_back(x); });
+slint_testing::send_mouse_click(&instance, 5., 250.);
+assert(*clicked == std::vector<int>{12});
+```
+
+```js
+var instance = new slint.TestCase();
+var clicked = new Array();
+instance.clicked = function(x) { clicked.push(x); };
+slintlib.private_api.send_mouse_click(instance, 5., 250.);
+assert.deepEqual(clicked, [12]);
+slintlib.private_api.send_mouse_click(instance, 5., 263.);
+slintlib.private_api.send_mouse_click(instance, 5., 239.);
+assert.deepEqual(clicked, [12, 13, 11]);
+
+instance.viewport_y=(-20. * 1000.);
+clicked.length = 0;
+slintlib.private_api.send_mouse_click(instance, 5., 250.);
+assert.deepEqual(clicked, [1012]);
+slintlib.private_api.send_mouse_click(instance, 5., 263.);
+slintlib.private_api.send_mouse_click(instance, 5., 239.);
+assert.deepEqual(clicked, [1012, 1013, 1011]);
+
+instance.viewport_y=(-20. * 100000.);
+clicked.length = 0;
+slintlib.private_api.send_mouse_click(instance, 5., 250.);
+assert.deepEqual(clicked, [100012]);
+slintlib.private_api.send_mouse_click(instance, 5., 263.);
+slintlib.private_api.send_mouse_click(instance, 5., 239.);
+assert.deepEqual(clicked, [100012, 100013, 100011]);
+
+instance.viewport_y=(-20. * 10000000.);
+clicked.length = 0;
+slintlib.private_api.send_mouse_click(instance, 5., 250.);
+assert.deepEqual(clicked, [10000012]);
+slintlib.private_api.send_mouse_click(instance, 5., 263.);
+slintlib.private_api.send_mouse_click(instance, 5., 239.);
+assert.deepEqual(clicked, [10000012, 10000013, 10000011]);
+
+instance.viewport_y=(-20. * 210000000.);
+clicked.length = 0;
+slintlib.private_api.send_mouse_click(instance, 5., 250.);
+assert.deepEqual(clicked, [210000012]);
+slintlib.private_api.send_mouse_click(instance, 5., 263.);
+slintlib.private_api.send_mouse_click(instance, 5., 239.);
+assert.deepEqual(clicked, [210000012, 210000013, 210000011]);
+```
+
+
+*/

--- a/tests/cases/elements/listview-millions.slint
+++ b/tests/cases/elements/listview-millions.slint
@@ -72,6 +72,10 @@ assert_eq!(clicked.borrow().as_slice(), &[210000012]);
 slint_testing::send_mouse_click(&instance, 5., 263.);
 slint_testing::send_mouse_click(&instance, 5., 239.);
 assert_eq!(clicked.borrow().as_slice(), &[210000012, 210000013, 210000011]);
+
+// go all the way to the end, it shouldn't crash or loop forever
+instance.set_viewport_y(-20. * (2130000000. - 5.));
+slint_testing::send_mouse_click(&instance, 5., 250.);
 ```
 
 ```cpp
@@ -124,6 +128,10 @@ assert.deepEqual(clicked, [210000012]);
 slintlib.private_api.send_mouse_click(instance, 5., 263.);
 slintlib.private_api.send_mouse_click(instance, 5., 239.);
 assert.deepEqual(clicked, [210000012, 210000013, 210000011]);
+
+// go all the way to the end, it shouldn't crash or loop forever
+instance.viewport_y=(-20. * (2130000000. - 5.));
+slintlib.private_api.send_mouse_click(instance, 5., 250.);
 ```
 
 


### PR DESCRIPTION
The problem is that the precision of f32 for coordinate wouldn't be accurate enough with such big viewport to put the elements so that they are next to eachother.
So put the elements relative to the Flickable instead of relative to the created moving viewport Rectangle.

Fixes #3700

Note that the ListView still use f32 for the scrollbar value, meaning that at some point, the wheel stops working as the wheel increment is smaller than the f32 increment, and scrolling becomes somehow fuzzy. But this only happens after one more billions pixels now, so one can have more than 50 millions of elements without much problems

