### PR TITLE
live-preview: Get rid of the "dummy" workaround

### DIFF
--- a/tools/lsp/ui/components/widgets/brush-widget.slint
+++ b/tools/lsp/ui/components/widgets/brush-widget.slint
@@ -17,8 +17,6 @@ export component BrushWidget inherits GridLayout {
     in property <bool> has-code-action <=> sub.has-code-action;
     in property <bool> has-reset-action <=> sub.has-reset-action;
 
-    private property <PropertyValue> dummy: property-value; // Needed to make changed signal work...
-
     callback code-action();
     callback reset-action();
 
@@ -86,7 +84,7 @@ export component BrushWidget inherits GridLayout {
         }
     }
 
-    changed dummy => {
+    changed property-value => {
         if self.property-value.kind != PropertyValueKind.color && self.property-value.kind != PropertyValueKind.brush {
             return;
         }

--- a/tools/lsp/ui/components/widgets/color-basics.slint
+++ b/tools/lsp/ui/components/widgets/color-basics.slint
@@ -93,7 +93,6 @@ export component Preview {
 
 export component ColorMainContent inherits HorizontalLayout {
     in-out property <color> current-color;
-    private property <color> dummy-current-color: current-color;
 
     in property <bool> enabled;
 
@@ -102,7 +101,7 @@ export component ColorMainContent inherits HorizontalLayout {
     callback set-color-binding(text: string);
     callback test-color-binding(text: string) -> bool;
 
-    private property <ColorData> current-color-data: Api.color-to-data(self.dummy-current-color);
+    private property <ColorData> current-color-data: Api.color-to-data(self.current-color);
 
     function apply-value() {
         rle.default-text = current-color-data.text;

--- a/tools/lsp/ui/components/widgets/color-widget.slint
+++ b/tools/lsp/ui/components/widgets/color-widget.slint
@@ -15,7 +15,6 @@ export component ColorWidget inherits GridLayout {
     in property <bool> has-code-action <=> sub.has-code-action;
     in property <bool> has-reset-action <=> sub.has-reset-action;
 
-    private property <PropertyValue> dummy: property-value; // Needed to make changed signal work...
     private property <color> current-color: Colors.transparent;
 
     callback code-action();
@@ -43,7 +42,7 @@ export component ColorWidget inherits GridLayout {
         }
     }
 
-    changed dummy => {
+    changed property-value => {
         if self.property-value.kind != PropertyValueKind.color && self.property-value.kind != PropertyValueKind.brush {
             return;
         }

--- a/tools/lsp/ui/components/widgets/enum-widget.slint
+++ b/tools/lsp/ui/components/widgets/enum-widget.slint
@@ -13,9 +13,7 @@ export component EnumWidget inherits GridLayout {
     in property <string> property-name;
     in property <PropertyValue> property-value;
 
-    private property <PropertyValue> dummy: self.property-value;
-
-    changed dummy => {
+    changed property-value => {
         if self.property-value.kind == PropertyValueKind.enum {
             cb.current-index = root.property-value.value-int;
         }

--- a/tools/lsp/ui/components/widgets/float-widget.slint
+++ b/tools/lsp/ui/components/widgets/float-widget.slint
@@ -17,7 +17,6 @@ export component FloatWidget inherits GridLayout {
     callback set-float-binding(text: string, unit: string);
 
     private property <string> current-unit;
-    private property <PropertyValue> dummy: self.property-value;
 
     pure function find_current_unit(value: PropertyValue) -> string {
         if value.visual-items.length == 0 {
@@ -43,7 +42,7 @@ export component FloatWidget inherits GridLayout {
         current-unit = find_current_unit(property-value);
     }
 
-    changed dummy => {
+    changed property-value => {
         if !number.has-focus && self.property-value.kind == PropertyValueKind.float {
             apply-value();
         }

--- a/tools/lsp/ui/components/widgets/gradient-basics.slint
+++ b/tools/lsp/ui/components/widgets/gradient-basics.slint
@@ -72,11 +72,9 @@ export component GradientMainContent inherits HorizontalLayout {
 
     in-out property <[GradientStop]> gradient-stops;
     in-out property <float> current-position;
-    private property <float> dummy-current-position: current-position;
     private property <float> current-position_: index-position(self.selected-index);
 
     in-out property <color> current-color;
-    private property <color> dummy-current-color;
     private property <color> current-color_: index-color(self.selected-index);
 
     out property <bool> has-focus: ta.has-hover || self.dot-hover-count > 0;
@@ -90,9 +88,9 @@ export component GradientMainContent inherits HorizontalLayout {
         self.current-color = current-color_;
     }
 
-    changed dummy-current-color => {
+    changed current-color => {
         if self.selected-index >= 0 && self.selected-index < self.gradient-stops.length {
-            self.gradient-stops[self.selected-index].color = dummy-current-color;
+            self.gradient-stops[self.selected-index].color = current-color;
         }
         apply-model-change-to-ui();
     }
@@ -101,9 +99,9 @@ export component GradientMainContent inherits HorizontalLayout {
         self.current-position = current-position_;
     }
 
-    changed dummy-current-position => {
+    changed current-position => {
         if self.selected-index >= 0 && self.selected-index < self.gradient-stops.length {
-            self.gradient-stops[self.selected-index].position = dummy-current-position;
+            self.gradient-stops[self.selected-index].position = current-position;
         }
         apply-model-change-to-ui();
     }

--- a/tools/lsp/ui/components/widgets/string-widget.slint
+++ b/tools/lsp/ui/components/widgets/string-widget.slint
@@ -23,8 +23,6 @@ export component StringWidget inherits GridLayout {
 
     property <bool> open: false;
 
-    private property <PropertyValue> dummy: self.property-value;
-
     private property <bool> is-translated;
     private property <string> tr-context-value;
 
@@ -62,7 +60,7 @@ export component StringWidget inherits GridLayout {
         }
     }
 
-    changed dummy => {
+    changed property-value => {
         if !has-focus {
             apply-value();
         }


### PR DESCRIPTION
... used to get changed notifications for aliased properties.

This was fixed last week, so it is no longer necessary.