### PR TITLE
Qt: Fix event forwarding for native popups

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -133,12 +133,17 @@ cpp! {{
         std::tuple<QPoint, void*> adjust_mouse_event_to_popup_parent(QMouseEvent *event) {
             auto pos = event->pos();
             if (auto p = dynamic_cast<const SlintWidget*>(parent()); p && !rect().contains(pos)) {
+    #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                QPoint eventPos = event->globalPosition().toPoint();
+    #else
+                QPoint eventPos = event->globalPos();
+    #endif
                 while (auto pp = dynamic_cast<const SlintWidget*>(p->parent())) {
-                    if (p->rect().contains(p->mapFromGlobal(event->globalPosition().toPoint())))
+                    if (p->rect().contains(p->mapFromGlobal(eventPos)))
                         break;
                     p = pp;
                 }
-                return { p->mapFromGlobal(event->globalPosition().toPoint()), p->rust_window };
+                return { p->mapFromGlobal(eventPos), p->rust_window };
             } else {
                 return { pos, rust_window };
             }


### PR DESCRIPTION
So that popup menus can handle hover events.

This also remove some of the code in the qt backend that used the private API
