### PR TITLE
Added window_handle_06_rc and display_handle_06_rc in WindowAdapter

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -142,6 +142,7 @@ pub trait WindowAdapter {
 
     /// Re-implement this to support exposing raw window handles (version 0.6).
     #[cfg(feature = "raw-window-handle-06")]
+    #[deprecated(since = "1.10.0", note = "use `window_handle_06_rc` instead.")]
     fn window_handle_06(
         &self,
     ) -> Result<raw_window_handle_06::WindowHandle<'_>, raw_window_handle_06::HandleError> {
@@ -150,9 +151,28 @@ pub trait WindowAdapter {
 
     /// Re-implement this to support exposing raw display handles (version 0.6).
     #[cfg(feature = "raw-window-handle-06")]
+    #[deprecated(since = "1.10.0", note = "use `display_handle_06_rc` instead.")]
     fn display_handle_06(
         &self,
     ) -> Result<raw_window_handle_06::DisplayHandle<'_>, raw_window_handle_06::HandleError> {
+        Err(raw_window_handle_06::HandleError::NotSupported)
+    }
+
+    /// Re-implement this to support exposing raw window handles (version 0.6).
+    #[cfg(feature = "raw-window-handle-06")]
+    fn window_handle_06_rc(
+        &self,
+    ) -> Result<Rc<dyn raw_window_handle_06::HasWindowHandle>, raw_window_handle_06::HandleError>
+    {
+        Err(raw_window_handle_06::HandleError::NotSupported)
+    }
+
+    /// Re-implement this to support exposing raw display handles (version 0.6).
+    #[cfg(feature = "raw-window-handle-06")]
+    fn display_handle_06_rc(
+        &self,
+    ) -> Result<Rc<dyn raw_window_handle_06::HasDisplayHandle>, raw_window_handle_06::HandleError>
+    {
         Err(raw_window_handle_06::HandleError::NotSupported)
     }
 }


### PR DESCRIPTION
Added `window_handle_06_rc` and `display_handle_06_rc` in `slint::platform::WindowAdapter`, existing functions (`window_handle_06` and `display_handle_06` )  are flawed and can not be used in practical use.
I have not removed them but marked them deprecated.