### PR TITLE
Mark all format-like macros for Clippy

### DIFF
--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -131,6 +131,7 @@ pub fn print_to_console(env: Env, function: &str, arguments: core::fmt::Argument
 }
 
 #[macro_export]
+#[clippy::format_args]
 macro_rules! console_err {
     ($env:expr, $($t:tt)*) => ($crate::print_to_console($env, "error", format_args!($($t)*)))
 }

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -19,6 +19,7 @@ use core::ops::Deref;
 /// assert_eq!(s, slint::SharedString::from("Hello world"));
 /// ```
 #[macro_export]
+#[clippy::format_args]
 macro_rules! format {
     ($($arg:tt)*) => {{
         $crate::string::format(core::format_args!($($arg)*))

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -117,9 +117,10 @@ pub fn default_debug_log(_arguments: core::fmt::Arguments) {
     }
 }
 
-#[macro_export]
 /// This macro allows producing debug output that will appear on stderr in regular builds
 /// and in the console log for wasm builds.
+#[macro_export]
+#[clippy::format_args]
 macro_rules! debug_log {
     ($($t:tt)*) => ($crate::tests::debug_log_impl(format_args!($($t)*)))
 }


### PR DESCRIPTION
Allows Clippy to lint format-like usage of non-standard macros

See https://doc.rust-lang.org/nightly/clippy/attribs.html#clippyformat_args
