### PR TITLE
Fix panic in DirtyRegion::intersection when there's no intersection

### DIFF
--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -612,8 +612,8 @@ impl DirtyRegion {
             if let Some(x) = ret.rectangles[i].intersection(&other) {
                 ret.rectangles[i] = x;
             } else {
-                ret.rectangles.swap(i, ret.count);
                 ret.count -= 1;
+                ret.rectangles.swap(i, ret.count);
                 continue;
             }
             i += 1;
@@ -1121,4 +1121,15 @@ impl PartialRenderingState {
     pub fn force_screen_refresh(&self) {
         self.force_screen_refresh.set(true);
     }
+}
+
+#[test]
+fn dirty_region_no_intersection() {
+    let mut region = DirtyRegion::default();
+    region.add_rect(LogicalRect::new(LogicalPoint::new(10., 10.), LogicalSize::new(16., 16.)));
+    region.add_rect(LogicalRect::new(LogicalPoint::new(100., 100.), LogicalSize::new(16., 16.)));
+    region.add_rect(LogicalRect::new(LogicalPoint::new(200., 100.), LogicalSize::new(16., 16.)));
+    let i = region
+        .intersection(LogicalRect::new(LogicalPoint::new(50., 50.), LogicalSize::new(10., 10.)));
+    assert_eq!(i.iter().count(), 0);
 }


### PR DESCRIPTION
swap_remove() on a slice needs to operate on len - 1 as index of the last element, not len.

Reproducible with linuxkms-skia-software and partial rendering enabled, when moving the mouse cursor outside of the screen.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
