### PR TITLE
C++: Stabilize line by line renderer

### DIFF
--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -21,9 +21,7 @@
  *                     allocated by the `esp_lcd` driver and set `buffer1` and `buffer2`.
  * * Line-by-line rendering: Set neither `buffer1` nor `buffer2` to instruct Slint to allocate
  *                           a buffer (with MALLOC_CAP_INTERNAL) big enough to hold one line,
- *                           render into it, and send it to the display. This is an experimental
- *                           feature that requires enabling the `SLINT_FEATURE_EXPERIMENTAL` CMake
- *                           option.
+ *                           render into it, and send it to the display.
  *
  *  Use single-buffering if you can allocate a buffer in a memory region that allows the esp_lcd
  *  driver to efficiently transfer to the display. Use double-buffering if your driver supports

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -49,13 +49,6 @@ struct EspPlatform : public slint::platform::Platform
           byte_swap(config.byte_swap),
           rotation(config.rotation)
     {
-#if !defined(SLINT_FEATURE_EXPERIMENTAL)
-        if (!buffer1 && !buffer2) {
-            ESP_LOGI(TAG,
-                     "FATAL: Line-by-line rendering requested for use with slint-esp is "
-                     "experimental and not enabled in this build.");
-        }
-#endif
     }
 
     std::unique_ptr<slint::platform::WindowAdapter> create_window_adapter() override;
@@ -268,7 +261,6 @@ void EspPlatform<PixelType>::run_event_loop()
                             }
                         }
                     }
-#ifdef SLINT_FEATURE_EXPERIMENTAL
                 } else {
                     std::unique_ptr<PixelType, void (*)(void *)> lb(
                             static_cast<PixelType *>(heap_caps_malloc(
@@ -288,7 +280,6 @@ void EspPlatform<PixelType>::run_event_loop()
                                 esp_lcd_panel_draw_bitmap(panel_handle, line_start, line_y,
                                                           line_end, line_y + 1, lb.get());
                             });
-#endif
                 }
             }
 

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -693,7 +693,6 @@ public:
         return PhysicalRegion { r };
     }
 
-#    ifdef SLINT_FEATURE_EXPERIMENTAL
     /// Render the window scene, line by line. The provided Callback will be invoked for each line
     /// that needs to rendered.
     ///
@@ -740,7 +739,6 @@ public:
                           "Unsupported PixelType. It must be either Rgba8Pixel or Rgb565Pixel");
         }
     }
-#    endif
 
     /// This enum describes the rotation that is applied to the buffer when rendering.
     /// To be used in set_rendering_rotation()

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -403,7 +403,6 @@ mod software_renderer {
         renderer.render(buffer, pixel_stride)
     }
 
-    #[cfg(feature = "experimental")]
     struct LineByLineProcessor<TargetPixel> {
         process_line_fn: extern "C" fn(
             *mut core::ffi::c_void,
@@ -416,7 +415,6 @@ mod software_renderer {
         user_data: *mut core::ffi::c_void,
     }
 
-    #[cfg(feature = "experimental")]
     impl<TargetPixel: i_slint_core::software_renderer::TargetPixel>
         i_slint_core::software_renderer::LineBufferProvider for LineByLineProcessor<TargetPixel>
     {
@@ -431,7 +429,6 @@ mod software_renderer {
         }
     }
 
-    #[cfg(feature = "experimental")]
     impl<TargetPixel> LineByLineProcessor<TargetPixel> {
         fn cpp_process_line<RenderFn: FnOnce(&mut [TargetPixel])>(
             &mut self,
@@ -467,7 +464,6 @@ mod software_renderer {
         }
     }
 
-    #[cfg(feature = "experimental")]
     #[no_mangle]
     pub unsafe extern "C" fn slint_software_renderer_render_by_line_rgb565(
         r: SoftwareRendererOpaque,
@@ -486,7 +482,6 @@ mod software_renderer {
         renderer.render_by_line(processor)
     }
 
-    #[cfg(feature = "experimental")]
     #[no_mangle]
     pub unsafe extern "C" fn slint_software_renderer_render_by_line_rgb8(
         r: SoftwareRendererOpaque,


### PR DESCRIPTION
Fixes https://github.com/slint-ui/slint/issues/7505

ChangeLog: C++: Added `SoftwareRenderer::render_by_line`.
