### PR TITLE
live-preview: Do not pass on signals from "invisible" widgets

### DIFF
--- a/tools/lsp/ui/components/property-widgets.slint
+++ b/tools/lsp/ui/components/property-widgets.slint
@@ -52,7 +52,9 @@ export component PropertyValueWidget inherits VerticalLayout {
             property-value <=> root.property-value;
 
             set-bool-binding(value) => {
-                root.set-bool-binding(value);
+                if root.property-value.kind == PropertyValueKind.boolean {
+                    root.set-bool-binding(value);
+                }
             }
         }
     }
@@ -69,17 +71,27 @@ export component PropertyValueWidget inherits VerticalLayout {
             has-reset-action: root.has-reset-action;
 
             test-color-binding(text) => {
-                return (root.test-color-binding(text));
+                if root.property-value.kind == PropertyValueKind.color {
+                    return (root.test-color-binding(text));
+                } else {
+                    return false;
+                }
             }
             set-color-binding(text) => {
-                root.set-color-binding(text);
+                if root.property-value.kind == PropertyValueKind.color {
+                    root.set-color-binding(text);
+                }
             }
 
             reset-action() => {
-                root.reset-action();
+                if root.property-value.kind == PropertyValueKind.color {
+                    root.reset-action();
+                }
             }
             code-action() => {
-                root.code-action();
+                if root.property-value.kind == PropertyValueKind.color {
+                    root.code-action();
+                }
             }
         }
     }
@@ -96,17 +108,27 @@ export component PropertyValueWidget inherits VerticalLayout {
             has-reset-action: root.has-reset-action;
 
             test-brush-binding(kind, angle, color, stops) => {
-                return root.test-brush-binding(kind, angle, color, stops);
+                if root.property-value.kind == PropertyValueKind.brush {
+                    return root.test-brush-binding(kind, angle, color, stops);
+                } else {
+                    return false;
+                }
             }
             set-brush-binding(kind, angle, color, stops) => {
-                root.set-brush-binding(kind, angle, color, stops);
+                if root.property-value.kind == PropertyValueKind.brush {
+                    root.set-brush-binding(kind, angle, color, stops);
+                }
             }
 
             reset-action() => {
-                root.reset-action();
+                if root.property-value.kind == PropertyValueKind.brush {
+                    root.reset-action();
+                }
             }
             code-action() => {
-                root.code-action();
+                if root.property-value.kind == PropertyValueKind.brush {
+                    root.code-action();
+                }
             }
         }
     }
@@ -120,10 +142,14 @@ export component PropertyValueWidget inherits VerticalLayout {
             property-value <=> root.property-value;
 
             reset-action() => {
-                root.reset-action();
+                if root.property-value.kind == PropertyValueKind.code {
+                    root.reset-action();
+                }
             }
             code-action() => {
-                root.code-action();
+                if root.property-value.kind == PropertyValueKind.code {
+                    root.code-action();
+                }
             }
         }
     }
@@ -137,7 +163,9 @@ export component PropertyValueWidget inherits VerticalLayout {
             property-value <=> root.property-value;
 
             set-enum-binding(text) => {
-                root.set-enum-binding(text);
+                if root.property-value.kind == PropertyValueKind.enum {
+                    root.set-enum-binding(text);
+                }
             }
         }
     }
@@ -151,10 +179,16 @@ export component PropertyValueWidget inherits VerticalLayout {
             property-value <=> root.property-value;
 
             test-float-binding(text, unit) => {
-                return (root.test-float-binding(text, unit));
+                if root.property-value.kind == PropertyValueKind.float {
+                    return (root.test-float-binding(text, unit));
+                } else {
+                    return false;
+                }
             }
             set-float-binding(text, unit) => {
-                root.set-float-binding(text, unit);
+                if root.property-value.kind == PropertyValueKind.float {
+                    root.set-float-binding(text, unit);
+                }
             }
         }
     }
@@ -168,10 +202,16 @@ export component PropertyValueWidget inherits VerticalLayout {
             property-value <=> root.property-value;
 
             test-integer-binding(text) => {
-                return (root.test-code-binding(text));
+                if root.property-value.kind == PropertyValueKind.integer {
+                    return (root.test-code-binding(text));
+                } else {
+                    return false;
+                }
             }
             set-integer-binding(text) => {
-                root.set-code-binding(text);
+                if root.property-value.kind == PropertyValueKind.integer {
+                    root.set-code-binding(text);
+                }
             }
         }
     }
@@ -189,16 +229,26 @@ export component PropertyValueWidget inherits VerticalLayout {
             is-translatable <=> root.strings-are-translatable;
 
             reset-action() => {
-                root.reset-action();
+                if root.property-value.kind == PropertyValueKind.string {
+                    root.reset-action();
+                }
             }
             code-action() => {
-                root.code-action();
+                if root.property-value.kind == PropertyValueKind.string {
+                    root.code-action();
+                }
             }
             test-string-binding(text, is_translated) => {
-                return root.test-string-binding(text, is_translated);
+                if root.property-value.kind == PropertyValueKind.string {
+                    return root.test-string-binding(text, is_translated);
+                } else {
+                    return false;
+                }
             }
             set-string-binding(text, is_translated) => {
-                root.set-string-binding(text, is_translated);
+                if root.property-value.kind == PropertyValueKind.string {
+                    root.set-string-binding(text, is_translated);
+                }
             }
         }
     }


### PR DESCRIPTION
This stops e.g. the color widget filling in default values for empty strings.