### PR TITLE
esp-idf: deprecate the old `slint_esp_init` variant

### DIFF
--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -81,21 +81,14 @@ SlintPlatformConfiguration(Args...) -> SlintPlatformConfiguration<>;
  *
  * Note: For compatibility, this function overload selects RGB16 byte swapping if single-buffering
  * is selected as rendering method.
+ *
+ *  \deprecated Prefer the overload taking a SlintPlatformConfiguration
  */
+[[deprecated("Use the overload taking a SlintPlatformConfiguration")]]
 void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     std::optional<esp_lcd_touch_handle_t> touch,
                     std::span<slint::platform::Rgb565Pixel> buffer1,
                     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2 = {});
-
-#ifdef SLINT_FEATURE_EXPERIMENTAL
-/**
- * Same as the other overload but do rendering line-by-line, by allocating a line buffer with
- * MALLOC_CAP_INTERNAL, and flush it to the screen with esp_lcd_panel_draw_bitmap. (experimental)
- */
-void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
-                    std::optional<esp_lcd_touch_handle_t> touch,
-                    slint::platform::SoftwareRenderer::RenderingRotation rotation = {});
-#endif
 
 /**
  * Initialize the Slint platform for ESP-IDF.

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -349,26 +349,10 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
         .buffer2 = buffer2,
         // For compatibility with earlier versions of Slint, we compute the value of
         // byte_swap the way it was implemented in Slint (slint-esp) <= 1.6.0:
-        .byte_swap = buffer2.has_value()
+        .byte_swap = !buffer2.has_value()
     };
     slint_esp_init(config);
 }
-
-#ifdef SLINT_FEATURE_EXPERIMENTAL
-void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
-                    std::optional<esp_lcd_touch_handle_t> touch,
-                    slint::platform::SoftwareRenderer::RenderingRotation rotation)
-{
-    SlintPlatformConfiguration config { .size = size,
-                                        .panel_handle = panel,
-                                        .touch_handle = touch ? *touch : nullptr,
-                                        .buffer1 = std::nullopt,
-                                        .buffer2 = std::nullopt,
-                                        .rotation = rotation,
-                                        .color_swap = false };
-    slint_esp_init(config);
-}
-#endif
 
 void slint_esp_init(const SlintPlatformConfiguration<slint::platform::Rgb565Pixel> &config)
 {


### PR DESCRIPTION
Only support the one that take a configuration

CC #7597
