### PR TITLE
Allow checking at runtime about the current theme

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -576,6 +576,7 @@ fn gen_corelib(
             "slint_windowrc_color_scheme",
             "slint_windowrc_supports_native_menu_bar",
             "slint_windowrc_setup_native_menu_bar",
+            "slint_windowrc_style_name",
             "slint_windowrc_default_font_size",
             "slint_windowrc_dispatch_pointer_event",
             "slint_windowrc_dispatch_key_event",

--- a/internal/backends/qt/qt_widgets/palette.rs
+++ b/internal/backends/qt/qt_widgets/palette.rs
@@ -30,6 +30,7 @@ struct PaletteStyleChangeListener : QWidget {
 #[pin]
 #[pin_drop]
 pub struct NativePalette {
+    pub style_name: Property<StyleName>,
     pub background: Property<Brush>,
     pub foreground: Property<Brush>,
     pub alternate_background: Property<Brush>,

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -459,6 +459,20 @@ macro_rules! for_each_enums {
                 /// The stroke ends with a square projection beyond the path.
                 Square,
             }
+
+            /// This enum describes the specific theme
+            enum StyleName {
+                /// The Qt theme
+                Qt,
+                /// The Fluent theme
+                Fluent,
+                /// The Material theme
+                Material,
+                /// The Cupertino theme
+                Cupertino,
+                /// The Cosmic theme
+                Cosmic,
+            }
         ];
     };
 }

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -701,6 +701,7 @@ export global NativeStyleMetrics {
 }
 
 export global NativePalette {
+    out property <StyleName> style-name: StyleName.Qt;
     out property <brush> background;
     out property <brush> foreground;
     out property <brush> alternate-background;

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -83,6 +83,7 @@ pub enum BuiltinFunction {
     /// When there are 4 arguments, the last one is a reference to the MenuItem tree root (just like the entries in the [`Self::ShowPopupMenu`] call)
     /// then the code will assign the callback handler and properties
     SetupNativeMenuBar,
+    StyleName,
     Use24HourFormat,
     MonthDayCount,
     MonthOffset,
@@ -237,6 +238,9 @@ declare_builtin_function_types!(
     SupportsNativeMenuBar: () -> Type::Bool,
     // entries, sub-menu, activate. But the types here are not accurate.
     SetupNativeMenuBar: (Type::Model, typeregister::noarg_callback_type(), typeregister::noarg_callback_type()) -> Type::Void,
+    StyleName: () -> Type::Enumeration(
+        typeregister::BUILTIN.with(|e| e.enums.StyleName.clone()),
+    ),
     MonthDayCount: (Type::Int32, Type::Int32) -> Type::Int32,
     MonthOffset: (Type::Int32, Type::Int32) -> Type::Int32,
     FormatDate: (Type::String, Type::Int32, Type::Int32, Type::Int32) -> Type::String,
@@ -272,6 +276,7 @@ impl BuiltinFunction {
             BuiltinFunction::ColorScheme => false,
             BuiltinFunction::SupportsNativeMenuBar => false,
             BuiltinFunction::SetupNativeMenuBar => false,
+            BuiltinFunction::StyleName => false,
             BuiltinFunction::MonthDayCount => false,
             BuiltinFunction::MonthOffset => false,
             BuiltinFunction::FormatDate => false,
@@ -349,6 +354,7 @@ impl BuiltinFunction {
             BuiltinFunction::ColorScheme => true,
             BuiltinFunction::SupportsNativeMenuBar => true,
             BuiltinFunction::SetupNativeMenuBar => false,
+            BuiltinFunction::StyleName => true,
             BuiltinFunction::MonthDayCount => true,
             BuiltinFunction::MonthOffset => true,
             BuiltinFunction::FormatDate => true,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3689,6 +3689,9 @@ fn compile_builtin_function_call(
                 panic!("internal error: incorrect arguments to SetupNativeMenuBar")
             }
         }
+        BuiltinFunction::StyleName => {
+            format!("{}.style_name()", access_window_field(ctx))
+        }
         BuiltinFunction::Use24HourFormat => {
             "slint::cbindgen_private::slint_date_time_use_24_hour_format()".to_string()
         }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3162,6 +3162,10 @@ fn compile_builtin_function_call(
                 panic!("internal error: incorrect arguments to SetupNativeMenuBar")
             }
         }
+        BuiltinFunction::StyleName => {
+            let window_adapter_tokens = access_window_adapter_field(ctx);
+            quote!(sp::WindowInner::from_pub(#window_adapter_tokens.window()).style_name())
+        }
         BuiltinFunction::MonthDayCount => {
             let (m, y) = (a.next().unwrap(), a.next().unwrap());
             quote!(sp::month_day_count(#m as u32, #y as i32).unwrap_or(0))

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -136,6 +136,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::ColorScheme => PROPERTY_ACCESS_COST,
         BuiltinFunction::SupportsNativeMenuBar => 10,
         BuiltinFunction::SetupNativeMenuBar => isize::MAX,
+        BuiltinFunction::StyleName => PROPERTY_ACCESS_COST,
         BuiltinFunction::MonthDayCount => isize::MAX,
         BuiltinFunction::MonthOffset => isize::MAX,
         BuiltinFunction::FormatDate => isize::MAX,

--- a/internal/compiler/widgets/cosmic/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic/std-widgets-impl.slint
@@ -24,7 +24,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
-    out property <string> style-name: "cosmic";
+    out property <StyleName> style-name: StyleName.Cosmic;
     out property <brush> background: CosmicPalette.background;
     out property <brush> foreground: CosmicPalette.foreground;
     out property <brush> alternate-background: CosmicPalette.alternate-background;

--- a/internal/compiler/widgets/cosmic/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic/std-widgets-impl.slint
@@ -24,6 +24,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
+    out property <string> style-name: "cosmic";
     out property <brush> background: CosmicPalette.background;
     out property <brush> foreground: CosmicPalette.foreground;
     out property <brush> alternate-background: CosmicPalette.alternate-background;

--- a/internal/compiler/widgets/cupertino/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino/std-widgets-impl.slint
@@ -22,7 +22,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
-    out property <string> style-name: "cupertino";
+    out property <StyleName> style-name: StyleName.Cupertino;
     out property <brush> background: CupertinoPalette.background;
     out property <brush> foreground: CupertinoPalette.foreground;
     out property <brush> alternate-background: CupertinoPalette.alternate-background;

--- a/internal/compiler/widgets/cupertino/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino/std-widgets-impl.slint
@@ -22,6 +22,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
+    out property <string> style-name: "cupertino";
     out property <brush> background: CupertinoPalette.background;
     out property <brush> foreground: CupertinoPalette.foreground;
     out property <brush> alternate-background: CupertinoPalette.alternate-background;

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -22,6 +22,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
+    out property <string> style-name: "fluent";
     out property <brush> background: FluentPalette.background;
     out property <brush> foreground: FluentPalette.foreground;
     out property <brush> alternate-background: FluentPalette.alternate-background;

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -22,7 +22,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
-    out property <string> style-name: "fluent";
+    out property <StyleName> style-name: StyleName.Fluent;
     out property <brush> background: FluentPalette.background;
     out property <brush> foreground: FluentPalette.foreground;
     out property <brush> alternate-background: FluentPalette.alternate-background;

--- a/internal/compiler/widgets/material/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material/std-widgets-impl.slint
@@ -27,6 +27,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
+    out property <string> style-name: "material";
     out property <brush> background: MaterialPalette.background;
     out property <brush> foreground: MaterialPalette.foreground;
     out property <brush> alternate-background: MaterialPalette.alternate-background;

--- a/internal/compiler/widgets/material/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material/std-widgets-impl.slint
@@ -27,7 +27,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
-    out property <string> style-name: "material";
+    out property <StyleName> style-name: StyleName.Material;
     out property <brush> background: MaterialPalette.background;
     out property <brush> foreground: MaterialPalette.foreground;
     out property <brush> alternate-background: MaterialPalette.alternate-background;

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -5,7 +5,7 @@ use crate::api::{SetPropertyError, Struct, Value};
 use crate::dynamic_item_tree::{CallbackHandler, InstanceRef};
 use core::pin::Pin;
 use corelib::graphics::{GradientStop, LinearGradientBrush, PathElement, RadialGradientBrush};
-use corelib::items::{ColorScheme, StyleName, ItemRef, MenuEntry, PropertyAnimation};
+use corelib::items::{ColorScheme, ItemRef, MenuEntry, PropertyAnimation, StyleName};
 use corelib::menus::{Menu, MenuFromItemTree, MenuVTable};
 use corelib::model::{Model, ModelExt, ModelRc, VecModel};
 use corelib::rtti::AnimatedBindingKind;

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -5,7 +5,7 @@ use crate::api::{SetPropertyError, Struct, Value};
 use crate::dynamic_item_tree::{CallbackHandler, InstanceRef};
 use core::pin::Pin;
 use corelib::graphics::{GradientStop, LinearGradientBrush, PathElement, RadialGradientBrush};
-use corelib::items::{ColorScheme, ItemRef, MenuEntry, PropertyAnimation};
+use corelib::items::{ColorScheme, StyleName, ItemRef, MenuEntry, PropertyAnimation};
 use corelib::menus::{Menu, MenuFromItemTree, MenuVTable};
 use corelib::model::{Model, ModelExt, ModelRc, VecModel};
 use corelib::rtti::AnimatedBindingKind;
@@ -1214,6 +1214,16 @@ fn call_builtin_function(
             }
             Value::Void
         }
+        BuiltinFunction::StyleName => match local_context.component_instance {
+            ComponentInstance::InstanceRef(component) => component
+                .window_adapter()
+                .internal(corelib::InternalToken)
+                .map_or(StyleName::Unknown, |x| x.style_name())
+                .into(),
+            ComponentInstance::GlobalComponent(_) => {
+                panic!("Cannot get the window from a global component")
+            }
+        },
         BuiltinFunction::MonthDayCount => {
             let m: u32 = eval_expression(&arguments[0], local_context).try_into().unwrap();
             let y: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();


### PR DESCRIPTION
Although std-widgets provides many properties that adapt to the current theme users who would like to go beyond these properties and do theme dependent changes are limited. One option would be to add even more properties to the Palette, however this would potentially bloat the object, it's not obvious what properties users care about and this approach doesn't scale. In many cases developers could simply create their own properties if they knew what the current runtime theme was.

This simple change allows an app to know what the current theme is and present theme appropriate UI's.