### PR TITLE
Fix support for menu bars provided by native code

### DIFF
--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -285,14 +285,9 @@ pub fn send_message_to_lsp(message: PreviewToLspMessage) {
 fn init_apple_platform(
 ) -> Result<(muda::MenuItem, muda::MenuItem, muda::CheckMenuItem), i_slint_core::api::PlatformError>
 {
-    use i_slint_backend_winit::winit;
     use muda::{accelerator, CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu};
-    use winit::platform::macos::EventLoopBuilderExtMacOS;
-    let mut builder = winit::event_loop::EventLoop::with_user_event();
-    builder.with_default_menu(false);
 
-    let backend =
-        i_slint_backend_winit::Backend::builder().with_event_loop_builder(builder).build()?;
+    let backend = i_slint_backend_winit::Backend::builder().with_default_menu_bar(false).build()?;
 
     slint::platform::set_platform(Box::new(backend)).map_err(|set_platform_err| {
         i_slint_core::api::PlatformError::from(set_platform_err.to_string())


### PR DESCRIPTION
We said that when the app provides an event loop builder, we assume it also provides a menu bar.

Fixes the lsp's Window -> Keep on top menu on macOS.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
