### PR TITLE
docs: Tweak the tutorial

### DIFF
--- a/docs/astro/src/content/docs/tutorial/creating_the_tiles.mdx
+++ b/docs/astro/src/content/docs/tutorial/creating_the_tiles.mdx
@@ -48,7 +48,7 @@ in a <LangRefLink lang="nodejs" relpath="classes/ArrayModel">`slint.ArrayModel.h
   The code uses the `rand` dependency for the randomization. Add it to the `Cargo.toml` file using the `cargo` command.
 
     ```sh
-    cargo add rand@0.8
+    cargo add rand
     ```
 
 Change the main function to the following:

--- a/docs/astro/src/content/docs/tutorial/creating_the_tiles.mdx
+++ b/docs/astro/src/content/docs/tutorial/creating_the_tiles.mdx
@@ -48,7 +48,7 @@ in a <LangRefLink lang="nodejs" relpath="classes/ArrayModel">`slint.ArrayModel.h
   The code uses the `rand` dependency for the randomization. Add it to the `Cargo.toml` file using the `cargo` command.
 
     ```sh
-    cargo add rand
+    cargo add rand@0.8
     ```
 
 Change the main function to the following:

--- a/docs/astro/src/content/docs/tutorial/polishing_the_tile.mdx
+++ b/docs/astro/src/content/docs/tutorial/polishing_the_tile.mdx
@@ -9,7 +9,7 @@ import { extractLines } from '/src/utils/utils.ts';
 
 In this step, you add a curtain-like cover that opens when clicked. Slint files have an implicit z order for drawing items.
 Each subsequent item is drawn above the previous one. So a `Rectangle` on line 10 would be underneath another declared later
-in the file on line 50. To give the impression of curtains that cover the image, 
+in the file on line 50. To give the impression of curtains that cover the image,
 declare two rectangles after the <span class="hljs-built_in">Image</span>, so that Slint draws them over the Image.
 
 The <span class="hljs-built_in">TouchArea</span> element declares a transparent rectangular region that allows

--- a/docs/astro/src/content/docs/tutorial/polishing_the_tile.mdx
+++ b/docs/astro/src/content/docs/tutorial/polishing_the_tile.mdx
@@ -7,8 +7,10 @@ description: Polishing the Tile
 import { Code } from '@astrojs/starlight/components';
 import { extractLines } from '/src/utils/utils.ts';
 
-In this step, you add a curtain-like cover that opens when clicked. You do this by declaring two rectangles
-below the <span class="hljs-built_in">Image</span>, so that Slint draws them after the Image and thus on top of the image.
+In this step, you add a curtain-like cover that opens when clicked. Slint files have an implicit z order for drawing items.
+Each subsequent item is drawn above the previous one. So a `Rectangle` on line 10 would be underneath another declared later
+in the file on line 50. To give the impression of curtains that cover the image, 
+declare two rectangles after the <span class="hljs-built_in">Image</span>, so that Slint draws them over the Image.
 
 The <span class="hljs-built_in">TouchArea</span> element declares a transparent rectangular region that allows
 reacting to user input such as a mouse click or tap. The element forwards a callback to the <em>MainWindow</em> indicating that a user clicked the tile.


### PR DESCRIPTION
The wording was quite confusing before. To talk about declaring items 'below' to then draw in 'above'. So the thinking here is that 'before' and 'after' is just for talking about the text in the file. Then 'above' and 'below' is just used when talking about how items are drawn? Maybe even remove the text and just show the slint snipet?