### PR TITLE
VecModel<T>: Don't require that T implements Default

### DIFF
--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -315,10 +315,15 @@ impl<M: Model> Model for Rc<M> {
 }
 
 /// A [`Model`] backed by a `Vec<T>`, using interior mutability.
-#[derive(Default)]
 pub struct VecModel<T> {
     array: RefCell<Vec<T>>,
     notify: ModelNotify,
+}
+
+impl<T> Default for VecModel<T> {
+    fn default() -> Self {
+        Self { array: Default::default(), notify: Default::default() }
+    }
 }
 
 impl<T: 'static> VecModel<T> {
@@ -1539,5 +1544,16 @@ mod tests {
 
         assert_eq!(model.iter().max().unwrap(), 9);
         assert_eq!(model.max_requested_row.get(), 9);
+    }
+
+    #[test]
+    fn vecmodel_doesnt_require_default() {
+        #[derive(Clone)]
+        struct MyNoDefaultType {
+            _foo: bool,
+        }
+        let model = VecModel::<MyNoDefaultType>::default();
+        assert_eq!(model.row_count(), 0);
+        model.push(MyNoDefaultType { _foo: true });
     }
 }


### PR DESCRIPTION
ChangeLog: Rust: Removed the requirement that for VecModel<T> T has to implement Default.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
