### PR TITLE
Implement Sync for SharedVector and Weak

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -914,6 +914,9 @@ mod weak_handle {
     #[allow(unsafe_code)]
     #[cfg(any(feature = "std", feature = "unsafe-single-threaded"))]
     unsafe impl<T: ComponentHandle> Send for Weak<T> {}
+    #[allow(unsafe_code)]
+    #[cfg(any(feature = "std", feature = "unsafe-single-threaded"))]
+    unsafe impl<T: ComponentHandle> Sync for Weak<T> {}
 }
 
 pub use weak_handle::*;

--- a/internal/core/sharedvector.rs
+++ b/internal/core/sharedvector.rs
@@ -79,8 +79,11 @@ pub struct SharedVector<T> {
     inner: NonNull<SharedVectorInner<T>>,
 }
 
-// Safety: We use atomic reference counting, and if T is Send, we can send the vector to another thread
-unsafe impl<T: Send> Send for SharedVector<T> {}
+// Safety: We use atomic reference counting, and if T is Send and Sync, we can send the vector to another thread
+unsafe impl<T: Send + Sync> Send for SharedVector<T> {}
+// Safety: We use atomic reference counting, and if T is Send and Sync, we can access the vector from multiple threads
+unsafe impl<T: Send + Sync> Sync for SharedVector<T> {}
+
 
 impl<T> Drop for SharedVector<T> {
     fn drop(&mut self) {

--- a/internal/core/sharedvector.rs
+++ b/internal/core/sharedvector.rs
@@ -84,7 +84,6 @@ unsafe impl<T: Send + Sync> Send for SharedVector<T> {}
 // Safety: We use atomic reference counting, and if T is Send and Sync, we can access the vector from multiple threads
 unsafe impl<T: Send + Sync> Sync for SharedVector<T> {}
 
-
 impl<T> Drop for SharedVector<T> {
     fn drop(&mut self) {
         unsafe {


### PR DESCRIPTION
Note that this also make sure that a SharedVector for something that isn't Sync isn't send. Otherwise we could send a `SharedVector<Cell<i32>>` between threads, and because it is shared, different thread could modify the same Cell at the same time, which is unsound.

Since SharedString is a wrapper to ShareVector, this will also add the Sync impl there

ChangeLog: Fixed Sync and Send bound on SharedVector, SharedString, and Weak

