### PR TITLE
Improve font embedding for MCUs when bundling translations

### DIFF
--- a/demos/usecases/ui/app.slint
+++ b/demos/usecases/ui/app.slint
@@ -42,6 +42,4 @@ export component App inherits Window {
     changed height => {
         DialogGlobal.window-height = root.height;
     }
-
-    out property <string> trick-to-include-german-umlauts: "äöüÄÖÜ"; // required for translations
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4047,7 +4047,7 @@ fn generate_type_aliases(file: &mut File, doc: &Document) {
 
 #[cfg(feature = "bundle-translations")]
 fn generate_translation(
-    translations: &llr::translations::Translations,
+    translations: &crate::translations::Translations,
     compilation_unit: &llr::CompilationUnit,
     declarations: &mut Vec<Declaration>,
 ) {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3451,7 +3451,7 @@ fn generate_named_exports(doc: &Document) -> Vec<TokenStream> {
 
 #[cfg(feature = "bundle-translations")]
 fn generate_translations(
-    translations: &llr::translations::Translations,
+    translations: &crate::translations::Translations,
     compilation_unit: &llr::CompilationUnit,
 ) -> TokenStream {
     let strings = translations.strings.iter().map(|strings| {

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -34,6 +34,8 @@ pub mod namedreference;
 pub mod object_tree;
 pub mod parser;
 pub mod pathutils;
+#[cfg(feature = "bundle-translations")]
+pub mod translations;
 pub mod typeloader;
 pub mod typeregister;
 

--- a/internal/compiler/llr.rs
+++ b/internal/compiler/llr.rs
@@ -10,8 +10,6 @@ pub use item_tree::*;
 pub mod lower_expression;
 pub mod lower_to_item_tree;
 pub mod pretty_print;
-#[cfg(feature = "bundle-translations")]
-pub mod translations;
 
 /// The optimization passes over the LLR
 pub mod optim_passes {

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -387,7 +387,7 @@ pub struct CompilationUnit {
     pub popup_menu: Option<PopupMenu>,
     pub has_debug_info: bool,
     #[cfg(feature = "bundle-translations")]
-    pub translations: Option<super::translations::Translations>,
+    pub translations: Option<crate::translations::Translations>,
 }
 
 impl CompilationUnit {

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -24,7 +24,7 @@ pub fn lower_to_item_tree(
     #[cfg(feature = "bundle-translations")]
     if let Some(path) = &compiler_config.translation_path_bundle {
         state.translation_builder = Some(
-            super::translations::TranslationsBuilder::load_translations(
+            crate::translations::TranslationsBuilder::load_translations(
                 path,
                 compiler_config.translation_domain.as_deref().unwrap_or(""),
             )
@@ -186,7 +186,7 @@ pub struct LoweringState {
     sub_components: TiVec<SubComponentIdx, LoweredSubComponent>,
     pub sub_component_mapping: HashMap<ByAddress<Rc<Component>>, SubComponentIdx>,
     #[cfg(feature = "bundle-translations")]
-    pub translation_builder: Option<super::translations::TranslationsBuilder>,
+    pub translation_builder: Option<crate::translations::TranslationsBuilder>,
 }
 
 impl LoweringState {

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -22,14 +22,8 @@ pub fn lower_to_item_tree(
     let mut state = LoweringState::default();
 
     #[cfg(feature = "bundle-translations")]
-    if let Some(path) = &compiler_config.translation_path_bundle {
-        state.translation_builder = Some(
-            crate::translations::TranslationsBuilder::load_translations(
-                path,
-                compiler_config.translation_domain.as_deref().unwrap_or(""),
-            )
-            .map_err(|e| std::io::Error::other(format!("Cannot load bundled translation: {e}")))?,
-        );
+    {
+        state.translation_builder = document.translation_builder.clone();
     }
 
     let mut globals = TiVec::new();

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -42,7 +42,7 @@ macro_rules! unwrap_or_continue {
 }
 
 /// The full document (a complete file)
-#[derive(Default, Debug)]
+#[derive(Default)]
 pub struct Document {
     pub node: Option<syntax_nodes::Document>,
     pub inner_components: Vec<Rc<Component>>,
@@ -58,6 +58,9 @@ pub struct Document {
     /// disk on the build system
     pub embedded_file_resources:
         RefCell<BTreeMap<SmolStr, crate::embedded_resources::EmbeddedResources>>,
+
+    #[cfg(feature = "bundle-translations")]
+    pub translation_builder: Option<crate::translations::TranslationsBuilder>,
 
     /// The list of used extra types used recursively.
     pub used_types: RefCell<UsedSubTypes>,
@@ -259,6 +262,8 @@ impl Document {
             imports,
             exports,
             embedded_file_resources: Default::default(),
+            #[cfg(feature = "bundle-translations")]
+            translation_builder: None,
             used_types: Default::default(),
             popup_menu_impl: None,
         }

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -287,6 +287,8 @@ impl Snapshotter {
             imports: document.imports.clone(),
             exports,
             embedded_file_resources: document.embedded_file_resources.clone(),
+            #[cfg(feature = "bundle-translations")]
+            translation_builder: document.translation_builder.clone(),
             used_types: RefCell::new(self.snapshot_used_sub_types(&document.used_types.borrow())),
             popup_menu_impl: document.popup_menu_impl.as_ref().map(|p| {
                 Weak::upgrade(&self.use_component(p))


### PR DESCRIPTION
Include messages from bundled translations into the character set used for deciding which glyphs to embed.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
