### PR TITLE
live-preview: Polish: Do not expand empty Property Groups

### DIFF
--- a/tools/lsp/ui/components/property-widgets.slint
+++ b/tools/lsp/ui/components/property-widgets.slint
@@ -1306,7 +1306,7 @@ export component ExpandableGroup  {
     in property <string> text;
     in property <length> panel-width;
 
-    property <bool> open: true;
+    in-out property <bool> open: true;
 
     group-layer := Rectangle {
         content-layer := VerticalLayout {

--- a/tools/lsp/ui/views/preview-data-view.slint
+++ b/tools/lsp/ui/views/preview-data-view.slint
@@ -32,6 +32,8 @@ export component PreviewDataView inherits ScrollView {
             text: ep.container-name;
             panel-width: root.width;
 
+            open: ep.properties.length != 0;
+
             VerticalLayout {
                 spacing: EditorSpaceSettings.property-spacing;
                 padding: EditorSpaceSettings.default-padding;


### PR DESCRIPTION
Those contain only one element informing about there not being any properties to show. While I think it is important to show that information so users have a chance to figure out how to actually use the live data tab, it is not that important that we need to always show it.
