### PR TITLE
Fix all format arg inlining

### DIFF
--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -477,7 +477,7 @@ pub fn compile_with_output_path(
         }
     });
 
-    write!(code_formatter, "{}", generated).map_err(CompileError::SaveError)?;
+    write!(code_formatter, "{generated}").map_err(CompileError::SaveError)?;
     dependencies.push(input_slint_file_path.as_ref().to_path_buf());
 
     for resource in doc.embedded_file_resources.borrow().keys() {
@@ -502,7 +502,7 @@ pub fn print_rustc_flags() -> std::io::Result<()> {
             toml.get("link_args").and_then(toml_edit::Item::as_array).into_iter().flatten()
         {
             if let Some(option) = link_arg.as_str() {
-                println!("cargo:rustc-link-arg={}", option);
+                println!("cargo:rustc-link-arg={option}");
             }
         }
 

--- a/internal/backends/qt/build.rs
+++ b/internal/backends/qt/build.rs
@@ -27,9 +27,8 @@ fn main() {
     if !qt_version.starts_with("5.15") && !qt_version.starts_with("6.") {
         println!("cargo:rustc-cfg=no_qt");
         println!(
-            "cargo:warning=Qt {} is not supported, you need at least Qt 5.15. The Qt backend will not be functional. \
-             See https://github.com/slint-ui/slint/blob/master/docs/install_qt.md for more info",
-            qt_version
+            "cargo:warning=Qt {qt_version} is not supported, you need at least Qt 5.15. The Qt backend will not be functional. \
+             See https://github.com/slint-ui/slint/blob/master/docs/install_qt.md for more info"
         );
         return;
     }

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -78,7 +78,7 @@ cfg_if::cfg_if! {
                     Ok(platform) => return Ok(platform),
                     Err(err) => {
                         backend_errors.push(if !backend_name.is_empty() {
-                            format!("Error from {} backend: {}", backend_name, err).into()
+                            format!("Error from {backend_name} backend: {err}").into()
                         } else {
                             "No backends configured.".into()
                         });
@@ -115,7 +115,7 @@ cfg_if::cfg_if! {
             }
 
             if !backend_config.is_empty() {
-                eprintln!("Could not load rendering backend {}, fallback to default", backend_config)
+                eprintln!("Could not load rendering backend {backend_config}, fallback to default")
             }
             create_default_backend()
         }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -315,8 +315,7 @@ impl BackendBuilder {
             (Some(renderer_name), _) => {
                 if self.allow_fallback {
                     eprintln!(
-                        "slint winit: unrecognized renderer {}, falling back to {}",
-                        renderer_name, DEFAULT_RENDERER_NAME
+                        "slint winit: unrecognized renderer {renderer_name}, falling back to {DEFAULT_RENDERER_NAME}"
                     );
                     default_renderer_factory
                 } else {

--- a/internal/backends/winit/renderer/femtovg/glcontext.rs
+++ b/internal/backends/winit/renderer/femtovg/glcontext.rs
@@ -148,7 +148,7 @@ impl OpenGLContext {
             gl_display
                 .create_context(&gl_config, &preferred_context_attributes)
                 .or_else(|_| gl_display.create_context(&gl_config, &fallback_context_attributes))
-                .map_err(|glutin_err| format!("Cannot create OpenGL context: {}", glutin_err))?
+                .map_err(|glutin_err| format!("Cannot create OpenGL context: {glutin_err}"))?
         };
 
         let window = match window {
@@ -162,7 +162,7 @@ impl OpenGLContext {
                 }
             }
             .map_err(|winit_os_error| {
-                format!("Error finalizing window for OpenGL rendering: {}", winit_os_error)
+                format!("Error finalizing window for OpenGL rendering: {winit_os_error}")
             })?,
         };
 
@@ -193,7 +193,7 @@ impl OpenGLContext {
 
         let surface = unsafe {
             gl_display.create_window_surface(&gl_config, &attrs).map_err(|glutin_err| {
-                format!("Error creating OpenGL Window surface: {}", glutin_err)
+                format!("Error creating OpenGL Window surface: {glutin_err}")
             })?
         };
 

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -177,7 +177,7 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
     ) -> Result<Rc<winit::window::Window>, PlatformError> {
         let winit_window = crate::event_loop::with_window_target(|event_loop| {
             event_loop.create_window(window_attributes).map_err(|winit_os_error| {
-                format!("Error creating native window for software rendering: {}", winit_os_error)
+                format!("Error creating native window for software rendering: {winit_os_error}")
                     .into()
             })
         })?;
@@ -187,7 +187,7 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
             .map_err(|e| format!("Error creating softbuffer context: {e}"))?;
 
         let surface = softbuffer::Surface::new(&context, winit_window.clone()).map_err(
-            |softbuffer_error| format!("Error creating softbuffer surface: {}", softbuffer_error),
+            |softbuffer_error| format!("Error creating softbuffer surface: {softbuffer_error}"),
         )?;
 
         *self._context.borrow_mut() = Some(context);

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -320,8 +320,7 @@ impl BuildDiagnostics {
     ) {
         debug_assert!(
             !message.as_str().ends_with('.'),
-            "Error message should not end with a period: ({:?})",
-            message
+            "Error message should not end with a period: ({message:?})"
         );
         self.inner.push(Diagnostic { message, span, level });
     }
@@ -349,8 +348,7 @@ impl BuildDiagnostics {
     ) {
         self.push_diagnostic_with_span(
             format!(
-                "The property '{}' has been deprecated. Please use '{}' instead",
-                old_property, new_property
+                "The property '{old_property}' has been deprecated. Please use '{new_property}' instead"
             ),
             source.to_source_location(),
             crate::diagnostics::DiagnosticLevel::Warning,

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -58,7 +58,7 @@ impl std::str::FromStr for OutputFormat {
             #[cfg(feature = "rust")]
             "rust" => Ok(Self::Rust),
             "llr" => Ok(Self::Llr),
-            _ => Err(format!("Unknown output format {}", s)),
+            _ => Err(format!("Unknown output format {s}")),
         }
     }
 }
@@ -76,12 +76,12 @@ pub fn generate(
         #[cfg(feature = "cpp")]
         OutputFormat::Cpp(config) => {
             let output = cpp::generate(doc, config, compiler_config)?;
-            write!(destination, "{}", output)?;
+            write!(destination, "{output}")?;
         }
         #[cfg(feature = "rust")]
         OutputFormat::Rust => {
             let output = rust::generate(doc, compiler_config)?;
-            write!(destination, "{}", output)?;
+            write!(destination, "{output}")?;
         }
         OutputFormat::Interpreter => {
             return Err(std::io::Error::new(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2665,7 +2665,7 @@ fn compile_builtin_function_call(
                     sp::WindowInner::from_pub(#window_tokens.window()).set_focus_item(#focus_item, true)
                 )
             } else {
-                panic!("internal error: invalid args to SetFocusItem {:?}", arguments)
+                panic!("internal error: invalid args to SetFocusItem {arguments:?}")
             }
         }
         BuiltinFunction::ClearFocusItem => {
@@ -2676,7 +2676,7 @@ fn compile_builtin_function_call(
                     sp::WindowInner::from_pub(#window_tokens.window()).set_focus_item(#focus_item, false)
                 )
             } else {
-                panic!("internal error: invalid args to ClearFocusItem {:?}", arguments)
+                panic!("internal error: invalid args to ClearFocusItem {arguments:?}")
             }
         }
         BuiltinFunction::ShowPopupWindow => {
@@ -2727,7 +2727,7 @@ fn compile_builtin_function_call(
                     #popup_window_id::user_init(popup_instance_vrc.clone());
                 })
             } else {
-                panic!("internal error: invalid args to ShowPopupWindow {:?}", arguments)
+                panic!("internal error: invalid args to ShowPopupWindow {arguments:?}")
             }
         }
         BuiltinFunction::ClosePopupWindow => {
@@ -2751,7 +2751,7 @@ fn compile_builtin_function_call(
                     }
                 )
             } else {
-                panic!("internal error: invalid args to ClosePopupWindow {:?}", arguments)
+                panic!("internal error: invalid args to ClosePopupWindow {arguments:?}")
             }
         }
         BuiltinFunction::ShowPopupMenu => {
@@ -2866,7 +2866,7 @@ fn compile_builtin_function_call(
                     #item.set_selection_offsets(#window_adapter_tokens, #item_rc, #start as i32, #end as i32)
                 ))
             } else {
-                panic!("internal error: invalid args to set-selection-offsets {:?}", arguments)
+                panic!("internal error: invalid args to set-selection-offsets {arguments:?}")
             }
         }
         BuiltinFunction::ItemMemberFunction(name) => {
@@ -2881,7 +2881,7 @@ fn compile_builtin_function_call(
                     )
                 })
             } else {
-                panic!("internal error: invalid args to ItemMemberFunction {:?}", arguments)
+                panic!("internal error: invalid args to ItemMemberFunction {arguments:?}")
             }
         }
         BuiltinFunction::ItemFontMetrics => {
@@ -2894,7 +2894,7 @@ fn compile_builtin_function_call(
                     )
                 })
             } else {
-                panic!("internal error: invalid args to ItemMemberFunction {:?}", arguments)
+                panic!("internal error: invalid args to ItemMemberFunction {arguments:?}")
             }
         }
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
@@ -2907,7 +2907,7 @@ fn compile_builtin_function_call(
                     )
                 })
             } else {
-                panic!("internal error: invalid args to ImplicitLayoutInfo {:?}", arguments)
+                panic!("internal error: invalid args to ImplicitLayoutInfo {arguments:?}")
             }
         }
         BuiltinFunction::RegisterCustomFontByPath => {
@@ -2916,7 +2916,7 @@ fn compile_builtin_function_call(
                 let path = path.as_str();
                 quote!(#window_adapter_tokens.renderer().register_font_from_path(&std::path::PathBuf::from(#path)).unwrap())
             } else {
-                panic!("internal error: invalid args to RegisterCustomFontByPath {:?}", arguments)
+                panic!("internal error: invalid args to RegisterCustomFontByPath {arguments:?}")
             }
         }
         BuiltinFunction::RegisterCustomFontByMemory => {
@@ -2926,7 +2926,7 @@ fn compile_builtin_function_call(
                 let window_adapter_tokens = access_window_adapter_field(ctx);
                 quote!(#window_adapter_tokens.renderer().register_font_from_memory(#symbol.into()).unwrap())
             } else {
-                panic!("internal error: invalid args to RegisterCustomFontByMemory {:?}", arguments)
+                panic!("internal error: invalid args to RegisterCustomFontByMemory {arguments:?}")
             }
         }
         BuiltinFunction::RegisterBitmapFont => {
@@ -3176,7 +3176,7 @@ fn compile_builtin_function_call(
                     sp::logical_position_to_api((*#item_rc).map_to_window(::core::default::Default::default()))
                 )
             } else {
-                panic!("internal error: invalid args to MapPointToWindow {:?}", arguments)
+                panic!("internal error: invalid args to MapPointToWindow {arguments:?}")
             }
         }
         BuiltinFunction::UpdateTimers => {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -123,7 +123,7 @@ impl Display for Type {
                         if i > 0 {
                             write!(f, ",")?;
                         }
-                        write!(f, "{}", arg)?;
+                        write!(f, "{arg}")?;
                     }
                     write!(f, ")")?
                 }
@@ -137,7 +137,7 @@ impl Display for Type {
                     if i > 0 {
                         write!(f, ",")?;
                     }
-                    write!(f, "{}", arg)?;
+                    write!(f, "{arg}")?;
                 }
                 write!(f, ") -> {}", function.return_type)
             }
@@ -154,8 +154,8 @@ impl Display for Type {
             Type::Image => write!(f, "image"),
             Type::Bool => write!(f, "bool"),
             Type::Model => write!(f, "model"),
-            Type::Array(t) => write!(f, "[{}]", t),
-            Type::Struct(t) => write!(f, "{}", t),
+            Type::Array(t) => write!(f, "[{t}]"),
+            Type::Struct(t) => write!(f, "{t}"),
             Type::PathData => write!(f, "pathdata"),
             Type::Easing => write!(f, "easing"),
             Type::Brush => write!(f, "brush"),
@@ -540,7 +540,7 @@ impl ElementType {
                         if !tr.expose_internal_types
                             && matches!(&t, Self::Builtin(e) if e.is_internal)
                         {
-                            format!("Unknown element '{}'. (The type exist as an internal type, but cannot be accessed in this scope)", name)
+                            format!("Unknown element '{name}'. (The type exist as an internal type, but cannot be accessed in this scope)")
                         } else {
                             return Ok(t);
                         }
@@ -558,7 +558,7 @@ impl ElementType {
             }
             _ => tr.lookup_element(name).and_then(|t| {
                 if !tr.expose_internal_types && matches!(&t, Self::Builtin(e) if e.is_internal) {
-                    Err(format!("Unknown element '{}'. (The type exist as an internal type, but cannot be accessed in this scope)", name))
+                    Err(format!("Unknown element '{name}'. (The type exist as an internal type, but cannot be accessed in this scope)"))
                 } else {
                     Ok(t)
                 }
@@ -651,7 +651,7 @@ pub struct NativeClass {
 
 impl NativeClass {
     pub fn new(class_name: &str) -> Self {
-        let cpp_vtable_getter = format!("SLINT_GET_ITEM_VTABLE({}VTable)", class_name);
+        let cpp_vtable_getter = format!("SLINT_GET_ITEM_VTABLE({class_name}VTable)");
         Self {
             class_name: class_name.into(),
             cpp_vtable_getter,
@@ -790,12 +790,12 @@ impl Display for Struct {
                 // write the slint type and not the native type
                 write!(f, "{}", &name[separator_pos + 2..])
             } else {
-                write!(f, "{}", name)
+                write!(f, "{name}")
             }
         } else {
             write!(f, "{{ ")?;
             for (k, v) in &self.fields {
-                write!(f, "{}: {},", k, v)?;
+                write!(f, "{k}: {v},")?;
             }
             write!(f, "}}")
         }

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -245,15 +245,15 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
         let ctx = self.1;
         let e = |e: &'a Expression| DisplayExpression(e, ctx);
         match self.0 {
-            Expression::StringLiteral(x) => write!(f, "{:?}", x),
-            Expression::NumberLiteral(x) => write!(f, "{:?}", x),
-            Expression::BoolLiteral(x) => write!(f, "{:?}", x),
+            Expression::StringLiteral(x) => write!(f, "{x:?}"),
+            Expression::NumberLiteral(x) => write!(f, "{x:?}"),
+            Expression::BoolLiteral(x) => write!(f, "{x:?}"),
             Expression::PropertyReference(x) => write!(f, "{}", DisplayPropertyRef(x, ctx)),
-            Expression::FunctionParameterReference { index } => write!(f, "arg_{}", index),
+            Expression::FunctionParameterReference { index } => write!(f, "arg_{index}"),
             Expression::StoreLocalVariable { name, value } => {
                 write!(f, "{} = {}", name, e(value))
             }
-            Expression::ReadLocalVariable { name, .. } => write!(f, "{}", name),
+            Expression::ReadLocalVariable { name, .. } => write!(f, "{name}"),
             Expression::StructFieldAccess { base, name } => write!(f, "{}.{}", e(base), name),
             Expression::ArrayIndex { array, index } => write!(f, "{}[{}]", e(array), e(index)),
             Expression::Cast { from, to } => write!(f, "{} /*as {:?}*/", e(from), to),
@@ -296,9 +296,9 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
             }
             Expression::UnaryOp { sub, op } => write!(f, "{}{}", op, e(sub)),
             Expression::ImageReference { resource_ref, nine_slice } => {
-                write!(f, "{:?}", resource_ref)?;
+                write!(f, "{resource_ref:?}")?;
                 if let Some(nine_slice) = &nine_slice {
-                    write!(f, "nine-slice({:?})", nine_slice)?;
+                    write!(f, "nine-slice({nine_slice:?})")?;
                 }
                 Ok(())
             }
@@ -313,7 +313,7 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                 "{{ {} }}",
                 values.iter().map(|(k, v)| format!("{}: {}", k, e(v))).join(", ")
             ),
-            Expression::EasingCurve(x) => write!(f, "{:?}", x),
+            Expression::EasingCurve(x) => write!(f, "{x:?}"),
             Expression::LinearGradient { angle, stops } => write!(
                 f,
                 "@linear-gradient({}, {})",
@@ -325,7 +325,7 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                 "@radial-gradient(circle, {})",
                 stops.iter().map(|(e1, e2)| format!("{} {}", e(e1), e(e2))).join(", ")
             ),
-            Expression::EnumerationValue(x) => write!(f, "{}", x),
+            Expression::EnumerationValue(x) => write!(f, "{x}"),
             Expression::LayoutCacheAccess { layout_cache_prop, index, repeater_index: None } => {
                 write!(f, "{}[{}]", DisplayPropertyRef(layout_cache_prop, ctx), index)
             }

--- a/internal/compiler/llr/translations.rs
+++ b/internal/compiler/llr/translations.rs
@@ -50,7 +50,7 @@ impl TranslationsBuilder {
             vec![Some(plural_rule_parser::parse_rule_expression("n!=1").unwrap())];
         for l in std::fs::read_dir(path)? {
             let l = l?;
-            let path = l.path().join("LC_MESSAGES").join(format!("{}.po", domain));
+            let path = l.path().join("LC_MESSAGES").join(format!("{domain}.po"));
             if path.exists() {
                 let catalog = polib::po_file::parse(&path).map_err(|e| {
                     std::io::Error::other(format!("Error parsing {}: {e}", path.display()))

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -29,7 +29,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
         let vec = diag.to_string_vec();
         #[cfg(feature = "display-diagnostics")]
         diag.print();
-        panic!("Error parsing the builtin elements: {:?}", vec);
+        panic!("Error parsing the builtin elements: {vec:?}");
     }
 
     assert_eq!(node.kind(), crate::parser::SyntaxKind::Document);
@@ -194,7 +194,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
             .map(|size_type| match size_type.as_deref() {
                 Some("expands_to_parent_geometry") => DefaultSizeBinding::ExpandsToParentGeometry,
                 Some("implicit_size") => DefaultSizeBinding::ImplicitSize,
-                other => panic!("invalid default size binding {:?}", other),
+                other => panic!("invalid default size binding {other:?}"),
             })
             .unwrap_or(DefaultSizeBinding::None);
         builtin.additional_accepted_child_types = e
@@ -240,7 +240,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
         let vec = diag.to_string_vec();
         #[cfg(feature = "display-diagnostics")]
         diag.print();
-        panic!("Error loading the builtin elements: {:?}", vec);
+        panic!("Error loading the builtin elements: {vec:?}");
     }
 }
 
@@ -260,7 +260,7 @@ fn compiled(
         let vec = diag.to_string_vec();
         #[cfg(feature = "display-diagnostics")]
         diag.print();
-        panic!("Error parsing the builtin elements: {:?}", vec);
+        panic!("Error parsing the builtin elements: {vec:?}");
     }
     e
 }

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -478,7 +478,7 @@ pub fn check_deprecated_stylemetrics(
             .and_then(|x| x.node.source_file())
             .map_or(true, |x| x.path().starts_with("builtin:"))
         && !name.starts_with("layout-"))
-    .then(|| format!("Palette.{}", name))
+    .then(|| format!("Palette.{name}"))
 }
 
 fn expression_from_reference(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -788,7 +788,7 @@ pub fn pretty_print(
     for (name, expr) in &e.bindings {
         let expr = expr.borrow();
         indent!();
-        write!(f, "{}: ", name)?;
+        write!(f, "{name}: ")?;
         expression_tree::pretty_print(f, &expr.expression)?;
         if expr.analysis.as_ref().map_or(false, |a| a.is_const) {
             write!(f, "/*const*/")?;
@@ -797,11 +797,11 @@ pub fn pretty_print(
         //writeln!(f, "; /*{}*/", expr.priority)?;
         if let Some(anim) = &expr.animation {
             indent!();
-            writeln!(f, "animate {} {:?}", name, anim)?;
+            writeln!(f, "animate {name} {anim:?}")?;
         }
         for nr in &expr.two_way_bindings {
             indent!();
-            writeln!(f, "{} <=> {:?};", name, nr)?;
+            writeln!(f, "{name} <=> {nr:?};")?;
         }
     }
     for (name, ch) in &e.change_callbacks {
@@ -826,7 +826,7 @@ pub fn pretty_print(
     }
     if let Some(g) = &e.geometry_props {
         indent!();
-        writeln!(f, "geometry {:?} ", g)?;
+        writeln!(f, "geometry {g:?} ")?;
     }
 
     /*if let Type::Component(base) = &e.base_type {
@@ -948,7 +948,7 @@ impl Element {
         } else if parent_type == ElementType::Global {
             // This must be a global component it can only have properties and callback
             let mut error_on = |node: &dyn Spanned, what: &str| {
-                diag.push_error(format!("A global component cannot have {}", what), node);
+                diag.push_error(format!("A global component cannot have {what}"), node);
             };
             node.SubElement().for_each(|n| error_on(&n, "sub elements"));
             node.RepeatedElement().for_each(|n| error_on(&n, "sub elements"));
@@ -1019,14 +1019,14 @@ impl Element {
             match maybe_existing_prop_type {
                 Type::Callback { .. } => {
                     diag.push_error(
-                        format!("Cannot declare property '{}' when a callback with the same name exists", prop_name),
+                        format!("Cannot declare property '{prop_name}' when a callback with the same name exists"),
                         &prop_decl.DeclaredIdentifier().child_token(SyntaxKind::Identifier).unwrap(),
                     );
                     continue;
                 }
                 Type::Function { .. } => {
                     diag.push_error(
-                        format!("Cannot declare property '{}' when a function with the same name exists", prop_name),
+                        format!("Cannot declare property '{prop_name}' when a function with the same name exists"),
                         &prop_decl.DeclaredIdentifier().child_token(SyntaxKind::Identifier).unwrap(),
                     );
                     continue;
@@ -1034,7 +1034,7 @@ impl Element {
                 Type::Invalid => {} // Ok to proceed with a new declaration
                 _ => {
                     diag.push_error(
-                        format!("Cannot override property '{}'", unresolved_prop_name),
+                        format!("Cannot override property '{unresolved_prop_name}'"),
                         &prop_decl
                             .DeclaredIdentifier()
                             .child_token(SyntaxKind::Identifier)
@@ -1147,7 +1147,7 @@ impl Element {
                         );
                     } else {
                         diag.push_error(
-                            format!("Cannot override callback '{}'", existing_name),
+                            format!("Cannot override callback '{existing_name}'"),
                             &sig_decl.DeclaredIdentifier(),
                         )
                     }
@@ -1224,12 +1224,12 @@ impl Element {
                 if matches!(maybe_existing_prop_type, Type::Callback { .. } | Type::Function { .. })
                 {
                     diag.push_error(
-                        format!("Cannot override '{}'", existing_name),
+                        format!("Cannot override '{existing_name}'"),
                         &func.DeclaredIdentifier(),
                     )
                 } else {
                     diag.push_error(
-                        format!("Cannot declare function '{}' when a property with the same name exists", existing_name),
+                        format!("Cannot declare function '{existing_name}' when a property with the same name exists"),
                         &func.DeclaredIdentifier(),
                     );
                 }
@@ -1587,7 +1587,7 @@ impl Element {
         let mut id = parser::identifier_text(&node).unwrap_or_default();
         if matches!(id.as_ref(), "parent" | "self" | "root") {
             diag.push_error(
-                format!("'{}' is a reserved id", id),
+                format!("'{id}' is a reserved id"),
                 &node.child_token(SyntaxKind::Identifier).unwrap(),
             );
             id = SmolStr::default();
@@ -1721,7 +1721,7 @@ impl Element {
                             }
                         }
                         Type::Callback { .. } => {
-                            diag.push_error(format!("'{}' is a callback. Use `=>` to connect", unresolved_name),
+                            diag.push_error(format!("'{unresolved_name}' is a callback. Use `=>` to connect"),
                             &name_token)
                         }
                         _ => diag.push_error(format!(
@@ -1922,10 +1922,10 @@ pub fn type_from_node(
         let prop_type = tr.lookup_qualified(&qualified_type.members);
 
         if prop_type == Type::Invalid && tr.lookup_element(&qualified_type.to_smolstr()).is_err() {
-            diag.push_error(format!("Unknown type '{}'", qualified_type), &qualified_type_node);
+            diag.push_error(format!("Unknown type '{qualified_type}'"), &qualified_type_node);
         } else if !prop_type.is_property_type() {
             diag.push_error(
-                format!("'{}' is not a valid type", qualified_type),
+                format!("'{qualified_type}' is not a valid type"),
                 &qualified_type_node,
             );
         }
@@ -2029,7 +2029,7 @@ fn lookup_property_from_qualified_name_for_state(
         [unresolved_prop_name] => {
             let lookup_result = r.borrow().lookup_property(unresolved_prop_name.as_ref());
             if !lookup_result.property_type.is_property_type() {
-                diag.push_error(format!("'{}' is not a valid property", qualname), &node);
+                diag.push_error(format!("'{qualname}' is not a valid property"), &node);
             } else if !lookup_result.is_valid_for_assignment() {
                 diag.push_error(
                     format!(
@@ -2049,7 +2049,7 @@ fn lookup_property_from_qualified_name_for_state(
                 let lookup_result = element.borrow().lookup_property(unresolved_prop_name.as_ref());
                 if !lookup_result.is_valid() {
                     diag.push_error(
-                        format!("'{}' not found in '{}'", unresolved_prop_name, elem_id),
+                        format!("'{unresolved_prop_name}' not found in '{elem_id}'"),
                         &node,
                     );
                 } else if !lookup_result.is_valid_for_assignment() {
@@ -2066,12 +2066,12 @@ fn lookup_property_from_qualified_name_for_state(
                     lookup_result.property_type,
                 ))
             } else {
-                diag.push_error(format!("'{}' is not a valid element id", elem_id), &node);
+                diag.push_error(format!("'{elem_id}' is not a valid element id"), &node);
                 None
             }
         }
         _ => {
-            diag.push_error(format!("'{}' is not a valid property", qualname), &node);
+            diag.push_error(format!("'{qualname}' is not a valid property"), &node);
             None
         }
     }
@@ -2527,12 +2527,12 @@ impl Exports {
                     || type_registry.lookup(internal_name) != Type::Invalid
                 {
                     diag.push_error(
-                        format!("Cannot export '{}' because it is not a component", internal_name,),
+                        format!("Cannot export '{internal_name}' because it is not a component",),
                         internal_name_node,
                     );
                     None
                 } else {
-                    diag.push_error(format!("'{}' not found", internal_name,), internal_name_node);
+                    diag.push_error(format!("'{internal_name}' not found",), internal_name_node);
                     None
                 }
             };

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -541,7 +541,7 @@ mod parser_trait {
         /// Returns true if the token was consumed.
         fn expect(&mut self, kind: SyntaxKind) -> bool {
             if !self.test(kind) {
-                self.error(format!("Syntax error: expected {}", kind));
+                self.error(format!("Syntax error: expected {kind}"));
                 return false;
             }
             true

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -87,9 +87,7 @@ impl PropertyPath {
                         &element,
                         last.borrow().base_type.as_component()
                     ),
-                    "The element is not in the component pointed at by the path ({:?} / {:?})",
-                    self,
-                    second
+                    "The element is not in the component pointed at by the path ({self:?} / {second:?})"
                 );
                 element = last.0;
             } else {

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -82,8 +82,7 @@ pub fn embed_glyphs<'a>(
             } else {
                 diag.push_error(
                     format!(
-                        "Invalid font size '{}' specified in `SLINT_FONT_SIZES`",
-                        custom_size_str
+                        "Invalid font size '{custom_size_str}' specified in `SLINT_FONT_SIZES`"
                     ),
                     &generic_diag_location,
                 );
@@ -131,7 +130,7 @@ fn embed_glyphs_with_fontdb<'a>(
             for (font_path, import_token) in doc.custom_fonts.iter() {
                 let face_count = fontdb_mut.faces().count();
                 if let Err(e) = fontdb_mut.make_mut().load_font_file(font_path) {
-                    diag.push_error(format!("Error loading font: {}", e), import_token);
+                    diag.push_error(format!("Error loading font: {e}"), import_token);
                 } else {
                     custom_fonts.extend(fontdb_mut.faces().skip(face_count).map(|info| info.id))
                 }

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -158,7 +158,7 @@ fn embed_image(
                         }
                         Err(err) => {
                             diag.push_error(
-                                format!("Cannot load image file {}: {}", path, err),
+                                format!("Cannot load image file {path}: {err}"),
                                 source_location,
                             );
                             return ImageReference::None;
@@ -167,7 +167,7 @@ fn embed_image(
                 }
                 e.insert(EmbeddedResources { id: maybe_id, kind })
             } else {
-                diag.push_error(format!("Cannot find image file {}", path), source_location);
+                diag.push_error(format!("Cannot find image file {path}"), source_location);
                 return ImageReference::None;
             }
         }

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -126,7 +126,7 @@ fn resolve_alias(
     if old_type == Type::InferredProperty {
         if !ty.is_property_type() {
             diag.push_error(
-                format!("Could not infer type of property '{}'", prop),
+                format!("Could not infer type of property '{prop}'"),
                 &elem.borrow().property_declarations[prop].type_node(),
             );
         } else {
@@ -138,7 +138,7 @@ fn resolve_alias(
                 debug_assert!(diag.has_errors());
             } else {
                 diag.push_error(
-                    format!("Binding to callback '{}' must bind to another callback", prop),
+                    format!("Binding to callback '{prop}' must bind to another callback"),
                     &elem.borrow().property_declarations[prop].type_node(),
                 );
             }

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -779,7 +779,7 @@ fn set_prop_from_cache(
     );
     if let Some(old) = old.map(RefCell::into_inner) {
         diag.push_error(
-            format!("The property '{}' cannot be set for elements placed in this layout, because the layout is already setting it", prop),
+            format!("The property '{prop}' cannot be set for elements placed in this layout, because the layout is already setting it"),
             &old,
         );
     }
@@ -794,7 +794,7 @@ fn eval_const_expr(
     match expression {
         Expression::NumberLiteral(v, Unit::None) => {
             if *v < 0. || *v > u16::MAX as f64 || !v.trunc().approx_eq(v) {
-                diag.push_error(format!("'{}' must be a positive integer", name), span);
+                diag.push_error(format!("'{name}' must be a positive integer"), span);
                 None
             } else {
                 Some(*v as u16)
@@ -802,7 +802,7 @@ fn eval_const_expr(
         }
         Expression::Cast { from, .. } => eval_const_expr(from, name, span, diag),
         _ => {
-            diag.push_error(format!("'{}' must be an integer literal", name), span);
+            diag.push_error(format!("'{name}' must be an integer literal"), span);
             None
         }
     }
@@ -812,10 +812,10 @@ fn eval_const_expr(
 fn check_no_layout_properties(item: &ElementRc, diag: &mut BuildDiagnostics) {
     for (prop, expr) in item.borrow().bindings.iter() {
         if matches!(prop.as_ref(), "col" | "row" | "colspan" | "rowspan") {
-            diag.push_error(format!("{} used outside of a GridLayout", prop), &*expr.borrow());
+            diag.push_error(format!("{prop} used outside of a GridLayout"), &*expr.borrow());
         }
         if matches!(prop.as_ref(), "dialog-button-role") {
-            diag.push_error(format!("{} used outside of a Dialog", prop), &*expr.borrow());
+            diag.push_error(format!("{prop} used outside of a Dialog"), &*expr.borrow());
         }
     }
 }

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -210,10 +210,7 @@ fn process_context_menu(
 
         for (name, _) in &components.context_menu_internal.property_list() {
             if let Some(decl) = context_menu_elem.borrow().property_declarations.get(name) {
-                diag.push_error(
-                    format!("Cannot re-define internal property '{}'", name),
-                    &decl.node,
-                );
+                diag.push_error(format!("Cannot re-define internal property '{name}'"), &decl.node);
             }
         }
 
@@ -365,7 +362,7 @@ fn process_window(
             .property_declarations
             .insert(prop.into(), PropertyDeclaration { property_type: ty, ..Default::default() });
         if let Some(old) = old {
-            diag.push_error(format!("Cannot re-define internal property '{}'", prop), &old.node);
+            diag.push_error(format!("Cannot re-define internal property '{prop}'"), &old.node);
         }
     }
 

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -233,7 +233,7 @@ fn lower_popup_window(
 }
 
 fn report_const_error(prop: &str, span: &Option<SourceLocation>, diag: &mut BuildDiagnostics) {
-    diag.push_error(format!("The {} property only supports constants at the moment", prop), span);
+    diag.push_error(format!("The {prop} property only supports constants at the moment"), span);
 }
 
 fn check_element(

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -28,8 +28,7 @@ pub(crate) fn lower_property_to_element(
     if let Some(b) = component.root_element.borrow().bindings.get(property_name) {
         diag.push_warning(
             format!(
-                "The {} property cannot be used on the root element, it will not be applied",
-                property_name
+                "The {property_name} property cannot be used on the root element, it will not be applied"
             ),
             &*b.borrow(),
         );

--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -111,7 +111,7 @@ pub fn lower_shadow_properties(
         take_shadow_property_bindings(&component.root_element)
     {
         diag.push_warning(
-            format!("The {} property cannot be used on the root element, the shadow will not be visible", shadow_prop_name),
+            format!("The {shadow_prop_name} property cannot be used on the root element, the shadow will not be visible"),
             &shadow_prop_binding,
         );
     }

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -267,7 +267,7 @@ fn set_geometry_prop(
     );
     if let Some(old) = old.map(RefCell::into_inner) {
         diag.push_error(
-            format!("The property '{}' cannot be set for Tabs inside a TabWidget", prop),
+            format!("The property '{prop}' cannot be set for Tabs inside a TabWidget"),
             &old,
         );
     }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -945,7 +945,7 @@ impl Expression {
             _ => {
                 if ty != Type::Invalid {
                     ctx.diag.push_error(
-                        format!("the {}= operation cannot be done on a {}", op, ty),
+                        format!("the {op}= operation cannot be done on a {ty}"),
                         &lhs_n,
                     );
                 }
@@ -1140,7 +1140,7 @@ impl Expression {
 
         let ty = array_expr.ty();
         if !matches!(ty, Type::Array(_) | Type::Invalid | Type::Function(_) | Type::Callback(_)) {
-            ctx.diag.push_error(format!("{} is not an indexable type", ty), &node);
+            ctx.diag.push_error(format!("{ty} is not an indexable type"), &node);
         }
         Expression::ArrayIndex { array: Box::new(array_expr), index: Box::new(index_expr) }
     }
@@ -1566,7 +1566,7 @@ fn maybe_lookup_object(
                     LookupResult::Expression { expression, .. } => {
                         let ty_descr = match expression.ty() {
                             Type::Struct { .. } => String::new(),
-                            ty => format!(" of {}", ty),
+                            ty => format!(" of {ty}"),
                         };
                         ctx.diag.push_error(
                             format!("Cannot access the field '{}'{}", next.text(), ty_descr),

--- a/internal/compiler/passes/unique_id.rs
+++ b/internal/compiler/passes/unique_id.rs
@@ -79,7 +79,7 @@ fn check_unique_id_in_component(component: &Rc<Component>, diag: &mut BuildDiagn
         if !id.is_empty() {
             if let Some(other_loc) = seen_ids.get_mut(id) {
                 debug_assert!(!Rc::ptr_eq(&other_loc.element, elem));
-                let message = format!("duplicated element id '{}'", id);
+                let message = format!("duplicated element id '{id}'");
                 if !other_loc.error_reported {
                     diag.push_error(message.clone(), &*other_loc.element.borrow());
                     other_loc.error_reported = true;

--- a/internal/compiler/passes/z_order.rs
+++ b/internal/compiler/passes/z_order.rs
@@ -80,7 +80,7 @@ fn eval_const_expr(
         Expression::UnaryOp { sub, op: '-' } => eval_const_expr(sub, name, span, diag).map(|v| -v),
         Expression::UnaryOp { sub, op: '+' } => eval_const_expr(sub, name, span, diag),
         _ => {
-            diag.push_error(format!("'{}' must be an number literal", name), span);
+            diag.push_error(format!("'{name}' must be an number literal"), span);
             None
         }
     }

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -119,7 +119,7 @@ fn process_diagnostics(
         let rx = m.get(3).unwrap().as_str();
         let r = match regex::Regex::new(rx) {
             Err(e) => {
-                eprintln!("{:?}: Invalid regexp {:?} : {:?}", path, rx, e);
+                eprintln!("{path:?}: Invalid regexp {rx:?} : {e:?}");
                 return Ok(false);
             }
             Ok(r) => r,
@@ -142,7 +142,7 @@ fn process_diagnostics(
         let expected_diag_level = match warning_or_error {
             "warning" => i_slint_compiler::diagnostics::DiagnosticLevel::Warning,
             "error" => i_slint_compiler::diagnostics::DiagnosticLevel::Error,
-            _ => panic!("Unsupported diagnostic level {}", warning_or_error),
+            _ => panic!("Unsupported diagnostic level {warning_or_error}"),
         };
 
         match diags.iter().position(|e| {
@@ -155,10 +155,7 @@ fn process_diagnostics(
             }
             None => {
                 success = false;
-                println!(
-                    "{:?}: {} not found at offset {}: {:?}",
-                    path, warning_or_error, offset, rx
-                );
+                println!("{path:?}: {warning_or_error} not found at offset {offset}: {rx:?}");
             }
         }
     }
@@ -167,7 +164,7 @@ fn process_diagnostics(
     diags.retain(|d| !(d.message().contains("':='") && d.message().contains("deprecated")));
 
     if !diags.is_empty() {
-        println!("{:?}: Unexpected errors/warnings: {:#?}", path, diags);
+        println!("{path:?}: Unexpected errors/warnings: {diags:#?}");
 
         #[cfg(feature = "display-diagnostics")]
         if !_silent {

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -870,7 +870,7 @@ impl TypeLoader {
         known_styles.push("native");
         if !known_styles.contains(&style.as_ref())
             && myself
-                .find_file_in_include_path(None, &format!("{}/std-widgets.slint", style))
+                .find_file_in_include_path(None, &format!("{style}/std-widgets.slint"))
                 .is_none()
         {
             diag.push_diagnostic_with_span(

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -287,7 +287,7 @@ pub fn reserved_property(name: &str) -> PropertyLookupResult {
                     if b == "imum-" {
                         return PropertyLookupResult {
                             property_type: Type::LogicalLength,
-                            resolved_name: format!("{}-{}", pre, suf).into(),
+                            resolved_name: format!("{pre}-{suf}").into(),
                             is_local_to_component: false,
                             is_in_direct_base: false,
                             property_visibility: crate::object_tree::PropertyVisibility::InOut,
@@ -614,9 +614,9 @@ impl TypeRegister {
                     )
                 }
             } else if let Some(ty) = self.types.get(name) {
-                format!("'{}' cannot be used as an element", ty)
+                format!("'{ty}' cannot be used as an element")
             } else {
-                format!("Unknown element '{}'", name)
+                format!("Unknown element '{name}'")
             }
         })
     }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -275,7 +275,7 @@ impl<'a> core::fmt::Debug for GraphicsAPI<'a> {
         match self {
             GraphicsAPI::NativeOpenGL { .. } => write!(f, "GraphicsAPI::NativeOpenGL"),
             GraphicsAPI::WebGL { context_type, .. } => {
-                write!(f, "GraphicsAPI::WebGL(context_type = {})", context_type)
+                write!(f, "GraphicsAPI::WebGL(context_type = {context_type})")
             }
         }
     }

--- a/internal/core/graphics/rendering_metrics_collector.rs
+++ b/internal/core/graphics/rendering_metrics_collector.rs
@@ -34,7 +34,7 @@ pub struct RenderingMetrics {
 impl core::fmt::Display for RenderingMetrics {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if let Some(layer_count) = self.layers_created {
-            write!(f, "[{} layers created]", layer_count)
+            write!(f, "[{layer_count} layers created]")
         } else {
             Ok(())
         }

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -676,8 +676,7 @@ impl PropertyHandle {
                     *(dependencies as *mut *const u32),
                     (&CONSTANT_PROPERTY_SENTINEL) as *const u32,
                 ),
-                "Constant property being changed {}",
-                debug_name
+                "Constant property being changed {debug_name}"
             );
             mark_dependencies_dirty(dependencies)
         };

--- a/internal/core/sharedvector.rs
+++ b/internal/core/sharedvector.rs
@@ -46,7 +46,7 @@ unsafe fn drop_inner<T>(mut inner: NonNull<SharedVectorInner<T>>) {
 /// Allocate the memory for the SharedVector with the given capacity. Return the inner with size and refcount set to 1
 fn alloc_with_capacity<T>(capacity: usize) -> NonNull<SharedVectorInner<T>> {
     let ptr = unsafe { ::alloc::alloc::alloc(compute_inner_layout::<T>(capacity)) };
-    assert!(!ptr.is_null(), "allocation of {:?} bytes failed", capacity);
+    assert!(!ptr.is_null(), "allocation of {capacity:?} bytes failed");
     unsafe {
         core::ptr::write(
             ptr as *mut SharedVectorHeader,

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -112,7 +112,7 @@ pub fn default_debug_log(_arguments: core::fmt::Arguments) {
 
             log(&_arguments.to_string());
         } else if #[cfg(feature = "std")] {
-            std::eprintln!("{}", _arguments);
+            std::eprintln!("{_arguments}");
         }
     }
 }

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -209,7 +209,7 @@ fn translate_gettext(
     use std::string::String;
     global_translation_property();
     fn mangle_context(ctx: &str, s: &str) -> String {
-        std::format!("{}\u{4}{}", ctx, s)
+        std::format!("{ctx}\u{4}{s}")
     }
     fn demangle_context(r: String) -> String {
         if let Some(x) = r.split('\u{4}').last() {

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -184,22 +184,22 @@ impl std::fmt::Debug for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Value::Void => write!(f, "Value::Void"),
-            Value::Number(n) => write!(f, "Value::Number({:?})", n),
-            Value::String(s) => write!(f, "Value::String({:?})", s),
-            Value::Bool(b) => write!(f, "Value::Bool({:?})", b),
-            Value::Image(i) => write!(f, "Value::Image({:?})", i),
+            Value::Number(n) => write!(f, "Value::Number({n:?})"),
+            Value::String(s) => write!(f, "Value::String({s:?})"),
+            Value::Bool(b) => write!(f, "Value::Bool({b:?})"),
+            Value::Image(i) => write!(f, "Value::Image({i:?})"),
             Value::Model(m) => {
                 write!(f, "Value::Model(")?;
                 f.debug_list().entries(m.iter()).finish()?;
                 write!(f, "])")
             }
-            Value::Struct(s) => write!(f, "Value::Struct({:?})", s),
-            Value::Brush(b) => write!(f, "Value::Brush({:?})", b),
-            Value::PathData(e) => write!(f, "Value::PathElements({:?})", e),
-            Value::EasingCurve(c) => write!(f, "Value::EasingCurve({:?})", c),
-            Value::EnumerationValue(n, v) => write!(f, "Value::EnumerationValue({:?}, {:?})", n, v),
-            Value::LayoutCache(v) => write!(f, "Value::LayoutCache({:?})", v),
-            Value::ComponentFactory(factory) => write!(f, "Value::ComponentFactory({:?})", factory),
+            Value::Struct(s) => write!(f, "Value::Struct({s:?})"),
+            Value::Brush(b) => write!(f, "Value::Brush({b:?})"),
+            Value::PathData(e) => write!(f, "Value::PathElements({e:?})"),
+            Value::EasingCurve(c) => write!(f, "Value::EasingCurve({c:?})"),
+            Value::EnumerationValue(n, v) => write!(f, "Value::EnumerationValue({n:?}, {v:?})"),
+            Value::LayoutCache(v) => write!(f, "Value::LayoutCache({v:?})"),
+            Value::ComponentFactory(factory) => write!(f, "Value::ComponentFactory({factory:?})"),
         }
     }
 }
@@ -2064,7 +2064,7 @@ fn component_definition_model_properties() {
                 assert_eq!(m.row_data(i).unwrap(), Value::Number(*v));
             }
         } else {
-            panic!("{:?} not a model", val);
+            panic!("{val:?} not a model");
         }
     }
 

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1253,7 +1253,7 @@ pub(crate) fn generate_item_tree<'id>(
             | Type::Model
             | Type::PathData
             | Type::UnitProduct(_)
-            | Type::ElementReference => panic!("bad type {:?}", ty),
+            | Type::ElementReference => panic!("bad type {ty:?}"),
         })
     }
 
@@ -1607,7 +1607,7 @@ pub fn instantiate(
                                 Box::new(make_callback_eval_closure(expr, &self_weak)),
                             );
                         } else {
-                            panic!("unknown callback {}", prop_name)
+                            panic!("unknown callback {prop_name}")
                         }
                     }
                 }
@@ -2088,7 +2088,7 @@ extern "C" fn accessible_string_property(
 ) -> bool {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
-    let prop_name = format!("accessible-{}", what);
+    let prop_name = format!("accessible-{what}");
     let nr = instance_ref.description.original_elements[item_index as usize]
         .borrow()
         .accessibility_props

--- a/internal/interpreter/dynamic_type.rs
+++ b/internal/interpreter/dynamic_type.rs
@@ -194,7 +194,7 @@ impl<'id> Instance<'id> {
 
 impl core::fmt::Debug for Instance<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Instance({:p})", self)
+        write!(f, "Instance({self:p})")
     }
 }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -231,7 +231,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     if let (Some(a), Some(b)) = (a, b) {
                         a.merge(&b).into()
                     } else {
-                        panic!("unsupported {:?} {} {:?}", a, op, b);
+                        panic!("unsupported {a:?} {op} {b:?}");
                     }
                 }
                 ('-', Value::Number(a), Value::Number(b)) => Value::Number(a - b),
@@ -249,7 +249,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 ('!', a, b) => Value::Bool(a != b),
                 ('&', Value::Bool(a), Value::Bool(b)) => Value::Bool(a && b),
                 ('|', Value::Bool(a), Value::Bool(b)) => Value::Bool(a || b),
-                (op, lhs, rhs) => panic!("unsupported {:?} {} {:?}", lhs, op, rhs),
+                (op, lhs, rhs) => panic!("unsupported {lhs:?} {op} {rhs:?}"),
             }
         }
         Expression::UnaryOp { sub, op } => {
@@ -258,7 +258,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 (Value::Number(a), '+') => Value::Number(a),
                 (Value::Number(a), '-') => Value::Number(-a),
                 (Value::Bool(a), '!') => Value::Bool(!a),
-                (sub, op) => panic!("unsupported {} {:?}", op, sub),
+                (sub, op) => panic!("unsupported {op} {sub:?}"),
             }
         }
         Expression::ImageReference{ resource_ref, nine_slice, .. } => {
@@ -287,7 +287,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                     todo!()
                 }
             }.unwrap_or_else(|_| {
-                eprintln!("Could not load image {:?}",resource_ref );
+                eprintln!("Could not load image {resource_ref:?}" );
                 Default::default()
             });
             if let Some(n) = nine_slice {
@@ -1294,7 +1294,7 @@ fn call_builtin_function(
                     .layout_info(crate::eval_layout::to_runtime(orient), &window_adapter)
                     .into()
             } else {
-                panic!("internal error: incorrect arguments to ImplicitLayoutInfo {:?}", arguments);
+                panic!("internal error: incorrect arguments to ImplicitLayoutInfo {arguments:?}");
             }
         }
         BuiltinFunction::ItemAbsolutePosition => {
@@ -1405,7 +1405,7 @@ fn eval_assignment(lhs: &Expression, op: char, rhs: Value, local_context: &mut E
         (Value::Number(a), Value::Number(b), '-') => Value::Number(a - b),
         (Value::Number(a), Value::Number(b), '/') => Value::Number(a / b),
         (Value::Number(a), Value::Number(b), '*') => Value::Number(a * b),
-        (lhs, rhs, op) => panic!("unsupported {:?} {} {:?}", lhs, op, rhs),
+        (lhs, rhs, op) => panic!("unsupported {lhs:?} {op} {rhs:?}"),
     };
     match lhs {
         Expression::PropertyReference(nr) => {

--- a/internal/interpreter/global_component.rs
+++ b/internal/interpreter/global_component.rs
@@ -178,7 +178,7 @@ pub fn instantiate(
         CompiledGlobal::Builtin { element, .. } => {
             trait Helper {
                 fn instantiate(name: &str) -> Pin<Rc<dyn GlobalComponent>> {
-                    panic!("Cannot find native global {}", name)
+                    panic!("Cannot find native global {name}")
                 }
             }
             impl Helper for () {}

--- a/internal/interpreter/json.rs
+++ b/internal/interpreter/json.rs
@@ -72,7 +72,7 @@ pub fn value_from_json(t: &langtype::Type, v: &serde_json::Value) -> Result<Valu
                 if let Some(c) = string_to_color(s) {
                     Ok(Value::Brush(i_slint_core::Brush::SolidColor(c)))
                 } else {
-                    Err(format!("Failed to parse color: {}", s))
+                    Err(format!("Failed to parse color: {s}"))
                 }
             }
             langtype::Type::String => Ok(SharedString::from(s.as_str()).into()),

--- a/internal/interpreter/value_model.rs
+++ b/internal/interpreter/value_model.rs
@@ -49,7 +49,7 @@ impl Model for ValueModel {
             Value::Number(x) => x.max(Default::default()) as usize,
             Value::Void => 0,
             Value::Model(model_ptr) => model_ptr.row_count(),
-            x => panic!("Invalid model {:?}", x),
+            x => panic!("Invalid model {x:?}"),
         }
     }
 
@@ -61,7 +61,7 @@ impl Model for ValueModel {
                 Value::Bool(_) => Value::Void,
                 Value::Number(_) => Value::Number(row as _),
                 Value::Model(model_ptr) => model_ptr.row_data(row)?,
-                x => panic!("Invalid model {:?}", x),
+                x => panic!("Invalid model {x:?}"),
             })
         }
     }

--- a/tests/doctests/build.rs
+++ b/tests/doctests/build.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .replace(['.'], "ᐧ")
             .to_lowercase();
 
-        writeln!(tests_file, "\nmod {} {{", stem)?;
+        writeln!(tests_file, "\nmod {stem} {{")?;
 
         let mut rest = file.as_str();
         let mut line = 1;

--- a/tests/doctests/main.rs
+++ b/tests/doctests/main.rs
@@ -13,8 +13,7 @@ fn do_test(snippet: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> 
                 Button, CheckBox, ComboBox, DatePickerPopup, LineEdit, ProgressIndicator, ScrollView,
                 Slider, SpinBox, Spinner, StandardButton, StandardListView, StandardTableView,
                 Switch, TabWidget, TextEdit, TimePickerPopup}} from\"std-widgets.slint\";
-            component Example {{\n{}\n}}",
-            snippet
+            component Example {{\n{snippet}\n}}"
         )
     } else {
         snippet.into()

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -15,7 +15,7 @@ fn main() -> std::io::Result<()> {
         if module_name.starts_with(|c: char| !c.is_ascii_alphabetic()) {
             module_name.insert(0, '_');
         }
-        writeln!(generated_file, "#[path=\"{0}.rs\"] mod r#{0};", module_name)?;
+        writeln!(generated_file, "#[path=\"{module_name}.rs\"] mod r#{module_name};")?;
         let source = std::fs::read_to_string(&testcase.absolute_path)?;
         let ignored = if testcase.is_ignored("rust") {
             "#[ignore = \"testcase ignored for rust\"]"
@@ -26,7 +26,7 @@ fn main() -> std::io::Result<()> {
         };
 
         let mut output = BufWriter::new(std::fs::File::create(
-            Path::new(&std::env::var_os("OUT_DIR").unwrap()).join(format!("{}.rs", module_name)),
+            Path::new(&std::env::var_os("OUT_DIR").unwrap()).join(format!("{module_name}.rs")),
         )?);
 
         #[cfg(not(feature = "build-time"))]

--- a/tests/screenshots/build.rs
+++ b/tests/screenshots/build.rs
@@ -69,14 +69,14 @@ fn main() -> std::io::Result<()> {
             .escape_default()
             .to_string();
 
-        reference_path = format!("\"{}\"", reference_path);
+        reference_path = format!("\"{reference_path}\"");
 
         println!("cargo:rerun-if-changed={}", testcase.absolute_path.display());
         let mut module_name = testcase.identifier();
         if module_name.starts_with(|c: char| !c.is_ascii_alphabetic()) {
             module_name.insert(0, '_');
         }
-        writeln!(generated_file, "#[path=\"{0}.rs\"] mod r#{0};", module_name)?;
+        writeln!(generated_file, "#[path=\"{module_name}.rs\"] mod r#{module_name};")?;
         let source = std::fs::read_to_string(&testcase.absolute_path)?;
 
         let needle = "SLINT_SCALE_FACTOR=";
@@ -103,7 +103,7 @@ fn main() -> std::io::Result<()> {
         let skip_clipping = source.contains("SKIP_CLIPPING");
 
         let mut output = BufWriter::new(std::fs::File::create(
-            Path::new(&std::env::var_os("OUT_DIR").unwrap()).join(format!("{}.rs", module_name)),
+            Path::new(&std::env::var_os("OUT_DIR").unwrap()).join(format!("{module_name}.rs")),
         )?);
 
         generate_source(

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -187,7 +187,7 @@ fn main() -> std::io::Result<()> {
             if !fileaccess::load_file(std::path::Path::new(resource))
                 .map_or(false, |f| f.is_builtin())
             {
-                write!(f, " {}", resource)?;
+                write!(f, " {resource}")?;
             }
         }
 

--- a/tools/figma_import/src/main.rs
+++ b/tools/figma_import/src/main.rs
@@ -87,7 +87,7 @@ async fn load_from_network(opt: &Opt) -> Result<figmatypes::File, Box<dyn std::e
     let mut images = stream::iter(i.meta.images)
         .map(|(k, v)| async move {
             let mut resp = reqwest::Client::new().get(&v).send().await?.bytes_stream();
-            let mut file = tokio::fs::File::create(format!("figma_output/images/{}", k)).await?;
+            let mut file = tokio::fs::File::create(format!("figma_output/images/{k}")).await?;
             while let Some(bytes) = resp.next().await {
                 file.write_all(&(bytes?)).await?;
             }
@@ -123,11 +123,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let render_node = if let Some(node_id) = &opt.node_id {
                 doc.nodeHash
                     .get(node_id.as_str())
-                    .ok_or_else(|| Error(format!("Could not find node id {}", node_id)))?
+                    .ok_or_else(|| Error(format!("Could not find node id {node_id}")))?
             } else if let Some(child_index) = opt.child_index {
                 node.children
                     .get(child_index)
-                    .ok_or_else(|| Error(format!("The index {} does not exist", child_index)))?
+                    .ok_or_else(|| Error(format!("The index {child_index} does not exist")))?
             } else {
                 doc.nodeHash
                     .get(

--- a/tools/figma_import/src/rendered.rs
+++ b/tools/figma_import/src/rendered.rs
@@ -122,7 +122,7 @@ pub fn render(
     let mut ctx = Ctx::default();
     writeln!(ctx, "App := Window {{")?;
     ctx.indent += 1;
-    writeln!(ctx, "background: {};", background)?;
+    writeln!(ctx, "background: {background};")?;
     writeln!(ctx, "width: {}px;", frame.absoluteBoundingBox.width)?;
     writeln!(ctx, "height: {}px;", frame.absoluteBoundingBox.height)?;
     ctx.offset = frame.absoluteBoundingBox.origin();
@@ -349,7 +349,7 @@ fn handle_paint(p: &Paint, rc: &mut Ctx, arg: &str) -> Result<bool, Box<dyn std:
         has_something = true;
     } else if let Some(color) = &p.color {
         if !color.is_transparent() {
-            writeln!(rc, "{}: {};", arg, color)?;
+            writeln!(rc, "{arg}: {color};")?;
             has_something = true;
         }
     }

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -596,7 +596,7 @@ pub mod lsp_to_editor {
                     message: Some(message.into()),
                 },
             )
-            .unwrap_or_else(|e| eprintln!("Error sending notification: {:?}", e));
+            .unwrap_or_else(|e| eprintln!("Error sending notification: {e:?}"));
     }
 
     pub fn notify_lsp_diagnostics(

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -251,14 +251,14 @@ fn whitespace_to_one_of(
                 return Ok(SyntaxMatch::Found(expected_kind));
             }
             _ => {
-                eprintln!("Inconsistency: expected {:?},  found {:?}", elements, n);
+                eprintln!("Inconsistency: expected {elements:?},  found {n:?}");
                 fold(n, writer, state)?;
                 return Ok(SyntaxMatch::NotFound);
             }
         }
         fold(n, writer, state)?;
     }
-    eprintln!("Inconsistency: expected {:?},  not found", elements);
+    eprintln!("Inconsistency: expected {elements:?},  not found");
     Ok(SyntaxMatch::NotFound)
 }
 

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -544,11 +544,11 @@ fn extract_param<T: serde::de::DeserializeOwned>(
 ) -> Result<T, LspError> {
     let p = params.get(index).ok_or_else(|| LspError {
         code: LspErrorCode::InvalidParameter,
-        message: format!("{} parameter is missing", name),
+        message: format!("{name} parameter is missing"),
     })?;
     serde_json::from_value(p.clone()).map_err(|e| LspError {
         code: LspErrorCode::InvalidParameter,
-        message: format!("{} parameter is invalid: {}", name, e),
+        message: format!("{name} parameter is invalid: {e}"),
     })
 }
 
@@ -1032,9 +1032,7 @@ fn get_code_actions(
                 .text()
                 .to_string()
                 .lines()
-                .map(
-                    |line| if line.is_empty() { line.to_string() } else { format!("    {}", line) },
-                )
+                .map(|line| if line.is_empty() { line.to_string() } else { format!("    {line}") })
                 .collect::<Vec<String>>();
             let edits = vec![TextEdit::new(
                 lsp_types::Range::new(r.start, r.end),

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -665,12 +665,12 @@ fn resolve_expression_scope(
                 },
                 &mut |exported_name, file, the_import| {
                     r.push(CompletionItem {
-                        label: format!("{} (import from \"{}\")", exported_name, file),
+                        label: format!("{exported_name} (import from \"{file}\")"),
                         insert_text: Some(exported_name.to_string()),
                         insert_text_format: Some(InsertTextFormat::SNIPPET),
                         filter_text: Some(exported_name.to_string()),
                         kind: Some(CompletionItemKind::CLASS),
-                        detail: Some(format!("(import from \"{}\")", file)),
+                        detail: Some(format!("(import from \"{file}\")")),
                         additional_text_edits: Some(vec![the_import]),
                         ..Default::default()
                     });
@@ -834,16 +834,16 @@ fn add_components_to_import(
         },
         &mut |exported_name, file, the_import| {
             result.push(CompletionItem {
-                label: format!("{} (import from \"{}\")", exported_name, file),
+                label: format!("{exported_name} (import from \"{file}\")"),
                 insert_text: if is_followed_by_brace(token) {
                     Some(exported_name.to_string())
                 } else {
-                    Some(format!("{} {{$1}}", exported_name))
+                    Some(format!("{exported_name} {{$1}}"))
                 },
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 filter_text: Some(exported_name.to_string()),
                 kind: Some(CompletionItemKind::CLASS),
-                detail: Some(format!("(import from \"{}\")", file)),
+                detail: Some(format!("(import from \"{file}\")")),
                 additional_text_edits: Some(vec![the_import]),
                 ..Default::default()
             });
@@ -927,10 +927,10 @@ fn create_import_edit_impl(
         || {
             TextEdit::new(
                 Range::new(*missing_import_location, *missing_import_location),
-                format!("import {{ {} }} from \"{}\";\n", component, import_path),
+                format!("import {{ {component} }} from \"{import_path}\";\n"),
             )
         },
-        |pos| TextEdit::new(Range::new(*pos, *pos), format!(", {}", component)),
+        |pos| TextEdit::new(Range::new(*pos, *pos), format!(", {component}")),
     )
 }
 

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -277,7 +277,7 @@ fn main() {
                 let threads = match run_lsp_server(args) {
                     Ok(threads) => threads,
                     Err(error) => {
-                        eprintln!("Error running LSP server: {}", error);
+                        eprintln!("Error running LSP server: {error}");
                         return;
                     }
                 };

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -554,7 +554,7 @@ fn set_color_binding(
         element_version,
         element_offset,
         property_name,
-        format!("#{:08x}", value),
+        format!("#{value:08x}"),
     )
 }
 
@@ -716,7 +716,7 @@ fn drop_component(component_index: i32, x: f32, y: f32) {
             SelectionNotification::AfterUpdate,
         );
 
-        send_workspace_edit(format!("Add element {}", component_name), edit, false);
+        send_workspace_edit(format!("Add element {component_name}"), edit, false);
     };
 }
 

--- a/tools/lsp/preview/debug.rs
+++ b/tools/lsp/preview/debug.rs
@@ -159,7 +159,7 @@ fn recurse_into_element(state: &mut State, element: &ElementRc) -> (usize, Vec<S
     for c in &e.children {
         let (child_node_number, child_result) = recurse_into_element(state, c);
         lines.extend_from_slice(&child_result);
-        lines.push(format!("  n{} -> n{}", node_number, child_node_number));
+        lines.push(format!("  n{node_number} -> n{child_node_number}"));
     }
 
     (node_number, lines)

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -367,13 +367,13 @@ fn install_callbacks(instance: &ComponentInstance, callbacks: &[String]) {
             match instance.set_callback(callback, move |args| {
                 match execute_cmd(&cmd, args) {
                     Ok(()) => (),
-                    Err(e) => eprintln!("Error: {:?}", e),
+                    Err(e) => eprintln!("Error: {e:?}"),
                 }
                 Value::Void
             }) {
                 Ok(()) => (),
                 Err(e) => {
-                    eprintln!("Warning: cannot set callback handler for '{}': {}", callback, e)
+                    eprintln!("Warning: cannot set callback handler for '{callback}': {e}")
                 }
             }
         }
@@ -408,7 +408,7 @@ fn execute_cmd(cmd: &str, callback_args: &[Value]) -> Result<()> {
                     }
                     serde_json::to_string_pretty(&obj)?
                 }
-                _ => return Err(format!("Cannot convert argument to string: {:?}", v).into()),
+                _ => return Err(format!("Cannot convert argument to string: {v:?}").into()),
             })
         })
         .collect::<Result<Vec<String>>>()?;


### PR DESCRIPTION
Ran this command:

```shell
cargo clippy --fix -- -A clippy::all -W clippy::uninlined_format_args
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
