### PR TITLE
Fix `clippy::empty_line_after_doc_comments`

### DIFF
--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -68,8 +68,9 @@ pub enum ComponentSelection {
     /// and if no component is exported, the last component is selected
     #[default]
     ExportedWindows,
-    /// The Last component (legacy for the viewer / interpreter)
 
+    /// The Last component (legacy for the viewer / interpreter)
+    ///
     /// Only the last exported component is generated, regardless if this is a Window or not,
     /// (and it will be transformed in a Window)
     LastExported,

--- a/internal/core/graphics/color.rs
+++ b/internal/core/graphics/color.rs
@@ -238,7 +238,6 @@ impl Color {
     /// let blue = Color::from_argb_u8(200, 0, 0, 255);
     /// assert_eq!(blue.transparentize(-0.1), Color::from_argb_u8(220, 0, 0, 255));
     /// ```
-
     #[must_use]
     pub fn transparentize(&self, factor: f32) -> Self {
         let mut color = *self;

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -268,10 +268,9 @@ pub struct StaticTexture {
     pub index: usize,
 }
 
+/// A texture is stored in read-only memory and may be composed of sub-textures.
 #[repr(C)]
 #[derive(Clone, PartialEq, Debug)]
-/// A texture is stored in read-only memory and may be composed of sub-textures.
-
 pub struct StaticTextures {
     /// The total size of the image (this might not be the size of the full image
     /// as some transparent part are not part of any texture)


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
