### PR TITLE
Make the Figma plugin available via the nightly snapshot tag page

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -550,7 +550,7 @@ jobs:
 
     prepare_release:
         if: github.event.inputs.private != 'true'
-        needs: [cpp_package, slint-viewer-binary, slint-lsp-binary]
+        needs: [cpp_package, slint-viewer-binary, slint-lsp-binary, build-figma-plugin]
         runs-on: ubuntu-22.04
         permissions:
             contents: write
@@ -575,6 +575,9 @@ jobs:
               with:
                   pattern: slint-lsp-*
                   merge-multiple: true
+            - uses: actions/download-artifact@v4
+              with:
+                  name: figma-plugin
             - name: Extract files
               run: |
                   ls -l
@@ -590,6 +593,7 @@ jobs:
                   mv slint-lsp-aarch64-unknown-linux-gnu.tar.gz artifacts/
                   mv slint-lsp-macos.tar.gz artifacts/
                   mv slint-compiler-*.tar.gz artifacts/
+                  mv figma-plugin.zip artifacts/
             - uses: montudor/action-zip@v1
               with:
                   args: zip -r artifacts/slint-viewer-windows.zip slint-viewer

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -318,6 +318,32 @@ jobs:
                   path: |
                       ${{ steps.publishToVSCM.outputs.vsixPath }}
 
+    build-figma-plugin:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                node-version: 20
+              id: node-install
+            - uses: pnpm/action-setup@v4.1.0
+              with:
+                version: 10.3.0
+            - name: Run pnpm install
+              working-directory: tools/figma-inspector
+              run: pnpm install --frozen-lockfile
+            - name: Add build timestamp to readme
+              working-directory: tools/figma-inspector/public-zip
+              run: echo "Built on $(date '+%d-%m-%Y %H:%M:%S %Z')" >> readme.txt
+            - name: Build zip
+              working-directory: tools/figma-inspector
+              run: pnpm zip
+            - name: Archive zip
+              uses: actions/upload-artifact@v4
+              with:
+                  name: figma-plugin
+                  path: tools/figma-inspector/zip
+
     #  publish_tree_sitter:
     #    if: github.event.inputs.private != 'true'
     #    runs-on: ubuntu-22.04

--- a/tools/figma-inspector/README.md
+++ b/tools/figma-inspector/README.md
@@ -7,7 +7,7 @@
 
 Download the nightly snapshot [figma-plugin.zip](https://github.com/slint-ui/slint/releases/download/nightly/figma-plugin.zip).
 
-The prerequisites are either the Figma Desktop App or the Figma VSCode extension. 
+The prerequisites are either the Figma Desktop App or the Figma VSCode extension.
 A valid Figma subscription with at least 'Team Professional' is needed.
 
 In Figma Desktop or the VScode extension have a file open and right click on it. Select Plugins > Development > Import Plugin From Manifest.. and point it at the manifest.json file that you just unzipped.

--- a/tools/figma-inspector/README.md
+++ b/tools/figma-inspector/README.md
@@ -3,6 +3,18 @@
 ## Figma to Slint property inspector
 
 
+### Installing the plugin via nightly snapshot.
+
+Download the nightly snapshot [figma-plugin.zip](https://github.com/slint-ui/slint/releases/download/nightly/figma-plugin.zip).
+
+The prerequisites are either the Figma Desktop App or the Figma VSCode extension. 
+A valid Figma subscription with at least 'Team Professional' is needed.
+
+In Figma Desktop or the VScode extension have a file open and right click on it. Select Plugins > Development > Import Plugin From Manifest.. and point it at the manifest.json file that you just unzipped.
+
+The Slint properties will now show in the Dev mode inspector in the same place the standard CSS properties
+would have been shown.
+
 ### Build
 
 Figma is a web app (Chromium) and the plugin is just javascript. As with other web apps in the repo

--- a/tools/figma-inspector/public-zip/readme.txt
+++ b/tools/figma-inspector/public-zip/readme.txt
@@ -1,4 +1,3 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: MIT
 
-This is a sample readme that gets copied to the zip


### PR DESCRIPTION
Plugin will then be downloadable via https://github.com/slint-ui/slint/releases/download/nightly/figma-plugin.zip