### PR TITLE
Stop live-preview checkerboard shifting as window resizes

### DIFF
--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -237,6 +237,8 @@ export component PreviewView {
                 source: @image-url("../assets/background.svg");
                 vertical-tiling: repeat;
                 horizontal-tiling: repeat;
+                vertical-alignment: top;
+                horizontal-alignment: left;
                 colorize: Palette.alternate-background;
             }
 


### PR DESCRIPTION
This tiny change stops the background checkerboard shifting everytime anything resizes the content of the live-preview. 