### PR TITLE
live-preview: Bring back the JSON editor till the table works!

### DIFF
--- a/tools/lsp/ui/components/property-widgets.slint
+++ b/tools/lsp/ui/components/property-widgets.slint
@@ -1290,7 +1290,7 @@ export component PreviewDataPropertyValueWidget inherits VerticalLayout {
             debug("edit-in-spreadsheet TRIGGERED: ", property-group-name, data, values);
         }
     }
-    if root.preview-data.kind == PreviewDataKind.Json: EditJsonWidget {
+    if root.preview-data.kind == PreviewDataKind.Json || (root.preview-data.kind == PreviewDataKind.Table && true): EditJsonWidget {
         enabled: root.preview-data.has-setter;
         property-name: root.preview-data.name;
         property-value <=> root.value;


### PR DESCRIPTION
I accidentally disabled the JSON editor for "table-like" elements. Bring it back for now.
