### PR TITLE
infra: Test out mise

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -18,58 +18,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-    format_lint_typecheck:
+    format_fix:
         runs-on: ubuntu-24.04
         env:
             CARGO_INCREMENTAL: false
         steps:
             - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4.1.0
-              with:
-                version: 10.3.0
-            - uses: actions/setup-node@v4
-              with:
-                node-version: 20
-            - uses: ./.github/actions/install-linux-dependencies
-            - uses: ./.github/actions/setup-rust
-              with:
-                  toolchain: nightly
-                  components: rustfmt
-                  target: aarch64-linux-android
-            - name: Install wasm-pack
-              run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-            - name: Rust format
-              run: cargo fmt --
-            - name: C++ format
-              run: find -iname \*.h -o -iname \*.cpp | xargs clang-format -i
-            - name: Format, Lint on npm projects
-              run: |
-                  pnpm install --frozen-lockfile
-                  pnpm format:fix
-                  pnpm lint
-            - name: Check license headers
-              run: cargo xtask check_license_headers --fix-it
-            - name: remove trailing whitespace
-              run: git grep -I -l -O'sed -i "s/[[:space:]]*$//"' -e '' -- ':!*.patch'
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-            - name: Install uv
-              uses: astral-sh/setup-uv@v5
-            - name: Format Python
-              run: uv tool run ruff format
+            - uses: jdx/mise-action@v2
+            - name: Run fixes
+              run: mise run --force --jobs=1 'ci:autofix:fix'
             - name: Suggest format changes
               uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef
-            - name: Build wasm-interpreter before type check
-              working-directory: tools/slintpad
-              run: pnpm build:wasm_interpreter
-            - name: Build wasm-lsp before type check
-              working-directory: editors/vscode
-              run: pnpm build:wasm_lsp
-            - name: Typecheck on npm projects
-              run: |
-                  pnpm type-check
-            - run: sudo apt-get install pipx
-            - run: pipx install reuse
-            - name: Check reuse compliance
-              run: cargo xtask check_reuse_compliance
+
+    lint_typecheck:
+        runs-on: ubuntu-24.04
+        env:
+            CARGO_INCREMENTAL: false
+        steps:
+            - uses: actions/checkout@v4
+            - uses: jdx/mise-action@v2
+            - name: Run lints
+              run: mise run --force --jobs=1 'ci:autofix:lint'

--- a/.gitignore
+++ b/.gitignore
@@ -13,20 +13,19 @@ Pipfile.lock
 /docs/astro/src/content/collections/structs/
 /playwright-report
 
-# MISE local files:
-/.mise.local.toml
-/.mise/
-
 # Ignore all package-lock.json files
 **/package-lock.json
 # But keep these specific ones
 !editors/vscode/package-lock.json
 
+# MISE local files:
+/.mise.local.toml
+/.mise/tasks/local/
+
+
 *.node
 *.d.ts
 
-.env
-.envrc
 __pycache__
 uv.lock
 .python-version

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,0 +1,21 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+# cspell:ignore pipx
+
+[tools]
+"aqua:sharkdp/fd" = "latest"
+"rust" = { version = "stable", profile = "default" }
+node = "20"
+pnpm = "latest"
+
+## C++:
+"ubi:EmbarkStudios/cargo-about" = "0.6.6"
+"pipx:cmake" = "latest"
+"pipx:ninja" = "latest"
+"pipx:pipenv" = "latest"
+# doxygen = "latest" ## This is not available anywhere
+# graphviz = "latest" ## This is not available anywhere
+
+[task_config]
+includes = [ ".mise/tasks.toml", ".mise/tasks" ]

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -1,0 +1,75 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+# Use https://mise.jdx.dev/schema/mise-task.json for validation.
+
+### fixes
+
+["fix:cpp:format"]
+description = "Run clang format fix on all C++ files"
+run = '''fd '.*\.(h|H|hpp|hxx|h\+\+|c|C|cpp|cxx|c\+\+)$' -0 | xargs -0 clang-format -i'''
+tools = { "pipx:clang-format" = "latest" }
+
+["fix:legal:copyright"]
+description = "Run the check_license_headers --fix xtask"
+run = "cargo xtask check_license_headers --fix-it"
+
+["fix:python:format"]
+description = "Run ruff format"
+run = "ruff format"
+tools = { "ruff" = "latest" }
+
+["fix:rust:format"]
+description = "Run cargo fmt --all"
+run = "cargo fmt --all"
+
+["fix:ts:format"]
+description = "Run pnpm format:fix"
+run = "pnpm run format:fix"
+depends = ["prepare:pnpm-install"]
+
+["fix:ts:biome"]
+description = "Run pnpm lint:fix"
+run = "pnpm run lint:fix"
+depends = ["prepare:pnpm-install"]
+
+### Lints
+
+["lint:ts:typecheck"]
+description = "Run pnpm format:fix"
+run = "pnpm type-check"
+depends = ["prepare:pnpm-install", "build:lsp:wasm", "build:interpreter:wasm"]
+
+### Build
+
+["build:lsp:wasm"]
+description = "Build the LSP (WASM)"
+dir = "editors/vscode"
+sources = [ "tools/lsp/Cargo.toml", "tools/lsp/**/*.rs", "tools/lsp/ui/**/*.slint" ]
+outputs = [ "tools/lsp/pkg/*" ]
+run = "pnpm run build:wasm_lsp"
+tools = { "npm:wasm-pack" = "latest" }
+depends = ["prepare:pnpm-install"]
+
+["build:interpreter:wasm"]
+description = "Build the Slint interpreteer (WASM)"
+dir = "tools/slintpad"
+sources = [ "api/wasm-interpreter/Cargo.toml", "api/wasm-interpreter/src/**/*.rs" ]
+outputs = [ "api/wasm-interpreter/pkg/*" ]
+run = "pnpm run build:wasm_interpreter"
+tools = { "npm:wasm-pack" = "latest" }
+depends = ["prepare:pnpm-install"]
+
+["prepare:pnpm-install"]
+hide = true
+run = "pnpm install --frozen-lockfile"
+
+### CI
+
+["ci:autofix:fix"]
+description = "CI autofix job -- fix steps"
+depends = ["fix:cpp:format", "fix:legal:copyright", "fix:python:format", "fix:rust:format", "fix:text:trailing_spaces", "fix:ts:biome", "fix:ts:format"]
+
+["ci:autofix:lint"]
+description = "CI autofix job -- lint steps"
+depends = ["lint:legal:reuse", "lint:ts:typecheck"]

--- a/.mise/tasks/fix/text/trailing_spaces
+++ b/.mise/tasks/fix/text/trailing_spaces
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#MISE description="Run trailing WS fix on all files"
+
+set -e
+
+if test -f .git/HEAD ; then
+    git grep -I -l -O'sed -i "s/[[:space:]]*$//"' -e '' -- ':!*.patch'
+else
+    while IFS= read -r -d '' -u 9
+    do
+        if [[ "$(file -bs --mime-type -- "$REPLY")" = text/* ]]
+        then
+            sed -i "s/[[:space:]]*$//" -- "$REPLY"
+        fi
+    done 9< <(fd -0)
+fi

--- a/.mise/tasks/lint/legal/reuse
+++ b/.mise/tasks/lint/legal/reuse
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#MISE description="Run xtask check reuse compliance on all files"
+#MISE tools={ "pipx:reuse" = 5 }
+
+set -e
+
+if test -d "target" ; then
+  if test -n "$CI" ; then
+    echo "ERROR: Directory is not clean in CI run, NOT running reuse"
+    exit 1
+  else
+    echo "Warning: Directory is not clean, not running reuse"
+    exit 0
+  fi
+fi
+
+cargo xtask check_reuse_compliance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,13 @@ on [RFC tagged](https://github.com/slint-ui/slint/labels/rfc) issues.
 Issues which we think are suitable for new contributors are tagged with
 [good first issue](https://github.com/slint-ui/slint/labels/good%20first%20issue).
 
+## Internal documentation
+
+ - [Development guide](docs/development.md)
+ - [Building Slint from sources in this repository](docs/building.md)
+ - [Testing](docs/testing.md)
+ - [GitHub issues triage and labels](docs/triage.md)
+
 ## Contributor License Agreement
 
 All contributions are accepted under the terms of the MIT No Attribution License.
@@ -19,13 +26,6 @@ In any other case, please let us know.
 
 When opening a pull request, you will be asked to sign a
 [Contributor License Agreement (CLA)](https://cla-assistant.io/slint-ui/slint).
-
-## Internal documentation
-
- - [Development guide](docs/development.md)
- - [Building Slint from sources in this repository](docs/building.md)
- - [Testing](docs/testing.md)
- - [GitHub issues triage and labels](docs/triage.md)
 
 ## Coding Style
 

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -781,7 +781,7 @@ public:
     /// Rgb8Pixel.
     template<typename PixelType, typename Callback>
         requires requires(Callback callback) {
-            callback(size_t(0), size_t(0), size_t(0), [&callback](std::span<PixelType>) {});
+            callback(size_t(0), size_t(0), size_t(0), [&callback](std::span<PixelType>) { });
         }
     PhysicalRegion render_by_line(Callback process_line_callback) const
     {

--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -57,8 +57,8 @@ public:
              typename R = std::invoke_result_t<Visitor, ElementHandle>>
         requires((std::is_constructible_v<bool, R> && std::is_default_constructible_v<R>)
                  || std::is_void_v<R>)
-    static auto visit_elements(const ComponentHandle<T> &component,
-                               Visitor visitor) -> std::invoke_result_t<Visitor, ElementHandle>
+    static auto visit_elements(const ComponentHandle<T> &component, Visitor visitor)
+            -> std::invoke_result_t<Visitor, ElementHandle>
     {
         // using R = std::invoke_result_t<Visitor, ElementHandle>;
         auto vrc = component.into_dyn();

--- a/api/cpp/include/slint_point.h
+++ b/api/cpp/include/slint_point.h
@@ -32,17 +32,17 @@ using Point2D = Point<T>;
 struct LogicalPosition : public Point<float>
 {
     /// Explicitly convert a Point<float> to a LogicalPosition
-    explicit LogicalPosition(const Point<float> p) : Point<float>(p) {};
+    explicit LogicalPosition(const Point<float> p) : Point<float>(p) { };
     /// Default construct a LogicalPosition in the origin
-    LogicalPosition() : Point<float> { 0., 0. } {};
+    LogicalPosition() : Point<float> { 0., 0. } { };
 };
 /// A position in physical pixel coordinates
 struct PhysicalPosition : public Point<int32_t>
 {
     /// Explicitly convert a Point<int32_t> to a LogicalPosition
-    explicit PhysicalPosition(const Point<int32_t> p) : Point<int32_t>(p) {};
+    explicit PhysicalPosition(const Point<int32_t> p) : Point<int32_t>(p) { };
     /// Default construct a PhysicalPosition in the origin
-    PhysicalPosition() : Point<int32_t> { 0, 0 } {};
+    PhysicalPosition() : Point<int32_t> { 0, 0 } { };
 };
 
 }

--- a/api/cpp/tests/platform_eventloop.cpp
+++ b/api/cpp/tests/platform_eventloop.cpp
@@ -28,7 +28,7 @@ struct TestPlatform : slint::platform::Platform
 #ifdef SLINT_FEATURE_RENDERER_SOFTWARE
         struct TestWindowAdapter : slint::platform::WindowAdapter
         {
-            slint::platform::SoftwareRenderer r { {} };
+            slint::platform::SoftwareRenderer r { { } };
             slint::PhysicalSize size() override { return slint::PhysicalSize({}); }
             slint::platform::AbstractRenderer &renderer() override { return r; }
         };

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,16 @@
 The build instructions are in the [building.md](./building.md) file.
 The testing instructions are in the [testing.md](./testing.md) file.
 
+## Environment Setup
+
+[`mise-en-place`](https://mise.jdx.dev/) can be used to install the necessary
+development tooling. After installing `mise` and registering `mise` with your
+shell, go into your git checkout directory and `mise trust -a` the configuration
+we ship. Afterwards `mise install` makes all the necessary tooling available.
+
+Even if you do not want to use mise: `.mise/config.toml` contains a handy list of tools
+to make available.
+
 ## Repository structures
 
 ### `helper_crates`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1756,6 +1756,9 @@ packages:
   '@vitest/pretty-format@3.0.8':
     resolution: {integrity: sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==}
 
+  '@vitest/pretty-format@3.0.9':
+    resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
+
   '@vitest/runner@3.0.8':
     resolution: {integrity: sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==}
 
@@ -6444,6 +6447,10 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@3.0.9':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/runner@3.0.8':
     dependencies:
       '@vitest/utils': 3.0.8
@@ -9811,7 +9818,7 @@ snapshots:
     dependencies:
       '@vitest/expect': 3.0.8
       '@vitest/mocker': 3.0.8(vite@6.2.2(@types/node@20.16.10)(yaml@2.7.0))
-      '@vitest/pretty-format': 3.0.8
+      '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8
       '@vitest/spy': 3.0.8

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -438,7 +438,7 @@ lazy_static! {
         ("^\\.clang-format$", LicenseLocation::NoLicense),
         ("^\\.github/.*\\.md$", LicenseLocation::NoLicense),
         ("^\\.mailmap$", LicenseLocation::NoLicense),
-        ("^\\.reuse/dep5$", LicenseLocation::NoLicense), // .reuse files have no license headers
+        ("^\\.mise/tasks/", LicenseLocation::Tag(LicenseTagStyle::shell_comment_style())),
         ("^api/cpp/docs/conf\\.py$", LicenseLocation::NoLicense),
         ("^docs/reference/Pipfile$", LicenseLocation::NoLicense),
         ("^docs/reference/conf\\.py$", LicenseLocation::NoLicense),


### PR DESCRIPTION
I found `mise` a tool to help manage development projects. https://mise.jdx.dev/

It basically can manage ENV vars based on the directory you are in, manages tools you need (and makes thoser available based on the directory you are in), and allows to define simple tasks that can then be shared between developers.

Tools can be found in npm, pipx, aqua, binaries on github, ... and it tries to verify signatures and all that (if supported by the repo the data comes from).

I replaces the entire autofix workflow with mise tooling and tasks, just to give it a try :-)

# Why do I want this?

## New contributor setup

`mise install` should be enough to get most tools into place. That makes things so much simpler!

## Faster turn around times

I can run at least the autofix thing locally now, which takes < 10s. That's much more convenient than pushing and waiting for CI.

Mid term I want to turn the autoformat CI tasks into a git commit hook -- which is trival to do as mise can install all the required tools :-)

## Better DX

I have all the tools I need available *while in the folder I need them*. Env vars can also be auto-set :-)

## Easier CI improvements

I can drop a task file into mise and test it out locally. This is a so much better workflow to improve CI than fiddling with the github yaml files, uploading and waiting...

# How can I test this?

```sh
> cargo install mise # to get the tool itself

# Follow the necessary step
# https://mise.jdx.dev/installing-mise.html#shells
# to intergate into your shell

> cd /your/slint/folder

# Mise will now ask whether or not to trust this dir and prints the
# command needed to do so. Run that.

> mise install # Install all the tools defined in .mise/config.toml

# Add a .mise.local.toml with local overrides. Git will ignore this file.
# Or add tasks into .mise/tasks/local ... Git will also ignore those.

> mise run 'ci:autofix:**:all' # To run all the tasks in `.mise/tasks/ci/autofix/*` that are called `all`.
```

It is so much faster to see these checks fail locally than it is to bother CI with them :-)

This could easily be extended with more formats and checks (e.g. `taplo` for TOML formatting or `actionlint` for linting github workflows) as it is trivial to grab the tool in the expected version.

This should also lent itself pretty well co git commit hooks ;-)
