### PR TITLE
Convey clipping of children to accesskit

### DIFF
--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -431,6 +431,10 @@ impl Item for NativeButton {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeButton {

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -431,7 +431,7 @@ impl Item for NativeButton {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -183,6 +183,10 @@ impl Item for NativeCheckBox {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeCheckBox {

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -183,7 +183,7 @@ impl Item for NativeCheckBox {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -149,7 +149,7 @@ impl Item for NativeComboBox {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }
@@ -272,7 +272,7 @@ impl Item for NativeComboBoxPopup {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -149,6 +149,10 @@ impl Item for NativeComboBox {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeComboBox {
@@ -267,6 +271,10 @@ impl Item for NativeComboBoxPopup {
         geometry: LogicalRect,
     ) -> LogicalRect {
         geometry
+    }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -243,6 +243,10 @@ impl Item for NativeGroupBox {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeGroupBox {

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -243,7 +243,7 @@ impl Item for NativeGroupBox {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -164,7 +164,7 @@ impl Item for NativeLineEdit {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -164,6 +164,10 @@ impl Item for NativeLineEdit {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeLineEdit {

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -202,7 +202,7 @@ impl Item for NativeStandardListViewItem {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -202,6 +202,10 @@ impl Item for NativeStandardListViewItem {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeStandardListViewItem {

--- a/internal/backends/qt/qt_widgets/progress_indicator.rs
+++ b/internal/backends/qt/qt_widgets/progress_indicator.rs
@@ -138,7 +138,7 @@ impl Item for NativeProgressIndicator {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/progress_indicator.rs
+++ b/internal/backends/qt/qt_widgets/progress_indicator.rs
@@ -138,6 +138,10 @@ impl Item for NativeProgressIndicator {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeProgressIndicator {

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -454,7 +454,7 @@ impl Item for NativeScrollView {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -454,6 +454,10 @@ impl Item for NativeScrollView {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeScrollView {

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -372,7 +372,7 @@ impl Item for NativeSlider {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -372,6 +372,10 @@ impl Item for NativeSlider {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl NativeSlider {

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -347,6 +347,10 @@ impl Item for NativeSpinBox {
     ) -> LogicalRect {
         geometry
     }
+    
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeSpinBox {

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -347,7 +347,7 @@ impl Item for NativeSpinBox {
     ) -> LogicalRect {
         geometry
     }
-    
+
     fn clips_children(self: core::pin::Pin<&Self>) -> bool {
         false
     }

--- a/internal/backends/qt/qt_widgets/tableheadersection.rs
+++ b/internal/backends/qt/qt_widgets/tableheadersection.rs
@@ -163,6 +163,10 @@ impl Item for NativeTableHeaderSection {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeTableHeaderSection {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -324,6 +324,10 @@ impl Item for NativeTabWidget {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for NativeTabWidget {
@@ -545,6 +549,10 @@ impl Item for NativeTab {
         geometry: LogicalRect,
     ) -> LogicalRect {
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -507,6 +507,10 @@ impl NodeCollection {
             node.set_hidden();
         }
 
+        if item.borrow().as_ref().clips_children() {
+            node.set_clips_children();
+        }
+
         let geometry = item.geometry();
         let absolute_origin = item.map_to_window(geometry.origin) + window_position.to_vector();
         let physical_origin = (absolute_origin * scale_factor).cast::<f64>();

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -650,7 +650,7 @@ pub(crate) fn send_exit_events(
             *p -= g.origin.to_vector();
         }
         if !contains || clipped {
-            if crate::item_rendering::is_clipping_item(item.borrow()) {
+            if item.borrow().as_ref().clips_children() {
                 clipped = true;
             }
             item.borrow().as_ref().input_event(MouseEvent::Exit, window_adapter, &item);
@@ -759,7 +759,7 @@ fn send_mouse_event_to_item(
     event_for_children.translate(-geom.origin.to_vector());
 
     let filter_result = if mouse_event.position().is_some_and(|p| geom.contains(p))
-        || crate::item_rendering::is_clipping_item(item)
+        || item.as_ref().clips_children()
     {
         item.as_ref().input_event_filter_before_children(
             event_for_children,

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -355,7 +355,7 @@ impl ItemRc {
         let geometry = self.geometry().translate(parent_geometry.origin.to_vector());
 
         let item = self.borrow();
-        if crate::item_rendering::is_clipping_item(item) {
+        if item.as_ref().clips_children() {
             clip = geometry.intersection(&clip).unwrap_or_default();
         }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -178,6 +178,8 @@ pub struct ItemVTable {
         self_rc: &ItemRc,
         geometry: LogicalRect,
     ) -> LogicalRect,
+
+    pub clips_children: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>) -> bool,
 }
 
 /// Alias for `vtable::VRef<ItemVTable>` which represent a pointer to a `dyn Item` with
@@ -256,6 +258,10 @@ impl Item for Empty {
     ) -> LogicalRect {
         geometry.size = LogicalSize::zero();
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 
@@ -343,6 +349,10 @@ impl Item for Rectangle {
         geometry: LogicalRect,
     ) -> LogicalRect {
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 
@@ -439,6 +449,10 @@ impl Item for BasicBorderRectangle {
         geometry: LogicalRect,
     ) -> LogicalRect {
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 
@@ -548,6 +562,10 @@ impl Item for BorderRectangle {
         geometry: LogicalRect,
     ) -> LogicalRect {
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 
@@ -683,6 +701,10 @@ impl Item for Clip {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        self.clip()
+    }
 }
 
 impl Clip {
@@ -778,6 +800,10 @@ impl Item for Opacity {
         geometry: LogicalRect,
     ) -> LogicalRect {
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 
@@ -892,6 +918,10 @@ impl Item for Layer {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for Layer {
@@ -984,6 +1014,10 @@ impl Item for Rotate {
         geometry: LogicalRect,
     ) -> LogicalRect {
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 
@@ -1121,6 +1155,10 @@ impl Item for WindowItem {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl RenderRectangle for WindowItem {
@@ -1256,6 +1294,10 @@ impl Item for ContextMenu {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ContextMenu {
@@ -1368,6 +1410,10 @@ impl Item for BoxShadow {
         geometry
             .outer_rect(euclid::SideOffsets2D::from_length_all_same(self.blur()))
             .translate(LogicalVector::from_lengths(self.offset_x(), self.offset_y()))
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -230,6 +230,10 @@ impl Item for ComponentContainer {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl RenderRectangle for ComponentContainer {

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -155,6 +155,10 @@ impl Item for Flickable {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        true
+    }
 }
 
 impl ItemConsts for Flickable {

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -117,6 +117,10 @@ impl Item for ImageItem {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl RenderImage for ImageItem {
@@ -262,6 +266,10 @@ impl Item for ClippedImage {
         geometry: LogicalRect,
     ) -> LogicalRect {
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -238,6 +238,10 @@ impl Item for TouchArea {
         geometry.size = LogicalSize::zero();
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for TouchArea {
@@ -358,6 +362,10 @@ impl Item for FocusScope {
     ) -> LogicalRect {
         geometry.size = LogicalSize::zero();
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 
@@ -556,6 +564,10 @@ impl Item for SwipeGestureHandler {
     ) -> LogicalRect {
         geometry.size = LogicalSize::zero();
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -139,6 +139,10 @@ impl Item for Path {
     ) -> LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl Path {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -133,6 +133,10 @@ impl Item for ComplexText {
     ) -> LogicalRect {
         self.text_bounding_rect(window_adapter, geometry.cast()).cast()
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl ItemConsts for ComplexText {
@@ -306,6 +310,10 @@ impl Item for SimpleText {
         geometry: LogicalRect,
     ) -> LogicalRect {
         self.text_bounding_rect(window_adapter, geometry.cast()).cast()
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 
@@ -1004,6 +1012,10 @@ impl Item for TextInput {
             self.wrap(),
         ));
         geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
     }
 }
 

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -198,6 +198,10 @@ impl crate::items::Item for MenuItem {
     ) -> crate::lengths::LogicalRect {
         geometry
     }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
 }
 
 impl crate::items::ItemConsts for MenuItem {


### PR DESCRIPTION
and while at it, move is_clipping_item() that casts a function of the ItemVTable.

Fixes #2341
Fixes #7382

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
