### PR TITLE
CI: Update ubuntu version

### DIFF
--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -28,9 +28,9 @@ jobs:
             CARGO_INCREMENTAL: false
         strategy:
             matrix:
-                os: [ubuntu-20.04, macOS-13, macos-14, windows-2022]
+                os: [ubuntu-22.04, macOS-13, macos-14, windows-2022]
                 include:
-                    - os: ubuntu-20.04
+                    - os: ubuntu-22.04
                       package_suffix: linux
                     - os: macOS-13
                       package_suffix: macos-x86_64
@@ -47,7 +47,7 @@ jobs:
                   old-ubuntu: true
             - name: Install Qt (Ubuntu)
               uses: jurplel/install-qt-action@v4
-              if: matrix.os == 'ubuntu-20.04'
+              if: matrix.os == 'ubuntu-22.04'
               with:
                   version: 6.2.2
                   cache: true
@@ -92,7 +92,7 @@ jobs:
             matrix:
                 target: [thumbv7em-none-eabihf]
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
             - uses: ./.github/actions/install-linux-dependencies
@@ -229,9 +229,9 @@ jobs:
             CARGO_INCREMENTAL: false
         strategy:
             matrix:
-                os: [ubuntu-20.04, macOS-13, macos-14, windows-2022]
+                os: [ubuntu-22.04, macOS-13, macos-14, windows-2022]
                 include:
-                    - os: ubuntu-20.04
+                    - os: ubuntu-22.04
                       package_suffix: Linux-x86_64
                     - os: macOS-13
                       package_suffix: Darwin-x86_64

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -83,7 +83,7 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - os: ubuntu-20.04
+                    - os: ubuntu-22.04
                       toolchain: x86_64-unknown-linux-gnu
                       binary_built: slint-lsp
                       artifact_name: slint-lsp-x86_64-unknown-linux-gnu
@@ -210,7 +210,7 @@ jobs:
                 target:
                     - armv7-unknown-linux-gnueabihf
                     - aarch64-unknown-linux-gnu
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
             - uses: ./.github/actions/setup-rust
@@ -320,7 +320,7 @@ jobs:
 
     #  publish_tree_sitter:
     #    if: github.event.inputs.private != 'true'
-    #    runs-on: ubuntu-20.04
+    #    runs-on: ubuntu-22.04
     #    steps:
     #      - uses: actions/checkout@v4
     #      - name: Upload artifact
@@ -332,7 +332,7 @@ jobs:
     publish_artifacts:
         if: ${{ github.event.inputs.private != 'true' }}
         needs: [docs, wasm_demo, wasm, check-for-secrets, android]
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/download-artifact@v4
               with:

--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -54,7 +54,7 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - os: ubuntu-20.04
+                    - os: ubuntu-22.04
                       rust-target: x86_64-unknown-linux-gnu
                       napi-rs-target: linux-x64-gnu
                     - os: ubuntu-22.04-arm

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -86,7 +86,7 @@ jobs:
                       pkg
 
     build_linux:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
             - uses: ./.github/actions/install-linux-dependencies
@@ -115,7 +115,7 @@ jobs:
                   path: slint-${{ github.event.inputs.program || inputs.program }}-linux.tar.gz
 
     build_linux_arm:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       strategy:
         matrix:
             target:


### PR DESCRIPTION
Ubuntu 20.04 container is being discontinued, so use the 22.04 instead. This is mostly used to generate binary packages
