### PR TITLE
The links to the STM templates are broken.

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -104,14 +104,15 @@ jobs:
                 if [ "$RELEASE_INPUT" != "true" ]; then
                     base_url="https://snapshots.slint.dev"
                     base_path="/master/docs/slint/"
-                    slint_version=${{ steps.version.outputs.VERSION }}
+                    slint_download_version=nightly
                 else
                     base_url="https://releases.slint.dev"
                     base_path="/${{ steps.version.outputs.VERSION }}/docs/slint/"
+                    slint_download_version=v${{ steps.version.outputs.VERSION }}
                 fi
                 sed -i "s|BASE_URL = \".*\"|BASE_URL = \"$base_url\"|" docs/astro/src/utils/site-config.ts
                 sed -i "s|BASE_PATH = \".*\"|BASE_PATH = \"$base_path\"|" docs/astro/src/utils/site-config.ts
-                sed -i "s|SLINT_VERSION = \".*\"|SLINT_VERSION = \"$slint_version\"|" docs/astro/src/utils/site-config.ts
+                sed -i "s|SLINT_DOWNLOAD_VERSION = \".*\"| SLINT_DOWNLOAD_VERSION = \"$slint_download_version\"|" docs/astro/src/utils/site-config.ts
             - name: "Slint Language Documentation"
               run: cargo xtask slintdocs
             - name: Spellcheck

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -104,12 +104,14 @@ jobs:
                 if [ "$RELEASE_INPUT" != "true" ]; then
                     base_url="https://snapshots.slint.dev"
                     base_path="/master/docs/slint/"
+                    slint_version=${{ steps.version.outputs.VERSION }}
                 else
                     base_url="https://releases.slint.dev"
                     base_path="/${{ steps.version.outputs.VERSION }}/docs/slint/"
                 fi
                 sed -i "s|BASE_URL = \".*\"|BASE_URL = \"$base_url\"|" docs/astro/src/utils/site-config.ts
                 sed -i "s|BASE_PATH = \".*\"|BASE_PATH = \"$base_path\"|" docs/astro/src/utils/site-config.ts
+                sed -i "s|SLINT_VERSION = \".*\"|SLINT_VERSION = \"$slint_version\"|" docs/astro/src/utils/site-config.ts
             - name: "Slint Language Documentation"
               run: cargo xtask slintdocs
             - name: Spellcheck

--- a/docs/astro/src/components/ReleaseLink.astro
+++ b/docs/astro/src/components/ReleaseLink.astro
@@ -2,7 +2,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-import { SLINT_VERSION } from "../utils/site-config.ts";
+import { SLINT_DOWNLOAD_VERSION } from "../utils/site-config.ts";
 
 const LINK_MAP = {
     "slint-cpp-template-stm32h735g-dk.zip": `https://github.com/slint-ui/slint/releases/download/${SLINT_DOWNLOAD_VERSION}/slint-cpp-template-stm32h735g-dk.zip`,

--- a/docs/astro/src/components/ReleaseLink.astro
+++ b/docs/astro/src/components/ReleaseLink.astro
@@ -10,7 +10,6 @@ type linkID =
 
 interface Props {
     id: linkID;
-
 }
 
 const { id } = Astro.props as Props;
@@ -19,8 +18,6 @@ const link = {
     "slint-cpp-template-stm32h735g-dk.zip": `https://github.com/slint-ui/slint/releases/download/v${SLINT_VERSION}/slint-cpp-template-stm32h735g-dk.zip`,
     "slint-cpp-template-stm32h747i-disco.zip": `https://github.com/slint-ui/slint/releases/download/v${SLINT_VERSION}/slint-cpp-template-stm32h747i-disco.zip`,
 }[id];
-
-
 ---
 
 <a href={link}><span>{id}</span></a>

--- a/docs/astro/src/components/ReleaseLink.astro
+++ b/docs/astro/src/components/ReleaseLink.astro
@@ -5,8 +5,8 @@
 import { SLINT_VERSION } from "../utils/site-config.ts";
 
 const LINK_MAP = {
-    "slint-cpp-template-stm32h735g-dk.zip": `https://github.com/slint-ui/slint/releases/download/v${SLINT_VERSION}/slint-cpp-template-stm32h735g-dk.zip`,
-    "slint-cpp-template-stm32h747i-disco.zip": `https://github.com/slint-ui/slint/releases/download/v${SLINT_VERSION}/slint-cpp-template-stm32h747i-disco.zip`,
+    "slint-cpp-template-stm32h735g-dk.zip": `https://github.com/slint-ui/slint/releases/download/${SLINT_DOWNLOAD_VERSION}/slint-cpp-template-stm32h735g-dk.zip`,
+    "slint-cpp-template-stm32h747i-disco.zip": `https://github.com/slint-ui/slint/releases/download/${SLINT_DOWNLOAD_VERSION}/slint-cpp-template-stm32h747i-disco.zip`,
 } as const;
 
 type LinkID = keyof typeof LINK_MAP;

--- a/docs/astro/src/components/ReleaseLink.astro
+++ b/docs/astro/src/components/ReleaseLink.astro
@@ -1,0 +1,27 @@
+---
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { SLINT_VERSION } from "../utils/site-config.ts";
+
+type linkID =
+    | "slint-cpp-template-stm32h735g-dk.zip"
+    | "slint-cpp-template-stm32h747i-disco.zip";
+
+interface Props {
+    id: linkID;
+
+}
+
+const { id } = Astro.props as Props;
+
+const link = {
+    "slint-cpp-template-stm32h735g-dk.zip": `https://github.com/slint-ui/slint/releases/download/v${SLINT_VERSION}/slint-cpp-template-stm32h735g-dk.zip`,
+    "slint-cpp-template-stm32h747i-disco.zip": `https://github.com/slint-ui/slint/releases/download/v${SLINT_VERSION}/slint-cpp-template-stm32h747i-disco.zip`,
+}[id];
+
+
+---
+
+<a href={link}><span>{id}</span></a>
+

--- a/docs/astro/src/components/ReleaseLink.astro
+++ b/docs/astro/src/components/ReleaseLink.astro
@@ -4,21 +4,24 @@
 
 import { SLINT_VERSION } from "../utils/site-config.ts";
 
-type linkID =
-    | "slint-cpp-template-stm32h735g-dk.zip"
-    | "slint-cpp-template-stm32h747i-disco.zip";
-
-interface Props {
-    id: linkID;
-}
-
-const { id } = Astro.props as Props;
-
-const link = {
+const LINK_MAP = {
     "slint-cpp-template-stm32h735g-dk.zip": `https://github.com/slint-ui/slint/releases/download/v${SLINT_VERSION}/slint-cpp-template-stm32h735g-dk.zip`,
     "slint-cpp-template-stm32h747i-disco.zip": `https://github.com/slint-ui/slint/releases/download/v${SLINT_VERSION}/slint-cpp-template-stm32h747i-disco.zip`,
-}[id];
+} as const;
+
+type LinkID = keyof typeof LINK_MAP;
+
+interface Props {
+    id: LinkID;
+}
+
+const props = Astro.props;
+if (!Object.keys(LINK_MAP).includes(props.id)) {
+    throw new Error(`Invalid link ID: ${props.id}`);
+}
+
+const { id } = props;
+const link = LINK_MAP[id];
 ---
 
 <a href={link}><span>{id}</span></a>
-

--- a/docs/astro/src/content/docs/guide/platforms/embedded.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/embedded.mdx
@@ -164,7 +164,7 @@ CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xte
 <Tabs syncKey="dev-language">
 <TabItem label="C++">
 #### STM32H735G-DK
-You can start with the template <ReleaseLink id="slint-cpp-template-stm32h735g-dk.zip" /> 
+You can start with the template <ReleaseLink id="slint-cpp-template-stm32h735g-dk.zip" />
 
 #### STM32H747I-DISCO
 You can start with the template <ReleaseLink id="slint-cpp-template-stm32h747i-disco.zip" />

--- a/docs/astro/src/content/docs/guide/platforms/embedded.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/embedded.mdx
@@ -6,6 +6,7 @@ description: Embedded Platforms on which Slint has been tested
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ReleaseLink from '/src/components/ReleaseLink.astro';
 
 Slint runs on many embedded platforms.
 
@@ -163,10 +164,10 @@ CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xte
 <Tabs syncKey="dev-language">
 <TabItem label="C++">
 #### STM32H735G-DK
-You can start with the template [slint-cpp-template-stm32h735g-dk.zip](https://github.com/slint-ui/slint/releases/download/%7Bdownload_version%7D/slint-cpp-template-stm32h735g-dk.zip)
+You can start with the template <ReleaseLink id="slint-cpp-template-stm32h735g-dk.zip" /> 
 
 #### STM32H747I-DISCO
-You can start with the template [slint-cpp-template-stm32h747i-disco.zip](https://github.com/slint-ui/slint/releases/download/%7Bdownload_version%7D/slint-cpp-template-stm32h747i-disco.zip)
+You can start with the template <ReleaseLink id="slint-cpp-template-stm32h747i-disco.zip" />
 
 </TabItem>
 <TabItem label="Rust">

--- a/docs/astro/src/utils/site-config.ts
+++ b/docs/astro/src/utils/site-config.ts
@@ -3,4 +3,4 @@
 
 export const BASE_URL = "https://localhost";
 export const BASE_PATH = "/docs/";
-export const SLINT_VERSION = "1.10.0";
+export const SLINT_DOWNLOAD_VERSION = "nightly";

--- a/docs/astro/src/utils/site-config.ts
+++ b/docs/astro/src/utils/site-config.ts
@@ -3,3 +3,4 @@
 
 export const BASE_URL = "https://localhost";
 export const BASE_PATH = "/docs/";
+export const SLINT_VERSION = "1.10.0";


### PR DESCRIPTION
I suspect I am not updating the CI correctly. This PR won't work till we do an actual release as this has to point to actual release artefacts. As in the links in the snapshot will be broken?