### PR TITLE
MinimalSoftwareWindow: fix sizing with scale factor

### DIFF
--- a/internal/core/software_renderer/minimal_software_window.rs
+++ b/internal/core/software_renderer/minimal_software_window.rs
@@ -88,9 +88,10 @@ impl WindowAdapter for MinimalSoftwareWindow {
         self.size.get()
     }
     fn set_size(&self, size: crate::api::WindowSize) {
-        self.size.set(size.to_physical(1.));
+        let sf = self.window.scale_factor();
+        self.size.set(size.to_physical(sf));
         self.window
-            .dispatch_event(crate::platform::WindowEvent::Resized { size: size.to_logical(1.) })
+            .dispatch_event(crate::platform::WindowEvent::Resized { size: size.to_logical(sf) })
     }
 
     fn request_redraw(&self) {


### PR DESCRIPTION

(This causes the combobox popup in the printerdemo_mcu to be shown in the wrong place when using a scale factor, as it tries to fit them into the window which reports a size smaller than it is)