### PR TITLE
live-preview: Don't let unselect work when clicking on live content

### DIFF
--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -247,8 +247,21 @@ export component PreviewView {
                 mouse-cursor: root.mode == DrawAreaMode.selecting ? MouseCursor.crosshair : MouseCursor.default;
 
                 changed has-hover => {
-                    StatusLineApi.help-text = "<click> unselect";
+                    if self.has-hover {
+                        StatusLineApi.help-text = "<click> unselect";
+                    } else {
+                         StatusLineApi.help-text = "";
+                    }
                 }
+            }
+
+            unselect-area-blocker:= TouchArea {
+                x: content-border.x;
+                y: content-border.y;
+                width: content-border.width;
+                height: content-border.height;
+
+                mouse-cursor: root.mode == DrawAreaMode.selecting ? MouseCursor.crosshair : MouseCursor.default;
             }
 
             content-border := Rectangle {


### PR DESCRIPTION
The previous behaviour meant when in normal mode for live-preview you could click outside the bounds of your running slint UI and it would unselect the current selection. e.g. some Rect would be unseletedand the root element would gain selection.

However if your Slint app had areas with no TouchAreas if you clicked in these areas of the running UI it would also cause the current selection to become unselected.

This change adds an additional TouchArea the same size as the running UI that blocks these stray clicks and makes select/unselect feel more predictable. Any user with a semi complex UI would probably never hit this issue, but anyone starting out with a simple UI would experience this. 