### PR TITLE
A few more format arg inlining

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -262,7 +262,7 @@ extern "C" {{
 "#,
         items
             .iter()
-            .map(|item_name| format!("SLINT_DECL_ITEM({});", item_name))
+            .map(|item_name| format!("SLINT_DECL_ITEM({item_name});"))
             .collect::<Vec<_>>()
             .join("\n")
     )
@@ -644,7 +644,7 @@ fn gen_corelib(
             .with_src(crate_dir.join("window.rs"))
             .with_include("slint_enums_internal.h")
             .generate()
-            .with_context(|| format!("Unable to generate bindings for {}", internal_header))?
+            .with_context(|| format!("Unable to generate bindings for {internal_header}"))?
             .write_to_file(include_dir.join(internal_header));
     }
 

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -254,7 +254,7 @@ impl Platform for CppPlatform {
 
     #[cfg(feature = "esp-println")]
     fn debug_log(&self, arguments: core::fmt::Arguments) {
-        esp_println::println!("{}", arguments);
+        esp_println::println!("{arguments}");
     }
 }
 

--- a/api/node/rust/interpreter/component_instance.rs
+++ b/api/node/rust/interpreter/component_instance.rs
@@ -141,7 +141,7 @@ impl JsComponentInstance {
 
                     move |args| {
                         let Ok(callback) = function_ref.get::<JsFunction>() else {
-                            eprintln!("Node.js: cannot get reference of callback {} because it has the wrong type", callback_name);
+                            eprintln!("Node.js: cannot get reference of callback {callback_name} because it has the wrong type");
                             return Value::Void;
                         };
 
@@ -175,7 +175,7 @@ impl JsComponentInstance {
             return Ok(());
         }
 
-        Err(napi::Error::from_reason(format!("{} is not a callback", callback_name).as_str()))
+        Err(napi::Error::from_reason(format!("{callback_name} is not a callback").as_str()))
     }
 
     #[napi]
@@ -211,8 +211,7 @@ impl JsComponentInstance {
                     move |args| {
                         let Ok(callback) = function_ref.get::<JsFunction>() else {
                             eprintln!(
-                                "Node.js: cannot get reference of callback {} of global {} because it has the wrong type",
-                                callback_name, global_name
+                                "Node.js: cannot get reference of callback {callback_name} of global {global_name} because it has the wrong type"
                             );
                             return Value::Void;
                         };
@@ -247,7 +246,7 @@ impl JsComponentInstance {
             return Ok(());
         }
 
-        Err(napi::Error::from_reason(format!("{} is not a callback", callback_name).as_str()))
+        Err(napi::Error::from_reason(format!("{callback_name} is not a callback").as_str()))
     }
 
     fn invoke_args(
@@ -291,7 +290,7 @@ impl JsComponentInstance {
             .ok_or(())
             .map_err(|_| {
                 napi::Error::from_reason(
-                    format!("Callback {} not found in the component", callback_name).as_str(),
+                    format!("Callback {callback_name} not found in the component").as_str(),
                 )
             })?;
 
@@ -301,7 +300,7 @@ impl JsComponentInstance {
             }
             _ => {
                 return Err(napi::Error::from_reason(
-                    format!("{} is not a callback or a function", callback_name).as_str(),
+                    format!("{callback_name} is not a callback or a function").as_str(),
                 ));
             }
         };
@@ -331,8 +330,7 @@ impl JsComponentInstance {
             .map_err(|_| {
                 napi::Error::from_reason(
                     format!(
-                        "Callback {} of global {global_name} not found in the component",
-                        callback_name
+                        "Callback {callback_name} of global {global_name} not found in the component"
                     )
                     .as_str(),
                 )
@@ -345,8 +343,7 @@ impl JsComponentInstance {
             _ => {
                 return Err(napi::Error::from_reason(
                     format!(
-                        "{} is not a callback or a function on global {}",
-                        callback_name, global_name
+                        "{callback_name} is not a callback or a function on global {global_name}"
                     )
                     .as_str(),
                 ));

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -198,8 +198,7 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
                     let expected_size: usize = (width as usize) * (height as usize) * BPP;
                     if actual_size != expected_size {
                         return Err(napi::Error::from_reason(format!(
-                            "data property does not have the correct size; expected {} (width) * {} (height) * {} = {}; got {}",
-                            width, height, BPP, actual_size, expected_size
+                            "data property does not have the correct size; expected {width} (width) * {height} (height) * {BPP} = {actual_size}; got {expected_size}"
                         )));
                     }
 
@@ -244,8 +243,7 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
                     vec.push(to_value(
                         env,
                         array.get(i)?.ok_or(napi::Error::from_reason(format!(
-                            "Cannot access array element at index {}",
-                            i
+                            "Cannot access array element at index {i}"
                         )))?,
                         a,
                     )?);

--- a/api/node/rust/types/model.rs
+++ b/api/node/rust/types/model.rs
@@ -184,8 +184,7 @@ impl Model for JsModel {
             &[self.env.create_double(row as f64).unwrap().into_unknown(), js_data],
         ) {
             eprintln!(
-                "Node.js: JavaScript Model<T>'s setRowData function threw an exception: {}",
-                exception
+                "Node.js: JavaScript Model<T>'s setRowData function threw an exception: {exception}"
             );
         }
     }

--- a/api/python/models.rs
+++ b/api/python/models.rs
@@ -84,8 +84,7 @@ impl i_slint_core::model::Model for PyModelShared {
                 Ok(result) => result,
                 Err(err) => {
                     eprintln!(
-                        "Python: Model implementation of row_count() threw an exception: {}",
-                        err
+                        "Python: Model implementation of row_count() threw an exception: {err}"
                     );
                     return 0;
                 }
@@ -94,7 +93,7 @@ impl i_slint_core::model::Model for PyModelShared {
             match result.extract::<usize>(py) {
                 Ok(count) => count,
                 Err(err) => {
-                    eprintln!("Python: Model implementation of row_count() returned value that cannot be cast to usize: {}", err);
+                    eprintln!("Python: Model implementation of row_count() returned value that cannot be cast to usize: {err}");
                     0
                 }
             }
@@ -114,8 +113,7 @@ impl i_slint_core::model::Model for PyModelShared {
                 Err(err) if err.is_instance_of::<PyIndexError>(py) => return None,
                 Err(err) => {
                     eprintln!(
-                        "Python: Model implementation of row_data() threw an exception: {}",
-                        err
+                        "Python: Model implementation of row_data() threw an exception: {err}"
                     );
                     return None;
                 }
@@ -124,7 +122,7 @@ impl i_slint_core::model::Model for PyModelShared {
             match result.extract::<PyValue>(py) {
                 Ok(pv) => Some(pv.0),
                 Err(err) => {
-                    eprintln!("Python: Model implementation of row_data() returned value that cannot be converted to Rust: {}", err);
+                    eprintln!("Python: Model implementation of row_data() returned value that cannot be converted to Rust: {err}");
                     None
                 }
             }
@@ -141,8 +139,7 @@ impl i_slint_core::model::Model for PyModelShared {
 
             if let Err(err) = obj.call_method1(py, "set_row_data", (row, PyValue::from(data))) {
                 eprintln!(
-                    "Python: Model implementation of set_row_data() threw an exception: {}",
-                    err
+                    "Python: Model implementation of set_row_data() threw an exception: {err}"
                 );
             };
         });

--- a/api/python/value.rs
+++ b/api/python/value.rs
@@ -50,7 +50,7 @@ impl<'a> ToPyObject for PyValueRef<'a> {
                 crate::brush::PyBrush::from(brush.clone()).into_py(py)
             }
             v @ _ => {
-                eprintln!("Python: conversion from slint to python needed for {:#?} and not implemented yet", v);
+                eprintln!("Python: conversion from slint to python needed for {v:#?} and not implemented yet");
                 ().into_py(py)
             }
         }

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -406,11 +406,11 @@ pub fn slint(stream: TokenStream) -> TokenStream {
         return diag.report_macro_diagnostic(&tokens);
     }
 
-    //println!("{:#?}", syntax_node);
+    //println!("{syntax_node:#?}");
     compiler_config.translation_domain = std::env::var("CARGO_PKG_NAME").ok();
     let (root_component, diag, loader) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));
-    //println!("{:#?}", tree);
+    //println!("{tree:#?}");
     if diag.has_errors() {
         return diag.report_macro_diagnostic(&tokens);
     }

--- a/demos/weather-demo/src/weather/dummyweathercontroller.rs
+++ b/demos/weather-demo/src/weather/dummyweathercontroller.rs
@@ -39,7 +39,7 @@ impl DummyWeatherController {
                 return weather_data;
             }
             Err(e) => {
-                log::warn!("Cannot read dummy weather data! Error: {}", e);
+                log::warn!("Cannot read dummy weather data! Error: {e}");
             }
         }
 

--- a/demos/weather-demo/src/weather/openweathercontroller.rs
+++ b/demos/weather-demo/src/weather/openweathercontroller.rs
@@ -264,7 +264,7 @@ impl WeatherController for OpenWeatherController {
 
     fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(storage_path) = &self.storage_path {
-            log::debug!("Saving data to: {:?}", storage_path.to_str());
+            log::debug!("Saving data to: {:?}", storage_path.display());
 
             // Ensure the parent directories exist
             if let Some(parent_dir) = storage_path.parent() {

--- a/demos/weather-demo/src/weather/weatherdisplaycontroller.rs
+++ b/demos/weather-demo/src/weather/weatherdisplaycontroller.rs
@@ -93,16 +93,9 @@ fn forecast_graph_command(
             let cp_day1 = (day_mid + day1) / 2.0;
             let cp_day2 = (day_mid + day2) / 2.0;
 
+            // Q {x1} {y1} {cx1} {cy1} Q {x2} {y2} {cx2} {cy2}
             command += format!(
-                "Q {x1} {y1} {cx1} {cy1} Q {x2} {y2} {cx2} {cy2} ",
-                x1 = cp_day1,
-                y1 = temp1,
-                cx1 = day_mid,
-                cy1 = temp_mid,
-                x2 = cp_day2,
-                y2 = temp2,
-                cx2 = day2,
-                cy2 = temp2
+                "Q {cp_day1} {temp1} {day_mid} {temp_mid} Q {cp_day2} {temp2} {day2} {temp2} "
             )
             .as_str();
         }

--- a/examples/maps/main.rs
+++ b/examples/maps/main.rs
@@ -180,7 +180,7 @@ impl World {
                         let response = match response {
                             Ok(response) => response,
                             Err(err) => {
-                                eprintln!("Error loading {url}: {}", err);
+                                eprintln!("Error loading {url}: {err}");
                                 return slint::Image::default();
                             }
                         };
@@ -195,7 +195,7 @@ impl World {
                             let image = match image::load_from_memory(&bytes) {
                                 Ok(image) => image,
                                 Err(err) => {
-                                    eprintln!("Error reading {url}: {}", err);
+                                    eprintln!("Error reading {url}: {err}");
                                     return None;
                                 }
                             };

--- a/helper_crates/const-field-offset/macro/macro.rs
+++ b/helper_crates/const-field-offset/macro/macro.rs
@@ -194,9 +194,8 @@ pub fn const_field_offset(input: TokenStream) -> TokenStream {
     };
 
     let doc = format!(
-        "Helper struct containing the offsets of the fields of the struct [`{}`]\n\n\
-        Generated from the `#[derive(FieldOffsets)]` macro from the [`const-field-offset`]({}) crate",
-        struct_name, crate_
+        "Helper struct containing the offsets of the fields of the struct [`{struct_name}`]\n\n\
+        Generated from the `#[derive(FieldOffsets)]` macro from the [`const-field-offset`]({crate_}) crate",
     );
 
     let (ensure_pin_safe, ensure_no_unpin, pin_flag, new_from_offset) = if !pin {

--- a/helper_crates/vtable/macro/macro.rs
+++ b/helper_crates/vtable/macro/macro.rs
@@ -215,10 +215,8 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
         restriction: Default::default(),
     };
 
-    let additional_doc = format!(
-        "\nNote: Was generated from the [`#[vtable]`](vtable) macro on [`{}`]",
-        vtable_name
-    );
+    let additional_doc =
+        format!("\nNote: Was generated from the [`#[vtable]`](vtable) macro on [`{vtable_name}`]");
     generated_trait
         .attrs
         .append(&mut Attribute::parse_outer.parse2(quote!(#[doc = #additional_doc])).unwrap());
@@ -277,7 +275,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
             let mut sig_extern = sig.clone();
             sig_extern.abi = Some(parse_str("extern \"C\"").unwrap());
-            sig_extern.generics = parse_str(&format!("<T : {}>", trait_name)).unwrap();
+            sig_extern.generics = parse_str(&format!("<T : {trait_name}>")).unwrap();
 
             // check parameters
             let mut call_code = None;
@@ -577,8 +575,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
             let generated_trait_assoc_const =
                 generated_trait_assoc_const.get_or_insert_with(|| ItemTrait {
                     attrs: Attribute::parse_outer.parse_str(&format!(
-                        "/** Trait containing the associated constant relative to the trait {}.\n{} */",
-                        trait_name, additional_doc
+                        "/** Trait containing the associated constant relative to the trait {trait_name}.\n{additional_doc} */",
                     )).unwrap(),
                     ident: quote::format_ident!("{}Consts", trait_name),
                     items: vec![],

--- a/internal/backends/android-activity/build.rs
+++ b/internal/backends/android-activity/build.rs
@@ -151,7 +151,7 @@ fn test_parse_version() {
 }
 
 fn env_var(var: &str) -> Result<String, env::VarError> {
-    println!("cargo:rerun-if-env-changed={}", var);
+    println!("cargo:rerun-if-env-changed={var}");
     env::var(var)
 }
 

--- a/internal/common/sharedfontdb.rs
+++ b/internal/common/sharedfontdb.rs
@@ -154,7 +154,7 @@ fn init_fontdb() -> FontDatabase {
                         fontconfig_fallback_families = fallback_families;
                     }
                     Err(e) => {
-                        eprintln!("Error opening libfontconfig.so.1: {}", e);
+                        eprintln!("Error opening libfontconfig.so.1: {e}");
                     }
                 }
             }

--- a/internal/compiler/parser-test-macro/lib.rs
+++ b/internal/compiler/parser-test-macro/lib.rs
@@ -9,7 +9,7 @@ use core::str::FromStr;
 use proc_macro::{Delimiter, TokenStream, TokenTree};
 
 fn error(e: &str) -> String {
-    format!("::core::compile_error!{{\"{}\"}}", e)
+    format!("::core::compile_error!{{\"{e}\"}}")
 }
 
 fn generate_test(fn_name: &str, doc: &str, extra_args: usize) -> String {
@@ -45,11 +45,10 @@ fn generate_test(fn_name: &str, doc: &str, extra_args: usize) -> String {
         None => String::new(),
         Some(kind) => {
             format!(
-                "syntax_nodes::{}::verify(SyntaxNode {{
+                "syntax_nodes::{kind}::verify(SyntaxNode {{
                     node: rowan::SyntaxNode::new_root(p.builder.finish()),
                     source_file: Default::default(),
                 }});",
-                kind
             )
         }
     };
@@ -173,7 +172,7 @@ pub fn parser_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let test_function = TokenStream::from_str(&generate_test(&fn_name, &doc, extra_args))
         .unwrap_or_else(|e| {
-            TokenStream::from_str(&error(&format!("Lex error in generated test: {:?}", e))).unwrap()
+            TokenStream::from_str(&error(&format!("Lex error in generated test: {e:?}"))).unwrap()
         });
 
     result.extend(test_function);

--- a/internal/core-macros/slint_doc.rs
+++ b/internal/core-macros/slint_doc.rs
@@ -58,7 +58,7 @@ impl Visitor {
                     .expect("invalid string in link-data.json");
                 format!("https://releases.slint.dev/{}/docs/slint/{dst}", env!("CARGO_PKG_VERSION"),)
             } else {
-                panic!("Unknown link {}", link);
+                panic!("Unknown link {link}");
             };
             doc.replace_range(pos..pos + NEEDLE.len() + link.len(), &dst);
             begin = pos + dst.len();

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -549,7 +549,7 @@ fn test_filter_model_source_model() {
     let expected = &[2, 4, 6];
     assert_eq!(model.row_count(), expected.len());
     for (i, v) in expected.iter().enumerate() {
-        assert_eq!(model.row_data(i), Some(*v), "Expected {} at index {}", v, i);
+        assert_eq!(model.row_data(i), Some(*v), "Expected {v} at index {i}");
     }
 }
 
@@ -1065,7 +1065,7 @@ mod sort_tests {
         let expected = &[1, 2, 3, 4, 5, 6];
         assert_eq!(model.row_count(), expected.len());
         for (i, v) in expected.iter().enumerate() {
-            assert_eq!(model.row_data(i), Some(*v), "Expected {} at index {}", v, i);
+            assert_eq!(model.row_data(i), Some(*v), "Expected {v} at index {i}");
         }
     }
 }
@@ -1226,7 +1226,7 @@ mod reversed_tests {
     fn check_content(model: &ReverseModel<Rc<VecModel<i32>>>, expected: &[i32]) {
         assert_eq!(model.row_count(), expected.len());
         for (i, v) in expected.iter().enumerate() {
-            assert_eq!(model.row_data(i), Some(*v), "Expected {} at index {}", v, i);
+            assert_eq!(model.row_data(i), Some(*v), "Expected {v} at index {i}");
         }
     }
 
@@ -1245,7 +1245,7 @@ mod reversed_tests {
     #[test]
     fn test_reversed_model_insert() {
         for (idx, mapped_idx) in [(0, 4), (1, 3), (2, 2), (3, 1), (4, 0)] {
-            std::println!("Inserting at {} expecting mapped to {}", idx, mapped_idx);
+            std::println!("Inserting at {idx} expecting mapped to {mapped_idx}");
             let wrapped_rc = Rc::new(VecModel::from(vec![1, 2, 3, 4]));
             let model = Rc::new(ReverseModel::new(wrapped_rc.clone()));
             let _checker = ModelChecker::new(model.clone());
@@ -1271,7 +1271,7 @@ mod reversed_tests {
     #[test]
     fn test_reversed_model_remove() {
         for (idx, mapped_idx) in [(0, 3), (1, 2), (2, 1), (3, 0)] {
-            std::println!("Removing at {} expecting mapped to {}", idx, mapped_idx);
+            std::println!("Removing at {idx} expecting mapped to {mapped_idx}");
             let wrapped_rc = Rc::new(VecModel::from(vec![1, 2, 3, 4]));
             let model = Rc::new(ReverseModel::new(wrapped_rc.clone()));
             let _checker = ModelChecker::new(model.clone());
@@ -1296,7 +1296,7 @@ mod reversed_tests {
     #[test]
     fn test_reversed_model_changed() {
         for (idx, mapped_idx) in [(0, 3), (1, 2), (2, 1), (3, 0)] {
-            std::println!("Changing at {} expecting mapped to {}", idx, mapped_idx);
+            std::println!("Changing at {idx} expecting mapped to {mapped_idx}");
             let wrapped_rc = Rc::new(VecModel::from(std::vec![1, 2, 3, 4]));
             let model = Rc::new(ReverseModel::new(wrapped_rc.clone()));
             let _checker = ModelChecker::new(model.clone());

--- a/internal/renderers/femtovg/fonts.rs
+++ b/internal/renderers/femtovg/fonts.rs
@@ -717,7 +717,7 @@ pub(crate) fn layout_text_lines(
                     if current_x >= w.get() {
                         let txt = &line[..glyph.byte_index];
                         if elide {
-                            let elided = format!("{}…", txt);
+                            let elided = format!("{txt}…");
                             process_line(&elided, y, start, &text_metrics);
                         } else {
                             process_line(txt, y, start, &text_metrics);

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -126,7 +126,7 @@ impl super::Surface for SoftwareSurface {
 
         let surface =
             softbuffer::Surface::new(&_context, window_handle).map_err(|softbuffer_error| {
-                format!("Error creating softbuffer surface: {}", softbuffer_error)
+                format!("Error creating softbuffer surface: {softbuffer_error}")
             })?;
 
         let surface_access =

--- a/tests/driver/cpp/cppdriver.rs
+++ b/tests/driver/cpp/cppdriver.rs
@@ -86,13 +86,11 @@ namespace slint_testing = slint::private_api::testing;
 
     let mut cpp_file = tempfile::Builder::new().suffix(".cpp").tempfile()?;
 
-    cpp_file
-        .write(&generated_cpp)
-        .map_err(|err| format!("Error writing generated code: {}", err))?;
+    cpp_file.write(&generated_cpp).map_err(|err| format!("Error writing generated code: {err}"))?;
     cpp_file
         .as_file()
         .sync_all()
-        .map_err(|err| format!("Error flushing generated code to disk: {}", err))?;
+        .map_err(|err| format!("Error flushing generated code to disk: {err}"))?;
 
     let cpp_file = cpp_file.into_temp_path();
 
@@ -165,15 +163,15 @@ namespace slint_testing = slint::private_api::testing;
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .map_err(|err| format!("Error launching testcase binary: {}", err))?
+        .map_err(|err| format!("Error launching testcase binary: {err}"))?
         .wait_with_output()
-        .map_err(|err| format!("Test case could not be run: {}", err))?;
+        .map_err(|err| format!("Test case could not be run: {err}"))?;
 
     if !output.status.success() {
         print!("{}", String::from_utf8_lossy(output.stdout.as_ref()));
         print!("{}", String::from_utf8_lossy(output.stderr.as_ref()));
         if let Some(exit_code) = output.status.code() {
-            return Err(format!("Test case exited with non-zero code: {}", exit_code).into());
+            return Err(format!("Test case exited with non-zero code: {exit_code}").into());
         } else {
             return Err("Test case exited by signal".into());
         }

--- a/tests/driver/interpreter/interpreter.rs
+++ b/tests/driver/interpreter/interpreter.rs
@@ -66,7 +66,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
                     for (p, _) in component.properties() {
                         eprintln!(" {}: {:?}", p, instance.get_property(&p));
                     }
-                    panic!("Test Failed: {:?}", result);
+                    panic!("Test Failed: {result:?}");
                 }
             }
         };

--- a/tests/driver/nodejs/nodejs.rs
+++ b/tests/driver/nodejs/nodejs.rs
@@ -33,7 +33,7 @@ lazy_static::lazy_static! {
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output()
-                .map_err(|err| format!("Could not launch npm install: {}", err)).unwrap();
+                .map_err(|err| format!("Could not launch npm install: {err}")).unwrap();
 
         check_output(o);
 
@@ -45,7 +45,7 @@ lazy_static::lazy_static! {
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output()
-                .map_err(|err| format!("Could not launch npm install: {}", err)).unwrap();
+                .map_err(|err| format!("Could not launch npm install: {err}")).unwrap();
 
         check_output(o);
 
@@ -94,7 +94,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
-        .map_err(|err| format!("Could not launch npm start: {}", err))?;
+        .map_err(|err| format!("Could not launch npm start: {err}"))?;
 
     if !output.status.success() {
         print!("{}", String::from_utf8_lossy(output.stdout.as_ref()));

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -201,7 +201,7 @@ impl<'a> SourceFileWithTags<'a> {
         let new_header = if next_char == Some(&b'\n') || next_char.is_none() {
             new_header
         } else {
-            format!("{}\n", new_header)
+            format!("{new_header}\n")
         };
 
         match loc {
@@ -842,7 +842,7 @@ impl LicenseHeaderCheck {
             if result.is_err() {
                 seen_errors = true;
                 if self.show_all {
-                    eprintln!("Error: {:?}", result);
+                    eprintln!("Error: {result:?}");
                 } else {
                     return result.map_err(|e| e.into());
                 }
@@ -1014,7 +1014,7 @@ impl LicenseHeaderCheck {
             }
             LicenseLocation::NoLicense => {
                 if self.verbose {
-                    println!("Skipping {} as configured", path_str);
+                    println!("Skipping {path_str} as configured");
                 }
                 Ok(())
             }

--- a/xtask/src/reuse_compliance_check.rs
+++ b/xtask/src/reuse_compliance_check.rs
@@ -14,7 +14,7 @@ where
     I::Item: AsRef<OsStr>,
 {
     let home_dir = std::env::var("HOME").context("HOME is not set in the environment")?;
-    Ok(sh.cmd(command).args(args).env("PATH", &format!("/bin:/usr/bin:{}/.local/bin", home_dir)))
+    Ok(sh.cmd(command).args(args).env("PATH", &format!("/bin:/usr/bin:{home_dir}/.local/bin")))
 }
 
 pub fn find_reuse() -> Result<PathBuf> {


### PR DESCRIPTION
Used these commands and some manual searching

```
cargo clippy --fix  --all-targets --workspace --exclude gstreamer-player --exclude i-slint-backend-linuxkms --exclude uefi-demo --exclude ffmpeg -- -A clippy::all -W clippy::uninlined_format_args
cargo clippy --all-targets -- -A clippy::all -W clippy::uninlined_format_args
cargo clippy --fix -- -A clippy::all -W clippy::uninlined_format_args
```
