### PR TITLE
C++: support for RGB8 in the line by line rendering

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -896,7 +896,8 @@ fn gen_platform(
         .with_include("slint_internal.h")
         .with_after_include(
             r"
-namespace slint::cbindgen_private { struct WindowProperties; }
+namespace slint::platform { struct Rgb565Pixel; }
+namespace slint::cbindgen_private { struct WindowProperties; using slint::platform::Rgb565Pixel; }
 ",
         )
         .generate()

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -713,9 +713,8 @@ public:
     /// Rgb8Pixel.
     template<typename PixelType, typename Callback>
         requires requires(Callback callback) {
-                     callback(size_t(0), size_t(0), size_t(0),
-                              [&callback](std::span<PixelType>) {});
-                 }
+            callback(size_t(0), size_t(0), size_t(0), [&callback](std::span<PixelType>) {});
+        }
     PhysicalRegion render_by_line(Callback process_line_callback) const
     {
         auto process_line_fn = [](void *process_line_callback_ptr, uintptr_t line,


### PR DESCRIPTION
Note: this adds a mendatory template parametter to the (experimental) `render_by_line` function.
I tried to get the PixelType auto-detected from the callback but i didn't manage

