### PR TITLE
Fix typescript errors not showing in-line for VScode

### DIFF
--- a/tools/figma-inspector/backend/tsconfig.json
+++ b/tools/figma-inspector/backend/tsconfig.json
@@ -1,11 +1,4 @@
 {
-  "compilerOptions": {
-    "typeRoots": [
-      "../../../node_modules/@types",
-      "../../../node_modules/@figma",
-      "../src/globals.d.ts",
-      "../shared/universals.d.ts"
-    ]
-  },
+   "extends": "../tsconfig.json",
   "include": ["./**/*.ts"]
 }


### PR DESCRIPTION
Technically the Figma plugin is two typescript projects. A backend and a frontend. While typechecking via `pnpm type-check` works correctly, you would see no inline errors in VScode for the backend project. This lead to surpirses latert on when the CI runs the type-check script.

This fixes the issue so the experience inside VScode and from the type-check script match up.