### PR TITLE
Enable partial rendering with Skia's software renderer by default

### DIFF
--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -72,10 +72,9 @@ struct SkiaTestWindow {
 impl SkiaTestWindow {
     fn new() -> Rc<Self> {
         let render_buffer = Rc::new(SkiaTestSoftwareBuffer::default());
-        let mut renderer = SkiaRenderer::new_with_surface(Box::new(
+        let renderer = SkiaRenderer::new_with_surface(Box::new(
             i_slint_renderer_skia::software_surface::SoftwareSurface::from(render_buffer.clone()),
         ));
-        i_slint_renderer_skia::SkiaRendererExt::enable_partial_rendering(&mut renderer);
         Rc::new_cyclic(|w: &Weak<Self>| Self {
             window: slint::Window::new(w.clone()),
             renderer,

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -190,6 +190,10 @@ impl super::Surface for SoftwareSurface {
     fn bits_per_pixel(&self) -> Result<u8, i_slint_core::platform::PlatformError> {
         Ok(24)
     }
+
+    fn use_partial_rendering(&self) -> bool {
+        true
+    }
 }
 
 impl<T: RenderBuffer + 'static> From<T> for SoftwareSurface {


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
