### PR TITLE
Improve accessibility of ComboBox widgets

### DIFF
--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -382,6 +382,19 @@ public:
         return std::nullopt;
     }
 
+    /// Returns the accessible-expandable of that element, if any.
+    std::optional<bool> accessible_expandable() const
+    {
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::Expandable)) {
+            if (*result == "true")
+                return true;
+            else if (*result == "false")
+                return false;
+        }
+        return std::nullopt;
+    }
+
     /// Sets the accessible-value of that element.
     ///
     /// Setting the value will invoke the `accessible-action-set-value` callback.

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -407,6 +407,27 @@ public:
         return std::nullopt;
     }
 
+    /// Invokes the expand accessibility action of that element
+    /// (`accessible-action-expand`).
+    void invoke_accessible_expand_action() const
+    {
+        if (inner.element_index != 0)
+            return;
+        if (auto item = private_api::upgrade_item_weak(inner.item)) {
+            union ExpandActionHelper {
+                cbindgen_private::AccessibilityAction action;
+                ExpandActionHelper()
+                {
+                    action.tag = cbindgen_private::AccessibilityAction::Tag::Expand;
+                }
+                ~ExpandActionHelper() { }
+
+            } action;
+            item->item_tree.vtable()->accessibility_action(item->item_tree.borrow(), item->index,
+                                                           &action.action);
+        }
+    }
+
     /// Sets the accessible-value of that element.
     ///
     /// Setting the value will invoke the `accessible-action-set-value` callback.

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -382,6 +382,18 @@ public:
         return std::nullopt;
     }
 
+    /// Returns the accessible-expanded of that element, if any.
+    std::optional<bool> accessible_expanded() const
+    {
+        if (auto result = get_accessible_string_property(
+                    cbindgen_private::AccessibleStringProperty::Expanded)) {
+            if (*result == "true")
+                return true;
+            else if (*result == "false")
+                return false;
+        }
+        return std::nullopt;
+    }
     /// Returns the accessible-expandable of that element, if any.
     std::optional<bool> accessible_expandable() const
     {

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -207,6 +207,11 @@ The description for the current element.
 Whether the element is enabled or not. This maps to the "enabled" state of most widgets. (default value: `true`)
 </SlintProperty>
 
+### accessible-expandable
+<SlintProperty typeName="bool" propName="accessible-expandable" default="false">
+Whether the element can be expanded or not.
+</SlintProperty>
+
 ### accessible-label
 <SlintProperty typeName="string" propName="accessible-label" default='""'>
 The label for an interactive element. (default value: empty for most elements, or the value of the `text` property for Text elements)

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -212,6 +212,12 @@ Whether the element is enabled or not. This maps to the "enabled" state of most 
 Whether the element can be expanded or not.
 </SlintProperty>
 
+### accessible-expanded
+<SlintProperty typeName="bool" propName="accessible-expanded" default="false">
+Whether the element is expanded or not. Applies to combo boxes, menu items,
+tree view items and other widgets.
+</SlintProperty>
+
 ### accessible-label
 <SlintProperty typeName="string" propName="accessible-label" default='""'>
 The label for an interactive element. (default value: empty for most elements, or the value of the `text` property for Text elements)

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -283,3 +283,6 @@ Invoked when the user requests to increment the value.
 
 ### accessible-action-decrement()
 Invoked when the user requests to decrement the value.
+
+### accessible-action-expand()
+Invoked when the user requests to expand the widget (eg: disclose the list of available choices for a combo box).

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -209,7 +209,8 @@ Whether the element is enabled or not. This maps to the "enabled" state of most 
 
 ### accessible-expandable
 <SlintProperty typeName="bool" propName="accessible-expandable" default="false">
-Whether the element can be expanded or not.
+Whether the element can be expanded or not. For example, a `ComboBox` widget should set this to true,
+as its selection can be changed via an expandable popup.
 </SlintProperty>
 
 ### accessible-expanded

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -31,6 +31,7 @@ const VALUE_MAXIMUM: u32 = VALUE_MINIMUM + 1;
 const VALUE_STEP: u32 = VALUE_MAXIMUM + 1;
 const CHECKABLE: u32 = VALUE_STEP + 1;
 const EXPANDABLE: u32 = CHECKABLE + 1;
+const EXPANDED: u32 = EXPANDABLE + 1;
 
 pub struct AccessibleItemPropertiesTracker {
     obj: *mut c_void,
@@ -210,6 +211,7 @@ impl SlintAccessibleItemData {
                 item_rc.accessible_string_property(AccessibleStringProperty::Checkable);
                 item_rc.accessible_string_property(AccessibleStringProperty::Checked);
                 item_rc.accessible_string_property(AccessibleStringProperty::Expandable);
+                item_rc.accessible_string_property(AccessibleStringProperty::Expanded);
             }
         });
     }
@@ -270,6 +272,7 @@ cpp! {{
     const uint32_t VALUE_STEP { VALUE_MAXIMUM + 1 };
     const uint32_t CHECKABLE { VALUE_STEP + 1 };
     const uint32_t EXPANDABLE { CHECKABLE + 1 };
+    const uint32_t EXPANDED { EXPANDABLE + 1 };
 
     // ------------------------------------------------------------------------------
     // Helper:
@@ -366,6 +369,7 @@ cpp! {{
                     VALUE_STEP => item.accessible_string_property(AccessibleStringProperty::ValueStep),
                     CHECKABLE => item.accessible_string_property(AccessibleStringProperty::Checkable),
                     EXPANDABLE => item.accessible_string_property(AccessibleStringProperty::Expandable),
+                    EXPANDED => item.accessible_string_property(AccessibleStringProperty::Expanded),
                     _ => None,
                 };
                 if let Some(string) = string {
@@ -625,7 +629,14 @@ cpp! {{
             state.focused = has_focus_delegation;
             state.checked = (checked == "true") ? 1 : 0;
             state.checkable = (item_string_property(m_data, CHECKABLE) == "true") ? 1 : 0;
-            state.expandable = (item_string_property(m_data, EXPANDABLE) == "true") ? 1 : 0;
+            if (item_string_property(m_data, EXPANDABLE) == "true") {
+                state.expandable = 1;
+                if (item_string_property(m_data, EXPANDED) == "true") {
+                    state.expanded = 1;
+                } else {
+                    state.collapsed = 1;
+                }
+            }
             return state; /* FIXME */
         }
 

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -685,6 +685,8 @@ cpp! {{
                 actions << QAccessibleActionInterface::increaseAction();
             if (supported & rust!(Slint_accessible_item_an3 [] -> SupportedAccessibilityAction as "uint" { SupportedAccessibilityAction::Decrement }))
                 actions << QAccessibleActionInterface::decreaseAction();
+            if (supported & rust!(Slint_accessible_item_an4 [] -> SupportedAccessibilityAction as "uint" { SupportedAccessibilityAction::Expand }))
+                actions << QAccessibleActionInterface::pressAction();
             return actions;
         }
 
@@ -692,7 +694,12 @@ cpp! {{
             if (actionName == QAccessibleActionInterface::pressAction()) {
                 rust!(Slint_accessible_item_do_action1 [m_data: Pin<&SlintAccessibleItemData> as "void*"] {
                     let Some(item) = m_data.item.upgrade() else {return};
-                    item.accessible_action(&AccessibilityAction::Default);
+                    let supported_actions = item.supported_accessibility_actions();
+                    if supported_actions.contains(SupportedAccessibilityAction::Expand) {
+                        item.accessible_action(&AccessibilityAction::Expand);
+                    } else {
+                        item.accessible_action(&AccessibilityAction::Default);
+                    }
                 });
             } else if (actionName == QAccessibleActionInterface::increaseAction()) {
                 rust!(Slint_accessible_item_do_action2 [m_data: Pin<&SlintAccessibleItemData> as "void*"] {

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -30,6 +30,7 @@ const VALUE_MINIMUM: u32 = CHECKED + 1;
 const VALUE_MAXIMUM: u32 = VALUE_MINIMUM + 1;
 const VALUE_STEP: u32 = VALUE_MAXIMUM + 1;
 const CHECKABLE: u32 = VALUE_STEP + 1;
+const EXPANDABLE: u32 = CHECKABLE + 1;
 
 pub struct AccessibleItemPropertiesTracker {
     obj: *mut c_void,
@@ -208,6 +209,7 @@ impl SlintAccessibleItemData {
             if let Some(item_rc) = item.upgrade() {
                 item_rc.accessible_string_property(AccessibleStringProperty::Checkable);
                 item_rc.accessible_string_property(AccessibleStringProperty::Checked);
+                item_rc.accessible_string_property(AccessibleStringProperty::Expandable);
             }
         });
     }
@@ -267,6 +269,7 @@ cpp! {{
     const uint32_t VALUE_MAXIMUM { VALUE_MINIMUM + 1 };
     const uint32_t VALUE_STEP { VALUE_MAXIMUM + 1 };
     const uint32_t CHECKABLE { VALUE_STEP + 1 };
+    const uint32_t EXPANDABLE { CHECKABLE + 1 };
 
     // ------------------------------------------------------------------------------
     // Helper:
@@ -362,6 +365,7 @@ cpp! {{
                     VALUE_MAXIMUM => item.accessible_string_property(AccessibleStringProperty::ValueMaximum),
                     VALUE_STEP => item.accessible_string_property(AccessibleStringProperty::ValueStep),
                     CHECKABLE => item.accessible_string_property(AccessibleStringProperty::Checkable),
+                    EXPANDABLE => item.accessible_string_property(AccessibleStringProperty::Expandable),
                     _ => None,
                 };
                 if let Some(string) = string {
@@ -621,6 +625,7 @@ cpp! {{
             state.focused = has_focus_delegation;
             state.checked = (checked == "true") ? 1 : 0;
             state.checkable = (item_string_property(m_data, CHECKABLE) == "true") ? 1 : 0;
+            state.expandable = (item_string_property(m_data, EXPANDABLE) == "true") ? 1 : 0;
             return state; /* FIXME */
         }
 

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -647,6 +647,17 @@ impl ElementHandle {
         })
     }
 
+    /// Returns the value of the `accessible-expandable` property, if present
+    pub fn accessible_expandable(&self) -> Option<bool> {
+        if self.element_index != 0 {
+            return None;
+        }
+        self.item
+            .upgrade()
+            .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Expandable))
+            .and_then(|item| item.parse().ok())
+    }
+
     /// Returns the size of the element in logical pixels. This corresponds to the value of the `width` and
     /// `height` properties in Slint code. Returns a zero size if the element is not valid.
     pub fn size(&self) -> i_slint_core::api::LogicalSize {

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -737,6 +737,17 @@ impl ElementHandle {
         }
     }
 
+    /// Invokes the element's `accessible-action-expand` callback, if declared. On widgets such as combo boxes, this
+    /// typically discloses the list of available choices.
+    pub fn invoke_accessible_expand_action(&self) {
+        if self.element_index != 0 {
+            return;
+        }
+        if let Some(item) = self.item.upgrade() {
+            item.accessible_action(&AccessibilityAction::Expand)
+        }
+    }
+
     /// Simulates a single click (or touch tap) on the element at its center point with the
     /// specified button.
     pub async fn single_click(&self, button: i_slint_core::platform::PointerEventButton) {

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -647,6 +647,17 @@ impl ElementHandle {
         })
     }
 
+    /// Returns the value of the `accessible-expanded` property, if present
+    pub fn accessible_expanded(&self) -> Option<bool> {
+        if self.element_index != 0 {
+            return None;
+        }
+        self.item
+            .upgrade()
+            .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Expanded))
+            .and_then(|item| item.parse().ok())
+    }
+
     /// Returns the value of the `accessible-expandable` property, if present
     pub fn accessible_expandable(&self) -> Option<bool> {
         if self.element_index != 0 {

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -16,6 +16,7 @@ enum ElementAccessibilityAction {
     Default_ = 0;
     Increment = 1;
     Decrement = 2;
+    Expand = 3;
 }
 
 enum PointerEventButton {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -380,6 +380,7 @@ impl TestingClient {
             proto::ElementAccessibilityAction::Decrement => {
                 element.invoke_accessible_decrement_action()
             }
+            proto::ElementAccessibilityAction::Expand => element.invoke_accessible_expand_action(),
         }
         Ok(())
     }

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -149,6 +149,7 @@ impl AccessKitAdapter {
                 }
                 _ => return None,
             },
+            Action::Expand => AccessibilityAction::Expand,
             _ => return None,
         };
         self.nodes
@@ -623,6 +624,9 @@ impl NodeCollection {
         }
         if supported.contains(SupportedAccessibilityAction::ReplaceSelectedText) {
             node.add_action(accesskit::Action::ReplaceSelectedText);
+        }
+        if supported.contains(SupportedAccessibilityAction::Expand) {
+            node.add_action(accesskit::Action::Expand);
         }
 
         node

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -520,6 +520,16 @@ impl NodeCollection {
             node.set_description(description.to_string());
         }
 
+        if item
+            .accessible_string_property(AccessibleStringProperty::Expandable)
+            .is_some_and(|x| x == "true")
+        {
+            node.set_expanded(
+                item.accessible_string_property(AccessibleStringProperty::Expanded)
+                    .is_some_and(|x| x == "true"),
+            );
+        }
+
         if matches!(
             role,
             Role::Button

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -198,6 +198,7 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-description", Type::String),
         ("accessible-enabled", Type::Bool),
         ("accessible-expandable", Type::Bool),
+        ("accessible-expanded", Type::Bool),
         ("accessible-label", Type::String),
         ("accessible-value", Type::String),
         ("accessible-value-maximum", Type::Float32),

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -209,6 +209,7 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-action-increment", noarg_callback_type()),
         ("accessible-action-decrement", noarg_callback_type()),
         ("accessible-action-set-value", strarg_callback_type()),
+        ("accessible-action-expand", noarg_callback_type()),
         ("accessible-item-selectable", Type::Bool),
         ("accessible-item-selected", Type::Bool),
         ("accessible-item-index", Type::Int32),

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -197,6 +197,7 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-delegate-focus", Type::Int32),
         ("accessible-description", Type::String),
         ("accessible-enabled", Type::Bool),
+        ("accessible-expandable", Type::Bool),
         ("accessible-label", Type::String),
         ("accessible-value", Type::String),
         ("accessible-value-maximum", Type::Float32),

--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -66,6 +66,7 @@ export component ComboBox {
                 font-weight: CosmicFontSettings.body.font-weight;
                 color: CosmicPalette.control-foreground;
                 text: root.current-value;
+                accessible-role: none;
             }
 
             Image {

--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -29,6 +29,7 @@ export component ComboBox {
     accessible-expandable: true;
     accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
+    accessible-action-expand => { base.show-popup(); }
 
     states [
         disabled when !root.enabled : {

--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -26,6 +26,7 @@ export component ComboBox {
     forward-focus: base;
     accessible-role: combobox;
     accessible-enabled: root.enabled;
+    accessible-value <=> root.current-value;
 
     states [
         disabled when !root.enabled : {

--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -27,6 +27,7 @@ export component ComboBox {
     accessible-role: combobox;
     accessible-enabled: root.enabled;
     accessible-expandable: true;
+    accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
 
     states [

--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -26,6 +26,7 @@ export component ComboBox {
     forward-focus: base;
     accessible-role: combobox;
     accessible-enabled: root.enabled;
+    accessible-expandable: true;
     accessible-value <=> root.current-value;
 
     states [

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -98,6 +98,7 @@ export component ComboBox {
             font-weight: CupertinoFontSettings.body.font-weight;
             color: CupertinoPalette.foreground;
             text: root.current-value;
+            accessible-role: none;
         }
 
         VerticalLayout {

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -29,6 +29,7 @@ export component ComboBox {
     accessible-expandable: true;
     accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
+    accessible-action-expand => { base.show-popup(); }
 
     states [
         disabled when !root.enabled : {

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -26,6 +26,7 @@ export component ComboBox {
     forward-focus: base;
     accessible-role: combobox;
     accessible-enabled: root.enabled;
+    accessible-value <=> root.current-value;
 
     states [
         disabled when !root.enabled : {

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -27,6 +27,7 @@ export component ComboBox {
     accessible-role: combobox;
     accessible-enabled: root.enabled;
     accessible-expandable: true;
+    accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
 
     states [

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -26,6 +26,7 @@ export component ComboBox {
     forward-focus: base;
     accessible-role: combobox;
     accessible-enabled: root.enabled;
+    accessible-expandable: true;
     accessible-value <=> root.current-value;
 
     states [

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -26,6 +26,7 @@ export component ComboBox {
 
     accessible-role: combobox;
     accessible-enabled: root.enabled;
+    accessible-expandable: true;
     accessible-value <=> root.current-value;
 
     states [

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -80,6 +80,7 @@ export component ComboBox {
                 font-weight: FluentFontSettings.body.font-weight;
                 color: FluentPalette.control-foreground;
                 text: root.current-value;
+                accessible-role: none;
             }
 
             icon := Image {

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -29,6 +29,7 @@ export component ComboBox {
     accessible-expandable: true;
     accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
+    accessible-action-expand => { base.show-popup(); }
 
     states [
         disabled when !root.enabled : {

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -26,6 +26,7 @@ export component ComboBox {
 
     accessible-role: combobox;
     accessible-enabled: root.enabled;
+    accessible-value <=> root.current-value;
 
     states [
         disabled when !root.enabled : {

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -27,6 +27,7 @@ export component ComboBox {
     accessible-role: combobox;
     accessible-enabled: root.enabled;
     accessible-expandable: true;
+    accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
 
     states [

--- a/internal/compiler/widgets/material/combobox.slint
+++ b/internal/compiler/widgets/material/combobox.slint
@@ -25,6 +25,7 @@ export component ComboBox {
     forward-focus: base;
     accessible-role: combobox;
     accessible-enabled: root.enabled;
+    accessible-value <=> root.current-value;
 
     states [
         disabled when !root.enabled : {

--- a/internal/compiler/widgets/material/combobox.slint
+++ b/internal/compiler/widgets/material/combobox.slint
@@ -28,6 +28,7 @@ export component ComboBox {
     accessible-expandable: true;
     accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
+    accessible-action-expand => { base.show-popup(); }
 
     states [
         disabled when !root.enabled : {

--- a/internal/compiler/widgets/material/combobox.slint
+++ b/internal/compiler/widgets/material/combobox.slint
@@ -26,6 +26,7 @@ export component ComboBox {
     accessible-role: combobox;
     accessible-enabled: root.enabled;
     accessible-expandable: true;
+    accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
 
     states [

--- a/internal/compiler/widgets/material/combobox.slint
+++ b/internal/compiler/widgets/material/combobox.slint
@@ -25,6 +25,7 @@ export component ComboBox {
     forward-focus: base;
     accessible-role: combobox;
     accessible-enabled: root.enabled;
+    accessible-expandable: true;
     accessible-value <=> root.current-value;
 
     states [

--- a/internal/compiler/widgets/material/combobox.slint
+++ b/internal/compiler/widgets/material/combobox.slint
@@ -77,6 +77,7 @@ export component ComboBox {
             // font-family: MaterialFontSettings.body-large.font;
             font-size: MaterialFontSettings.body-large.font-size;
             font-weight: MaterialFontSettings.body-large.font-weight;
+            accessible-role: none;
         }
 
         icon := Image {

--- a/internal/compiler/widgets/qt/combobox.slint
+++ b/internal/compiler/widgets/qt/combobox.slint
@@ -16,6 +16,7 @@ export component ComboBox {
     accessible-role: combobox;
     accessible-enabled: root.enabled;
     accessible-expandable: true;
+    accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
     forward-focus: base;
 

--- a/internal/compiler/widgets/qt/combobox.slint
+++ b/internal/compiler/widgets/qt/combobox.slint
@@ -18,6 +18,9 @@ export component ComboBox {
     accessible-expandable: true;
     accessible-expanded: base.popup-has-focus;
     accessible-value <=> root.current-value;
+    accessible-action-expand => {
+        base.show-popup();
+    }
     forward-focus: base;
 
     HorizontalLayout {

--- a/internal/compiler/widgets/qt/combobox.slint
+++ b/internal/compiler/widgets/qt/combobox.slint
@@ -15,6 +15,7 @@ export component ComboBox {
 
     accessible-role: combobox;
     accessible-enabled: root.enabled;
+    accessible-expandable: true;
     accessible-value <=> root.current-value;
     forward-focus: base;
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -38,6 +38,7 @@ pub enum AccessibilityAction {
     Default,
     Decrement,
     Increment,
+    Expand,
     /// This is currently unused
     ReplaceSelectedText(SharedString),
     SetValue(SharedString),
@@ -51,8 +52,9 @@ bitflags! {
         const Default = 1;
         const Decrement = 1 << 1;
         const Increment = 1 << 2;
-        const ReplaceSelectedText = 1 << 3;
-        const SetValue = 1 << 4;
+        const Expand = 1 << 3;
+        const ReplaceSelectedText = 1 << 4;
+        const SetValue = 1 << 5;
     }
 }
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -17,6 +17,7 @@ pub enum AccessibleStringProperty {
     DelegateFocus,
     Description,
     Enabled,
+    Expandable,
     ItemCount,
     ItemIndex,
     ItemSelectable,

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -18,6 +18,7 @@ pub enum AccessibleStringProperty {
     Description,
     Enabled,
     Expandable,
+    Expanded,
     ItemCount,
     ItemIndex,
     ItemSelectable,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2113,6 +2113,7 @@ extern "C" fn accessibility_action(
         AccessibilityAction::Default => perform("accessible-action-default", &[]),
         AccessibilityAction::Decrement => perform("accessible-action-decrement", &[]),
         AccessibilityAction::Increment => perform("accessible-action-increment", &[]),
+        AccessibilityAction::Expand => perform("accessible-action-expand", &[]),
         AccessibilityAction::ReplaceSelectedText(_a) => {
             //perform("accessible-action-replace-selected-text", &[Value::String(a.clone())])
             i_slint_core::debug_log!("AccessibilityAction::ReplaceSelectedText not implemented in interpreter's accessibility_action");

--- a/tests/cases/widgets/combobox.slint
+++ b/tests/cases/widgets/combobox.slint
@@ -45,6 +45,7 @@ assert_eq!(instance.get_has_focus(), false);
 
 let mut combobox_search = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::box");
 let combobox = combobox_search.next().unwrap();
+assert_eq!(combobox.accessible_expandable(), Some(true));
 assert_eq!(combobox.accessible_value(), Some(SharedString::from("Aaa")));
 
 // Change the index programmatically

--- a/tests/cases/widgets/combobox.slint
+++ b/tests/cases/widgets/combobox.slint
@@ -153,6 +153,19 @@ slint_testing::send_mouse_click(&instance, 100., 10.);
 assert_eq!(instance.get_output(), "clicked-under\n");
 assert_eq!(combobox.accessible_expanded(), Some(false));
 assert_eq!(instance.get_has_focus(), true);
+instance.set_output(Default::default());
+
+
+// The accessible expand action should open the popup
+combobox.invoke_accessible_expand_action();
+assert_eq!(instance.get_output(), "");
+assert_eq!(instance.get_has_focus(), true);
+assert_eq!(combobox.accessible_expanded(), Some(true));
+// close the popup
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Escape));
+assert_eq!(instance.get_output(), "");
+assert_eq!(instance.get_has_focus(), true);
+assert_eq!(combobox.accessible_expanded(), Some(false));
 
 
 // Set current-index to -1

--- a/tests/cases/widgets/combobox.slint
+++ b/tests/cases/widgets/combobox.slint
@@ -46,6 +46,7 @@ assert_eq!(instance.get_has_focus(), false);
 let mut combobox_search = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::box");
 let combobox = combobox_search.next().unwrap();
 assert_eq!(combobox.accessible_expandable(), Some(true));
+assert_eq!(combobox.accessible_expanded(), Some(false));
 assert_eq!(combobox.accessible_value(), Some(SharedString::from("Aaa")));
 
 // Change the index programmatically
@@ -65,6 +66,7 @@ assert_eq!(instance.get_has_focus(), false);
 slint_testing::send_mouse_click(&instance, 100., 100.);
 assert_eq!(instance.get_output(), "");
 assert_eq!(instance.get_has_focus(), true);
+assert_eq!(combobox.accessible_expanded(), Some(true));
 
 // click outside of the combobox, this should close it
 slint_testing::send_mouse_click(&instance, 100., 10.);
@@ -73,6 +75,7 @@ assert_eq!(instance.get_current_value(), "Aaa");
 assert_eq!(instance.get_current_index(), 0);
 assert_eq!(combobox.accessible_value(), Some(SharedString::from("Aaa")));
 assert_eq!(instance.get_has_focus(), true);
+assert_eq!(combobox.accessible_expanded(), Some(false));
 
 // click outside of the combobox again
 slint_testing::send_mouse_click(&instance, 100., 10.);
@@ -82,6 +85,7 @@ assert_eq!(instance.get_current_value(), "Aaa");
 assert_eq!(instance.get_current_index(), 0);
 assert_eq!(combobox.accessible_value(), Some(SharedString::from("Aaa")));
 assert_eq!(instance.get_has_focus(), true);
+assert_eq!(combobox.accessible_expanded(), Some(false));
 
 
 // The arrow change the values
@@ -105,13 +109,16 @@ instance.set_output(Default::default());
 // show the popup
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Return));
 assert_eq!(instance.get_output(), "");
+assert_eq!(combobox.accessible_expanded(), Some(true));
 // click outside causes the popup to close
 slint_testing::send_mouse_click(&instance, 100., 10.);
 assert_eq!(instance.get_output(), "");
 assert_eq!(instance.get_has_focus(), true);
+assert_eq!(combobox.accessible_expanded(), Some(false));
 slint_testing::send_mouse_click(&instance, 100., 10.);
 assert_eq!(instance.get_output(), "clicked-under\n");
 assert_eq!(instance.get_has_focus(), true);
+assert_eq!(combobox.accessible_expanded(), Some(false));
 instance.set_output(Default::default());
 
 instance.set_current_index(0);
@@ -144,6 +151,7 @@ assert_eq!(instance.get_output(), "selected(Bbb,1)\nselected(Ccc,2)\nselected(Bb
 instance.set_output(Default::default());
 slint_testing::send_mouse_click(&instance, 100., 10.);
 assert_eq!(instance.get_output(), "clicked-under\n");
+assert_eq!(combobox.accessible_expanded(), Some(false));
 assert_eq!(instance.get_has_focus(), true);
 
 

--- a/tests/cases/widgets/combobox.slint
+++ b/tests/cases/widgets/combobox.slint
@@ -43,14 +43,20 @@ assert_eq!(instance.get_current_value(), "Aaa");
 assert_eq!(instance.get_current_index(), 0);
 assert_eq!(instance.get_has_focus(), false);
 
+let mut combobox_search = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::box");
+let combobox = combobox_search.next().unwrap();
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Aaa")));
+
 // Change the index programmatically
 instance.set_current_index(1);
 assert_eq!(instance.get_current_value(), "Bbb");
 assert_eq!(instance.get_current_index(), 1);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Bbb")));
 assert_eq!(instance.get_output(), "");
 instance.set_current_index(0);
 assert_eq!(instance.get_current_value(), "Aaa");
 assert_eq!(instance.get_current_index(), 0);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Aaa")));
 assert_eq!(instance.get_output(), "");
 assert_eq!(instance.get_has_focus(), false);
 
@@ -64,6 +70,7 @@ slint_testing::send_mouse_click(&instance, 100., 10.);
 assert_eq!(instance.get_output(), "");
 assert_eq!(instance.get_current_value(), "Aaa");
 assert_eq!(instance.get_current_index(), 0);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Aaa")));
 assert_eq!(instance.get_has_focus(), true);
 
 // click outside of the combobox again
@@ -72,6 +79,7 @@ assert_eq!(instance.get_output(), "clicked-under\n");
 instance.set_output(Default::default());
 assert_eq!(instance.get_current_value(), "Aaa");
 assert_eq!(instance.get_current_index(), 0);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Aaa")));
 assert_eq!(instance.get_has_focus(), true);
 
 
@@ -79,14 +87,17 @@ assert_eq!(instance.get_has_focus(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
 assert_eq!(instance.get_current_value(), "Bbb");
 assert_eq!(instance.get_current_index(), 1);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Bbb")));
 assert_eq!(instance.get_output(), "selected(Bbb,1)\n");
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
 assert_eq!(instance.get_current_value(), "Ccc");
 assert_eq!(instance.get_current_index(), 2);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Ccc")));
 assert_eq!(instance.get_output(), "selected(Bbb,1)\nselected(Ccc,2)\n");
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::UpArrow));
 assert_eq!(instance.get_current_value(), "Bbb");
 assert_eq!(instance.get_current_index(), 1);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Bbb")));
 assert_eq!(instance.get_output(), "selected(Bbb,1)\nselected(Ccc,2)\nselected(Bbb,1)\n");
 instance.set_output(Default::default());
 
@@ -111,19 +122,23 @@ slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key:
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
 assert_eq!(instance.get_current_value(), "Bbb");
 assert_eq!(instance.get_current_index(), 1);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Bbb")));
 assert_eq!(instance.get_output(), "selected(Bbb,1)\n");
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
 assert_eq!(instance.get_current_value(), "Ccc");
 assert_eq!(instance.get_current_index(), 2);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Ccc")));
 assert_eq!(instance.get_output(), "selected(Bbb,1)\nselected(Ccc,2)\n");
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::UpArrow));
 assert_eq!(instance.get_current_value(), "Bbb");
 assert_eq!(instance.get_current_index(), 1);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Bbb")));
 assert_eq!(instance.get_output(), "selected(Bbb,1)\nselected(Ccc,2)\nselected(Bbb,1)\n");
 // close the popup
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Escape));
 assert_eq!(instance.get_current_value(), "Bbb");
 assert_eq!(instance.get_current_index(), 1);
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("Bbb")));
 assert_eq!(instance.get_output(), "selected(Bbb,1)\nselected(Ccc,2)\nselected(Bbb,1)\n");
 instance.set_output(Default::default());
 slint_testing::send_mouse_click(&instance, 100., 10.);
@@ -135,13 +150,14 @@ assert_eq!(instance.get_has_focus(), true);
 instance.set_current_index(-1);
 mock_elapsed_time(500);
 assert_eq!(instance.get_current_value(), &SharedString::from(""));
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("")));
 
 // Replace model
 instance.set_model(Rc::new(VecModel::from_slice(&[SharedString::from("A"), SharedString::from("B")])).into());
 mock_elapsed_time(500);
 assert_eq!(instance.get_current_index(), 0);
 assert_eq!(instance.get_current_value(), &SharedString::from("A"));
-
+assert_eq!(combobox.accessible_value(), Some(SharedString::from("A")));
 ```
 
 */


### PR DESCRIPTION
<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

This improves how ComboBox widgets are represented in the accessibility tree so that they can be interacted with using assistive technologies. The "expanded state" is still unusable for now but since the value is properly reported, arrow keys can already be used to pick a choice without opening the popup.

The AccessKit platform adapters currently don't expose the `Node::is_expanded` property to the various accessibility layers, but this is expected to ship in the next release or so. Testing was performed with a branch of mine.

## Changelog

- Improved accessibility of ComboBox widgets
- Added `accessible-expandable` and `accessible-expanded` properties, as well as `accessible-action-expand`.