### PR TITLE
Menu: don't remove the title properties

### DIFF
--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -632,16 +632,6 @@ fn generate_menu_entries(
         assert!(borrow_mut.repeated.is_none());
 
         let mut values = HashMap::<SmolStr, Expression>::new();
-        if !is_separator {
-            for prop in ["title"] {
-                if let Some(binding) = borrow_mut.bindings.remove(prop) {
-                    values.insert(SmolStr::new_static(prop), binding.into_inner().expression);
-                }
-            }
-        } else {
-            values.insert(SmolStr::new_static("is_separator"), Expression::BoolLiteral(true));
-        }
-
         state.id += 1;
         let id_str = format_smolstr!("{}", state.id);
         values.insert(SmolStr::new_static("id"), Expression::StringLiteral(id_str.clone()));
@@ -660,6 +650,21 @@ fn generate_menu_entries(
             ));
             values
                 .insert(SmolStr::new_static("has-sub-menu"), Expression::BoolLiteral(true).into());
+        }
+
+        drop(borrow_mut);
+        if !is_separator {
+            for prop in ["title"] {
+                if item.borrow().bindings.contains_key(prop) {
+                    let n = SmolStr::new_static(prop);
+                    values.insert(
+                        n.clone(),
+                        Expression::PropertyReference(NamedReference::new(&item, n)),
+                    );
+                }
+            }
+        } else {
+            values.insert(SmolStr::new_static("is_separator"), Expression::BoolLiteral(true));
         }
 
         entries.push(mk_struct(state.menu_entry.clone(), values));

--- a/tests/cases/elements/menubar_for.slint
+++ b/tests/cases/elements/menubar_for.slint
@@ -14,7 +14,7 @@ export component TestCase inherits Window {
             title: "File";
             MenuItem {
                 title: "New";
-                activated => { debug("New"); }
+                activated => { result += self.title; debug("New"); }
             }
             MenuItem {
                 title: "Open";
@@ -84,6 +84,13 @@ slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key:
 assert_eq!(instance.get_result(), "");
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("\n"));
 assert_eq!(instance.get_result(), "Recent 43");
+
+instance.set_result("".into());
+slint_testing::send_mouse_click(&instance, 10., 10.);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("\n"));
+assert_eq!(instance.get_result(), "New");
+
 ```
 
 ```cpp
@@ -102,6 +109,12 @@ slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_cod
 assert_eq(instance.get_result(), "");
 slint_testing::send_keyboard_string_sequence(&instance, "\n");
 assert_eq(instance.get_result(), "Recent 43");
+
+instance.set_result("");
+slint_testing::send_mouse_click(&instance, 10., 10.);
+slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::DownArrow);
+slint_testing::send_keyboard_string_sequence(&instance, "\n");
+assert_eq(instance.get_result(), "New");
 ```
 
 ```js
@@ -119,5 +132,11 @@ slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F700}");
 assert.equal(instance.result, "");
 slintlib.private_api.send_keyboard_string_sequence(instance, "\n");
 assert.equal(instance.result, "Recent 44");
+
+instance.result = "";
+slintlib.private_api.send_mouse_click(instance, 10., 10.);
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\n");
+assert.equal(instance.result, "New");
 
 */

--- a/tests/cases/widgets/menubar.slint
+++ b/tests/cases/widgets/menubar.slint
@@ -16,7 +16,7 @@ export component TestCase inherits Window {
             MenuSeparator {} // should be hidden
             MenuItem {
                 title: "New";
-                activated => { result += "New"; debug("New"); }
+                activated => { result += self.title; debug("New"); }
             }
             MenuItem {
                 title: "Open";


### PR DESCRIPTION
Let further pass materialize them, and most likely remove them anyway. That way, they can be properly set and read from the rest of the .slint code.

Fixes #8080
