### PR TITLE
Remove workaround for mcu-embassy example having its own workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     'demos/energy-monitor',
     'demos/home-automation/rust',
     'examples/mcu-board-support',
+    'examples/mcu-embassy',
     'examples/uefi-demo',
     'demos/weather-demo',
     'demos/usecases/rust',

--- a/examples/mcu-embassy/Cargo.toml
+++ b/examples/mcu-embassy/Cargo.toml
@@ -1,10 +1,6 @@
 # Copyright © 2025 David Haig
 # SPDX-License-Identifier: MIT
 
-# A work around for an embassy-time-driver conflict with esp32-hal's embassy dependency.
-# Remove this workspace and add 'examples/mcu-embassy' as a member to the slint root Cargo.toml once this issue has been resolved
-[workspace]
-
 [package]
 name = "mcu-embassy"
 version = "1.11.0"


### PR DESCRIPTION
Amends commit c47074e698927eee2146b1911995453a89c3acda

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
