### PR TITLE
C++: add `notify_` prefix to the Model functions and add docs

### DIFF
--- a/api/cpp/include/slint_models.h
+++ b/api/cpp/include/slint_models.h
@@ -63,8 +63,8 @@ long int model_length(const std::shared_ptr<M> &model)
 /// `Model::notify_row_changed()`, `Model::notify_row_added()`, `Model::notify_row_removed()`, or
 /// `Model::notify_reset()` functions when the underlying data changes.
 ///
-/// Note that the Model is not thread-safe. All Model operation needs to be done in the main thread.
-/// If you need to update the model data from another thread, you can use the
+/// Note that the Model is not thread-safe. All Model operations need to be done in the main thread.
+/// If you need to update the model data from another thread, use the
 /// `slint::invoke_from_event_loop()` function to send the data to the main thread and update the
 /// model.
 template<typename ModelData>

--- a/tests/cases/models/model.slint
+++ b/tests/cases/models/model.slint
@@ -267,8 +267,8 @@ class MyModel : public slint::Model<ModelData> {
     }
     void update() {
         data.push_back(mk_data("Olivier"));
-        reset();
-        row_changed(data.size() - 1);
+        notify_reset();
+        notify_row_changed(data.size() - 1);
     }
 };
 


### PR DESCRIPTION
The `notify_*` function are used by the model to notify the view. As opposed to the function without the prefix, which are used to get notified when a source model change

Fixes #3888
CC #3945 (for the docs about thread safety)
