### PR TITLE
Add `AccessibleRole::Image` and use it in the `AboutSlint` widget

### DIFF
--- a/docs/astro/src/content/docs/reference/elements/image.mdx
+++ b/docs/astro/src/content/docs/reference/elements/image.mdx
@@ -251,3 +251,31 @@ Use the <Link type="ImageType" label="`@image-url` macro" /> to specify the imag
 
 Properties in source image coordinates that define the region of the source image that is rendered.
 By default the entire source image is visible:
+
+## Accessibility
+
+### Alternative text
+
+Consider giving an alternative text description of your image by setting the `accessible-label` property:
+
+```slint
+Image {
+    width: 100px;
+    height: 100px;
+    source: @image-url("slint-logo.png");
+    accessible-label: "Slint logo";
+}
+```
+
+### Filtering out images for users of assistive technologies
+
+By default, images have the `accessible-role` property set to `image`.
+If your image is purely decorative and does not convey any information,
+consider removing it from the accessibility tree:
+
+```slint
+Image {
+    source: @image-url("mini-banner.png");
+    accessible-role: none;
+}
+```

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -329,6 +329,7 @@ cpp! {{
                     i_slint_core::items::AccessibleRole::ListItem => QAccessible_Role_ListItem,
                     i_slint_core::items::AccessibleRole::TabPanel => QAccessible_Role_Pane,
                     i_slint_core::items::AccessibleRole::Groupbox => QAccessible_Role_Grouping,
+                    i_slint_core::items::AccessibleRole::Image => QAccessible_Role_Graphic,
                     _ => QAccessible_Role_NoRole,
                 }
             });

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -100,6 +100,7 @@ enum AccessibleRole {
     ListItem = 15;
     TabPanel = 16;
     Groupbox = 17;
+    Image = 18;
 }
 
 message ElementQueryInstruction {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -531,6 +531,7 @@ fn convert_to_proto_accessible_role(
         i_slint_core::items::AccessibleRole::Switch => proto::AccessibleRole::Switch,
         i_slint_core::items::AccessibleRole::ListItem => proto::AccessibleRole::ListItem,
         i_slint_core::items::AccessibleRole::TabPanel => proto::AccessibleRole::TabPanel,
+        i_slint_core::items::AccessibleRole::Image => proto::AccessibleRole::Image,
         _ => return None,
     })
 }
@@ -559,6 +560,7 @@ fn convert_from_proto_accessible_role(
         proto::AccessibleRole::Switch => i_slint_core::items::AccessibleRole::Switch,
         proto::AccessibleRole::ListItem => i_slint_core::items::AccessibleRole::ListItem,
         proto::AccessibleRole::TabPanel => i_slint_core::items::AccessibleRole::TabPanel,
+        proto::AccessibleRole::Image => i_slint_core::items::AccessibleRole::Image,
     })
 }
 

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -477,6 +477,7 @@ impl NodeCollection {
                     }
                     i_slint_core::items::AccessibleRole::Switch => Role::Switch,
                     i_slint_core::items::AccessibleRole::ListItem => Role::ListBoxOption,
+                    i_slint_core::items::AccessibleRole::Image => Role::Image,
                     _ => Role::Unknown,
                 },
                 item.accessible_string_property(

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -352,6 +352,8 @@ macro_rules! for_each_enums {
                 Combobox,
                 /// The element is a `GroupBox` or behaves like one.
                 Groupbox,
+                /// The element is an `Image` or behaves like one.
+                Image,
                 /// The element is a `ListView` or behaves like one.
                 List,
                 /// The element is a `Slider` or behaves like one.

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -74,5 +74,13 @@ fn apply_builtin(e: &ElementRc) {
         e.borrow_mut().set_binding_if_not_set("accessible-label".into(), || {
             Expression::PropertyReference(text_prop)
         });
+    } else if bty.name == "Image" {
+        e.borrow_mut().set_binding_if_not_set("accessible-role".into(), || {
+            let enum_ty = crate::typeregister::BUILTIN.with(|e| e.enums.AccessibleRole.clone());
+            Expression::EnumerationValue(EnumerationValue {
+                value: enum_ty.values.iter().position(|v| v == "image").unwrap(),
+                enumeration: enum_ty,
+            })
+        });
     }
 }

--- a/internal/compiler/widgets/common/about-slint.slint
+++ b/internal/compiler/widgets/common/about-slint.slint
@@ -18,6 +18,7 @@ export component AboutSlint {
             source: Palette.color-scheme == ColorScheme.dark ? @image-url("MadeWithSlint-logo-dark.svg") : @image-url("MadeWithSlint-logo-light.svg");
             preferred-width: 256px;
             min-height: 48px;
+            accessible-label: "#MadeWithSlint";
         }
 
         Text {

--- a/internal/compiler/widgets/common/menus.slint
+++ b/internal/compiler/widgets/common/menus.slint
@@ -45,6 +45,7 @@ export component PopupMenuImpl inherits Window {
                     if entry.has-sub-menu : Image {
                         source: @image-url("../fluent/_arrow_forward.svg");
                         colorize: menu-text.color;
+                        accessible-role: none;
                     }
                 }
                 TouchArea {

--- a/internal/compiler/widgets/cosmic/checkbox.slint
+++ b/internal/compiler/widgets/cosmic/checkbox.slint
@@ -66,6 +66,7 @@ export component CheckBox {
                 source: Icons.check-mark;
                 colorize: CosmicPalette.accent-foreground;
                 width: 12px;
+                accessible-role: none;
 
                 animate colorize { duration: 150ms; }
             }

--- a/internal/compiler/widgets/cosmic/combobox.slint
+++ b/internal/compiler/widgets/cosmic/combobox.slint
@@ -76,6 +76,7 @@ export component ComboBox {
                 height: 16px;
                 colorize: CosmicPalette.control-foreground;
                 source: Icons.dropdown;
+                accessible-role: none;
             }
         }
 

--- a/internal/compiler/widgets/cosmic/components.slint
+++ b/internal/compiler/widgets/cosmic/components.slint
@@ -149,6 +149,7 @@ export component ListItem {
                     visible: root.is-selected;
                     colorize: text.color;
                     source: Icons.check-mark;
+                    accessible-role: none;
                 }
             }
 

--- a/internal/compiler/widgets/cosmic/tableview.slint
+++ b/internal/compiler/widgets/cosmic/tableview.slint
@@ -34,6 +34,7 @@ component TableViewColumn inherits Rectangle {
             width: 12px;
             y: (parent.height - self.height) / 2;
             source: root.sort-order == SortOrder.ascending ? Icons.arrow-down : Icons.arrow-up;
+            accessible-role: none;
 
             animate colorize { duration: 150ms; }
         }

--- a/internal/compiler/widgets/cupertino/checkbox.slint
+++ b/internal/compiler/widgets/cupertino/checkbox.slint
@@ -110,6 +110,7 @@ export component CheckBox {
                 source: Icons.check-mark;
                 colorize: root.icon-color;
                 width: 12px;
+                accessible-role: none;
 
                 animate colorize { duration: 150ms; }
             }

--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -153,12 +153,14 @@ export component ComboBox {
                         x: (parent.width - self.width) / 2;
                         colorize: CupertinoPalette.accent-foreground;
                         source: Icons.chevron-up;
+                        accessible-role: none;
                     }
 
                     bottom-icon := Image {
                         x: (parent.width - self.width) / 2;
                         colorize: CupertinoPalette.accent-foreground;
                         source: Icons.chevron-down;
+                        accessible-role: none;
                     }
                 }
             }

--- a/internal/compiler/widgets/cupertino/components.slint
+++ b/internal/compiler/widgets/cupertino/components.slint
@@ -94,6 +94,7 @@ export component ListItem {
                     colorize: CupertinoPalette.foreground;
                     visible: root.is-selected;
                     width: 10px;
+                    accessible-role: none;
                 }
 
                 i-text := Text {

--- a/internal/compiler/widgets/cupertino/spinbox.slint
+++ b/internal/compiler/widgets/cupertino/spinbox.slint
@@ -51,6 +51,7 @@ component SpinBoxButton {
             image-fit: contain;
             colorize: root.icon-color;
             width: 12px;
+            accessible-role: none;
 
             animate colorize { duration: 150ms; }
         }

--- a/internal/compiler/widgets/cupertino/tableview.slint
+++ b/internal/compiler/widgets/cupertino/tableview.slint
@@ -37,6 +37,7 @@ component TableViewColumn inherits Rectangle {
             width: 8px;
             y: (parent.height - self.height) / 2;
             source: root.sort-order == SortOrder.ascending ? Icons.chevron-down : Icons.chevron-up;
+            accessible-role: none;
 
             animate colorize { duration: 150ms; }
         }

--- a/internal/compiler/widgets/fluent/checkbox.slint
+++ b/internal/compiler/widgets/fluent/checkbox.slint
@@ -72,6 +72,7 @@ export component CheckBox {
                 source: Icons.check-mark;
                 colorize: FluentPalette.accent-foreground;
                 width: 12px;
+                accessible-role: none;
 
                 animate colorize { duration: 150ms; }
             }

--- a/internal/compiler/widgets/fluent/combobox.slint
+++ b/internal/compiler/widgets/fluent/combobox.slint
@@ -89,6 +89,7 @@ export component ComboBox {
                 width: 12px;
                 source: Icons.dropdown;
                 y: 2px;
+                accessible-role: none;
 
                 animate colorize { duration: 150ms; }
             }

--- a/internal/compiler/widgets/fluent/scrollview.slint
+++ b/internal/compiler/widgets/fluent/scrollview.slint
@@ -16,6 +16,7 @@ component ScrollViewButton inherits TouchArea {
         width: parent.width;
         source: root.icon;
         colorize: FluentPalette.border;
+        accessible-role: none;
 
         animate colorize, opacity { duration: 150ms; }
         animate width, height { duration: 150ms; easing: ease-out; }

--- a/internal/compiler/widgets/fluent/spinbox.slint
+++ b/internal/compiler/widgets/fluent/spinbox.slint
@@ -25,6 +25,7 @@ component SpinBoxButton {
             image-fit: contain;
             colorize: FluentPalette.text-secondary;
             width: 12px;
+            accessible-role: none;
 
             animate colorize { duration: 150ms; }
         }

--- a/internal/compiler/widgets/fluent/tableview.slint
+++ b/internal/compiler/widgets/fluent/tableview.slint
@@ -41,6 +41,7 @@ component TableViewColumn inherits Rectangle {
             width: 12px;
             y: (parent.height - self.height) / 2;
             source: root.sort-order == SortOrder.ascending ? Icons.arrow-down : Icons.arrow-up;
+            accessible-role: none;
 
             animate colorize { duration: 150ms; }
         }

--- a/internal/compiler/widgets/material/checkbox.slint
+++ b/internal/compiler/widgets/material/checkbox.slint
@@ -110,6 +110,7 @@ export component CheckBox {
                     height: 80%;
                     source: Icons.check-mark;
                     colorize: MaterialPalette.accent-foreground;
+                    accessible-role: none;
 
                     states [
                         disabled when !root.enabled : {

--- a/internal/compiler/widgets/material/combobox.slint
+++ b/internal/compiler/widgets/material/combobox.slint
@@ -87,6 +87,7 @@ export component ComboBox {
             y: (parent.height - self.height) / 2;
             source: Icons.expand-more;
             colorize: MaterialPalette.control-foreground;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/material/spinbox.slint
+++ b/internal/compiler/widgets/material/spinbox.slint
@@ -134,6 +134,7 @@ export component SpinBox {
                         source: Icons.arrow-drop-up;
                         opacity: parent.icon-opacity;
                         colorize: parent.icon-fill;
+                        accessible-role: none;
                     }
 
                     clicked => {
@@ -150,6 +151,7 @@ export component SpinBox {
                         source: Icons.arrow-drop-down;
                         opacity: parent.icon-opacity;
                         colorize: parent.icon-fill;
+                        accessible-role: none;
                     }
 
                     clicked => {

--- a/internal/compiler/widgets/material/tableview.slint
+++ b/internal/compiler/widgets/material/tableview.slint
@@ -36,6 +36,7 @@ component TableViewColumn inherits Rectangle {
                 Icons.arrow-upward :
                 Icons.arrow-downward;
             colorize: MaterialPalette.control-foreground;
+            accessible-role: none;
         }
     }
 

--- a/tests/cases/elements/image.slint
+++ b/tests/cases/elements/image.slint
@@ -37,7 +37,7 @@ assert(instance.get_test());
 auto img_search = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::img");
 assert_eq(img_search.size(), 1);
 auto img = img_search[0];
-assert_eq(*img.accessible_role(), slint::testing::AccessibleRole::Image);
+assert(*img.accessible_role() == slint::testing::AccessibleRole::Image);
 ```
 
 

--- a/tests/cases/elements/image.slint
+++ b/tests/cases/elements/image.slint
@@ -33,15 +33,26 @@ const TestCase &instance = *handle;
 assert_eq(instance.get_img_width(), 320.);
 assert_eq(instance.get_img_height(), 480.);
 assert(instance.get_test());
+
+auto img_search = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::img");
+assert_eq(img_search.size(), 1);
+auto img = img_search[0];
+assert_eq(*img.accessible_role(), slint::testing::AccessibleRole::Image);
 ```
 
 
 ```rust
+use i_slint_backend_testing::AccessibleRole;
+
 let instance = TestCase::new().unwrap();
 
 assert_eq!(instance.get_img_width(), 320.);
 assert_eq!(instance.get_img_height(), 480.);
 assert!(instance.get_test());
+
+let mut img_search = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::img");
+let img = img_search.next().unwrap();
+assert_eq!(img.accessible_role(), Some(AccessibleRole::Image));
 ```
 
 ```js

--- a/tests/cases/widgets/about.slint
+++ b/tests/cases/widgets/about.slint
@@ -1,0 +1,22 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { AboutSlint } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    about := AboutSlint { }
+}
+
+
+/*
+```rust
+use i_slint_backend_testing::AccessibleRole;
+
+let instance = TestCase::new().unwrap();
+
+let mut image_search = slint_testing::ElementHandle::find_by_accessible_label(&instance, "#MadeWithSlint");
+let image = image_search.next().unwrap();
+
+assert_eq!(image.accessible_role(), Some(AccessibleRole::Image));
+```
+*/


### PR DESCRIPTION
<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Introduces a new `AccessibleRole` to represent images and maps it to the appropriate role for each accessibility backend. The role could be set by default but (1) it would probably have to be done in a compiler pass and (2) the `Image` widget is already used extensively to represent icons and other visual elements that really should not be part of the accessibility tree, so it would be annoying to set `accessible-role: none` everywhere.

I took this opportunity to improve the `AboutSlint` widget. I chose "#MadeWithSlint" as the label because I think this is the most important piece of information carried out by the image, but this is your branding so feel free to suggest something else.