### PR TITLE
Refactoring: get rid in the callable in the Expression tree

### DIFF
--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -6,7 +6,7 @@
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{
-    BuiltinFunction, BuiltinMacroFunction, EasingCurve, Expression, MinMaxOp, Unit,
+    BuiltinFunction, BuiltinMacroFunction, Callable, EasingCurve, Expression, MinMaxOp, Unit,
 };
 use crate::langtype::{EnumerationValue, Type};
 use crate::parser::NodeOrToken;
@@ -18,7 +18,7 @@ static COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize:
 /// "Expand" the macro `mac` (at location `n`) with the arguments `sub_expr`
 pub fn lower_macro(
     mac: BuiltinMacroFunction,
-    n: Option<NodeOrToken>,
+    n: &dyn Spanned,
     mut sub_expr: impl Iterator<Item = (Expression, Option<NodeOrToken>)>,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
@@ -37,7 +37,7 @@ pub fn lower_macro(
             // Maybe "cubic_bezier" should be a function that is lowered later
             let mut a = || match sub_expr.next() {
                 None => {
-                    has_error.get_or_insert((n.clone(), "Not enough arguments"));
+                    has_error.get_or_insert((n.to_source_location(), "Not enough arguments"));
                     0.
                 }
                 Some((Expression::NumberLiteral(val, Unit::None), _)) => val as f32,
@@ -45,18 +45,20 @@ pub fn lower_macro(
                 Some((Expression::UnaryOp { sub, op: '-' }, n)) => match *sub {
                     Expression::NumberLiteral(val, Unit::None) => (-1.0 * val) as f32,
                     _ => {
-                        has_error.get_or_insert((n, expected_argument_type_error));
+                        has_error
+                            .get_or_insert((n.to_source_location(), expected_argument_type_error));
                         0.
                     }
                 },
                 Some((_, n)) => {
-                    has_error.get_or_insert((n, expected_argument_type_error));
+                    has_error.get_or_insert((n.to_source_location(), expected_argument_type_error));
                     0.
                 }
             };
             let expr = Expression::EasingCurve(EasingCurve::CubicBezier(a(), a(), a(), a()));
             if let Some((_, n)) = sub_expr.next() {
-                has_error.get_or_insert((n, "Too many argument for bezier curve"));
+                has_error
+                    .get_or_insert((n.to_source_location(), "Too many argument for bezier curve"));
             }
             if let Some((n, msg)) = has_error {
                 diag.push_error(msg.into(), &n);
@@ -70,18 +72,18 @@ pub fn lower_macro(
 }
 
 fn min_max_macro(
-    node: Option<NodeOrToken>,
+    node: &dyn Spanned,
     op: MinMaxOp,
     args: Vec<(Expression, Option<NodeOrToken>)>,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
     if args.is_empty() {
-        diag.push_error("Needs at least one argument".into(), &node);
+        diag.push_error("Needs at least one argument".into(), node);
         return Expression::Invalid;
     }
     let ty = Expression::common_target_type_for_type_list(args.iter().map(|expr| expr.0.ty()));
     if ty.as_unit_product().is_none() {
-        diag.push_error("Invalid argument type".into(), &node);
+        diag.push_error("Invalid argument type".into(), node);
         return Expression::Invalid;
     }
     let mut args = args.into_iter();
@@ -95,7 +97,7 @@ fn min_max_macro(
 }
 
 fn clamp_macro(
-    node: Option<NodeOrToken>,
+    node: &dyn Spanned,
     args: Vec<(Expression, Option<NodeOrToken>)>,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
@@ -103,7 +105,7 @@ fn clamp_macro(
         diag.push_error(
             "`clamp` needs three values: the `value` to clamp, the `minimum` and the `maximum`"
                 .into(),
-            &node,
+            node,
         );
         return Expression::Invalid;
     }
@@ -124,12 +126,12 @@ fn clamp_macro(
 }
 
 fn mod_macro(
-    node: Option<NodeOrToken>,
+    node: &dyn Spanned,
     args: Vec<(Expression, Option<NodeOrToken>)>,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
     if args.len() != 2 {
-        diag.push_error("Needs 2 arguments".into(), &node);
+        diag.push_error("Needs 2 arguments".into(), node);
         return Expression::Invalid;
     }
     let (lhs_ty, rhs_ty) = (args[0].0.ty(), args[1].0.ty());
@@ -145,11 +147,8 @@ fn mod_macro(
         Type::Float32
     };
 
-    let source_location = node.map(|n| n.to_source_location());
-    let function = Box::new(Expression::BuiltinFunctionReference(
-        BuiltinFunction::Mod,
-        source_location.clone(),
-    ));
+    let source_location = Some(node.to_source_location());
+    let function = Callable::Builtin(BuiltinFunction::Mod);
     let arguments = args.into_iter().map(|(e, n)| e.maybe_convert_to(common_ty.clone(), &n, diag));
     if matches!(common_ty, Type::Float32) {
         Expression::FunctionCall { function, arguments: arguments.collect(), source_location }
@@ -169,12 +168,12 @@ fn mod_macro(
 }
 
 fn abs_macro(
-    node: Option<NodeOrToken>,
+    node: &dyn Spanned,
     args: Vec<(Expression, Option<NodeOrToken>)>,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
     if args.len() != 1 {
-        diag.push_error("Needs 1 argument".into(), &node);
+        diag.push_error("Needs 1 argument".into(), node);
         return Expression::Invalid;
     }
     let ty = args[0].0.ty();
@@ -184,11 +183,8 @@ fn abs_macro(
         Type::Float32
     };
 
-    let source_location = node.map(|n| n.to_source_location());
-    let function = Box::new(Expression::BuiltinFunctionReference(
-        BuiltinFunction::Abs,
-        source_location.clone(),
-    ));
+    let source_location = Some(node.to_source_location());
+    let function = Callable::Builtin(BuiltinFunction::Abs);
     if matches!(ty, Type::Float32) {
         let arguments =
             args.into_iter().map(|(e, n)| e.maybe_convert_to(ty.clone(), &n, diag)).collect();
@@ -210,14 +206,14 @@ fn abs_macro(
 }
 
 fn rgb_macro(
-    node: Option<NodeOrToken>,
+    node: &dyn Spanned,
     args: Vec<(Expression, Option<NodeOrToken>)>,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
     if args.len() < 3 || args.len() > 4 {
         diag.push_error(
             format!("This function needs 3 or 4 arguments, but {} were provided", args.len()),
-            &node,
+            node,
         );
         return Expression::Invalid;
     }
@@ -244,24 +240,21 @@ fn rgb_macro(
         arguments.push(Expression::NumberLiteral(1., Unit::None))
     }
     Expression::FunctionCall {
-        function: Box::new(Expression::BuiltinFunctionReference(
-            BuiltinFunction::Rgb,
-            node.as_ref().map(|t| t.to_source_location()),
-        )),
+        function: BuiltinFunction::Rgb.into(),
         arguments,
         source_location: Some(node.to_source_location()),
     }
 }
 
 fn hsv_macro(
-    node: Option<NodeOrToken>,
+    node: &dyn Spanned,
     args: Vec<(Expression, Option<NodeOrToken>)>,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
     if args.len() < 3 || args.len() > 4 {
         diag.push_error(
             format!("This function needs 3 or 4 arguments, but {} were provided", args.len()),
-            &node,
+            node,
         );
         return Expression::Invalid;
     }
@@ -271,23 +264,20 @@ fn hsv_macro(
         arguments.push(Expression::NumberLiteral(1., Unit::None))
     }
     Expression::FunctionCall {
-        function: Box::new(Expression::BuiltinFunctionReference(
-            BuiltinFunction::Hsv,
-            node.as_ref().map(|t| t.to_source_location()),
-        )),
+        function: BuiltinFunction::Hsv.into(),
         arguments,
         source_location: Some(node.to_source_location()),
     }
 }
 
 fn debug_macro(
-    node: Option<NodeOrToken>,
+    node: &dyn Spanned,
     args: Vec<(Expression, Option<NodeOrToken>)>,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
     let mut string = None;
     for (expr, node) in args {
-        let val = to_debug_string(expr, node, diag);
+        let val = to_debug_string(expr, &node, diag);
         string = Some(match string {
             None => val,
             Some(string) => Expression::BinaryExpression {
@@ -301,20 +291,16 @@ fn debug_macro(
             },
         });
     }
-    let sl = node.map(|node| node.to_source_location());
     Expression::FunctionCall {
-        function: Box::new(Expression::BuiltinFunctionReference(
-            BuiltinFunction::Debug,
-            sl.clone(),
-        )),
+        function: BuiltinFunction::Debug.into(),
         arguments: vec![string.unwrap_or_else(|| Expression::default_value_for_type(&Type::String))],
-        source_location: sl,
+        source_location: Some(node.to_source_location()),
     }
 }
 
 fn to_debug_string(
     expr: Expression,
-    node: Option<NodeOrToken>,
+    node: &dyn Spanned,
     diag: &mut BuildDiagnostics,
 ) -> Expression {
     let ty = expr.ty();
@@ -330,10 +316,10 @@ fn to_debug_string(
         | Type::LayoutCache
         | Type::Model
         | Type::PathData => {
-            diag.push_error("Cannot debug this expression".into(), &node);
+            diag.push_error("Cannot debug this expression".into(), node);
             Expression::Invalid
         }
-        Type::Float32 | Type::Int32 => expr.maybe_convert_to(Type::String, &node, diag),
+        Type::Float32 | Type::Int32 => expr.maybe_convert_to(Type::String, node, diag),
         Type::String => expr,
         // TODO
         Type::Color | Type::Brush | Type::Image | Type::Easing | Type::Array(_) => {
@@ -349,7 +335,7 @@ fn to_debug_string(
             lhs: Box::new(
                 Expression::Cast { from: Box::new(expr), to: Type::Float32 }.maybe_convert_to(
                     Type::String,
-                    &node,
+                    node,
                     diag,
                 ),
             ),
@@ -383,7 +369,7 @@ fn to_debug_string(
                         }),
                         name: k.clone(),
                     },
-                    node.clone(),
+                    node,
                     diag,
                 );
                 let field = Expression::BinaryExpression {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -390,6 +390,28 @@ impl BuiltinFunction {
     }
 }
 
+/// The base of a Expression::FunctionCall
+#[derive(Debug, Clone)]
+pub enum Callable {
+    Callback(NamedReference),
+    Function(NamedReference),
+    Builtin(BuiltinFunction),
+}
+impl Callable {
+    pub fn ty(&self) -> Type {
+        match self {
+            Callable::Callback(nr) => nr.ty(),
+            Callable::Function(nr) => nr.ty(),
+            Callable::Builtin(b) => Type::Function(b.ty()),
+        }
+    }
+}
+impl From<BuiltinFunction> for Callable {
+    fn from(function: BuiltinFunction) -> Self {
+        Self::Builtin(function)
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum OperatorClass {
     ComparisonOp,
@@ -520,31 +542,8 @@ pub enum Expression {
     /// Bool
     BoolLiteral(bool),
 
-    /// Reference to the callback `<name>` in the `<element>`
-    ///
-    /// Note: if we are to separate expression and statement, we probably do not need to have callback reference within expressions
-    CallbackReference(NamedReference, Option<NodeOrToken>),
-
     /// Reference to the property
     PropertyReference(NamedReference),
-
-    /// Reference to a function
-    FunctionReference(NamedReference, Option<NodeOrToken>),
-
-    /// Reference to a function built into the run-time, implemented natively
-    BuiltinFunctionReference(BuiltinFunction, Option<SourceLocation>),
-
-    /// A MemberFunction expression exists only for a short time, for example for `item.focus()` to be translated to
-    /// a regular FunctionCall expression where the base becomes the first argument.
-    MemberFunction {
-        base: Box<Expression>,
-        base_node: Option<NodeOrToken>,
-        member: Box<Expression>,
-    },
-
-    /// Reference to a macro understood by the compiler.
-    /// These should be transformed to other expression before reaching generation
-    BuiltinMacroReference(BuiltinMacroFunction, Option<NodeOrToken>),
 
     /// A reference to a specific element. This isn't possible to create in .slint syntax itself, but intermediate passes may generate this
     /// type of expression.
@@ -610,7 +609,7 @@ pub enum Expression {
 
     /// A function call
     FunctionCall {
-        function: Box<Expression>,
+        function: Callable,
         arguments: Vec<Expression>,
         source_location: Option<SourceLocation>,
     },
@@ -708,12 +707,7 @@ impl Expression {
             Expression::StringLiteral(_) => Type::String,
             Expression::NumberLiteral(_, unit) => unit.ty(),
             Expression::BoolLiteral(_) => Type::Bool,
-            Expression::CallbackReference(nr, _) => nr.ty(),
-            Expression::FunctionReference(nr, _) => nr.ty(),
             Expression::PropertyReference(nr) => nr.ty(),
-            Expression::BuiltinFunctionReference(funcref, _) => Type::Function(funcref.ty()),
-            Expression::MemberFunction { member, .. } => member.ty(),
-            Expression::BuiltinMacroReference { .. } => Type::Invalid, // We don't know the type
             Expression::ElementReference(_) => Type::ElementReference,
             Expression::RepeaterIndexReference { .. } => Type::Int32,
             Expression::RepeaterModelReference { element } => element
@@ -833,16 +827,8 @@ impl Expression {
             Expression::StringLiteral(_) => {}
             Expression::NumberLiteral(_, _) => {}
             Expression::BoolLiteral(_) => {}
-            Expression::CallbackReference { .. } => {}
             Expression::PropertyReference { .. } => {}
-            Expression::FunctionReference { .. } => {}
             Expression::FunctionParameterReference { .. } => {}
-            Expression::BuiltinFunctionReference { .. } => {}
-            Expression::MemberFunction { base, member, .. } => {
-                visitor(base);
-                visitor(member);
-            }
-            Expression::BuiltinMacroReference { .. } => {}
             Expression::ElementReference(_) => {}
             Expression::StructFieldAccess { base, .. } => visitor(base),
             Expression::ArrayIndex { array, index } => {
@@ -855,8 +841,7 @@ impl Expression {
             Expression::CodeBlock(sub) => {
                 sub.iter().for_each(visitor);
             }
-            Expression::FunctionCall { function, arguments, source_location: _ } => {
-                visitor(function);
+            Expression::FunctionCall { function: _, arguments, source_location: _ } => {
                 arguments.iter().for_each(visitor);
             }
             Expression::SelfAssignment { lhs, rhs, .. } => {
@@ -935,16 +920,8 @@ impl Expression {
             Expression::StringLiteral(_) => {}
             Expression::NumberLiteral(_, _) => {}
             Expression::BoolLiteral(_) => {}
-            Expression::CallbackReference { .. } => {}
             Expression::PropertyReference { .. } => {}
-            Expression::FunctionReference { .. } => {}
             Expression::FunctionParameterReference { .. } => {}
-            Expression::BuiltinFunctionReference { .. } => {}
-            Expression::MemberFunction { base, member, .. } => {
-                visitor(base);
-                visitor(member);
-            }
-            Expression::BuiltinMacroReference { .. } => {}
             Expression::ElementReference(_) => {}
             Expression::StructFieldAccess { base, .. } => visitor(base),
             Expression::ArrayIndex { array, index } => {
@@ -957,8 +934,7 @@ impl Expression {
             Expression::CodeBlock(sub) => {
                 sub.iter_mut().for_each(visitor);
             }
-            Expression::FunctionCall { function, arguments, source_location: _ } => {
-                visitor(function);
+            Expression::FunctionCall { function: _, arguments, source_location: _ } => {
                 arguments.iter_mut().for_each(visitor);
             }
             Expression::SelfAssignment { lhs, rhs, .. } => {
@@ -1052,23 +1028,21 @@ impl Expression {
             Expression::StringLiteral(_) => true,
             Expression::NumberLiteral(_, _) => true,
             Expression::BoolLiteral(_) => true,
-            Expression::CallbackReference { .. } => false,
-            Expression::FunctionReference(nr, _) => nr.is_constant(),
             Expression::PropertyReference(nr) => nr.is_constant(),
-            Expression::BuiltinFunctionReference(func, _) => func.is_const(),
-            Expression::MemberFunction { .. } => false,
             Expression::ElementReference(_) => false,
             Expression::RepeaterIndexReference { .. } => false,
             Expression::RepeaterModelReference { .. } => false,
             Expression::FunctionParameterReference { .. } => false,
-            Expression::BuiltinMacroReference { .. } => true,
             Expression::StructFieldAccess { base, .. } => base.is_constant(),
             Expression::ArrayIndex { array, index } => array.is_constant() && index.is_constant(),
             Expression::Cast { from, .. } => from.is_constant(),
             Expression::CodeBlock(sub) => sub.len() == 1 && sub.first().unwrap().is_constant(),
             Expression::FunctionCall { function, arguments, .. } => {
-                // Assume that constant function are, in fact, pure
-                function.is_constant() && arguments.iter().all(|a| a.is_constant())
+                let is_const = match function {
+                    Callable::Builtin(b) => b.is_const(),
+                    Callable::Callback(nr) | Callable::Function(nr) => nr.is_constant(),
+                };
+                is_const && arguments.iter().all(|a| a.is_constant())
             }
             Expression::SelfAssignment { .. } => false,
             Expression::ImageReference { .. } => true,
@@ -1117,7 +1091,7 @@ impl Expression {
     pub fn maybe_convert_to(
         self,
         target_type: Type,
-        node: &impl Spanned,
+        node: &dyn Spanned,
         diag: &mut BuildDiagnostics,
     ) -> Expression {
         let ty = self.ty();
@@ -1195,12 +1169,7 @@ impl Expression {
                                         result = Expression::BinaryExpression {
                                             lhs: Box::new(result),
                                             rhs: Box::new(Expression::FunctionCall {
-                                                function: Box::new(
-                                                    Expression::BuiltinFunctionReference(
-                                                        builtin_fn.clone(),
-                                                        Some(node.to_source_location()),
-                                                    ),
-                                                ),
+                                                function: Callable::Builtin(builtin_fn.clone()),
                                                 arguments: vec![],
                                                 source_location: Some(node.to_source_location()),
                                             }),
@@ -1598,16 +1567,7 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
         Expression::StringLiteral(s) => write!(f, "{:?}", s),
         Expression::NumberLiteral(vl, unit) => write!(f, "{}{}", vl, unit),
         Expression::BoolLiteral(b) => write!(f, "{:?}", b),
-        Expression::CallbackReference(a, _) => write!(f, "{:?}", a),
         Expression::PropertyReference(a) => write!(f, "{:?}", a),
-        Expression::FunctionReference(a, _) => write!(f, "{:?}", a),
-        Expression::BuiltinFunctionReference(a, _) => write!(f, "{:?}", a),
-        Expression::MemberFunction { base, base_node: _, member } => {
-            pretty_print(f, base)?;
-            write!(f, ".")?;
-            pretty_print(f, member)
-        }
-        Expression::BuiltinMacroReference(a, _) => write!(f, "{:?}", a),
         Expression::ElementReference(a) => write!(f, "{:?}", a),
         Expression::RepeaterIndexReference { element } => {
             crate::namedreference::pretty_print_element_ref(f, element)
@@ -1646,7 +1606,10 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
             write!(f, "}}")
         }
         Expression::FunctionCall { function, arguments, source_location: _ } => {
-            pretty_print(f, function)?;
+            match function {
+                Callable::Builtin(b) => write!(f, "{:?}", b)?,
+                Callable::Callback(nr) | Callable::Function(nr) => write!(f, "{:?}", nr)?,
+            }
             write!(f, "(")?;
             for e in arguments {
                 pretty_print(f, e)?;

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1040,7 +1040,8 @@ impl Expression {
             Expression::FunctionCall { function, arguments, .. } => {
                 let is_const = match function {
                     Callable::Builtin(b) => b.is_const(),
-                    Callable::Callback(nr) | Callable::Function(nr) => nr.is_constant(),
+                    Callable::Function(nr) => nr.is_constant(),
+                    Callable::Callback(..) => false,
                 };
                 is_const && arguments.iter().all(|a| a.is_constant())
             }

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -545,10 +545,7 @@ pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> 
                 }
             }
             _ => Expression::FunctionCall {
-                function: Box::new(Expression::BuiltinFunctionReference(
-                    BuiltinFunction::ImplicitLayoutInfo(orientation),
-                    None,
-                )),
+                function: BuiltinFunction::ImplicitLayoutInfo(orientation).into(),
                 arguments: vec![Expression::ElementReference(Rc::downgrade(elem))],
                 source_location: None,
             },

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -8,7 +8,7 @@
 // cSpell: ignore qualname
 
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
-use crate::expression_tree::{self, BindingExpression, Expression, Unit};
+use crate::expression_tree::{self, BindingExpression, Callable, Expression, Unit};
 use crate::langtype::{
     BuiltinElement, BuiltinPropertyDefault, Enumeration, EnumerationValue, Function, NativeClass,
     Struct, Type,
@@ -2280,9 +2280,11 @@ pub fn visit_named_references_in_expression(
 ) {
     expr.visit_mut(|sub| visit_named_references_in_expression(sub, vis));
     match expr {
-        Expression::PropertyReference(r)
-        | Expression::CallbackReference(r, _)
-        | Expression::FunctionReference(r, _) => vis(r),
+        Expression::PropertyReference(r) => vis(r),
+        Expression::FunctionCall {
+            function: Callable::Callback(r) | Callable::Function(r),
+            ..
+        } => vis(r),
         Expression::LayoutCacheAccess { layout_cache_prop, .. } => vis(layout_cache_prop),
         Expression::SolveLayout(l, _) => l.visit_named_references(vis),
         Expression::ComputeLayoutInfo(l, _) => l.visit_named_references(vis),

--- a/internal/compiler/passes/collect_custom_fonts.rs
+++ b/internal/compiler/passes/collect_custom_fonts.rs
@@ -23,9 +23,9 @@ pub fn collect_custom_fonts<'a>(
     }
 
     let registration_function = if embed_fonts {
-        Expression::BuiltinFunctionReference(BuiltinFunction::RegisterCustomFontByMemory, None)
+        BuiltinFunction::RegisterCustomFontByMemory
     } else {
-        Expression::BuiltinFunctionReference(BuiltinFunction::RegisterCustomFontByPath, None)
+        BuiltinFunction::RegisterCustomFontByPath
     };
 
     let prepare_font_registration_argument: Box<dyn Fn(&SmolStr) -> Expression> = if embed_fonts {
@@ -59,7 +59,7 @@ pub fn collect_custom_fonts<'a>(
     for c in doc.exported_roots() {
         c.init_code.borrow_mut().font_registration_code.extend(all_fonts.iter().map(|font_path| {
             Expression::FunctionCall {
-                function: Box::new(registration_function.clone()),
+                function: registration_function.clone().into(),
                 arguments: vec![prepare_font_registration_argument(font_path)],
                 source_location: None,
             }

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -148,10 +148,7 @@ fn simplify_expression(expr: &mut Expression) -> bool {
             }
             can_inline
         }
-        Expression::CallbackReference { .. } => false,
         Expression::ElementReference { .. } => false,
-        // FIXME
-        Expression::FunctionReference { .. } => false,
         Expression::LayoutCacheAccess { .. } => false,
         Expression::SolveLayout { .. } => false,
         Expression::ComputeLayoutInfo { .. } => false,

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -443,10 +443,7 @@ fn make_default_aspect_ratio_preserving_binding(
             Expression::StoreLocalVariable {
                 name: "image_implicit_size".into(),
                 value: Box::new(Expression::FunctionCall {
-                    function: Box::new(Expression::BuiltinFunctionReference(
-                        BuiltinFunction::ImageSize,
-                        None,
-                    )),
+                    function: BuiltinFunction::ImageSize.into(),
                     arguments: vec![Expression::PropertyReference(NamedReference::new(
                         elem,
                         SmolStr::new_static("source"),
@@ -514,10 +511,7 @@ fn adjust_image_clip_rect(elem: &ElementRc, builtin: &Rc<BuiltinElement>) {
         let make_expr = |dim: &str, prop: NamedReference| Expression::BinaryExpression {
             lhs: Box::new(Expression::StructFieldAccess {
                 base: Box::new(Expression::FunctionCall {
-                    function: Box::new(Expression::BuiltinFunctionReference(
-                        BuiltinFunction::ImageSize,
-                        None,
-                    )),
+                    function: BuiltinFunction::ImageSize.into(),
                     arguments: vec![Expression::PropertyReference(source.clone())],
                     source_location: None,
                 }),

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -265,10 +265,7 @@ fn embed_glyphs_with_fontdb<'a>(
 
         for c in doc.exported_roots() {
             c.init_code.borrow_mut().font_registration_code.push(Expression::FunctionCall {
-                function: Box::new(Expression::BuiltinFunctionReference(
-                    BuiltinFunction::RegisterBitmapFont,
-                    None,
-                )),
+                function: BuiltinFunction::RegisterBitmapFont.into(),
                 arguments: vec![Expression::NumberLiteral(resource_id as _, Unit::None)],
                 source_location: None,
             });

--- a/internal/compiler/passes/lower_absolute_coordinates.rs
+++ b/internal/compiler/passes/lower_absolute_coordinates.rs
@@ -43,10 +43,7 @@ pub fn lower_absolute_coordinates(component: &Rc<Component>) {
             Expression::StoreLocalVariable {
                 name: "parent_position".into(),
                 value: Expression::FunctionCall {
-                    function: Box::new(Expression::BuiltinFunctionReference(
-                        BuiltinFunction::ItemAbsolutePosition,
-                        None,
-                    )),
+                    function: BuiltinFunction::ItemAbsolutePosition.into(),
                     arguments: vec![Expression::ElementReference(Rc::downgrade(&elem))],
                     source_location: None,
                 }

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -68,7 +68,7 @@
 //!
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
-use crate::expression_tree::{BuiltinFunction, Expression, NamedReference};
+use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference};
 use crate::langtype::{ElementType, Type};
 use crate::object_tree::*;
 use core::cell::RefCell;
@@ -189,11 +189,7 @@ fn process_context_menu(
     // generate the show callback
     let source_location = Some(context_menu_elem.borrow().to_source_location());
     let expr = Expression::FunctionCall {
-        function: Expression::BuiltinFunctionReference(
-            BuiltinFunction::ShowPopupMenu,
-            source_location.clone(),
-        )
-        .into(),
+        function: BuiltinFunction::ShowPopupMenu.into(),
         arguments: vec![
             Expression::ElementReference(Rc::downgrade(context_menu_elem)),
             Expression::PropertyReference(NamedReference::new(
@@ -267,11 +263,7 @@ fn process_window(
             model: Expression::UnaryOp {
                 op: '!',
                 sub: Expression::FunctionCall {
-                    function: Expression::BuiltinFunctionReference(
-                        BuiltinFunction::SupportsNativeMenuBar,
-                        None,
-                    )
-                    .into(),
+                    function: BuiltinFunction::SupportsNativeMenuBar.into(),
                     arguments: vec![],
                     source_location: None,
                 }
@@ -307,7 +299,7 @@ fn process_window(
         let nr = NamedReference::new(&menu_bar, SmolStr::new_static(prop));
         let forward_expr = if let Type::Callback(cb) = &ty {
             Expression::FunctionCall {
-                function: Expression::CallbackReference(nr, None).into(),
+                function: Callable::Callback(nr),
                 arguments: cb
                     .args
                     .iter()
@@ -335,24 +327,20 @@ fn process_window(
     menu_bar.borrow_mut().children = vec![menubar_impl, child];
 
     let setup_menubar = Expression::FunctionCall {
-        function: Expression::BuiltinFunctionReference(
-            BuiltinFunction::SetupNativeMenuBar,
-            source_location.clone(),
-        )
-        .into(),
+        function: BuiltinFunction::SetupNativeMenuBar.into(),
         arguments: vec![
             Expression::PropertyReference(NamedReference::new(
                 &menu_bar,
                 SmolStr::new_static(ENTRIES),
             )),
-            Expression::CallbackReference(
-                NamedReference::new(&menu_bar, SmolStr::new_static(SUB_MENU)),
-                None,
-            ),
-            Expression::CallbackReference(
-                NamedReference::new(&menu_bar, SmolStr::new_static(ACTIVATED)),
-                None,
-            ),
+            Expression::PropertyReference(NamedReference::new(
+                &menu_bar,
+                SmolStr::new_static(SUB_MENU),
+            )),
+            Expression::PropertyReference(NamedReference::new(
+                &menu_bar,
+                SmolStr::new_static(ACTIVATED),
+            )),
         ],
         source_location: source_location.clone(),
     };

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -219,9 +219,11 @@ fn expression_for_property(element: &ElementRc, name: &str) -> ExpressionForProp
                     // Check that the expression is valid in the new scope
                     let mut has_invalid = false;
                     expr.visit_recursive_mut(&mut |ex| match ex {
-                        Expression::CallbackReference(nr, _)
-                        | Expression::PropertyReference(nr)
-                        | Expression::FunctionReference(nr, _) => {
+                        Expression::PropertyReference(nr)
+                        | Expression::FunctionCall {
+                            function: Callable::Callback(nr) | Callable::Function(nr),
+                            ..
+                        } => {
                             let e = nr.element();
                             if Rc::ptr_eq(&e, &elem) {
                                 *nr = NamedReference::new(element, nr.name().clone());

--- a/internal/compiler/passes/lower_text_input_interface.rs
+++ b/internal/compiler/passes/lower_text_input_interface.rs
@@ -13,11 +13,7 @@ pub fn lower_text_input_interface(component: &Rc<Component>) {
         e.visit_recursive_mut(&mut |e| match e {
             Expression::PropertyReference(nr) if is_input_text_focused_prop(nr) => {
                 *e = Expression::FunctionCall {
-                    function: Expression::BuiltinFunctionReference(
-                        BuiltinFunction::TextInputFocused,
-                        None,
-                    )
-                    .into(),
+                    function: BuiltinFunction::TextInputFocused.into(),
                     arguments: vec![],
                     source_location: None,
                 };
@@ -26,11 +22,7 @@ pub fn lower_text_input_interface(component: &Rc<Component>) {
                 if matches!(&**lhs, Expression::PropertyReference(nr)  if is_input_text_focused_prop(nr) ) {
                     let rhs = std::mem::take(&mut **rhs);
                     *e = Expression::FunctionCall {
-                        function: Expression::BuiltinFunctionReference(
-                            BuiltinFunction::SetTextInputFocused,
-                            None,
-                        )
-                        .into(),
+                        function: BuiltinFunction::SetTextInputFocused.into(),
                         arguments: vec![rhs],
                         source_location: None,
                     };

--- a/internal/compiler/passes/lower_timers.rs
+++ b/internal/compiler/passes/lower_timers.rs
@@ -67,7 +67,7 @@ fn lower_timer(
         triggered: NamedReference::new(timer_element, SmolStr::new_static("triggered")),
     });
     let update_timers = Expression::FunctionCall {
-        function: Expression::BuiltinFunctionReference(BuiltinFunction::UpdateTimers, None).into(),
+        function: BuiltinFunction::UpdateTimers.into(),
         arguments: vec![],
         source_location: None,
     };

--- a/internal/compiler/tests/syntax/expressions/clamp.slint
+++ b/internal/compiler/tests/syntax/expressions/clamp.slint
@@ -29,7 +29,7 @@ export component SuperSimple {
 //                          ^error{`clamp` needs three values}
 
     property <float> h: ok1.clamp;
-//                          ^error{Member function must be called}
+//                      ^error{Member function must be called}
 
     property <float> i: 42.0.clamp;
 //                           ^error{Member function must be called}

--- a/internal/compiler/tests/syntax/expressions/math-macro.slint
+++ b/internal/compiler/tests/syntax/expressions/math-macro.slint
@@ -58,6 +58,4 @@ export component Foo {
 
     property <float> sq2: 1.0.sqrt;
     //                        ^error{Member function must be called}
-    //                    ^^error{Cannot convert function\(float\) -> float to float}
-
 }

--- a/internal/compiler/tests/syntax/focus/focus_not_called.slint
+++ b/internal/compiler/tests/syntax/focus/focus_not_called.slint
@@ -27,15 +27,13 @@ export X := Rectangle {
     TouchArea {
         clicked => {
             (edit.focus)();
-//           ^error{'edit.focus' must be called. Did you forgot the '\(\)'\?}
+//           ^error{Member function must be called. Did you forgot the '\(\)'\?}
             edit.focus;
-//          ^error{'edit.focus' must be called. Did you forgot the '\(\)'\?}
+//          ^error{Member function must be called. Did you forgot the '\(\)'\?}
         }
     }
     x: edit.focus;
-//     ^error{Cannot convert function\(element ref\) -> void to length}
-//     ^^error{'edit.focus' must be called. Did you forgot the '\(\)'\?}
-//          ^^^warning{Call of impure function}
+//     ^error{Member function must be called. Did you forgot the '\(\)'\?}
 
     BadOne {}
     SecondBadOne {}

--- a/internal/compiler/tests/syntax/functions/functions_call.slint
+++ b/internal/compiler/tests/syntax/functions/functions_call.slint
@@ -54,7 +54,7 @@ export Xxx := Rectangle {
         45()()();
 //      ^error{The expression is not a function}
         (foo)(1);
-//       ^error{'foo' must be called. Did you forgot the '\(\)'}
+//       ^error{Function must be called. Did you forgot the '\(\)'}
 
     }
 

--- a/internal/compiler/tests/syntax/functions/functions_purity_recursive_5220.slint
+++ b/internal/compiler/tests/syntax/functions/functions_purity_recursive_5220.slint
@@ -3,14 +3,10 @@
 
 export component App inherits Window{
     background: blue;
-    //          ^error{'blue' must be called}
-    //          ^^error{Cannot convert function\(\) -> color to brush}
+    //          ^error{Function must be called}
     function blue()->color {
-//  ^error{The binding for the property 'blue' is part of a binding loop}
-//  ^^error{Cannot convert function\(\) -> color to color}
-
        blue
-//     ^error{'blue' must be called}
+//     ^error{Function must be called}
     }
 
 

--- a/internal/compiler/tests/syntax/fuzzing/6650.slint
+++ b/internal/compiler/tests/syntax/fuzzing/6650.slint
@@ -11,12 +11,12 @@ export component Foo {
     TouchArea{
         function abc(x:int){}
         clicked=>{abc[9]()}
-//                ^error{'abc' must be called. Did you forgot the '\(\)'?}
+//                ^error{Function must be called. Did you forgot the '\(\)'?}
     }
 
     TouchArea{
         clicked=>{self.moved[9]()}
-//                ^error{'self.moved' must be called. Did you forgot the '\(\)'?}
+//                ^error{Callback must be called. Did you forgot the '\(\)'?}
     }
 }
 

--- a/internal/compiler/tests/syntax/lookup/callback_not_called.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_not_called.slint
@@ -6,7 +6,7 @@ export Demo := Window {
     TouchArea {
         clicked => {
             root
-//          ^error{'root.foobar' must be called. Did you forgot the '\(\)'\?}
+//          ^error{Callback must be called. Did you forgot the '\(\)'\?}
                 .foobar
         }
     }

--- a/internal/compiler/tests/syntax/lookup/color.slint
+++ b/internal/compiler/tests/syntax/lookup/color.slint
@@ -44,11 +44,11 @@ export X := Rectangle {
         property<color> c2: rgb(45);
 //                          ^error{This function needs 3 or 4 arguments, but 1 were provided}
         property<color> c3: Colors.rgb(45,45);
-//                          ^error{This function needs 3 or 4 arguments, but 2 were provided}
+//                                 ^error{This function needs 3 or 4 arguments, but 2 were provided}
         property<color> c4: Colors.rgba(1,2,3,4,5);
-//                          ^error{This function needs 3 or 4 arguments, but 5 were provided}
+//                                 ^error{This function needs 3 or 4 arguments, but 5 were provided}
         property<color> c5: Colors.hsv(1,2,3,4,5);
-//                          ^error{This function needs 3 or 4 arguments, but 5 were provided}
+//                                 ^error{This function needs 3 or 4 arguments, but 5 were provided}
 
 
     }

--- a/internal/compiler/tests/syntax/lookup/conversion.slint
+++ b/internal/compiler/tests/syntax/lookup/conversion.slint
@@ -62,5 +62,4 @@ export X := Rectangle {
 
     property <int> to-float: "foobar".to-float;
 //                                    ^error{Member function must be called}
-//                           ^^error{Cannot convert function\(string\) -> float to int}
 }

--- a/internal/compiler/tests/syntax/lookup/signal_arg.slint
+++ b/internal/compiler/tests/syntax/lookup/signal_arg.slint
@@ -23,12 +23,11 @@ export Xxx := Rectangle {
 //      ^error{The expression is not a function}
 //                ^^error{Unknown unqualified identifier 'fff'}
         (plop)("45", #fff, 42);
-//       ^error{'plop' must be called. Did you forgot the '\(\)'\?}
+//       ^error{Callback must be called. Did you forgot the '\(\)'\?}
         (root.plop)("45", #fff, 42);
-//       ^error{'root.plop' must be called. Did you forgot the '\(\)'\?}
+//       ^error{Callback must be called. Did you forgot the '\(\)'\?}
         (root.plop)("45", #fff, "45");
-//       ^error{'root.plop' must be called. Did you forgot the '\(\)'\?}
-//                              ^^error{Cannot convert string to int}
+//       ^error{Callback must be called. Did you forgot the '\(\)'\?}
     }
 
     x: 12phx;

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -506,12 +506,7 @@ impl TypeRegister {
             property_visibility: PropertyVisibility::Output,
             default_value: BuiltinPropertyDefault::Fn(|elem| {
                 crate::expression_tree::Expression::FunctionCall {
-                    function: Box::new(
-                        crate::expression_tree::Expression::BuiltinFunctionReference(
-                            BuiltinFunction::ItemFontMetrics,
-                            None,
-                        ),
-                    ),
+                    function: BuiltinFunction::ItemFontMetrics.into(),
                     arguments: vec![crate::expression_tree::Expression::ElementReference(
                         Rc::downgrade(elem),
                     )],

--- a/tools/lsp/common/token_info.rs
+++ b/tools/lsp/common/token_info.rs
@@ -3,9 +3,9 @@
 
 use crate::common;
 use i_slint_compiler::diagnostics::Spanned;
-use i_slint_compiler::expression_tree::Expression;
+use i_slint_compiler::expression_tree::{Callable, Expression};
 use i_slint_compiler::langtype::{ElementType, EnumerationValue, Type};
-use i_slint_compiler::lookup::{LookupObject, LookupResult};
+use i_slint_compiler::lookup::{LookupObject, LookupResult, LookupResultCallable};
 use i_slint_compiler::namedreference::NamedReference;
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{syntax_nodes, SyntaxKind, SyntaxToken};
@@ -86,10 +86,7 @@ pub fn token_info(document_cache: &common::DocumentCache, token: SyntaxToken) ->
                             ..
                         } => Some(TokenInfo::ElementRc(e.upgrade()?)),
                         LookupResult::Expression {
-                            expression:
-                                Expression::CallbackReference(nr, _)
-                                | Expression::PropertyReference(nr)
-                                | Expression::FunctionReference(nr, _),
+                            expression: Expression::PropertyReference(nr),
                             ..
                         } => Some(TokenInfo::NamedReference(nr)),
                         LookupResult::Expression {
@@ -97,6 +94,9 @@ pub fn token_info(document_cache: &common::DocumentCache, token: SyntaxToken) ->
                             ..
                         } => Some(TokenInfo::EnumerationValue(v)),
                         LookupResult::Enumeration(e) => Some(TokenInfo::Type(Type::Enumeration(e))),
+                        LookupResult::Callable(LookupResultCallable::Callable(
+                            Callable::Callback(nr) | Callable::Function(nr),
+                        )) => Some(TokenInfo::NamedReference(nr)),
                         _ => return None,
                     }
                 }

--- a/tools/updater/experiments/lookup_changes.rs
+++ b/tools/updater/experiments/lookup_changes.rs
@@ -4,9 +4,9 @@
 use crate::Cli;
 use by_address::ByAddress;
 use i_slint_compiler::{
-    expression_tree::Expression,
+    expression_tree::{Callable, Expression},
     langtype::Type,
-    lookup::{LookupCtx, LookupObject, LookupResult},
+    lookup::{LookupCtx, LookupObject, LookupResult, LookupResultCallable},
     namedreference::NamedReference,
     object_tree::ElementRc,
     parser::{SyntaxKind, SyntaxNode},
@@ -125,13 +125,12 @@ fn fully_qualify_property_access(
         ctx.current_token = Some(first.clone().into());
         let global_lookup = i_slint_compiler::lookup::global_lookup();
         match global_lookup.lookup(ctx, &first_str) {
-            Some(LookupResult::Expression {
-                expression:
-                    Expression::PropertyReference(nr)
-                    | Expression::CallbackReference(nr, _)
-                    | Expression::FunctionReference(nr, _),
-                ..
-            }) => {
+            Some(
+                LookupResult::Expression { expression: Expression::PropertyReference(nr), .. }
+                | LookupResult::Callable(LookupResultCallable::Callable(
+                    Callable::Callback(nr) | Callable::Function(nr),
+                )),
+            ) => {
                 if let Some(new_name) = state.lookup_change.property_mappings.get(&nr) {
                     write!(file, "root.{new_name} ")?;
                     Ok(true)


### PR DESCRIPTION
Have a special node for them in FunctionCall


