### PR TITLE
Don't enable image-default-formats by default, remove compat-1-10 feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,7 @@ All notable changes to this project are documented in this file.
 ### Rust
 
  - Upgraded image crate to 0.25, added a new cargo feature
-   to enable all image formats. This feature is enabled by default with
-   `compat-1-2`. Use `compat-1-10` to disable it.
+   to enable all image formats.
  - Ignore pedantic and nursery clippy warnings in generated code.
  - Fixed edition 2024 warnings in generated code.
  - Fixed `Sync` and `Send` bounds on `SharedVector`, `SharedString`, and `Weak`.

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -55,7 +55,7 @@ i-slint-backend-selector = { workspace = true, optional = true }
 i-slint-backend-testing = { workspace = true, optional = true, features = ["ffi"] }
 i-slint-renderer-skia = {  workspace = true, features = ["default", "x11", "wayland"], optional = true }
 i-slint-core = { workspace = true, features = ["ffi"] }
-slint-interpreter = { workspace = true, features = ["ffi", "compat-1-10"], optional = true }
+slint-interpreter = { workspace = true, features = ["ffi", "compat-1-2"], optional = true }
 raw-window-handle = { version = "0.6", optional = true }
 
 esp-backtrace = { version = "0.14.0", features = ["panic-handler", "println"], optional = true }

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -25,18 +25,16 @@ default = [
   "backend-default",
   "renderer-femtovg",
   "renderer-software",
-  "image-default-formats",
   "accessibility",
-  "compat-1-10",
+  "compat-1-2",
 ]
 
 ## Mandatory feature:
-## This feature is required to keep the compatibility with Slint 1.10
+## This feature is required to keep the compatibility with Slint 12
 ## Newer patch version may put current functionality behind a new feature
 ## that would be enabled by default only if this feature was added.
 ## [More info in this blog post](https://slint.dev/blog/rust-adding-default-cargo-feature.html)
-"compat-1-10" = []
-"compat-1-2" = ["compat-1-10", "image-default-formats"]
+"compat-1-2" = []
 "compat-1-0" = ["compat-1-2", "renderer-software"]
 
 ## Enable use of the Rust standard library.

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -30,7 +30,7 @@ default = [
 ]
 
 ## Mandatory feature:
-## This feature is required to keep the compatibility with Slint 12
+## This feature is required to keep the compatibility with Slint 1.2
 ## Newer patch version may put current functionality behind a new feature
 ## that would be enabled by default only if this feature was added.
 ## [More info in this blog post](https://slint.dev/blog/rust-adding-default-cargo-feature.html)

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -202,9 +202,9 @@ each instance will have their own instance of associated globals singletons.
 
 extern crate alloc;
 
-#[cfg(not(feature = "compat-1-10"))]
+#[cfg(not(feature = "compat-1-2"))]
 compile_error!(
-    "The feature `compat-1-10` must be enabled to ensure \
+    "The feature `compat-1-2` must be enabled to ensure \
     forward compatibility with future version of this crate"
 );
 

--- a/api/rs/slint/mcu.md
+++ b/api/rs/slint/mcu.md
@@ -29,7 +29,7 @@ Start by adding a dependency to the `slint` and the `slint-build` crates to your
 Start with the `slint` crate like this:
 
 ```sh
-cargo add slint@1.10.0 --no-default-features --features "compat-1-10 unsafe-single-threaded libm renderer-software"
+cargo add slint@1.10.0 --no-default-features --features "compat-1-2 unsafe-single-threaded libm renderer-software"
 ```
 
 The default features of the `slint` crate are tailored towards hosted environments and includes the "std" feature. In bare metal environments,
@@ -37,7 +37,7 @@ you need to disable the default features.
 
 In the snippet above, three features are selected:
 
- * `compat-1-10`: We select this feature when disabling the default features. For a detailed explanation see our blog post ["Adding default cargo features without breaking Semantic Versioning"](https://slint.dev/blog/rust-adding-default-cargo-feature.html).
+ * `compat-1-2`: We select this feature when disabling the default features. For a detailed explanation see our blog post ["Adding default cargo features without breaking Semantic Versioning"](https://slint.dev/blog/rust-adding-default-cargo-feature.html).
  * `unsafe-single-threaded`: Slint internally uses Rust's [`thread_local!`](https://doc.rust-lang.org/std/macro.thread_local.html) macro to store global data.
    This macro is only available in the Rust Standard Library (std), but not in bare metal environments. As a fallback, the `unsafe-single-threaded`
    feature changes Slint to use unsafe static for storage. This way, you guarantee to use Slint API only from a single thread, and not from interrupt handlers.
@@ -70,7 +70,7 @@ edition = "2021"
 [dependencies.slint]
 version = "1.10.0"
 default-features = false
-features = ["compat-1-10", "unsafe-single-threaded", "libm", "renderer-software"]
+features = ["compat-1-2", "unsafe-single-threaded", "libm", "renderer-software"]
 [build-dependencies]
 slint-build = "1.10.0"
 ```

--- a/api/wasm-interpreter/Cargo.toml
+++ b/api/wasm-interpreter/Cargo.toml
@@ -17,7 +17,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-slint-interpreter = { workspace = true, features = ["std", "backend-winit", "renderer-femtovg", "compat-1-10", "internal"] }
+slint-interpreter = { workspace = true, features = ["std", "backend-winit", "renderer-femtovg", "compat-1-2", "internal"] }
 send_wrapper = { workspace = true }
 
 vtable = { workspace = true }

--- a/demos/energy-monitor/Cargo.toml
+++ b/demos/energy-monitor/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-10"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
 mcu-board-support = { path = "../../examples/mcu-board-support", optional = true }
 chrono = { version = "0.4.34", optional = true, default-features = false, features = ["clock", "std", "wasmbind"] }
 weer_api = { version = "0.1", optional = true }

--- a/demos/printerdemo_mcu/Cargo.toml
+++ b/demos/printerdemo_mcu/Cargo.toml
@@ -19,7 +19,7 @@ simulator = ["slint/renderer-software", "slint/backend-winit", "slint/std"]
 default = ["simulator"]
 
 [dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-10"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
 mcu-board-support = { path = "../../examples/mcu-board-support" }
 
 [build-dependencies]

--- a/examples/carousel/rust/Cargo.toml
+++ b/examples/carousel/rust/Cargo.toml
@@ -15,7 +15,7 @@ path = "main.rs"
 name = "carousel"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-10"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
 mcu-board-support = { path = "../../mcu-board-support", optional = true }
 
 [build-dependencies]

--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -25,7 +25,7 @@ esp32-s2-kaluga-1 = ["slint/unsafe-single-threaded", "esp-hal/esp32s2", "embedde
 esp32-s3-box = ["slint/unsafe-single-threaded", "esp-hal/esp32s3", "embedded-hal", "embedded-hal-bus", "esp-alloc", "esp-println/esp32s3", "esp-backtrace/esp32s3", "dep:mipidsi", "embedded-graphics-core", "slint/libm", "tt21100"]
 
 [dependencies]
-slint = { version = "=1.10.0", path = "../../api/rs/slint", default-features = false, features = ["compat-1-10", "renderer-software"] }
+slint = { version = "=1.10.0", path = "../../api/rs/slint", default-features = false, features = ["compat-1-2", "renderer-software"] }
 i-slint-core-macros = { version = "=1.10.0", path = "../../internal/core-macros" }
 
 derive_more = { workspace = true }

--- a/examples/uefi-demo/Cargo.toml
+++ b/examples/uefi-demo/Cargo.toml
@@ -18,7 +18,7 @@ uefi = { version = "0.33", features = ["panic_handler", "global_allocator"] }
 minipng = "=0.1.1"
 
 slint = { path = "../../api/rs/slint", default-features = false, features = [
-    "compat-1-10",
+    "compat-1-2",
     "renderer-software",
     "libm",
     "log",

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -37,6 +37,6 @@ image = { workspace = true, optional = true, features = ["png"] }
 pb-rs = { version = "0.10.0", optional = true, default-features = false }
 
 [dev-dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-10"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }
 i-slint-core-macros = { path = "../../core-macros" }
 i-slint-common = { path = "../../common" }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -84,7 +84,7 @@ objc2-app-kit = { version = "0.3.0" }
 cfg_aliases = { workspace = true }
 
 [dev-dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-10", "backend-winit", "renderer-software", "raw-window-handle-06"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "backend-winit", "renderer-software", "raw-window-handle-06"] }
 
 [package.metadata.docs.rs]
 features = ["wayland", "renderer-software", "raw-window-handle-06"]

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -108,7 +108,7 @@ web-sys = { workspace = true, features = [ "HtmlImageElement" ] }
 fontdb = { workspace = true, optional = true, default-features = true }
 
 [dev-dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-10"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2"] }
 i-slint-backend-testing = { path="../backends/testing" }
 rustybuzz = { workspace = true }
 ttf-parser = { workspace = true }

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -20,14 +20,13 @@ path = "lib.rs"
 
 [features]
 
-default = ["backend-default", "renderer-femtovg", "renderer-software", "accessibility", "image-default-formats", "compat-1-10"]
+default = ["backend-default", "renderer-femtovg", "renderer-software", "accessibility", "compat-1-2"]
 
 ## Mandatory feature:
-## This feature is required to keep the compatibility with Slint 1.10
+## This feature is required to keep the compatibility with Slint 1.2
 ## Newer patch version may put current functionality behind a new feature
 ## that would be enabled by default only if this feature was added
-"compat-1-10" = []
-"compat-1-2" = ["compat-1-10", "image-default-formats"]
+"compat-1-2" = []
 "compat-1-0" = ["compat-1-2"]
 
 ## enable the [`print_diagnostics`] function to show diagnostic in the console output

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -72,9 +72,9 @@ instance.run().unwrap();
 #![warn(missing_docs)]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 
-#[cfg(not(feature = "compat-1-10"))]
+#[cfg(not(feature = "compat-1-2"))]
 compile_error!(
-    "The feature `compat-1-10` must be enabled to ensure \
+    "The feature `compat-1-2` must be enabled to ensure \
     forward compatibility with future version of this crate"
 );
 

--- a/tests/driver/interpreter/Cargo.toml
+++ b/tests/driver/interpreter/Cargo.toml
@@ -18,7 +18,7 @@ path = "main.rs"
 name = "test-driver-interpreter"
 
 [dev-dependencies]
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-10"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2"] }
 i-slint-backend-testing = { workspace = true }
 
 itertools = { workspace = true }

--- a/tests/driver/rust/Cargo.toml
+++ b/tests/driver/rust/Cargo.toml
@@ -23,7 +23,7 @@ build-time = ["i-slint-compiler", "spin_on"]
 [dependencies]
 slint = { workspace = true, features = ["std", "compat-1-2"] }
 i-slint-backend-testing = { workspace = true, features = ["internal"] }
-slint-interpreter = { workspace = true, features = ["std", "compat-1-10", "internal"] }
+slint-interpreter = { workspace = true, features = ["std", "compat-1-2", "internal"] }
 spin_on = { workspace = true }
 
 [build-dependencies]

--- a/tests/screenshots/Cargo.toml
+++ b/tests/screenshots/Cargo.toml
@@ -18,7 +18,7 @@ path = "main.rs"
 name = "test-driver-screenshot"
 
 [dependencies]
-slint = { workspace = true, features = ["std", "compat-1-10"] }
+slint = { workspace = true, features = ["std", "compat-1-2"] }
 i-slint-core = { workspace = true, features = ["default", "software-renderer"] }
 i-slint-backend-testing = { workspace = true }
 image = { workspace = true }

--- a/tools/docsnapper/Cargo.toml
+++ b/tools/docsnapper/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["viewer", "gui", "ui", "toolkit"]
 [dependencies]
 i-slint-compiler = { workspace = true }
 i-slint-core = { workspace = true }
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-10", "internal", "accessibility"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility"] }
 i-slint-renderer-skia = { workspace = true, features = ["default", "wayland"] }
 
 clap = { workspace = true }

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -92,8 +92,8 @@ smol_str = { workspace = true }
 # for the preview-engine feature
 i-slint-backend-selector = { workspace = true, optional = true }
 i-slint-core = { workspace = true, features = ["std"], optional = true }
-slint = { workspace = true, features = ["compat-1-10"], optional = true }
-slint-interpreter = { workspace = true, features = ["compat-1-10", "internal", "internal-highlight", "internal-json", "image-default-formats"], optional = true  }
+slint = { workspace = true, features = ["compat-1-2"], optional = true }
+slint-interpreter = { workspace = true, features = ["compat-1-2", "internal", "internal-highlight", "internal-json", "image-default-formats"], optional = true  }
 
 [target.'cfg(not(any(target_env = "msvc", target_arch = "wasm32")))'.dependencies]
 tikv-jemallocator = { workspace = true }

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -53,7 +53,7 @@ default = ["backend-default", "renderer-femtovg", "renderer-software"]
 [dependencies]
 i-slint-compiler = { workspace = true }
 i-slint-core = { workspace = true }
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-10", "internal", "accessibility", "image-default-formats", "internal-json"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility", "image-default-formats", "internal-json"] }
 i-slint-backend-selector = { workspace = true }
 
 clap = { workspace = true }


### PR DESCRIPTION
We decided that the compatibility with people having enabled the extra format in image 0.24 [1] is not worth it compared to the extra compilation time most people gets by default when they don't need this feature. (Which is less than 10% slower when the feature is enabled)

Since then there is no need for compat-1-10, remove it

[1] by depending directly on image 0.24 in their Cargo.toml and enabling the features, which will not work with Slint 1.10 that now use image 0.25
