### PR TITLE
C++ hwaccel: textures and background fill

### DIFF
--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -549,6 +549,11 @@ struct TargetPixelBuffer
 
     virtual bool fill_rectangle(int16_t x, int16_t y, int16_t width, int16_t height,
                                 const RgbaColor<uint8_t> &premultiplied_color) = 0;
+    virtual bool draw_texture(int16_t x, int16_t y, int16_t width, int16_t height,
+                              const uint8_t *src, uint16_t src_stride, int16_t src_width,
+                              int16_t src_height, uint8_t src_pixel_format, uint16_t src_dx,
+                              uint16_t src_dy, uint16_t src_off_x, uint16_t src_off_y,
+                              uint32_t colorize, uint8_t alpha, uint8_t rotation) = 0;
 };
 #    endif
 
@@ -719,6 +724,18 @@ public:
                         return buffer->fill_rectangle(
                                 x, y, width, height,
                                 Color::from_argb_uint8(alpha, red, green, blue));
+                    },
+            .draw_texture =
+                    [](void *self, int16_t x, int16_t y, int16_t width, int16_t handle,
+                       const uint8_t *src, uint16_t src_stride, int16_t src_width,
+                       int16_t src_height, uint8_t src_pixel_format, uint16_t src_dx,
+                       uint16_t src_dy, uint16_t src_off_x, uint16_t src_off_y, uint32_t colorize,
+                       uint8_t alpha, uint8_t rotation) {
+                        auto *buffer = reinterpret_cast<TargetPixelBuffer<Rgb8Pixel> *>(self);
+                        return buffer->draw_texture(x, y, width, handle, src, src_stride, src_width,
+                                                    src_height, src_pixel_format, src_dx, src_dy,
+                                                    src_off_x, src_off_y, colorize, alpha,
+                                                    rotation);
                     }
         };
         auto r =
@@ -749,6 +766,18 @@ public:
                         return buffer->fill_rectangle(
                                 x, y, width, height,
                                 Color::from_argb_uint8(alpha, red, green, blue));
+                    },
+            .draw_texture =
+                    [](void *self, int16_t x, int16_t y, int16_t width, int16_t handle,
+                       const uint8_t *src, uint16_t src_stride, int16_t src_width,
+                       int16_t src_height, uint8_t src_pixel_format, uint16_t src_dx,
+                       uint16_t src_dy, uint16_t src_off_x, uint16_t src_off_y, uint32_t colorize,
+                       uint8_t alpha, uint8_t rotation) {
+                        auto *buffer = reinterpret_cast<TargetPixelBuffer<Rgb8Pixel> *>(self);
+                        return buffer->draw_texture(x, y, width, handle, src, src_stride, src_width,
+                                                    src_height, src_pixel_format, src_dx, src_dy,
+                                                    src_off_x, src_off_y, colorize, alpha,
+                                                    rotation);
                     }
         };
         auto r = cbindgen_private::slint_software_renderer_render_accel_rgb565(inner,

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -384,6 +384,25 @@ mod software_renderer {
             u8,
             u8,
         ) -> bool,
+        draw_texture: unsafe extern "C" fn(
+            CppTargetPixelBufferUserData,
+            i16,
+            i16,
+            i16,
+            i16,
+            *const u8,
+            u16,
+            i16,
+            i16,
+            u8,
+            u16,
+            u16,
+            u16,
+            u16,
+            u32,
+            u8,
+            u8,
+        ) -> bool,
     }
 
     impl TargetPixelBuffer for CppRgb8TargetPixelBuffer {
@@ -424,6 +443,48 @@ mod software_renderer {
                 )
             }
         }
+
+        fn draw_texture(
+            &mut self,
+            x: i16,
+            y: i16,
+            width: i16,
+            height: i16,
+            src: *const u8,
+            src_stride: u16,
+            src_width: i16,
+            src_height: i16,
+            src_pixel_format: u8,
+            dx: u16,
+            dy: u16,
+            off_x: u16,
+            off_y: u16,
+            colorize: u32,
+            alpha: u8,
+            rotation: u8,
+        ) -> bool {
+            unsafe {
+                (self.draw_texture)(
+                    self.user_data,
+                    x,
+                    y,
+                    width,
+                    height,
+                    src,
+                    src_stride,
+                    src_width,
+                    src_height,
+                    src_pixel_format,
+                    dx,
+                    dy,
+                    off_x,
+                    off_y,
+                    colorize,
+                    alpha,
+                    rotation,
+                )
+            }
+        }
     }
 
     #[repr(C)]
@@ -444,6 +505,25 @@ mod software_renderer {
             i16,
             u8,
             u8,
+            u8,
+            u8,
+        ) -> bool,
+        draw_texture: unsafe extern "C" fn(
+            CppTargetPixelBufferUserData,
+            i16,
+            i16,
+            i16,
+            i16,
+            *const u8,
+            u16,
+            i16,
+            i16,
+            u8,
+            u16,
+            u16,
+            u16,
+            u16,
+            u32,
             u8,
             u8,
         ) -> bool,
@@ -484,6 +564,48 @@ mod software_renderer {
                     color.green,
                     color.blue,
                     color.alpha,
+                )
+            }
+        }
+
+        fn draw_texture(
+            &mut self,
+            x: i16,
+            y: i16,
+            width: i16,
+            height: i16,
+            src: *const u8,
+            src_stride: u16,
+            src_width: i16,
+            src_height: i16,
+            src_pixel_format: u8,
+            dx: u16,
+            dy: u16,
+            off_x: u16,
+            off_y: u16,
+            colorize: u32,
+            alpha: u8,
+            rotation: u8,
+        ) -> bool {
+            unsafe {
+                (self.draw_texture)(
+                    self.user_data,
+                    x,
+                    y,
+                    width,
+                    height,
+                    src,
+                    src_stride,
+                    src_width,
+                    src_height,
+                    src_pixel_format,
+                    dx,
+                    dy,
+                    off_x,
+                    off_y,
+                    colorize,
+                    alpha,
+                    rotation,
                 )
             }
         }


### PR DESCRIPTION
See this thread for context: https://chat.slint.dev/public/pl/shzj7t7ps7d1tnq1t8cyocufpw

This PR builds on Simon's work on the C++ API for implementing synchronous hardware acceleration within the Software Renderer.  It adds an API for texture drawing acceleration.  As well, it uses the new process_rectangle API for doing the initial background fill when rendering.

For performance, with our UI on a STM32U5G9 and implementing DMA2D with these APIs, I see our worst case render times reduced from 33.6ms to 18.1ms. That's a nearly 50% improvement!

A couple notes:

- The texture API is quite verbose with a lot of variables. These could maybe be bundled up, but technically all could contain relevant info for the C++ side
- The dx/dy/off_x/off_y types are all Fixed<...> with integers backing them. This API expects the C++ layer to understand this and use them appropriately (For our targets, I intend to simply abort the acceleration if these have fractional parts, but other targets may be able to use them.)
- The background fill seems to work, but I did not extensively test transparent backgrounds. In my limited testing this seems to be okay.