### PR TITLE
Prospective CI fix with Rust nightly

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2427,7 +2427,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                 return sub;
             }
             let op = proc_macro2::Punct::new(*op, proc_macro2::Spacing::Alone);
-            quote!( #op #sub )
+            quote!( (#op #sub) )
         }
         Expression::ImageReference { resource_ref, nine_slice } => {
             let image = match resource_ref {

--- a/tests/cases/expr/arithmetic.slint
+++ b/tests/cases/expr/arithmetic.slint
@@ -45,7 +45,7 @@ assert_eq!(instance.get_t1(), 4 + 3 * 2 + 2 - 50 - 2);
 assert_eq!(instance.get_t2(), 500 / 2 * 30 - 1);
 instance.set_a(42);
 assert_eq!(instance.get_t3(), 42 - (3 + 2 * (42 + 2)));
-assert_eq!(instance.get_t4(), 3 + - 5 - 8 - -9 * --- 120);
+assert_eq!(instance.get_t4(), 3 + - 5 - 8 - -9 * -(-(-120)));
 instance.invoke_foo();
 assert_eq!(instance.get_a(), (((42 + 8) * 10) / 2) - 3);
 


### PR DESCRIPTION
New warning introduced in nightly rust

```
error: use of a double negation
  --> /home/runner/work/slint/slint/target/debug/build/test-driver-rust-805d926ab786688f/out/expr_arithmetic.rs:10:55
   |
10 |     assert_eq!(instance.get_t4(), 3 + - 5 - 8 - -9 * --- 120);
   |                                                       ^^^^^^
   |
   = note: the prefix `--` could be misinterpreted as a decrement operator which exists in other languages
   = note: use `-= 1` if you meant to decrement the value
help: add parentheses for clarity
   |
10 |     assert_eq!(instance.get_t4(), 3 + - 5 - 8 - -9 * --(- 120));
   |
```

In addition, add a check for 2024 edition warnings so we make sure user can use Slint in a crate using the 2024 edition when it gets released  (there were no warnings according to my tests)

