### PR TITLE
Allow checking at runtime about the current theme

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/style.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/style.mdx
@@ -58,6 +58,37 @@ main.greeting = "Hello friends";
 </TabItem>
 </Tabs>
 
+## Using Style Properties In Your Own Components
+
+The global Palette and StyleMetrics properties can be accessed and will be set to the appropriate values of the current style.
+
+```slint playground
+import { Palette, StyleMetrics } from "std-widgets.slint";
+
+export component Example inherits Window {
+    Rectangle {
+        border-radius: StyleMetrics.layout-padding;
+        border-width: 2px;
+        border-color: Palette.border;
+        background: Palette.background;
+    }
+}
+```
+
+In situations where the specific property is not available you can detect the style via Palette.style-name.
+
+```slint playground
+import { Palette } from "std-widgets.slint";
+
+export component Example inherits Window {
+    Rectangle {
+        border-radius: Palette.style-name == "fluent" ? 4px : 2px;
+        border-width: Palette.style-name == "fluent" ? 2px : 1px;
+        border-color: Palette.border;
+        background: Palette.background;
+    }
+}
+```
 
 ## Previewing Designs With `slint-viewer`
 

--- a/docs/astro/src/content/docs/reference/std-widgets/style.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/style.mdx
@@ -75,7 +75,7 @@ export component Example inherits Window {
 }
 ```
 
-In situations where the specific property is not available you can detect the style via Palette.style-name.
+In situations where the specific property is not available you can detect the style via `Palette.style-name`.
 
 ```slint playground
 import { Palette } from "std-widgets.slint";

--- a/docs/astro/src/content/docs/reference/std-widgets/style.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/style.mdx
@@ -60,7 +60,7 @@ main.greeting = "Hello friends";
 
 ## Using Style Properties In Your Own Components
 
-The global Palette and StyleMetrics properties can be accessed and will be set to the appropriate values of the current style.
+The global `Palette` and `StyleMetrics` properties can be accessed and will be set to the appropriate values of the current style.
 
 ```slint playground
 import { Palette, StyleMetrics } from "std-widgets.slint";

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -676,7 +676,6 @@ export component NativeTab {
 }
 
 export global NativeStyleMetrics {
-    out property <string> style-name: "qt";
     out property <length> layout-spacing;
     out property <length> layout-padding;
     out property <length> text-cursor-width;
@@ -702,6 +701,7 @@ export global NativeStyleMetrics {
 }
 
 export global NativePalette {
+    out property <string> style-name: "qt";
     out property <brush> background;
     out property <brush> foreground;
     out property <brush> alternate-background;

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -676,6 +676,7 @@ export component NativeTab {
 }
 
 export global NativeStyleMetrics {
+    out property <string> style-name: "qt";
     out property <length> layout-spacing;
     out property <length> layout-padding;
     out property <length> text-cursor-width;

--- a/internal/compiler/widgets/cosmic/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic/std-widgets-impl.slint
@@ -11,7 +11,6 @@ export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 import { CosmicPalette } from "styling.slint";
 
 export global StyleMetrics  {
-    out property <string> style-name: "cosmic";
     out property <length> layout-spacing: 8px;
     out property <length> layout-padding: 8px;
     out property <length> text-cursor-width: 1px;
@@ -25,6 +24,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
+    out property <string> style-name: "cosmic";
     out property <brush> background: CosmicPalette.background;
     out property <brush> foreground: CosmicPalette.foreground;
     out property <brush> alternate-background: CosmicPalette.alternate-background;

--- a/internal/compiler/widgets/cosmic/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic/std-widgets-impl.slint
@@ -11,6 +11,7 @@ export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 import { CosmicPalette } from "styling.slint";
 
 export global StyleMetrics  {
+    out property <string> style-name: "cosmic";
     out property <length> layout-spacing: 8px;
     out property <length> layout-padding: 8px;
     out property <length> text-cursor-width: 1px;

--- a/internal/compiler/widgets/cupertino/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino/std-widgets-impl.slint
@@ -9,7 +9,6 @@ import { CupertinoPalette } from "styling.slint";
 export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
 export global StyleMetrics  {
-    out property <string> style-name: "cupertino";
     out property <length> layout-spacing: 10px;
     out property <length> layout-padding: 12px;
     out property <length> text-cursor-width: 1px;
@@ -23,6 +22,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
+    out property <string> style-name: "cupertino";
     out property <brush> background: CupertinoPalette.background;
     out property <brush> foreground: CupertinoPalette.foreground;
     out property <brush> alternate-background: CupertinoPalette.alternate-background;

--- a/internal/compiler/widgets/cupertino/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino/std-widgets-impl.slint
@@ -9,6 +9,7 @@ import { CupertinoPalette } from "styling.slint";
 export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
 export global StyleMetrics  {
+    out property <string> style-name: "cupertino";
     out property <length> layout-spacing: 10px;
     out property <length> layout-padding: 12px;
     out property <length> text-cursor-width: 1px;

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -9,7 +9,6 @@ import { FluentPalette } from "styling.slint";
 export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
 export global StyleMetrics  {
-    out property <string> style-name: "fluent";
     out property <length> layout-spacing: 8px;
     out property <length> layout-padding: 8px;
     out property <length> text-cursor-width: 1px;
@@ -23,6 +22,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
+    out property <string> style-name: "fluent";
     out property <brush> background: FluentPalette.background;
     out property <brush> foreground: FluentPalette.foreground;
     out property <brush> alternate-background: FluentPalette.alternate-background;

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -9,6 +9,7 @@ import { FluentPalette } from "styling.slint";
 export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
 export global StyleMetrics  {
+    out property <string> style-name: "fluent";
     out property <length> layout-spacing: 8px;
     out property <length> layout-padding: 8px;
     out property <length> text-cursor-width: 1px;

--- a/internal/compiler/widgets/material/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material/std-widgets-impl.slint
@@ -12,6 +12,7 @@ export { LineEdit } from "lineedit.slint";
 export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
 export global StyleMetrics  {
+    out property <string> style-name: "material";
     out property <length> layout-spacing: 16px;
     out property <length> layout-padding: 16px;
     out property <length> text-cursor-width: 2px;

--- a/internal/compiler/widgets/material/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material/std-widgets-impl.slint
@@ -12,7 +12,6 @@ export { LineEdit } from "lineedit.slint";
 export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
 export global StyleMetrics  {
-    out property <string> style-name: "material";
     out property <length> layout-spacing: 16px;
     out property <length> layout-padding: 16px;
     out property <length> text-cursor-width: 2px;
@@ -28,6 +27,7 @@ export global StyleMetrics  {
 }
 
 export global Palette {
+    out property <string> style-name: "material";
     out property <brush> background: MaterialPalette.background;
     out property <brush> foreground: MaterialPalette.foreground;
     out property <brush> alternate-background: MaterialPalette.alternate-background;


### PR DESCRIPTION
Although std-widgets provides many properties that adapt to the current theme users who would like to go beyond these properties and do theme dependent changes are limited. One option would be to add even more properties to the Palette, however this would potentially bloat the object, it's not obvious what properties users care about and this approach doesn't scale. In many cases developers could simply create their own properties if they knew what the current runtime theme was.

This simple change allows an app to know what the current theme is and present theme appropriate UI's.