### PR TITLE
Auto-fixed `clippy::needless_lifetimes`

### DIFF
--- a/api/python/value.rs
+++ b/api/python/value.rs
@@ -22,14 +22,14 @@ impl ToPyObject for PyValue {
     }
 }
 
-impl<'a> IntoPy<PyObject> for PyValueRef<'a> {
+impl IntoPy<PyObject> for PyValueRef<'_> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         // Share the conversion code below that operates on the reference
         self.to_object(py).into_py(py)
     }
 }
 
-impl<'a> ToPyObject for PyValueRef<'a> {
+impl ToPyObject for PyValueRef<'_> {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         match &self.0 {
             slint_interpreter::Value::Void => ().into_py(py),

--- a/demos/printerdemo_mcu/bench.rs
+++ b/demos/printerdemo_mcu/bench.rs
@@ -33,9 +33,7 @@ enum RenderMode {
 
 struct DrawBuffer<'a, T>(&'a mut [T]);
 
-impl<'a, T: TargetPixel> slint::platform::software_renderer::LineBufferProvider
-    for DrawBuffer<'a, T>
-{
+impl<T: TargetPixel> slint::platform::software_renderer::LineBufferProvider for DrawBuffer<'_, T> {
     type TargetPixel = T;
     fn process_line(
         &mut self,

--- a/helper_crates/const-field-offset/src/lib.rs
+++ b/helper_crates/const-field-offset/src/lib.rs
@@ -189,13 +189,13 @@ pub trait ConstFieldOffset: Copy {
         Self::OFFSET.apply_mut(x)
     }
 
-    fn apply_pin<'a>(self, x: Pin<&'a Self::Container>) -> Pin<&'a Self::Field>
+    fn apply_pin(self, x: Pin<&Self::Container>) -> Pin<&Self::Field>
     where
         Self: ConstFieldOffset<PinFlag = AllowPin>,
     {
         Self::OFFSET.apply_pin(x)
     }
-    fn apply_pin_mut<'a>(self, x: Pin<&'a mut Self::Container>) -> Pin<&'a mut Self::Field>
+    fn apply_pin_mut(self, x: Pin<&mut Self::Container>) -> Pin<&mut Self::Field>
     where
         Self: ConstFieldOffset<PinFlag = AllowPin>,
     {

--- a/helper_crates/vtable/src/lib.rs
+++ b/helper_crates/vtable/src/lib.rs
@@ -227,15 +227,15 @@ pub struct VRef<'a, T: ?Sized + VTableMeta> {
 }
 
 // Need to implement manually otherwise it is not implemented if T does not implement Copy / Clone
-impl<'a, T: ?Sized + VTableMeta> Copy for VRef<'a, T> {}
+impl<T: ?Sized + VTableMeta> Copy for VRef<'_, T> {}
 
-impl<'a, T: ?Sized + VTableMeta> Clone for VRef<'a, T> {
+impl<T: ?Sized + VTableMeta> Clone for VRef<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, T: ?Sized + VTableMeta> Deref for VRef<'a, T> {
+impl<T: ?Sized + VTableMeta> Deref for VRef<'_, T> {
     type Target = T::Target;
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.inner.deref::<T>() }
@@ -319,14 +319,14 @@ pub struct VRefMut<'a, T: ?Sized + VTableMeta> {
     phantom: PhantomData<&'a mut T::Target>,
 }
 
-impl<'a, T: ?Sized + VTableMeta> Deref for VRefMut<'a, T> {
+impl<T: ?Sized + VTableMeta> Deref for VRefMut<'_, T> {
     type Target = T::Target;
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.inner.deref::<T>() }
     }
 }
 
-impl<'a, T: ?Sized + VTableMeta> DerefMut for VRefMut<'a, T> {
+impl<T: ?Sized + VTableMeta> DerefMut for VRefMut<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *(self.inner.deref_mut::<T>() as *mut _) }
     }

--- a/helper_crates/vtable/src/vrc.rs
+++ b/helper_crates/vtable/src/vrc.rs
@@ -73,7 +73,7 @@ struct VRcInner<'vt, VTable: VTableMeta, X> {
     data: X,
 }
 
-impl<'vt, VTable: VTableMeta, X> VRcInner<'vt, VTable, X> {
+impl<VTable: VTableMeta, X> VRcInner<'_, VTable, X> {
     unsafe fn data_ptr(s: *const Self) -> *const X {
         (s as *const u8).add(*core::ptr::addr_of!((*s).data_offset) as usize) as *const X
     }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -746,7 +746,7 @@ pub struct PropertyLookupResult<'a> {
     pub is_in_direct_base: bool,
 }
 
-impl<'a> PropertyLookupResult<'a> {
+impl PropertyLookupResult<'_> {
     pub fn is_valid(&self) -> bool {
         self.property_type != Type::Invalid
     }

--- a/internal/compiler/lexer.rs
+++ b/internal/compiler/lexer.rs
@@ -22,7 +22,7 @@ pub trait LexingRule {
     fn lex(&self, text: &str, state: &mut LexState) -> usize;
 }
 
-impl<'a> LexingRule for &'a str {
+impl LexingRule for &str {
     #[inline]
     fn lex(&self, text: &str, _: &mut LexState) -> usize {
         if text.starts_with(*self) {

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -468,12 +468,12 @@ pub struct ParentCtx<'a, T = ()> {
     pub repeater_index: Option<RepeatedElementIdx>,
 }
 
-impl<'a, T> Clone for ParentCtx<'a, T> {
+impl<T> Clone for ParentCtx<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
-impl<'a, T> Copy for ParentCtx<'a, T> {}
+impl<T> Copy for ParentCtx<'_, T> {}
 
 impl<'a, T> ParentCtx<'a, T> {
     pub fn new(
@@ -686,7 +686,7 @@ impl<'a, T> EvaluationContext<'a, T> {
     }
 }
 
-impl<'a, T> TypeResolutionContext for EvaluationContext<'a, T> {
+impl<T> TypeResolutionContext for EvaluationContext<'_, T> {
     fn property_ty(&self, prop: &PropertyReference) -> &Type {
         match prop {
             PropertyReference::Local { sub_component_path, property_index } => {

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -20,7 +20,7 @@ struct PrettyPrinter<'a> {
     indentation: usize,
 }
 
-impl<'a> PrettyPrinter<'a> {
+impl PrettyPrinter<'_> {
     fn print_root(&mut self, root: &CompilationUnit) -> Result {
         for (idx, g) in root.globals.iter_enumerated() {
             if !g.is_builtin {

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -909,7 +909,7 @@ impl LookupObject for Expression {
 }
 
 struct StringExpression<'a>(&'a Expression);
-impl<'a> LookupObject for StringExpression<'a> {
+impl LookupObject for StringExpression<'_> {
     fn for_each_entry<R>(
         &self,
         ctx: &LookupCtx,
@@ -938,7 +938,7 @@ impl<'a> LookupObject for StringExpression<'a> {
     }
 }
 struct ColorExpression<'a>(&'a Expression);
-impl<'a> LookupObject for ColorExpression<'a> {
+impl LookupObject for ColorExpression<'_> {
     fn for_each_entry<R>(
         &self,
         ctx: &LookupCtx,
@@ -987,7 +987,7 @@ impl<'a> LookupObject for ColorExpression<'a> {
 }
 
 struct ImageExpression<'a>(&'a Expression);
-impl<'a> LookupObject for ImageExpression<'a> {
+impl LookupObject for ImageExpression<'_> {
     fn for_each_entry<R>(
         &self,
         ctx: &LookupCtx,
@@ -1010,7 +1010,7 @@ impl<'a> LookupObject for ImageExpression<'a> {
 }
 
 struct ArrayExpression<'a>(&'a Expression);
-impl<'a> LookupObject for ArrayExpression<'a> {
+impl LookupObject for ArrayExpression<'_> {
     fn for_each_entry<R>(
         &self,
         ctx: &LookupCtx,
@@ -1031,7 +1031,7 @@ impl<'a> LookupObject for ArrayExpression<'a> {
 
 /// An expression of type int or float
 struct NumberExpression<'a>(&'a Expression);
-impl<'a> LookupObject for NumberExpression<'a> {
+impl LookupObject for NumberExpression<'_> {
     fn for_each_entry<R>(
         &self,
         ctx: &LookupCtx,
@@ -1061,7 +1061,7 @@ impl<'a> LookupObject for NumberExpression<'a> {
 
 /// An expression of any numerical value with an unit
 struct NumberWithUnitExpression<'a>(&'a Expression);
-impl<'a> LookupObject for NumberWithUnitExpression<'a> {
+impl LookupObject for NumberWithUnitExpression<'_> {
     fn for_each_entry<R>(
         &self,
         ctx: &LookupCtx,

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -591,12 +591,12 @@ mod parser_trait {
     /// and finishes the node on Drop
     #[derive(derive_more::DerefMut)]
     pub struct Node<'a, P: Parser>(&'a mut P);
-    impl<'a, P: Parser> Drop for Node<'a, P> {
+    impl<P: Parser> Drop for Node<'_, P> {
         fn drop(&mut self) {
             self.0.finish_node_impl(NodeToken(()));
         }
     }
-    impl<'a, P: Parser> core::ops::Deref for Node<'a, P> {
+    impl<P: Parser> core::ops::Deref for Node<'_, P> {
         type Target = P;
         fn deref(&self) -> &Self::Target {
             self.0

--- a/internal/compiler/passes/deduplicate_property_read.rs
+++ b/internal/compiler/passes/deduplicate_property_read.rs
@@ -41,7 +41,7 @@ struct DedupPropState<'a> {
     counts: RefCell<PropertyReadCounts>,
 }
 
-impl<'a> DedupPropState<'a> {
+impl DedupPropState<'_> {
     fn add(&self, nr: &NamedReference) {
         if self.parent_state.map_or(false, |pc| pc.add_from_children(nr)) {
             return;

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -173,13 +173,13 @@ fn clip_path_for_rect_alike_item(
     rect_with_radius_to_path(clip_rect, radius)
 }
 
-impl<'a> GLItemRenderer<'a> {
+impl GLItemRenderer<'_> {
     pub fn global_alpha_transparent(&self) -> bool {
         self.state.last().unwrap().global_alpha == 0.0
     }
 }
 
-impl<'a> ItemRenderer for GLItemRenderer<'a> {
+impl ItemRenderer for GLItemRenderer<'_> {
     fn draw_rectangle(
         &mut self,
         rect: Pin<&dyn RenderRectangle>,

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -369,7 +369,7 @@ impl<'a> SkiaItemRenderer<'a> {
     }
 }
 
-impl<'a> ItemRenderer for SkiaItemRenderer<'a> {
+impl ItemRenderer for SkiaItemRenderer<'_> {
     fn draw_rectangle(
         &mut self,
         rect: Pin<&dyn i_slint_core::item_rendering::RenderRectangle>,
@@ -1032,7 +1032,7 @@ pub fn to_skia_rrect(rect: &PhysicalRect, radius: &PhysicalBorderRadius) -> skia
     }
 }
 
-impl<'a> ItemRendererFeatures for SkiaItemRenderer<'a> {
+impl ItemRendererFeatures for SkiaItemRenderer<'_> {
     const SUPPORTS_TRANSFORMATIONS: bool = true;
 }
 

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -575,7 +575,7 @@ const MIT_OR_APACHE2_LICENSE: &str = "MIT OR Apache-2.0";
 // Copyright prefix is enforced by the tag scanning (tag_start).
 pub struct LicenseHeader<'a>(&'a str);
 
-impl<'a> LicenseHeader<'a> {
+impl LicenseHeader<'_> {
     fn to_string(&self, style: &LicenseTagStyle, license: &str) -> String {
         let mut result = [style.line_prefix, style.line_indentation, self.0].concat();
 

--- a/xtask/src/reuse_compliance_check.rs
+++ b/xtask/src/reuse_compliance_check.rs
@@ -8,7 +8,7 @@ use xshell::{Cmd, Shell};
 use std::collections::BTreeMap;
 use std::{ffi::OsStr, path::Path, path::PathBuf};
 
-fn cmd<'a, I>(sh: &'a Shell, command: impl AsRef<Path>, args: I) -> Result<Cmd<'a>>
+fn cmd<I>(sh: &Shell, command: impl AsRef<Path>, args: I) -> Result<Cmd<'_>>
 where
     I: IntoIterator,
     I::Item: AsRef<OsStr>,


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

```
__CARGO_FIX_YOLO=1 cargo clippy --fix --all-targets --workspace --exclude gstreamer-player --exclude i-slint-backend-linuxkms --exclude uefi-demo --exclude ffmpeg -- -A clippy::all -W clippy::needless_lifetimes

cargo fmt --all
```

`__CARGO_FIX_YOLO=1` is a hack, but it does help a lot with the tedious fixes where the result is fairly clear.