### PR TITLE
Fix panic when using gradient backgrounds on Window

### DIFF
--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -176,27 +176,6 @@ impl<'a> GLItemRenderer<'a> {
     pub fn global_alpha_transparent(&self) -> bool {
         self.state.last().unwrap().global_alpha == 0.0
     }
-
-    /// Draws a `Rectangle` using the `GLItemRenderer`.
-    pub fn draw_rect(&mut self, size: LogicalSize, brush: Brush) {
-        let geometry = PhysicalRect::from(size * self.scale_factor);
-        if geometry.is_empty() {
-            return;
-        }
-        if self.global_alpha_transparent() {
-            return;
-        }
-        // TODO: cache path in item to avoid re-tesselation
-        let path = rect_to_path(geometry);
-        let paint = match self.brush_to_paint(brush, &path) {
-            Some(paint) => paint,
-            None => return,
-        }
-        // Since we're filling a straight rectangle with either color or gradient, save
-        // the extra stroke triangle strip around the edges
-        .with_anti_alias(false);
-        self.canvas.borrow_mut().fill_path(&path, &paint);
-    }
 }
 
 impl<'a> ItemRenderer for GLItemRenderer<'a> {
@@ -1033,6 +1012,27 @@ impl<'a> ItemRenderer for GLItemRenderer<'a> {
         self.canvas.borrow_mut().save_with(|canvas| {
             canvas.fill_path(&path, &fill_paint);
         })
+    }
+
+    /// Draws a `Rectangle` using the `GLItemRenderer`.
+    fn draw_rect(&mut self, size: LogicalSize, brush: Brush) {
+        let geometry = PhysicalRect::from(size * self.scale_factor);
+        if geometry.is_empty() {
+            return;
+        }
+        if self.global_alpha_transparent() {
+            return;
+        }
+        // TODO: cache path in item to avoid re-tesselation
+        let path = rect_to_path(geometry);
+        let paint = match self.brush_to_paint(brush, &path) {
+            Some(paint) => paint,
+            None => return,
+        }
+        // Since we're filling a straight rectangle with either color or gradient, save
+        // the extra stroke triangle strip around the edges
+        .with_anti_alias(false);
+        self.canvas.borrow_mut().fill_path(&path, &paint);
     }
 
     fn window(&self) -> &i_slint_core::window::WindowInner {

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -350,21 +350,6 @@ impl<'a> SkiaItemRenderer<'a> {
         })
     }
 
-    /// Draws a `Rectangle` using the `GLItemRenderer`.
-    pub fn draw_rect(&mut self, size: LogicalSize, brush: Brush) {
-        let geometry = PhysicalRect::from(size * self.scale_factor);
-        if geometry.is_empty() {
-            return;
-        }
-
-        let paint =
-            match self.brush_to_paint(brush, geometry.width_length(), geometry.height_length()) {
-                Some(paint) => paint,
-                None => return,
-            };
-        self.canvas.draw_rect(to_skia_rect(&geometry), &paint);
-    }
-
     fn pixel_align_origin(&self) -> Option<skia_safe::canvas::AutoRestoredCanvas<'_>> {
         let local_to_device = self.canvas.local_to_device_as_3x3();
         let Some(device_to_local) = local_to_device.invert() else {
@@ -941,6 +926,20 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
             skia_safe::Point::default(),
             self.default_paint().as_ref(),
         );
+    }
+
+    fn draw_rect(&mut self, size: LogicalSize, brush: Brush) {
+        let geometry = PhysicalRect::from(size * self.scale_factor);
+        if geometry.is_empty() {
+            return;
+        }
+
+        let paint =
+            match self.brush_to_paint(brush, geometry.width_length(), geometry.height_length()) {
+                Some(paint) => paint,
+                None => return,
+            };
+        self.canvas.draw_rect(to_skia_rect(&geometry), &paint);
     }
 
     fn window(&self) -> &i_slint_core::window::WindowInner {


### PR DESCRIPTION
This regressed with commit 3cb4bd174d0eae0ec7bf1517580980524962c43e, which introduced the draw_rect() hook in ItemRenderer, but unfortunately it wasn't in the `impl ItemRenderer` section
in the FemtoVG and Skia renderers.

ChangeLog: Fix panic when using gradient backgrounds with `Window`.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
