### PR TITLE
Add support for box shadows and out-of-geometry text items with the partial renderer

### DIFF
--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -422,6 +422,14 @@ impl Item for NativeButton {
             qApp->style()->drawControl(QStyle::CE_PushButton, &option, painter->get(), widget);
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeButton {

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -423,7 +423,7 @@ impl Item for NativeButton {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -425,6 +425,7 @@ impl Item for NativeButton {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -174,6 +174,14 @@ impl Item for NativeCheckBox {
             qApp->style()->drawControl(QStyle::CE_CheckBox, &option, painter->get(), widget);
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeCheckBox {

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -175,7 +175,7 @@ impl Item for NativeCheckBox {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -177,6 +177,7 @@ impl Item for NativeCheckBox {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -143,6 +143,7 @@ impl Item for NativeComboBox {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -261,6 +262,7 @@ impl Item for NativeComboBoxPopup {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -140,6 +140,14 @@ impl Item for NativeComboBox {
             qApp->style()->drawControl(QStyle::CE_ComboBoxLabel, &option, painter->get(), widget);
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeComboBox {
@@ -249,6 +257,14 @@ impl Item for NativeComboBoxPopup {
             option.frameShape = QFrame::Shape(frameStyle & QFrame::Shape_Mask);
             style->drawControl(QStyle::CE_ShapedFrame, &option, painter->get(), widget);
         });
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -141,7 +141,7 @@ impl Item for NativeComboBox {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -260,7 +260,7 @@ impl Item for NativeComboBoxPopup {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -237,6 +237,7 @@ impl Item for NativeGroupBox {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -235,7 +235,7 @@ impl Item for NativeGroupBox {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -234,6 +234,14 @@ impl Item for NativeGroupBox {
             qApp->style()->drawComplexControl(QStyle::CC_GroupBox, &option, painter->get(), widget);
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeGroupBox {

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -156,7 +156,7 @@ impl Item for NativeLineEdit {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -155,6 +155,14 @@ impl Item for NativeLineEdit {
             qApp->style()->drawPrimitive(QStyle::PE_PanelLineEdit, &option, painter->get(), widget);
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeLineEdit {

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -158,6 +158,7 @@ impl Item for NativeLineEdit {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -193,6 +193,14 @@ impl Item for NativeStandardListViewItem {
             }
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeStandardListViewItem {

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -194,7 +194,7 @@ impl Item for NativeStandardListViewItem {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -196,6 +196,7 @@ impl Item for NativeStandardListViewItem {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/progress_indicator.rs
+++ b/internal/backends/qt/qt_widgets/progress_indicator.rs
@@ -132,6 +132,7 @@ impl Item for NativeProgressIndicator {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/progress_indicator.rs
+++ b/internal/backends/qt/qt_widgets/progress_indicator.rs
@@ -129,6 +129,14 @@ impl Item for NativeProgressIndicator {
             qApp->style()->drawControl(QStyle::CE_ProgressBar, &option, painter_, widget);
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeProgressIndicator {

--- a/internal/backends/qt/qt_widgets/progress_indicator.rs
+++ b/internal/backends/qt/qt_widgets/progress_indicator.rs
@@ -130,7 +130,7 @@ impl Item for NativeProgressIndicator {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -445,6 +445,14 @@ impl Item for NativeScrollView {
             );
         }
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeScrollView {

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -446,7 +446,7 @@ impl Item for NativeScrollView {
         }
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -448,6 +448,7 @@ impl Item for NativeScrollView {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -363,6 +363,14 @@ impl Item for NativeSlider {
             style->drawComplexControl(QStyle::CC_Slider, &option, painter->get(), widget);
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl NativeSlider {

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -366,6 +366,7 @@ impl Item for NativeSlider {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -364,7 +364,7 @@ impl Item for NativeSlider {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -339,7 +339,7 @@ impl Item for NativeSpinBox {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -338,6 +338,14 @@ impl Item for NativeSpinBox {
             (*painter)->drawText(text_rect, QString::number(value), QTextOption(static_cast<Qt::AlignmentFlag>(horizontal_alignment)));
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeSpinBox {

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -341,6 +341,7 @@ impl Item for NativeSpinBox {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/tableheadersection.rs
+++ b/internal/backends/qt/qt_widgets/tableheadersection.rs
@@ -155,7 +155,7 @@ impl Item for NativeTableHeaderSection {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_widgets/tableheadersection.rs
+++ b/internal/backends/qt/qt_widgets/tableheadersection.rs
@@ -154,6 +154,14 @@ impl Item for NativeTableHeaderSection {
             #endif
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeTableHeaderSection {

--- a/internal/backends/qt/qt_widgets/tableheadersection.rs
+++ b/internal/backends/qt/qt_widgets/tableheadersection.rs
@@ -157,6 +157,7 @@ impl Item for NativeTableHeaderSection {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -318,6 +318,7 @@ impl Item for NativeTabWidget {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -539,6 +540,7 @@ impl Item for NativeTab {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -315,6 +315,14 @@ impl Item for NativeTabWidget {
                 style->drawPrimitive(QStyle::PE_FrameTabBarBase, &optTabBase, painter->get(), widget);*/
         });
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for NativeTabWidget {
@@ -527,6 +535,14 @@ impl Item for NativeTab {
             option.features |= QStyleOptionTab::HasFrame;
             qApp->style()->drawControl(QStyle::CE_TabBarTab, &option, painter->get(), widget);
         });
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -316,7 +316,7 @@ impl Item for NativeTabWidget {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -538,7 +538,7 @@ impl Item for NativeTab {
         });
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1591,10 +1591,12 @@ impl QtItemRenderer<'_> {
 
             std::mem::swap(&mut self.painter, &mut layer_painter);
 
+            let window_adapter = self.window().window_adapter();
+
             i_slint_core::item_rendering::render_item_children(
                 self,
                 &item_rc.item_tree(),
-                item_rc.index() as isize,
+                item_rc.index() as isize, &window_adapter
             );
 
             std::mem::swap(&mut self.painter, &mut layer_painter);
@@ -1713,6 +1715,7 @@ impl QtWindow {
 
     fn paint_event(&self, painter: QPainterPtr) {
         let runtime_window = WindowInner::from_pub(&self.window);
+        let window_adapter = runtime_window.window_adapter();
         runtime_window.draw_contents(|components| {
             i_slint_core::animations::update_animations();
             let mut renderer = QtItemRenderer {
@@ -1727,6 +1730,7 @@ impl QtWindow {
                     component,
                     &mut renderer,
                     *origin,
+                    &window_adapter,
                 );
             }
 

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -512,7 +512,7 @@ pub trait ItemRenderer {
         // Query bounding rect untracked, as properties that affect the bounding rect are already tracked
         // when rendering the item.
         let bounding_rect = crate::properties::evaluate_no_tracking(|| {
-            item.bounding_rect_for_geometry(&item_geometry, window_adapter)
+            item.bounding_rect(&item_geometry, window_adapter)
         });
         (self.get_current_clip().intersects(&bounding_rect), item_geometry)
     }
@@ -597,7 +597,7 @@ impl CachedItemGeometryAndTransform {
         // Evaluate the bounding rect untracked, as properties that affect the bounding rect are already tracked
         // at rendering time.
         let bounding_rect = crate::properties::evaluate_no_tracking(|| {
-            item_rc.bounding_rect_for_geometry(&geometry, window_adapter)
+            item_rc.bounding_rect(&geometry, window_adapter)
         });
 
         if let Some(complex_child_transform) =

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -438,12 +438,12 @@ impl ItemRc {
         comp_ref_pin.as_ref().item_geometry(self.index)
     }
 
-    pub fn bounding_rect_for_geometry(
+    pub fn bounding_rect(
         &self,
         geometry: &LogicalRect,
         window_adapter: &WindowAdapterRc,
     ) -> LogicalRect {
-        self.borrow().as_ref().bounding_rect_for_geometry(window_adapter, self, *geometry)
+        self.borrow().as_ref().bounding_rect(window_adapter, self, *geometry)
     }
 
     /// Returns an absolute position of `p` in the parent item coordinate system

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -438,6 +438,10 @@ impl ItemRc {
         comp_ref_pin.as_ref().item_geometry(self.index)
     }
 
+    pub fn bounding_rect_for_geometry(&self, geometry: &LogicalRect) -> LogicalRect {
+        self.borrow().as_ref().bounding_rect_for_geometry(self, *geometry)
+    }
+
     /// Returns an absolute position of `p` in the parent item coordinate system
     /// (does not add this item's x and y)
     pub fn map_to_window(&self, p: LogicalPoint) -> LogicalPoint {

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -438,8 +438,12 @@ impl ItemRc {
         comp_ref_pin.as_ref().item_geometry(self.index)
     }
 
-    pub fn bounding_rect_for_geometry(&self, geometry: &LogicalRect) -> LogicalRect {
-        self.borrow().as_ref().bounding_rect_for_geometry(self, *geometry)
+    pub fn bounding_rect_for_geometry(
+        &self,
+        geometry: &LogicalRect,
+        window_adapter: &WindowAdapterRc,
+    ) -> LogicalRect {
+        self.borrow().as_ref().bounding_rect_for_geometry(window_adapter, self, *geometry)
     }
 
     /// Returns an absolute position of `p` in the parent item coordinate system

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -172,6 +172,7 @@ pub struct ItemVTable {
 
     pub bounding_rect_for_geometry: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
+        window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect,
@@ -247,6 +248,7 @@ impl Item for Empty {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -333,6 +335,7 @@ impl Item for Rectangle {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -428,6 +431,7 @@ impl Item for BasicBorderRectangle {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -536,6 +540,7 @@ impl Item for BorderRectangle {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -669,6 +674,7 @@ impl Item for Clip {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -764,6 +770,7 @@ impl Item for Opacity {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -876,6 +883,7 @@ impl Item for Layer {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -968,6 +976,7 @@ impl Item for Rotate {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -1103,6 +1112,7 @@ impl Item for WindowItem {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -1236,6 +1246,7 @@ impl Item for ContextMenu {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -1327,6 +1338,7 @@ impl Item for BoxShadow {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -250,8 +250,9 @@ impl Item for Empty {
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
-        geometry: LogicalRect,
+        mut geometry: LogicalRect,
     ) -> LogicalRect {
+        geometry.size = LogicalSize::zero();
         geometry
     }
 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -170,7 +170,7 @@ pub struct ItemVTable {
         size: LogicalSize,
     ) -> RenderingResult,
 
-    pub bounding_rect_for_geometry: extern "C" fn(
+    pub bounding_rect: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
@@ -246,7 +246,7 @@ impl Item for Empty {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -334,7 +334,7 @@ impl Item for Rectangle {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -430,7 +430,7 @@ impl Item for BasicBorderRectangle {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -539,7 +539,7 @@ impl Item for BorderRectangle {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -673,7 +673,7 @@ impl Item for Clip {
         (*backend).visit_clip(self, self_rc, size)
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -769,7 +769,7 @@ impl Item for Opacity {
         backend.visit_opacity(self, self_rc, size)
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -882,7 +882,7 @@ impl Item for Layer {
         backend.visit_layer(self, self_rc, size)
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -975,7 +975,7 @@ impl Item for Rotate {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -1111,7 +1111,7 @@ impl Item for WindowItem {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -1245,7 +1245,7 @@ impl Item for ContextMenu {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -1337,7 +1337,7 @@ impl Item for BoxShadow {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -224,6 +224,7 @@ impl Item for ComponentContainer {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -17,7 +17,7 @@ use crate::item_rendering::{CachedRenderingData, RenderRectangle};
 use crate::item_tree::{IndexRange, ItemTreeRc, ItemTreeWeak, ItemWeak};
 use crate::item_tree::{ItemTreeNode, ItemVisitorVTable, TraversalOrder, VisitChildrenResult};
 use crate::layout::{LayoutInfo, Orientation};
-use crate::lengths::{LogicalLength, LogicalSize};
+use crate::lengths::{LogicalLength, LogicalRect, LogicalSize};
 use crate::properties::{Property, PropertyTracker};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
@@ -220,6 +220,14 @@ impl Item for ComponentContainer {
     ) -> RenderingResult {
         backend.draw_rectangle(self, item_rc, size, &self.cached_rendering_data);
         RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -222,7 +222,7 @@ impl Item for ComponentContainer {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -147,7 +147,7 @@ impl Item for Flickable {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -149,6 +149,7 @@ impl Item for Flickable {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -146,6 +146,14 @@ impl Item for Flickable {
         );
         RenderingResult::ContinueRenderingChildren
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for Flickable {

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -109,7 +109,7 @@ impl Item for ImageItem {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -255,7 +255,7 @@ impl Item for ClippedImage {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -111,6 +111,7 @@ impl Item for ImageItem {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -256,6 +257,7 @@ impl Item for ClippedImage {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -18,7 +18,7 @@ use crate::input::{
 use crate::item_rendering::ItemRenderer;
 use crate::item_rendering::{CachedRenderingData, RenderImage};
 use crate::layout::{LayoutInfo, Orientation};
-use crate::lengths::{LogicalLength, LogicalSize};
+use crate::lengths::{LogicalLength, LogicalRect, LogicalSize};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use crate::window::WindowAdapter;
@@ -107,6 +107,14 @@ impl Item for ImageItem {
     ) -> RenderingResult {
         (*backend).draw_image(self, self_rc, size, &self.cached_rendering_data);
         RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 
@@ -244,6 +252,14 @@ impl Item for ClippedImage {
     ) -> RenderingResult {
         (*backend).draw_image(self, self_rc, size, &self.cached_rendering_data);
         RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -229,7 +229,7 @@ impl Item for TouchArea {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -350,7 +350,7 @@ impl Item for FocusScope {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -548,7 +548,7 @@ impl Item for SwipeGestureHandler {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -228,6 +228,14 @@ impl Item for TouchArea {
     ) -> RenderingResult {
         RenderingResult::ContinueRenderingChildren
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for TouchArea {
@@ -338,6 +346,14 @@ impl Item for FocusScope {
         _size: LogicalSize,
     ) -> RenderingResult {
         RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 
@@ -526,6 +542,14 @@ impl Item for SwipeGestureHandler {
         _size: LogicalSize,
     ) -> RenderingResult {
         RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -233,8 +233,9 @@ impl Item for TouchArea {
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
-        geometry: LogicalRect,
+        mut geometry: LogicalRect,
     ) -> LogicalRect {
+        geometry.size = LogicalSize::zero();
         geometry
     }
 }
@@ -353,8 +354,9 @@ impl Item for FocusScope {
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
-        geometry: LogicalRect,
+        mut geometry: LogicalRect,
     ) -> LogicalRect {
+        geometry.size = LogicalSize::zero();
         geometry
     }
 }
@@ -550,8 +552,9 @@ impl Item for SwipeGestureHandler {
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
-        geometry: LogicalRect,
+        mut geometry: LogicalRect,
     ) -> LogicalRect {
+        geometry.size = LogicalSize::zero();
         geometry
     }
 }

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -231,6 +231,7 @@ impl Item for TouchArea {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -350,6 +351,7 @@ impl Item for FocusScope {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {
@@ -546,6 +548,7 @@ impl Item for SwipeGestureHandler {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -18,7 +18,8 @@ use crate::item_rendering::CachedRenderingData;
 
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{
-    LogicalBorderRadius, LogicalLength, LogicalSize, LogicalVector, PointLengths, RectLengths,
+    LogicalBorderRadius, LogicalLength, LogicalRect, LogicalSize, LogicalVector, PointLengths,
+    RectLengths,
 };
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
@@ -128,6 +129,14 @@ impl Item for Path {
             (*backend).restore_state();
         }
         RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -131,7 +131,7 @@ impl Item for Path {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -133,6 +133,7 @@ impl Item for Path {
 
     fn bounding_rect_for_geometry(
         self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -125,7 +125,7 @@ impl Item for ComplexText {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -299,7 +299,7 @@ impl Item for SimpleText {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
@@ -988,7 +988,7 @@ impl Item for TextInput {
         RenderingResult::ContinueRenderingChildren
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: core::pin::Pin<&Self>,
         window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -122,6 +122,14 @@ impl Item for ComplexText {
         (*backend).draw_text(self, self_rc, size, &self.cached_rendering_data);
         RenderingResult::ContinueRenderingChildren
     }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
+    }
 }
 
 impl ItemConsts for ComplexText {
@@ -286,6 +294,14 @@ impl Item for SimpleText {
     ) -> RenderingResult {
         (*backend).draw_text(self, self_rc, size, &self.cached_rendering_data);
         RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 
@@ -966,6 +982,14 @@ impl Item for TextInput {
         });
         (*backend).draw_text_input(self, self_rc, size);
         RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect_for_geometry(
+        self: core::pin::Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry
     }
 }
 

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -184,6 +184,7 @@ impl crate::items::Item for MenuItem {
 
     fn bounding_rect_for_geometry(
         self: Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
         geometry: crate::lengths::LogicalRect,
     ) -> crate::lengths::LogicalRect {

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -182,7 +182,7 @@ impl crate::items::Item for MenuItem {
         Default::default()
     }
 
-    fn bounding_rect_for_geometry(
+    fn bounding_rect(
         self: Pin<&Self>,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -181,6 +181,14 @@ impl crate::items::Item for MenuItem {
     ) -> crate::items::RenderingResult {
         Default::default()
     }
+
+    fn bounding_rect_for_geometry(
+        self: Pin<&Self>,
+        _self_rc: &ItemRc,
+        geometry: crate::lengths::LogicalRect,
+    ) -> crate::lengths::LogicalRect {
+        geometry
+    }
 }
 
 impl crate::items::ItemConsts for MenuItem {

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -501,6 +501,7 @@ impl SoftwareRenderer {
             rotation,
         );
         let mut renderer = self.partial_rendering_state.create_partial_renderer(buffer_renderer);
+        let window_adapter = renderer.window_adapter.clone();
 
         window_inner
             .draw_contents(|components| {
@@ -568,6 +569,7 @@ impl SoftwareRenderer {
                         component,
                         &mut renderer,
                         *origin,
+                        &window_adapter,
                     );
                 }
 
@@ -992,6 +994,7 @@ fn prepare_scene(
     );
     let mut renderer =
         software_renderer.partial_rendering_state.create_partial_renderer(prepare_scene);
+    let window_adapter = renderer.window_adapter.clone();
 
     let mut dirty_region = PhysicalRegion::default();
     window.draw_contents(|components| {
@@ -1034,7 +1037,12 @@ fn prepare_scene(
         drop(i);
 
         for (component, origin) in components {
-            crate::item_rendering::render_component_items(component, &mut renderer, *origin);
+            crate::item_rendering::render_component_items(
+                component,
+                &mut renderer,
+                *origin,
+                &window_adapter,
+            );
         }
     });
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1192,10 +1192,13 @@ impl<'a> GLItemRenderer<'a> {
                     current_render_target: layer_image.as_render_target(),
                 };
 
+                let window_adapter = self.window().window_adapter();
+
                 i_slint_core::item_rendering::render_item_children(
                     self,
                     item_rc.item_tree(),
                     item_rc.index() as isize,
+                    &window_adapter,
                 );
 
                 {

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -286,6 +286,7 @@ impl FemtoVGRenderer {
                         component,
                         &mut item_renderer,
                         *origin,
+                        &self.window_adapter()?,
                     );
                 }
 

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -344,6 +344,7 @@ impl<'a> SkiaItemRenderer<'a> {
                 &mut sub_renderer,
                 &item_rc.item_tree(),
                 item_rc.index() as isize,
+                &WindowInner::from_pub(self.window).window_adapter(),
             );
 
             Some(surface.image_snapshot())
@@ -972,10 +973,13 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
             self.state_stack.push(self.current_state);
             self.current_state.alpha = 1.0;
 
+            let window_adapter = WindowInner::from_pub(self.window).window_adapter();
+
             i_slint_core::item_rendering::render_item_children(
                 self,
                 &item_rc.item_tree(),
                 item_rc.index() as isize,
+                &window_adapter,
             );
 
             self.current_state = self.state_stack.pop().unwrap();

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -489,6 +489,7 @@ impl SkiaRenderer {
         components: &[(&i_slint_core::item_tree::ItemTreeRc, LogicalPoint)],
     ) -> Option<DirtyRegion> {
         let window_inner = WindowInner::from_pub(window);
+        let window_adapter = window_inner.window_adapter();
 
         let mut box_shadow_cache = Default::default();
 
@@ -612,6 +613,7 @@ impl SkiaRenderer {
                     component,
                     item_renderer,
                     *origin,
+                    &window_adapter,
                 );
             }
 

--- a/tests/manual/partial-rendering-circus.slint
+++ b/tests/manual/partial-rendering-circus.slint
@@ -14,4 +14,15 @@ export component AppWindow inherits Window {
         rotation-angle: mod(animation-tick(), 2s) / 2s * 360deg;
         colorize: green;
     }
+
+    Rectangle {
+        x: 10px + mod(animation-tick(), 5s) / 5s * 100px;
+        y: 10px;
+        width: 20px;
+        height: 20px;
+        drop-shadow-blur: 5px;
+        drop-shadow-offset-x: 15px;
+        drop-shadow-offset-y: 5px;
+        drop-shadow-color: red;
+    }
 }

--- a/tests/manual/partial-rendering-circus.slint
+++ b/tests/manual/partial-rendering-circus.slint
@@ -25,4 +25,17 @@ export component AppWindow inherits Window {
         drop-shadow-offset-y: 5px;
         drop-shadow-color: red;
     }
+
+    Text {
+        x: 10px + mod(animation-tick(), 5s) / 5s * 100px;
+        y: 40px;
+        width: 40px;
+        height: 30px;
+        text: "This is a long piece\nof text that\nwill render out of\nthe bounds.";
+
+        Rectangle {
+            border-width: 1px;
+            border-color: green;
+        }
+    }
 }


### PR DESCRIPTION
cc #7247

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
