### PR TITLE
Qt: re-arm the timer after callback from `invoke_from_event_loop`

### DIFF
--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -243,8 +243,11 @@ impl i_slint_core::platform::Platform for Backend {
                                 rust!(Slint_call_event_holder [fnbox: *mut dyn FnOnce() as "TraitObject"] {
                                    let b = Box::from_raw(fnbox);
                                    b();
+                                   // in case the callback started a new timer
+                                   crate::qt_window::restart_timer();
                                 });
                             }
+
                        }
                    };
                 }};

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2538,7 +2538,10 @@ thread_local! {
 /// Called by C++'s TimerHandler::timerEvent, or every time a timer might have been started
 pub(crate) fn timer_event() {
     i_slint_core::platform::update_timers_and_animations();
+    restart_timer();
+}
 
+pub(crate) fn restart_timer() {
     let timeout = i_slint_core::timers::TimerList::next_timeout().map(|instant| {
         let now = std::time::Instant::now();
         let instant: std::time::Instant = instant.into();


### PR DESCRIPTION
This fixes the preview window not showing with the Qt backend, because the preview uses a timer to show the window, but we would not start the Qt timer and so the window was never shown
