### PR TITLE
Add callback forwarding

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
@@ -141,6 +141,7 @@ But there are also differences:
 - The syntax for defining a callback is different
 - Callbacks can be declared without assigning a block of code to them
 - Callbacks have a special syntax for declaring aliases using the two-way binding operator `<=>`
+- Callbacks have a special syntax for forwarding them using the `=>` operator
 - Callback visibility is always similar to `public` functions
 
 In general, the biggest reason to use callbacks is to be able to handle them from the backend code. Use
@@ -219,22 +220,63 @@ export component Example inherits Rectangle {
 
 ## Forwarding
 
-A callback can be forwarded to another callback as long as the number and types of their arguments match:
+A callback can be forwarded to another callback or function as long as they have compatible signatures:
 
 ```slint
-export component Example inherits Rectangle {
-    callback hello;
+export component HasCallbacks {
+    callback no-args;
+    callback int-arg(n: int);
+    callback string-arg(s: string);
+    callback int-ret() -> int;
+    callback string-ret() -> string;
+    callback args-2(int, float);
+    callback args-3(int, float, string);
+    pure callback cb-pure;
+    callback cb-impure;
+    callback cb;
+    callback abs(int) -> int;
+}
 
-    foo := TouchArea {
-        // forward clicked calls to hello using `=>`
-        clicked => hello;
-    }
+export component CallbackForwarding {
+    callback no-args;
+    callback int-arg(n: int);
+    callback string-arg(s: string);
+    callback int-ret() -> int;
+    callback string-ret() -> string;
+    callback args-2(int, float);
+    callback args-3(int, float, string);
+    pure callback cb-pure;
+    callback cb-impure;
+    callback cb;
+    function fn() {}
 
-    callback bye(foo: int);
+    HasCallbacks {
+        // forward no-args calls to root.no-args using `=>`
+        no-args => root.no-args;
 
-    bar := TouchArea {
-        // Compiler error!
-        // clicked => bye;
+        // arguments and return types are converted automatically if possible
+        int-arg => root.string-arg;
+        // compiler error! string argument cannot be converted to int
+        // string-arg => root.int-arg;
+        string-ret => root.int-ret;
+        // compiler error! string return type cannot be converted to int
+        // int-ret => root.string-ret;
+
+        // additional arguments will not be forwarded
+        args-3 => root.args-2;
+        // compiler error! root.args-3 requires 3 arguments but args-2 only has 2
+        // args-2 => root.args-3;
+
+        // purity constraints are respected
+        cb-pure => root.cb-pure;
+        cb-impure => root.cb-pure;
+        // compiler error! cannot forward pure callback to impure callback
+        // cb-pure => root.cb-impure;
+
+        // callbacks can be forwarded to functions
+        cb => root.fn;
+        // including built-in functions
+        abs => Math.abs;
     }
 }
 ```

--- a/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
@@ -217,3 +217,25 @@ export component Example inherits Rectangle {
 }
 ```
 
+## Forwarding
+
+A callback can be forwarded to another callback as long as the number and types of their arguments match:
+
+```slint
+export component Example inherits Rectangle {
+    callback hello;
+
+    foo := TouchArea {
+        // forward clicked calls to hello using `=>`
+        clicked => hello;
+    }
+
+    callback bye(foo: int);
+
+    bar := TouchArea {
+        // Compiler error!
+        // clicked => bye;
+    }
+}
+```
+

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -336,8 +336,8 @@ declare_syntax! {
         /// `id := Element { ... }`
         SubElement -> [ Element ],
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
-                     *CallbackDeclaration, *ConditionalElement, *Function, *SubElement,
-                     *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
+                     *CallbackForwarding, *CallbackDeclaration, *ConditionalElement, *Function,
+                     *SubElement, *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
                      *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
         RepeatedIndex -> [],
@@ -350,6 +350,8 @@ declare_syntax! {
         /// `-> type`  (but without the ->)
         ReturnType -> [Type],
         CallbackConnection -> [ *DeclaredIdentifier,  CodeBlock ],
+        /// `xxx => yyy`
+        CallbackForwarding -> [ Expression ],
         /// Declaration of a property.
         PropertyDeclaration-> [ ?Type , DeclaredIdentifier, ?BindingExpression, ?TwoWayBinding ],
         /// QualifiedName are the properties name

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -43,6 +43,7 @@ pub fn parse_element(p: &mut impl Parser) -> bool {
 /// for xx in model: Sub {}
 /// if condition : Sub {}
 /// clicked => {}
+/// clicked => root.clicked;
 /// callback foobar;
 /// property<int> width;
 /// animate someProp { }
@@ -63,9 +64,13 @@ pub fn parse_element_content(p: &mut impl Parser) {
                 SyntaxKind::ColonEqual | SyntaxKind::LBrace => {
                     had_parse_error |= !parse_sub_element(&mut *p)
                 }
-                SyntaxKind::FatArrow | SyntaxKind::LParent if p.peek().as_str() != "if" => {
+                SyntaxKind::LParent if p.peek().as_str() != "if" => {
                     parse_callback_connection(&mut *p)
                 }
+                SyntaxKind::FatArrow if p.peek().as_str() != "if" => match p.nth(2).kind() {
+                    SyntaxKind::LBrace => parse_callback_connection(&mut *p),
+                    _ => parse_callback_forwarding(&mut *p),
+                },
                 SyntaxKind::DoubleArrow => parse_two_way_binding(&mut *p),
                 SyntaxKind::Identifier if p.peek().as_str() == "for" => {
                     parse_repeated_element(&mut *p);
@@ -295,6 +300,19 @@ fn parse_callback_connection(p: &mut impl Parser) {
     }
     p.expect(SyntaxKind::FatArrow);
     parse_code_block(&mut *p);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,CallbackForwarding
+/// clicked => clicked;
+/// clicked => root.clicked;
+/// ```
+fn parse_callback_forwarding(p: &mut impl Parser) {
+    let mut p = p.start_node(SyntaxKind::CallbackForwarding);
+    p.consume(); // the indentifier
+    p.expect(SyntaxKind::FatArrow);
+    parse_expression(&mut *p);
+    p.expect(SyntaxKind::Semicolon);
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -280,7 +280,8 @@ impl Expression {
             (lookup_qualified_name_node(qn, ctx, LookupPhase::default()), sl)
         } else {
             ctx.diag.push_error(
-                "The expression in a callback forwarding must be a callback/function reference".into(),
+                "The expression in a callback forwarding must be a callback/function reference"
+                    .into(),
                 &node.Expression(),
             );
             return Self::Invalid;

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -285,7 +285,10 @@ impl Expression {
             return Self::Invalid;
         };
         let LookupResult::Callable(function) = function else {
-            ctx.diag.push_error("Callbacks can only be forwarded to callbacks and functions".into(), &node);
+            ctx.diag.push_error(
+                "Callbacks can only be forwarded to callbacks and functions".into(),
+                &node,
+            );
             return Self::Invalid;
         };
 

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -279,6 +279,10 @@ impl Expression {
             let sl = qn.last_token().unwrap().to_source_location();
             (lookup_qualified_name_node(qn, ctx, LookupPhase::default()), sl)
         } else {
+            ctx.diag.push_error(
+                "The expression in a callback forwarding must be a callback/function reference".into(),
+                &node.Expression(),
+            );
             return Self::Invalid;
         };
         let Some(function) = function else {

--- a/internal/compiler/tests/syntax/basic/signal.slint
+++ b/internal/compiler/tests/syntax/basic/signal.slint
@@ -15,8 +15,26 @@ export SubElements := Rectangle {
     callback invalid_arg(InvalidType);
 //                       ^error{Unknown type 'InvalidType'}
 
+    callback return_string() -> string;
+    callback return_int() -> int;
+    callback return_void();
+
+    callback string_arg(bool, string);
+    callback int_arg(bool, int);
+
+    callback abs(int) -> int;
+    
     TouchArea {
         clicked => { foobar() }
+    }
+
+    TouchArea {
+        clicked => foobar;
+    }
+    
+    TouchArea {
+        clicked => callback_with_arg;
+//      ^error{Cannot forward callback with 0 arguments to callback or function with 2 arguments}
     }
 
     TouchArea {
@@ -29,6 +47,18 @@ export SubElements := Rectangle {
     TouchArea {
         clicked => { foobar() }
         clicked => { foobar() }
+//      ^error{Duplicated callback}
+    }
+
+    TouchArea {
+        clicked => foobar;
+        clicked => foobar;
+//      ^error{Duplicated callback}
+    }
+
+    TouchArea {
+        clicked => { foobar() }
+        clicked => foobar;
 //      ^error{Duplicated callback}
     }
 
@@ -55,4 +85,23 @@ export SubElements := Rectangle {
 
     callback width;
 //           ^error{Cannot declare callback 'width' when a property with the same name exists}
+
+    TouchArea {
+        clicked => pressed;
+//      ^error{Callbacks can only be forwarded to callbacks and functions}
+    }
+
+    return_int => return_string;
+//  ^error{Cannot convert string to int}
+
+    return_string => return_int;
+
+    return_void => return_int;
+
+    string_arg => int_arg;
+//  ^error{Cannot forward argument 1 of callback because string cannot be converted to int}
+
+    int_arg => string_arg;
+
+    abs => Math.abs;
 }

--- a/internal/compiler/tests/syntax/basic/signal.slint
+++ b/internal/compiler/tests/syntax/basic/signal.slint
@@ -122,4 +122,4 @@ export SubElements := Rectangle {
     cb_pure => foobar;
 //  ^warning{Call of impure callback 'foobar'}
 
-} 
+}

--- a/internal/compiler/tests/syntax/basic/signal.slint
+++ b/internal/compiler/tests/syntax/basic/signal.slint
@@ -23,7 +23,7 @@ export SubElements := Rectangle {
     callback int_arg(bool, int);
 
     callback abs(int) -> int;
-    
+
     TouchArea {
         clicked => { foobar() }
     }
@@ -31,7 +31,7 @@ export SubElements := Rectangle {
     TouchArea {
         clicked => foobar;
     }
-    
+
     TouchArea {
         clicked => callback_with_arg;
 //      ^error{Cannot forward callback with 0 arguments to callback or function with 2 arguments}

--- a/internal/compiler/tests/syntax/basic/signal.slint
+++ b/internal/compiler/tests/syntax/basic/signal.slint
@@ -3,6 +3,8 @@
 
 Base := Rectangle {
     callback blah;
+    function private_fn() {}
+    public function public_fn() {}
 }
 
 export SubElements := Rectangle {
@@ -23,6 +25,9 @@ export SubElements := Rectangle {
     callback int_arg(bool, int);
 
     callback abs(int) -> int;
+    pure callback cb_pure();
+
+    foo := Base {}
 
     TouchArea {
         clicked => { foobar() }
@@ -33,8 +38,17 @@ export SubElements := Rectangle {
     }
 
     TouchArea {
-        clicked => callback_with_arg;
-//      ^error{Cannot forward callback with 0 arguments to callback or function with 2 arguments}
+        clicked => 3 + 3;
+//                 ^error{The expression in a callback forwarding must be a callback/function reference}
+    }
+
+    TouchArea {
+        clicked => foo.public_fn;
+    }
+
+    TouchArea {
+        clicked => foo.private_fn;
+//                     ^error{The function 'private_fn' is private. Annotate it with 'public' to make it accessible from other components}
     }
 
     TouchArea {
@@ -104,4 +118,8 @@ export SubElements := Rectangle {
     int_arg => string_arg;
 
     abs => Math.abs;
-}
+
+    cb_pure => foobar;
+//  ^warning{Call of impure callback 'foobar'}
+
+} 

--- a/tests/cases/callbacks/callback_forwarding.slint
+++ b/tests/cases/callbacks/callback_forwarding.slint
@@ -9,7 +9,6 @@ Callbacks := Rectangle {
     pure callback cb_pure(int) -> int;
     callback cb(int) -> int;
     callback abs(int) -> int;
-    callback brush_ret() -> brush;
 }
 
 TestCase := Rectangle {
@@ -20,7 +19,6 @@ TestCase := Rectangle {
     pure callback cb_pure_alias <=> callbacks.cb_pure;
     callback cb_alias <=> callbacks.cb;
     callback abs_alias <=> callbacks.abs;
-    callback brush_ret_alias <=> callbacks.brush_ret;
 
     callback no_args;
     callback args_2(x: int, y: int);
@@ -56,7 +54,6 @@ TestCase := Rectangle {
         cb_pure => root.cb_pure;
         cb => root.fn;
         abs => Math.abs;
-        brush_ret => @linear-gradient(90deg, #3f87a6 0%, #ebf8e1 50%, #f96d3c 100%);
     }
 }
 
@@ -76,7 +73,6 @@ assert_eq(instance.invoke_string_ret_alias(), "6");
 assert_eq(instance.invoke_cb_pure_alias(3), 1);
 assert_eq(instance.invoke_cb_alias(1), 1);
 assert_eq(instance.invoke_abs_alias(-10), 10);
-instance.invoke_brush_ret_alias();
 ```
 
 ```rust
@@ -93,7 +89,6 @@ assert_eq!(instance.invoke_string_ret_alias(), "6");
 assert_eq!(instance.invoke_cb_pure_alias(3), 1);
 assert_eq!(instance.invoke_cb_alias(1), 1);
 assert_eq!(instance.invoke_abs_alias(-10), 10);
-instance.invoke_brush_ret_alias();
 ```
 
 ```js
@@ -111,6 +106,5 @@ assert.equal(instance.string_ret_alias(), "6");
 assert.equal(instance.cb_pure_alias(3), 1);
 assert.equal(instance.cb_alias(1), 1);
 assert.equal(instance.abs_alias(-10), 10);
-instance.brush_ret_alias();
 ```
 */

--- a/tests/cases/callbacks/callback_forwarding.slint
+++ b/tests/cases/callbacks/callback_forwarding.slint
@@ -1,0 +1,116 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+Callbacks := Rectangle {
+    callback no_args;
+    callback args_3(int, float, string);
+    callback int_arg(int);
+    callback string_ret() -> string;
+    pure callback cb_pure(int) -> int;
+    callback cb(int) -> int;
+    callback abs(int) -> int;
+    callback brush_ret() -> brush;
+}
+
+TestCase := Rectangle {
+    callback no_args_alias <=> callbacks.no_args;
+    callback args_3_alias <=> callbacks.args_3;
+    callback int_arg_alias <=> callbacks.int_arg;
+    callback string_ret_alias <=> callbacks.string_ret;
+    pure callback cb_pure_alias <=> callbacks.cb_pure;
+    callback cb_alias <=> callbacks.cb;
+    callback abs_alias <=> callbacks.abs;
+    callback brush_ret_alias <=> callbacks.brush_ret;
+
+    callback no_args;
+    callback args_2(x: int, y: int);
+    callback string_arg(s: string);
+    callback int_ret() -> int;
+    pure callback cb_pure(i: int) -> float;
+    property<int> n;
+
+    no_args => {
+        n += 1;
+    }
+    args_2(x, y) => {
+        n += x + y;
+    }
+    string_arg(s) => {
+        n += s.to-float();
+    }
+    cb_pure(i) => {
+        return i / 2.0;
+    }
+    int_ret => {
+        return n;
+    }
+    pure function fn(i: int) -> int {
+        return i;
+    }
+
+    callbacks := Callbacks {
+        no_args => root.no_args;
+        args_3 => root.args_2;
+        int_arg => root.string_arg;
+        string_ret => root.int_ret;
+        cb_pure => root.cb_pure;
+        cb => root.fn;
+        abs => Math.abs;
+        brush_ret => @linear-gradient(90deg, #3f87a6 0%, #ebf8e1 50%, #f96d3c 100%);
+    }
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+instance.set_n(0);
+assert_eq(instance.get_n(), 0);
+instance.invoke_no_args_alias();
+assert_eq(instance.get_n(), 1);
+instance.invoke_args_3_alias(1, 2.5, "dropped");
+assert_eq(instance.get_n(), 4);
+instance.invoke_int_arg_alias(2);
+assert_eq(instance.get_n(), 6);
+assert_eq(instance.invoke_string_ret_alias(), "6");
+assert_eq(instance.invoke_cb_pure_alias(3), 1);
+assert_eq(instance.invoke_cb_alias(1), 1);
+assert_eq(instance.invoke_abs_alias(-10), 10);
+instance.invoke_brush_ret_alias();
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+instance.set_n(0);
+assert_eq!(instance.get_n(), 0);
+instance.invoke_no_args_alias();
+assert_eq!(instance.get_n(), 1);
+instance.invoke_args_3_alias(1, 2.5, "dropped".into());
+assert_eq!(instance.get_n(), 4);
+instance.invoke_int_arg_alias(2);
+assert_eq!(instance.get_n(), 6);
+assert_eq!(instance.invoke_string_ret_alias(), "6");
+assert_eq!(instance.invoke_cb_pure_alias(3), 1);
+assert_eq!(instance.invoke_cb_alias(1), 1);
+assert_eq!(instance.invoke_abs_alias(-10), 10);
+instance.invoke_brush_ret_alias();
+```
+
+```js
+var instance = new slint.TestCase({});
+var callbacks = instance.callbacks;
+instance.n = 0;
+assert.equal(instance.n, 0);
+instance.no_args_alias();
+assert.equal(instance.n, 1);
+instance.args_3_alias(1, 2.5, "dropped");
+assert.equal(instance.n, 4);
+instance.int_arg_alias(2);
+assert.equal(instance.n, 6);
+assert.equal(instance.string_ret_alias(), "6");
+assert.equal(instance.cb_pure_alias(3), 1);
+assert.equal(instance.cb_alias(1), 1);
+assert.equal(instance.abs_alias(-10), 10);
+instance.brush_ret_alias();
+```
+*/

--- a/tools/lsp/common/token_info.rs
+++ b/tools/lsp/common/token_info.rs
@@ -174,6 +174,22 @@ pub fn token_info(document_cache: &common::DocumentCache, token: SyntaxToken) ->
                 return Some(TokenInfo::LocalCallback(p));
             }
             return find_property_declaration_in_base(document_cache, element, &prop_name);
+        } else if let Some(n) = syntax_nodes::CallbackForwarding::new(node.clone()) {
+            if token.kind() != SyntaxKind::Identifier {
+                return None;
+            }
+            let prop_name = i_slint_compiler::parser::normalize_identifier(token.text());
+            if prop_name != i_slint_compiler::parser::identifier_text(&n)? {
+                return None;
+            }
+            let element = syntax_nodes::Element::new(n.parent()?)?;
+            if let Some(p) = element.CallbackDeclaration().find_map(|p| {
+                (i_slint_compiler::parser::identifier_text(&p.DeclaredIdentifier())? == prop_name)
+                    .then_some(p)
+            }) {
+                return Some(TokenInfo::LocalCallback(p));
+            }
+            return find_property_declaration_in_base(document_cache, element, &prop_name);
         } else if node.kind() == SyntaxKind::DeclaredIdentifier {
             if token.kind() != SyntaxKind::Identifier {
                 return None;

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -479,7 +479,7 @@ fn resolve_element_scope(
                 c.kind = Some(CompletionItemKind::METHOD);
                 let ins_text = match cb_args {
                     Some(a) => format!("{}({}) => {{$1}}", c.label, a.join(", ")),
-                    None => format!("{} => {{$1}}", c.label),
+                    None => format!("{} => $1", c.label),
                 };
                 with_insert_text(c, &ins_text, with_snippets)
             } else {

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -1183,7 +1183,7 @@ mod tests {
         );
         assert_eq!(
             res.iter().find(|ci| ci.label == "the-callback").unwrap().insert_text,
-            Some("the-callback => {$1}".into())
+            Some("the-callback => $1".into())
         );
     }
 
@@ -1659,7 +1659,7 @@ mod tests {
         // builtin callback don't have named argument yet
         assert_eq!(
             res.iter().find(|ci| ci.label == "accessible-action-set-value").unwrap().insert_text,
-            Some("accessible-action-set-value => {$1}".into())
+            Some("accessible-action-set-value => $1".into())
         );
         let source = r#"
             import { StandardTableView } from "std-widgets.slint";
@@ -1681,11 +1681,11 @@ mod tests {
         );
         assert_eq!(
             res.iter().find(|ci| ci.label == "clicked").unwrap().insert_text,
-            Some("clicked => {$1}".into())
+            Some("clicked => $1".into())
         );
         assert_eq!(
             res.iter().find(|ci| ci.label == "cb1").unwrap().insert_text,
-            Some("cb1 => {$1}".into())
+            Some("cb1 => $1".into())
         );
         assert_eq!(
             res.iter().find(|ci| ci.label == "cb2").unwrap().insert_text,
@@ -1693,7 +1693,7 @@ mod tests {
         );
         assert_eq!(
             res.iter().find(|ci| ci.label == "cb3").unwrap().insert_text,
-            Some("cb3 => {$1}".into())
+            Some("cb3 => $1".into())
         );
     }
 }

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -173,6 +173,10 @@ export component Test {
   Image {
       source: @image-url("assets\\windows-test.png");
   }
+  callback uvw(string, int);
+  another-ta := TA {
+      xyz => uvw;
+  }
 }"#;
         let (mut dc, uri, _) = crate::language::test::loaded_document_cache(source.into());
         let doc = dc.get_document(&uri).unwrap().node.clone().unwrap();
@@ -241,6 +245,14 @@ export component Test {
         assert_tooltip(
             get_tooltip(&mut dc, find_tk("pointer-event", 5.into())),
             "```slint\ncallback pointer-event(event: PointerEvent)\n```",
+        );
+        assert_tooltip(
+            get_tooltip(&mut dc, find_tk("xyz =>", 0.into())),
+            "```slint\ncallback xyz(string, int)\n```"
+        );
+        assert_tooltip(
+            get_tooltip(&mut dc, find_tk("=> uvw;", 3.into())),
+            "```slint\ncallback uvw(string, int)\n```"
         );
         // functions
         assert_tooltip(

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -248,11 +248,11 @@ export component Test {
         );
         assert_tooltip(
             get_tooltip(&mut dc, find_tk("xyz =>", 0.into())),
-            "```slint\ncallback xyz(string, int)\n```"
+            "```slint\ncallback xyz(string, int)\n```",
         );
         assert_tooltip(
             get_tooltip(&mut dc, find_tk("=> uvw;", 3.into())),
-            "```slint\ncallback uvw(string, int)\n```"
+            "```slint\ncallback uvw(string, int)\n```",
         );
         // functions
         assert_tooltip(

--- a/tools/lsp/language/semantic_tokens.rs
+++ b/tools/lsp/language/semantic_tokens.rs
@@ -51,6 +51,7 @@ pub fn get_semantic_tokens(
                 SyntaxKind::ConditionalElement => Some((self::KEYWORD, 0)),
                 SyntaxKind::CallbackDeclaration => Some((self::KEYWORD, 0)),
                 SyntaxKind::CallbackConnection => Some((self::FUNCTION, 0)),
+                SyntaxKind::CallbackForwarding => Some((self::FUNCTION, 0)),
                 SyntaxKind::PropertyDeclaration => Some((self::KEYWORD, 0)),
                 SyntaxKind::Function => Some((self::KEYWORD, 0)),
                 SyntaxKind::PropertyAnimation => Some((self::KEYWORD, 0)),

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -266,7 +266,10 @@ fn lookup_expression_context(mut n: SyntaxNode) -> Option<ExpressionContextInfo>
             break (element, prop_name, false);
         }
         match n.kind() {
-            SyntaxKind::Binding | SyntaxKind::TwoWayBinding | SyntaxKind::CallbackConnection | SyntaxKind::CallbackForwarding => {
+            SyntaxKind::Binding
+            | SyntaxKind::TwoWayBinding
+            | SyntaxKind::CallbackConnection
+            | SyntaxKind::CallbackForwarding => {
                 let mut parent = n.parent()?;
                 if parent.kind() == SyntaxKind::PropertyAnimation {
                     let prop_name = i_slint_compiler::parser::identifier_text(&n)?;

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -266,7 +266,7 @@ fn lookup_expression_context(mut n: SyntaxNode) -> Option<ExpressionContextInfo>
             break (element, prop_name, false);
         }
         match n.kind() {
-            SyntaxKind::Binding | SyntaxKind::TwoWayBinding | SyntaxKind::CallbackConnection => {
+            SyntaxKind::Binding | SyntaxKind::TwoWayBinding | SyntaxKind::CallbackConnection | SyntaxKind::CallbackForwarding => {
                 let mut parent = n.parent()?;
                 if parent.kind() == SyntaxKind::PropertyAnimation {
                     let prop_name = i_slint_compiler::parser::identifier_text(&n)?;


### PR DESCRIPTION
This PR implements a new callback forwarding syntax that reduces boilerplate code for callback connections that only call another callback/function as requested in #6373.

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
