### PR TITLE
Fix support for Window.background tracking with the partial renderer

### DIFF
--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -475,3 +475,29 @@ fn rotated_image() {
         Some(slint::LogicalPosition { x: 1., y: 50. })
     );
 }
+
+#[test]
+fn window_background() {
+    slint::slint! {
+        export component Ui inherits Window {
+            in property <color> c: yellow;
+            background: c;
+        }
+    }
+
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+    let ui = Ui::new().unwrap();
+    let window = WINDOW.with(|x| x.clone());
+    window.set_size(slint::PhysicalSize::new(180, 260));
+    ui.show().unwrap();
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 0, 0, 180, 260);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+    ui.set_c(slint::Color::from_rgb_u8(45, 12, 13));
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 0, 0, 180, 260);
+    }));
+    ui.set_c(slint::Color::from_rgb_u8(45, 12, 13));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+}

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -674,6 +674,16 @@ impl ItemRenderer for QtItemRenderer<'_> {
         );
     }
 
+    fn draw_window_background(
+        &mut self,
+        _rect: Pin<&dyn RenderRectangle>,
+        _self_rc: &ItemRc,
+        _size: LogicalSize,
+        _cache: &CachedRenderingData,
+    ) {
+        // Background is applied via WindowProperties::background()
+    }
+
     fn draw_image(
         &mut self,
         image: Pin<&dyn RenderImage>,

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -344,6 +344,13 @@ pub trait ItemRenderer {
         _size: LogicalSize,
         _cache: &CachedRenderingData,
     );
+    fn draw_window_background(
+        &mut self,
+        rect: Pin<&dyn RenderRectangle>,
+        self_rc: &ItemRc,
+        size: LogicalSize,
+        cache: &CachedRenderingData,
+    );
     fn draw_image(
         &mut self,
         image: Pin<&dyn RenderImage>,
@@ -461,12 +468,6 @@ pub trait ItemRenderer {
     fn draw_string(&mut self, string: &str, color: crate::Color);
 
     fn draw_image_direct(&mut self, image: crate::graphics::Image);
-
-    /// Fills a rectangle at (0,0) with the given size. This is used for example by the Skia renderer to
-    /// handle window backgrounds with a brush (gradient).
-    fn draw_rect(&mut self, _size: LogicalSize, _brush: Brush) {
-        unimplemented!()
-    }
 
     /// This is called before it is being rendered (before the draw_* function).
     /// Returns
@@ -963,6 +964,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRendere
 
     forward_rendering_call2!(fn draw_rectangle(dyn RenderRectangle));
     forward_rendering_call2!(fn draw_border_rectangle(dyn RenderBorderRectangle));
+    forward_rendering_call2!(fn draw_window_background(dyn RenderRectangle));
     forward_rendering_call2!(fn draw_image(dyn RenderImage));
     forward_rendering_call2!(fn draw_text(dyn RenderText));
     forward_rendering_call!(fn draw_text_input(TextInput));
@@ -1027,10 +1029,6 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRendere
 
     fn draw_image_direct(&mut self, image: crate::graphics::image::Image) {
         self.actual_renderer.draw_image_direct(image)
-    }
-
-    fn draw_rect(&mut self, size: LogicalSize, brush: Brush) {
-        self.actual_renderer.draw_rect(size, brush);
     }
 
     fn window(&self) -> &crate::window::WindowInner {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1021,11 +1021,18 @@ impl Item for WindowItem {
 
     fn render(
         self: Pin<&Self>,
-        _backend: &mut ItemRendererRef,
-        _self_rc: &ItemRc,
-        _size: LogicalSize,
+        backend: &mut ItemRendererRef,
+        self_rc: &ItemRc,
+        size: LogicalSize,
     ) -> RenderingResult {
+        backend.draw_window_background(self, self_rc, size, &self.cached_rendering_data);
         RenderingResult::ContinueRenderingChildren
+    }
+}
+
+impl RenderRectangle for WindowItem {
+    fn background(self: Pin<&Self>) -> Brush {
+        self.background()
     }
 }
 

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1914,6 +1914,17 @@ impl<'a, T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'
         }
     }
 
+    fn draw_window_background(
+        &mut self,
+        rect: Pin<&dyn RenderRectangle>,
+        _self_rc: &ItemRc,
+        _size: LogicalSize,
+        _cache: &CachedRenderingData,
+    ) {
+        // register a dependency for the partial renderer's dirty tracker. The actual rendering is done earlier in the software renderer.
+        let _ = rect.background();
+    }
+
     fn draw_image(
         &mut self,
         image: Pin<&dyn RenderImage>,

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1247,6 +1247,19 @@ impl WindowInner {
         self.strong_component_ref.borrow().is_some()
     }
 
+    /// Returns the window item that is the first item in the component. When Some()
+    /// is returned, it's guaranteed to be safe to downcast to `WindowItem`.
+    pub fn window_item_rc(&self) -> Option<ItemRc> {
+        self.try_component().and_then(|component_rc| {
+            let item_rc = ItemRc::new(component_rc, 0);
+            if item_rc.downcast::<crate::items::WindowItem>().is_some() {
+                Some(item_rc)
+            } else {
+                None
+            }
+        })
+    }
+
     /// Returns the window item that is the first item in the component.
     pub fn window_item(&self) -> Option<VRcMapped<ItemTreeVTable, crate::items::WindowItem>> {
         self.try_component().and_then(|component_rc| {

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -260,16 +260,24 @@ impl FemtoVGRenderer {
                     height.get(),
                 );
 
-                // Draws the window background as gradient
-                match window_background_brush {
-                    Some(Brush::SolidColor(..)) | None => {}
-                    Some(brush) => {
-                        item_renderer.draw_rect(
-                            i_slint_core::lengths::logical_size_from_api(
-                                window.size().to_logical(window_inner.scale_factor()),
-                            ),
-                            brush,
-                        );
+                if let Some(window_item_rc) = window_inner.window_item_rc() {
+                    let window_item =
+                        window_item_rc.downcast::<i_slint_core::items::WindowItem>().unwrap();
+                    match window_item.as_pin_ref().background() {
+                        Brush::SolidColor(..) => {
+                            // clear_rect is called earlier
+                        }
+                        _ => {
+                            // Draws the window background as gradient
+                            item_renderer.draw_rectangle(
+                                window_item.as_pin_ref(),
+                                &window_item_rc,
+                                i_slint_core::lengths::logical_size_from_api(
+                                    window.size().to_logical(window_inner.scale_factor()),
+                                ),
+                                &window_item.as_pin_ref().cached_rendering_data,
+                            );
+                        }
                     }
                 }
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -571,19 +571,24 @@ impl SkiaRenderer {
                 item_renderer = &mut partial_renderer;
             }
 
-            // Draws the window background as gradient
-            match window_inner.window_item().map(|w| w.as_pin_ref().background()) {
-                Some(Brush::SolidColor(clear_color)) => {
-                    skia_canvas.clear(itemrenderer::to_skia_color(&clear_color));
-                }
-                None => {}
-                Some(brush @ _) => {
-                    item_renderer.draw_rect(
-                        i_slint_core::lengths::logical_size_from_api(
-                            window.size().to_logical(window_inner.scale_factor()),
-                        ),
-                        brush,
-                    );
+            if let Some(window_item_rc) = window_inner.window_item_rc() {
+                let window_item =
+                    window_item_rc.downcast::<i_slint_core::items::WindowItem>().unwrap();
+                match window_item.as_pin_ref().background() {
+                    Brush::SolidColor(clear_color) => {
+                        skia_canvas.clear(itemrenderer::to_skia_color(&clear_color));
+                    }
+                    _ => {
+                        // Draws the window background as gradient
+                        item_renderer.draw_rectangle(
+                            window_item.as_pin_ref(),
+                            &window_item_rc,
+                            i_slint_core::lengths::logical_size_from_api(
+                                window.size().to_logical(window_inner.scale_factor()),
+                            ),
+                            &window_item.as_pin_ref().cached_rendering_data,
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #5219

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
