### PR TITLE
live-preview: Show why no live data is present

### DIFF
--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -1110,23 +1110,22 @@ pub fn ui_set_preview_data(
         container_name: String,
         container_id: String,
         properties: &[preview_data::PreviewData],
-    ) -> Option<PropertyContainer> {
+    ) -> PropertyContainer {
         let properties =
             properties.iter().filter_map(map_preview_data_property).collect::<Vec<_>>();
 
-        (!properties.is_empty()).then(|| PropertyContainer {
+        PropertyContainer {
             container_name: container_name.into(),
             container_id: container_id.into(),
             properties: Rc::new(slint::VecModel::from(properties)).into(),
-        })
+        }
     }
 
     let mut result: Vec<PropertyContainer> = vec![];
 
     if let Some(main) = preview_data.get(&preview_data::PropertyContainer::Main) {
-        if let Some(c) = fill_container("<MAIN>".to_string(), String::new(), main) {
-            result.push(c)
-        }
+        let c = fill_container("<MAIN>".to_string(), String::new(), main);
+        result.push(c);
     }
 
     for component_key in
@@ -1134,9 +1133,8 @@ pub fn ui_set_preview_data(
     {
         if let Some(component) = preview_data.get(component_key) {
             let component_key = component_key.to_string();
-            if let Some(c) = fill_container(component_key.clone(), component_key, component) {
-                result.push(c);
-            }
+            let c = fill_container(component_key.clone(), component_key, component);
+            result.push(c);
         }
     }
 

--- a/tools/lsp/ui/views/preview-data-view.slint
+++ b/tools/lsp/ui/views/preview-data-view.slint
@@ -40,7 +40,7 @@ export component PreviewDataView inherits ScrollView {
                     width: 100%;
                     horizontal-alignment: center;
 
-                    text: @tr("No \"in\", \"in-out\" or \"out\" property");
+                    text: @tr("No \"in\", \"in-out\", or \"out\" property declared.");
                 }
                 for p in ep.properties: PreviewDataPropertyValueWidget {
                     preview-data: p;

--- a/tools/lsp/ui/views/preview-data-view.slint
+++ b/tools/lsp/ui/views/preview-data-view.slint
@@ -36,13 +36,18 @@ export component PreviewDataView inherits ScrollView {
                 spacing: EditorSpaceSettings.property-spacing;
                 padding: EditorSpaceSettings.default-padding;
 
+                if ep.properties.length == 0 && root.element-loaded: Text {
+                    width: 100%;
+                    horizontal-alignment: center;
+
+                    text: @tr("No \"in\", \"in-out\" or \"out\" property");
+                }
                 for p in ep.properties: PreviewDataPropertyValueWidget {
                     preview-data: p;
                     property-container-id: ep.container-id;
                 }
             }
         }
-
     }
 
     Rectangle {


### PR DESCRIPTION
Always list all elements that *could* have live
data, add a Text about "no properties" into empty
ones.

![image](https://github.com/user-attachments/assets/23bb5aec-6d53-4fd3-9a76-30099392b4f8)
