### PR TITLE
live-preview: Do not offer plural forms in UI

### DIFF
--- a/tools/lsp/ui/components/property-widgets.slint
+++ b/tools/lsp/ui/components/property-widgets.slint
@@ -295,6 +295,9 @@ component FloatWidget inherits VerticalLayout {
 }
 
 component StringWidget {
+    // FIXME: @ogoffart says the plural support is not working at this time, so
+    //        we do not offer it in the UI for the time being...
+
     in property <bool> enabled;
     in property <string> property-name;
     in property <PropertyValue> property-value;
@@ -306,10 +309,12 @@ component StringWidget {
     callback set-string-binding(text: string, is-translated: bool);
 
     function tsb() -> bool {
-        return test-string-binding(Api.string-to-code(text-rle.text, tr-cb.checked, tr-context.text, tr-plural.text, tr-plural-expression.text), tr-cb.checked);
+        // return test-string-binding(Api.string-to-code(text-rle.text, tr-cb.checked, tr-context.text, tr-plural.text, tr-plural-expression.text), tr-cb.checked);
+        return test-string-binding(Api.string-to-code(text-rle.text, tr-cb.checked, tr-context.text, "", ""), tr-cb.checked);
     }
     function ssb() {
-        set-string-binding(Api.string-to-code(text-rle.text, tr-cb.checked, tr-context.text, tr-plural.text, tr-plural-expression.text), tr-cb.checked);
+        // set-string-binding(Api.string-to-code(text-rle.text, tr-cb.checked, tr-context.text, tr-plural.text, tr-plural-expression.text), tr-cb.checked);
+        set-string-binding(Api.string-to-code(text-rle.text, tr-cb.checked, tr-context.text, "", ""), tr-cb.checked);
     }
     property <bool> open: false;
 
@@ -378,41 +383,41 @@ component StringWidget {
                         }
                     }
                 }
-                Row {
-                    Text {
-                        vertical-alignment: center;
-                        horizontal-alignment: right;
-                        text: "Plural";
-                    }
-                    tr-plural := ResettingLineEdit {
-                        enabled: root.enabled && tr-cb.checked;
-                        default-text: root.property-value.tr-plural;
-                        edited(text) => {
-                            self.can-compile = root.tsb();
-                        }
-                        accepted(text) => {
-                            root.ssb();
-                        }
-                    }
-                }
-                Row {
-                    Text {
-                        vertical-alignment: center;
-                        horizontal-alignment: right;
-                        text: "Expression";
-                    }
-                    tr-plural-expression := ResettingLineEdit {
-                        enabled: root.enabled && tr-cb.checked;
-                        default-text: root.property-value.tr-plural-expression;
-                        edited(text) => {
-                            self.can-compile = root.tsb();
-                            tr-plural.can-compile = self.can-compile;
-                        }
-                        accepted(text) => {
-                            root.ssb();
-                        }
-                    }
-                }
+                // Row {
+                //     Text {
+                //         vertical-alignment: center;
+                //         horizontal-alignment: right;
+                //         text: "Plural";
+                //     }
+                //     tr-plural := ResettingLineEdit {
+                //         enabled: root.enabled && tr-cb.checked;
+                //         default-text: root.property-value.tr-plural;
+                //         edited(text) => {
+                //             self.can-compile = root.tsb();
+                //         }
+                //         accepted(text) => {
+                //             root.ssb();
+                //         }
+                //     }
+                // }
+                // Row {
+                //     Text {
+                //         vertical-alignment: center;
+                //         horizontal-alignment: right;
+                //         text: "Expression";
+                //     }
+                //     tr-plural-expression := ResettingLineEdit {
+                //         enabled: root.enabled && tr-cb.checked;
+                //         default-text: root.property-value.tr-plural-expression;
+                //         edited(text) => {
+                //             self.can-compile = root.tsb();
+                //             tr-plural.can-compile = self.can-compile;
+                //         }
+                //         accepted(text) => {
+                //             root.ssb();
+                //         }
+                //     }
+                // }
             }
         }
     }


### PR DESCRIPTION
@ogoffart relorts those do not fully work yet, so
let's just disable those for the time being.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
