### PR TITLE
Fix accessing properties within the `MenuItem`

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2206,6 +2206,11 @@ pub fn recurse_elem_including_sub_components_no_borrow<State>(
         .borrow()
         .iter()
         .for_each(|p| recurse_elem_including_sub_components_no_borrow(&p.component, state, vis));
+    component
+        .menu_item_tree
+        .borrow()
+        .iter()
+        .for_each(|c| recurse_elem_including_sub_components_no_borrow(c, state, vis));
 }
 
 /// This visit the binding attached to this element, but does not recurse in children elements

--- a/tests/cases/elements/menubar_for.slint
+++ b/tests/cases/elements/menubar_for.slint
@@ -26,7 +26,7 @@ export component TestCase inherits Window {
                     title: "Recent " + num;
                     activated => {
                         if self.title != "Recent " + num {
-                            result += "ERROR: invalid self.title";
+                            result += "Error: invalid self.title";
                         }
                         result += self.title;
                         debug("Recent", num);

--- a/tests/cases/elements/menubar_for.slint
+++ b/tests/cases/elements/menubar_for.slint
@@ -25,7 +25,10 @@ export component TestCase inherits Window {
                 for num in 45 : MenuItem {
                     title: "Recent " + num;
                     activated => {
-                        result += "Recent " + num;
+                        if self.title != "Recent " + num {
+                            result += "ERROR: invalid self.title";
+                        }
+                        result += self.title;
                         debug("Recent", num);
                     }
                 }


### PR DESCRIPTION
We were not visiting properly the MenuItem from
`recurse_elem_including_sub_components_no_borrow`
(`recurse_elem_including_sub_components` was correctly modified before)

Fixes #8090
