### PR TITLE
No need for biome CLI

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -38,14 +38,10 @@ jobs:
                   target: aarch64-linux-android
             - name: Install wasm-pack
               run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-            - name: Setup Biome CLI
-              uses: biomejs/setup-biome@v2
             - name: Rust format
               run: cargo fmt --
             - name: C++ format
               run: find -iname \*.h -o -iname \*.cpp | xargs clang-format -i
-            - name: Run biome for top-level json config itself
-              run: biome format biome.json
             - name: Format, Lint on npm projects
               run: |
                   pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "format": "pnpm --stream -r format",
-    "format:fix": "pnpm -r format:fix",
+    "format": "biome format biome.json && pnpm --stream -r format",
+    "format:fix": "biome format biome.json --write && pnpm --stream -r format:fix",
     "lint": "pnpm --stream -r lint",
-    "lint:fix": "pnpm -r lint:fix",
+    "lint:fix": "pnpm --stream -r lint:fix",
     "type-check": "pnpm --stream -r type-check"
   },
   "packageManager": "pnpm@10.3.0",


### PR DESCRIPTION
Autofix is installing an extra version of Biome just to check a single file, the biome.json in the root. This responsibility is moved to the root package.json. 