### PR TITLE
Brush Picker limit hex input length

### DIFF
--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -282,6 +282,11 @@ component ColorModeColorAndApply {
                     }
                     self.clear-focus();
                 }
+                edited => {
+                    if self.text.character-count > 8 {
+                        self.text = Api.color-to-data(PickerData.current-color).short-text.to-uppercase();
+                    }
+                }
             }
 
             divider := Rectangle {
@@ -488,7 +493,10 @@ component GradientStopValue {
             x: 35px;
             text: Api.color-to-data(PickerData.current-gradient-stops[stop-index].color).short-text.to-uppercase();
             letter-spacing: 0.8px;
+            input-type: text;
+
             property <{hue: float, saturation: float, value: float}> hsv-color;
+
             accepted => {
                 if Api.string-is-color("#\{self.text}") {
                     PickerData.hue = Api.string-to-color("#\{self.text}").to-hsv().hue;
@@ -504,6 +512,11 @@ component GradientStopValue {
                     self.text = Api.color-to-data(PickerData.current-color).short-text.to-uppercase();
                 }
                 self.clear-focus();
+            }
+            edited => {
+                if self.text.character-count > 8 {
+                    self.text = Api.color-to-data(PickerData.current-color).short-text.to-uppercase();
+                }
             }
         }
 


### PR DESCRIPTION
If the # hex value gets longer than 8 characters it will reset to the previous valid value.
Fixes an issue where gradient stops could not be fully keyboard edited. 