### PR TITLE
janitor: Update .gitignore to make local use of mise possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ Pipfile.lock
 /docs/astro/src/content/collections/structs/
 /playwright-report
 
+# MISE local files:
+/.mise.local.toml
+/.mise/
+
 # Ignore all package-lock.json files
 **/package-lock.json
 # But keep these specific ones


### PR DESCRIPTION
Project wide use of mise dopes not seem popular, so just update .gitignore to allow for local use.
