### PR TITLE
Clean up rendering of component container

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -13,7 +13,8 @@ use i_slint_core::graphics::{
 };
 use i_slint_core::input::{KeyEvent, KeyEventType, MouseEvent};
 use i_slint_core::item_rendering::{
-    CachedRenderingData, ItemCache, ItemRenderer, RenderBorderRectangle, RenderImage, RenderText,
+    CachedRenderingData, ItemCache, ItemRenderer, RenderBorderRectangle, RenderImage,
+    RenderRectangle, RenderText,
 };
 use i_slint_core::item_tree::{ItemTreeRc, ItemTreeRef};
 use i_slint_core::items::{
@@ -641,7 +642,13 @@ struct QtItemRenderer<'a> {
 }
 
 impl ItemRenderer for QtItemRenderer<'_> {
-    fn draw_rectangle(&mut self, rect_: Pin<&items::Rectangle>, _: &ItemRc, size: LogicalSize) {
+    fn draw_rectangle(
+        &mut self,
+        rect_: Pin<&dyn RenderRectangle>,
+        _: &ItemRc,
+        size: LogicalSize,
+        _cache: &CachedRenderingData,
+    ) {
         let rect: qttypes::QRectF = check_geometry!(size);
         let brush: qttypes::QBrush = into_qbrush(rect_.background(), rect.width, rect.height);
         let painter: &mut QPainterPtr = &mut self.painter;

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -284,6 +284,12 @@ pub fn item_children_bounding_rect(
 
 /// Trait for an item that represent a Rectangle to the Renderer
 #[allow(missing_docs)]
+pub trait RenderRectangle {
+    fn background(self: Pin<&Self>) -> Brush;
+}
+
+/// Trait for an item that represent a Rectangle with a border to the Renderer
+#[allow(missing_docs)]
 pub trait RenderBorderRectangle {
     fn background(self: Pin<&Self>) -> Brush;
     fn border_width(self: Pin<&Self>) -> LogicalLength;
@@ -324,7 +330,13 @@ pub trait RenderText {
 /// draw_rectangle should draw a rectangle in `(pos.x + rect.x, pos.y + rect.y)`
 #[allow(missing_docs)]
 pub trait ItemRenderer {
-    fn draw_rectangle(&mut self, rect: Pin<&Rectangle>, _self_rc: &ItemRc, _size: LogicalSize);
+    fn draw_rectangle(
+        &mut self,
+        rect: Pin<&dyn RenderRectangle>,
+        _self_rc: &ItemRc,
+        _size: LogicalSize,
+        _cache: &CachedRenderingData,
+    );
     fn draw_border_rectangle(
         &mut self,
         rect: Pin<&dyn RenderBorderRectangle>,
@@ -949,7 +961,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRendere
         (draw, item_geometry)
     }
 
-    forward_rendering_call!(fn draw_rectangle(Rectangle));
+    forward_rendering_call2!(fn draw_rectangle(dyn RenderRectangle));
     forward_rendering_call2!(fn draw_border_rectangle(dyn RenderBorderRectangle));
     forward_rendering_call2!(fn draw_image(dyn RenderImage));
     forward_rendering_call2!(fn draw_text(dyn RenderText));

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -25,7 +25,7 @@ use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEventResult,
     KeyEventType, MouseEvent,
 };
-use crate::item_rendering::{CachedRenderingData, RenderBorderRectangle};
+use crate::item_rendering::{CachedRenderingData, RenderBorderRectangle, RenderRectangle};
 pub use crate::item_tree::ItemRc;
 use crate::layout::LayoutInfo;
 use crate::lengths::{
@@ -311,8 +311,14 @@ impl Item for Rectangle {
         self_rc: &ItemRc,
         size: LogicalSize,
     ) -> RenderingResult {
-        (*backend).draw_rectangle(self, self_rc, size);
+        (*backend).draw_rectangle(self, self_rc, size, &self.cached_rendering_data);
         RenderingResult::ContinueRenderingChildren
+    }
+}
+
+impl RenderRectangle for Rectangle {
+    fn background(self: Pin<&Self>) -> Brush {
+        self.background()
     }
 }
 

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -7,13 +7,13 @@ This module contains the builtin `ComponentContainer` and related items
 When adding an item or a property, it needs to be kept in sync with different place.
 Lookup the [`crate::items`] module documentation.
 */
-use super::{Item, ItemConsts, ItemRc, Rectangle, RenderingResult};
+use super::{Item, ItemConsts, ItemRc, RenderingResult};
 use crate::component_factory::{ComponentFactory, FactoryContext};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
     KeyEventResult, MouseEvent,
 };
-use crate::item_rendering::CachedRenderingData;
+use crate::item_rendering::{CachedRenderingData, RenderRectangle};
 use crate::item_tree::{IndexRange, ItemTreeRc, ItemTreeWeak, ItemWeak};
 use crate::item_tree::{ItemTreeNode, ItemVisitorVTable, TraversalOrder, VisitChildrenResult};
 use crate::layout::{LayoutInfo, Orientation};
@@ -218,19 +218,23 @@ impl Item for ComponentContainer {
         item_rc: &ItemRc,
         size: LogicalSize,
     ) -> RenderingResult {
-        if let Some(item_tree) = self.item_tree.borrow().clone() {
-            let item_tree = vtable::VRc::borrow_pin(&item_tree);
-            let root_item = item_tree.as_ref().get_item_ref(0);
-            if let Some(window_item) =
-                crate::items::ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)
-            {
-                let mut rect = Rectangle::default();
-                rect.background.set(window_item.background());
-                backend.draw_rectangle(core::pin::pin!(rect).as_ref(), item_rc, size);
-            }
-        }
-
+        backend.draw_rectangle(self, item_rc, size, &self.cached_rendering_data);
         RenderingResult::ContinueRenderingChildren
+    }
+}
+
+impl RenderRectangle for ComponentContainer {
+    fn background(self: Pin<&Self>) -> crate::Brush {
+        self.item_tree
+            .borrow()
+            .clone()
+            .and_then(|item_tree| {
+                let item_tree = vtable::VRc::borrow_pin(&item_tree);
+                let root_item = item_tree.as_ref().get_item_ref(0);
+                crate::items::ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)
+                    .map(|window_item| window_item.background())
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -23,6 +23,7 @@ use crate::graphics::{
 };
 use crate::item_rendering::{
     CachedRenderingData, DirtyRegion, PartialRenderingState, RenderBorderRectangle, RenderImage,
+    RenderRectangle,
 };
 use crate::items::{ItemRc, TextOverflow, TextWrap};
 use crate::lengths::{
@@ -1657,9 +1658,10 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
     #[allow(clippy::unnecessary_cast)] // Coord!
     fn draw_rectangle(
         &mut self,
-        rect: Pin<&crate::items::Rectangle>,
+        rect: Pin<&dyn RenderRectangle>,
         _: &ItemRc,
         size: LogicalSize,
+        _cache: &CachedRenderingData,
     ) {
         let geom = LogicalRect::from(size);
         if self.should_draw(&geom) {

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -12,7 +12,8 @@ use i_slint_core::graphics::euclid::{self};
 use i_slint_core::graphics::rendering_metrics_collector::RenderingMetrics;
 use i_slint_core::graphics::{IntRect, Point, Size};
 use i_slint_core::item_rendering::{
-    CachedRenderingData, ItemCache, ItemRenderer, RenderBorderRectangle, RenderImage, RenderText,
+    CachedRenderingData, ItemCache, ItemRenderer, RenderBorderRectangle, RenderImage,
+    RenderRectangle, RenderText,
 };
 use i_slint_core::items::{
     self, Clip, FillRule, ImageRendering, ImageTiling, ItemRc, Layer, Opacity, RenderingResult,
@@ -179,7 +180,13 @@ impl<'a> GLItemRenderer<'a> {
 }
 
 impl<'a> ItemRenderer for GLItemRenderer<'a> {
-    fn draw_rectangle(&mut self, rect: Pin<&items::Rectangle>, _: &ItemRc, size: LogicalSize) {
+    fn draw_rectangle(
+        &mut self,
+        rect: Pin<&dyn RenderRectangle>,
+        _: &ItemRc,
+        size: LogicalSize,
+        _cache: &CachedRenderingData,
+    ) {
         self.draw_rect(size, rect.background());
     }
 

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -371,9 +371,10 @@ impl<'a> SkiaItemRenderer<'a> {
 impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
     fn draw_rectangle(
         &mut self,
-        rect: Pin<&i_slint_core::items::Rectangle>,
+        rect: Pin<&dyn i_slint_core::item_rendering::RenderRectangle>,
         _self_rc: &i_slint_core::items::ItemRc,
         size: LogicalSize,
+        _cache: &CachedRenderingData,
     ) {
         self.draw_rect(size, rect.background());
     }


### PR DESCRIPTION
Instead of creating a dummy Rectangle with background property, implement a RenderRectangle trait.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
