### PR TITLE
LLR: used typed index for vectors in the LLR

### DIFF
--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -54,6 +54,7 @@ by_address = { workspace = true }
 itertools = { workspace = true }
 url = "2.2.1"
 linked_hash_set = "0.1.4"
+typed-index-collections = "3.2"
 
 # for processing and embedding the rendered image (texture)
 image = { workspace = true, optional = true, features = ["default"] }

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -24,7 +24,7 @@ pub fn count_property_use(root: &CompilationUnit) {
             visit_property(&p.prop, &root_ctx);
         }
     }
-    for (idx, g) in root.globals.iter().enumerate().filter(|(_, g)| g.exported) {
+    for (idx, g) in root.globals.iter_enumerated().filter(|(_, g)| g.exported) {
         let ctx = EvaluationContext::new_global(root, idx, ());
         for p in g.public_properties.iter().filter(|p| {
             !matches!(
@@ -63,7 +63,7 @@ pub fn count_property_use(root: &CompilationUnit) {
             expr.borrow().visit_property_references(ctx, &mut visit_property);
         }
         // 4. the models
-        for (idx, r) in sc.repeated.iter().enumerate() {
+        for (idx, r) in sc.repeated.iter_enumerated() {
             r.model.borrow().visit_property_references(ctx, &mut visit_property);
             if let Some(lv) = &r.listview {
                 visit_property(&lv.viewport_y, ctx);
@@ -76,7 +76,7 @@ pub fn count_property_use(root: &CompilationUnit) {
                     root,
                     r.sub_tree.root,
                     (),
-                    Some(ParentCtx::new(ctx, Some(idx as u32))),
+                    Some(ParentCtx::new(ctx, Some(idx))),
                 );
                 visit_property(&lv.prop_y, &rep_ctx);
                 visit_property(&lv.prop_height, &rep_ctx);
@@ -136,7 +136,7 @@ pub fn count_property_use(root: &CompilationUnit) {
     });
 
     // TODO: only visit used function
-    for (idx, g) in root.globals.iter().enumerate() {
+    for (idx, g) in root.globals.iter_enumerated() {
         let ctx = EvaluationContext::new_global(root, idx, ());
         for f in &g.functions {
             f.code.visit_property_references(&ctx, &mut visit_property);

--- a/internal/compiler/llr/translations.rs
+++ b/internal/compiler/llr/translations.rs
@@ -385,10 +385,10 @@ mod plural_rule_parser {
         fn p(string: &str) -> String {
             let ctx = crate::llr::EvaluationContext {
                 compilation_unit: &crate::llr::CompilationUnit {
-                    public_components: Vec::new(),
-                    sub_components: Vec::new(),
-                    used_sub_components: Vec::new(),
-                    globals: Vec::new(),
+                    public_components: Default::default(),
+                    sub_components: Default::default(),
+                    used_sub_components: Default::default(),
+                    globals: Default::default(),
                     has_debug_info: false,
                     translations: None,
                     popup_menu: None,


### PR DESCRIPTION
type-safety+=1

This would avoid for example using a sub-component index in an array of instances or items.
It also self-document what the index is for.

There are still a couple of cast from repeater-index to u32 because we do some hack with the repeater-index number for component containers We also cast back to numbers in order to convert it to string in the generated code.
