### PR TITLE
live-preview: Improve std-widget use detection

### DIFF
--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -217,7 +217,7 @@ impl DocumentCache {
         false
     }
 
-    /// Returns a vector of Documents the `doc_url` depends upon
+    /// Returns true if doc_url uses (possibly indirectly) widgets from "std-widgets.slint"
     pub fn uses_widgets(&self, doc_url: &Url) -> bool {
         let Some(doc_path) = uri_to_file(doc_url) else {
             return false;

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1010,17 +1010,7 @@ fn finish_parsing(preview_url: &Url, previewed_component: Option<String>, succes
             }
         }
 
-        let uses_widgets = document_cache
-            .get_document(preview_url)
-            .and_then(|d| d.node.as_ref())
-            .map(|n| {
-                n.ImportSpecifier().any(|is| {
-                    is.child_token(i_slint_compiler::parser::SyntaxKind::StringLiteral)
-                        .map(|sl| sl.text() == "\"std-widgets.slint\"")
-                        .unwrap_or_default()
-                })
-            })
-            .unwrap_or_default();
+        let uses_widgets = document_cache.uses_widgets(preview_url);
 
         let mut components = Vec::new();
         component_catalog::builtin_components(&document_cache, &mut components);


### PR DESCRIPTION
... so we do not hide the Style combobox when std-widgets get used by imported components, even if they are not used by the previewed component.

Fixes: #7172