### PR TITLE
ci: Fix packaging breaking due to taplo formatiing

### DIFF
--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -97,14 +97,19 @@ jobs:
                   if [ "$RELEASE_INPUT" != "true" ]; then
                       npm version $PKG_VERSION
                   fi
+            - uses: baptiste0928/cargo-install@v3
+              with:
+                  crate: taplo
             - name: Prepare feature config for binaries
               working-directory: api/node
               shell: bash
               run: |
-                  perl -pi -e 's,^default =.*,,' Cargo.toml
-                  perl -pi -e 's,# binaries:,,' Cargo.toml
-                  echo "New defaults:"
-                  grep "^\s*default =" Cargo.toml
+                cat Cargo.toml | taplo format --option column_width=100000 --stdin-filepath=Cargo.toml - | \
+                  perl -p -e 's,^\s*default\s*=.*,,' | \
+                  perl -p -e 's,# binaries:\s?,,' > Cargo.toml.new
+                cat Cargo.toml.new | taplo format --stdin-filepath=Cargo.toml - > Cargo.toml
+                rm Cargo.toml.new
+                taplo get -f Cargo.toml features.default
             - name: Build binary
               shell: bash
               working-directory: api/node

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -45,14 +45,20 @@ jobs:
             - uses: actions/setup-python@v5
               with:
                 python-version: '3.12'
+            - uses: baptiste0928/cargo-install@v3
+              with:
+                  crate: taplo
             - name: Prepare feature config for binaries
               working-directory: api/python
               shell: bash
               run: |
-                perl -pi -e 's,^default =.*,,' Cargo.toml
-                perl -pi -e 's,# binaries:,,' Cargo.toml
-                echo "New defaults:"
-                grep "^\s*default =" Cargo.toml
+                cat Cargo.toml | taplo format --option column_width=100000 --stdin-filepath=Cargo.toml - | \
+                  perl -p -e 's,^\s*default\s*=.*,,' | \
+                  perl -p -e 's,# binaries:\s?,,' > Cargo.toml.new
+                cat Cargo.toml.new | taplo format --stdin-filepath=Cargo.toml - > Cargo.toml
+                rm Cargo.toml.new
+                taplo get -f Cargo.toml features.default
+
             - name: Build a binary wheel
               uses: PyO3/maturin-action@v1
               with:


### PR DESCRIPTION
Make the Cargo.toml patching process work independent of the actual formatting and formatter settings by using taplo.

Use mise to grep a copy of taplo.