### PR TITLE
Auto-fixed `clippy::needless_return`

### DIFF
--- a/api/node/rust/interpreter/component_compiler.rs
+++ b/api/node/rust/interpreter/component_compiler.rs
@@ -128,9 +128,9 @@ impl JsComponentCompiler {
                         ))),
                     );
 
-                    return Some((name.to_string(), struct_instance.ok()?));
+                    Some((name.to_string(), struct_instance.ok()?))
                 }
-                _ => return None,
+                _ => None,
             }
         }
 
@@ -156,9 +156,9 @@ impl JsComponentCompiler {
                         )
                         .ok()?;
                     }
-                    return Some((en.name.to_string(), o.into_unknown()));
+                    Some((en.name.to_string(), o.into_unknown()))
                 }
-                _ => return None,
+                _ => None,
             }
         }
 

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -306,10 +306,10 @@ fn brush_from_color(rgb_color: Object) -> Result<Value> {
         return Err(Error::from_reason("A channel of Color cannot be negative"));
     }
 
-    return Ok(Value::Brush(Brush::SolidColor(Color::from_argb_u8(
+    Ok(Value::Brush(Brush::SolidColor(Color::from_argb_u8(
         alpha as u8,
         red as u8,
         green as u8,
         blue as u8,
-    ))));
+    ))))
 }

--- a/api/node/rust/types/brush.rs
+++ b/api/node/rust/types/brush.rs
@@ -286,21 +286,16 @@ impl SlintBrush {
     #[napi]
     pub fn to_string(&self) -> String {
         match &self.inner {
-            Brush::SolidColor(_) => {
-                return self.slint_color().to_string();
-            }
+            Brush::SolidColor(_) => self.slint_color().to_string(),
             Brush::LinearGradient(gradient) => {
-                return format!(
+                format!(
                     "linear-gradient({}deg, {})",
                     gradient.angle(),
                     gradient_stops_to_string(gradient.stops())
-                );
+                )
             }
             Brush::RadialGradient(gradient) => {
-                return format!(
-                    "radial-gradient(circle, {})",
-                    gradient_stops_to_string(gradient.stops())
-                );
+                format!("radial-gradient(circle, {})", gradient_stops_to_string(gradient.stops()))
             }
             _ => String::default(),
         }

--- a/api/node/rust/types/model.rs
+++ b/api/node/rust/types/model.rs
@@ -277,6 +277,6 @@ impl ModelIterator {
                 self.model.row_data(row).and_then(|value| to_js_unknown(&self.env, &value).ok()),
             )?
         }
-        return Ok(result.into_unknown());
+        Ok(result.into_unknown())
     }
 }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -506,7 +506,7 @@ impl ElementType {
                         base_type
                     }
                 };
-                return base_type.lookup_type_for_child_element(name, tr);
+                base_type.lookup_type_for_child_element(name, tr)
             }
             Self::Builtin(builtin) => {
                 if builtin.disallow_global_types_as_child_elements {

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -611,36 +611,29 @@ impl<'a, T> EvaluationContext<'a, T> {
         match prop {
             PropertyReference::Local { property_index, .. } => {
                 if let Some(g) = self.current_global() {
-                    return PropertyInfoResult {
+                    PropertyInfoResult {
                         analysis: Some(&g.prop_analysis[*property_index]),
                         binding: g.init_values[*property_index]
                             .as_ref()
                             .map(|b| (b, ContextMap::Identity)),
                         animation: None,
                         property_decl: Some(&g.properties[*property_index]),
-                    };
+                    }
                 } else if let Some(sc) = self.current_sub_component() {
-                    return match_in_sub_component(
-                        self.compilation_unit,
-                        sc,
-                        prop,
-                        ContextMap::Identity,
-                    );
+                    match_in_sub_component(self.compilation_unit, sc, prop, ContextMap::Identity)
                 } else {
                     unreachable!()
                 }
             }
-            PropertyReference::InNativeItem { .. } => {
-                return match_in_sub_component(
-                    self.compilation_unit,
-                    self.current_sub_component().unwrap(),
-                    prop,
-                    ContextMap::Identity,
-                );
-            }
+            PropertyReference::InNativeItem { .. } => match_in_sub_component(
+                self.compilation_unit,
+                self.current_sub_component().unwrap(),
+                prop,
+                ContextMap::Identity,
+            ),
             PropertyReference::Global { global_index, property_index } => {
                 let g = &self.compilation_unit.globals[*global_index];
-                return PropertyInfoResult {
+                PropertyInfoResult {
                     analysis: Some(&g.prop_analysis[*property_index]),
                     animation: None,
                     binding: g
@@ -649,7 +642,7 @@ impl<'a, T> EvaluationContext<'a, T> {
                         .and_then(Option::as_ref)
                         .map(|b| (b, ContextMap::InGlobal(*global_index))),
                     property_decl: Some(&g.properties[*property_index]),
-                };
+                }
             }
             PropertyReference::InParent { level, parent_reference } => {
                 let mut ctx = self;

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -160,13 +160,11 @@ impl LoweredSubComponentMapping {
                 }
                 unreachable!()
             }
-            LoweredElement::NativeItem { item_index } => {
-                return PropertyReference::InNativeItem {
-                    sub_component_path: vec![],
-                    item_index: *item_index,
-                    prop_name: from.name().to_string(),
-                };
-            }
+            LoweredElement::NativeItem { item_index } => PropertyReference::InNativeItem {
+                sub_component_path: vec![],
+                item_index: *item_index,
+                prop_name: from.name().to_string(),
+            },
             LoweredElement::Repeated { .. } => unreachable!(),
             LoweredElement::ComponentPlaceholder { .. } => unreachable!(),
         }

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1321,7 +1321,7 @@ pub(crate) mod ffi {
 
     #[no_mangle]
     pub unsafe extern "C" fn slint_image_compare_equal(image1: &Image, image2: &Image) -> bool {
-        return image1.eq(image2);
+        image1.eq(image2)
     }
 
     /// Call [`Image::set_nine_slice_edges`]

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -507,6 +507,6 @@ mod ffi {
     #[no_mangle]
     pub extern "C" fn slint_translate_select_bundled_translation(language: Slice<u8>) -> bool {
         let language = core::str::from_utf8(&language).unwrap();
-        return select_bundled_translation(language).is_ok();
+        select_bundled_translation(language).is_ok()
     }
 }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1528,12 +1528,12 @@ pub mod ffi {
         parent_item: &ItemRc,
     ) -> NonZeroU32 {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        return WindowInner::from_pub(window_adapter.window()).show_popup(
+        WindowInner::from_pub(window_adapter.window()).show_popup(
             popup,
             position,
             close_policy,
             parent_item,
-        );
+        )
     }
 
     /// Close the popup by the given ID.

--- a/tools/updater/experiments/geometry_changes.rs
+++ b/tools/updater/experiments/geometry_changes.rs
@@ -78,23 +78,23 @@ fn new_geometry_binding(elem: &ElementRc, pos_prop: &str, size_prop: &str, exten
 fn is_layout_base(elem: &ElementRc) -> bool {
     match &elem.borrow().base_type {
         i_slint_compiler::langtype::ElementType::Builtin(b) => {
-            return matches!(
+            matches!(
                 b.name.as_str(),
                 "GridLayout" | "HorizontalLayout" | "VerticalLayout" | "Row" | "Path" | "Dialog"
-            );
+            )
         }
         i_slint_compiler::langtype::ElementType::Component(c) => {
             if c.id == "ListView" {
                 return true;
             }
             if let Some(ins) = &*c.child_insertion_point.borrow() {
-                return is_layout_base(&ins.0);
+                is_layout_base(&ins.0)
             } else {
-                return is_layout_base(&c.root_element);
+                is_layout_base(&c.root_element)
             }
         }
-        _ => return false,
-    };
+        _ => false,
+    }
 }
 
 fn is_path(elem: &ElementRc) -> bool {

--- a/tools/updater/main.rs
+++ b/tools/updater/main.rs
@@ -109,7 +109,7 @@ fn process_markdown_file(source: String, mut file: impl Write, args: &Cli) -> st
             diag.print();
         }
     }
-    return file.write_all(source_slice.as_bytes());
+    file.write_all(source_slice.as_bytes())
 }
 
 fn process_file(

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -636,7 +636,7 @@ impl CargoDependency {
     fn new(encoded_value: &toml_edit::Value) -> Option<Self> {
         match encoded_value {
             toml_edit::Value::String(s) => {
-                return Some(Self::Full { version: s.value().clone(), path: String::new() })
+                Some(Self::Full { version: s.value().clone(), path: String::new() })
             }
             toml_edit::Value::Float(_) => None,
             toml_edit::Value::Datetime(_) => None,

--- a/xtask/src/slintdocs.rs
+++ b/xtask/src/slintdocs.rs
@@ -109,7 +109,7 @@ pub fn extract_enum_docs() -> std::collections::BTreeMap<String, EnumDoc> {
         i_slint_common::for_each_enums!(gen_enums);
     }
 
-    return enums;
+    enums
 }
 
 pub fn generate_enum_docs() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

```
__CARGO_FIX_YOLO=1 cargo clippy --fix --all-targets --workspace --exclude gstreamer-player --exclude i-slint-backend-linuxkms --exclude uefi-demo --exclude ffmpeg -- -A clippy::all -W clippy::needless_return

cargo fmt --all
```

`__CARGO_FIX_YOLO=1` is a hack, but it does help a lot with the tedious fixes where the result is fairly clear.

