### PR TITLE
Revert "Attempt to work around llvm / clang-cl bug for Skia build"

### DIFF
--- a/.github/actions/install-skia-dependencies/action.yaml
+++ b/.github/actions/install-skia-dependencies/action.yaml
@@ -14,16 +14,8 @@ runs:
           shell: bash
         - name: Upgrade LLVM for Skia build on Windows
           if: runner.os == 'Windows'
-          run: choco upgrade llvm --version "19.1.7"
+          run: choco upgrade llvm
           shell: bash
-        - name: Apply workaround for https://github.com/llvm/llvm-project/issues/95133
-          if: runner.os == 'Windows'
-          shell: cmd
-          run: |
-              perl -i -ne "print unless /unsigned __int32 xbegin\(void\);/" "C:\Program Files\LLVM\lib\clang\19\include\intrin.h"
-              perl -i -ne "print unless /void _xend\(void\);/" "C:\Program Files\LLVM\lib\clang\19\include\intrin.h"
-              findstr /C:"unsigned __int32 xbegin(void);" "C:\Program Files\LLVM\lib\clang\19\include\intrin.h" || exit /b 0
-              findstr /C:"void _xend(void);" "C:\Program Files\LLVM\lib\clang\19\include\intrin.h" || exit /b 0
         # See https://github.com/ilammy/msvc-dev-cmd?tab=readme-ov-file#caveats
         - name: Remove GNU link.exe from GH actions
           if: runner.os == 'Windows'


### PR DESCRIPTION
This reverts commit 4fef985fbc717f9939bdf9be6b2b16a1c788bd12.

As per https://github.com/rust-skia/rust-skia/pull/1114 this shouldn't be needed anymore.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
