### PR TITLE
compiler: Try to keep the generated code more deterministic 

### DIFF
--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -10,7 +10,7 @@ use crate::layout::Orientation;
 use core::num::NonZeroUsize;
 use itertools::Either;
 use smol_str::SmolStr;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 #[derive(Debug, Clone)]
@@ -139,7 +139,7 @@ pub enum Expression {
     },
     Struct {
         ty: Rc<crate::langtype::Struct>,
-        values: HashMap<SmolStr, Expression>,
+        values: BTreeMap<SmolStr, Expression>,
     },
 
     EasingCurve(crate::expression_tree::EasingCurve),

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -897,7 +897,7 @@ pub fn get_layout_info(
                     },
                 )
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         for (nr, s) in constraints.for_each_restrictions(orientation) {
             values.insert(
@@ -1031,7 +1031,7 @@ pub fn make_struct(
     it: impl IntoIterator<Item = (&'static str, Type, llr_Expression)>,
 ) -> llr_Expression {
     let mut fields = BTreeMap::<SmolStr, Type>::new();
-    let mut values = HashMap::<SmolStr, llr_Expression>::new();
+    let mut values = BTreeMap::<SmolStr, llr_Expression>::new();
     for (name, ty, expr) in it {
         fields.insert(SmolStr::new(name), ty);
         values.insert(SmolStr::new(name), expr);

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -616,7 +616,7 @@ fn lower_geometry(
     ctx: &ExpressionLoweringCtx<'_>,
 ) -> super::Expression {
     let mut fields = BTreeMap::default();
-    let mut values = HashMap::with_capacity(4);
+    let mut values = BTreeMap::default();
     for (f, v) in [("x", &geom.x), ("y", &geom.y), ("width", &geom.width), ("height", &geom.height)]
     {
         fields.insert(f.into(), Type::LogicalLength);

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -57,7 +57,7 @@ pub struct Document {
     /// Map of resources that should be embedded in the generated code, indexed by their absolute path on
     /// disk on the build system
     pub embedded_file_resources:
-        RefCell<HashMap<SmolStr, crate::embedded_resources::EmbeddedResources>>,
+        RefCell<BTreeMap<SmolStr, crate::embedded_resources::EmbeddedResources>>,
 
     /// The list of used extra types used recursively.
     pub used_types: RefCell<UsedSubTypes>,

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -10,7 +10,7 @@ use crate::EmbedResourcesKind;
 use image::GenericImageView;
 use smol_str::SmolStr;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -83,7 +83,7 @@ fn collect_image_urls_from_expression(
 fn embed_images_from_expression(
     e: &mut Expression,
     urls: &HashMap<SmolStr, Option<SmolStr>>,
-    global_embedded_resources: &RefCell<HashMap<SmolStr, EmbeddedResources>>,
+    global_embedded_resources: &RefCell<BTreeMap<SmolStr, EmbeddedResources>>,
     embed_files: EmbedResourcesKind,
     scale_factor: f64,
     diag: &mut BuildDiagnostics,
@@ -126,7 +126,7 @@ fn embed_images_from_expression(
 }
 
 fn embed_image(
-    global_embedded_resources: &RefCell<HashMap<SmolStr, EmbeddedResources>>,
+    global_embedded_resources: &RefCell<BTreeMap<SmolStr, EmbeddedResources>>,
     embed_files: EmbedResourcesKind,
     path: &str,
     _scale_factor: f64,
@@ -136,8 +136,8 @@ fn embed_image(
     let mut resources = global_embedded_resources.borrow_mut();
     let maybe_id = resources.len();
     let e = match resources.entry(path.into()) {
-        std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
-        std::collections::hash_map::Entry::Vacant(e) => {
+        std::collections::btree_map::Entry::Occupied(e) => e.into_mut(),
+        std::collections::btree_map::Entry::Vacant(e) => {
             // Check that the file exists, so that later we can unwrap safely in the generators, etc.
             if embed_files == EmbedResourcesKind::ListAllResources {
                 // Really do nothing with the image!


### PR DESCRIPTION
Use BTreeMap instead of HashMap when possible.

I wanted to make a test for it by running the compiler twice in the cpp driver test, but that's failing because we use `static COUNT` atomic variable in several places to get unique ids.
We should find another way to get unique ID that's more deterministic. This should still be deterministic when using different processes.

Although there are still some source of non determinism so this doesn't close the issue #7642