### PR TITLE
compiler: Add a DebugHook expression

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1423,7 +1423,7 @@ impl Expression {
     pub fn ignore_debug_hooks(&self) -> &Expression {
         match self {
             Expression::DebugHook { expression, .. } => expression.as_ref(),
-            _ => return self,
+            _ => self,
         }
     }
 }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -716,6 +716,11 @@ pub enum Expression {
         rhs: Box<Expression>,
     },
 
+    DebugHook {
+        expression: Box<Expression>,
+        id: SmolStr,
+    },
+
     EmptyComponentFactory,
 }
 
@@ -837,6 +842,7 @@ impl Expression {
             Expression::SolveLayout(..) => Type::LayoutCache,
             Expression::MinMax { ty, .. } => ty.clone(),
             Expression::EmptyComponentFactory => Type::ComponentFactory,
+            Expression::DebugHook { expression, .. } => expression.ty(),
         }
     }
 
@@ -931,6 +937,7 @@ impl Expression {
                 visitor(rhs);
             }
             Expression::EmptyComponentFactory => {}
+            Expression::DebugHook { expression, .. } => visitor(expression),
         }
     }
 
@@ -1027,6 +1034,7 @@ impl Expression {
                 visitor(rhs);
             }
             Expression::EmptyComponentFactory => {}
+            Expression::DebugHook { expression, .. } => visitor(expression),
         }
     }
 
@@ -1108,6 +1116,7 @@ impl Expression {
             Expression::SolveLayout(..) => false,
             Expression::MinMax { lhs, rhs, .. } => lhs.is_constant() && rhs.is_constant(),
             Expression::EmptyComponentFactory => true,
+            Expression::DebugHook { .. } => false,
         }
     }
 
@@ -1407,6 +1416,14 @@ impl Expression {
                 ctx.diag.push_error(format!("{what} needs to be done on a property"), node);
                 false
             }
+        }
+    }
+
+    /// Unwrap DebugHook expressions to their contained sub-expression
+    pub fn ignore_debug_hooks(&self) -> &Expression {
+        match self {
+            Expression::DebugHook { expression, .. } => expression.as_ref(),
+            _ => return self,
         }
     }
 }
@@ -1738,5 +1755,10 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
             write!(f, ")")
         }
         Expression::EmptyComponentFactory => write!(f, "<empty-component-factory>"),
+        Expression::DebugHook { expression, id } => {
+            write!(f, "debug-hook(")?;
+            pretty_print(f, expression)?;
+            write!(f, "\"{id}\")")
+        }
     }
 }

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -149,7 +149,7 @@ pub struct CompilerConfiguration {
     pub debug_info: bool,
 
     /// Generate debug hooks to inspect/override properties.
-    pub debug_hooks: bool,
+    pub debug_hooks: Option<std::hash::RandomState>,
 
     pub components_to_generate: ComponentSelection,
 
@@ -229,7 +229,7 @@ impl CompilerConfiguration {
             translation_domain: None,
             cpp_namespace,
             debug_info,
-            debug_hooks: false,
+            debug_hooks: None,
             components_to_generate: ComponentSelection::ExportedWindows,
             #[cfg(feature = "software-renderer")]
             font_cache: Default::default(),

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -148,6 +148,9 @@ pub struct CompilerConfiguration {
     /// Generate debug information for elements (ids, type names)
     pub debug_info: bool,
 
+    /// Generate debug hooks to inspect/override properties.
+    pub debug_hooks: bool,
+
     pub components_to_generate: ComponentSelection,
 
     #[cfg(feature = "software-renderer")]
@@ -226,6 +229,7 @@ impl CompilerConfiguration {
             translation_domain: None,
             cpp_namespace,
             debug_info,
+            debug_hooks: false,
             components_to_generate: ComponentSelection::ExportedWindows,
             #[cfg(feature = "software-renderer")]
             font_cache: Default::default(),

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -252,6 +252,7 @@ pub fn lower_expression(
             rhs: Box::new(lower_expression(rhs, ctx)),
         },
         tree_Expression::EmptyComponentFactory => llr_Expression::EmptyComponentFactory,
+        tree_Expression::DebugHook { expression, .. } => lower_expression(expression, ctx),
     }
 }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -641,6 +641,9 @@ pub struct ElementDebugInfo {
     // The id qualified with the enclosing component name. Given `foo := Bar {}` this is `EnclosingComponent::foo`
     pub qualified_id: Option<SmolStr>,
     pub type_name: String,
+    // Hold an id for each element that is unique during this build.
+    // It helps to cross-reference the element in the different build stages the LSP has to deal with.
+    pub element_id: u64,
     pub node: syntax_nodes::Element,
     // Field to indicate whether this element was a layout that had
     // been lowered into a rectangle in the lower_layouts pass.
@@ -997,6 +1000,7 @@ impl Element {
             base_type,
             debug: vec![ElementDebugInfo {
                 qualified_id,
+                element_id: 0,
                 type_name,
                 node: node.clone(),
                 layout: None,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -641,9 +641,11 @@ pub struct ElementDebugInfo {
     // The id qualified with the enclosing component name. Given `foo := Bar {}` this is `EnclosingComponent::foo`
     pub qualified_id: Option<SmolStr>,
     pub type_name: String,
-    // Hold an id for each element that is unique during this build.
-    // It helps to cross-reference the element in the different build stages the LSP has to deal with.
-    pub element_id: u64,
+    // Hold an id for each element that is unique during this build, based on the source file and
+    // the offset of the `LBrace` token.
+    //
+    // This helps to cross-reference the element in the different build stages the LSP has to deal with.
+    pub element_hash: u64,
     pub node: syntax_nodes::Element,
     // Field to indicate whether this element was a layout that had
     // been lowered into a rectangle in the lower_layouts pass.
@@ -1000,7 +1002,7 @@ impl Element {
             base_type,
             debug: vec![ElementDebugInfo {
                 qualified_id,
-                element_id: 0,
+                element_hash: 0,
                 type_name,
                 node: node.clone(),
                 layout: None,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -93,8 +93,6 @@ pub async fn run_passes(
 
     let global_type_registry = type_loader.global_type_registry.clone();
 
-    inject_debug_hooks::inject_debug_hooks(doc, type_loader);
-
     run_import_passes(doc, type_loader, diag);
     check_public_api::check_public_api(doc, &type_loader.compiler_config, diag);
 
@@ -327,6 +325,7 @@ pub fn run_import_passes(
     type_loader: &crate::typeloader::TypeLoader,
     diag: &mut crate::diagnostics::BuildDiagnostics,
 ) {
+    inject_debug_hooks::inject_debug_hooks(doc, type_loader);
     infer_aliases_types::resolve_aliases(doc, diag);
     resolving::resolve_expressions(doc, type_loader, diag);
     purity_check::purity_check(doc, diag);

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -207,6 +207,7 @@ fn simplify_expression(expr: &mut Expression) -> bool {
         Expression::LayoutCacheAccess { .. } => false,
         Expression::SolveLayout { .. } => false,
         Expression::ComputeLayoutInfo { .. } => false,
+        Expression::DebugHook { .. } => false, // This is not const by design
         _ => {
             let mut result = true;
             expr.visit_mut(|expr| result &= simplify_expression(expr));

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -207,7 +207,6 @@ fn simplify_expression(expr: &mut Expression) -> bool {
         Expression::LayoutCacheAccess { .. } => false,
         Expression::SolveLayout { .. } => false,
         Expression::ComputeLayoutInfo { .. } => false,
-        Expression::DebugHook { .. } => false, // This is not const by design
         _ => {
             let mut result = true;
             expr.visit_mut(|expr| result &= simplify_expression(expr));

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -82,7 +82,8 @@ impl<'a> LocalFocusForwards<'a> {
                 return;
             };
 
-            let Expression::ElementReference(focus_target) = &forward_focus_binding.expression
+            let Expression::ElementReference(focus_target) =
+                super::ignore_debug_hooks(&forward_focus_binding.expression)
             else {
                 // resolve expressions pass has produced type errors
                 debug_assert!(diag.has_errors());

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -82,7 +82,7 @@ fn resolve_alias(
         assert!(diag.has_errors());
         return;
     };
-    let nr = match &binding.borrow().expression {
+    let nr = match super::ignore_debug_hooks(&binding.borrow().expression) {
         Expression::Uncompiled(node) => {
             let Some(node) = syntax_nodes::TwoWayBinding::new(node.clone()) else {
                 assert!(

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -5,51 +5,68 @@
 
 use crate::{expression_tree, object_tree, typeloader};
 
-pub fn inject_debug_hooks(
-    doc: &mut object_tree::Document,
-    type_loader: &mut typeloader::TypeLoader,
-) {
-    if !type_loader.compiler_config.debug_info {
+pub fn inject_debug_hooks(doc: &object_tree::Document, type_loader: &typeloader::TypeLoader) {
+    let Some(random_state) = &type_loader.compiler_config.debug_hooks else {
         return;
-    }
-
-    let mut counter = 1_u64;
+    };
 
     doc.visit_all_used_components(|component| {
         object_tree::recurse_elem_including_sub_components(component, &(), &mut |e, &()| {
-            process_element(e, counter, &type_loader.compiler_config);
-            counter += 1;
+            process_element(e, random_state);
         })
     });
 }
 
-fn property_id(counter: u64, name: &smol_str::SmolStr) -> smol_str::SmolStr {
-    smol_str::format_smolstr!("?{counter}-{name}")
+fn property_id(element_id: u64, name: &smol_str::SmolStr) -> smol_str::SmolStr {
+    smol_str::format_smolstr!("?{element_id}-{name}")
 }
 
-fn process_element(
-    element: &object_tree::ElementRc,
-    counter: u64,
-    config: &crate::CompilerConfiguration,
-) {
-    let mut elem = element.borrow_mut();
-    assert_eq!(elem.debug.len(), 1); // We did not merge Elements yet and we have debug info!
+fn calculate_element_hash(
+    elem: &object_tree::Element,
+    random_state: &std::hash::RandomState,
+) -> u64 {
+    let node = &elem.debug.first().expect("There was one element a moment ago").node;
 
-    if config.debug_hooks {
-        elem.bindings.iter().for_each(|(name, be)| {
-            let expr = std::mem::take(&mut be.borrow_mut().expression);
-            be.borrow_mut().expression = {
-                let stripped = super::ignore_debug_hooks(&expr);
-                if matches!(stripped, expression_tree::Expression::Invalid) {
-                    stripped.clone()
-                } else {
-                    expression_tree::Expression::DebugHook {
-                        expression: Box::new(expr),
-                        id: property_id(counter, name),
-                    }
-                }
-            };
-        });
+    let elem_path = node.source_file.path();
+    let elem_offset = node
+        .child_token(crate::parser::SyntaxKind::LBrace)
+        .expect("All elements have a opening Brace")
+        .text_range()
+        .start();
+
+    use std::hash::{BuildHasher, Hasher};
+    let mut hasher = random_state.build_hasher();
+    hasher.write(elem_path.as_os_str().as_encoded_bytes());
+    hasher.write_u32(elem_offset.into());
+    hasher.finish()
+}
+
+fn process_element(element: &object_tree::ElementRc, random_state: &std::hash::RandomState) {
+    let mut elem = element.borrow_mut();
+    // We did not merge Elements yet and we have debug info!
+    assert_eq!(elem.debug.len(), 1);
+
+    // Ignore nodes previously set up
+    if elem.debug.first().expect("There was one element a moment ago").element_hash != 0 {
+        return;
     }
-    elem.debug.first_mut().expect("There was one element a moment ago").element_id = counter;
+
+    let element_hash = calculate_element_hash(&elem, random_state);
+
+    elem.bindings.iter().for_each(|(name, be)| {
+        let expr = std::mem::take(&mut be.borrow_mut().expression);
+        be.borrow_mut().expression = {
+            let stripped = super::ignore_debug_hooks(&expr);
+            if matches!(stripped, expression_tree::Expression::Invalid) {
+                stripped.clone()
+            } else {
+                expression_tree::Expression::DebugHook {
+                    expression: Box::new(expr),
+                    id: property_id(element_hash, name),
+                }
+            }
+        };
+    });
+
+    elem.debug.first_mut().expect("There was one element a moment ago").element_hash = element_hash;
 }

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -1,0 +1,55 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Hooks properties for live inspection.
+
+use crate::{expression_tree, object_tree, typeloader};
+
+pub fn inject_debug_hooks(
+    doc: &mut object_tree::Document,
+    type_loader: &mut typeloader::TypeLoader,
+) {
+    if !type_loader.compiler_config.debug_info {
+        return;
+    }
+
+    let mut counter = 1_u64;
+
+    doc.visit_all_used_components(|component| {
+        object_tree::recurse_elem_including_sub_components(component, &(), &mut |e, &()| {
+            process_element(e, counter, &type_loader.compiler_config);
+            counter += 1;
+        })
+    });
+}
+
+fn property_id(counter: u64, name: &smol_str::SmolStr) -> smol_str::SmolStr {
+    smol_str::format_smolstr!("?{counter}-{name}")
+}
+
+fn process_element(
+    element: &object_tree::ElementRc,
+    counter: u64,
+    config: &crate::CompilerConfiguration,
+) {
+    let mut elem = element.borrow_mut();
+    assert_eq!(elem.debug.len(), 1); // We did not merge Elements yet and we have debug info!
+
+    if config.debug_hooks {
+        elem.bindings.iter().for_each(|(name, be)| {
+            let expr = std::mem::take(&mut be.borrow_mut().expression);
+            be.borrow_mut().expression = {
+                let stripped = super::ignore_debug_hooks(&expr);
+                if matches!(stripped, expression_tree::Expression::Invalid) {
+                    stripped.clone()
+                } else {
+                    expression_tree::Expression::DebugHook {
+                        expression: Box::new(expr),
+                        id: property_id(counter, name),
+                    }
+                }
+            };
+        });
+    }
+    elem.debug.first_mut().expect("There was one element a moment ago").element_id = counter;
+}

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -22,7 +22,9 @@ pub fn lower_accessibility_properties(component: &Rc<Component>, diag: &mut Buil
             apply_builtin(elem);
             let accessible_role_set = match elem.borrow().bindings.get("accessible-role") {
                 Some(role) => {
-                    if let Expression::EnumerationValue(val) = &role.borrow().expression {
+                    if let Expression::EnumerationValue(val) =
+                        super::ignore_debug_hooks(&role.borrow().expression)
+                    {
                         debug_assert_eq!(val.enumeration.name, "AccessibleRole");
                         debug_assert_eq!(val.enumeration.values[0], "none");
                         if val.value == 0 {

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -60,7 +60,7 @@ pub fn lower_layouts(
 fn check_preferred_size_100(elem: &ElementRc, prop: &str, diag: &mut BuildDiagnostics) -> bool {
     let ret = if let Some(p) = elem.borrow().bindings.get(prop) {
         if p.borrow().expression.ty() == Type::Percent {
-            if !matches!(p.borrow().expression.ignore_debug_hook(), Expression::NumberLiteral(val, _) if val == 100.)
+            if !matches!(p.borrow().expression.ignore_debug_hooks(), Expression::NumberLiteral(val, _) if *val == 100.)
             {
                 diag.push_error(
                     format!("{prop} must either be a length, or the literal '100%'"),

--- a/internal/compiler/passes/remove_return.rs
+++ b/internal/compiler/passes/remove_return.rs
@@ -39,6 +39,9 @@ fn process_expression(
     ty: &Type,
 ) -> ExpressionResult {
     match e {
+        Expression::DebugHook { expression, .. } => {
+            process_expression(*expression, toplevel, ctx, ty)
+        }
         Expression::ReturnStatement(expr) => ExpressionResult::Return(expr.map(|e| *e)),
         Expression::CodeBlock(expr) => {
             process_codeblock(expr.into_iter().peekable(), toplevel, ty, ctx)
@@ -69,14 +72,14 @@ fn process_expression(
                 }
                 (ExpressionResult::Return(te), ExpressionResult::Return(fe)) => {
                     ExpressionResult::Return(Some(Expression::Condition {
-                        condition: condition.into(),
+                        condition,
                         true_expr: te.unwrap_or(Expression::CodeBlock(vec![])).into(),
                         false_expr: fe.unwrap_or(Expression::CodeBlock(vec![])).into(),
                     }))
                 }
                 (te, fe) => {
-                    let te = te.into_return_object(&ty, &ctx.ret_ty);
-                    let fe = fe.into_return_object(&ty, &ctx.ret_ty);
+                    let te = te.into_return_object(ty, &ctx.ret_ty);
+                    let fe = fe.into_return_object(ty, &ctx.ret_ty);
                     ExpressionResult::ReturnObject {
                         has_value: has_value(ty),
                         has_return_value: has_value(&ctx.ret_ty),

--- a/internal/compiler/passes/z_order.rs
+++ b/internal/compiler/passes/z_order.rs
@@ -74,7 +74,7 @@ fn eval_const_expr(
     span: &dyn crate::diagnostics::Spanned,
     diag: &mut BuildDiagnostics,
 ) -> Option<f64> {
-    match expression {
+    match super::ignore_debug_hooks(expression) {
         Expression::NumberLiteral(v, Unit::None) => Some(*v),
         Expression::Cast { from, .. } => eval_const_expr(from, name, span, diag),
         Expression::UnaryOp { sub, op: '-' } => eval_const_expr(sub, name, span, diag).map(|v| -v),

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -395,7 +395,8 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 MinMaxOp::Max => Value::Number(lhs.max(rhs)),
             }
         }
-        Expression::EmptyComponentFactory => Value::ComponentFactory(Default::default())
+        Expression::EmptyComponentFactory => Value::ComponentFactory(Default::default()),
+        Expression::DebugHook { expression, .. } => eval_expression(expression, local_context),
     }
 }
 


### PR DESCRIPTION
You can not create this expression manually, but there is a pass in the compiler that adds it to all set
properties in a compilation run.

All it does is basically associate an id with an expression, so that we can then in a later step have the interpreter do something with that information. Apart from that, it tries to be as transparent as possible.

The LLR lowering removes that expression again, just so we can be sure it does not end up in the generated live code.