### PR TITLE
Auto-fixed `clippy::useless_format`

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2170,7 +2170,7 @@ fn generate_sub_component(
     if !component.timers.is_empty() {
         let mut update_timers = vec!["auto self = this;".into()];
         for (i, tmr) in component.timers.iter().enumerate() {
-            user_init.push(format!("self->update_timers();"));
+            user_init.push("self->update_timers();".to_string());
             let name = format_smolstr!("timer{}", i);
             let running = compile_expression(&tmr.running.borrow(), &ctx);
             let interval = compile_expression(&tmr.interval.borrow(), &ctx);
@@ -3662,7 +3662,7 @@ fn compile_builtin_function_call(
             }
         }
         BuiltinFunction::Use24HourFormat => {
-            format!("slint::cbindgen_private::slint_date_time_use_24_hour_format()")
+            "slint::cbindgen_private::slint_date_time_use_24_hour_format()".to_string()
         }
         BuiltinFunction::MonthDayCount => {
             format!("slint::cbindgen_private::slint_date_time_month_day_count({}, {})", a.next().unwrap(), a.next().unwrap())

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1423,7 +1423,11 @@ fn continue_lookup_within_element(
             ctx.diag.push_error(format!("The property '{}' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components", second.text()), &second);
             return None;
         } else if lookup_result.property_visibility == PropertyVisibility::Fake {
-            ctx.diag.push_error(format!("This special property can only be used to make a binding and cannot be accessed"), &second);
+            ctx.diag.push_error(
+                "This special property can only be used to make a binding and cannot be accessed"
+                    .to_string(),
+                &second,
+            );
             return None;
         } else if lookup_result.resolved_name != prop_name.as_str() {
             ctx.diag.push_property_deprecation_warning(

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -96,11 +96,11 @@ struct SuspendedRenderer {}
 
 unsafe impl OpenGLInterface for SuspendedRenderer {
     fn ensure_current(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        Err(format!("ensure current called on suspended renderer").into())
+        Err("ensure current called on suspended renderer".to_string().into())
     }
 
     fn swap_buffers(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        Err(format!("swap_buffers called on suspended renderer").into())
+        Err("swap_buffers called on suspended renderer".to_string().into())
     }
 
     fn resize(

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -654,11 +654,9 @@ impl SkiaRenderer {
     }
 
     fn window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
-        self.maybe_window_adapter
-            .borrow()
-            .as_ref()
-            .and_then(|w| w.upgrade())
-            .ok_or_else(|| format!("Renderer must be associated with component before use").into())
+        self.maybe_window_adapter.borrow().as_ref().and_then(|w| w.upgrade()).ok_or_else(|| {
+            "Renderer must be associated with component before use".to_string().into()
+        })
     }
 
     /// Sets the specified callback, that's invoked before presenting the rendered buffer to the windowing system.
@@ -892,7 +890,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
             None,
             None,
         )
-        .ok_or_else(|| format!("Error wrapping target buffer for rendering into with Skia"))?;
+        .ok_or_else(|| "Error wrapping target buffer for rendering into with Skia".to_string())?;
 
         self.render_to_canvas(surface_borrow.canvas(), 0., (0.0, 0.0), None, 0, None, window, None);
 

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -200,7 +200,8 @@ impl OpenGLSurface {
 
             skia_safe::gpu::gl::FramebufferInfo {
                 fboid: fboid.try_into().map_err(|_| {
-                    format!("Skia Renderer: Internal error, framebuffer binding returned signed id")
+                    "Skia Renderer: Internal error, framebuffer binding returned signed id"
+                        .to_string()
                 })?,
                 format: skia_safe::gpu::gl::Format::RGBA8.into(),
                 ..Default::default()
@@ -211,12 +212,12 @@ impl OpenGLSurface {
             current_glutin_context.display().get_proc_address(name) as *const _
         })
         .ok_or_else(|| {
-            format!("Skia Renderer: Internal Error: Could not create OpenGL Interface")
+            "Skia Renderer: Internal Error: Could not create OpenGL Interface".to_string()
         })?;
 
         let mut gr_context =
             skia_safe::gpu::direct_contexts::make_gl(gl_interface, None).ok_or_else(|| {
-                format!("Skia Renderer: Internal Error: Could not create Skia Direct Context from GL interface")
+                "Skia Renderer: Internal Error: Could not create Skia Direct Context from GL interface".to_string()
             })?;
 
         let width: i32 = size.width.try_into().map_err(|e| {
@@ -396,10 +397,11 @@ impl OpenGLSurface {
             .get_proc_address(&std::ffi::CString::new("glCreateShader").unwrap())
             .is_null()
         {
-            return Err(format!(
+            return Err(
                 "Failed to initialize OpenGL driver: Could not locate glCreateShader symbol"
-            )
-            .into());
+                    .to_string()
+                    .into(),
+            );
         }
 
         // Try to default to vsync and ignore if the driver doesn't support it.

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -173,7 +173,7 @@ impl super::Surface for SoftwareSurface {
                     None,
                 )
                 .ok_or_else(|| {
-                    format!("Error wrapping target buffer for rendering into with Skia")
+                    "Error wrapping target buffer for rendering into with Skia".to_string()
                 })?;
 
                 let dirty_region = callback(surface_borrow.canvas(), None, age);


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

```
__CARGO_FIX_YOLO=1 cargo clippy --fix --all-targets --workspace --exclude gstreamer-player --exclude i-slint-backend-linuxkms --exclude uefi-demo --exclude ffmpeg -- -A clippy::all -W clippy::useless_format

cargo fmt --all
```

`__CARGO_FIX_YOLO=1` is a hack, but it does help a lot with the tedious fixes where the result is fairly clear.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
