### PR TITLE
nigel/picker-polish

### DIFF
--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -110,6 +110,7 @@ pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, Platfor
         g: c.green() as i32,
         b: c.blue() as i32,
         text: color_to_string(c).into(),
+        short_text: color_to_short_string(c).into()
     });
     api.on_rgba_to_color(|r, g, b, a| {
         if (0..256).contains(&r)
@@ -439,6 +440,14 @@ fn color_to_string(color: slint::Color) -> String {
     let b = color.blue();
 
     format!("#{r:02x}{g:02x}{b:02x}{a:02x}")
+}
+
+fn color_to_short_string(color: slint::Color) -> String {
+    let r = color.red();
+    let g = color.green();
+    let b = color.blue();
+
+    format!("{r:02x}{g:02x}{b:02x}")
 }
 
 fn string_to_color(text: &str) -> Option<slint::Color> {

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -101,6 +101,7 @@ export struct ColorData {
     b: int,
     a: int,
     text: string,
+    short-text: string,
 }
 
 export enum PropertyValueKind {

--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -26,7 +26,7 @@ component ColorPicker {
     callback close <=> t-close.clicked;
 
     width: 240px;
-    height: 340px;
+    height: 370px;
 
     Rectangle {
         background: Styles.background-color;
@@ -346,12 +346,78 @@ component ColorPicker {
         }
     }
 
-    Button {
+    Rectangle {
+        width: 100%;
+        height: 60px;
         y: hsva-controls.y + hsva-controls.height + 16px;
-        width: 100px;
-        text: "Apply";
-        clicked => {
-            WindowManager.apply-current-value(Api.color-to-data(root.current-color).text);
+        VerticalLayout {
+            alignment: center;
+            spacing: 10px;
+            Rectangle {
+                x: Styles.left-margin;
+                width: 170px;
+                height: 25px;
+                background: Styles.section-color;
+                border-radius: Styles.property-border-radius;
+                border-width: 1px;
+
+                Rectangle {
+                    x: 5px;
+                    width: 15px;
+                    height: self.width;
+                    border-radius: 2px;
+                    background: root.current-color;
+                }
+
+                Text {
+                    x: 25px;
+                    font-family: "Inter";
+                    font-size: 13px;
+                    color: white;
+                    text: "DEDEDE";
+                    letter-spacing: 0.8px;
+                }
+
+                divider := Rectangle {
+                    x: parent.width - 45px;
+                    width: 1px;
+                    height: parent.height;
+                    background: Styles.background-color;
+                }
+
+                Rectangle {
+                    x: parent.width - self.width;
+                    width: 43px;
+                    height: parent.height;
+
+                    Text {
+                        x: 5px;
+                        vertical-alignment: center;
+                        font-family: "Inter";
+                        font-size: 13px;
+                        color: white;
+                        text: root.alpha;
+                    }
+
+                    Text {
+                        x: parent.width - self.width - 5px;
+                        vertical-alignment: center;
+                        font-family: "Inter";
+                        font-size: 12px;
+                        color: #9d9d9d;
+                        text: "%";
+                        font-weight: 800;
+                    }
+                }
+            }
+            Button {
+                x: Styles.left-margin;
+                width: 100px;
+                text: "Apply";
+                clicked => {
+                    WindowManager.apply-current-value(Api.color-to-data(root.current-color).text);
+                }
+            }
         }
     }
 }

--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -126,7 +126,7 @@ component ColorPicker {
                     width: 8px;
                     height: 8px;
                     border-radius: self.width / 2;
-                    background: root.current-color;
+                    background: hsv(root.hue, root.saturation, root.value);
                 }
             }
         }
@@ -349,7 +349,7 @@ component ColorPicker {
     Rectangle {
         width: 100%;
         height: 60px;
-        y: hsva-controls.y + hsva-controls.height + 16px;
+        y: hsva-controls.y + hsva-controls.height + 8px;
         VerticalLayout {
             alignment: center;
             spacing: 10px;
@@ -371,10 +371,22 @@ component ColorPicker {
 
                 Text {
                     x: 25px;
+                    y: 8px;
+                    vertical-alignment: center;
                     font-family: "Inter";
-                    font-size: 13px;
+                    font-size: 11px;
+                    color: #9d9d9d;
+                    text: "#";
+                    font-weight: 800;
+                }
+
+                Text {
+                    x: 35px;
+                    y: 8px;
+                    font-family: "Inter";
+                    font-size: 12px;
                     color: white;
-                    text: "DEDEDE";
+                    text: Api.color-to-data(root.current-color).short-text.to-uppercase();
                     letter-spacing: 0.8px;
                 }
 
@@ -394,7 +406,7 @@ component ColorPicker {
                         x: 5px;
                         vertical-alignment: center;
                         font-family: "Inter";
-                        font-size: 13px;
+                        font-size: 12px;
                         color: white;
                         text: root.alpha;
                     }
@@ -403,7 +415,7 @@ component ColorPicker {
                         x: parent.width - self.width - 5px;
                         vertical-alignment: center;
                         font-family: "Inter";
-                        font-size: 12px;
+                        font-size: 11px;
                         color: #9d9d9d;
                         text: "%";
                         font-weight: 800;


### PR DESCRIPTION
New: Readonly value showing the HEX and alpha percentages. This will be editable in later versions. As the color is not applied instantly this helps know what colour has been selected.

Fix: The selection circle on the main area of the picker used the final applied color as a preview. This meant if you set the transparency low it also faded away. This circle now just show the color with 100% alpha.

![Screenshot 2025-04-01 at 17 18 53](https://github.com/user-attachments/assets/0c5d3a2e-e03d-410f-8c26-48f7496d54d5)
