### PR TITLE
Add error handling for the slide puzzle example

### DIFF
--- a/examples/slide_puzzle/index.html
+++ b/examples/slide_puzzle/index.html
@@ -52,7 +52,17 @@
   </div>
   <script type="module">
     import init from './pkg/slide_puzzle.js';
-    init().finally(() => {
+    async function loadWasm() {
+      try {
+        await init();
+      } catch (error) {
+        const errorMessage = error.toString();
+        if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+          alert('Error loading WASM: ' + errorMessage);
+        }
+      }
+    }
+    loadWasm().finally(() => {
       document.getElementById("spinner").remove();
     });
   </script>

--- a/examples/slide_puzzle/main.rs
+++ b/examples/slide_puzzle/main.rs
@@ -165,7 +165,7 @@ impl AppState {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
@@ -230,5 +230,6 @@ pub fn main() {
             state_copy.borrow().auto_play_timer.stop();
         }
     });
-    main_window.run().unwrap();
+    main_window.run()?;
+    Ok(())
 }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -1031,6 +1031,16 @@ pub enum PlatformError {
     OtherError(Box<dyn std::error::Error + Send + Sync>),
 }
 
+
+#[cfg(target_arch = "wasm32")]
+impl From<PlatformError> for wasm_bindgen::JsValue {
+    fn from(err: PlatformError) -> wasm_bindgen::JsValue {
+        use crate::alloc::string::ToString;
+
+        wasm_bindgen::JsValue::from(err.to_string())
+    }
+}
+
 impl core::fmt::Display for PlatformError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {


### PR DESCRIPTION
Fix issue #896

- Added impl From PlatformError  for JsValue
- Added: Show an error alert if wasm lib/slint finishes with errors