### PR TITLE
Better dev commands for VScode development

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -43,7 +43,7 @@ The following step will build a local version of the vscode extension and the LS
 
 ```sh
 cargo install wasm-pack
-cargo build -p slint-lsp
+cargo build --features renderer-skia -p slint-lsp
 cd editors/vscode
 pnpm install --frozen-lockfile
 pnpm build:wasm_lsp
@@ -56,7 +56,7 @@ or `pnpm compile` to rebuild the typescript.
 You can run vscode with that extension by running, in the `editors/vscode` directory:
 
 ```sh
-code --extensionDevelopmentPath=$PWD ../..
+code --extensionDevelopmentPath=$PWD <path to a slint project that is different to the one already open in vscode>
 ```
 
 If you want to load the web extension, add `--extensionDevelopmentKind=web`


### PR DESCRIPTION
These small changes make developing the vscode extension more productive.
1. The lsp is compiled for Skia which on the Mac ensures the fonts render correctly and the UI will run at 120fps on dispalys that support high frame rates.
2. The compiled plugin will open with an actual project. This saves at least 2 extra clicks to open some project everytime you compile the extension and want to see it.