### PR TITLE
Fix documentation of image formats

### DIFF
--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -146,7 +146,7 @@ Slint looks for images in the following places:
 
 Loading image from `http` is only supported in [SlintPad](https://slintpad.com).
 
-Supported format are SVG, and formats supported by the [`image` crate](https://crates.io/crates/image): 
+Supported format are SVG, and formats supported by the [`image` crate](https://crates.io/crates/image):
 AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
 
 For Rust applications, not all formats are enabled by default and can be enabled with the `image-default-formats` compilation features

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -149,7 +149,7 @@ Loading image from `http` is only supported in [SlintPad](https://slintpad.com).
 Supported format are SVG, and formats supported by the [`image` crate](https://crates.io/crates/image):
 AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
 
-For Rust applications, not all formats are enabled by default and can be enabled with the `image-default-formats` compilation features
+For Rust applications, not all formats are enabled by default. Enable them with the `image-default-formats` Cargo feature.
 
 <Tabs syncKey="dev-language">
 <TabItem label="C++">

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -146,8 +146,10 @@ Slint looks for images in the following places:
 
 Loading image from `http` is only supported in [SlintPad](https://slintpad.com).
 
-Supported format are SVG, as well as formats supported by the [`image` crate](https://crates.io/crates/image):
-AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
+Supported format are SVG, PNG, and JPEG.
+Other formats supported by the [`image` crate](https://crates.io/crates/image)
+(AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP)
+can be enabled using the `image-default-formats` compilation feature.
 
 <Tabs syncKey="dev-language">
 <TabItem label="C++">

--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -146,10 +146,10 @@ Slint looks for images in the following places:
 
 Loading image from `http` is only supported in [SlintPad](https://slintpad.com).
 
-Supported format are SVG, PNG, and JPEG.
-Other formats supported by the [`image` crate](https://crates.io/crates/image)
-(AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP)
-can be enabled using the `image-default-formats` compilation feature.
+Supported format are SVG, and formats supported by the [`image` crate](https://crates.io/crates/image): 
+AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
+
+For Rust applications, not all formats are enabled by default and can be enabled with the `image-default-formats` compilation features
 
 <Tabs syncKey="dev-language">
 <TabItem label="C++">

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -665,9 +665,9 @@ impl Image {
     /// Load an Image from a path to a file containing an image.
     ///
     /// Supported formats are SVG, PNG and JPEG.
-    /// Other formats supported by the [`image` crate](https://crates.io/crates/image) (
+    /// Enable support for additional formats supported by the [`image` crate](https://crates.io/crates/image) (
     /// AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP)
-    /// can be enabled using the `image-default-formats` cargo feature.
+    /// by enabling the `image-default-formats` cargo feature.
     pub fn load_from_path(path: &std::path::Path) -> Result<Self, LoadImageError> {
         self::cache::IMAGE_CACHE.with(|global_cache| {
             let path: SharedString = path.to_str().ok_or(LoadImageError(()))?.into();

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -664,9 +664,10 @@ impl Image {
     #[cfg(feature = "image-decoders")]
     /// Load an Image from a path to a file containing an image.
     ///
-    /// Supported formats are SVG, as well as formats supported by the [`image` crate](https://crates.io/crates/image):
-    /// AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
-    /// Note that some formats can be disabled using cargo features to reduce binary size and speed up compilation.
+    /// Supported formats are SVG, PNG and JPEG.
+    /// Other formats supported by the [`image` crate](https://crates.io/crates/image) (
+    /// AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP)
+    /// can be enabled using the `image-default-formats` cargo feature.
     pub fn load_from_path(path: &std::path::Path) -> Result<Self, LoadImageError> {
         self::cache::IMAGE_CACHE.with(|global_cache| {
             let path: SharedString = path.to_str().ok_or(LoadImageError(()))?.into();


### PR DESCRIPTION
Shortly before 1.10, we decided not to enable most format by default. But the documentation was not updated to reflect that

Closes #6574
