### PR TITLE
C++: Fix segfault when calling Model::row_changed() after Model::reset()

### DIFF
--- a/api/cpp/include/slint_models.h
+++ b/api/cpp/include/slint_models.h
@@ -852,6 +852,10 @@ class Repeater
 
         void row_added(size_t index, size_t count) override
         {
+            if (index > data.size()) {
+                // Can happen before ensure_updated was called
+                return;
+            }
             is_dirty.set(true);
             data.resize(data.size() + count);
             std::rotate(data.begin() + index, data.end() - count, data.end());
@@ -862,6 +866,9 @@ class Repeater
         }
         void row_changed(size_t index) override
         {
+            if (index >= data.size()) {
+                return;
+            }
             auto &c = data[index];
             if (model && c.ptr) {
                 (*c.ptr)->update_data(index, *model->row_data(index));
@@ -872,6 +879,10 @@ class Repeater
         }
         void row_removed(size_t index, size_t count) override
         {
+            if (index + count > data.size()) {
+                // Can happen before ensure_updated was called
+                return;
+            }
             is_dirty.set(true);
             data.erase(data.begin() + index, data.begin() + index + count);
             for (std::size_t i = index; i < data.size(); ++i) {

--- a/tests/cases/models/model.slint
+++ b/tests/cases/models/model.slint
@@ -248,5 +248,41 @@ assert.equal(instance.clicked_internal_state, 2);
 assert.equal(instance.clicked_index, 1);
 ```
 
+////////// Issue #8021
+```cpp
+using ModelData = std::tuple<slint::SharedString, slint::SharedString, float>;
+static auto mk_data = [](slint::SharedString name) { return ModelData{name, name, 0.}; };
+class MyModel : public slint::Model<ModelData> {
+    std::vector<ModelData> data;
+
+  public:
+    MyModel() {
+        data.push_back(mk_data("John"));
+        data.push_back(mk_data("Mary"));
+        data.push_back(mk_data("Bob"));
+    }
+    std::size_t row_count() const override {return data.size();}
+    std::optional<ModelData> row_data(std::size_t i) const override {
+        return (i < data.size()) ? std::make_optional(data.at(i)) : std::nullopt;
+    }
+    void update() {
+        data.push_back(mk_data("Olivier"));
+        reset();
+        row_changed(data.size() - 1);
+    }
+};
+
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+
+auto model = std::make_shared<MyModel>();
+instance.set_model(model);
+slint_testing::send_mouse_click(&instance, 15., 5.);
+assert_eq(instance.get_clicked_name(), "Mary");
+model->update();
+slint_testing::send_mouse_click(&instance, 35., 5.);
+assert_eq(instance.get_clicked_name(), "Olivier");
+```
 
 */


### PR DESCRIPTION
Fixes #8021
