### PR TITLE
Material SpinBox: Fix binding loop in some layout

### DIFF
--- a/internal/compiler/widgets/material/spinbox.slint
+++ b/internal/compiler/widgets/material/spinbox.slint
@@ -12,8 +12,6 @@ component SpinBoxButton inherits Rectangle {
 
     callback clicked <=> touch-area.clicked;
 
-    width: root.height;
-
     states [
         disabled when !root.enabled : {
             background.background: MaterialPalette.control-foreground;
@@ -125,6 +123,7 @@ export component SpinBox {
 
             VerticalLayout {
                 spacing: 4px;
+                width: (base.min-height.max(56px - layout.padding-top - layout.padding-bottom) - self.spacing) / 2;
 
                 SpinBoxButton {
                     enabled: root.enabled;


### PR DESCRIPTION
Having the width depending on the height is asking for trouble because usually it is the height that depends on the width, so if the SpinBox is getting in a complex layout, it causes a binding loop. Workaround the problem by using the computed height.

This should fix the gallery build with the material style (which is currently making the nightly build fail)
