### PR TITLE
Fix Gallery example sidebar accessibility

### DIFF
--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -65,44 +65,9 @@ export component SideBar inherits Rectangle {
 
     width: 180px;
     forward-focus: fs;
-    accessible-role: tab-list;
-    accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current-item;
-    accessible-label: root.title;
-    accessible-item-count: root.model.length;
 
     Rectangle {
         background: Palette.background.darker(0.2);
-
-        fs := FocusScope {
-            key-pressed(event) => {
-                if (event.text == "\n") {
-                     root.current-item = root.current-focused;
-                     return accept;
-                }
-                if (event.text == Key.UpArrow) {
-                     self.focused-tab = Math.max(self.focused-tab - 1,  0);
-                     return accept;
-                }
-                if (event.text == Key.DownArrow) {
-                     self.focused-tab = Math.min(self.focused-tab + 1, root.model.length - 1);
-                     return accept;
-                }
-                return reject;
-            }
-
-            key-released(event) => {
-                if (event.text == " ") {
-                     root.current-item = root.current-focused;
-                     return accept;
-                }
-                return reject;
-            }
-
-            property <int> focused-tab: 0;
-
-            x: 0;
-            width: 0; // Do not react on clicks
-        }
     }
 
     VerticalBox {
@@ -118,6 +83,42 @@ export component SideBar inherits Rectangle {
         navigation := VerticalLayout {
             alignment: start;
             vertical-stretch: 0;
+            accessible-role: tab-list;
+            accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current-item;
+            accessible-label: root.title;
+            accessible-item-count: root.model.length;
+
+            fs := FocusScope {
+                key-pressed(event) => {
+                    if (event.text == "\n") {
+                         root.current-item = root.current-focused;
+                         return accept;
+                    }
+                    if (event.text == Key.UpArrow) {
+                         self.focused-tab = Math.max(self.focused-tab - 1, 0);
+                         return accept;
+                    }
+                    if (event.text == Key.DownArrow) {
+                         self.focused-tab = Math.min(self.focused-tab + 1, root.model.length - 1);
+                         return accept;
+                    }
+                    return reject;
+                }
+    
+                key-released(event) => {
+                    if (event.text == " ") {
+                         root.current-item = root.current-focused;
+                         return accept;
+                    }
+                    return reject;
+                }
+    
+                property <int> focused-tab: 0;
+    
+                x: 0;
+                width: 0; // Do not react on clicks
+            }
+
             for item[index] in root.model : SideBarItem {
                 clicked => { root.current-item = index; }
 

--- a/examples/gallery/ui/side_bar.slint
+++ b/examples/gallery/ui/side_bar.slint
@@ -104,7 +104,7 @@ export component SideBar inherits Rectangle {
                     }
                     return reject;
                 }
-    
+
                 key-released(event) => {
                     if (event.text == " ") {
                          root.current-item = root.current-focused;
@@ -112,9 +112,9 @@ export component SideBar inherits Rectangle {
                     }
                     return reject;
                 }
-    
+
                 property <int> focused-tab: 0;
-    
+
                 x: 0;
                 width: 0; // Do not react on clicks
             }


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

The `accessible-delegate-focus` property is currently confused by the presence of the label at the top, since it expects an index in the accessible children list. Therefore the focused item would be off by one as far as assistive technologies are concerned.

I also had to move the `FocusScope` because `accessible-delegate-focus` is searched for in the ancestors of the element which is focused.

The tablist is now properly reported. Unfortunately these changes raise a more confusing bug: focus changes inside the tablist (using the arrow keys) don't seem to trigger a rebuild of the tree. When a tab is selected it is properly reported though. Even stranger: the focus changes are triggered if the focus is on the sidebar, when the toplevel window gains focus. Tabbing out of the sidebar and back on triggers the bug again though.