### PR TITLE
ListView: fix continuous redraw with fluent style and adjust the viewport-width to the min-width of the content

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -1237,12 +1237,13 @@ public:
                                   float listview_width, float viewport_y) const
     {
         float offset = viewport_y;
-        viewport_width->set(listview_width);
+        auto vp_width = listview_width;
         if (!inner)
             return offset;
         for (auto &x : inner->data) {
-            (*x.ptr)->listview_layout(&offset, viewport_width);
+            vp_width = std::max(vp_width, (*x.ptr)->listview_layout(&offset));
         }
+        viewport_width->set(vp_width);
         return offset;
     }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2487,7 +2487,6 @@ fn generate_repeated_component(
     if let Some(listview) = &repeated.listview {
         let p_y = access_member(&listview.prop_y, &ctx);
         let p_height = access_member(&listview.prop_height, &ctx);
-        let p_width = access_member(&listview.prop_width, &ctx);
 
         repeater_struct.members.push((
             Access::Public, // Because Repeater accesses it
@@ -2498,7 +2497,7 @@ fn generate_repeated_component(
                     "[[maybe_unused]] auto self = this;".into(),
                     format!("{}.set(*offset_y);", p_y),
                     format!("*offset_y += {}.get();", p_height),
-                    format!("return {}.get();", p_width),
+                    "return layout_info({&static_vtable, const_cast<void *>(static_cast<const void *>(this))}, slint::cbindgen_private::Orientation::Horizontal).min;".into(),
                 ]),
                 ..Function::default()
             }),

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2493,18 +2493,12 @@ fn generate_repeated_component(
             Access::Public, // Because Repeater accesses it
             Declaration::Function(Function {
                 name: "listview_layout".into(),
-                signature:
-                    "(float *offset_y, const slint::private_api::Property<float> *viewport_width) const -> void"
-                        .to_owned(),
+                signature: "(float *offset_y) const -> float".to_owned(),
                 statements: Some(vec![
                     "[[maybe_unused]] auto self = this;".into(),
-                    "float vp_w = viewport_width->get();".to_owned(),
-
-                    format!("{}.set(*offset_y);", p_y), // FIXME: shouldn't that be handled by apply layout?
+                    format!("{}.set(*offset_y);", p_y),
                     format!("*offset_y += {}.get();", p_height),
-                    format!("float w = {}.get();", p_width),
-                    "if (vp_w < w)".to_owned(),
-                    "    viewport_width->set(w);".to_owned(),
+                    format!("return {}.get();", p_width),
                 ]),
                 ..Function::default()
             }),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1773,16 +1773,11 @@ fn generate_repeated_component(
             fn listview_layout(
                 self: core::pin::Pin<&Self>,
                 offset_y: &mut sp::LogicalLength,
-                viewport_width: core::pin::Pin<&sp::Property<sp::LogicalLength>>,
-            ) {
+            ) -> sp::LogicalLength {
                 let _self = self;
-                let vp_w = viewport_width.get();
                 #p_y.set(*offset_y);
                 *offset_y += #p_height.get();
-                let w = #p_width.get();
-                if vp_w < w {
-                    viewport_width.set(w);
-                }
+                #p_width.get()
             }
         }
     } else {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1768,16 +1768,15 @@ fn generate_repeated_component(
     let extra_fn = if let Some(listview) = &repeated.listview {
         let p_y = access_member(&listview.prop_y, &ctx).unwrap();
         let p_height = access_member(&listview.prop_height, &ctx).unwrap();
-        let p_width = access_member(&listview.prop_width, &ctx).unwrap();
         quote! {
             fn listview_layout(
-                self: core::pin::Pin<&Self>,
+                self: ::core::pin::Pin<&Self>,
                 offset_y: &mut sp::LogicalLength,
             ) -> sp::LogicalLength {
                 let _self = self;
                 #p_y.set(*offset_y);
                 *offset_y += #p_height.get();
-                #p_width.get()
+                sp::LogicalLength::new(self.as_ref().layout_info(sp::Orientation::Horizontal).min)
             }
         }
     } else {

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -132,8 +132,6 @@ pub struct ListViewInfo {
     // In the repeated component context
     pub prop_y: PropertyReference,
     // In the repeated component context
-    pub prop_width: PropertyReference,
-    // In the repeated component context
     pub prop_height: PropertyReference,
 }
 

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -655,7 +655,6 @@ fn lower_repeated_component(
         listview_height: ctx.map_property_reference(&lv.listview_height),
         listview_width: ctx.map_property_reference(&lv.listview_width),
         prop_y: sc.mapping.map_property_reference(&geom.y, ctx.state),
-        prop_width: sc.mapping.map_property_reference(&geom.width, ctx.state),
         prop_height: sc.mapping.map_property_reference(&geom.height, ctx.state),
     });
 

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -79,7 +79,6 @@ pub fn count_property_use(root: &CompilationUnit) {
                     Some(ParentCtx::new(ctx, Some(idx as u32))),
                 );
                 visit_property(&lv.prop_y, &rep_ctx);
-                visit_property(&lv.prop_width, &rep_ctx);
                 visit_property(&lv.prop_height, &rep_ctx);
             }
             for idx in r.data_prop.iter().chain(r.index_prop.iter()) {

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -730,7 +730,7 @@ pub trait RepeatedItemTree:
     /// offset_y is the `y` position where this item should be placed.
     /// it should be updated to be to the y position of the next item.
     ///
-    /// Returns the item width
+    /// Returns the minimum item width which will be used to compute the listview's viewport width
     fn listview_layout(self: Pin<&Self>, _offset_y: &mut LogicalLength) -> LogicalLength {
         LogicalLength::default()
     }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -138,11 +138,7 @@ impl RepeatedItemTree for ErasedItemTreeBox {
         self.run_setup_code();
     }
 
-    fn listview_layout(
-        self: Pin<&Self>,
-        offset_y: &mut LogicalLength,
-        viewport_width: Pin<&Property<LogicalLength>>,
-    ) {
+    fn listview_layout(self: Pin<&Self>, offset_y: &mut LogicalLength) -> LogicalLength {
         generativity::make_guard!(guard);
         let s = self.unerase(guard);
 
@@ -177,10 +173,7 @@ impl RepeatedItemTree for ErasedItemTreeBox {
         let h = LogicalLength::new(h);
         let w = LogicalLength::new(w);
         *offset_y += h;
-        let vp_w = viewport_width.get();
-        if vp_w < w {
-            viewport_width.set(w);
-        }
+        w
     }
 
     fn box_layout_data(self: Pin<&Self>, o: Orientation) -> BoxLayoutCellData {

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -152,7 +152,7 @@ impl RepeatedItemTree for ErasedItemTreeBox {
         )
         .expect("cannot set y");
 
-        let h: f32 = crate::eval::load_property(
+        let h: LogicalLength = crate::eval::load_property(
             s.borrow_instance(),
             &geom.height.element(),
             geom.height.name(),
@@ -161,19 +161,8 @@ impl RepeatedItemTree for ErasedItemTreeBox {
         .try_into()
         .expect("height not the right type");
 
-        let w: f32 = crate::eval::load_property(
-            s.borrow_instance(),
-            &geom.width.element(),
-            geom.width.name(),
-        )
-        .expect("missing width")
-        .try_into()
-        .expect("width not the right type");
-
-        let h = LogicalLength::new(h);
-        let w = LogicalLength::new(w);
         *offset_y += h;
-        w
+        LogicalLength::new(self.borrow().as_ref().layout_info(Orientation::Horizontal).min)
     }
 
     fn box_layout_data(self: Pin<&Self>, o: Orientation) -> BoxLayoutCellData {

--- a/tests/cases/elements/listview.slint
+++ b/tests/cases/elements/listview.slint
@@ -7,7 +7,14 @@ TestCase := Window {
     width: 400px;
     height: 540px;
 
-    property <string> value;
+    in-out property <string> value;
+    out property listview-viewport-height <=> listview.viewport-height;
+    out property listview-viewport-width <=> listview.viewport-width;
+    out property listview-preferred-height <=> listview.preferred-height;
+
+    out property <bool> test: true;
+
+
 
     listview := ListView {
         for data in [
@@ -27,6 +34,7 @@ TestCase := Window {
                     text: data.text;
                     color: data.color;
                     font_size: 20px ;
+                    min-width: 1500px;
                 }
             }
             TouchArea { clicked => { value = data.text; } }
@@ -40,18 +48,27 @@ auto handle = TestCase::create();
 const TestCase &instance = *handle;
 slint_testing::send_mouse_click(&instance, 5., 205.);
 assert_eq(instance.get_value(), "Green");
+assert(instance.get_test());
+assert_eq(instance.get_listview_viewport_height(), 8. * 100.);
+assert_eq(instance.get_listview_viewport_width(), 1500.);
 ```
 
 ```rust
 let instance = TestCase::new().unwrap();
 slint_testing::send_mouse_click(&instance, 5., 205.);
 assert_eq!(instance.get_value(), "Green");
+assert!(instance.get_test());
+assert_eq!(instance.get_listview_viewport_height(), 8. * 100.);
+assert_eq!(instance.get_listview_viewport_width(), 1500.);
 ```
 
 ```js
 var instance = new slint.TestCase();
 slintlib.private_api.send_mouse_click(instance, 5., 205.);
 assert.equal(instance.value, "Green");
+assert(instance.test);
+assert.equal(instance.listview_viewport_height, 8. * 100.);
+assert.equal(instance.listview_viewport_width, 1500.);
 ```
 
 */


### PR DESCRIPTION
Because we set the viewport-width several time to different value during the layouting of the ListView, it will cause this property to always be dirty. In particular, this causes permanent restart of the fluent's scrollbar animation on the size of the handle, causing continuous repaints.


Edit: Also fix the viewport width to be based on the minimum width of the content.
