### PR TITLE
Disable jemalloc for slint-lsp/slint-viewer/slint-compiler on aarch64…

### DIFF
--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -33,5 +33,5 @@ proc-macro2 = "1.0.11"
 spin_on = { workspace = true }
 itertools = { workspace = true }
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
+[target.'cfg(not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -7,10 +7,16 @@ use i_slint_compiler::*;
 use itertools::Itertools;
 use std::io::{BufWriter, Write};
 
-#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
+#[cfg(all(
+    feature = "jemalloc",
+    not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux")))
+))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(all(feature = "jemalloc", not(target_os = "windows")))]
+#[cfg(all(
+    feature = "jemalloc",
+    not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux")))
+))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -104,7 +104,7 @@ i-slint-core = { workspace = true, features = ["std"], optional = true }
 slint = { workspace = true, features = ["compat-1-2"], optional = true }
 slint-interpreter = { workspace = true, features = ["compat-1-2", "internal", "internal-highlight", "internal-json", "image-default-formats"], optional = true }
 
-[target.'cfg(not(any(target_os = "windows", target_arch = "wasm32")))'.dependencies]
+[target.'cfg(not(any(target_os = "windows", target_arch = "wasm32", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -40,10 +40,18 @@ use std::task::{Poll, Waker};
 
 use crate::common::document_cache::CompilerConfiguration;
 
-#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
+#[cfg(not(any(
+    target_os = "windows",
+    target_arch = "wasm32",
+    all(target_arch = "aarch64", target_os = "linux")
+)))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
+#[cfg(not(any(
+    target_os = "windows",
+    target_arch = "wasm32",
+    all(target_arch = "aarch64", target_os = "linux")
+)))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -67,7 +67,7 @@ itertools = { workspace = true }
 serde_json = { workspace = true }
 smol_str = { workspace = true }
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
+[target.'cfg(not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [[bin]]

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -15,10 +15,10 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
…-linux

With jemalloc the page size is a compile time constant that results in the process aborting on memory allocation if the compile time determined page size does not match the kernel reported page size at run-time.

When we, or our users, compile the above programs for aarch64-linux, there is a fair expectation that the resulting binary works on any aarch64-linux system. As we can't determine the target page size reliably, disable jemalloc.

Fixes #8134

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
