### PR TITLE
Don't instanciate ListView items that are just above the viewport when scrolling down

### DIFF
--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1060,7 +1060,7 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
                     c.0 = RepeatedInstanceState::Clean;
                 }
                 let h = c.1.as_ref().unwrap().as_pin_ref().item_geometry(0).height_length();
-                if it_y + h >= zero || new_offset + 1 >= row_count {
+                if it_y + h > zero || new_offset + 1 >= row_count {
                     break;
                 }
                 it_y += h;


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Fixes #7381 

If an item can just fit above the viewport while scrolling, it is now not instanciated anymore as it is fully hidden. The issue occurs frequently when using the arrow keys to jump through the items, since the scroll delta will usually be the height of exactly one item. This previously meant that an extra node would be added at the start of `ListView`s accessibility tree.