### PR TITLE
Silence 2024 edition warnings

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -225,6 +225,7 @@ pub fn generate(
         #[allow(non_snake_case, non_camel_case_types)]
         #[allow(unused_braces, unused_parens)]
         #[allow(clippy::all, clippy::pedantic, clippy::nursery)]
+        #[allow(unknown_lints, if_let_rescope, tail_expr_drop_order)] // We don't have fancy Drop
         mod #generated_mod {
             use slint::private_unstable_api::re_exports as sp;
             #[allow(unused_imports)]

--- a/tests/driver/rust/main.rs
+++ b/tests/driver/rust/main.rs
@@ -4,6 +4,7 @@
 #![deny(warnings)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
+#![deny(rust_2024_compatibility)]
 
 #[cfg(test)]
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));


### PR DESCRIPTION
Add a check for 2024 edition warnings so we make sure users can use Slint in a crate using the 2024 edition when it gets released.

The warnings can be silenced as we don't handle types in Slint that have Drop with side effects other than memory allocations
