### PR TITLE
Use find_package to search for Corrosion

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -9,9 +9,8 @@ project(Slint HOMEPAGE_URL "https://slint.dev/" LANGUAGES C CXX VERSION 1.10.0)
 include(FeatureSummary)
 include(CMakeDependentOption)
 
-find_package(Corrosion QUIET)
+find_package(Corrosion QUIET 0.5)
 if (NOT Corrosion_FOUND)
-    message("Corrosion could not be located in the CMake module search path. Downloading it from Git and building it locally")
     include(FetchContent)
     FetchContent_Declare(
         Corrosion

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -9,13 +9,18 @@ project(Slint HOMEPAGE_URL "https://slint.dev/" LANGUAGES C CXX VERSION 1.10.0)
 include(FeatureSummary)
 include(CMakeDependentOption)
 
-include(FetchContent)
-FetchContent_Declare(
-    Corrosion
-    GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.5.1
-)
-FetchContent_MakeAvailable(Corrosion)
+find_package(Corrosion QUIET)
+if (NOT Corrosion_FOUND)
+    message("Corrosion could not be located in the CMake module search path. Downloading it from Git and building it locally")
+    include(FetchContent)
+    FetchContent_Declare(
+        Corrosion
+        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+        GIT_TAG v0.5.1
+    )
+
+    FetchContent_MakeAvailable(Corrosion)
+endif (NOT Corrosion_FOUND)
 
 list(PREPEND CMAKE_MODULE_PATH ${Corrosion_SOURCE_DIR}/cmake)
 find_package(Rust 1.82 REQUIRED MODULE)


### PR DESCRIPTION
This PR adds a cmake module search for corrosion via find_package. This is to enable Nix which requires downloading of dependencies prior to build time.

I've also created a proof-of-concept fork of the stm32 C++ template which shows a nix derivation for Slint:

https://github.com/scristall-bennu/slint-cpp-templates-stm32-nix