### PR TITLE
Implement Property::set_constant in C++

### DIFF
--- a/api/cpp/include/slint_properties.h
+++ b/api/cpp/include/slint_properties.h
@@ -186,6 +186,8 @@ struct Property
 
     const T &get_internal() const { return value; }
 
+    void set_constant() const { cbindgen_private::slint_property_set_constant(&inner); }
+
 private:
     cbindgen_private::PropertyHandleOpaque inner;
     mutable T value {};

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2058,6 +2058,12 @@ fn generate_sub_component(
             handle_property_init(prop, expression, &mut properties_init_code, &ctx)
         }
     }
+    for prop in &component.const_properties {
+        if component.prop_used(prop, root) {
+            let p = access_member(prop, &ctx);
+            properties_init_code.push(format!("{p}.set_constant();"));
+        }
+    }
 
     for item in &component.items {
         target_struct.members.push((

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -153,6 +153,12 @@ pub extern "C" fn slint_property_mark_dirty(handle: &PropertyHandleOpaque) {
     handle.0.mark_dirty()
 }
 
+/// Marks the property as dirty and notifies dependencies.
+#[no_mangle]
+pub extern "C" fn slint_property_set_constant(handle: &PropertyHandleOpaque) {
+    handle.0.set_constant()
+}
+
 /// Destroy handle
 #[no_mangle]
 pub unsafe extern "C" fn slint_property_drop(handle: *mut PropertyHandleOpaque) {


### PR DESCRIPTION
Save some heap allocations for the dependency nodes