### PR TITLE
Expose more kinds of text edit widgets to AccessKit

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -474,7 +474,23 @@ impl NodeCollection {
                     i_slint_core::items::AccessibleRole::Text => Role::Label,
                     i_slint_core::items::AccessibleRole::Table => Role::Table,
                     i_slint_core::items::AccessibleRole::Tree => Role::Tree,
-                    i_slint_core::items::AccessibleRole::TextInput => Role::TextInput,
+                    i_slint_core::items::AccessibleRole::TextInput => {
+                        if let Some(text_input) = i_slint_core::accessibility::find_text_input(item)
+                        {
+                            if !text_input.single_line.get_internal() {
+                                Role::MultilineTextInput
+                            } else {
+                                match text_input.input_type.get_internal() {
+                                    i_slint_core::items::InputType::Decimal
+                                    | i_slint_core::items::InputType::Number => Role::NumberInput,
+                                    i_slint_core::items::InputType::Password => Role::PasswordInput,
+                                    _ => Role::TextInput,
+                                }
+                            }
+                        } else {
+                            Role::TextInput
+                        }
+                    }
                     i_slint_core::items::AccessibleRole::ProgressIndicator => {
                         Role::ProgressIndicator
                     }
@@ -556,9 +572,13 @@ impl NodeCollection {
                 | Role::CheckBox
                 | Role::ComboBox
                 | Role::ListBoxOption
+                | Role::MultilineTextInput
+                | Role::NumberInput
+                | Role::PasswordInput
                 | Role::Slider
                 | Role::SpinButton
                 | Role::Tab
+                | Role::TextInput
         ) {
             node.add_action(Action::Focus);
         }

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -63,7 +63,7 @@ export component LineEditBase inherits Rectangle {
         font-family: text-input.font-family;
         color: root.placeholder-color;
         horizontal-alignment: root.horizontal-alignment;
-        // the label is set on the LineEdit itself
+        // `accessible-placeholder-text` is set on LineEdit already
         accessible-role: none;
     }
 

--- a/internal/compiler/widgets/common/spinbox-base.slint
+++ b/internal/compiler/widgets/common/spinbox-base.slint
@@ -70,8 +70,8 @@ export component SpinBoxBase {
         width: 100%;
         height: 100%;
 
-        accessible-role: AccessibleRole.text-input;
-        accessible-value: self.text;
+        // Disable TextInput's built-in accessibility support as the widget takes care of that.
+        accessible-role: none;
 
         accepted => {
             if !self.text.is-float() {

--- a/internal/compiler/widgets/common/textedit-base.slint
+++ b/internal/compiler/widgets/common/textedit-base.slint
@@ -138,7 +138,7 @@ export component TextEditBase inherits Rectangle {
         font-family: text-input.font-family;
         color: root.placeholder-color;
         overflow: elide;
-        // the label is set on the TextEdit itself
+        // `accessible-placeholder-text` is set on TextEdit already
         accessible-role: none;
     }
 

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -221,7 +221,7 @@ export component TextEdit {
         font-family: text-input.font-family;
         color: CupertinoPalette.foreground-secondary;
         overflow: elide;
-        // the label is set on the TextEdit itself
+        // `accessible-placeholder-text` is set on TextEdit already
         accessible-role: none;
     }
 }

--- a/tests/cases/widgets/spinbox_basic.slint
+++ b/tests/cases/widgets/spinbox_basic.slint
@@ -88,9 +88,9 @@ edits.borrow_mut().clear();
 instance.set_value(30);
 mock_elapsed_time(500);
 
-let mut text_input_search = slint_testing::ElementHandle::find_by_element_id(&instance, "SpinBoxBase::text-input");
-let text_input = text_input_search.next().unwrap();
-assert_eq!(text_input.accessible_value().unwrap(), "30");
+let mut spinbox_search = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::box");
+let spinbox = spinbox_search.next().unwrap();
+assert_eq!(spinbox.accessible_value().unwrap(), "30");
 edits.borrow_mut().clear();
 
 ```


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Relates to #2895 

Which value is allowed in a text input should be communicated to assistive technologies. In AccessKit this means setting different roles when possible, instead of the generic `Role::TextInput`. I chose to not introduce a new accessibility property for this:

- it would only make sense on `LineEdit` widgets, and a multiline property would only be valid on `TextEdit`,
- building a text edit from scratch without the built-in components doesn't seem feasible,
- more importantly, we will need to access the built-in `TextInput` item from the AccessKit backend anyway to expose text runs and I now believe that doing some compiler magic is going to be very tricky if possible at all.

Fixes the Spinbox widget while at it.