### PR TITLE
ContextMenu: show submenu on hover after a timeout

### DIFF
--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -156,7 +156,7 @@ public:
         auto p = pos(popup);
         auto popup_dyn = popup.into_dyn();
         auto id = cbindgen_private::slint_windowrc_show_popup(&inner, &popup_dyn, p, close_policy,
-                                                              &parent_item);
+                                                              &parent_item, false);
         popup->user_init();
         return id;
     }
@@ -179,7 +179,7 @@ public:
         auto popup_dyn = popup.into_dyn();
         auto id = cbindgen_private::slint_windowrc_show_popup(
                 &inner, &popup_dyn, pos, cbindgen_private::PopupClosePolicy::CloseOnClickOutside,
-                &context_menu_rc);
+                &context_menu_rc, true);
         popup->user_init();
         return id;
     }

--- a/docs/astro/src/content/docs/reference/window/contextmenu.mdx
+++ b/docs/astro/src/content/docs/reference/window/contextmenu.mdx
@@ -20,6 +20,10 @@ Define the structure of the menu by placing `MenuItem` elements into the `Contex
 
 Call this function to programmatically show the context menu at the given position relative to the `ContextMenu` element.
 
+## close()
+
+Close the context menu if it is currently open.
+
 ## `MenuItem`
 
 A `MenuItem` represents a single menu entry. It can be placed as a child of a `ContextMenu`,

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -211,11 +211,13 @@ component ContextMenu inherits Empty {
     callback activated(entry: MenuEntry);
     callback sub-menu(entry: MenuEntry) -> [MenuEntry];
     callback show(position: Point);
+    function close() {}
 }
 
 // Lowered in lower_menus pass.
 export component ContextMenuInternal inherits ContextMenu {
     in property <[MenuEntry]> entries;
+    function close() {}
     //-default_size_binding:expands_to_parent_geometry
     //-is_internal
 }
@@ -226,6 +228,7 @@ export component ContextMenuInternal inherits ContextMenu {
 component ActualContextMenuElement inherits Empty {
     // This is actually function as part of out interface, but a callback as much is the runtime concerned
     callback show(position: Point);
+    function close() {}
     //-default_size_binding:expands_to_parent_geometry
     MenuItem {}
 }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -47,6 +47,7 @@ pub enum BuiltinFunction {
     /// Show a context popup menu.
     /// Arguments are `(parent, entries, position)`
     ///
+    /// The first argument (parent) is a reference to the `ContectMenu` native item
     /// The second argument (entries) can either be of type Array of MenuEntry, or a reference to a MenuItem tree.
     /// When it is a menu item tree, it is a ElementReference to the root of the tree, and in the LLR, a NumberLiteral to an index in  [`crate::llr::SubComponent::menu_item_trees`]
     ShowPopupMenu,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3806,7 +3806,7 @@ fn compile_builtin_function_call(
                         {fw_activated}
                     }}")
             };
-            format!("{window}.show_popup_menu<{popup_id}>({globals}, {position}, {{ {context_menu_rc} }}, [self](auto popup_menu) {{ {init} }})", globals = ctx.generator_state.global_access)
+            format!("{window}.close_popup({context_menu}.popup_id); {context_menu}.popup_id = {window}.show_popup_menu<{popup_id}>({globals}, {position}, {{ {context_menu_rc} }}, [self](auto popup_menu) {{ {init} }})", globals = ctx.generator_state.global_access)
         }
         BuiltinFunction::SetSelectionOffsets => {
             if let [llr::Expression::PropertyReference(pr), from, to] = arguments {

--- a/internal/compiler/widgets/common/menus.slint
+++ b/internal/compiler/widgets/common/menus.slint
@@ -51,6 +51,13 @@ export component PopupMenuImpl inherits Window {
                         fs.focus();
                         if event.kind == PointerEventKind.move {
                             current = idx;
+                            open-sub-menu-after-timeout.running = true;
+                        }
+                    }
+
+                    changed has-hover => {
+                        if !self.has-hover && current == idx {
+                            current = -1
                         }
                     }
 
@@ -64,6 +71,7 @@ export component PopupMenuImpl inherits Window {
             layout.padding + idx * (layout.height - 2 * layout.padding) / entries.length
         }
         key-pressed(event) => {
+            open-sub-menu-after-timeout.running = false;
             if event.text == Key.UpArrow {
                 if current >= 1 {
                     current -= 1;
@@ -93,6 +101,21 @@ export component PopupMenuImpl inherits Window {
             }
             return reject;
         }
+
+        open-sub-menu-after-timeout := Timer {
+            interval: 500ms;
+            running: false;
+            triggered => {
+                self.running = false;
+                if current >= 0 {
+                    if entries[current].has-sub-menu {
+                        activate(entries[current], y-pos(current));
+                    } else {
+                        subMenu.close();
+                    }
+                }
+            }
+        }
     }
 
     subMenu := ContextMenuInternal {
@@ -102,6 +125,7 @@ export component PopupMenuImpl inherits Window {
     }
 
     function activate(entry : MenuEntry, y: length) {
+        open-sub-menu-after-timeout.running = false;
         if entry.has-sub-menu {
             subMenu.entries = root.sub-menu(entry);
             subMenu.show({
@@ -129,7 +153,8 @@ export component MenuBarImpl {
         alignment: start;
         spacing: 1*px;
         for entry in entries: e := Rectangle {
-            background: ta.has-hover || ta.pressed ? Palette.alternate-background : transparent;
+            // FIXME: note that the fluent style uses the secondary color for highlighted item
+            background: ta.has-hover || ta.pressed ? Palette.accent-background : transparent;
             border-radius: 3*px;
             HorizontalLayout {
                 padding: 11*px;
@@ -137,6 +162,7 @@ export component MenuBarImpl {
                 padding-bottom: 6*px;
                 Text {
                     text: entry.title;
+                    color: ta.has-hover || ta.pressed ? Palette.accent-foreground : Palette.foreground;
                 }
             }
             ta := TouchArea {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -34,10 +34,12 @@ use crate::lengths::{
 };
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use crate::window::{WindowAdapter, WindowAdapterRc};
+use crate::window::{WindowAdapter, WindowAdapterRc, WindowInner};
 use crate::{Callback, Coord, Property, SharedString};
 use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
+use core::cell::Cell;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use i_slint_core_macros::*;
 use vtable::*;
@@ -1175,6 +1177,7 @@ pub struct ContextMenu {
     pub activated: Callback<MenuEntryArg>,
     pub show: Callback<PointArg>,
     pub cached_rendering_data: CachedRenderingData,
+    pub popup_id: Cell<Option<NonZeroU32>>,
 }
 
 impl Item for ContextMenu {
@@ -1255,7 +1258,13 @@ impl Item for ContextMenu {
     }
 }
 
-impl ContextMenu {}
+impl ContextMenu {
+    pub fn close(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>, _: &ItemRc) {
+        if let Some(id) = self.popup_id.take() {
+            WindowInner::from_pub(window_adapter.window()).close_popup(id);
+        }
+    }
+}
 
 impl ItemConsts for ContextMenu {
     const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1275,6 +1275,19 @@ declare_item_vtable! {
     fn slint_get_ContextMenuVTable() -> ContextMenuVTable for ContextMenu
 }
 
+#[cfg(feature = "ffi")]
+#[no_mangle]
+pub unsafe extern "C" fn slint_contextmenu_close(
+    s: Pin<&ContextMenu>,
+    window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
+    self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
+    self_index: u32,
+) {
+    let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
+    let self_rc = ItemRc::new(self_component.clone(), self_index);
+    s.close(window_adapter, &self_rc);
+}
+
 /// The implementation of the `BoxShadow` element
 #[repr(C)]
 #[derive(FieldOffsets, Default, SlintElement)]

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2411,6 +2411,7 @@ pub fn show_popup(
             pos,
             close_policy,
             parent_item,
+            false,
         ),
     );
     inst.run_setup_code();


### PR DESCRIPTION
This means that the parent menu still get the mouse events

Also add the ability to close the menu programmatically
