### PR TITLE
Attempt to provide better diagnostics when the translation bundle dir…

### DIFF
--- a/internal/compiler/llr/translations.rs
+++ b/internal/compiler/llr/translations.rs
@@ -48,7 +48,9 @@ impl TranslationsBuilder {
         let mut catalogs = Vec::new();
         let mut plural_rules =
             vec![Some(plural_rule_parser::parse_rule_expression("n!=1").unwrap())];
-        for l in std::fs::read_dir(path)? {
+        for l in std::fs::read_dir(path)
+            .map_err(|e| std::io::Error::other(format!("Error reading directory {path:?}: {e}")))?
+        {
             let l = l?;
             let path = l.path().join("LC_MESSAGES").join(format!("{domain}.po"));
             if path.exists() {


### PR DESCRIPTION
…ectory path can't be read

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
