### PR TITLE
Various doc fixes

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -65,7 +65,9 @@ When your design becomes bigger in terms of markup code, you may want move it to
 /*!Use a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html) to compile
 your main `.slint` file:
 
-In your Cargo.toml add a `build` assignment and use the `slint-build` crate in `build-dependencies`:
+*/
+#![doc = i_slint_core_macros::slint_doc_str!("In your Cargo.toml add a `build` assignment and use the [`slint-build`](slint:rust:slint_build/) crate in `build-dependencies`:")]
+/*
 
 ```toml
 [package]
@@ -352,6 +354,7 @@ pub fn spawn_local<F: core::future::Future + 'static>(
 /// available for you to instantiate.
 ///
 /// Check the documentation of the `slint-build` crate for more information.
+#[doc = i_slint_core_macros::slint_doc_str!("Check the documentation of the [`slint-build`](slint:rust:slint_build/) crate for more information.")]
 #[macro_export]
 macro_rules! include_modules {
     () => {

--- a/docs/astro/src/content/docs/reference/window/menubar.mdx
+++ b/docs/astro/src/content/docs/reference/window/menubar.mdx
@@ -29,9 +29,11 @@ export component Example inherits Window {
             title: @tr("File");
             MenuItem {
                 title: @tr("New");
+                activated => { file-new(); }
             }
             MenuItem {
                 title: @tr("Open");
+                activated => { file-open(); }
             }
         }
         Menu {
@@ -56,6 +58,10 @@ export component Example inherits Window {
             }
         }
     }
+
+    callback file-new();
+    callback file-open();
+
     // ... actual window content goes here
 }
 ```

--- a/docs/astro/src/content/docs/reference/window/menubar.mdx
+++ b/docs/astro/src/content/docs/reference/window/menubar.mdx
@@ -1,0 +1,61 @@
+---
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+title: MenuBar
+description: MenuBar element api.
+---
+import SlintProperty from '/src/components/SlintProperty.astro';
+import Link from '/src/components/Link.astro';
+
+Use the `MenuBar` element in a <Link type="Window" /> to declare the structure of a menu bar, including the actual
+menus and sub-menus.
+
+:::note{Note}
+There can only be one `MenuBar` element in a `Window` and it must not be in a `for` or a `if`.
+:::
+
+The `MenuBar` doesn't have properties, but it must contain <Link type="Menu" /> as children that represent top level entries in the menu bar.
+
+Depending on the platform, the menu bar might be native or rendered by Slint.
+This means that for example, on macOS, the menu bar will be at the top of the screen.
+The `width` and `height` property of the <Link type="Window" /> define the client area, excluding the menu bar.
+The `x` and `y` properties of `Window` children are also relative to the client area.
+
+### Example
+
+```slint
+export component Example inherits Window {
+    MenuBar {
+        Menu {
+            title: @tr("File");
+            MenuItem {
+                title: @tr("New");
+            }
+            MenuItem {
+                title: @tr("Open");
+            }
+        }
+        Menu {
+            title: @tr("Edit");
+            MenuItem {
+                title: @tr("Copy");
+            }
+            MenuItem {
+                title: @tr("Paste");
+            }
+            Menu {
+                title: @tr("Find");
+                MenuItem {
+                    title: @tr("Find in document...");
+                }
+                MenuItem {
+                    title: @tr("Find Next");
+                }
+                MenuItem {
+                    title: @tr("Find Previous");
+                }
+            }
+        }
+    }
+    // ... actual window content goes here
+}
+```

--- a/docs/astro/src/content/docs/reference/window/window.mdx
+++ b/docs/astro/src/content/docs/reference/window/window.mdx
@@ -12,6 +12,8 @@ The `Window` geometry will be restricted by its layout constraints: Setting the 
 and the window manager will respect the `min-width` and `max-width` so the window can't be resized bigger
 or smaller. The initial width can be controlled with the `preferred-width` property. The same applies to the `Window`s height.
 
+Use the <Link type="MenuBar" /> element to declare a menu bar for the window.
+
 ## Properties
 
 ### always-on-top
@@ -58,58 +60,3 @@ Whether the window should be borderless/frameless or not.
 <SlintProperty propName="title" typeName="string">
 The window title that is shown in the title bar.
 </SlintProperty>
-
-## `MenuBar` element
-
-Place a single `MenuBar` element into a `Window` to declare a menu bar for the window.
-
-:::note{Note}
-There can only be one `MenuBar` element in a `Window` and it must not be in a `for` or a `if`.
-:::
-
-The `MenuBar` doesn't have properties, but it must contain <Link type="Menu" /> as children that represent top level entries in the menu bar.
-
-Depending on the platform, the menu bar might be native or rendered by Slint.
-This means that for example, on macOS, the menu bar will be at the top of the screen.
-The `width` and `height` property of the `Window` define the client area, excluding the menu bar.
-The `x` and `y` properties of `Window` children are also relative to the client area.
-
-### Example
-
-```slint
-export component Example inherits Window {
-    MenuBar {
-        Menu {
-            title: @tr("File");
-            MenuItem {
-                title: @tr("New");
-            }
-            MenuItem {
-                title: @tr("Open");
-            }
-        }
-        Menu {
-            title: @tr("Edit");
-            MenuItem {
-                title: @tr("Copy");
-            }
-            MenuItem {
-                title: @tr("Paste");
-            }
-            Menu {
-                title: @tr("Find");
-                MenuItem {
-                    title: @tr("Find in document...");
-                }
-                MenuItem {
-                    title: @tr("Find Next");
-                }
-                MenuItem {
-                    title: @tr("Find Previous");
-                }
-            }
-        }
-    }
-    // ... actual window content goes here
-}
-```

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -93,7 +93,7 @@
         "href": "guide/backends-and-renderers/backend_linuxkms/"
     },
     "MenuBar": {
-        "href": "reference/window/window/#menubar"
+        "href": "reference/window/menubar/"
     },
     "Menu": {
         "href": "reference/window/contextmenuarea/#menu"
@@ -197,5 +197,4 @@
     "index": {
         "href": ""
     }
-
 }


### PR DESCRIPTION
- Separate out `MenuBar` into an item of its own
- Fix missing links to `slint-build` crate.