### PR TITLE
LLR Refactor: Try to make the LLR easier to work with

### DIFF
--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -13,6 +13,8 @@ use std::rc::Rc;
 pub type PropertyIndex = usize;
 // Index in CompilationUint::sub_components
 pub type SubComponentIndex = usize;
+// Index in CompilationUnit::globas
+pub type GlobalIndex = usize;
 
 #[derive(Debug, Clone, derive_more::Deref)]
 pub struct MutExpression(RefCell<Expression>);
@@ -94,12 +96,12 @@ pub enum PropertyReference {
     /// The properties is a property relative to a parent ItemTree (`level` level deep)
     InParent { level: NonZeroUsize, parent_reference: Box<PropertyReference> },
     /// The property within a GlobalComponent
-    Global { global_index: usize, property_index: usize },
+    Global { global_index: GlobalIndex, property_index: usize },
 
     /// A function in a sub component.
     Function { sub_component_path: Vec<usize>, function_index: usize },
     /// A function in a global.
-    GlobalFunction { global_index: usize, function_index: usize },
+    GlobalFunction { global_index: GlobalIndex, function_index: usize },
 }
 
 #[derive(Debug, Default)]
@@ -437,8 +439,8 @@ impl CompilationUnit {
                 visitor(e, ctx);
             }
         });
-        for g in &self.globals {
-            let ctx = EvaluationContext::new_global(self, g, ());
+        for (idx, g) in self.globals.iter().enumerate() {
+            let ctx = EvaluationContext::new_global(self, idx, ());
             for e in g.init_values.iter().filter_map(|x| x.as_ref()) {
                 visitor(&e.expression, &ctx)
             }

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -20,11 +20,17 @@ use crate::namedreference::NamedReference;
 use crate::object_tree::{Element, ElementRc, PropertyAnimation};
 use crate::typeregister::BUILTIN;
 
-pub struct ExpressionContext<'a> {
+pub struct ExpressionContextInner<'a> {
     pub component: &'a Rc<crate::object_tree::Component>,
+    /// The mapping for the current component
     pub mapping: &'a LoweredSubComponentMapping,
-    pub state: &'a LoweringState,
-    pub parent: Option<&'a ExpressionContext<'a>>,
+    pub parent: Option<&'a ExpressionContextInner<'a>>,
+}
+#[derive(derive_more::Deref)]
+pub struct ExpressionContext<'a> {
+    pub state: &'a mut LoweringState,
+    #[deref]
+    pub inner: ExpressionContextInner<'a>,
 }
 
 impl ExpressionContext<'_> {
@@ -32,7 +38,7 @@ impl ExpressionContext<'_> {
         let element = from.element();
         let enclosing = &element.borrow().enclosing_component.upgrade().unwrap();
         if !enclosing.is_global() {
-            let mut map = self;
+            let mut map = &self.inner;
             let mut level = 0;
             while !Rc::ptr_eq(enclosing, map.component) {
                 map = map.parent.unwrap();

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -14,7 +14,7 @@ pub fn count_property_use(root: &CompilationUnit) {
     // Visit the root properties that are used.
     // 1. the public properties
     for c in &root.public_components {
-        let root_ctx = EvaluationContext::new_sub_component(root, &c.item_tree.root, (), None);
+        let root_ctx = EvaluationContext::new_sub_component(root, c.item_tree.root, (), None);
         for p in c.public_properties.iter().filter(|p| {
             !matches!(
                 p.prop,
@@ -43,7 +43,7 @@ pub fn count_property_use(root: &CompilationUnit) {
                 PropertyReference::Local { sub_component_path, property_index } => {
                     let mut sc = sc;
                     for i in sub_component_path {
-                        sc = &sc.sub_components[*i].ty;
+                        sc = &ctx.compilation_unit.sub_components[sc.sub_components[*i].ty];
                     }
                     if sc.properties[*property_index].use_count.get() == 0 {
                         continue;
@@ -74,7 +74,7 @@ pub fn count_property_use(root: &CompilationUnit) {
 
                 let rep_ctx = EvaluationContext::new_sub_component(
                     root,
-                    &r.sub_tree.root,
+                    r.sub_tree.root,
                     (),
                     Some(ParentCtx::new(ctx, Some(idx as u32))),
                 );
@@ -83,7 +83,7 @@ pub fn count_property_use(root: &CompilationUnit) {
             }
             for idx in r.data_prop.iter().chain(r.index_prop.iter()) {
                 // prevent optimizing model properties
-                let p = &r.sub_tree.root.properties[*idx];
+                let p = &root.sub_components[r.sub_tree.root].properties[*idx];
                 p.use_count.set(2);
             }
         }
@@ -121,7 +121,7 @@ pub fn count_property_use(root: &CompilationUnit) {
         for popup in &sc.popup_windows {
             let popup_ctx = EvaluationContext::new_sub_component(
                 root,
-                &popup.item_tree.root,
+                popup.item_tree.root,
                 (),
                 Some(ParentCtx::new(&ctx, None)),
             );
@@ -144,7 +144,7 @@ pub fn count_property_use(root: &CompilationUnit) {
     }
 
     if let Some(p) = &root.popup_menu {
-        let ctx = EvaluationContext::new_sub_component(&root, &p.item_tree.root, (), None);
+        let ctx = EvaluationContext::new_sub_component(&root, p.item_tree.root, (), None);
         visit_property(&p.entries, &ctx);
         visit_property(&p.sub_menu, &ctx);
         visit_property(&p.activated, &ctx);

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -24,8 +24,8 @@ pub fn count_property_use(root: &CompilationUnit) {
             visit_property(&p.prop, &root_ctx);
         }
     }
-    for g in root.globals.iter().filter(|g| g.exported) {
-        let ctx = EvaluationContext::new_global(root, g, ());
+    for (idx, g) in root.globals.iter().enumerate().filter(|(_, g)| g.exported) {
+        let ctx = EvaluationContext::new_global(root, idx, ());
         for p in g.public_properties.iter().filter(|p| {
             !matches!(
                 p.prop,
@@ -136,8 +136,8 @@ pub fn count_property_use(root: &CompilationUnit) {
     });
 
     // TODO: only visit used function
-    for g in root.globals.iter() {
-        let ctx = EvaluationContext::new_global(root, g, ());
+    for (idx, g) in root.globals.iter().enumerate() {
+        let ctx = EvaluationContext::new_global(root, idx, ());
         for f in &g.functions {
             f.code.visit_property_references(&ctx, &mut visit_property);
         }

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -8,19 +8,11 @@ use itertools::Itertools;
 use crate::expression_tree::MinMaxOp;
 
 use super::{
-    CompilationUnit, EvaluationContext, Expression, ParentCtx, PropertyReference, SubComponent,
+    CompilationUnit, EvaluationContext, Expression, ParentCtx, PropertyReference, SubComponentIndex,
 };
 
 pub fn pretty_print(root: &CompilationUnit, writer: &mut dyn Write) -> Result {
     PrettyPrinter { writer, indentation: 0 }.print_root(root)
-}
-
-pub fn pretty_print_component(
-    root: &CompilationUnit,
-    component: &SubComponent,
-    writer: &mut dyn Write,
-) -> Result {
-    PrettyPrinter { writer, indentation: 0 }.print_component(root, component, None)
 }
 
 struct PrettyPrinter<'a> {
@@ -35,22 +27,21 @@ impl<'a> PrettyPrinter<'a> {
                 self.print_global(root, g)?;
             }
         }
-        for c in &root.sub_components {
+        for c in 0..root.sub_components.len() {
             self.print_component(root, c, None)?
         }
-        for p in &root.public_components {
-            self.print_component(root, &p.item_tree.root, None)?
-        }
+
         Ok(())
     }
 
     fn print_component(
         &mut self,
         root: &CompilationUnit,
-        sc: &SubComponent,
+        sc_idx: SubComponentIndex,
         parent: Option<ParentCtx<'_>>,
     ) -> Result {
-        let ctx = EvaluationContext::new_sub_component(root, sc, (), parent);
+        let ctx = EvaluationContext::new_sub_component(root, sc_idx, (), parent);
+        let sc = &root.sub_components[sc_idx];
         writeln!(self.writer, "component {} {{", sc.name)?;
         self.indentation += 1;
         for p in &sc.properties {
@@ -98,7 +89,7 @@ impl<'a> PrettyPrinter<'a> {
         }
         for ssc in &sc.sub_components {
             self.indent()?;
-            writeln!(self.writer, "{} := {} {{}};", ssc.name, ssc.ty.name)?;
+            writeln!(self.writer, "{} := {} {{}};", ssc.name, root.sub_components[ssc.ty].name)?;
         }
         for (item, geom) in std::iter::zip(&sc.items, &sc.geometries) {
             self.indent()?;
@@ -112,13 +103,13 @@ impl<'a> PrettyPrinter<'a> {
             write!(self.writer, "for in {} : ", DisplayExpression(&r.model.borrow(), &ctx))?;
             self.print_component(
                 root,
-                &r.sub_tree.root,
+                r.sub_tree.root,
                 Some(ParentCtx::new(&ctx, Some(idx as u32))),
             )?
         }
         for w in &sc.popup_windows {
             self.indent()?;
-            self.print_component(root, &w.item_tree.root, Some(ParentCtx::new(&ctx, None)))?
+            self.print_component(root, w.item_tree.root, Some(ParentCtx::new(&ctx, None)))?
         }
         self.indentation -= 1;
         self.indent()?;
@@ -196,19 +187,19 @@ impl<T> Display for DisplayPropertyRef<'_, T> {
                 if let Some(g) = ctx.current_global {
                     write!(f, "{}.{}", g.name, g.properties[*property_index].name)
                 } else {
-                    let mut sc = ctx.current_sub_component.unwrap();
+                    let mut sc = ctx.current_sub_component().unwrap();
                     for i in sub_component_path {
                         write!(f, "{}.", sc.sub_components[*i].name)?;
-                        sc = &sc.sub_components[*i].ty;
+                        sc = &ctx.compilation_unit.sub_components[sc.sub_components[*i].ty];
                     }
                     write!(f, "{}", sc.properties[*property_index].name)
                 }
             }
             PropertyReference::InNativeItem { sub_component_path, item_index, prop_name } => {
-                let mut sc = ctx.current_sub_component.unwrap();
+                let mut sc = ctx.current_sub_component().unwrap();
                 for i in sub_component_path {
                     write!(f, "{}.", sc.sub_components[*i].name)?;
-                    sc = &sc.sub_components[*i].ty;
+                    sc = &ctx.compilation_unit.sub_components[sc.sub_components[*i].ty];
                 }
                 let i = &sc.items[*item_index as usize];
                 write!(f, "{}.{}", i.name, prop_name)
@@ -227,10 +218,10 @@ impl<T> Display for DisplayPropertyRef<'_, T> {
                 if let Some(g) = ctx.current_global {
                     write!(f, "{}.{}", g.name, g.functions[*function_index].name)
                 } else {
-                    let mut sc = ctx.current_sub_component.unwrap();
+                    let mut sc = ctx.current_sub_component().unwrap();
                     for i in sub_component_path {
                         write!(f, "{}.", sc.sub_components[*i].name)?;
-                        sc = &sc.sub_components[*i].ty;
+                        sc = &ctx.compilation_unit.sub_components[sc.sub_components[*i].ty];
                     }
                     write!(f, "{}", sc.functions[*function_index].name)
                 }

--- a/internal/compiler/llr/translations.rs
+++ b/internal/compiler/llr/translations.rs
@@ -387,6 +387,7 @@ mod plural_rule_parser {
                 compilation_unit: &crate::llr::CompilationUnit {
                     public_components: Vec::new(),
                     sub_components: Vec::new(),
+                    used_sub_components: Vec::new(),
                     globals: Vec::new(),
                     has_debug_info: false,
                     translations: None,


### PR DESCRIPTION
I'd like to go in a direction when we can do more pass on the LLR by mutating it. So we can transform earlier in the compilation process to LLR and interpret the LLR.