### PR TITLE
Fix panic when inlining into clip during the second phase of inlining

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -514,6 +514,9 @@ jobs:
                             --skip test_interpreter_models_assign_equal_model \
                             --skip example_carousel \
                             --skip example_fancy_demo \
+                            --skip example_dial \
+                            --skip example_fancy_switches \
+                            --skip example_sprite_sheet \
                             --skip test_interpreter_elements_path_fit \
                             --skip test_interpreter_layout_path \
                             --skip test_interpreter_7guis_booker \

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -131,14 +131,16 @@ fn inline_element(
             let children = std::mem::take(&mut elem_mut.children);
             let old_count = children.len();
             if let Some(insertion_element) = mapping.get(&element_key(insertion_element.clone())) {
-                if !Rc::ptr_eq(elem, insertion_element) {
-                    debug_assert!(std::rc::Weak::ptr_eq(
-                        &insertion_element.borrow().enclosing_component,
-                        &elem_mut.enclosing_component,
-                    ));
-                    insertion_element.borrow_mut().children.splice(index..index, children);
-                } else {
-                    new_children.splice(index..index, children);
+                if old_count > 0 {
+                    if !Rc::ptr_eq(elem, insertion_element) {
+                        debug_assert!(std::rc::Weak::ptr_eq(
+                            &insertion_element.borrow().enclosing_component,
+                            &elem_mut.enclosing_component,
+                        ));
+                        insertion_element.borrow_mut().children.splice(index..index, children);
+                    } else {
+                        new_children.splice(index..index, children);
+                    }
                 }
                 let mut cip = root_component.child_insertion_point.borrow_mut();
                 if let Some(cip) = cip.as_mut() {

--- a/tests/cases/children/children_in_clip.slint
+++ b/tests/cases/children/children_in_clip.slint
@@ -1,0 +1,23 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// TestCase from #7724
+// compilation shouldn't panic
+
+component Hallo {
+    inner := Rectangle {
+        clip: true;
+        @children
+        Rectangle {}
+    }
+}
+
+component World inherits Hallo {
+    Rectangle {}
+    Rectangle {}
+    Rectangle {}
+}
+
+export component Demo {
+    World { }
+}

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -149,6 +149,37 @@ assert_eq!(instance.get_offset_x(), 0.);
 assert_eq!(instance.get_offset_y(), 0.);
 
 instance.set_clicked(-1);
+// - Same but over a longer period (long press) so it should be pressed
+
+// Start a press
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(165.0, 175.0), button: PointerEventButton::Left });
+assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), -1);
+// make a small move
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(166.0, 174.0) });
+assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+slint_testing::mock_elapsed_time(30);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(167.0, 175.0) });
+assert!(!instance.get_inner_ta_pressed());
+slint_testing::mock_elapsed_time(300);
+assert!(instance.get_inner_ta_pressed(), "now we should be marked as pressed");
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(166.0, 175.0) });
+assert!(instance.get_inner_ta_pressed(), "still pressed");
+slint_testing::mock_elapsed_time(30);
+assert!(instance.get_inner_ta_pressed(), "still pressed");
+// and release
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(167.0, 174.0), button: PointerEventButton::Left });
+assert!(!instance.get_inner_ta_pressed());
+assert!(instance.get_inner_ta_has_hover());
+assert_eq!(instance.get_clicked(), 7_00014);
+assert_eq!(instance.get_double_clicked(), 7_00014);
+assert_eq!(instance.get_offset_x(), 0.);
+assert_eq!(instance.get_offset_y(), 0.);
+
+instance.set_double_clicked(0);
+instance.set_clicked(-1);
 
 // Start a press
 instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(175.0, 175.0), button: PointerEventButton::Left });

--- a/tests/driver/interpreter/main.rs
+++ b/tests/driver/interpreter/main.rs
@@ -40,6 +40,12 @@ test_example!(example_fancy_demo, "examples/fancy_demo/main.slint");
 test_example!(example_bash_sysinfo, "examples/bash/sysinfo.slint");
 test_example!(example_carousel, "examples/carousel/ui/carousel_demo.slint");
 test_example!(example_iot_dashboard, "examples/iot-dashboard/main.slint");
+test_example!(example_dial, "examples/dial/dial.slint");
+test_example!(example_sprite_sheet, "examples/sprite-sheet/demo.slint");
+test_example!(example_fancy_switches, "examples/fancy-switches/demo.slint");
+test_example!(example_home_automation, "demos/home-automation/ui/demo.slint");
+test_example!(example_energy_monitor, "demos/energy-monitor/ui/desktop_window.slint");
+test_example!(example_weather, "demos/weather-demo/ui/main.slint");
 
 fn main() {
     println!("Nothing to see here, please run me through cargo test :)");


### PR DESCRIPTION
During the second phase, anything that involve `@children` should already
have been processed, so there shouldn't be anything left to inline.
But the children insertion point may be pointing to the wrong location
if some items were moved around (eg because of the `clip`).
So work it around by not accessing the children array at that indax that
might be out of range.

Fixes https://github.com/slint-ui/slint/issues/7724