### PR TITLE
Qt: don't clear selection when the window gain focus

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -354,7 +354,8 @@ cpp! {{
                         text: i_slint_core::format!("{}", commit_string),
                         preedit_text: i_slint_core::format!("{}", preedit_string),
                         preedit_selection: (preedit_cursor >= 0).then_some(preedit_cursor..preedit_cursor),
-                        replacement_range: Some(replacement_start..replacement_start+replacement_length),
+                        replacement_range: (!commit_string.is_empty() || !preedit_string.is_empty() || preedit_cursor >= 0)
+                            .then_some(replacement_start..replacement_start+replacement_length),
                         ..Default::default()
                     };
                     runtime_window.process_key_input(event);


### PR DESCRIPTION
(or popup menu gets closed)

We receive an empty `QInputMethodEvent` when the window gets active and we should not have a replacement range if there is nothing to replace, otherwise we clear the selection
