### PR TITLE
matching the math for skia and femtovg renders for radial gradient

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -578,7 +578,7 @@ fn into_qbrush(
             cpp_class!(unsafe struct QRadialGradient as "QRadialGradient");
             let mut qrg = cpp! {
                 unsafe [width as "qreal", height as "qreal"] -> QRadialGradient as "QRadialGradient" {
-                    QRadialGradient qrg(width / 2, height / 2, (width + height) / 4);
+                    QRadialGradient qrg(width / 2, height / 2, sqrt(width * width + height * height) / 2);
                     return qrg;
                 }
             };

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1564,7 +1564,7 @@ impl<'a> GLItemRenderer<'a> {
                     path_width / 2.,
                     path_height / 2.,
                     0.,
-                    (path_width + path_height) / 4.,
+                    path_width.max(path_height) / 2.,
                     stops,
                 )
             }

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1564,7 +1564,7 @@ impl<'a> GLItemRenderer<'a> {
                     path_width / 2.,
                     path_height / 2.,
                     0.,
-                    path_width.max(path_height) / 2.,
+                    0.5 * (path_width * path_width + path_height * path_height).sqrt(),
                     stops,
                 )
             }

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -121,7 +121,8 @@ impl<'a> SkiaItemRenderer<'a> {
             Brush::RadialGradient(g) => {
                 let (colors, pos): (Vec<_>, Vec<_>) =
                     g.stops().map(|s| (to_skia_color(&s.color), s.position)).unzip();
-                let circle_scale = width.max(height) / 2.;
+                let circle_scale =
+                    0.5 * (width.get() * width.get() + height.get() * height.get()).sqrt();
 
                 paint.set_dither(true);
 
@@ -132,7 +133,7 @@ impl<'a> SkiaItemRenderer<'a> {
                     Some(&*pos),
                     TileMode::Clamp,
                     skia_safe::gradient_shader::Flags::INTERPOLATE_COLORS_IN_PREMUL,
-                    skia_safe::Matrix::scale((circle_scale.get(), circle_scale.get()))
+                    skia_safe::Matrix::scale((circle_scale, circle_scale))
                         .post_translate((width.get() / 2., height.get() / 2.))
                         as &skia_safe::Matrix,
                 )


### PR DESCRIPTION
skia works correctly

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
