### PR TITLE
Fix cross-compilation of slint-compiler in Yocto environments (or whe…

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -136,6 +136,21 @@ endif()
 
 if(SLINT_FEATURE_COMPILER AND NOT SLINT_COMPILER)
     corrosion_set_hostbuild(slint-compiler)
+    set_property(
+        TARGET slint-compiler
+        PROPERTY CORROSION_NO_DEFAULT_FEATURES
+        ON
+    )
+    list(APPEND slint_compiler_features "software-renderer")
+    # Enable jemalloc, except when cross-compiling. (#7463)
+    if(NOT CMAKE_CROSSCOMPILING)
+        list(APPEND slint_compiler_features "jemalloc")
+    endif()
+    set_property(
+        TARGET slint-compiler
+        PROPERTY CORROSION_FEATURES
+        ${slint_compiler_features}
+    )
 endif()
 
 if (SLINT_BUILD_RUNTIME)

--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -19,8 +19,10 @@ path = "main.rs"
 
 [features]
 software-renderer = ["i-slint-compiler/software-renderer"]
+jemalloc = ["dep:tikv-jemallocator"]
 
-default = ["software-renderer"]
+# Keep defaults in sync with defaults applied in api/cpp/CMakeLists.txt for slint-compiler
+default = ["software-renderer", "jemalloc"]
 
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "display-diagnostics", "bundle-translations", "cpp", "rust"]}
@@ -31,4 +33,4 @@ spin_on = { workspace = true }
 itertools = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true, optional = true }

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -7,10 +7,10 @@ use i_slint_compiler::*;
 use itertools::Itertools;
 use std::io::{BufWriter, Write};
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
…n CC, etc. are set)

Don't enable jemalloc when cross-compiling.

Fixes #7463

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
