### PR TITLE
esp-idf: Be smarter about RGB888 and RGB565

### DIFF
--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -30,10 +30,18 @@
  *  to internal memory (MALLOC_CAP_INTERNAL) and flushing to the display is faster than rendering
  *  into memory buffers that may be slower to access for the CPU.
  *
- *  The data structure is a template where the pixel type is configurable. The default is for
- *  RGB565 displays, but you can also use `slint::Rgb8Pixel` if you're targeting an RGB888 display.
+ *  The data structure is a template where the pixel type is configurable.
+ *  The default depends on the sdkconfig, but you can use either `slint::Rgb8Pixel` or
+ *  `slint::platform::Rgb565Pixel`, depending on how the display is configured.
  */
-template<typename PixelType = slint::platform::Rgb565Pixel>
+template<typename PixelType =
+#if CONFIG_BSP_LCD_COLOR_FORMAT_RGB888
+                 slint::Rgb8Pixel
+#else
+                 slint::platform::Rgb565Pixel
+#endif
+         >
+
 struct SlintPlatformConfiguration
 {
     /// The size of the screen in pixels.

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -341,7 +341,7 @@ void slint_esp_init(slint::PhysicalSize size, esp_lcd_panel_handle_t panel,
                     std::optional<std::span<slint::platform::Rgb565Pixel>> buffer2)
 {
 
-    SlintPlatformConfiguration config {
+    SlintPlatformConfiguration<slint::platform::Rgb565Pixel> config {
         .size = size,
         .panel_handle = panel,
         .touch_handle = touch ? *touch : nullptr,


### PR DESCRIPTION
This changes the default if the user has selected
`CONFIG_BSP_LCD_COLOR_FORMAT_RGB888` in their sdkconfig, (which will result in build error if the buffer were passed as Rgb565Pixel, or in garbage of the screen if the screen was configured programatically to use rgb565 without calling `bsp_display_new` which is unlikely if they set CONFIG_BSP_LCD_COLOR_FORMAT_RGB888)

