### PR TITLE
Prepare for `objc2` frameworks v0.3

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -62,10 +62,29 @@ skia-safe = { version = "0.78.0", features = ["d3d"] }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc2 = { version = "0.5.2" }
-objc2-metal = { version = "0.2.2", features = ["MTLCommandQueue", "MTLCommandBuffer", "MTLResource", "MTLTexture", "MTLTypes"] }
-objc2-foundation = { version = "0.2.2"}
-objc2-quartz-core = { version = "0.2.2" }
-objc2-app-kit = { version = "0.2.2" }
+objc2-metal = { version = "0.2.2", default-features = false, features = [
+    "std",
+    "MTLCommandQueue",
+    "MTLCommandBuffer",
+    "MTLResource",
+    "MTLTexture",
+    "MTLTypes",
+] }
+objc2-foundation = { version = "0.2.2", default-features = false, features = [
+    "std",
+    "NSGeometry",
+] }
+objc2-quartz-core = { version = "0.2.2", default-features = false, features = [
+    "std",
+    "objc2-metal",
+    "CALayer",
+    "CAMetalLayer",
+] }
+objc2-app-kit = { version = "0.2.2", default-features = false, features = [
+    "std",
+    "NSResponder",
+    "NSView",
+] }
 skia-safe = { version = "0.78.0", features = ["metal"] }
 raw-window-metal = "1.0"
 


### PR DESCRIPTION
The next version of the `objc2` framework crates will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).