### PR TITLE
C++: fix a bug in which a substraction could overflow

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3268,6 +3268,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                         '&' => "&&",
                         '|' => "||",
                         '/' => "/(float)",
+                        '-' => "-(float)", // conversion to float to avoid overflow between unsigned
                         _ => op.encode_utf8(&mut buffer),
                     },
                 )

--- a/tests/cases/elements/image.slint
+++ b/tests/cases/elements/image.slint
@@ -21,8 +21,9 @@ TestCase := Rectangle {
 
     property <length> img_width: img.width;
     property <length> img_height: img.height;
+    in-out property <float> test_no_overflow: (21 - img.source.width) / 2; // (21 - 320)/2 = -149.5
     property <bool> test: img2.source-clip-height * 1px == img2.height && img2.source-clip-width * 1px == img2.width &&
-         img2.width/1px == img2.source.width - 20 && img3.source.width == 0 && img3.source.height == 0;
+         img2.width/1px == img2.source.width - 20 && img3.source.width == 0 && img3.source.height == 0 && test_no_overflow == -149.5;
 }
 
 /*


### PR DESCRIPTION
There was an image like this:
```slint
height: 40px
Image {
     width: parent.width;
     height: self.source.height * 1px;
     source: @image-url("....");
}
```

The `y` propery ended inlined like so:
`(40 - the_image.source.get().size().height)/float(2)` but since height was `unsigned` the C++ rules means that the operation happens as unsigned and we have an overflow. and `y` turned out to be very big instead of slightly negative (for image whose height was larger than 40)
