### PR TITLE
live-preview: "Fix" types with units

### DIFF
--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -901,29 +901,46 @@ fn map_value_and_type(
                 kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 value_string: format!("{}{}", get_value::<f32>(value), Unit::Ms).into(),
-                visual_items: unit_model(&[Unit::S, Unit::Ms]),
+                visual_items: unit_model(&[Unit::Ms]),
                 value_int: 0,
                 code: get_code(value),
                 default_selection: 1,
                 ..Default::default()
             });
         }
-        Type::PhysicalLength | Type::LogicalLength | Type::Rem => {
-            // TODO: Is this correct? That unit is the Value anyway?!
+        Type::PhysicalLength => {
+            mapping.header.push(mapping.name_prefix.clone());
+            mapping.current_values.push(PropertyValue {
+                kind: PropertyValueKind::Float,
+                value_float: get_value::<f32>(value),
+                value_string: format!("{}{}", get_value::<f32>(value), Unit::Phx).into(),
+                visual_items: unit_model(&[Unit::Phx]),
+                value_int: 0,
+                code: get_code(value),
+                default_selection: 0,
+                ..Default::default()
+            });
+        }
+        Type::LogicalLength => {
             mapping.header.push(mapping.name_prefix.clone());
             mapping.current_values.push(PropertyValue {
                 kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 value_string: format!("{}{}", get_value::<f32>(value), Unit::Px).into(),
-                visual_items: unit_model(&[
-                    Unit::Px,
-                    Unit::Cm,
-                    Unit::Mm,
-                    Unit::In,
-                    Unit::Pt,
-                    Unit::Phx,
-                    Unit::Rem,
-                ]),
+                visual_items: unit_model(&[Unit::Px]),
+                value_int: 0,
+                code: get_code(value),
+                default_selection: 0,
+                ..Default::default()
+            });
+        }
+        Type::Rem => {
+            mapping.header.push(mapping.name_prefix.clone());
+            mapping.current_values.push(PropertyValue {
+                kind: PropertyValueKind::Float,
+                value_float: get_value::<f32>(value),
+                value_string: format!("{}{}", get_value::<f32>(value), Unit::Rem).into(),
+                visual_items: unit_model(&[Unit::Rem]),
                 value_int: 0,
                 code: get_code(value),
                 default_selection: 0,
@@ -936,7 +953,7 @@ fn map_value_and_type(
                 kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 value_string: format!("{}{}", get_value::<f32>(value), Unit::Deg).into(),
-                visual_items: unit_model(&[Unit::Deg, Unit::Grad, Unit::Turn, Unit::Rad]),
+                visual_items: unit_model(&[Unit::Deg]),
                 value_int: 0,
                 code: get_code(value),
                 default_selection: 0,
@@ -1942,7 +1959,7 @@ export component Tester {{
     }
 
     #[test]
-    fn test_map_preview_data_length() {
+    fn test_map_preview_data_length_px() {
         validate_rp(
             "in",
             "",
@@ -1959,16 +1976,31 @@ export component Tester {{
                 kind: super::PropertyValueKind::Float,
                 value_float: 100.0,
                 value_string: "100px".into(),
-                visual_items: std::rc::Rc::new(slint::VecModel::from(vec![
-                    "px".into(),
-                    "cm".into(),
-                    "mm".into(),
-                    "in".into(),
-                    "pt".into(),
-                    "phx".into(),
-                    "rem".into(),
-                ]))
-                .into(),
+                visual_items: std::rc::Rc::new(slint::VecModel::from(vec!["px".into()])).into(),
+                ..Default::default()
+            },
+        );
+    }
+
+    #[test]
+    fn test_map_preview_data_length_cm() {
+        validate_rp(
+            "in",
+            "",
+            "length",
+            "10cm",
+            super::PreviewData {
+                name: "test".into(),
+                has_setter: true,
+                kind: super::PreviewDataKind::Value,
+                ..Default::default()
+            },
+            super::PropertyValue {
+                code: "378".into(),
+                kind: super::PropertyValueKind::Float,
+                value_float: 378.0,
+                value_string: "378px".into(),
+                visual_items: std::rc::Rc::new(slint::VecModel::from(vec!["px".into()])).into(),
                 ..Default::default()
             },
         );
@@ -1992,11 +2024,7 @@ export component Tester {{
                 kind: super::PropertyValueKind::Float,
                 value_float: 100000.0,
                 value_string: "100000ms".into(),
-                visual_items: std::rc::Rc::new(slint::VecModel::from(vec![
-                    "s".into(),
-                    "ms".into(),
-                ]))
-                .into(),
+                visual_items: std::rc::Rc::new(slint::VecModel::from(vec!["ms".into()])).into(),
                 default_selection: 1,
                 ..Default::default()
             },
@@ -2021,13 +2049,7 @@ export component Tester {{
                 kind: super::PropertyValueKind::Float,
                 value_float: 36000.0,
                 value_string: "36000deg".into(),
-                visual_items: std::rc::Rc::new(slint::VecModel::from(vec![
-                    "deg".into(),
-                    "grad".into(),
-                    "turn".into(),
-                    "rad".into(),
-                ]))
-                .into(),
+                visual_items: std::rc::Rc::new(slint::VecModel::from(vec!["deg".into()])).into(),
                 ..Default::default()
             },
         );

--- a/tools/lsp/ui/components/property-widgets.slint
+++ b/tools/lsp/ui/components/property-widgets.slint
@@ -229,8 +229,8 @@ component FloatWidget inherits VerticalLayout {
     in property <string> property-name;
     in property <PropertyValue> property-value;
 
-    pure callback test-float-binding(text: string) -> bool;
-    pure callback set-float-binding(text: string);
+    pure callback test-float-binding(text: string, unit: string) -> bool;
+    pure callback set-float-binding(text: string, unit: string);
 
     private property <string> current-unit;
     private property <PropertyValue> dummy: self.property-value;
@@ -247,11 +247,11 @@ component FloatWidget inherits VerticalLayout {
     }
 
     function set-binding() {
-        root.set-float-binding(number.text == "" ? "" : number.text + self.current-unit);
+        root.set-float-binding(number.text == "" ? "" : number.text, self.current-unit);
     }
 
     function test-binding() -> bool {
-        return root.test-float-binding(number.text == "" ? "" : number.text + self.current-unit);
+        return root.test-float-binding(number.text == "" ? "" : number.text, self.current-unit);
     }
 
     function apply-value() {
@@ -263,6 +263,10 @@ component FloatWidget inherits VerticalLayout {
         if !number.has-focus && self.property-value.kind == PropertyValueKind.float {
             apply-value();
         }
+    }
+
+    init => {
+        apply-value();
     }
 
     spacing: EditorSpaceSettings.default-spacing;
@@ -328,6 +332,7 @@ component FloatWidget inherits VerticalLayout {
             }
             if property-value.visual-items.length == 1: Text {
                 text: property-value.visual-items[0];
+                vertical-alignment: center;
 
                 changed text => {
                     root.current-unit = self.text;
@@ -969,6 +974,8 @@ export component PropertyValueWidget inherits VerticalLayout {
     pure callback set-bool-binding(value: bool);
     pure callback set-color-binding(text: string);
     pure callback test-color-binding(text: string) -> bool;
+    pure callback set-float-binding(text: string, unit: string);
+    pure callback test-float-binding(text: string, unit: string) -> bool;
     pure callback set-code-binding(text: string);
     pure callback test-code-binding(text: string) -> bool;
     pure callback set-string-binding(text: string, is_translated: bool);
@@ -1060,11 +1067,11 @@ export component PropertyValueWidget inherits VerticalLayout {
                 property-name <=> root.property-name;
                 property-value <=> root.property-value;
 
-                test-float-binding(text) => {
-                    return (root.test-code-binding(text));
+                test-float-binding(text, unit) => {
+                    return (root.test-float-binding(text, unit));
                 }
-                set-float-binding(text) => {
-                    root.set-code-binding(text);
+                set-float-binding(text, unit) => {
+                    root.set-float-binding(text, unit);
                 }
             }
         }
@@ -1135,6 +1142,12 @@ export component PropertyInformationWidget inherits VerticalLayout {
         }
         set-enum-binding(text) => {
             self.set-code-binding(text);
+        }
+        test-float-binding(text, unit) => {
+            return (self.test-code-binding(text + unit));
+        }
+        set-float-binding(text, unit) => {
+            self.set-code-binding(text + unit);
         }
 
         set-code-binding(text) => {
@@ -1224,6 +1237,12 @@ export component PreviewDataPropertyValueWidget inherits VerticalLayout {
         }
         test-color-binding(text) => {
             return (root.set-code-binding("\"\{text}\""));
+        }
+        set-float-binding(text, _unit) => {
+            self.set-code-binding("\{text}");
+        }
+        test-float-binding(text, _unit) => {
+            return (root.set-code-binding("\{text}"));
         }
         set-enum-binding(text) => {
             self.set-code-binding("\"\{text}\"");


### PR DESCRIPTION
We have several types that all support a range of units. Internally all those units match back to one "base unit" that the type is measured in.

In the spirit of simplicity: Support only that base unit for now.

We need a more elaborate JSON scheme to pass units around with those numbers :-/
