### PR TITLE
C++: implement the ItemTreeVTable::window_adapter

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1688,11 +1688,11 @@ fn generate_item_tree(
         Declaration::Function(Function {
             name: "window_adapter".into(),
             signature:
-                "([[maybe_unused]] slint::private_api::ItemTreeRef component, [[maybe_unused]] bool do_create, [[maybe_unused]] slint::cbindgen_private::Option<slint::private_api::WindowAdapterRc>* result) -> void"
+                "(slint::private_api::ItemTreeRef component, [[maybe_unused]] bool do_create, slint::cbindgen_private::Option<slint::private_api::WindowAdapterRc>* result) -> void"
                     .into(),
             is_static: true,
             statements: Some(vec![format!(
-                "/* TODO: implement this! */",
+                "*reinterpret_cast<slint::private_api::WindowAdapterRc*>(result) = reinterpret_cast<const {item_tree_class_name}*>(component.instance)->globals->window().window_handle();"
             )]),
             ..Default::default()
         }),

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1451,7 +1451,11 @@ pub mod ffi {
             core::mem::size_of::<Rc<dyn WindowAdapter>>(),
             core::mem::size_of::<WindowAdapterRcOpaque>()
         );
-        core::ptr::read(handle as *mut Rc<dyn WindowAdapter>);
+        assert_eq!(
+            core::mem::size_of::<Option<Rc<dyn WindowAdapter>>>(),
+            core::mem::size_of::<WindowAdapterRcOpaque>()
+        );
+        drop(core::ptr::read(handle as *mut Option<Rc<dyn WindowAdapter>>));
     }
 
     /// Releases the reference to the component window held by handle.


### PR DESCRIPTION
This is required to fix closing popup with the Qt backend, as we use the window_adapter as a hack to get the root window_adapter (as opposed to the popup one)

(That function was only used for the ComponentContainer and was not implemented for C++ before)

Note that this reinterpret a
`Option<slint::private_api::WindowAdapterRc>` to just a `WindowAdapterRc` This is because `Option` is only forward declared in C++ as it is not generaly `#[repr(C)]`,  but we assume (and assert) the usage of a niche.

As reported in https://chat.slint.dev/public/pl/ihnwtdgp7fb75k4aj5ou3p4idc
