### PR TITLE
MenuBar/ContextMenu: hide the `entries` interface

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -198,30 +198,39 @@ component MenuItem {
 component MenuBar {
     //-is_non_item_type
     //-disallow_global_types_as_child_elements
-    in property <[MenuEntry]> entries;
-
-    callback activated(entry: MenuEntry);
-    callback sub-menu(entry: MenuEntry) -> [MenuEntry];
 
     MenuItem {}
 
     // Currently experimental
 }
 
-// Lowered in lower_menus pass. See that pass documentation for more info
-export component ContextMenu {
+
+
+// The NativeItem, exported as ContextMenuInternal for the style
+component ContextMenu inherits Empty {
+    callback activated(entry: MenuEntry);
+    callback sub-menu(entry: MenuEntry) -> [MenuEntry];
+    callback show(position: Point);
+}
+
+// Lowered in lower_menus pass.
+export component ContextMenuInternal inherits ContextMenu {
+    in property <[MenuEntry]> entries;
+    //-default_size_binding:expands_to_parent_geometry
+    //-is_internal
+}
+
+// The public ContextMenu which is lowered in the lower_menus pass. See that pass documentation for more info
+// Note that this element cannot be named `ContextMenu` because that's the same name as a native item,
+// and the load_builtins code doesn't allow that. So use a placeholder name and re-export under `ContextMenu`
+component ActualContextMenuElement inherits Empty {
     // This is actually function as part of out interface, but a callback as much is the runtime concerned
     callback show(position: Point);
-    // Note that this property is not in the native item
-    in property <[MenuEntry]> entries;
-    callback activated(entry: MenuEntry);
-    callback sub-menu(entry: MenuEntry) -> [MenuEntry];
     //-default_size_binding:expands_to_parent_geometry
-
     MenuItem {}
-
-    // Currently experimental
 }
+
+export { ActualContextMenuElement as ContextMenu }
 
 component WindowItem {
     in-out property <length> width;

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -345,10 +345,7 @@ fn process_window(
             .property_declarations
             .insert(prop.into(), PropertyDeclaration { property_type: ty, ..Default::default() });
         if let Some(old) = old {
-            diag.push_error(
-                format!("Cannot re-define internal property '{}'", prop),
-                &old.node,
-            );
+            diag.push_error(format!("Cannot re-define internal property '{}'", prop), &old.node);
         }
     }
 

--- a/internal/compiler/tests/syntax/elements/contextmenu.slint
+++ b/internal/compiler/tests/syntax/elements/contextmenu.slint
@@ -7,6 +7,19 @@ export component A  {
 //      ^error{'show' is not a callback in ContextMenu}
             debug("hello");
         }
+
+        MenuItem {
+        }
+
+        property <int> entries: 45;
+//      ^error{Cannot re-define internal property 'entries'}
+        property <int> sub-menu: 45;
+//      ^error{Cannot re-define internal property 'sub-menu'}
+        property <string> activated: "me";
+//      ^error{Cannot re-define internal property 'activated'}
+
+        property <string> xyz: "me";
+
     }
 }
 

--- a/internal/compiler/tests/syntax/elements/contextmenu2.slint
+++ b/internal/compiler/tests/syntax/elements/contextmenu2.slint
@@ -1,0 +1,42 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component A  {
+    cb := ContextMenu {
+        entries: [];
+//      ^error{Unknown property entries in ContextMenu}
+        sub-menu => {
+//      ^error{'sub-menu' is not a callback in ContextMenu}
+            debug("hello");
+        }
+
+        MenuItem {
+            entries: [];
+//          ^error{Unknown property entries in MenuItem}
+            MenuItem {
+                title: "ok";
+                sub-menu => {}
+//              ^error{'sub-menu' is not a callback in MenuItem}
+                x: 45px;
+//              ^error{Unknown property x in MenuItem}
+                col: 45;
+//              ^error{Unknown property col in MenuItem}
+            }
+        }
+    }
+
+    TouchArea {
+        clicked => {
+            cb.activated({});
+//             ^error{Element 'ContextMenu' does not have a property 'activated'}
+            debug(cb.entries);
+//                   ^error{Element 'ContextMenu' does not have a property 'entries'}
+        }
+    }
+
+
+    ContextMenuInternal {
+//  ^error{Unknown element 'ContextMenuInternal'}
+    }
+}
+

--- a/internal/compiler/tests/syntax/elements/menubar.slint
+++ b/internal/compiler/tests/syntax/elements/menubar.slint
@@ -4,6 +4,11 @@
 
 export component A inherits Window {
     mb := MenuBar {
+        property <int> sub-menu: 45;
+//      ^error{Cannot re-define internal property 'sub-menu}
+
+        property <int> entries: 0;
+//      ^error{Cannot re-define internal property 'entries'}
     }
     MenuBar {
 //  ^error{Only one MenuBar is allowed in a Window}

--- a/internal/compiler/tests/syntax/elements/menubar2.slint
+++ b/internal/compiler/tests/syntax/elements/menubar2.slint
@@ -7,7 +7,7 @@ export component MyMenu inherits MenuBar {
 }
 
 export component A inherits Window {
-    MenuBar {
+    mb := MenuBar {
         Rectangle {}
 //      ^error{Rectangle is not allowed within MenuBar. Only MenuItem are valid children}
         x: 45px;
@@ -15,6 +15,7 @@ export component A inherits Window {
         width: 45px;
 //      ^error{Unknown property width in MenuBar}
         entries: [];
+//      ^error{Unknown property entries in MenuBar}
         init => {}
 //      ^error{'init' is not a callback in MenuBar}
 
@@ -31,7 +32,10 @@ export component A inherits Window {
             }
 
             MenuItem {
-
+                activated => {
+                        mb.activated({});
+//                         ^error{Element 'MenuBar' does not have a property 'activated'}
+                }
             }
 
         }

--- a/internal/compiler/widgets/common/menus.slint
+++ b/internal/compiler/widgets/common/menus.slint
@@ -55,7 +55,7 @@ export component PopupMenuImpl inherits Window {
         }
     }
 
-    subMenu := ContextMenu {
+    subMenu := ContextMenuInternal {
         x: 0; y: 0; width: 0; height: 0;
         sub-menu(entry) => { root.sub-menu(entry); }
         activated(entry) => { root.activated(entry); }
@@ -106,7 +106,7 @@ export component MenuBarImpl {
     }
 
 
-    cm := ContextMenu {
+    cm := ContextMenuInternal {
         activated(entry) => { root.activated(entry); }
         sub-menu(entry) => { root.sub-menu(entry); }
     }

--- a/tests/cases/widgets/contextmenu.slint
+++ b/tests/cases/widgets/contextmenu.slint
@@ -56,8 +56,9 @@ export component TestCase inherits Window {
         }
 
         // When this focus scope has the focus, the ContextMenu can handle the Menu key
-        FocusScope {}
+        fs := FocusScope {}
     }
+
 
     out property <bool> test: true;
 }


### PR DESCRIPTION
This can only be used internally by the style to implement the actual ContextMenu

Only the declarative `MenuItem` interface is exposed.
