### PR TITLE
Rework lookup of sub-elements with regard to special accepted elements

### DIFF
--- a/internal/compiler/tests/syntax/elements/menubar-lookup.slint
+++ b/internal/compiler/tests/syntax/elements/menubar-lookup.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component MenuBar {
+    in property <int> foobar;
+}
+
+
+export component A inherits Window {
+    // This should lookup the re-defined menubar type and not the builtin one
+    MenuBar {
+        foobar: 42;
+        entries: [];
+//      ^error{Unknown property entries in MenuBar}
+    }
+}
+
+

--- a/tests/cases/children/children_placeholder_three_levels.slint
+++ b/tests/cases/children/children_placeholder_three_levels.slint
@@ -16,7 +16,7 @@ component Cde inherits HorizontalLayout {
 
 component Fgh inherits HorizontalLayout {
     Abc {}
-    Rectangle { background: yellow; @children}
+    Rectangle { background: yellow; GridLayout { @children } }
     Rectangle { background: gray; }
 }
 
@@ -38,7 +38,9 @@ export component TestCase inherits Window {
 
     Ijk {
         // Same as r2
-        r3 := Rectangle { background: brown; }
+        Row {
+            r3 := Rectangle { background: brown; }
+        }
     }
 
     out property r1_pos <=> r1.absolute-position;


### PR DESCRIPTION
Consider
```slint
// Some code in the wild actually have made their own menubar before
component MenuBar { /* ... */ }

component Row { /* ... */ }

export component Main inherits Window {
  // This should find the declared component and not the builtin component
  MenuBar { }

  GridLayout {
     Row {}
  }
}
```

Previously, `MenuBar` and `Row` were first resolved against `additional_accepted_child_types` and so it would always find the builtin one.
But this patch changes that to find the builtin one only if it hasn't been replaced by another component with the name name. (So we'd use the cusom MenuBar and the custom Row)

Another change is that we also lookup the
`additional_accepted_child_types` if they are in a `@children`.

```slint
component MyGrid {
   GridLayout { @children }
}
export component Main {
   MyGrid {
      // This used to be an error but is now accepted
      Row { }
   }
}
```
