### PR TITLE
Revert "fix(node): prevent 100% CPU usage on Wayland by enforcing minimum event timeout"

### DIFF
--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -3,7 +3,6 @@
 
 mod interpreter;
 use std::path::PathBuf;
-use std::sync::LazyLock;
 
 pub use interpreter::*;
 
@@ -14,8 +13,6 @@ use napi::{Env, JsFunction, JsObject};
 
 #[macro_use]
 extern crate napi_derive;
-
-static IS_WAYLAND: LazyLock<bool> = LazyLock::new(|| std::env::var("WAYLAND_DISPLAY").is_ok());
 
 #[napi]
 pub fn mock_elapsed_time(ms: f64) {
@@ -35,13 +32,8 @@ pub enum ProcessEventsResult {
 
 #[napi]
 pub fn process_events() -> napi::Result<ProcessEventsResult> {
-    // Using std::time::Duration::Zero with the winit backend in wayland causes slint to consume 100% of a cpu core
-    // https://github.com/slint-ui/slint/issues/5780
-    let min_timeout = std::time::Duration::from_millis(16);
-    let timeout = if *IS_WAYLAND { min_timeout } else { std::time::Duration::ZERO };
-
     i_slint_backend_selector::with_platform(|b| {
-        b.process_events(timeout, i_slint_core::InternalToken)
+        b.process_events(std::time::Duration::ZERO, i_slint_core::InternalToken)
     })
     .map_err(|e| napi::Error::from_reason(e.to_string()))
     .and_then(|result| {


### PR DESCRIPTION
Reverts slint-ui/slint#7550

As discussed in #7657

Closes https://github.com/slint-ui/slint/issues/7657