### PR TITLE
winit: separate menubar vbox from muda adapter

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -493,9 +493,7 @@ impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
                         e.parse::<usize>().ok()?,
                     ))
                 }) {
-                    if let Some(ma) = window.muda_adapter.borrow().as_ref() {
-                        ma.invoke(eid);
-                    }
+                    window.muda_event(eid);
                 };
             }
         }

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -13,7 +13,6 @@ use winit::window::Window;
 
 pub struct MudaAdapter {
     entries: Vec<MenuEntry>,
-    menubar: Option<vtable::VBox<MenuVTable>>,
     tracker: Option<Pin<Box<PropertyTracker<MudaPropertyTracker>>>>,
     menu: muda::Menu,
 }
@@ -27,11 +26,7 @@ impl PropertyDirtyHandler for MudaPropertyTracker {
         let win = self.window_adapter_weak.clone();
         i_slint_core::timers::Timer::single_shot(Default::default(), move || {
             if let Some(win) = win.upgrade() {
-                if let Some(winit_window) = win.winit_window() {
-                    if let Some(muda_adapter) = win.muda_adapter.borrow_mut().as_mut() {
-                        muda_adapter.rebuild_menu(&winit_window);
-                    }
-                }
+                win.rebuild_menubar();
             }
         })
     }
@@ -39,7 +34,7 @@ impl PropertyDirtyHandler for MudaPropertyTracker {
 
 impl MudaAdapter {
     pub fn setup(
-        menubar: vtable::VBox<MenuVTable>,
+        menubar: &vtable::VBox<MenuVTable>,
         winit_window: &Window,
         proxy: EventLoopProxy<SlintUserEvent>,
         window_adapter_weak: Weak<WinitWindowAdapter>,
@@ -67,12 +62,16 @@ impl MudaAdapter {
                 window_adapter_weak,
             })));
 
-        let mut s = Self { entries: Default::default(), menubar: Some(menubar), tracker, menu };
-        s.rebuild_menu(winit_window);
+        let mut s = Self { entries: Default::default(), tracker, menu };
+        s.rebuild_menu(winit_window, Some(menubar));
         s
     }
 
-    fn rebuild_menu(&mut self, winit_window: &Window) {
+    pub fn rebuild_menu(
+        &mut self,
+        winit_window: &Window,
+        menubar: Option<&vtable::VBox<MenuVTable>>,
+    ) {
         // clear the menu
         while self.menu.remove_at(0).is_some() {}
         self.entries.clear();
@@ -125,7 +124,7 @@ impl MudaAdapter {
         #[cfg(target_os = "macos")]
         create_default_app_menu(&self.menu).unwrap();
 
-        if let Some(menubar) = self.menubar.as_ref() {
+        if let Some(menubar) = menubar.as_ref() {
             let mut build_menu = || {
                 let mut menu_entries = Default::default();
                 menubar.sub_menu(None, &mut menu_entries);
@@ -151,9 +150,8 @@ impl MudaAdapter {
         }
     }
 
-    pub fn invoke(&self, entry_id: usize) {
+    pub fn invoke(&self, menubar: &vtable::VBox<MenuVTable>, entry_id: usize) {
         let Some(entry) = &self.entries.get(entry_id) else { return };
-        let Some(menubar) = self.menubar.as_ref() else { return };
         menubar.activate(entry);
     }
 
@@ -162,7 +160,7 @@ impl MudaAdapter {
         let menu_bar = muda::Menu::new();
         create_default_app_menu(&menu_bar)?;
         menu_bar.init_for_nsapp();
-        Ok(Self { entries: vec![], menubar: None, menu: menu_bar, tracker: None })
+        Ok(Self { entries: vec![], menu: menu_bar, tracker: None })
     }
 
     #[cfg(target_os = "macos")]

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1196,7 +1196,7 @@ impl WindowAdapterInternal for WinitWindowAdapter {
             &*self.winit_window_or_none.borrow()
         {
             // On Windows, we must destroy the muda menu before re-creating a new one
-            drop(self.muda_adapter.borrow_mut().take());
+            drop(muda_adapter.borrow_mut().take());
             muda_adapter.replace(Some(crate::muda::MudaAdapter::setup(
                 self.menubar.borrow().as_ref().unwrap(),
                 &self.winit_window().unwrap(),

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -126,6 +126,8 @@ enum WinitWindowOrNone {
         window: Rc<winit::window::Window>,
         #[cfg(enable_accesskit)]
         accesskit_adapter: RefCell<crate::accesskit::AccessKitAdapter>,
+        #[cfg(muda)]
+        muda_adapter: RefCell<Option<crate::muda::MudaAdapter>>,
     },
     None(RefCell<WindowAttributes>),
 }
@@ -294,7 +296,7 @@ pub struct WinitWindowAdapter {
     xdg_settings_watcher: RefCell<Option<i_slint_core::future::JoinHandle<()>>>,
 
     #[cfg(muda)]
-    pub(crate) muda_adapter: RefCell<Option<crate::muda::MudaAdapter>>,
+    menubar: RefCell<Option<vtable::VBox<i_slint_core::menus::MenuVTable>>>,
 
     #[cfg(all(muda, target_os = "macos"))]
     muda_enable_default_menu_bar: bool,
@@ -337,7 +339,7 @@ impl WinitWindowAdapter {
             #[cfg(not(use_winit_theme))]
             xdg_settings_watcher: Default::default(),
             #[cfg(muda)]
-            muda_adapter: Default::default(),
+            menubar: Default::default(),
             #[cfg(all(muda, target_os = "macos"))]
             muda_enable_default_menu_bar,
         });
@@ -408,6 +410,20 @@ impl WinitWindowAdapter {
                 self.event_loop_proxy.clone(),
             )
             .into(),
+            #[cfg(muda)]
+            muda_adapter: self
+                .menubar
+                .borrow()
+                .as_ref()
+                .map(|menubar| {
+                    crate::muda::MudaAdapter::setup(
+                        menubar,
+                        &self.winit_window().unwrap(),
+                        self.event_loop_proxy.clone(),
+                        self.self_weak.clone(),
+                    )
+                })
+                .into(),
         };
 
         self.shared_backend_data
@@ -502,6 +518,39 @@ impl WinitWindowAdapter {
 
     pub fn winit_window(&self) -> Option<Rc<winit::window::Window>> {
         self.winit_window_or_none.borrow().as_window()
+    }
+
+    #[cfg(muda)]
+    pub fn rebuild_menubar(&self) {
+        let WinitWindowOrNone::HasWindow {
+            window: winit_window,
+            muda_adapter: maybe_muda_adapter,
+            ..
+        } = &*self.winit_window_or_none.borrow()
+        else {
+            return;
+        };
+        let mut maybe_muda_adapter = maybe_muda_adapter.borrow_mut();
+        let Some(muda_adapter) = maybe_muda_adapter.as_mut() else { return };
+        muda_adapter.rebuild_menu(&winit_window, self.menubar.borrow().as_ref());
+    }
+
+    #[cfg(muda)]
+    pub fn muda_event(&self, entry_id: usize) {
+        let Ok(maybe_muda_adapter) = std::cell::Ref::filter_map(
+            self.winit_window_or_none.borrow(),
+            |winit_window_or_none| match winit_window_or_none {
+                WinitWindowOrNone::HasWindow { muda_adapter, .. } => Some(muda_adapter),
+                WinitWindowOrNone::None(..) => None,
+            },
+        ) else {
+            return;
+        };
+        let maybe_muda_adapter = maybe_muda_adapter.borrow();
+        let Some(muda_adapter) = maybe_muda_adapter.as_ref() else { return };
+        let menubar = self.menubar.borrow();
+        let Some(menubar) = menubar.as_ref() else { return };
+        muda_adapter.invoke(menubar, entry_id);
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -673,13 +722,20 @@ impl WinitWindowAdapter {
 
         #[cfg(all(muda, target_os = "macos"))]
         {
-            if self.muda_adapter.borrow().is_none() && self.muda_enable_default_menu_bar {
-                *self.muda_adapter.borrow_mut() =
-                    Some(crate::muda::MudaAdapter::setup_default_menu_bar()?);
-            }
+            if let WinitWindowOrNone::HasWindow { muda_adapter, .. } =
+                &*self.winit_window_or_none.borrow()
+            {
+                if muda_adapter.borrow().is_none()
+                    && self.muda_enable_default_menu_bar
+                    && self.menubar.borrow().is_none()
+                {
+                    *muda_adapter.borrow_mut() =
+                        Some(crate::muda::MudaAdapter::setup_default_menu_bar()?);
+                }
 
-            if let Some(muda_adapter) = self.muda_adapter.borrow().as_ref() {
-                muda_adapter.window_activation_changed(is_active);
+                if let Some(muda_adapter) = muda_adapter.borrow().as_ref() {
+                    muda_adapter.window_activation_changed(is_active);
+                }
             }
         }
 
@@ -1134,13 +1190,19 @@ impl WindowAdapterInternal for WinitWindowAdapter {
 
     #[cfg(muda)]
     fn setup_menubar(&self, menubar: vtable::VBox<i_slint_core::menus::MenuVTable>) {
-        drop(self.muda_adapter.borrow_mut().take());
-        self.muda_adapter.replace(Some(crate::muda::MudaAdapter::setup(
-            menubar,
-            &self.winit_window().unwrap(),
-            self.event_loop_proxy.clone(),
-            self.self_weak.clone(),
-        )));
+        drop(self.menubar.borrow_mut().take());
+        self.menubar.replace(Some(menubar));
+
+        if let WinitWindowOrNone::HasWindow { muda_adapter, .. } =
+            &*self.winit_window_or_none.borrow()
+        {
+            muda_adapter.replace(Some(crate::muda::MudaAdapter::setup(
+                self.menubar.borrow().as_ref().unwrap(),
+                &self.winit_window().unwrap(),
+                self.event_loop_proxy.clone(),
+                self.self_weak.clone(),
+            )));
+        }
     }
 
     #[cfg(enable_accesskit)]

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1190,12 +1190,13 @@ impl WindowAdapterInternal for WinitWindowAdapter {
 
     #[cfg(muda)]
     fn setup_menubar(&self, menubar: vtable::VBox<i_slint_core::menus::MenuVTable>) {
-        drop(self.menubar.borrow_mut().take());
         self.menubar.replace(Some(menubar));
 
         if let WinitWindowOrNone::HasWindow { muda_adapter, .. } =
             &*self.winit_window_or_none.borrow()
         {
+            // On Windows, we must destroy the muda menu before re-creating a new one
+            drop(self.muda_adapter.borrow_mut().take());
             muda_adapter.replace(Some(crate::muda::MudaAdapter::setup(
                 self.menubar.borrow().as_ref().unwrap(),
                 &self.winit_window().unwrap(),


### PR DESCRIPTION
The latter's life time is tied to the winit window and should live in WinitWindowOrNone.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
