### PR TITLE
Add float.to-fixed and float.to-precision

### DIFF
--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -215,6 +215,8 @@ pub mod re_exports {
     };
     pub use i_slint_core::slice::Slice;
     pub use i_slint_core::string::shared_string_from_number;
+    pub use i_slint_core::string::shared_string_from_number_fixed;
+    pub use i_slint_core::string::shared_string_from_number_precision;
     pub use i_slint_core::timers::{Timer, TimerMode};
     pub use i_slint_core::translations::{
         set_bundled_languages, translate_from_bundle, translate_from_bundle_with_plural,

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -275,6 +275,10 @@ The following conversions are possible:
 -   Arrays generally don't convert between each other. Array literals can be converted if the element types are convertible.
 -   String can be converted to float by using the `to-float` function. That function returns 0 if the string isn't
     a valid number. You can check with `is-float()` if the string contains a valid number
+-   `float` can be converted to a formatted `string` using `to-fixed` and `to-precision` which can be passed the
+    number of digits after the decimal point and and the number of significant digits respectively. They behave like their
+    JavaScript counterparts [`toFixed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)
+    and [`toPrecision()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision).
 
 ```slint
 export component Example {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -40,6 +40,8 @@ pub enum BuiltinFunction {
     ATan2,
     Log,
     Pow,
+    ToFixed,
+    ToPrecision,
     SetFocusItem,
     ClearFocusItem,
     ShowPopupWindow,
@@ -171,6 +173,8 @@ declare_builtin_function_types!(
     ATan2: (Type::Float32, Type::Float32) -> Type::Angle,
     Log: (Type::Float32, Type::Float32) -> Type::Float32,
     Pow: (Type::Float32, Type::Float32) -> Type::Float32,
+    ToFixed: (Type::Float32, Type::Int32) -> Type::String,
+    ToPrecision: (Type::Float32, Type::Int32) -> Type::String,
     SetFocusItem: (Type::ElementReference) -> Type::Void,
     ClearFocusItem: (Type::ElementReference) -> Type::Void,
     ShowPopupWindow: (Type::ElementReference) -> Type::Void,
@@ -289,7 +293,9 @@ impl BuiltinFunction {
             | BuiltinFunction::Log
             | BuiltinFunction::Pow
             | BuiltinFunction::ATan
-            | BuiltinFunction::ATan2 => true,
+            | BuiltinFunction::ATan2
+            | BuiltinFunction::ToFixed
+            | BuiltinFunction::ToPrecision => true,
             BuiltinFunction::SetFocusItem | BuiltinFunction::ClearFocusItem => false,
             BuiltinFunction::ShowPopupWindow
             | BuiltinFunction::ClosePopupWindow
@@ -363,7 +369,9 @@ impl BuiltinFunction {
             | BuiltinFunction::Log
             | BuiltinFunction::Pow
             | BuiltinFunction::ATan
-            | BuiltinFunction::ATan2 => true,
+            | BuiltinFunction::ATan2
+            | BuiltinFunction::ToFixed
+            | BuiltinFunction::ToPrecision => true,
             BuiltinFunction::SetFocusItem | BuiltinFunction::ClearFocusItem => false,
             BuiltinFunction::ShowPopupWindow
             | BuiltinFunction::ClosePopupWindow

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3541,6 +3541,16 @@ fn compile_builtin_function_call(
             ctx.generator_state.conditional_includes.cmath.set(true);
             format!("std::atan2({}, {}) / {}", a.next().unwrap(), a.next().unwrap(), pi_180)
         }
+        BuiltinFunction::ToFixed => {
+            format!("[](float n, int d) {{ slint::SharedString out; slint::cbindgen_private::slint_string_from_number_fixed(&out, std::n, std::max(d, 0); return out; }}({}, {})",
+                a.next().unwrap(), a.next().unwrap(),
+            )
+        }
+        BuiltinFunction::ToPrecision => {
+            format!("[](float n, int p) {{ slint::SharedString out; slint::cbindgen_private::slint_string_from_number_precision(&out, n, std::max(p, 0)); return out; }}({}, {})",
+                a.next().unwrap(), a.next().unwrap(),
+            )
+        }
         BuiltinFunction::SetFocusItem => {
             if let [llr::Expression::PropertyReference(pr)] = arguments {
                 let window = access_window_field(ctx);

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3542,12 +3542,12 @@ fn compile_builtin_function_call(
             format!("std::atan2({}, {}) / {}", a.next().unwrap(), a.next().unwrap(), pi_180)
         }
         BuiltinFunction::ToFixed => {
-            format!("[](float n, int d) {{ slint::SharedString out; slint::cbindgen_private::slint_string_from_number_fixed(&out, std::n, std::max(d, 0); return out; }}({}, {})",
+            format!("[](float n, int d) {{ slint::SharedString out; slint::cbindgen_private::slint_shared_string_from_number_fixed(&out, n, std::max(d, 0)); return out; }}({}, {})",
                 a.next().unwrap(), a.next().unwrap(),
             )
         }
         BuiltinFunction::ToPrecision => {
-            format!("[](float n, int p) {{ slint::SharedString out; slint::cbindgen_private::slint_string_from_number_precision(&out, n, std::max(p, 0)); return out; }}({}, {})",
+            format!("[](float n, int p) {{ slint::SharedString out; slint::cbindgen_private::slint_shared_string_from_number_precision(&out, n, std::max(p, 0)); return out; }}({}, {})",
                 a.next().unwrap(), a.next().unwrap(),
             )
         }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3542,12 +3542,12 @@ fn compile_builtin_function_call(
             format!("std::atan2({}, {}) / {}", a.next().unwrap(), a.next().unwrap(), pi_180)
         }
         BuiltinFunction::ToFixed => {
-            format!("[](float n, int d) {{ slint::SharedString out; slint::cbindgen_private::slint_shared_string_from_number_fixed(&out, n, std::max(d, 0)); return out; }}({}, {})",
+            format!("[](double n, int d) {{ slint::SharedString out; slint::cbindgen_private::slint_shared_string_from_number_fixed(&out, n, std::max(d, 0)); return out; }}({}, {})",
                 a.next().unwrap(), a.next().unwrap(),
             )
         }
         BuiltinFunction::ToPrecision => {
-            format!("[](float n, int p) {{ slint::SharedString out; slint::cbindgen_private::slint_shared_string_from_number_precision(&out, n, std::max(p, 0)); return out; }}({}, {})",
+            format!("[](double n, int p) {{ slint::SharedString out; slint::cbindgen_private::slint_shared_string_from_number_precision(&out, n, std::max(p, 0)); return out; }}({}, {})",
                 a.next().unwrap(), a.next().unwrap(),
             )
         }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3002,6 +3002,14 @@ fn compile_builtin_function_call(
             let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
             quote!((#a1 as f64).powf(#a2 as f64))
         }
+        BuiltinFunction::ToFixed => {
+            let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
+            quote!(sp::shared_string_from_number_fixed(#a1 as f64, (#a2 as i32).max(0) as usize))
+        }
+        BuiltinFunction::ToPrecision => {
+            let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
+            quote!(sp::shared_string_from_number_precision(#a1 as f64, (#a2 as i32).max(0) as usize))
+        }
         BuiltinFunction::StringToFloat => {
             quote!(#(#a)*.as_str().parse::<f64>().unwrap_or_default())
         }

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -102,6 +102,8 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::ATan2 => 10,
         BuiltinFunction::Log => 10,
         BuiltinFunction::Pow => 10,
+        BuiltinFunction::ToFixed => ALLOC_COST,
+        BuiltinFunction::ToPrecision => ALLOC_COST,
         BuiltinFunction::SetFocusItem | BuiltinFunction::ClearFocusItem => isize::MAX,
         BuiltinFunction::ShowPopupWindow
         | BuiltinFunction::ClosePopupWindow

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -1055,6 +1055,8 @@ impl LookupObject for NumberExpression<'_> {
             .or_else(|| f2("atan", member_function(BuiltinFunction::ATan)))
             .or_else(|| f2("log", member_function(BuiltinFunction::Log)))
             .or_else(|| f2("pow", member_function(BuiltinFunction::Pow)))
+            .or_else(|| f2("to-fixed", member_function(BuiltinFunction::ToFixed)))
+            .or_else(|| f2("to-precision", member_function(BuiltinFunction::ToPrecision)))
             .or_else(|| NumberWithUnitExpression(self.0).for_each_entry(ctx, f))
     }
 }

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -325,28 +325,7 @@ pub fn shared_string_from_number_fixed(n: f64, digits: usize) -> SharedString {
 
 /// Convert a f64 to a SharedString following a similar logic as JavaScript's Number.toPrecision()
 pub fn shared_string_from_number_precision(n: f64, precision: usize) -> SharedString {
-    let exponent: isize = if n.abs() < 1.0 {
-        let mut fract = n.abs();
-        let mut exponent = 0;
-
-        while fract < 1.0 {
-            fract *= 10.0;
-            exponent -= 1;
-        }
-
-        exponent
-    } else {
-        let mut int = n.abs();
-        let mut exponent = 0;
-
-        while int > 10.0 {
-            int /= 10.0;
-            exponent += 1;
-        }
-
-        exponent
-    };
-
+    let exponent = f64::log10(n.abs()).floor() as isize;
     if precision == 0 {
         shared_string_from_number(n)
     } else if exponent < -6 || (exponent >= 0 && exponent as usize >= precision) {

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -11,6 +11,7 @@ use alloc::string::String;
 use core::fmt::{Debug, Display, Write};
 use core::ops::Deref;
 #[cfg(not(feature = "std"))]
+#[allow(unused)]
 use num_traits::Float;
 
 /// This macro is the same as [`std::format!`], but it returns a [`SharedString`] instead.

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -484,155 +484,126 @@ pub(crate) mod ffi {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn slint_shared_string_from_number_fixed(
-        out: *mut SharedString,
+    pub extern "C" fn slint_shared_string_from_number_fixed(
+        out: &mut SharedString,
         n: f64,
         digits: usize,
     ) {
-        let str = shared_string_from_number_fixed(n, digits);
-        core::ptr::write(out, str);
+        *out = shared_string_from_number_fixed(n, digits);
     }
 
     #[test]
     fn test_slint_shared_string_from_number_fixed() {
-        unsafe {
-            let num = 12345.6789;
+        let mut s = SharedString::default();
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), num, 0);
-            assert_eq!(s.assume_init(), "12346");
+        let num = 12345.6789;
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), num, 1);
-            assert_eq!(s.assume_init(), "12345.7");
+        slint_shared_string_from_number_fixed(&mut s, num, 0);
+        assert_eq!(s.as_str(), "12346");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), num, 6);
-            assert_eq!(s.assume_init(), "12345.678900");
+        slint_shared_string_from_number_fixed(&mut s, num, 1);
+        assert_eq!(s.as_str(), "12345.7");
 
-            let num = -12345.6789;
+        slint_shared_string_from_number_fixed(&mut s, num, 6);
+        assert_eq!(s.as_str(), "12345.678900");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), num, 0);
-            assert_eq!(s.assume_init(), "-12346");
+        let num = -12345.6789;
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), num, 1);
-            assert_eq!(s.assume_init(), "-12345.7");
+        slint_shared_string_from_number_fixed(&mut s, num, 0);
+        assert_eq!(s.as_str(), "-12346");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), num, 6);
-            assert_eq!(s.assume_init(), "-12345.678900");
+        slint_shared_string_from_number_fixed(&mut s, num, 1);
+        assert_eq!(s.as_str(), "-12345.7");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), 1.23E+20_f64, 2);
-            assert_eq!(s.assume_init(), "123000000000000000000.00");
+        slint_shared_string_from_number_fixed(&mut s, num, 6);
+        assert_eq!(s.as_str(), "-12345.678900");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), 1.23E-10_f64, 2);
-            assert_eq!(s.assume_init(), "0.00");
+        slint_shared_string_from_number_fixed(&mut s, 1.23E+20_f64, 2);
+        assert_eq!(s.as_str(), "123000000000000000000.00");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), 2.34, 1);
-            assert_eq!(s.assume_init(), "2.3");
+        slint_shared_string_from_number_fixed(&mut s, 1.23E-10_f64, 2);
+        assert_eq!(s.as_str(), "0.00");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), 2.35, 1);
-            assert_eq!(s.assume_init(), "2.4");
+        slint_shared_string_from_number_fixed(&mut s, 2.34, 1);
+        assert_eq!(s.as_str(), "2.3");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_fixed(s.as_mut_ptr(), 2.55, 1);
-            assert_eq!(s.assume_init(), "2.5");
-        }
+        slint_shared_string_from_number_fixed(&mut s, 2.35, 1);
+        assert_eq!(s.as_str(), "2.4");
+
+        slint_shared_string_from_number_fixed(&mut s, 2.55, 1);
+        assert_eq!(s.as_str(), "2.5");
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn slint_shared_string_from_number_precision(
-        out: *mut SharedString,
+    pub extern "C" fn slint_shared_string_from_number_precision(
+        out: &mut SharedString,
         n: f64,
         precision: usize,
     ) {
-        let str = shared_string_from_number_precision(n, precision);
-        core::ptr::write(out, str);
+        *out = shared_string_from_number_precision(n, precision);
     }
 
     #[test]
     fn test_slint_shared_string_from_number_precision() {
-        unsafe {
-            let num = 5.123456;
+        let mut s = SharedString::default();
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 0);
-            assert_eq!(s.assume_init(), "5.123456");
+        let num = 5.123456;
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 5);
-            assert_eq!(s.assume_init(), "5.1235");
+        slint_shared_string_from_number_precision(&mut s, num, 0);
+        assert_eq!(s.as_str(), "5.123456");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 2);
-            assert_eq!(s.assume_init(), "5.1");
+        slint_shared_string_from_number_precision(&mut s, num, 5);
+        assert_eq!(s.as_str(), "5.1235");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 1);
-            assert_eq!(s.assume_init(), "5");
+        slint_shared_string_from_number_precision(&mut s, num, 2);
+        assert_eq!(s.as_str(), "5.1");
 
-            let num = 0.000123;
+        slint_shared_string_from_number_precision(&mut s, num, 1);
+        assert_eq!(s.as_str(), "5");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 0);
-            assert_eq!(s.assume_init(), "0.000123");
+        let num = 0.000123;
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 5);
-            assert_eq!(s.assume_init(), "0.00012300");
+        slint_shared_string_from_number_precision(&mut s, num, 0);
+        assert_eq!(s.as_str(), "0.000123");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 2);
-            assert_eq!(s.assume_init(), "0.00012");
+        slint_shared_string_from_number_precision(&mut s, num, 5);
+        assert_eq!(s.as_str(), "0.00012300");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 1);
-            assert_eq!(s.assume_init(), "0.0001");
+        slint_shared_string_from_number_precision(&mut s, num, 2);
+        assert_eq!(s.as_str(), "0.00012");
 
-            let num = 1234.5;
+        slint_shared_string_from_number_precision(&mut s, num, 1);
+        assert_eq!(s.as_str(), "0.0001");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 1);
-            assert_eq!(s.assume_init(), "1e3");
+        let num = 1234.5;
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 2);
-            assert_eq!(s.assume_init(), "1.2e3");
+        slint_shared_string_from_number_precision(&mut s, num, 1);
+        assert_eq!(s.as_str(), "1e3");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 6);
-            assert_eq!(s.assume_init(), "1234.50");
+        slint_shared_string_from_number_precision(&mut s, num, 2);
+        assert_eq!(s.as_str(), "1.2e3");
 
-            let num = -1234.5;
+        slint_shared_string_from_number_precision(&mut s, num, 6);
+        assert_eq!(s.as_str(), "1234.50");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 1);
-            assert_eq!(s.assume_init(), "-1e3");
+        let num = -1234.5;
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 2);
-            assert_eq!(s.assume_init(), "-1.2e3");
+        slint_shared_string_from_number_precision(&mut s, num, 1);
+        assert_eq!(s.as_str(), "-1e3");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 6);
-            assert_eq!(s.assume_init(), "-1234.50");
+        slint_shared_string_from_number_precision(&mut s, num, 2);
+        assert_eq!(s.as_str(), "-1.2e3");
 
-            let num = 0.00000012345;
+        slint_shared_string_from_number_precision(&mut s, num, 6);
+        assert_eq!(s.as_str(), "-1234.50");
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 1);
-            assert_eq!(s.assume_init(), "1e-7");
+        let num = 0.00000012345;
 
-            let mut s = core::mem::MaybeUninit::uninit();
-            slint_shared_string_from_number_precision(s.as_mut_ptr(), num, 10);
-            assert_eq!(s.assume_init(), "1.234500000e-7");
-        }
+        slint_shared_string_from_number_precision(&mut s, num, 1);
+        assert_eq!(s.as_str(), "1e-7");
+
+        slint_shared_string_from_number_precision(&mut s, num, 10);
+        assert_eq!(s.as_str(), "1.234500000e-7");
     }
 
     /// Append some bytes to an existing shared string

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -10,6 +10,8 @@ use crate::SharedVector;
 use alloc::string::String;
 use core::fmt::{Debug, Display, Write};
 use core::ops::Deref;
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
 
 /// This macro is the same as [`std::format!`], but it returns a [`SharedString`] instead.
 ///

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -323,7 +323,7 @@ pub fn shared_string_from_number_fixed(n: f64, digits: usize) -> SharedString {
 /// Convert a f64 to a SharedString following a similar logic as JavaScript's Number.toPrecision()
 pub fn shared_string_from_number_precision(n: f64, precision: usize) -> SharedString {
     let exponent: isize = if n.abs() < 1.0 {
-        let mut fract = n.abs().fract();
+        let mut fract = n.abs();
         let mut exponent = 0;
 
         while fract < 1.0 {
@@ -333,7 +333,7 @@ pub fn shared_string_from_number_precision(n: f64, precision: usize) -> SharedSt
 
         exponent
     } else {
-        let mut int = n.abs().trunc();
+        let mut int = n.abs();
         let mut exponent = 0;
 
         while int > 10.0 {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -490,6 +490,18 @@ fn call_builtin_function(
             let y: f64 = eval_expression(&arguments[1], local_context).try_into().unwrap();
             Value::Number(x.powf(y))
         }
+        BuiltinFunction::ToFixed => {
+            let n: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let digits: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
+            let digits: usize = digits.max(0) as usize;
+            Value::String(i_slint_core::string::shared_string_from_number_fixed(n, digits))
+        }
+        BuiltinFunction::ToPrecision => {
+            let n: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let precision: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
+            let precision: usize = precision.max(0) as usize;
+            Value::String(i_slint_core::string::shared_string_from_number_precision(n, precision))
+        }
         BuiltinFunction::SetFocusItem => {
             if arguments.len() != 1 {
                 panic!("internal error: incorrect argument count to SetFocusItem")

--- a/tests/cases/expr/to-fixed.slint
+++ b/tests/cases/expr/to-fixed.slint
@@ -1,0 +1,59 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+TestCase := Rectangle {
+    property<string> t1: 12345.6789.to-fixed(0);
+    property<string> t2: 12345.6789.to-fixed(1.0);
+    property<string> t3: 12345.6789.to-fixed(6);
+    property<string> t4: (-12345.6789).to-fixed(0);
+    property<string> t5: (-12345.6789).to-fixed(1);
+    property<string> t6: (-12345.6789).to-fixed(6.0);
+    property<string> t7: 2.34.to-fixed(1);
+    property<string> t8: 2.35.to-fixed(1.0);
+    property<string> t9: 2.55.to-fixed(1);
+    property<string> t10: 12345.6789.to-fixed(-1);
+}
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_t1(), "12346");
+assert_eq(instance.get_t2(), "12345.7");
+assert_eq(instance.get_t3(), "12345.678900");
+assert_eq(instance.get_t4(), "-12346");
+assert_eq(instance.get_t5(), "-12345.7");
+assert_eq(instance.get_t6(), "-12345.678900");
+assert_eq(instance.get_t7(), "2.3");
+assert_eq(instance.get_t8(), "2.4");
+assert_eq(instance.get_t9(), "2.5");
+assert_eq(instance.get_t10(), "12346");
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_t1(), "12346");
+assert_eq!(instance.get_t2(), "12345.7");
+assert_eq!(instance.get_t3(), "12345.678900");
+assert_eq!(instance.get_t4(), "-12346");
+assert_eq!(instance.get_t5(), "-12345.7");
+assert_eq!(instance.get_t6(), "-12345.678900");
+assert_eq!(instance.get_t7(), "2.3");
+assert_eq!(instance.get_t8(), "2.4");
+assert_eq!(instance.get_t9(), "2.5");
+assert_eq!(instance.get_t10(), "12346");
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equals(instance.t1, "12346");
+assert.equals(instance.t2, "12345.7");
+assert.equals(instance.t3, "12345.678900");
+assert.equals(instance.t4, "-12346");
+assert.equals(instance.t5, "-12345.7");
+assert.equals(instance.t6, "-12345.678900");
+assert.equals(instance.t7, "2.3");
+assert.equals(instance.t8, "2.4");
+assert.equals(instance.t9, "2.5");
+assert.equals(instance.t10, "12346");
+```
+*/

--- a/tests/cases/expr/to-fixed.slint
+++ b/tests/cases/expr/to-fixed.slint
@@ -45,15 +45,15 @@ assert_eq!(instance.get_t10(), "12346");
 
 ```js
 var instance = new slint.TestCase({});
-assert.equals(instance.t1, "12346");
-assert.equals(instance.t2, "12345.7");
-assert.equals(instance.t3, "12345.678900");
-assert.equals(instance.t4, "-12346");
-assert.equals(instance.t5, "-12345.7");
-assert.equals(instance.t6, "-12345.678900");
-assert.equals(instance.t7, "2.3");
-assert.equals(instance.t8, "2.4");
-assert.equals(instance.t9, "2.5");
-assert.equals(instance.t10, "12346");
+assert.equal(instance.t1, "12346");
+assert.equal(instance.t2, "12345.7");
+assert.equal(instance.t3, "12345.678900");
+assert.equal(instance.t4, "-12346");
+assert.equal(instance.t5, "-12345.7");
+assert.equal(instance.t6, "-12345.678900");
+assert.equal(instance.t7, "2.3");
+assert.equal(instance.t8, "2.4");
+assert.equal(instance.t9, "2.5");
+assert.equal(instance.t10, "12346");
 ```
 */

--- a/tests/cases/expr/to-precision.slint
+++ b/tests/cases/expr/to-precision.slint
@@ -57,19 +57,19 @@ assert_eq!(instance.get_t14(), "5.123456");
 
 ```js
 var instance = new slint.TestCase({});
-assert.equals(instance.t1, "5.123456");
-assert.equals(instance.t2, "5.1235");
-assert.equals(instance.t3, "5.1");
-assert.equals(instance.t4, "5");
-assert.equals(instance.t5, "0.000123");
-assert.equals(instance.t6, "0.00012300");
-assert.equals(instance.t7, "0.00012");
-assert.equals(instance.t8, "0.0001");
-assert.equals(instance.t9, "-1e3");
-assert.equals(instance.t10, "-1.2e3");
-assert.equals(instance.t11, "-1234.50");
-assert.equals(instance.t12, "1e-7");
-assert.equals(instance.t13, "1.234500000e-7");
-assert.equals(instance.t14, "5.123456");
+assert.equal(instance.t1, "5.123456");
+assert.equal(instance.t2, "5.1235");
+assert.equal(instance.t3, "5.1");
+assert.equal(instance.t4, "5");
+assert.equal(instance.t5, "0.000123");
+assert.equal(instance.t6, "0.00012300");
+assert.equal(instance.t7, "0.00012");
+assert.equal(instance.t8, "0.0001");
+assert.equal(instance.t9, "-1e3");
+assert.equal(instance.t10, "-1.2e3");
+assert.equal(instance.t11, "-1234.50");
+assert.equal(instance.t12, "1e-7");
+assert.equal(instance.t13, "1.234500000e-7");
+assert.equal(instance.t14, "5.123456");
 ```
 */

--- a/tests/cases/expr/to-precision.slint
+++ b/tests/cases/expr/to-precision.slint
@@ -1,0 +1,75 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+TestCase := Rectangle {
+    property<string> t1: 5.123456.to-precision(0.0);
+    property<string> t2: 5.123456.to-precision(5);
+    property<string> t3: 5.123456.to-precision(2);
+    property<string> t4: 5.123456.to-precision(1);
+    property<string> t5: 0.000123.to-precision(0);
+    property<string> t6: 0.000123.to-precision(5.0);
+    property<string> t7: 0.000123.to-precision(2);
+    property<string> t8: 0.000123.to-precision(1);
+    property<string> t9: (-1234.5).to-precision(1);
+    property<string> t10: (-1234.5).to-precision(2);
+    property<string> t11: (-1234.5).to-precision(6.0);
+    property<string> t12: 0.00000012345.to-precision(1);
+    property<string> t13: 0.00000012345.to-precision(10.0);
+    property<string> t14: 5.123456.to-precision(-1);
+}
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_t1(), "5.123456");
+assert_eq(instance.get_t2(), "5.1235");
+assert_eq(instance.get_t3(), "5.1");
+assert_eq(instance.get_t4(), "5");
+assert_eq(instance.get_t5(), "0.000123");
+assert_eq(instance.get_t6(), "0.00012300");
+assert_eq(instance.get_t7(), "0.00012");
+assert_eq(instance.get_t8(), "0.0001");
+assert_eq(instance.get_t9(), "-1e3");
+assert_eq(instance.get_t10(), "-1.2e3");
+assert_eq(instance.get_t11(), "-1234.50");
+assert_eq(instance.get_t12(), "1e-7");
+assert_eq(instance.get_t13(), "1.234500000e-7");
+assert_eq(instance.get_t14(), "5.123456");
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_t1(), "5.123456");
+assert_eq!(instance.get_t2(), "5.1235");
+assert_eq!(instance.get_t3(), "5.1");
+assert_eq!(instance.get_t4(), "5");
+assert_eq!(instance.get_t5(), "0.000123");
+assert_eq!(instance.get_t6(), "0.00012300");
+assert_eq!(instance.get_t7(), "0.00012");
+assert_eq!(instance.get_t8(), "0.0001");
+assert_eq!(instance.get_t9(), "-1e3");
+assert_eq!(instance.get_t10(), "-1.2e3");
+assert_eq!(instance.get_t11(), "-1234.50");
+assert_eq!(instance.get_t12(), "1e-7");
+assert_eq!(instance.get_t13(), "1.234500000e-7");
+assert_eq!(instance.get_t14(), "5.123456");
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equals(instance.t1, "5.123456");
+assert.equals(instance.t2, "5.1235");
+assert.equals(instance.t3, "5.1");
+assert.equals(instance.t4, "5");
+assert.equals(instance.t5, "0.000123");
+assert.equals(instance.t6, "0.00012300");
+assert.equals(instance.t7, "0.00012");
+assert.equals(instance.t8, "0.0001");
+assert.equals(instance.t9, "-1e3");
+assert.equals(instance.t10, "-1.2e3");
+assert.equals(instance.t11, "-1234.50");
+assert.equals(instance.t12, "1e-7");
+assert.equals(instance.t13, "1.234500000e-7");
+assert.equals(instance.t14, "5.123456");
+```
+*/


### PR DESCRIPTION
Add two new float to string conversion methods that mimic JavaScript's Number.toFixed() and Number.toPrecision().

They are implemented as no_mangle functions similar to the already existing float to shared string conversion.

Closes #5822

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
