### PR TITLE
Always create an app menu for the menubar

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -682,7 +682,7 @@ impl WinitWindowAdapter {
         {
             if self.muda_adapter.borrow().is_none() && self.muda_enable_default_menu_bar {
                 *self.muda_adapter.borrow_mut() =
-                    Some(crate::muda::MudaAdapter::setup_default_menu()?);
+                    Some(crate::muda::MudaAdapter::setup_default_menu_bar()?);
             }
 
             if let Some(muda_adapter) = self.muda_adapter.borrow().as_ref() {


### PR DESCRIPTION
This is the discussed stop-gap for macOS for the 1.10 release.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
