### PR TITLE
Clean up wasm-interpreter / winit interface

### DIFF
--- a/api/wasm-interpreter/Cargo.toml
+++ b/api/wasm-interpreter/Cargo.toml
@@ -24,6 +24,8 @@ slint-interpreter = { workspace = true, features = [
   "compat-1-2",
   "internal",
 ] }
+i-slint-backend-winit = { workspace = true }
+i-slint-core = { workspace = true }
 send_wrapper = { workspace = true }
 
 vtable = { workspace = true }

--- a/docs/astro/src/utils/slint-docs-preview.html
+++ b/docs/astro/src/utils/slint-docs-preview.html
@@ -85,15 +85,7 @@
     async function run() {
         await slint.default();
 
-        try {
-            slint.run_event_loop();
-            // this will trigger a JS exception, so this line will never be reached!
-        } catch (e) {
-            // The winit event loop, when targeting wasm, throws a JavaScript exception to break out of
-            // Rust without running any destructors. Don't rethrow the exception but swallow it, as
-            // this is no error and we truly want to resolve the promise of this function by returning
-            // the model markers.
-        }
+        slint.run_event_loop();
 
         let selector = ["code.language-slint", ".rustdoc pre.language-slint", "div.highlight-slint div.highlight", "div.highlight-slint\\,no-auto-preview div.highlight"]
             .map((sel) => `${sel}:not([class*=slint\\,ignore]):not([class*=slint\\,no-preview])`).join(",");

--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -109,11 +109,7 @@ function getPreviewHtml(
 
     const vscode = acquireVsCodeApi();
     let promises = {};
-    try {
-        slint_preview.run_event_loop();
-    } catch (_) {
-        // This is actually not an error:-/
-    }
+    slint_preview.run_event_loop();
 
     const canvas_id = "canvas";
 

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -446,10 +446,7 @@ fn send_event_via_global_event_loop_proxy(
 
 impl i_slint_core::platform::Platform for Backend {
     fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
-        let mut attrs = WinitWindowAdapter::window_attributes(
-            #[cfg(target_arch = "wasm32")]
-            "canvas".into(),
-        )?;
+        let mut attrs = WinitWindowAdapter::window_attributes()?;
 
         if let Some(hook) = &self.window_attributes_hook {
             attrs = hook(attrs);

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -85,20 +85,6 @@ mod xdg_color_scheme;
 #[cfg(target_arch = "wasm32")]
 pub(crate) mod wasm_input_helper;
 
-/// Create an open GL renderer for the HTML canvas element with the given `canvas_id`
-#[cfg(all(target_arch = "wasm32", feature = "renderer-femtovg"))]
-pub fn create_gl_window_with_canvas_id(
-    canvas_id: &str,
-) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
-    let attrs = WinitWindowAdapter::window_attributes(canvas_id)?;
-    let adapter = WinitWindowAdapter::new(
-        renderer::femtovg::GlutinFemtoVGRenderer::new_suspended(),
-        attrs,
-        None,
-    )?;
-    Ok(adapter)
-}
-
 cfg_if::cfg_if! {
     if #[cfg(feature = "renderer-femtovg")] {
         const DEFAULT_RENDERER_NAME: &str = "FemtoVG";

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -278,15 +278,8 @@ impl WasmInputHelper {
     ) {
         let closure = move |arg: Arg| {
             closure(arg);
-            crate::event_loop::GLOBAL_PROXY.with(|global_proxy| {
-                if let Ok(mut x) = global_proxy.try_borrow_mut() {
-                    if let Some(proxy) = &mut *x {
-                        let _ = proxy.send_event(crate::SlintUserEvent(
-                            crate::event_loop::CustomEvent::WakeEventLoopWorkaround,
-                        ));
-                    }
-                }
-            });
+            // wake up event loop
+            i_slint_core::api::invoke_from_event_loop(|| {}).ok();
         };
         let closure = Closure::wrap(Box::new(closure) as Box<dyn Fn(_)>);
         self.input

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -983,22 +983,6 @@ impl ComponentDefinition {
         })
     }
 
-    /// Instantiate the component for wasm using the given canvas id
-    #[cfg(target_arch = "wasm32")]
-    pub fn create_with_canvas_id(
-        &self,
-        canvas_id: &str,
-    ) -> Result<ComponentInstance, PlatformError> {
-        generativity::make_guard!(guard);
-        Ok(ComponentInstance {
-            inner: self
-                .inner
-                .unerase(guard)
-                .clone()
-                .create(WindowOptions::CreateWithCanvasId(canvas_id.into()))?,
-        })
-    }
-
     /// Instantiate the component using an existing window.
     #[doc(hidden)]
     #[cfg(feature = "internal")]

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1644,15 +1644,6 @@ pub fn spawn_local<F: Future + 'static>(fut: F) -> Result<JoinHandle<F::Output>,
         .map_err(|_| EventLoopError::NoEventLoopProvider)?
 }
 
-#[cfg(all(feature = "internal", target_arch = "wasm32"))]
-/// Spawn the event loop.
-///
-/// Like [`run_event_loop()`], but returns immediately as the loop is running within
-/// the browser's runtime
-pub fn spawn_event_loop() -> Result<(), PlatformError> {
-    i_slint_backend_selector::with_platform(|_| i_slint_backend_winit::spawn_event_loop())
-}
-
 /// This module contains a few functions used by the tests
 #[doc(hidden)]
 pub mod testing {

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -131,6 +131,7 @@ send_wrapper = { workspace = true }
 serde-wasm-bindgen = "0.6.0"
 wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"
+i-slint-backend-winit = { workspace = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 i-slint-backend-winit = { workspace = true, optional = true }

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -222,11 +222,7 @@ export class Lsp {
         style: string,
     ): Promise<Previewer> {
         if (this.#preview_connector === null) {
-            try {
-                slint_preview.run_event_loop();
-            } catch (e) {
-                // this is not an error!
-            }
+            slint_preview.run_event_loop();
 
             const params = new URLSearchParams(window.location.search);
             const experimental = params.get("SLINT_EXPERIMENTAL_FEATURES");


### PR DESCRIPTION
Replace various private APIs needed for the wasm builds with "public" APIs

This way, all window adapters are created through `create_window_adapter()` and all event loops are spawned through `Backend::run_event_loop()`.

Now we can replace the thread-local windows registry with reference-counted data that's shared between the backend and the window adapters.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
