### PR TITLE
component-container: Accept focus

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -78,6 +78,7 @@ export component ComponentContainer inherits Empty {
 
     in-out property <length> width;
     in-out property <length> height;
+    //-accepts_focus
 }
 
 export component Rotate inherits Empty {

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1750,6 +1750,9 @@ fn update_preview_area(
         let shared_document_cache = preview_state.document_cache.clone();
 
         if let Some(compiled) = compiled {
+            let api = ui.global::<ui::Api>();
+            api.set_focus_previewed_element(behavior == LoadBehavior::BringWindowToFront);
+
             set_preview_factory(
                 ui,
                 compiled,

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -227,6 +227,7 @@ export global Api {
     // std-widgets are used (=> show style dropdown)
     in-out property <bool> uses-widgets;
     in-out property <bool> always-on-top;
+    in property <bool> focus-previewed-element;
 
     // ## Component Data for ComponentList:
     // All the components

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -307,6 +307,12 @@ export component PreviewView {
                     }
 
                     Api.resize-to-preferred-size = false;
+
+                    if Api.focus-previewed-element {
+                        preview-area-container.focus();
+                    }
+
+                    Api.focus-previewed-element = false;
                 }
 
                 function resize-to-preview-constraints(width: length, height: length) {


### PR DESCRIPTION
So that we can pass the focus into the container when it first shows.

I thought this would be super complex to do property! What a nice surprise:-)

Fixes: #4055