### PR TITLE
Fix TargetPixelBuffer functions being called with regions not clipped…

### DIFF
--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1181,6 +1181,11 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
 
     fn process_texture_impl(&mut self, geometry: PhysicalRect, texture: SceneTexture<'_>) {
         self.foreach_region(&geometry, |buffer, rect, extra_left_clip, extra_right_clip| {
+            let tex_src_off_x = (texture.extra.off_x + Fixed::from_integer(extra_left_clip as u16))
+                * texture.extra.dx.truncate();
+            let tex_src_off_y = (texture.extra.off_y
+                + Fixed::from_integer((rect.origin.y - geometry.origin.y) as u16))
+                * texture.extra.dy.truncate();
             if !buffer.draw_texture(
                 rect.origin.x,
                 rect.origin.y,
@@ -1194,8 +1199,8 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
                     height: texture.source_size().height as u16,
                     delta_x: texture.extra.dx.0,
                     delta_y: texture.extra.dy.0,
-                    source_offset_x: texture.extra.off_x.0,
-                    source_offset_y: texture.extra.off_y.0,
+                    source_offset_x: tex_src_off_x.0,
+                    source_offset_y: tex_src_off_y.0,
                 },
                 texture.extra.colorize.as_argb_encoded(),
                 texture.extra.alpha,

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1182,10 +1182,10 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
     fn process_texture_impl(&mut self, geometry: PhysicalRect, texture: SceneTexture<'_>) {
         self.foreach_region(&geometry, |buffer, rect, extra_left_clip, extra_right_clip| {
             let tex_src_off_x = (texture.extra.off_x + Fixed::from_integer(extra_left_clip as u16))
-                * texture.extra.dx.truncate();
+                * Fixed::from_fixed(texture.extra.dx);
             let tex_src_off_y = (texture.extra.off_y
                 + Fixed::from_integer((rect.origin.y - geometry.origin.y) as u16))
-                * texture.extra.dy.truncate();
+                * Fixed::from_fixed(texture.extra.dy);
             if !buffer.draw_texture(
                 rect.origin.x,
                 rect.origin.y,

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1182,10 +1182,10 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
     fn process_texture_impl(&mut self, geometry: PhysicalRect, texture: SceneTexture<'_>) {
         self.foreach_region(&geometry, |buffer, rect, extra_left_clip, extra_right_clip| {
             if !buffer.draw_texture(
-                geometry.origin.x,
-                geometry.origin.y,
-                geometry.size.width,
-                geometry.size.height,
+                rect.origin.x,
+                rect.origin.y,
+                rect.size.width,
+                rect.size.height,
                 target_pixel_buffer::Texture {
                     bytes: texture.data,
                     pixel_format: texture.format,
@@ -1226,10 +1226,10 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
     ) {
         self.foreach_region(&geometry, |buffer, rect, _extra_left_clip, _extra_right_clip| {
             if !buffer.fill_rectangle(
-                geometry.origin.x,
-                geometry.origin.y,
-                geometry.size.width,
-                geometry.size.height,
+                rect.origin.x,
+                rect.origin.y,
+                rect.size.width,
+                rect.size.height,
                 color,
                 composition_mode,
             ) {

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -1180,28 +1180,28 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
     }
 
     fn process_texture_impl(&mut self, geometry: PhysicalRect, texture: SceneTexture<'_>) {
-        if !self.buffer.draw_texture(
-            geometry.origin.x,
-            geometry.origin.y,
-            geometry.size.width,
-            geometry.size.height,
-            target_pixel_buffer::Texture {
-                bytes: texture.data,
-                pixel_format: texture.format,
-                pixel_stride: texture.pixel_stride,
-                width: texture.source_size().width as u16,
-                height: texture.source_size().height as u16,
-                delta_x: texture.extra.dx.0,
-                delta_y: texture.extra.dy.0,
-                source_offset_x: texture.extra.off_x.0,
-                source_offset_y: texture.extra.off_y.0,
-            },
-            texture.extra.colorize.as_argb_encoded(),
-            texture.extra.alpha,
-            texture.extra.rotation,
-            CompositionMode::default(),
-        ) {
-            self.foreach_region(&geometry, |buffer, rect, extra_left_clip, extra_right_clip| {
+        self.foreach_region(&geometry, |buffer, rect, extra_left_clip, extra_right_clip| {
+            if !buffer.draw_texture(
+                geometry.origin.x,
+                geometry.origin.y,
+                geometry.size.width,
+                geometry.size.height,
+                target_pixel_buffer::Texture {
+                    bytes: texture.data,
+                    pixel_format: texture.format,
+                    pixel_stride: texture.pixel_stride,
+                    width: texture.source_size().width as u16,
+                    height: texture.source_size().height as u16,
+                    delta_x: texture.extra.dx.0,
+                    delta_y: texture.extra.dy.0,
+                    source_offset_x: texture.extra.off_x.0,
+                    source_offset_y: texture.extra.off_y.0,
+                },
+                texture.extra.colorize.as_argb_encoded(),
+                texture.extra.alpha,
+                texture.extra.rotation,
+                CompositionMode::default(),
+            ) {
                 let begin = rect.min_x();
                 let end = rect.max_x();
                 for l in rect.y_range() {
@@ -1214,8 +1214,8 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
                         extra_right_clip,
                     );
                 }
-            });
-        }
+            }
+        });
     }
 
     fn process_rectangle_impl(
@@ -1224,15 +1224,15 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
         color: PremultipliedRgbaColor,
         composition_mode: CompositionMode,
     ) {
-        if !self.buffer.fill_rectangle(
-            geometry.origin.x,
-            geometry.origin.y,
-            geometry.size.width,
-            geometry.size.height,
-            color,
-            composition_mode,
-        ) {
-            self.foreach_region(&geometry, |buffer, rect, _extra_left_clip, _extra_right_clip| {
+        self.foreach_region(&geometry, |buffer, rect, _extra_left_clip, _extra_right_clip| {
+            if !buffer.fill_rectangle(
+                geometry.origin.x,
+                geometry.origin.y,
+                geometry.size.width,
+                geometry.size.height,
+                color,
+                composition_mode,
+            ) {
                 let begin = rect.min_x();
                 let end = rect.max_x();
 
@@ -1254,8 +1254,8 @@ impl<B: target_pixel_buffer::TargetPixelBuffer> RenderToBuffer<'_, B> {
                         }
                     }
                 }
-            })
-        };
+            }
+        })
     }
 }
 

--- a/internal/core/software_renderer/fixed.rs
+++ b/internal/core/software_renderer/fixed.rs
@@ -116,7 +116,7 @@ where
 {
     type Output = Self;
     fn mul(self, rhs: Fixed<T, SHIFT>) -> Self::Output {
-        Self(self.0.mul(rhs.0) >> SHIFT)
+        Self(self.0.mul(rhs.0 >> SHIFT) + self.0.mul(rhs.0 & ((1 << SHIFT)-1)) >> SHIFT)
     }
 }
 

--- a/internal/core/software_renderer/fixed.rs
+++ b/internal/core/software_renderer/fixed.rs
@@ -112,11 +112,13 @@ impl<T: core::ops::Mul<Output = T>, const SHIFT: usize> core::ops::Mul<T> for Fi
 impl<T: core::ops::Mul<Output = T>, const SHIFT: usize> core::ops::Mul<Fixed<T, SHIFT>>
     for Fixed<T, SHIFT>
 where
-    T: core::ops::Shr<usize, Output = T>,
+    T: From<i64> + Into<i64>,
 {
     type Output = Self;
     fn mul(self, rhs: Fixed<T, SHIFT>) -> Self::Output {
-        Self(self.0.mul(rhs.0 >> SHIFT) + self.0.mul(rhs.0 & ((1 << SHIFT)-1)) >> SHIFT)
+        let lhs_i64: i64 = self.0.into();
+        let rhs_i64: i64 = rhs.0.into();
+        Self(T::from((lhs_i64 * rhs_i64) >> SHIFT))
     }
 }
 

--- a/internal/core/software_renderer/fixed.rs
+++ b/internal/core/software_renderer/fixed.rs
@@ -112,13 +112,14 @@ impl<T: core::ops::Mul<Output = T>, const SHIFT: usize> core::ops::Mul<T> for Fi
 impl<T: core::ops::Mul<Output = T>, const SHIFT: usize> core::ops::Mul<Fixed<T, SHIFT>>
     for Fixed<T, SHIFT>
 where
-    T: From<i64> + Into<i64>,
+    T: TryFrom<i64> + Into<i64>,
+    <T as TryFrom<i64>>::Error: core::fmt::Debug,
 {
     type Output = Self;
     fn mul(self, rhs: Fixed<T, SHIFT>) -> Self::Output {
         let lhs_i64: i64 = self.0.into();
         let rhs_i64: i64 = rhs.0.into();
-        Self(T::from((lhs_i64 * rhs_i64) >> SHIFT))
+        Self(T::try_from((lhs_i64 * rhs_i64) >> SHIFT).expect("attempt to multiply with overflow"))
     }
 }
 

--- a/internal/core/software_renderer/fixed.rs
+++ b/internal/core/software_renderer/fixed.rs
@@ -109,6 +109,17 @@ impl<T: core::ops::Mul<Output = T>, const SHIFT: usize> core::ops::Mul<T> for Fi
     }
 }
 
+impl<T: core::ops::Mul<Output = T>, const SHIFT: usize> core::ops::Mul<Fixed<T, SHIFT>>
+    for Fixed<T, SHIFT>
+where
+    T: core::ops::Shr<usize, Output = T>,
+{
+    type Output = Self;
+    fn mul(self, rhs: Fixed<T, SHIFT>) -> Self::Output {
+        Self(self.0.mul(rhs.0) >> SHIFT)
+    }
+}
+
 impl<T: core::ops::Neg<Output = T>, const SHIFT: usize> core::ops::Neg for Fixed<T, SHIFT> {
     type Output = Self;
     fn neg(self) -> Self::Output {


### PR DESCRIPTION
… against the dirty region

This got lost in the rebase/squash session of https://github.com/slint-ui/slint/pull/7685

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
