### PR TITLE
Auto-fixed `clippy::unnecessary_map_or`

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -192,7 +192,7 @@ fn ensure_cargo_rerun_for_crate(
     dependencies.push(crate_dir.to_path_buf());
     for entry in std::fs::read_dir(crate_dir)? {
         let entry = entry?;
-        if entry.path().extension().map_or(false, |e| e == "rs") {
+        if entry.path().extension().is_some_and(|e| e == "rs") {
             dependencies.push(entry.path());
         }
     }

--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -162,7 +162,7 @@ impl i_slint_renderer_skia::software_surface::RenderBuffer for SkiaTestSoftwareB
 
         let mut shared_pixel_buffer = self.pixels.borrow_mut().take();
 
-        if shared_pixel_buffer.as_ref().map_or(false, |existing_buffer| {
+        if shared_pixel_buffer.as_ref().is_some_and(|existing_buffer| {
             existing_buffer.width() != width.get() || existing_buffer.height() != height.get()
         }) {
             shared_pixel_buffer = None;

--- a/internal/backends/qt/build.rs
+++ b/internal/backends/qt/build.rs
@@ -8,7 +8,7 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(no_qt)");
 
     println!("cargo:rerun-if-env-changed=SLINT_NO_QT");
-    if std::env::var("TARGET").map_or(false, |t| t.starts_with("wasm"))
+    if std::env::var("TARGET").is_ok_and(|t| t.starts_with("wasm"))
         || std::env::var("SLINT_NO_QT").is_ok()
     {
         println!("cargo:rustc-cfg=no_qt");

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -51,31 +51,29 @@ impl SingleElementMatch {
     fn matches(&self, element: &ElementHandle) -> bool {
         match self {
             SingleElementMatch::MatchById { id, root_base } => {
-                if element.id().map_or(false, |candidate_id| candidate_id == id) {
+                if element.id().is_some_and(|candidate_id| candidate_id == id) {
                     return true;
                 }
-                root_base.as_ref().map_or(false, |root_base| {
+                root_base.as_ref().is_some_and(|root_base| {
                     element
                         .type_name()
-                        .map_or(false, |type_name_candidate| type_name_candidate == root_base)
+                        .is_some_and(|type_name_candidate| type_name_candidate == root_base)
                         || element
                             .bases()
-                            .map_or(false, |mut bases| bases.any(|base| base == root_base))
+                            .is_some_and(|mut bases| bases.any(|base| base == root_base))
                 })
             }
             SingleElementMatch::MatchByTypeName(type_name) => element
                 .type_name()
-                .map_or(false, |candidate_type_name| candidate_type_name == type_name),
+                .is_some_and(|candidate_type_name| candidate_type_name == type_name),
             SingleElementMatch::MatchByTypeNameOrBase(type_name) => {
                 element
                     .type_name()
-                    .map_or(false, |candidate_type_name| candidate_type_name == type_name)
-                    || element
-                        .bases()
-                        .map_or(false, |mut bases| bases.any(|base| base == type_name))
+                    .is_some_and(|candidate_type_name| candidate_type_name == type_name)
+                    || element.bases().is_some_and(|mut bases| bases.any(|base| base == type_name))
             }
             SingleElementMatch::MatchByAccessibleRole(role) => {
-                element.accessible_role().map_or(false, |candidate_role| candidate_role == *role)
+                element.accessible_role() == Some(*role)
             }
             SingleElementMatch::MatchByPredicate(predicate) => (predicate)(element),
         }
@@ -285,7 +283,7 @@ impl ElementHandle {
             .root_element()
             .query_descendants()
             .match_predicate(move |elem| {
-                elem.accessible_label().map_or(false, |candidate_label| candidate_label == label)
+                elem.accessible_label().is_some_and(|candidate_label| candidate_label == label)
             })
             .find_all();
         results.into_iter()

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -262,7 +262,7 @@ impl NodeCollection {
         window_adapter_weak
             .upgrade()
             .filter(|window_adapter| {
-                window_adapter.winit_window().map_or(false, |winit_window| winit_window.has_focus())
+                window_adapter.winit_window().is_some_and(|winit_window| winit_window.has_focus())
             })
             .and_then(|window_adapter| {
                 let window_inner = WindowInner::from_pub(window_adapter.window());

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -606,7 +606,7 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
             .window_adapter()
             .internal(i_slint_core::InternalToken)
             .and_then(|wa| wa.as_any().downcast_ref::<WinitWindowAdapter>())
-            .map_or(false, |adapter| adapter.winit_window().is_some())
+            .is_some_and(|adapter| adapter.winit_window().is_some())
     }
 
     fn with_winit_window<T>(

--- a/internal/compiler/build.rs
+++ b/internal/compiler/build.rs
@@ -25,7 +25,7 @@ fn widget_library() -> &'static [(&'static str, &'static BuiltinDirectory<'stati
     )?;
 
     for style in cargo_manifest_dir.join(&library_dir).read_dir()?.filter_map(Result::ok) {
-        if !style.file_type().map_or(false, |f| f.is_dir()) {
+        if !style.file_type().is_ok_and(|f| f.is_dir()) {
             continue;
         }
         let path = style.path();
@@ -50,7 +50,7 @@ fn process_style(cargo_manifest_dir: &Path, path: &Path) -> std::io::Result<Stri
         .read_dir()?
         .filter_map(Result::ok)
         .filter(|entry| {
-            entry.file_type().map_or(false, |f| !f.is_dir())
+            entry.file_type().is_ok_and(|f| !f.is_dir())
                 && entry
                     .path()
                     .extension()

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -173,7 +173,7 @@ pub fn load_from_path(path: &Path) -> Result<String, Diagnostic> {
         level: DiagnosticLevel::Error,
     })?;
 
-    if path.extension().map_or(false, |e| e == "rs") {
+    if path.extension().is_some_and(|e| e == "rs") {
         return crate::lexer::extract_rust_macro(string).ok_or_else(|| Diagnostic {
             message: "No `slint!` macro".into(),
             span: SourceLocation {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1357,7 +1357,7 @@ impl Expression {
                         .property_analysis
                         .borrow()
                         .get(nr.name())
-                        .map_or(false, |d| d.is_linked_to_read_only)
+                        .is_some_and(|d| d.is_linked_to_read_only)
                     {
                         true
                     } else if ctx.is_legacy_component() {

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -410,7 +410,7 @@ pub fn handle_property_bindings_init(
             return;
         }
         processed.insert(nr);
-        if binding_expression.analysis.as_ref().map_or(false, |a| a.is_const) {
+        if binding_expression.analysis.as_ref().is_some_and(|a| a.is_const) {
             // We must first handle all dependent properties in case it is a constant property
 
             binding_expression.expression.visit_recursive(&mut |e| {
@@ -468,7 +468,7 @@ pub fn for_each_const_properties(
                     .iter()
                     .filter(|(_, x)| {
                         x.property_type.is_property_type() &&
-                            !matches!( &x.property_type, crate::langtype::Type::Struct(s) if s.name.as_ref().map_or(false, |name| name.ends_with("::StateInfo")))
+                            !matches!( &x.property_type, crate::langtype::Type::Struct(s) if s.name.as_ref().is_some_and(|name| name.ends_with("::StateInfo")))
                     })
                     .map(|(k, _)| k.clone()),
             );

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -277,7 +277,7 @@ fn lower_sub_component(
 
     if let Some(parent) = component.parent_element.upgrade() {
         // Add properties for the model data and index
-        if parent.borrow().repeated.as_ref().map_or(false, |x| !x.is_conditional_element) {
+        if parent.borrow().repeated.as_ref().is_some_and(|x| !x.is_conditional_element) {
             sub_component.properties.push(Property {
                 name: "model_data".into(),
                 ty: crate::expression_tree::Expression::RepeaterModelReference {
@@ -429,7 +429,7 @@ fn lower_sub_component(
             let expression =
                 super::lower_expression::lower_expression(&binding.expression, &mut ctx).into();
 
-            let is_constant = binding.analysis.as_ref().map_or(false, |a| a.is_const);
+            let is_constant = binding.analysis.as_ref().is_some_and(|a| a.is_const);
             let animation = binding
                 .animation
                 .as_ref()
@@ -446,7 +446,7 @@ fn lower_sub_component(
 
             let is_state_info = matches!(
                 e.borrow().lookup_property(p).property_type,
-                Type::Struct(s) if s.name.as_ref().map_or(false, |name| name.ends_with("::StateInfo"))
+                Type::Struct(s) if s.name.as_ref().is_some_and(|name| name.ends_with("::StateInfo"))
             );
 
             sub_component.property_init.push((
@@ -640,7 +640,7 @@ fn get_property_analysis(elem: &ElementRc, p: &str) -> crate::object_tree::Prope
         let base = elem.borrow().base_type.clone();
         match base {
             ElementType::Native(n) => {
-                if n.properties.get(p).map_or(false, |p| p.is_native_output()) {
+                if n.properties.get(p).is_some_and(|p| p.is_native_output()) {
                     a.is_set = true;
                 }
             }
@@ -892,7 +892,7 @@ fn lower_global_expressions(
             }
             _ => unreachable!(),
         };
-        let is_constant = binding.borrow().analysis.as_ref().map_or(false, |a| a.is_const);
+        let is_constant = binding.borrow().analysis.as_ref().is_some_and(|a| a.is_const);
         lowered.init_values[property_index] = Some(BindingExpression {
             expression: expression.into(),
             animation: None,

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -147,7 +147,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
             Global,
             NativeParent(Rc<BuiltinElement>),
         }
-        let base = if c.child_text(SyntaxKind::Identifier).map_or(false, |t| t == "global") {
+        let base = if c.child_text(SyntaxKind::Identifier).is_some_and(|t| t == "global") {
             Base::Global
         } else if let Some(base) = e.QualifiedName() {
             let base = QualifiedTypeName::from_node(base).to_smolstr();

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -71,7 +71,7 @@ impl<'a> LookupCtx<'a> {
     }
 
     pub fn is_legacy_component(&self) -> bool {
-        self.component_scope.first().map_or(false, |e| e.borrow().is_legacy_syntax)
+        self.component_scope.first().is_some_and(|e| e.borrow().is_legacy_syntax)
     }
 
     /// True if the element is in the same component as the scope
@@ -535,7 +535,7 @@ impl LookupType {
                 if c.root_element
                     .borrow()
                     .builtin_type()
-                    .map_or(false, |x| x.is_internal && x.name == name)
+                    .is_some_and(|x| x.is_internal && x.name == name)
                     && !ctx.type_register.expose_internal_types
                 {
                     None

--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -76,20 +76,20 @@ impl NamedReference {
                 return false;
             }
         }
-        if e.property_analysis.borrow().get(self.name()).map_or(false, |a| a.is_set_externally) {
+        if e.property_analysis.borrow().get(self.name()).is_some_and(|a| a.is_set_externally) {
             return false;
         }
         drop(e);
 
         loop {
             let e = elem.borrow();
-            if e.property_analysis.borrow().get(self.name()).map_or(false, |a| a.is_set) {
+            if e.property_analysis.borrow().get(self.name()).is_some_and(|a| a.is_set) {
                 // if the property is set somewhere, it is not constant
                 return false;
             }
 
             if let Some(b) = e.bindings.get(self.name()) {
-                if check_binding && !b.borrow().analysis.as_ref().map_or(false, |a| a.is_const) {
+                if check_binding && !b.borrow().analysis.as_ref().is_some_and(|a| a.is_const) {
                     return false;
                 }
                 if !b.borrow().two_way_bindings.iter().all(|n| n.is_constant()) {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -414,7 +414,7 @@ impl Component {
             root_element: Element::from_node(
                 node.Element(),
                 "root".into(),
-                if node.child_text(SyntaxKind::Identifier).map_or(false, |t| t == "global") {
+                if node.child_text(SyntaxKind::Identifier).is_some_and(|t| t == "global") {
                     ElementType::Global
                 } else {
                     ElementType::Error
@@ -790,7 +790,7 @@ pub fn pretty_print(
         indent!();
         write!(f, "{name}: ")?;
         expression_tree::pretty_print(f, &expr.expression)?;
-        if expr.analysis.as_ref().map_or(false, |a| a.is_const) {
+        if expr.analysis.as_ref().is_some_and(|a| a.is_const) {
             write!(f, "/*const*/")?;
         }
         writeln!(f, ";")?;
@@ -959,13 +959,12 @@ impl Element {
             node.States().for_each(|n| error_on(&n, "states"));
             node.Transitions().for_each(|n| error_on(&n, "transitions"));
             node.CallbackDeclaration().for_each(|cb| {
-                if parser::identifier_text(&cb.DeclaredIdentifier()).map_or(false, |s| s == "init")
-                {
+                if parser::identifier_text(&cb.DeclaredIdentifier()).is_some_and(|s| s == "init") {
                     error_on(&cb, "an 'init' callback")
                 }
             });
             node.CallbackConnection().for_each(|cb| {
-                if parser::identifier_text(&cb).map_or(false, |s| s == "init") {
+                if parser::identifier_text(&cb).is_some_and(|s| s == "init") {
                     error_on(&cb, "an 'init' callback")
                 }
             });
@@ -1130,7 +1129,7 @@ impl Element {
                 unwrap_or_continue!(parser::identifier_text(&sig_decl.DeclaredIdentifier()); diag);
 
             let pure = Some(
-                sig_decl.child_token(SyntaxKind::Identifier).map_or(false, |t| t.text() == "pure"),
+                sig_decl.child_token(SyntaxKind::Identifier).is_some_and(|t| t.text() == "pure"),
             );
 
             let PropertyLookupResult {
@@ -1819,7 +1818,7 @@ impl Element {
     /// If `need_explicit` is true, then only consider binding set in the code, not the ones set
     /// by the compiler later.
     pub fn is_binding_set(self: &Element, property_name: &str, need_explicit: bool) -> bool {
-        if self.bindings.get(property_name).map_or(false, |b| {
+        if self.bindings.get(property_name).is_some_and(|b| {
             b.borrow().has_binding() && (!need_explicit || b.borrow().priority > 0)
         }) {
             true

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -79,7 +79,7 @@ impl PropertyPath {
                         || enclosing
                             .parent_element
                             .upgrade()
-                            .map_or(false, |e| check_that_element_is_in_the_component(&e, c))
+                            .is_some_and(|e| check_that_element_is_in_the_component(&e, c))
                 }
                 #[cfg(debug_assertions)]
                 debug_assert!(
@@ -207,7 +207,7 @@ fn analyze_binding(
     let mut depends_on_external = DependsOnExternal(false);
     let element = current.prop.element();
     let name = current.prop.name();
-    if context.currently_analyzing.back().map_or(false, |r| r == current)
+    if (context.currently_analyzing.back() == Some(current))
         && !element.borrow().bindings[name].borrow().two_way_bindings.is_empty()
     {
         let span = element.borrow().bindings[name]
@@ -242,7 +242,7 @@ fn analyze_binding(
     }
 
     let binding = &element.borrow().bindings[name];
-    if binding.borrow().analysis.as_ref().map_or(false, |a| a.no_external_dependencies) {
+    if binding.borrow().analysis.as_ref().is_some_and(|a| a.no_external_dependencies) {
         return depends_on_external;
     } else if !context.visited.insert(current.clone()) {
         return DependsOnExternal(true);
@@ -527,7 +527,7 @@ fn visit_implicit_layout_info_dependencies(
                     .property_analysis
                     .borrow()
                     .get("wrap")
-                    .map_or(false, |a| a.is_set || a.is_set_externally);
+                    .is_some_and(|a| a.is_set || a.is_set_externally);
             if wrap_set && orientation == Orientation::Vertical {
                 vis(&NamedReference::new(item, SmolStr::new_static("width")).into(), N);
             }

--- a/internal/compiler/passes/check_rotation.rs
+++ b/internal/compiler/passes/check_rotation.rs
@@ -47,9 +47,6 @@ fn has_any_children(e: &Element) -> bool {
 /// Returns true if the property is set.
 fn is_property_set(e: &Element, property_name: &str) -> bool {
     e.bindings.contains_key(property_name)
-        || e.property_analysis
-            .borrow()
-            .get(property_name)
-            .map_or(false, |a| a.is_set || a.is_linked)
+        || e.property_analysis.borrow().get(property_name).is_some_and(|a| a.is_set || a.is_linked)
         || matches!(&e.base_type, ElementType::Component(base) if is_property_set(&base.root_element.borrow(), property_name))
 }

--- a/internal/compiler/passes/clip.rs
+++ b/internal/compiler/passes/clip.rs
@@ -26,7 +26,7 @@ pub fn handle_clip(
         &(),
         &mut |elem_rc: &ElementRc, _| {
             let elem = elem_rc.borrow();
-            if elem.native_class().map_or(false, |n| Rc::ptr_eq(&n, &native_clip)) {
+            if elem.native_class().is_some_and(|n| Rc::ptr_eq(&n, &native_clip)) {
                 return;
             }
             if elem.bindings.contains_key("clip")
@@ -34,7 +34,7 @@ pub fn handle_clip(
                     .property_analysis
                     .borrow()
                     .get("clip")
-                    .map_or(false, |a| a.is_set || a.is_linked)
+                    .is_some_and(|a| a.is_set || a.is_linked)
             {
                 match elem.builtin_type().as_ref().map(|ty| ty.name.as_str()) {
                     Some("Rectangle") => {}

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -25,7 +25,7 @@ fn simplify_expression(expr: &mut Expression) -> bool {
             if nr.is_constant()
                 && !match nr.ty() {
                     Type::Struct(s) => {
-                        s.name.as_ref().map_or(false, |name| name.ends_with("::StateInfo"))
+                        s.name.as_ref().is_some_and(|name| name.ends_with("::StateInfo"))
                     }
                     _ => false,
                 }

--- a/internal/compiler/passes/deduplicate_property_read.rs
+++ b/internal/compiler/passes/deduplicate_property_read.rs
@@ -43,7 +43,7 @@ struct DedupPropState<'a> {
 
 impl<'a> DedupPropState<'a> {
     fn add(&self, nr: &NamedReference) {
-        if self.parent_state.map_or(false, |pc| pc.add_from_children(nr)) {
+        if self.parent_state.is_some_and(|pc| pc.add_from_children(nr)) {
             return;
         }
         let mut use_counts = self.counts.borrow_mut();
@@ -62,7 +62,7 @@ impl<'a> DedupPropState<'a> {
     }
 
     fn add_from_children(&self, nr: &NamedReference) -> bool {
-        if self.parent_state.map_or(false, |pc| pc.add_from_children(nr)) {
+        if self.parent_state.is_some_and(|pc| pc.add_from_children(nr)) {
             return true;
         }
         let mut use_counts = self.counts.borrow_mut();

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -193,7 +193,7 @@ fn gen_layout_info_prop(elem: &ElementRc, diag: &mut BuildDiagnostics) {
                     }
                     let explicit_constraints =
                         LayoutConstraints::new(c, diag, DiagnosticLevel::Error);
-                    let use_implicit_size = c.borrow().builtin_type().map_or(false, |b| {
+                    let use_implicit_size = c.borrow().builtin_type().is_some_and(|b| {
                         b.default_size_binding == DefaultSizeBinding::ImplicitSize
                     });
 
@@ -507,7 +507,7 @@ fn adjust_image_clip_rect(elem: &ElementRc, builtin: &Rc<BuiltinElement>) {
 
     if builtin.native_class.properties.keys().any(|p| {
         elem.borrow().bindings.contains_key(p)
-            || elem.borrow().property_analysis.borrow().get(p).map_or(false, |a| a.is_used())
+            || elem.borrow().property_analysis.borrow().get(p).is_some_and(|a| a.is_used())
     }) {
         let source = NamedReference::new(elem, SmolStr::new_static("source"));
         let x = NamedReference::new(elem, SmolStr::new_static("source-clip-x"));

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -121,7 +121,7 @@ pub fn ensure_window(
         } = expr
         {
             for arg in arguments.iter_mut() {
-                if matches!(arg, Expression::ElementReference(elr) if elr.upgrade().map_or(false, |elemrc| Rc::ptr_eq(&elemrc, &win_elem)))
+                if matches!(arg, Expression::ElementReference(elr) if elr.upgrade().is_some_and(|elemrc| Rc::ptr_eq(&elemrc, &win_elem)))
                 {
                     *arg = Expression::ElementReference(Rc::downgrade(&new_root))
                 }

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -276,8 +276,7 @@ fn call_set_focus_function(
             }
         }
     };
-    let builtin_focus_function =
-        element.borrow().builtin_type().map_or(false, |ty| ty.accepts_focus);
+    let builtin_focus_function = element.borrow().builtin_type().is_some_and(|ty| ty.accepts_focus);
 
     if declares_focus_function {
         Some(Expression::FunctionCall {

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -102,7 +102,7 @@ fn lower_element_layout(
                     && component
                         .parent_element
                         .upgrade()
-                        .map_or(false, |e| e.borrow().repeated.is_some()),
+                        .is_some_and(|e| e.borrow().repeated.is_some()),
                 "Error should have been caught at element lookup time"
             );
             return;
@@ -709,7 +709,7 @@ fn create_layout_item(
     diag: &mut BuildDiagnostics,
 ) -> Option<CreateLayoutItemResult> {
     let fix_explicit_percent = |prop: &str, item: &ElementRc| {
-        if !item.borrow().bindings.get(prop).map_or(false, |b| b.borrow().ty() == Type::Percent) {
+        if !item.borrow().bindings.get(prop).is_some_and(|b| b.borrow().ty() == Type::Percent) {
             return;
         }
         let mut item = item.borrow_mut();

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -52,7 +52,7 @@ pub(crate) fn lower_property_to_element(
                         .property_analysis
                         .borrow()
                         .get(property_name)
-                        .map_or(false, |a| a.is_set || a.is_linked))
+                        .is_some_and(|a| a.is_set || a.is_linked))
         };
 
         for mut child in old_children {

--- a/internal/compiler/passes/lower_text_input_interface.rs
+++ b/internal/compiler/passes/lower_text_input_interface.rs
@@ -35,7 +35,7 @@ pub fn lower_text_input_interface(component: &Rc<Component>) {
 }
 
 fn is_input_text_focused_prop(nr: &NamedReference) -> bool {
-    if !nr.element().borrow().builtin_type().map_or(false, |bt| bt.name == "TextInputInterface") {
+    if !nr.element().borrow().builtin_type().is_some_and(|bt| bt.name == "TextInputInterface") {
         return false;
     }
     assert_eq!(nr.name(), "text-input-focused");

--- a/internal/compiler/passes/optimize_useless_rectangles.rs
+++ b/internal/compiler/passes/optimize_useless_rectangles.rs
@@ -63,11 +63,11 @@ fn can_optimize(elem: &ElementRc) -> bool {
 
     let analysis = e.property_analysis.borrow();
     for coord in ["x", "y"] {
-        if e.bindings.contains_key(coord) || analysis.get(coord).map_or(false, |a| a.is_set) {
+        if e.bindings.contains_key(coord) || analysis.get(coord).is_some_and(|a| a.is_set) {
             return false;
         }
     }
-    if analysis.get("absolute-position").map_or(false, |a| a.is_read) {
+    if analysis.get("absolute-position").is_some_and(|a| a.is_read) {
         return false;
     }
 

--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -173,7 +173,7 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
                 .property_analysis
                 .borrow()
                 .get(remove.name())
-                .map_or(false, |v| v.is_read_externally || v.is_set_externally);
+                .is_some_and(|v| v.is_read_externally || v.is_set_externally);
             if let Some(d) = elem.property_declarations.get_mut(remove.name()) {
                 if d.expose_in_public_api || used_externally {
                     d.is_alias = Some(to.clone());

--- a/internal/compiler/passes/remove_unused_properties.rs
+++ b/internal/compiler/passes/remove_unused_properties.rs
@@ -17,7 +17,7 @@ pub fn remove_unused_properties(doc: &Document) {
                 for (prop, decl) in &elem.property_declarations {
                     if !decl.expose_in_public_api
                         && !elem.named_references.is_referenced(prop)
-                        && !elem.property_analysis.borrow().get(prop).map_or(false, |v| v.is_used())
+                        && !elem.property_analysis.borrow().get(prop).is_some_and(|v| v.is_used())
                         && !elem.change_callbacks.contains_key(prop)
                     {
                         to_remove.insert(prop.to_owned());

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -449,7 +449,7 @@ impl Expression {
                     return Expression::Invalid;
                 }
             };
-            if subs.next().map_or(false, |s| s.kind() != SyntaxKind::Comma) {
+            if subs.next().is_some_and(|s| s.kind() != SyntaxKind::Comma) {
                 ctx.diag.push_error(
                     "Angle expression must be an angle followed by a comma".into(),
                     &node,
@@ -475,7 +475,7 @@ impl Expression {
                 ctx.diag.push_error("'at' in @radial-gradient is not yet supported".into(), &comma);
                 return Expression::Invalid;
             }
-            if comma.as_ref().map_or(false, |s| s.kind() != SyntaxKind::Comma) {
+            if comma.as_ref().is_some_and(|s| s.kind() != SyntaxKind::Comma) {
                 ctx.diag.push_error(
                     "'circle' must be followed by a comma".into(),
                     comma.as_ref().map_or(&node, |x| x as &dyn Spanned),
@@ -1383,15 +1383,11 @@ fn continue_lookup_within_element(
             let e_borrowed = e.borrow();
             let mut id = e_borrowed.id.as_str();
             if id.is_empty() {
-                if ctx.component_scope.last().map_or(false, |x| Rc::ptr_eq(&e, x)) {
+                if ctx.component_scope.last().is_some_and(|x| Rc::ptr_eq(&e, x)) {
                     id = "self";
-                } else if ctx.component_scope.first().map_or(false, |x| Rc::ptr_eq(&e, x)) {
+                } else if ctx.component_scope.first().is_some_and(|x| Rc::ptr_eq(&e, x)) {
                     id = "root";
-                } else if ctx
-                    .component_scope
-                    .iter()
-                    .nth_back(1)
-                    .map_or(false, |x| Rc::ptr_eq(&e, x))
+                } else if ctx.component_scope.iter().nth_back(1).is_some_and(|x| Rc::ptr_eq(&e, x))
                 {
                     id = "parent";
                 }
@@ -1459,7 +1455,7 @@ fn continue_lookup_within_element(
         } else if lookup_result.property_visibility == PropertyVisibility::Protected
             && !local_to_component
             && !(lookup_result.is_in_direct_base
-                && ctx.component_scope.first().map_or(false, |x| Rc::ptr_eq(x, elem)))
+                && ctx.component_scope.first().is_some_and(|x| Rc::ptr_eq(x, elem)))
         {
             ctx.diag.push_error(format!("The function '{}' is protected", second.text()), &second);
         }

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -33,10 +33,9 @@ pub fn handle_visible(
         component,
         &(),
         &mut |elem: &ElementRc, _| {
-            let is_lowered_from_visible_property =
-                elem.borrow().native_class().map_or(false, |n| {
-                    Rc::ptr_eq(&n, &native_clip) && elem.borrow().id.ends_with("-visibility")
-                });
+            let is_lowered_from_visible_property = elem.borrow().native_class().is_some_and(|n| {
+                Rc::ptr_eq(&n, &native_clip) && elem.borrow().id.ends_with("-visibility")
+            });
             if is_lowered_from_visible_property {
                 // This is the element we just created. Skip it.
                 return;
@@ -55,7 +54,7 @@ pub fn handle_visible(
                             .property_analysis
                             .borrow()
                             .get("visible")
-                            .map_or(false, |a| a.is_set || a.is_linked))
+                            .is_some_and(|a| a.is_set || a.is_linked))
             };
 
             for mut child in old_children {

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -37,7 +37,7 @@ fn syntax_tests() -> std::io::Result<()> {
     let mut test_entries = Vec::new();
     for entry in std::fs::read_dir(format!("{}/tests/syntax", env!("CARGO_MANIFEST_DIR")))? {
         let entry = entry?;
-        if entry.file_type().map_or(false, |f| f.is_dir()) {
+        if entry.file_type().is_ok_and(|f| f.is_dir()) {
             let path = entry.path();
             for test_entry in path.read_dir()? {
                 let test_entry = test_entry?;

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1503,7 +1503,7 @@ impl TypeLoader {
             ))
             .chain(
                 (file_to_import == "std-widgets.slint"
-                    || referencing_file.map_or(false, |x| x.starts_with("builtin:/")))
+                    || referencing_file.is_some_and(|x| x.starts_with("builtin:/")))
                 .then(|| format!("builtin:/{}", self.style).into()),
             )
             .find_map(|include_dir| {
@@ -1647,7 +1647,7 @@ fn get_native_style(all_loaded_files: &mut std::collections::BTreeSet<PathBuf>) 
 /// Because from a proc_macro, we don't actually know the path of the current file, and this
 /// is why we must be relative to CARGO_MANIFEST_DIR.
 pub fn base_directory(referencing_file: &Path) -> PathBuf {
-    if referencing_file.extension().map_or(false, |e| e == "rs") {
+    if referencing_file.extension().is_some_and(|e| e == "rs") {
         // For .rs file, this is a rust macro, and rust macro locates the file relative to the CARGO_MANIFEST_DIR which is the directory that has a Cargo.toml file.
         let mut candidate = referencing_file;
         loop {

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1343,7 +1343,7 @@ pub(crate) mod ffi {
         width: &mut u32,
         height: &mut u32,
     ) -> bool {
-        image.to_rgb8().map_or(false, |pixel_buffer| {
+        image.to_rgb8().is_some_and(|pixel_buffer| {
             *data = pixel_buffer.data.clone();
             *width = pixel_buffer.width();
             *height = pixel_buffer.height();
@@ -1358,7 +1358,7 @@ pub(crate) mod ffi {
         width: &mut u32,
         height: &mut u32,
     ) -> bool {
-        image.to_rgba8().map_or(false, |pixel_buffer| {
+        image.to_rgba8().is_some_and(|pixel_buffer| {
             *data = pixel_buffer.data.clone();
             *width = pixel_buffer.width();
             *height = pixel_buffer.height();
@@ -1373,7 +1373,7 @@ pub(crate) mod ffi {
         width: &mut u32,
         height: &mut u32,
     ) -> bool {
-        image.to_rgba8_premultiplied().map_or(false, |pixel_buffer| {
+        image.to_rgba8_premultiplied().is_some_and(|pixel_buffer| {
             *data = pixel_buffer.data.clone();
             *width = pixel_buffer.width();
             *height = pixel_buffer.height();

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -645,7 +645,7 @@ pub(crate) fn send_exit_events(
     for (idx, it) in old_input_state.item_stack.iter().enumerate() {
         let Some(item) = it.0.upgrade() else { break };
         let g = item.geometry();
-        let contains = pos.map_or(false, |p| g.contains(p));
+        let contains = pos.is_some_and(|p| g.contains(p));
         if let Some(p) = pos.as_mut() {
             *p -= g.origin.to_vector();
         }
@@ -758,7 +758,7 @@ fn send_mouse_event_to_item(
     let mut event_for_children = mouse_event;
     event_for_children.translate(-geom.origin.to_vector());
 
-    let filter_result = if mouse_event.position().map_or(false, |p| geom.contains(p))
+    let filter_result = if mouse_event.position().is_some_and(|p| geom.contains(p))
         || crate::item_rendering::is_clipping_item(item)
     {
         item.as_ref().input_event_filter_before_children(

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -185,7 +185,7 @@ impl<T: Clone> ItemCache<T> {
 pub fn is_clipping_item(item: Pin<ItemRef>) -> bool {
     //(FIXME: there should be some flag in the vtable instead of down-casting)
     ItemRef::downcast_pin::<Flickable>(item).is_some()
-        || ItemRef::downcast_pin::<Clip>(item).map_or(false, |clip_item| clip_item.as_ref().clip())
+        || ItemRef::downcast_pin::<Clip>(item).is_some_and(|clip_item| clip_item.as_ref().clip())
 }
 
 /// Renders the children of the item with the specified index into the renderer.
@@ -1043,7 +1043,7 @@ impl<T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRenderer<'_
         };
 
         let clipped_geom = self.get_current_clip().intersection(&item_bounding_rect);
-        let draw = clipped_geom.map_or(false, |clipped_geom| {
+        let draw = clipped_geom.is_some_and(|clipped_geom| {
             let clipped_geom = clipped_geom.translate(self.translation());
             self.dirty_region.draw_intersects(clipped_geom)
         });

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -68,7 +68,7 @@ impl ComponentContainer {
             vtable::VRc::borrow_pin(&parent).as_ref().window_adapter(false, &mut window);
         }
         let prevent_focus_change =
-            window.as_ref().map_or(false, |w| w.window().0.prevent_focus_change.replace(true));
+            window.as_ref().is_some_and(|w| w.window().0.prevent_focus_change.replace(true));
 
         let factory_context = FactoryContext {
             parent_item_tree: self.my_component.get().unwrap().clone(),

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -241,7 +241,7 @@ impl FlickableData {
             }
             MouseEvent::Moved { position } => {
                 let do_intercept = inner.capture_events
-                    || inner.pressed_time.map_or(false, |pressed_time| {
+                    || inner.pressed_time.is_some_and(|pressed_time| {
                         if crate::animations::current_tick() - pressed_time > DURATION_THRESHOLD {
                             return false;
                         }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -684,7 +684,7 @@ pub fn reorder_dialog_button_layout(cells: &mut [GridLayoutCellData], roles: &[D
         std::env::var("XDG_CURRENT_DESKTOP")
             .ok()
             .and_then(|v| v.as_bytes().first().copied())
-            .map_or(false, |x| x.eq_ignore_ascii_case(&b'K'))
+            .is_some_and(|x| x.eq_ignore_ascii_case(&b'K'))
     }
     #[cfg(not(feature = "std"))]
     let is_kde = || true;

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -574,7 +574,7 @@ impl PropertyHandle {
     /// Implementation of Self::set_binding.
     fn set_binding_impl(&self, binding: *mut BindingHolder) {
         let previous_binding_intercepted = self.access(|b| {
-            b.map_or(false, |b| unsafe {
+            b.is_some_and(|b| unsafe {
                 // Safety: b is a BindingHolder<T>
                 (b.vtable.intercept_set_binding)(&*b as *const BindingHolder, binding)
             })
@@ -878,7 +878,7 @@ impl<T: Clone> Property<T> {
         T: PartialEq,
     {
         let previous_binding_intercepted = self.handle.access(|b| {
-            b.map_or(false, |b| unsafe {
+            b.is_some_and(|b| unsafe {
                 // Safety: b is a BindingHolder<T>
                 (b.vtable.intercept_set)(&*b as *const BindingHolder, &t as *const T as *const ())
             })
@@ -950,7 +950,7 @@ impl<T: Clone> Property<T> {
     /// Any of the properties accessed during the last evaluation of the closure called
     /// from the last call to evaluate is potentially dirty.
     pub fn is_dirty(&self) -> bool {
-        self.handle.access(|binding| binding.map_or(false, |b| b.dirty.get()))
+        self.handle.access(|binding| binding.is_some_and(|b| b.dirty.get()))
     }
 
     /// Internal function to mark the property as dirty and notify dependencies, regardless of

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -34,9 +34,10 @@ pub unsafe extern "C" fn slint_property_set_changed(
     handle: &PropertyHandleOpaque,
     value: *const c_void,
 ) {
-    if !handle.0.access(|b| {
-        b.map_or(false, |b| (b.vtable.intercept_set)(&*b as *const BindingHolder, value))
-    }) {
+    if !handle
+        .0
+        .access(|b| b.is_some_and(|b| (b.vtable.intercept_set)(&*b as *const BindingHolder, value)))
+    {
         handle.0.remove_binding();
     }
     handle.0.mark_dirty();
@@ -143,7 +144,7 @@ pub unsafe extern "C" fn slint_property_set_binding_internal(
 /// Returns whether the property behind this handle is marked as dirty
 #[no_mangle]
 pub extern "C" fn slint_property_is_dirty(handle: &PropertyHandleOpaque) -> bool {
-    handle.0.access(|binding| binding.map_or(false, |b| b.dirty.get()))
+    handle.0.access(|binding| binding.is_some_and(|b| b.dirty.get()))
 }
 
 /// Marks the property as dirty and notifies dependencies.

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1045,7 +1045,7 @@ impl WindowInner {
     pub fn supports_native_menu_bar(&self) -> bool {
         self.window_adapter()
             .internal(crate::InternalToken)
-            .map_or(false, |x| x.supports_native_menu_bar())
+            .is_some_and(|x| x.supports_native_menu_bar())
     }
 
     /// Setup the native menu bar
@@ -1720,9 +1720,7 @@ pub mod ffi {
         handle: *const WindowAdapterRcOpaque,
     ) -> bool {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        window_adapter
-            .internal(crate::InternalToken)
-            .map_or(false, |x| x.supports_native_menu_bar())
+        window_adapter.internal(crate::InternalToken).is_some_and(|x| x.supports_native_menu_bar())
     }
 
     /// Setup the native menu bar

--- a/tests/driver/driverlib/lib.rs
+++ b/tests/driver/driverlib/lib.rs
@@ -40,13 +40,13 @@ pub fn collect_test_cases(sub_folders: &str) -> std::io::Result<Vec<TestCase>> {
     let mut all_styles = vec!["fluent", "material", "cupertino", "cosmic"];
 
     // It is in the target/xxx/build directory
-    if std::env::var_os("OUT_DIR").map_or(false, |path| {
+    if std::env::var_os("OUT_DIR").is_some_and(|path| {
         // Same logic as in i-slint-backend-selector's build script to get the path
         let mut path: PathBuf = path.into();
         path.pop();
         path.pop();
         path.push("SLINT_DEFAULT_STYLE.txt");
-        std::fs::read_to_string(path).map_or(false, |style| style.trim().contains("qt"))
+        std::fs::read_to_string(path).is_ok_and(|style| style.trim().contains("qt"))
     }) {
         all_styles.push("qt");
     }

--- a/tests/screenshots/testing.rs
+++ b/tests/screenshots/testing.rs
@@ -226,7 +226,7 @@ fn compare_images(
 
     if result.is_err()
         && rotated == RenderingRotation::NoRotation
-        && std::env::var("SLINT_CREATE_SCREENSHOTS").map_or(false, |var| var == "1")
+        && std::env::var("SLINT_CREATE_SCREENSHOTS").is_ok_and(|var| var == "1")
     {
         eprintln!("saving rendered image as comparison to reference failed");
         image::save_buffer(

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -185,7 +185,7 @@ fn main() -> std::io::Result<()> {
         }
         for resource in doc.embedded_file_resources.borrow().keys() {
             if !fileaccess::load_file(std::path::Path::new(resource))
-                .map_or(false, |f| f.is_builtin())
+                .is_some_and(|f| f.is_builtin())
             {
                 write!(f, " {resource}")?;
             }

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -286,7 +286,7 @@ impl ElementRcNode {
 
     pub fn contains_offset(&self, offset: TextSize) -> bool {
         self.with_element_node(|node| {
-            node.parent().map_or(false, |n| n.text_range().contains(offset))
+            node.parent().is_some_and(|n| n.text_range().contains(offset))
         })
     }
 }

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -336,7 +336,7 @@ impl DocumentCache {
                 .borrow()
                 .debug
                 .iter()
-                .position(|n| n.node.parent().map_or(false, |n| n.text_range().contains(offset)))
+                .position(|n| n.node.parent().is_some_and(|n| n.text_range().contains(offset)))
         }
 
         for component in &document.inner_components {

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -693,7 +693,7 @@ fn format_conditional_expression(
     writer: &mut impl TokenWriter,
     state: &mut FormatState,
 ) -> Result<(), std::io::Error> {
-    let has_if = node.child_text(SyntaxKind::Identifier).map_or(false, |x| x == "if");
+    let has_if = node.child_text(SyntaxKind::Identifier).is_some_and(|x| x == "if");
 
     let mut sub = node.children_with_tokens();
     if has_if {
@@ -979,7 +979,7 @@ fn format_state(
     writer: &mut impl TokenWriter,
     state: &mut FormatState,
 ) -> Result<(), std::io::Error> {
-    let has_when = node.child_text(SyntaxKind::Identifier).map_or(false, |x| x == "when");
+    let has_when = node.child_text(SyntaxKind::Identifier).is_some_and(|x| x == "when");
     let mut sub = node.children_with_tokens();
     let ok = if has_when {
         whitespace_to(&mut sub, SyntaxKind::DeclaredIdentifier, writer, state, "")?

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -423,7 +423,7 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
             let gp = p.parent();
 
             if p.kind() == SyntaxKind::DeclaredIdentifier
-                && gp.as_ref().map_or(false, |n| n.kind() == SyntaxKind::Component)
+                && gp.as_ref().is_some_and(|n| n.kind() == SyntaxKind::Component)
             {
                 let element = gp.as_ref().unwrap().child_node(SyntaxKind::Element).unwrap();
 
@@ -439,7 +439,7 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
             }
 
             if p.kind() == SyntaxKind::QualifiedName
-                && gp.as_ref().map_or(false, |n| n.kind() == SyntaxKind::Element)
+                && gp.as_ref().is_some_and(|n| n.kind() == SyntaxKind::Element)
             {
                 let range = util::node_to_lsp_range(&p);
 
@@ -448,7 +448,7 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
                     .unwrap()
                     .parent()
                     .as_ref()
-                    .map_or(false, |n| n.kind() != SyntaxKind::Component)
+                    .is_some_and(|n| n.kind() != SyntaxKind::Component)
                 {
                     ctx.server_notifier.send_message_to_preview(
                         common::LspToPreviewMessage::HighlightFromEditor {
@@ -1070,7 +1070,7 @@ fn get_code_actions(
                     NodeOrToken::Node(_) => is_sub_element(n.kind()),
                     NodeOrToken::Token(t) => {
                         t.kind() == SyntaxKind::Whitespace
-                            && t.next_sibling_or_token().map_or(false, |n| is_sub_element(n.kind()))
+                            && t.next_sibling_or_token().is_some_and(|n| is_sub_element(n.kind()))
                     }
                 })
                 .collect::<Vec<_>>();

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -59,7 +59,7 @@ pub(crate) fn completion_at(
     } else if let Some(element) = syntax_nodes::Element::new(node.clone()) {
         if token.kind() == SyntaxKind::At
             || (token.kind() == SyntaxKind::Identifier
-                && token.prev_token().map_or(false, |t| t.kind() == SyntaxKind::At))
+                && token.prev_token().is_some_and(|t| t.kind() == SyntaxKind::At))
         {
             return Some(vec![CompletionItem::new_simple("children".into(), String::new())]);
         }
@@ -69,7 +69,7 @@ pub(crate) fn completion_at(
             let is_global = node
                 .parent()
                 .and_then(|n| n.child_text(SyntaxKind::Identifier))
-                .map_or(false, |k| k == "global");
+                .is_some_and(|k| k == "global");
 
             // add keywords
             r.extend(
@@ -201,7 +201,7 @@ pub(crate) fn completion_at(
     ) {
         if token.kind() == SyntaxKind::At
             || (token.kind() == SyntaxKind::Identifier
-                && token.prev_token().map_or(false, |t| t.kind() == SyntaxKind::At))
+                && token.prev_token().is_some_and(|t| t.kind() == SyntaxKind::At))
         {
             return Some(
                 [
@@ -360,7 +360,7 @@ pub(crate) fn completion_at(
             && offset >= id_range.end()
             && !c
                 .children_with_tokens()
-                .any(|c| c.as_token().map_or(false, |t| t.text() == "inherits"))
+                .any(|c| c.as_token().is_some_and(|t| t.text() == "inherits"))
         {
             let mut c = CompletionItem::new_simple("inherits".into(), String::new());
             c.kind = Some(CompletionItemKind::KEYWORD);

--- a/tools/lsp/language/semantic_tokens.rs
+++ b/tools/lsp/language/semantic_tokens.rs
@@ -107,7 +107,7 @@ pub fn get_semantic_tokens(
                 SyntaxKind::ExportIdentifier => {
                     Some((
                         self::TYPE,
-                        if token.parent().parent().map_or(false, |p| {
+                        if token.parent().parent().is_some_and(|p| {
                             p.children().any(|n| n.kind() == SyntaxKind::ExportName)
                         }) {
                             0
@@ -119,16 +119,18 @@ pub fn get_semantic_tokens(
                 SyntaxKind::ExportName => Some((self::TYPE, 1 << self::DECLARATION)),
                 SyntaxKind::ImportSpecifier => Some((self::KEYWORD, 0)),
                 SyntaxKind::ImportIdentifier => Some((self::KEYWORD, 0)),
-                SyntaxKind::ExternalName => Some((
-                    self::TYPE,
-                    if token.parent().parent().map_or(false, |p| {
-                        p.children().any(|n| n.kind() == SyntaxKind::InternalName)
-                    }) {
-                        0
-                    } else {
-                        1 << self::DECLARATION
-                    },
-                )),
+                SyntaxKind::ExternalName => {
+                    Some((
+                        self::TYPE,
+                        if token.parent().parent().is_some_and(|p| {
+                            p.children().any(|n| n.kind() == SyntaxKind::InternalName)
+                        }) {
+                            0
+                        } else {
+                            1 << self::DECLARATION
+                        },
+                    ))
+                }
                 SyntaxKind::InternalName => Some((self::TYPE, 1 << self::DECLARATION)),
                 SyntaxKind::ObjectTypeMember => Some((self::PROPERTY, 1 << self::DEFINITION)),
                 SyntaxKind::StructDeclaration => Some((self::KEYWORD, 0)),

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -131,7 +131,7 @@ pub fn lookup_current_element_type(mut node: SyntaxNode, tr: &TypeRegister) -> O
 
     let parent = node.parent()?;
     if parent.kind() == SyntaxKind::Component
-        && parent.child_text(SyntaxKind::Identifier).map_or(false, |x| x == "global")
+        && parent.child_text(SyntaxKind::Identifier).is_some_and(|x| x == "global")
     {
         return Some(ElementType::Global);
     }
@@ -202,7 +202,7 @@ pub fn with_property_lookup_ctx<R>(
         loop {
             scope.push(it.clone());
             if let Some(c) = it.clone().borrow().children.iter().find(|c| {
-                c.borrow().debug.first().map_or(false, |n| n.node.text_range().contains(offset))
+                c.borrow().debug.first().is_some_and(|n| n.node.text_range().contains(offset))
             }) {
                 it = c.clone();
             } else {
@@ -239,7 +239,7 @@ pub fn with_property_lookup_ctx<R>(
 
     if let Some(cb) = element
         .CallbackConnection()
-        .find(|p| i_slint_compiler::parser::identifier_text(p).map_or(false, |x| x == prop_name))
+        .find(|p| i_slint_compiler::parser::identifier_text(p).is_some_and(|x| x == prop_name))
     {
         lookup_context.arguments = cb
             .DeclaredIdentifier()
@@ -247,7 +247,7 @@ pub fn with_property_lookup_ctx<R>(
             .collect();
     } else if let Some(f) = element.Function().find(|p| {
         i_slint_compiler::parser::identifier_text(&p.DeclaredIdentifier())
-            .map_or(false, |x| x == prop_name)
+            .is_some_and(|x| x == prop_name)
     }) {
         lookup_context.arguments = f
             .ArgumentDeclaration()

--- a/tools/updater/experiments/geometry_changes.rs
+++ b/tools/updater/experiments/geometry_changes.rs
@@ -21,7 +21,7 @@ pub(crate) fn fold_node(
             let parent = &state.lookup_change.scope[state.lookup_change.scope.len() - 2];
 
             if !is_layout_base(parent) && !is_path(elem) && elem.borrow().is_legacy_syntax {
-                let extend = elem.borrow().builtin_type().map_or(false, |b| {
+                let extend = elem.borrow().builtin_type().is_some_and(|b| {
                     b.default_size_binding
                         != i_slint_compiler::langtype::DefaultSizeBinding::ImplicitSize
                 });

--- a/tools/updater/experiments/input_output_properties.rs
+++ b/tools/updater/experiments/input_output_properties.rs
@@ -12,13 +12,10 @@ pub(crate) fn fold_node(
     _args: &Cli,
 ) -> std::io::Result<bool> {
     if node.kind() == SyntaxKind::PropertyDeclaration
-        && node
-            .parent()
-            .and_then(|n| n.parent())
-            .map_or(false, |n| n.kind() == SyntaxKind::Component)
+        && node.parent().and_then(|n| n.parent()).is_some_and(|n| n.kind() == SyntaxKind::Component)
     {
         // check that the first identifier is "property" as opposed to an already converted "in-out" token
-        if node.child_token(SyntaxKind::Identifier).map_or(false, |t| t.text() == "property") {
+        if node.child_token(SyntaxKind::Identifier).is_some_and(|t| t.text() == "property") {
             // Consider that all property are in-out, because we don't do enough analysis in the slint-updater to know
             // if they should be private
             write!(file, "in-out ")?;

--- a/tools/updater/experiments/new_component_declaration.rs
+++ b/tools/updater/experiments/new_component_declaration.rs
@@ -14,7 +14,7 @@ pub(crate) fn fold_node(
     let kind = node.kind();
     if kind == SyntaxKind::Component && node.child_token(SyntaxKind::ColonEqual).is_some() {
         let is_global =
-            node.child_token(SyntaxKind::Identifier).map_or(false, |t| t.text() == "global");
+            node.child_token(SyntaxKind::Identifier).is_some_and(|t| t.text() == "global");
         if !is_global {
             write!(file, "component ")?;
         }
@@ -22,11 +22,11 @@ pub(crate) fn fold_node(
             if n.kind() == SyntaxKind::ColonEqual {
                 if !is_global {
                     let t = n.as_token().unwrap();
-                    if t.prev_token().map_or(false, |t| t.kind() != SyntaxKind::Whitespace) {
+                    if t.prev_token().is_some_and(|t| t.kind() != SyntaxKind::Whitespace) {
                         write!(file, " ")?;
                     }
                     write!(file, "inherits")?;
-                    if t.next_token().map_or(false, |t| t.kind() != SyntaxKind::Whitespace) {
+                    if t.next_token().is_some_and(|t| t.kind() != SyntaxKind::Whitespace) {
                         write!(file, " ")?;
                     }
                 }

--- a/tools/updater/experiments/purity.rs
+++ b/tools/updater/experiments/purity.rs
@@ -14,7 +14,7 @@ pub(crate) fn fold_node(
     _args: &Cli,
 ) -> std::io::Result<bool> {
     if let Some(s) = syntax_nodes::CallbackDeclaration::new(node.clone()) {
-        if state.current_elem.as_ref().map_or(false, |e| e.borrow().is_legacy_syntax)
+        if state.current_elem.as_ref().is_some_and(|e| e.borrow().is_legacy_syntax)
             && s.child_text(SyntaxKind::Identifier).as_deref() != Some("pure")
         {
             if s.ReturnType().is_some() {
@@ -42,7 +42,7 @@ pub(crate) fn fold_node(
             }
         }
     } else if let Some(s) = syntax_nodes::Function::new(node.clone()) {
-        if state.current_elem.as_ref().map_or(false, |e| e.borrow().is_legacy_syntax)
+        if state.current_elem.as_ref().is_some_and(|e| e.borrow().is_legacy_syntax)
             && s.ReturnType().is_some()
         {
             let (mut pure, mut public) = (false, false);

--- a/tools/updater/experiments/transitions.rs
+++ b/tools/updater/experiments/transitions.rs
@@ -27,7 +27,7 @@ pub(crate) fn fold_node(
                             if t.state_id == state_id
                                 && t.node
                                     .parent()
-                                    .map_or(false, |p| p.kind() == SyntaxKind::Transitions)
+                                    .is_some_and(|p| p.kind() == SyntaxKind::Transitions)
                             {
                                 for c in t.node.children_with_tokens() {
                                     if !matches!(

--- a/tools/updater/main.rs
+++ b/tools/updater/main.rs
@@ -223,10 +223,10 @@ fn visit_node(
                     .borrow()
                     .children
                     .iter()
-                    .find(|c| c.borrow().debug.first().map_or(false, |n| n.node.node == node.node))
+                    .find(|c| c.borrow().debug.first().is_some_and(|n| n.node.node == node.node))
                     .cloned()
             } else if let Some(parent_co) = &state.current_component {
-                if node.parent().map_or(false, |n| n.kind() == SyntaxKind::Component) {
+                if node.parent().is_some_and(|n| n.kind() == SyntaxKind::Component) {
                     state.current_elem = Some(parent_co.root_element.clone())
                 }
             }

--- a/tools/updater/transforms/renames.rs
+++ b/tools/updater/transforms/renames.rs
@@ -13,7 +13,7 @@ pub(crate) fn fold_node(
 ) -> std::io::Result<bool> {
     let kind = node.kind();
     if kind == SyntaxKind::QualifiedName
-        && node.parent().map_or(false, |n| n.kind() == SyntaxKind::Expression)
+        && node.parent().is_some_and(|n| n.kind() == SyntaxKind::Expression)
     {
         let q = i_slint_compiler::object_tree::QualifiedTypeName::from_node(node.clone().into())
             .to_string();

--- a/xtask/src/reuse_compliance_check.rs
+++ b/xtask/src/reuse_compliance_check.rs
@@ -83,7 +83,7 @@ fn find_licenses_directories(dir: &Path) -> Result<Vec<PathBuf>> {
     let dot_name: &OsStr = &OsStr::new(".");
 
     for d in std::fs::read_dir(dir)?
-        .filter(|d| d.as_ref().map_or(false, |e| e.file_type().map_or(false, |f| f.is_dir())))
+        .filter(|d| d.as_ref().is_ok_and(|e| e.file_type().is_ok_and(|f| f.is_dir())))
     {
         let path = d?.path();
         let parent_path = path.parent().expect("This is a subdirectory, so it must have a parent!");
@@ -124,7 +124,7 @@ fn populate_license_map(
 }
 
 fn is_symlink(path: &Path) -> bool {
-    std::fs::symlink_metadata(path).map_or(false, |m| m.file_type().is_symlink())
+    std::fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
 }
 
 fn validate_license_directory(dir: &Path, licenses: &[String], fix_it: bool) -> Result<()> {


### PR DESCRIPTION
`__CARGO_FIX_YOLO=1` is a hack, but it does help a lot with the tedious fixes where the result is fairly clear.

See https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or

```
__CARGO_FIX_YOLO=1 cargo clippy --fix  --all-targets --workspace --exclude gstreamer-player --exclude i-slint-backend-linuxkms --exclude uefi-demo --exclude ffmpeg -- -A clippy::all -W clippy::unnecessary_map_or

cargo fmt --all
```