### PR TITLE
Deprecate alias to global callback and error out when setting such callback

### DIFF
--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -144,6 +144,7 @@ fn resolve_alias(
             }
         } else {
             let nr = nr.unwrap();
+            let is_global = nr.element().borrow().base_type == crate::langtype::ElementType::Global;
             let purity = nr.element().borrow().lookup_property(nr.name()).declared_pure;
             let mut elem = elem.borrow_mut();
             let decl = elem.property_declarations.get_mut(prop).unwrap();
@@ -152,6 +153,9 @@ fn resolve_alias(
                     format!("Purity of callbacks '{prop}' and '{nr:?}' doesn't match"),
                     &decl.type_node(),
                 );
+            }
+            if is_global {
+                diag.push_warning("Aliases to global callback are deprecated".into(), &decl.node);
             }
             decl.property_type = ty;
         }

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -155,7 +155,7 @@ fn resolve_alias(
                 );
             }
             if is_global {
-                diag.push_warning("Aliases to global callback are deprecated".into(), &decl.node);
+                diag.push_warning("Aliases to global callback are deprecated. Export the global to access the global callback directly from native code".into(), &decl.node);
             }
             decl.property_type = ty;
         }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1817,7 +1817,7 @@ fn check_callback_alias_validity(
 
     if alias.element().borrow().base_type == ElementType::Global {
         diag.push_error(
-            "Can't set a local callback handler to an alias to a global callback".into(),
+            "Can't assign a local callback handler to an alias to a global callback".into(),
             &node.child_token(SyntaxKind::Identifier).unwrap(),
         );
     }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -26,6 +26,7 @@ use std::rc::Rc;
 struct ComponentScope(Vec<ElementRc>);
 
 fn resolve_expression(
+    elem: &ElementRc,
     expr: &mut Expression,
     property_name: Option<&str>,
     property_type: Type,
@@ -48,7 +49,11 @@ fn resolve_expression(
 
         let new_expr = match node.kind() {
             SyntaxKind::CallbackConnection => {
-                Expression::from_callback_connection(node.clone().into(), &mut lookup_ctx)
+                let node = syntax_nodes::CallbackConnection::from(node.clone());
+                if let Some(property_name) = property_name {
+                    check_callback_alias_validity(&node, elem, property_name, lookup_ctx.diag);
+                }
+                Expression::from_callback_connection(node, &mut lookup_ctx)
             }
             SyntaxKind::Function => Expression::from_function(node.clone().into(), &mut lookup_ctx),
             SyntaxKind::Expression => {
@@ -123,6 +128,7 @@ pub fn resolve_expressions(
                     };
 
                     resolve_expression(
+                        elem,
                         expr,
                         property_name,
                         property_type(),
@@ -1785,6 +1791,46 @@ pub fn resolve_two_way_binding(
                 &node,
             );
             None
+        }
+    }
+}
+
+/// For connection to callback aliases, some check are to be performed later
+fn check_callback_alias_validity(
+    node: &syntax_nodes::CallbackConnection,
+    elem: &ElementRc,
+    name: &str,
+    diag: &mut BuildDiagnostics,
+) {
+    let elem_borrow = elem.borrow();
+    let Some(decl) = elem_borrow.property_declarations.get(name) else {
+        if let ElementType::Component(c) = &elem_borrow.base_type {
+            check_callback_alias_validity(node, &c.root_element, name, diag);
+        }
+        return;
+    };
+    let Some(b) = elem_borrow.bindings.get(name) else { return };
+    // `try_borrow` because we might be called for the current binding
+    let Some(alias) = b.try_borrow().ok().and_then(|b| b.two_way_bindings.first().cloned()) else {
+        return;
+    };
+
+    if alias.element().borrow().base_type == ElementType::Global {
+        diag.push_error(
+            "Can't set a local callback handler to an alias to a global callback".into(),
+            &node.child_token(SyntaxKind::Identifier).unwrap(),
+        );
+    }
+    if let Type::Callback(callback) = &decl.property_type {
+        let num_arg = node.DeclaredIdentifier().count();
+        if num_arg > callback.args.len() {
+            diag.push_error(
+                format!(
+                    "'{name}' only has {} arguments, but {num_arg} were provided",
+                    callback.args.len(),
+                ),
+                &node.child_token(SyntaxKind::Identifier).unwrap(),
+            );
         }
     }
 }

--- a/internal/compiler/tests/syntax/lookup/callback_alias3.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias3.slint
@@ -25,7 +25,8 @@ export Xxx := Rectangle {
 
     Sub {
         compute_alias(a, b, c) => {
-            debug(b); // FIXME: one should actually check that the connection has the right amount of arguments
+//      ^error{'compute-alias' only has 1 arguments, but 3 were provided}
+            debug(b);
 //                ^error{Unknown unqualified identifier 'b'}
             return "hello";
 //          ^error{Cannot convert string to int}

--- a/internal/compiler/tests/syntax/lookup/callback_alias_global.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias_global.slint
@@ -13,6 +13,6 @@ component Wrapper {
 export component E inherits Window {
     Wrapper {
         foo => { debug("hello"); }
-//      ^error{Can't set a local callback handler to an alias to a global callback}
+//      ^error{Can't assign a local callback handler to an alias to a global callback}
     }
 }

--- a/internal/compiler/tests/syntax/lookup/callback_alias_global.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias_global.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export global Abc {
+    callback foobar;
+}
+
+component Wrapper {
+    callback foo <=> Abc.foobar;
+//  ^warning{Aliases to global callback are deprecated}
+}
+
+export component E inherits Window {
+    Wrapper {
+        foo => { debug("hello"); }
+//      ^error{Can't set a local callback handler to an alias to a global callback}
+    }
+}


### PR DESCRIPTION
Also properly error out when the number of arguments to a callback alias is not correct

Fixes #7806
