### PR TITLE
C++: put the parent in a weak pointer

### DIFF
--- a/tests/cases/widgets/menubar.slint
+++ b/tests/cases/widgets/menubar.slint
@@ -15,7 +15,7 @@ export component TestCase inherits Window {
             title: "File";
             MenuItem {
                 title: "New";
-                activated => { debug("New"); }
+                activated => { result += "New"; debug("New"); }
             }
             MenuItem {
                 title: "Open";
@@ -83,6 +83,14 @@ slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key:
 assert_eq!(instance.get_result(), "");
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("\n"));
 assert_eq!(instance.get_result(), "Recent 3");
+
+instance.set_result("".into());
+//click on the file menu
+slint_testing::send_mouse_click(&instance, 10., 16.);
+assert_eq!(instance.get_result(), "");
+// click on the first entry (new)  (this value seems to work with all styles)
+slint_testing::send_mouse_click(&instance, 30., 49.);
+assert_eq!(instance.get_result(), "New");
 ```
 
 ```cpp
@@ -100,5 +108,13 @@ slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_cod
 assert_eq(instance.get_result(), "");
 slint_testing::send_keyboard_string_sequence(&instance, "\n");
 assert_eq(instance.get_result(), "Recent 3");
+
+instance.set_result("");
+//click on the file menu
+slint_testing::send_mouse_click(&instance, 10., 16.);
+assert_eq(instance.get_result(), "");
+// click on the first entry (new)  (this value seems to work with all styles)
+slint_testing::send_mouse_click(&instance, 30., 49.);
+assert_eq(instance.get_result(), "New");
 ```
 */


### PR DESCRIPTION
Right now we always `lock().value()` it which is the equivalent of `upgrade().unwrap()` in rust, this helps because it keeps the parent alive when we are calling function in it.

Ideally we should also check that it wasn't deleted, but that's another issue.

Fixes #7880
