### PR TITLE
Fix VSCE build

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -26,6 +26,7 @@ path = [
   "**/.eslintrc.yml",
   "**/.gitignore",
   "**/.npmignore",
+  "**/.vscodeignore",
   ".dockerignore",
   ".gitattributes",
   ".gitignore",

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,6 @@
+**/*.ts
+**/tsconfig.json
+tsconfig.default.json
+tests/
+.vscode/
+bin/*.d

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -203,9 +203,6 @@
       }
     ]
   },
-  "files": [
-    "bin/slint-lsp-*"
-  ],
   "scripts": {
     "vscode:prepublish": "pnpm build:wasm_lsp-release && pnpm compile-production && shx echo \"GPL-3.0-only OR LicenseRef-Slint-Software-3.0\" > LICENSE.txt",
     "build:lsp": "cargo build -p slint-lsp",
@@ -214,7 +211,7 @@
     "build:wasm_lsp-release": "shx pwd | xargs -I {} wasm-pack build --release --target web --no-pack ../../tools/lsp --out-dir {}/out -- --no-default-features --features backend-winit,renderer-femtovg,preview",
     "compile": "node ./esbuild.js",
     "compile-production": "node ./esbuild.js --production",
-    "local-package": "shx mkdir -p bin && shx cp ../../target/debug/slint-lsp* bin/ && pnpm dlx vsce package --no-dependencies",
+    "local-package": "shx mkdir -p bin && shx cp ../../target/debug/slint-lsp* bin/ && pnpm dlx @vscode/vsce package --no-dependencies",
     "watch": "tsc -watch -p ./",
     "pretest": "pnpm compile && pnpm check",
     "check": "biome check",

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -489,6 +489,7 @@ lazy_static! {
         ("\\.css$", LicenseLocation::NoLicense),
         ("\\.gitattributes$", LicenseLocation::NoLicense),
         ("\\.gitignore$", LicenseLocation::NoLicense),
+        ("\\.vscodeignore$", LicenseLocation::NoLicense),
         ("\\.dockerignore$", LicenseLocation::NoLicense),
         ("\\.dockerignore$", LicenseLocation::NoLicense),
         ("\\.prettierignore$", LicenseLocation::NoLicense),


### PR DESCRIPTION
The CI has been using the deprecated vsce package to test .vsix creation, while it was renamed to @vscode/vsce a while ago. Last night, the vsce publish action we're using switched to @vscode/vsce and now the vsce build is failing, because of a bug that was hidden:

In vsce 2.25 support for `files` in `package.json` was introduced, which was just `bin/slint-lsp-*` in our package. That would omit the extension entry point and many other files, causing the vsce package creation step to fail.

Fix this by fixing the CI to use the same vsce version as the action is using, and replace the files with the default and the ignore setting of files we definitely want to exclude from the package.

With this, the package now contains these files:

```
slint-1.10.0.vsix
├─ [Content_Types].xml
├─ extension.vsixmanifest
└─ extension/
   ├─ .gitignore [0.03 KB]
   ├─ LICENSE.txt [0.04 KB]
   ├─ biome.json [0.2 KB]
   ├─ esbuild.js [2.22 KB]
   ├─ extension-logo.png [6.76 KB]
   ├─ language-configuration.json [1.49 KB]
   ├─ package.json [7.93 KB]
   ├─ readme.md [3.85 KB]
   ├─ slint-file-icon.svg [0.83 KB]
   ├─ slint.injection.json [1.61 KB]
   ├─ slint.markdown-injection.json [1.37 KB]
   ├─ slint.tmLanguage.json [8.79 KB]
   ├─ telemetry.json [2.21 KB]
   ├─ bin/
   │  └─ slint-lsp [82.21 MB]
   ├─ out/
   │  ├─ .gitignore [0 KB]
   │  ├─ browser.js [321.26 KB]
   │  ├─ browser.js.map [406.49 KB]
   │  ├─ browserServerMain.js [18.27 MB]
   │  ├─ browserServerMain.js.map [255.8 KB]
   │  ├─ extension.js [457.78 KB]
   │  ├─ extension.js.map [617.27 KB]
   │  ├─ slint_lsp_wasm.js [84.62 KB]
   │  └─ slint_lsp_wasm_bg.wasm [13.56 MB]
   ├─ snippets/
   │  └─ slint.json [0.53 KB]
   └─ static/
      └─ walkthroughs/
         └─ welcome/ (4 files) [17.1 KB]
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
