### PR TITLE
Auto-fixed `clippy::needless_borrow`

### DIFF
--- a/api/cpp/build.rs
+++ b/api/cpp/build.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let enabled_features = EnabledFeatures::from_env();
 
-    let dependencies = cbindgen::gen_all(&root_dir, &output_dir, enabled_features)?;
+    let dependencies = cbindgen::gen_all(root_dir, output_dir, enabled_features)?;
     for path in dependencies {
         println!("cargo:rerun-if-changed={}", path.display());
     }

--- a/api/node/rust/interpreter/component_instance.rs
+++ b/api/node/rust/interpreter/component_instance.rs
@@ -259,7 +259,7 @@ impl JsComponentInstance {
         let args = arguments
             .into_iter()
             .zip(args.into_iter())
-            .map(|(a, ty)| super::value::to_value(&env, a, &ty))
+            .map(|(a, ty)| super::value::to_value(&env, a, ty))
             .collect::<Result<Vec<_>, _>>()?;
         if args.len() != count {
             return Err(napi::Error::from_reason(

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -253,7 +253,7 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
                 )))))
             } else {
                 let rust_model =
-                    unknown.coerce_to_object().and_then(|obj| js_into_rust_model(env, &obj, &a))?;
+                    unknown.coerce_to_object().and_then(|obj| js_into_rust_model(env, &obj, a))?;
                 Ok(Value::Model(rust_model))
             }
         }

--- a/demos/printerdemo_mcu/bench.rs
+++ b/demos/printerdemo_mcu/bench.rs
@@ -74,11 +74,11 @@ fn render_only<T: TargetPixel + Default>(bencher: divan::Bencher, mode: RenderMo
 
     WINDOW.with(|window| {
         // Do a first rendering to evaluate bindings
-        let ok = do_rendering(&window, &mut buffer, mode);
+        let ok = do_rendering(window, &mut buffer, mode);
         assert!(ok);
 
         bencher.bench_local(|| {
-            let ok = do_rendering(&window, &mut buffer, mode);
+            let ok = do_rendering(window, &mut buffer, mode);
             assert!(ok);
         })
     });
@@ -93,7 +93,7 @@ fn full<T: TargetPixel + Default>(bencher: divan::Bencher) {
             let main_window = MainWindow::new().unwrap();
             let _ = main_window.show();
             main_window.window().set_size(SIZE);
-            let ok = do_rendering(&window, &mut buffer, RenderMode::FullBuffer);
+            let ok = do_rendering(window, &mut buffer, RenderMode::FullBuffer);
             assert!(ok);
         })
     });

--- a/internal/backends/testing/ffi.rs
+++ b/internal/backends/testing/ffi.rs
@@ -31,7 +31,7 @@ pub unsafe extern "C" fn slint_testing_element_visit_elements(
     RootWrapper(root)
         .root_element()
         .query_descendants()
-        .match_predicate(move |element| visitor(user_data, &element))
+        .match_predicate(move |element| visitor(user_data, element))
         .find_first()
         .is_some()
 }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -254,7 +254,7 @@ impl BuiltinFunction {
         thread_local! {
             static TYPES: BuiltinFunctionTypes = BuiltinFunctionTypes::new();
         }
-        TYPES.with(|types| types.ty(&self))
+        TYPES.with(|types| types.ty(self))
     }
 
     /// It is const if the return value only depends on its argument and has no side effect

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -707,7 +707,7 @@ pub fn generate(
         }
     }
 
-    let llr = llr::lower_to_item_tree::lower_to_item_tree(&doc, compiler_config)?;
+    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config)?;
 
     #[cfg(feature = "bundle-translations")]
     if let Some(translations) = &llr.translations {
@@ -2200,7 +2200,7 @@ fn generate_sub_component(
     }
 
     target_struct.members.extend(
-        generate_functions(&component.functions.as_ref(), &ctx).map(|x| (Access::Public, x)),
+        generate_functions(component.functions.as_ref(), &ctx).map(|x| (Access::Public, x)),
     );
 
     target_struct.members.push((
@@ -3720,7 +3720,7 @@ fn compile_builtin_function_call(
                     ctx.compilation_unit,
                     popup.item_tree.root,
                     CppGeneratorContext { global_access: "self->globals".into(), conditional_includes: ctx.generator_state.conditional_includes },
-                    Some(ParentCtx::new(&ctx, None)),
+                    Some(ParentCtx::new(ctx, None)),
                 );
                 let position = compile_expression(&popup.position.borrow(), &popup_ctx);
                 let close_policy = compile_expression(close_policy, ctx);

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -201,7 +201,7 @@ pub fn generate(
         .iter_enumerated()
         .filter(|(_, glob)| glob.must_generate())
         .map(|(idx, glob)| generate_global(idx, glob, &llr));
-    let shared_globals = generate_shared_globals(&llr, &compiler_config);
+    let shared_globals = generate_shared_globals(&llr, compiler_config);
     let globals_ids = llr.globals.iter().filter(|glob| glob.exported).flat_map(|glob| {
         std::iter::once(ident(&glob.name)).chain(glob.aliases.iter().map(|x| ident(x)))
     });
@@ -697,7 +697,7 @@ fn generate_sub_component(
             )
         })
         .chain(component.menu_item_trees.iter().map(|tree| {
-            generate_item_tree(&tree, root, Some(ParentCtx::new(&ctx, None)), None, false)
+            generate_item_tree(tree, root, Some(ParentCtx::new(&ctx, None)), None, false)
         }))
         .collect::<Vec<_>>();
 
@@ -1780,7 +1780,7 @@ fn generate_repeated_component(
     };
 
     let root_sc = &unit.sub_components[repeated.sub_tree.root];
-    let inner_component_id = self::inner_component_id(&root_sc);
+    let inner_component_id = self::inner_component_id(root_sc);
 
     let extra_fn = if let Some(listview) = &repeated.listview {
         let p_y = access_member(&listview.prop_y, &ctx).unwrap();
@@ -2702,7 +2702,7 @@ fn compile_builtin_function_call(
                     ctx.compilation_unit,
                     popup.item_tree.root,
                     RustGeneratorContext { global_access: quote!(_self.globals.get().unwrap()) },
-                    Some(ParentCtx::new(&ctx, None)),
+                    Some(ParentCtx::new(ctx, None)),
                 );
                 let position = compile_expression(&popup.position.borrow(), &popup_ctx);
 

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -69,7 +69,7 @@ pub fn lower_to_item_tree(
         .collect();
 
     let popup_menu = document.popup_menu_impl.as_ref().map(|c| {
-        let sc = lower_sub_component(&c, &mut state, None, compiler_config);
+        let sc = lower_sub_component(c, &mut state, None, compiler_config);
         let sub_menu = sc.mapping.map_property_reference(
             &NamedReference::new(&c.root_element, SmolStr::new_static("sub-menu")),
             &state,
@@ -508,7 +508,7 @@ fn lower_sub_component(
         .map(|c| {
             let sc = lower_sub_component(c, ctx.state, Some(&ctx.inner), compiler_config);
             ItemTree {
-                tree: make_tree(&ctx.state, &c.root_element, &sc, &[]),
+                tree: make_tree(ctx.state, &c.root_element, &sc, &[]),
                 root: ctx.state.push_sub_component(sc),
                 parent_context: None,
             }

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -123,7 +123,7 @@ pub fn count_property_use(root: &CompilationUnit) {
                 root,
                 popup.item_tree.root,
                 (),
-                Some(ParentCtx::new(&ctx, None)),
+                Some(ParentCtx::new(ctx, None)),
             );
             popup.position.borrow().visit_property_references(&popup_ctx, &mut visit_property)
         }
@@ -144,7 +144,7 @@ pub fn count_property_use(root: &CompilationUnit) {
     }
 
     if let Some(p) = &root.popup_menu {
-        let ctx = EvaluationContext::new_sub_component(&root, p.item_tree.root, (), None);
+        let ctx = EvaluationContext::new_sub_component(root, p.item_tree.root, (), None);
         visit_property(&p.entries, &ctx);
         visit_property(&p.sub_menu, &ctx);
         visit_property(&p.activated, &ctx);

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -391,7 +391,7 @@ impl LookupObject for InScopeLookup {
         Self::visit_scope(
             ctx,
             |str, r| (str == name).then_some(r),
-            |elem| elem.lookup(ctx, &name),
+            |elem| elem.lookup(ctx, name),
             |elem| {
                 elem.borrow().property_declarations.get(name).map(|prop| {
                     expression_from_reference(

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -357,7 +357,7 @@ fn fix_percent_size(
             parent = crate::object_tree::find_parent_element(&parent).unwrap_or(parent)
         }
         debug_assert_eq!(
-            parent.borrow().lookup_property(&property).property_type,
+            parent.borrow().lookup_property(property).property_type,
             Type::LogicalLength
         );
         let fill =
@@ -416,7 +416,7 @@ fn make_default_aspect_ratio_preserving_binding(
     missing_size_property: &'static str,
     given_size_property: &'static str,
 ) {
-    if elem.borrow().is_binding_set(&missing_size_property, false) {
+    if elem.borrow().is_binding_set(missing_size_property, false) {
         return;
     }
 
@@ -483,7 +483,7 @@ fn maybe_center_in_parent(
     pos_prop: &'static str,
     size_prop: &'static str,
 ) {
-    if elem.borrow().is_binding_set(&pos_prop, false) {
+    if elem.borrow().is_binding_set(pos_prop, false) {
         return;
     }
 

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -98,7 +98,7 @@ pub fn embed_glyphs<'a>(
     sharedfontdb::FONT_DB.with(|db| {
         embed_glyphs_with_fontdb(
             compiler_config,
-            &db,
+            db,
             doc,
             pixel_sizes,
             characters_seen,

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -204,7 +204,7 @@ impl<'a> LocalFocusForwards<'a> {
 
     fn gen_focus_functions(&mut self, elem: &ElementRc) {
         if let Some((root_focus_forward, focus_forward_location)) =
-            self.focus_forward_for_element(&elem)
+            self.focus_forward_for_element(elem)
         {
             for function in FocusFunctionType::iter() {
                 if let Some(set_or_clear_focus_code) = call_set_focus_function(

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -202,7 +202,7 @@ fn process_context_menu(
         });
 
         let item_tree_root = if !items.is_empty() {
-            lower_menu_items(context_menu_elem, items, &components)
+            lower_menu_items(context_menu_elem, items, components)
                 .map(|c| Expression::ElementReference(Rc::downgrade(&c.root_element)))
         } else {
             None
@@ -228,7 +228,7 @@ fn process_context_menu(
             Type::Array(components.menu_entry.clone().into()).into(),
         );
         Expression::PropertyReference(NamedReference::new(
-            &context_menu_elem,
+            context_menu_elem,
             SmolStr::new_static(ENTRIES),
         ))
     };
@@ -291,7 +291,7 @@ fn process_window(
     // Lower MenuItem's into entries
     let children = std::mem::take(&mut menu_bar.borrow_mut().children);
     let item_tree_root = if !children.is_empty() {
-        lower_menu_items(&menu_bar, children, &components)
+        lower_menu_items(&menu_bar, children, components)
             .map(|c| Expression::ElementReference(Rc::downgrade(&c.root_element)))
     } else {
         None
@@ -430,7 +430,7 @@ fn lower_menu_items(
 ) -> Option<Rc<Component>> {
     let mut has_repeated = false;
     for i in &children {
-        recurse_elem(&i, &(), &mut |e, _| {
+        recurse_elem(i, &(), &mut |e, _| {
             if e.borrow().repeated.is_some() {
                 has_repeated = true;
             }
@@ -494,7 +494,7 @@ fn lower_menu_items(
                 node: parent.borrow().debug.first().map(|n| n.node.clone().into()),
                 id: SmolStr::default(),
                 root_element,
-                parent_element: Rc::downgrade(&parent),
+                parent_element: Rc::downgrade(parent),
                 ..Default::default()
             }
         });

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -66,7 +66,7 @@ pub(crate) fn lower_property_to_element(
                             property_name,
                             extra_properties.clone(),
                             default_value_for_extra_properties,
-                            &element_name,
+                            element_name,
                             type_register,
                         ),
                     )
@@ -77,7 +77,7 @@ pub(crate) fn lower_property_to_element(
                     property_name,
                     extra_properties.clone(),
                     default_value_for_extra_properties,
-                    &element_name,
+                    element_name,
                     type_register,
                 );
                 crate::object_tree::adjust_geometry_for_injected_parent(&new_child, &child);
@@ -105,7 +105,7 @@ fn create_property_element(
                 BindingExpression::new_two_way(NamedReference::new(child, property_name.into()));
             if let Some(default_value_for_extra_properties) = default_value_for_extra_properties {
                 if !child.borrow().bindings.contains_key(property_name) {
-                    bind.expression = default_value_for_extra_properties(child, &property_name)
+                    bind.expression = default_value_for_extra_properties(child, property_name)
                 }
             }
             (property_name.into(), bind.into())

--- a/internal/compiler/passes/unique_id.rs
+++ b/internal/compiler/passes/unique_id.rs
@@ -33,7 +33,7 @@ fn assign_unique_id_in_component(component: &Rc<Component>, count: &mut u32) {
         elem_mut.id = format_smolstr!("{}-{}", old_id, count);
 
         let enclosing = elem_mut.enclosing_component.upgrade().unwrap();
-        if Rc::ptr_eq(&elem, &enclosing.root_element) {
+        if Rc::ptr_eq(elem, &enclosing.root_element) {
             for o in enclosing.optimized_elements.borrow().iter() {
                 *count += 1;
                 let mut elem_mut = o.borrow_mut();

--- a/internal/compiler/pathutils.rs
+++ b/internal/compiler/pathutils.rs
@@ -438,7 +438,7 @@ fn dirname_string(path: &str) -> String {
 fn test_dirname() {
     #[track_caller]
     fn th(input: &str, expected: &str) {
-        let result = dirname_string(&input);
+        let result = dirname_string(input);
         assert_eq!(result, expected);
     }
 

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1131,7 +1131,7 @@ impl TypeLoader {
                     if !file_to_import.ends_with(file_name)
                         && len >= file_name.len()
                         && file_name.eq_ignore_ascii_case(
-                            &file_to_import.get(len - file_name.len()..).unwrap_or(""),
+                            file_to_import.get(len - file_name.len()..).unwrap_or(""),
                         )
                     {
                         if import_token.as_ref().and_then(|x| x.source_file()).is_some() {

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -425,7 +425,7 @@ mod ffi {
         plural: &SharedString,
     ) {
         *to_translate =
-            translate(to_translate.as_str(), &context, &domain, arguments.as_slice(), n, &plural)
+            translate(to_translate.as_str(), context, domain, arguments.as_slice(), n, plural)
     }
 
     /// Mark all translated string as dirty to perform re-translation in case the language change

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -295,7 +295,7 @@ impl<'a> SkiaItemRenderer<'a> {
             let children_rect = i_slint_core::properties::evaluate_no_tracking(|| {
                 item_rc.geometry().union(
                     &i_slint_core::item_rendering::item_children_bounding_rect(
-                        &item_rc.item_tree(),
+                        item_rc.item_tree(),
                         item_rc.index() as isize,
                         &current_clip,
                     ),
@@ -334,7 +334,7 @@ impl<'a> SkiaItemRenderer<'a> {
 
             let mut sub_renderer = SkiaItemRenderer::new(
                 canvas,
-                &self.window,
+                self.window,
                 self.image_cache,
                 self.path_cache,
                 self.box_shadow_cache,
@@ -342,7 +342,7 @@ impl<'a> SkiaItemRenderer<'a> {
 
             i_slint_core::item_rendering::render_item_children(
                 &mut sub_renderer,
-                &item_rc.item_tree(),
+                item_rc.item_tree(),
                 item_rc.index() as isize,
                 &WindowInner::from_pub(self.window).window_adapter(),
             );
@@ -361,7 +361,7 @@ impl<'a> SkiaItemRenderer<'a> {
         target_point.x = target_point.x.round();
         target_point.y = target_point.y.round();
 
-        let restore_point = skia_safe::AutoCanvasRestore::guard(&self.canvas, true);
+        let restore_point = skia_safe::AutoCanvasRestore::guard(self.canvas, true);
 
         self.canvas.translate(device_to_local.map_point(target_point));
 
@@ -580,15 +580,15 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
 
         match (stroke_style, stroke_layout) {
             (TextStrokeStyle::Outside, Some((stroke_layout, stroke_layout_top_left))) => {
-                stroke_layout.paint(&mut self.canvas, to_skia_point(stroke_layout_top_left));
-                layout.paint(&mut self.canvas, to_skia_point(layout_top_left));
+                stroke_layout.paint(self.canvas, to_skia_point(stroke_layout_top_left));
+                layout.paint(self.canvas, to_skia_point(layout_top_left));
             }
             (TextStrokeStyle::Center, Some((stroke_layout, stroke_layout_top_left))) => {
-                layout.paint(&mut self.canvas, to_skia_point(layout_top_left));
-                stroke_layout.paint(&mut self.canvas, to_skia_point(stroke_layout_top_left));
+                layout.paint(self.canvas, to_skia_point(layout_top_left));
+                stroke_layout.paint(self.canvas, to_skia_point(stroke_layout_top_left));
             }
             _ => {
-                layout.paint(&mut self.canvas, to_skia_point(layout_top_left));
+                layout.paint(self.canvas, to_skia_point(layout_top_left));
             }
         };
     }
@@ -607,7 +607,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
         }
 
         let font_request =
-            text_input.font_request(&WindowInner::from_pub(&self.window).window_adapter());
+            text_input.font_request(&WindowInner::from_pub(self.window).window_adapter());
 
         let visual_representation = text_input.visual_representation(None);
         let paint =
@@ -651,7 +651,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
             selection.as_ref(),
         );
 
-        layout.paint(&mut self.canvas, to_skia_point(layout_top_left));
+        layout.paint(self.canvas, to_skia_point(layout_top_left));
 
         if let Some(cursor_position) = visual_representation.cursor_position {
             let cursor_rect = super::textlayout::cursor_rect(
@@ -977,7 +977,7 @@ impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
 
             i_slint_core::item_rendering::render_item_children(
                 self,
-                &item_rc.item_tree(),
+                item_rc.item_tree(),
                 item_rc.index() as isize,
                 &window_adapter,
             );
@@ -1018,10 +1018,10 @@ pub fn to_skia_rect(rect: &PhysicalRect) -> skia_safe::Rect {
 
 pub fn to_skia_rrect(rect: &PhysicalRect, radius: &PhysicalBorderRadius) -> skia_safe::RRect {
     if let Some(radius) = radius.as_uniform() {
-        skia_safe::RRect::new_rect_xy(to_skia_rect(&rect), radius, radius)
+        skia_safe::RRect::new_rect_xy(to_skia_rect(rect), radius, radius)
     } else {
         skia_safe::RRect::new_rect_radii(
-            to_skia_rect(&rect),
+            to_skia_rect(rect),
             &[
                 skia_safe::Point::new(radius.top_left, radius.top_left),
                 skia_safe::Point::new(radius.top_right, radius.top_right),

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -533,7 +533,7 @@ impl SkiaRenderer {
                     Some(
                         dirty_region_history[0..back_buffer_age as usize - 1]
                             .iter()
-                            .fold(DirtyRegion::default(), |acc, region| acc.union(&region)),
+                            .fold(DirtyRegion::default(), |acc, region| acc.union(region)),
                     )
                 } else {
                     Some(LogicalRect::from_size(logical_window_size).into())

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -99,7 +99,7 @@ impl super::Surface for OpenGLSurface {
             if width != surface.width() || height != surface.height() {
                 *surface = Self::create_internal_surface(
                     self.fb_info,
-                    &current_context,
+                    current_context,
                     gr_context,
                     width,
                     height,
@@ -121,7 +121,7 @@ impl super::Surface for OpenGLSurface {
             pre_present_callback();
         }
 
-        self.glutin_surface.swap_buffers(&current_context).map_err(|glutin_error| {
+        self.glutin_surface.swap_buffers(current_context).map_err(|glutin_error| {
             format!("Skia OpenGL Renderer: Error swapping buffers: {glutin_error}").into()
         })
     }

--- a/tools/docsnapper/main.rs
+++ b/tools/docsnapper/main.rs
@@ -407,7 +407,7 @@ fn build_and_snapshot(
     source: String,
     screenshot_path: &Path,
 ) -> Result<()> {
-    let compiler = init_compiler(&args);
+    let compiler = init_compiler(args);
     let r = spin_on::spin_on(compiler.build_from_source(source, doc_file_path.to_path_buf()));
     r.print_diagnostics();
     if r.has_errors() {
@@ -428,7 +428,7 @@ fn build_and_snapshot(
     let component = c.create()?;
 
     // FIXME: The scale factor needs to be set before the size is set!
-    headless::set_window_scale_factor(&component.window(), scale_factor);
+    headless::set_window_scale_factor(component.window(), scale_factor);
 
     if let Some((x, y)) = size {
         component.window().set_size(i_slint_core::api::LogicalSize::new(x as f32, y as f32));

--- a/tools/updater/experiments/lookup_changes.rs
+++ b/tools/updater/experiments/lookup_changes.rs
@@ -265,7 +265,7 @@ pub(crate) fn with_lookup_ctx<R>(
         .current_elem
         .as_ref()
         .zip(state.property_name.as_ref())
-        .map_or(Type::Invalid, |(e, n)| e.borrow().lookup_property(&n).property_type);
+        .map_or(Type::Invalid, |(e, n)| e.borrow().lookup_property(n).property_type);
 
     lookup_context.property_name = state.property_name.as_ref().map(SmolStr::as_str);
     lookup_context.property_type = ty;
@@ -285,7 +285,7 @@ pub(crate) fn collect_movable_properties(state: &mut crate::State) {
                     .iter()
                     .map(|(name, _)| NamedReference::new(c, name.clone())),
             );
-            collect_movable_properties_recursive(vec, &c);
+            collect_movable_properties_recursive(vec, c);
         }
     }
     if let Some(c) = &state.current_component {

--- a/xtask/src/reuse_compliance_check.rs
+++ b/xtask/src/reuse_compliance_check.rs
@@ -80,7 +80,7 @@ fn find_licenses_directories(dir: &Path) -> Result<Vec<PathBuf>> {
     let mut result = Vec::new();
 
     let licenses_name: Option<&OsStr> = Some(OsStr::new("LICENSES"));
-    let dot_name: &OsStr = &OsStr::new(".");
+    let dot_name: &OsStr = OsStr::new(".");
 
     for d in std::fs::read_dir(dir)?
         .filter(|d| d.as_ref().map_or(false, |e| e.file_type().map_or(false, |f| f.is_dir())))


### PR DESCRIPTION
`__CARGO_FIX_YOLO=1` is a hack, but it does help a lot with the tedious fixes where the result is fairly clear.

See https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

```
__CARGO_FIX_YOLO=1 cargo clippy --fix --all-targets --workspace --exclude gstreamer-player --exclude i-slint-backend-linuxkms --exclude uefi-demo --exclude ffmpeg -- -A clippy::all -W clippy::needless_borrow

cargo fmt --all
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
