### PR TITLE
infra: Add a spell-check script into top-level package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,16 @@
     "format:fix": "pnpm -r format:fix",
     "lint": "pnpm --stream -r lint",
     "lint:fix": "pnpm -r lint:fix",
-    "type-check": "pnpm --stream -r type-check"
+    "type-check": "pnpm --stream -r type-check",
+    "spell-check": "cspell --gitignore --quiet"
   },
   "packageManager": "pnpm@10.3.0",
   "pnpm": {
     "overrides": {
       "esbuild": ">=0.25.0"
     }
+  },
+  "dependencies": {
+    "cspell": "8.17.5"
   }
 }


### PR DESCRIPTION
Use with `pnpm run spell-check <PATH>` to run cspell on all files in a path.