### PR TITLE
Clean up TS <> React communication and restore clipboard copy notific…

### DIFF
--- a/tools/figma-inspector/backend/code.ts
+++ b/tools/figma-inspector/backend/code.ts
@@ -43,7 +43,7 @@ figma.on("selectionchange", () => {
     }
 });
 
-j("exportToFiles", async () => {
+listenTS("exportToFiles", async () => {
     try {
         const exportedFiles = await exportFigmaVariablesToSeparateFiles();
         console.log(`Exported ${exportedFiles.length} collection files`);
@@ -62,24 +62,6 @@ j("exportToFiles", async () => {
         figma.notify("Failed to export to files", { error: true });
     }
 });
-function j(messageType: string, callback: () => Promise<void>) {
-    console.log(`Registering handler for ${messageType}`);
-
-    // We need to create a listener specifically for this message type
-    figma.ui.on("message", async (msg) => {
-        // Only execute if this message matches our type
-        if (msg.type === messageType) {
-            console.log(`Received ${messageType} message:`, msg);
-            try {
-                await callback();
-                console.log(`Successfully handled ${messageType}`);
-            } catch (error) {
-                console.error(`Error in ${messageType} handler:`, error);
-                figma.notify(`Error handling ${messageType}`, { error: true });
-            }
-        }
-    });
-}
 
 // Define state variables outside any function (at module level)
 const variableMonitoring: {
@@ -98,7 +80,7 @@ const variableMonitoring: {
 const DEBOUNCE_INTERVAL = 3000; // 3 seconds
 
 // Replace your monitorVariableChanges handler
-j("monitorVariableChanges", async () => {
+listenTS("monitorVariableChanges", async () => {
     console.log("Setting up variable change monitoring in plugin");
 
     // Set up event listeners for variable changes
@@ -172,7 +154,7 @@ j("monitorVariableChanges", async () => {
 });
 
 // Replace your checkVariableChanges handler
-j("checkVariableChanges", async () => {
+listenTS("checkVariableChanges", async () => {
     try {
         // Use the async version as required
         const collections =

--- a/tools/figma-inspector/shared/universals.d.ts
+++ b/tools/figma-inspector/shared/universals.d.ts
@@ -18,4 +18,9 @@ export interface EventTS {
             content: string;
         }>;
     };
+    monitorVariableChanges: {
+        enabled: boolean;
+    };
+    checkVariableChanges: {};
+    exportToFiles: {};
 }

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -4,11 +4,12 @@
 import React, { useEffect, useState } from "react";
 import JSZip from "jszip";
 import {
+    dispatchTS,
     listenTS,
     getColorTheme,
     subscribeColorTheme,
 } from "./utils/bolt-utils";
-import { getCopyToClipboard, getExportAll } from "./utils/utils.js";
+import { copyToClipboard } from "./utils/utils.js";
 import CodeSnippet from "./snippet/CodeSnippet";
 import "./main.css";
 
@@ -133,22 +134,7 @@ export const App = () => {
         return () => window.removeEventListener("message", directHandler);
     }, []);
 
-    // Function to communicate with the TypeScript side of the plugin
-    function dispatchTS(eventName: string, payload: {}): void {
-        // Send a message to the plugin code
-        parent.postMessage(
-            {
-                pluginMessage: {
-                    type: eventName,
-                    ...payload,
-                },
-            },
-            "*",
-        );
-    }
-
     // Create the functions with access to dispatchTS
-    const copyToClipboardFn = getCopyToClipboard(dispatchTS);
     const downloadZipFile = async (
         files: Array<{ name: string; content: string }>,
     ) => {
@@ -221,8 +207,8 @@ export const App = () => {
                     <div>
                         <span
                             id="copy-icon"
-                            onClick={() => copyToClipboardFn(slintProperties)}
-                            onKeyDown={() => copyToClipboardFn(slintProperties)}
+                            onClick={() => copyToClipboard(slintProperties)}
+                            onKeyDown={() => copyToClipboard(slintProperties)}
                             className="copy-icon"
                         >
                             📋

--- a/tools/figma-inspector/src/utils/utils.ts
+++ b/tools/figma-inspector/src/utils/utils.ts
@@ -33,34 +33,15 @@ export async function writeTextToClipboard(str: string) {
     }
 }
 
-// Modify these functions to accept dispatchTS
-interface DispatchTSFunction {
-    (action: string, payload: { result: boolean }): void;
-}
-
-type CopyToClipboardFunction = (slintProperties: string) => Promise<void>;
-
-export const getCopyToClipboard =
-    (dispatchTS: DispatchTSFunction): CopyToClipboardFunction =>
-    async (slintProperties: string) => {
-        try {
-            await writeTextToClipboard(slintProperties);
-            dispatchTS("copyToClipboard", {
-                result: true,
-            });
-        } catch (error) {
-            dispatchTS("copyToClipboard", {
-                result: false,
-            });
-        }
-    };
-
-type ExportAllFunction = () => void;
-
-export const getExportAll =
-    (dispatchTS: DispatchTSFunction): ExportAllFunction =>
-    () => {
-        dispatchTS("exportAll", {
+export async function copyToClipboard(slintProperties: string) {
+    try {
+        await writeTextToClipboard(slintProperties);
+        dispatchTS("copyToClipboard", {
             result: true,
         });
-    };
+    } catch (error) {
+        dispatchTS("copyToClipboard", {
+            result: false,
+        });
+    }
+}


### PR DESCRIPTION
…ation

Replace the famously named function `j` with the existing listenTS function, and replace the dispatchTS replacement with the original dispatchTS, along with new keys in the EventTS, for use with the variable collection exports.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
