### PR TITLE
Disable jemalloc on Windows

### DIFF
--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -33,5 +33,5 @@ proc-macro2 = "1.0.11"
 spin_on = { workspace = true }
 itertools = { workspace = true }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -7,10 +7,10 @@ use i_slint_compiler::*;
 use itertools::Itertools;
 use std::io::{BufWriter, Write};
 
-#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -95,7 +95,7 @@ i-slint-core = { workspace = true, features = ["std"], optional = true }
 slint = { workspace = true, features = ["compat-1-2"], optional = true }
 slint-interpreter = { workspace = true, features = ["compat-1-2", "internal", "internal-highlight", "internal-json", "image-default-formats"], optional = true  }
 
-[target.'cfg(not(any(target_env = "msvc", target_arch = "wasm32")))'.dependencies]
+[target.'cfg(not(any(target_os = "windows", target_arch = "wasm32")))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -40,10 +40,10 @@ use std::task::{Poll, Waker};
 
 use crate::common::document_cache::CompilerConfiguration;
 
-#[cfg(not(any(target_env = "msvc", target_arch = "wasm32")))]
+#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_env = "msvc", target_arch = "wasm32")))]
+#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -67,7 +67,7 @@ itertools = { workspace = true }
 serde_json = { workspace = true }
 smol_str = { workspace = true }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [[bin]]

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -15,10 +15,10 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(target_os = "windows"))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(target_os = "windows"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
Upstream isn't even compile-testing on Windows ( https://github.com/tikv/jemallocator/blob/main/.github/workflows/main.yml ), so we should disable it as well.

This should fix the build failing with mingw.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
