### PR TITLE
Docs: add a note about event processing for `quit_event_loop`

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -967,6 +967,9 @@ pub fn invoke_from_event_loop(func: impl FnOnce() + Send + 'static) -> Result<()
 /// the initial call to `slint::run_event_loop()` will return.
 ///
 /// This function can be called from any thread
+///
+/// Any previously queued events may or may not be processed before the loop terminates.
+/// This is platform dependent behaviour.
 pub fn quit_event_loop() -> Result<(), EventLoopError> {
     crate::platform::with_event_loop_proxy(|proxy| {
         proxy.ok_or(EventLoopError::NoEventLoopProvider)?.quit_event_loop()


### PR DESCRIPTION
Fixes #6562
