### PR TITLE
live-preview: Force 'fluent' style on MacOS

### DIFF
--- a/tools/lsp/build.rs
+++ b/tools/lsp/build.rs
@@ -13,8 +13,7 @@ fn main() {
     {
         #[cfg(target_os = "macos")]
         {
-            let config = slint_build::CompilerConfiguration::new()
-                .with_style("fluent".into());
+            let config = slint_build::CompilerConfiguration::new().with_style("fluent".into());
             slint_build::compile_with_config("ui/main.slint", config).unwrap();
         }
     }

--- a/tools/lsp/build.rs
+++ b/tools/lsp/build.rs
@@ -5,16 +5,8 @@ fn main() {
     // Make the compiler handle ComponentContainer:
     std::env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1");
     #[cfg(not(target_os = "macos"))]
-    {
-        slint_build::compile("ui/main.slint").unwrap();
-    }
+    std::env::set_var("SLINT_STYLE", "fluent");
 
     #[cfg(feature = "preview-engine")]
-    {
-        #[cfg(target_os = "macos")]
-        {
-            let config = slint_build::CompilerConfiguration::new().with_style("fluent".into());
-            slint_build::compile_with_config("ui/main.slint", config).unwrap();
-        }
-    }
+    slint_build::compile("ui/main.slint").unwrap();
 }

--- a/tools/lsp/build.rs
+++ b/tools/lsp/build.rs
@@ -4,6 +4,18 @@
 fn main() {
     // Make the compiler handle ComponentContainer:
     std::env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1");
+    #[cfg(not(target_os = "macos"))]
+    {
+        slint_build::compile("ui/main.slint").unwrap();
+    }
+
     #[cfg(feature = "preview-engine")]
-    slint_build::compile("ui/main.slint").unwrap();
+    {
+        #[cfg(target_os = "macos")]
+        {
+            let config = slint_build::CompilerConfiguration::new()
+                .with_style("fluent".into());
+            slint_build::compile_with_config("ui/main.slint", config).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
The Cupertino std-widgets suffer from an 'uncanny valley' issue. Where they look enough like real MacOS widgets that all the missing details are extra noticable.

The live-preview might benefit from custom componenents anyway as they all need to do a range of non standard things that designers expect. Before making that leap this change forces the 'fluent' style when the live-preview runs on MacOS. It's a trial stepping stone to custom components, but most importantly makes the app feel a lot more modern and polished on MacOS.