### PR TITLE
Skia: Use software rendering by default on Windows

### DIFF
--- a/internal/renderers/skia/build.rs
+++ b/internal/renderers/skia/build.rs
@@ -8,7 +8,6 @@ fn main() {
     cfg_aliases! {
        skia_backend_opengl: { any(feature = "opengl", not(any(target_vendor = "apple", target_family = "windows", target_arch = "wasm32"))) },
        skia_backend_metal: { all(target_vendor = "apple", not(feature = "opengl")) },
-       skia_backend_d3d: { all(target_family = "windows", not(feature = "opengl")) },
        skia_backend_vulkan: { feature = "vulkan" },
        skia_backend_software: { not(target_os = "android") },
     }

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -58,7 +58,7 @@ cfg_if::cfg_if! {
         type DefaultSurface = opengl_surface::OpenGLSurface;
     } else if #[cfg(skia_backend_metal)] {
         type DefaultSurface = metal_surface::MetalSurface;
-    }  else if #[cfg(skia_backend_software)] {
+    } else if #[cfg(skia_backend_software)] {
         type DefaultSurface = software_surface::SoftwareSurface;
     }
 }

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -58,8 +58,8 @@ cfg_if::cfg_if! {
         type DefaultSurface = opengl_surface::OpenGLSurface;
     } else if #[cfg(skia_backend_metal)] {
         type DefaultSurface = metal_surface::MetalSurface;
-    } else if #[cfg(skia_backend_d3d)] {
-        type DefaultSurface = d3d_surface::D3DSurface;
+    }  else if #[cfg(skia_backend_software)] {
+        type DefaultSurface = software_surface::SoftwareSurface;
     }
 }
 


### PR DESCRIPTION
We've had some reports like #7641 . Now that we enable partial rendering by default, let's default to software rendering for Skia on Windows, until perhaps the Skia dawn backend arrives.

Closes #7641

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
