### PR TITLE
figma-plugin: Render properties for Figma 'FrameNodes'

### DIFF
--- a/tools/figma-inspector/backend/utils/property-parsing.ts
+++ b/tools/figma-inspector/backend/utils/property-parsing.ts
@@ -204,8 +204,7 @@ export function generateSlintSnippet(sceneNode: SceneNode): string | null {
 
     switch (nodeType) {
         case "FRAME": {
-            // Not handled. It's a type of layout node in Figma.
-            break;
+            return generateRectangleSnippet(sceneNode);
         }
         case "RECTANGLE": {
             return generateRectangleSnippet(sceneNode);

--- a/tools/figma-inspector/figma.config.ts
+++ b/tools/figma-inspector/figma.config.ts
@@ -6,7 +6,7 @@ import { version } from "./package.json";
 
 export const manifest: PluginManifest = {
     name: "Figma to Slint",
-    id: "slint.figma.plugin",
+    id: "1474418299182276871",
     api: "1.0.0",
     main: "code.js",
     ui: "index.html",

--- a/tools/figma-inspector/tests/property-parsing.test.ts
+++ b/tools/figma-inspector/tests/property-parsing.test.ts
@@ -129,12 +129,6 @@ test("Multiple border radius", () => {
     expect(snippet).toBe(expectedSnippet);
 });
 
-test("FRAME node", () => {
-    const jsonNode = findNodeById(testJson, testFrameNode);
-    expect(jsonNode).not.toBeNull();
-    const snippet = generateSlintSnippet(jsonNode);
-    expect(snippet).toBe(null);
-});
 
 test("Border width and color", () => {
     const jsonNode = findNodeById(testJson, testBorderWidthColor);

--- a/tools/figma-inspector/tests/property-parsing.test.ts
+++ b/tools/figma-inspector/tests/property-parsing.test.ts
@@ -129,7 +129,6 @@ test("Multiple border radius", () => {
     expect(snippet).toBe(expectedSnippet);
 });
 
-
 test("Border width and color", () => {
     const jsonNode = findNodeById(testJson, testBorderWidthColor);
     expect(jsonNode).not.toBeNull();


### PR DESCRIPTION
Frames can be converted as if they are Rectangles.

This also adds a unique ID so the plugin can be plublished.