### PR TITLE
Interpreter: Fix panic when animating a `%` property

### DIFF
--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -712,16 +712,23 @@ fn create_layout_item(
         if !item.borrow().bindings.get(prop).is_some_and(|b| b.borrow().ty() == Type::Percent) {
             return;
         }
+        let min_name = format_smolstr!("min-{}", prop);
+        let max_name = format_smolstr!("max-{}", prop);
+        let mut min_ref = BindingExpression::from(Expression::PropertyReference(
+            NamedReference::new(item, min_name.clone()),
+        ));
         let mut item = item.borrow_mut();
-        let b = item.bindings.remove(prop).unwrap();
-        item.bindings.insert(format_smolstr!("min-{}", prop), b.clone());
-        item.bindings.insert(format_smolstr!("max-{}", prop), b);
+        let b = item.bindings.remove(prop).unwrap().into_inner();
+        min_ref.span = b.span.clone();
+        min_ref.priority = b.priority;
+        item.bindings.insert(max_name.clone(), min_ref.into());
+        item.bindings.insert(min_name.clone(), b.into());
         item.property_declarations.insert(
-            format_smolstr!("min-{}", prop),
+            min_name,
             PropertyDeclaration { property_type: Type::Percent, ..PropertyDeclaration::default() },
         );
         item.property_declarations.insert(
-            format_smolstr!("max-{}", prop),
+            max_name,
             PropertyDeclaration { property_type: Type::Percent, ..PropertyDeclaration::default() },
         );
     };

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1224,7 +1224,7 @@ pub(crate) fn generate_item_tree<'id>(
             Type::Struct(_) => property_info::<Value>(),
             Type::Array(_) => property_info::<Value>(),
             Type::Easing => property_info::<i_slint_core::animations::EasingCurve>(),
-            Type::Percent => property_info::<f32>(),
+            Type::Percent => animated_property_info::<f32>(),
             Type::Enumeration(e) => {
                 macro_rules! match_enum_type {
                     ($( $(#[$enum_doc:meta])* enum $Name:ident { $($body:tt)* })*) => {

--- a/tests/cases/layout/issue_7761_animated_pc_size.slint
+++ b/tests/cases/layout/issue_7761_animated_pc_size.slint
@@ -1,0 +1,78 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+
+export component TestCase {
+    width: 200px;
+    height: 300px;
+    in-out property <bool> flag;
+
+    HorizontalLayout {
+        r1 := Rectangle {
+            width: root.flag ? 0% : 50%;
+            animate width { duration: 200ms; }
+            background: red;
+        }
+
+        ta := TouchArea {
+            clicked => {
+                root.flag = !root.flag;
+            }
+        }
+    }
+
+    out property <int> ta-width: ta.width / 1px;
+    out property <bool> test: ta-width == 100;
+}
+
+
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_ta_width(), 100);
+assert(instance.get_test());
+instance.set_flag(true);
+assert_eq(instance.get_ta_width(), 100);
+// Half the animation
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_ta_width(), 150);
+// finish animation, and more
+slint_testing::mock_elapsed_time(200);
+assert_eq(instance.get_ta_width(), 200);
+
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_ta_width(), 100);
+assert!(instance.get_test());
+instance.set_flag(true);
+assert_eq!(instance.get_ta_width(), 100);
+// Half the animation
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_ta_width(), 150);
+// finish animation, and more
+slint_testing::mock_elapsed_time(200);
+assert_eq!(instance.get_ta_width(), 200);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.ta_width, 100);
+assert(instance.test);
+instance.flag = true;
+assert.equal(instance.ta_width, 100);
+// Half the animation
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.ta_width, 150);
+// finish animation, and more
+slintlib.private_api.mock_elapsed_time(200);
+assert.equal(instance.ta_width, 200);
+```
+
+
+*/


### PR DESCRIPTION
Should register the Type::Percent as animated

Also avoid duplicating the binding for both min and max, and just make one use the other.

Fixes #7761
