### PR TITLE
Fix incorrect bounding text for Text(Input) when element is bigger th…

### DIFF
--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -627,3 +627,54 @@ fn shadow_redraw_beyond_geometry() {
         Some(slint::LogicalPosition { x: old_shadow_x, y: old_shadow_y })
     );
 }
+
+#[test]
+fn text_alignment() {
+    slint::slint! {
+        export component Ui inherits Window {
+            in property <color> c: green;
+            Text {
+                x: 10px;
+                y: 10px;
+                width: 200px;
+                height: 50px;
+                text: "Ok";
+                color: c;
+            }
+        }
+    }
+
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+
+    let window = SKIA_WINDOW.with(|w| w.clone());
+    NEXT_WINDOW_CHOICE.with(|choice| {
+        *choice.borrow_mut() = Some(window.clone());
+    });
+    let ui = Ui::new().unwrap();
+    window.set_size(slint::PhysicalSize::new(250, 250).into());
+    ui.show().unwrap();
+
+    assert!(window.draw_if_needed());
+    assert_eq!(
+        window.last_dirty_region_bounding_box_size(),
+        Some(slint::LogicalSize { width: 250., height: 250. })
+    );
+    assert_eq!(
+        window.last_dirty_region_bounding_box_origin(),
+        Some(slint::LogicalPosition { x: 0., y: 0. })
+    );
+
+    assert!(!window.draw_if_needed());
+
+    ui.set_c(slint::Color::from_rgb_u8(45, 12, 13));
+
+    assert!(window.draw_if_needed());
+    assert_eq!(
+        window.last_dirty_region_bounding_box_size(),
+        Some(slint::LogicalSize { width: 200., height: 50. })
+    );
+    assert_eq!(
+        window.last_dirty_region_bounding_box_origin(),
+        Some(slint::LogicalPosition { x: 10., y: 10. })
+    );
+}

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -340,16 +340,18 @@ pub trait RenderText {
         let font_request = self.font_request(window_inner);
         let scale_factor = crate::lengths::ScaleFactor::new(window_inner.scale_factor());
         let max_width = geometry.size.width_length();
-        geometry.size = window_adapter
-            .renderer()
-            .text_size(
-                font_request.clone(),
-                text_string.as_str(),
-                Some(max_width.cast()),
-                scale_factor,
-                self.wrap(),
-            )
-            .cast();
+        geometry.size = geometry.size.max(
+            window_adapter
+                .renderer()
+                .text_size(
+                    font_request.clone(),
+                    text_string.as_str(),
+                    Some(max_width.cast()),
+                    scale_factor,
+                    self.wrap(),
+                )
+                .cast(),
+        );
         geometry
     }
 }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -999,13 +999,13 @@ impl Item for TextInput {
         let font_request = self.font_request(window_adapter);
         let scale_factor = crate::lengths::ScaleFactor::new(window_inner.scale_factor());
         let max_width = geometry.size.width_length();
-        geometry.size = window_adapter.renderer().text_size(
+        geometry.size = geometry.size.max(window_adapter.renderer().text_size(
             font_request.clone(),
             text_string.as_str(),
             Some(max_width),
             scale_factor,
             self.wrap(),
-        );
+        ));
         geometry
     }
 }


### PR DESCRIPTION
…an intrinsic text size

The Text element may be given a size that exceeds its intrinsic size, however we returned the intrinsic size. The broke partial rendering when for example text was aligned within the bigger geometry:

    Text {
        text: "Ok";
        horizontal-alignment: right;
        x: 0px;
        y: 0px;
        width: 100px;
        height: 50px;
    }

This would return a bounding rect with an origin of (0, 0) and a width of maybe 20px, while the text is being rendered centered in the 100px wide geometry. That in turn meant that if that area with the text was marked as dirty, due to some overlap or for example linuxkms mouse cursor, then the Text element wasn't re-rendered because the bounding rect doesn't intersect with the clip.

One option would be to teach the renderers text_size() about alignment, but it turns out that this is the only place where this is needed. So instead, fix this by using bounding_rect() to cover only the case it was originally introduced for - text exceeding the geometry - and otherwise return the geometry.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
