### PR TITLE
Add string.to-lowercase and string.to-uppercase

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -81,7 +81,11 @@
                 "vectormodel",
                 "structslint",
                 "namespaceslint",
-                "compilerconfiguration"
+                "compilerconfiguration",
+                "tschüß",
+                "TSCHÜSS",
+                "ὈΔΥΣΣΕΎΣ",
+                "ὀδυσσεύς"
             ],
         }
     ],

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -71,6 +71,17 @@ export component CharacterCountOfString {
 }
 ```
 
+The `to-lowercase` and `to-uppercase` methods convert `string` to lowercase or uppercase according to the [Unicode Character Property](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-4/#G124722).
+
+```slint
+export component ChangeCaseOfString {
+    property<string> hello: "HELLO".to-lowercase(); // "hello"
+    property<string> bye: "tschüß".to-uppercase(); // "TSCHÜSS"
+    property<string> odysseus: "ὈΔΥΣΣΕΎΣ".to-lowercase(); // "ὀδυσσεύς"
+    property<string> new_year: "农历新年".to-uppercase(); // "农历新年"
+}
+```
+
 </SlintProperty>
 
 ## Numeric Types

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -65,6 +65,8 @@ pub enum BuiltinFunction {
     StringIsEmpty,
     /// the "42".length
     StringCharacterCount,
+    StringToLowercase,
+    StringToUppercase,
     ColorRgbaStruct,
     ColorHsvaStruct,
     ColorBrighter,
@@ -187,6 +189,8 @@ declare_builtin_function_types!(
     StringIsFloat: (Type::String) -> Type::Bool,
     StringIsEmpty: (Type::String) -> Type::Bool,
     StringCharacterCount: (Type::String) -> Type::Int32,
+    StringToLowercase: (Type::String) -> Type::String,
+    StringToUppercase: (Type::String) -> Type::String,
     ImplicitLayoutInfo(..): (Type::ElementReference) -> Type::Struct(typeregister::layout_info_type()),
     ColorRgbaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct {
         fields: IntoIterator::into_iter([
@@ -306,7 +310,9 @@ impl BuiltinFunction {
             BuiltinFunction::StringToFloat
             | BuiltinFunction::StringIsFloat
             | BuiltinFunction::StringIsEmpty
-            | BuiltinFunction::StringCharacterCount => true,
+            | BuiltinFunction::StringCharacterCount
+            | BuiltinFunction::StringToLowercase
+            | BuiltinFunction::StringToUppercase => true,
             BuiltinFunction::ColorRgbaStruct
             | BuiltinFunction::ColorHsvaStruct
             | BuiltinFunction::ColorBrighter
@@ -382,7 +388,9 @@ impl BuiltinFunction {
             BuiltinFunction::StringToFloat
             | BuiltinFunction::StringIsFloat
             | BuiltinFunction::StringIsEmpty
-            | BuiltinFunction::StringCharacterCount => true,
+            | BuiltinFunction::StringCharacterCount
+            | BuiltinFunction::StringToLowercase
+            | BuiltinFunction::StringToUppercase => true,
             BuiltinFunction::ColorRgbaStruct
             | BuiltinFunction::ColorHsvaStruct
             | BuiltinFunction::ColorBrighter

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3593,6 +3593,12 @@ fn compile_builtin_function_call(
         BuiltinFunction::StringCharacterCount => {
             format!("[](const auto &a){{ return slint::cbindgen_private::slint_string_character_count(&a); }}({})", a.next().unwrap())
         }
+        BuiltinFunction::StringToLowercase => {
+            format!("{}.to_lowercase()", a.next().unwrap())
+        }
+        BuiltinFunction::StringToUppercase => {
+            format!("{}.to_uppercase()", a.next().unwrap())
+        }
         BuiltinFunction::ColorRgbaStruct => {
             format!("{}.to_argb_uint()", a.next().unwrap())
         }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3021,6 +3021,8 @@ fn compile_builtin_function_call(
         BuiltinFunction::StringCharacterCount => {
             quote!( sp::UnicodeSegmentation::graphemes(#(#a)*.as_str(), true).count() as i32 )
         }
+        BuiltinFunction::StringToLowercase => quote!(sp::SharedString::from(#(#a)*.to_lowercase())),
+        BuiltinFunction::StringToUppercase => quote!(sp::SharedString::from(#(#a)*.to_uppercase())),
         BuiltinFunction::ColorRgbaStruct => quote!( #(#a)*.to_argb_u8()),
         BuiltinFunction::ColorHsvaStruct => quote!( #(#a)*.to_hsva()),
         BuiltinFunction::ColorBrighter => {

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -115,6 +115,8 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::StringIsFloat => 50,
         BuiltinFunction::StringIsEmpty => 50,
         BuiltinFunction::StringCharacterCount => 50,
+        BuiltinFunction::StringToLowercase => ALLOC_COST,
+        BuiltinFunction::StringToUppercase => ALLOC_COST,
         BuiltinFunction::ColorRgbaStruct => 50,
         BuiltinFunction::ColorHsvaStruct => 50,
         BuiltinFunction::ColorBrighter => 50,

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -935,6 +935,8 @@ impl LookupObject for StringExpression<'_> {
             .or_else(|| f("to-float", member_function(BuiltinFunction::StringToFloat)))
             .or_else(|| f("is-empty", function_call(BuiltinFunction::StringIsEmpty)))
             .or_else(|| f("character-count", function_call(BuiltinFunction::StringCharacterCount)))
+            .or_else(|| f("to-lowercase", member_function(BuiltinFunction::StringToLowercase)))
+            .or_else(|| f("to-uppercase", member_function(BuiltinFunction::StringToUppercase)))
     }
 }
 struct ColorExpression<'a>(&'a Expression);

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1006,6 +1006,26 @@ fn call_builtin_function(
                 panic!("Argument not a string");
             }
         }
+        BuiltinFunction::StringToLowercase => {
+            if arguments.len() != 1 {
+                panic!("internal error: incorrect argument count to StringToLowercase")
+            }
+            if let Value::String(s) = eval_expression(&arguments[0], local_context) {
+                Value::String(s.to_lowercase().into())
+            } else {
+                panic!("Argument not a string");
+            }
+        }
+        BuiltinFunction::StringToUppercase => {
+            if arguments.len() != 1 {
+                panic!("internal error: incorrect argument count to StringToUppercase")
+            }
+            if let Value::String(s) = eval_expression(&arguments[0], local_context) {
+                Value::String(s.to_uppercase().into())
+            } else {
+                panic!("Argument not a string");
+            }
+        }
         BuiltinFunction::ColorRgbaStruct => {
             if arguments.len() != 1 {
                 panic!("internal error: incorrect argument count to ColorRGBAComponents")

--- a/tests/cases/types/string_to_lowercase.slint
+++ b/tests/cases/types/string_to_lowercase.slint
@@ -1,0 +1,36 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase {
+    out property<string> hello: "HELLO".to-lowercase();
+    out property<string> sigma: "Σ".to-lowercase();
+    out property<string> odysseus: "ὈΔΥΣΣΕΎΣ".to-lowercase();
+    out property<string> new_year: "农历新年".to-lowercase();
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_hello(), "hello");
+assert_eq(instance.get_sigma(), "σ");
+assert_eq(instance.get_odysseus(), "ὀδυσσεύς");
+assert_eq(instance.get_new_year(), "农历新年");
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_hello(), "hello");
+assert_eq!(instance.get_sigma(), "σ");
+assert_eq!(instance.get_odysseus(), "ὀδυσσεύς");
+assert_eq!(instance.get_new_year(), "农历新年");
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.hello, "hello");
+assert.equal(instance.sigma, "σ");
+assert.equal(instance.odysseus, "ὀδυσσεύς");
+assert.equal(instance.new_year, "农历新年");
+```
+*/

--- a/tests/cases/types/string_to_uppercase.slint
+++ b/tests/cases/types/string_to_uppercase.slint
@@ -1,0 +1,40 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase {
+    out property<string> hello: "hello".to-uppercase();
+    out property<string> sigma: "σ".to-uppercase();
+    out property<string> odysseus: "ὀδυσσεύς".to-uppercase();
+    out property<string> new_year: "农历新年".to-uppercase();
+    out property<string> bye: "tschüß".to-uppercase();
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_hello(), "HELLO");
+assert_eq(instance.get_sigma(), "Σ");
+assert_eq(instance.get_odysseus(), "ὈΔΥΣΣΕΎΣ");
+assert_eq(instance.get_new_year(), "农历新年");
+assert_eq(instance.get_bye(), "TSCHÜSS");
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_hello(), "HELLO");
+assert_eq!(instance.get_sigma(), "Σ");
+assert_eq!(instance.get_odysseus(), "ὈΔΥΣΣΕΎΣ");
+assert_eq!(instance.get_new_year(), "农历新年");
+assert_eq!(instance.get_bye(), "TSCHÜSS");
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.hello, "HELLO");
+assert.equal(instance.sigma, "Σ");
+assert.equal(instance.odysseus, "ὈΔΥΣΣΕΎΣ");
+assert.equal(instance.new_year, "农历新年");
+assert.equal(instance.bye, "TSCHÜSS");
+```
+*/


### PR DESCRIPTION
Adds methods to change a `string`'s case to lowercase or uppercase. They use Rust's `to_lowercase` and `to_uppercase` `String` methods.

Closes #7860

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
