### PR TITLE
fix(node): prevent 100% CPU usage on Wayland by enforcing minimum event timeout

### DIFF
--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -3,6 +3,7 @@
 
 mod interpreter;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 pub use interpreter::*;
 
@@ -13,6 +14,8 @@ use napi::{Env, JsFunction, JsObject};
 
 #[macro_use]
 extern crate napi_derive;
+
+static IS_WAYLAND: LazyLock<bool> = LazyLock::new(|| std::env::var("WAYLAND_DISPLAY").is_ok());
 
 #[napi]
 pub fn mock_elapsed_time(ms: f64) {
@@ -32,8 +35,15 @@ pub enum ProcessEventsResult {
 
 #[napi]
 pub fn process_events() -> napi::Result<ProcessEventsResult> {
+    let min_timeout = std::time::Duration::from_millis(16);
+    let timeout = if *IS_WAYLAND {
+        min_timeout
+    } else {
+        std::time::Duration::ZERO
+    };
+
     i_slint_backend_selector::with_platform(|b| {
-        b.process_events(std::time::Duration::ZERO, i_slint_core::InternalToken)
+        b.process_events(timeout, i_slint_core::InternalToken)
     })
     .map_err(|e| napi::Error::from_reason(e.to_string()))
     .and_then(|result| {


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

This worksaround https://github.com/slint-ui/slint/issues/5780 in my testing