### PR TITLE
Node.js: Avoid running epoll() in the wayland event loop when pumping…

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -278,7 +278,7 @@ pub struct EventLoopState {
     current_resize_direction: Option<ResizeDirection>,
 
     /// Set to true when pumping events for the shortest amount of time possible.
-    quit_loop_asap: bool,
+    pumping_events_instantly: bool,
 }
 
 impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
@@ -611,7 +611,7 @@ impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
             }
         }
 
-        if self.quit_loop_asap {
+        if self.pumping_events_instantly {
             event_loop.set_control_flow(ControlFlow::Poll);
         }
     }
@@ -773,12 +773,12 @@ impl EventLoopState {
 
         let mut winit_loop = not_running_loop_instance.instance;
 
-        self.quit_loop_asap = timeout.is_some_and(|duration| duration.is_zero());
+        self.pumping_events_instantly = timeout.is_some_and(|duration| duration.is_zero());
 
         let result = winit_loop
             .pump_app_events(timeout, &mut ActiveEventLoopSetterDuringEventProcessing(&mut self));
 
-        self.quit_loop_asap = false;
+        self.pumping_events_instantly = false;
 
         *GLOBAL_PROXY.get_or_init(Default::default).lock().unwrap() = Default::default();
 

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -773,7 +773,7 @@ impl EventLoopState {
 
         let mut winit_loop = not_running_loop_instance.instance;
 
-        self.quit_loop_asap = timeout.map_or(false, |duration| duration.is_zero());
+        self.quit_loop_asap = timeout.is_some_and(|duration| duration.is_zero());
 
         let result = winit_loop
             .pump_app_events(timeout, &mut ActiveEventLoopSetterDuringEventProcessing(&mut self));


### PR DESCRIPTION
… events for the shortest amount of time

Work around pump_events() with `Some(std::time::Duration::ZERO)` still entering `epoll` and thus not returning, preventing us from processing node events.

cc  #7657

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
