### PR TITLE
Menu: Add enabled property

### DIFF
--- a/docs/astro/src/content/docs/reference/window/contextmenuarea.mdx
+++ b/docs/astro/src/content/docs/reference/window/contextmenuarea.mdx
@@ -39,6 +39,12 @@ Use `MenuItem` children of individual menu items, `Menu` children to create sub-
 This is the label of the menu as written in the menu bar or in the parent menu.
 </SlintProperty>
 
+#### enabled
+
+<SlintProperty propName="enabled" typeName="bool" defaultValue="true">
+When disabled, the `Menu` can be selected but not activated.
+</SlintProperty>
+
 ## `MenuItem`
 
 A `MenuItem` represents a single menu entry. It's must be a child of a `Menu` element.
@@ -49,6 +55,12 @@ A `MenuItem` represents a single menu entry. It's must be a child of a `Menu` el
 
 <SlintProperty propName="title" typeName="string" defaultValue='""'>
 The title shown for this menu item.
+</SlintProperty>
+
+#### enabled
+
+<SlintProperty propName="enabled" typeName="bool" defaultValue="true">
+When disabled, the `MenuItem` can be selected but not activated.
 </SlintProperty>
 
 ### Callbacks of `MenuItem`

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -194,8 +194,8 @@ macro_rules! for_each_builtin_structs {
                     /// an opaque id that can be used to identify the menu entry
                     id: SharedString,
                     // keyboard_shortcut: KeySequence,
-                    // /// whether the menu entry is enabled
-                    // enabled: bool,
+                    /// whether the menu entry is enabled
+                    enabled: bool,
                     /// Sub menu
                     has_sub_menu: bool,
                     /// The menu entry is a separator

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -187,6 +187,7 @@ export component SwipeGestureHandler {
 component MenuItem {
     in property <string> title;
     callback activated();
+    in property <bool> enabled: true;
     //-disallow_global_types_as_child_elements
     //-is_non_item_type
 }
@@ -198,6 +199,7 @@ component MenuSeparator {
 
 component Menu {
     in property <string> title;
+    in property <bool> enabled: true;
     MenuItem {}
     MenuSeparator {}
     Menu {}

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -654,7 +654,7 @@ fn generate_menu_entries(
 
         drop(borrow_mut);
         if !is_separator {
-            for prop in ["title"] {
+            for prop in ["title", "enabled"] {
                 if item.borrow().bindings.contains_key(prop) {
                     let n = SmolStr::new_static(prop);
                     values.insert(

--- a/internal/compiler/widgets/common/menu-base.slint
+++ b/internal/compiler/widgets/common/menu-base.slint
@@ -115,6 +115,7 @@ export component MenuItemBase {
 
         touch-area := TouchArea {
             visible: !entry.is-separator;
+            enabled: entry.enabled;
 
             layout := HorizontalLayout {
                 padding-top: root.padding-top;
@@ -140,11 +141,12 @@ export component MenuItemBase {
             pointer-event(event) => {
                 if event.kind == PointerEventKind.move && !root.is-current {
                     root.set-current()
-                } else if event.kind == PointerEventKind.down && entry.has-sub-menu {
+                } else if event.kind == PointerEventKind.down && entry.has-sub-menu && entry.enabled {
                     activate(entry, self.absolute-position.y);
                 } else if event.kind == PointerEventKind.up
                         && self.mouse-y > 0 && self.mouse-y < self.height
-                        && self.mouse-x > 0 && self.mouse-x < self.width {
+                        && self.mouse-x > 0 && self.mouse-x < self.width
+                        && entry.enabled {
                     // can't put this in `clicked` because then the menu would close causing a panic in the pointer-event
                     activate(entry, self.absolute-position.y);
                 }
@@ -167,6 +169,9 @@ export component MenuItemBase {
         is-current when root.is-current : {
             background-layer.background: root.current-background;
             label.color: root.current-foreground;
+        }
+        disabled when !entry.enabled : {
+            label.opacity: 0.5;
         }
     ]
 }

--- a/internal/compiler/widgets/common/menus.slint
+++ b/internal/compiler/widgets/common/menus.slint
@@ -85,12 +85,12 @@ export component PopupMenuImpl inherits Window {
                 }
                 return accept;
             } else if event.text == Key.Return {
-                if current-highlight >= 0 && current-highlight < entries.length {
+                if current-highlight >= 0 && current-highlight < entries.length && entries[current-highlight].enabled {
                     activate(entries[current-highlight], y-pos(current-highlight), current-highlight);
                 }
                 return accept;
             } else if event.text == Key.RightArrow {
-                if current-highlight >= 0 && current-highlight < entries.length && entries[current-highlight].has-sub-menu {
+                if current-highlight >= 0 && current-highlight < entries.length && entries[current-highlight].has-sub-menu && entries[current-highlight].enabled {
                     activate(entries[current-highlight], y-pos(current-highlight), current-highlight);
                 }
                 return accept;

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -85,11 +85,12 @@ impl MenuFromItemTree {
                     let item = ItemRc::new(item_tree.clone(), index);
                     let children = self.update_shadow_tree_recursive(&item);
                     let has_sub_menu = !children.is_empty();
+                    let enabled = menu_item.enabled();
                     self.item_cache.borrow_mut().insert(
                         id.clone(),
                         ShadowTreeNode { item: ItemRc::downgrade(&item), children },
                     );
-                    result.push(MenuEntry { title, id, has_sub_menu, is_separator });
+                    result.push(MenuEntry { title, id, has_sub_menu, is_separator, enabled });
                 }
                 VisitChildrenResult::CONTINUE
             };
@@ -143,6 +144,7 @@ pub struct MenuItem {
     pub cached_rendering_data: CachedRenderingData,
     pub title: Property<SharedString>,
     pub activated: Callback<VoidArg>,
+    pub enabled: Property<bool>,
 }
 
 impl crate::items::Item for MenuItem {

--- a/tests/cases/elements/menubar_for.slint
+++ b/tests/cases/elements/menubar_for.slint
@@ -58,6 +58,12 @@ export component TestCase inherits Window {
                 title: "Paste";
                 activated => { debug("Paste"); }
             }
+            MenuSeparator {}
+            MenuItem {
+                title: "Disabled";
+                enabled: false;
+                activated => { result += self.title; }
+            }
         }
     }
     vl := VerticalLayout {
@@ -94,6 +100,15 @@ slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key:
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("\n"));
 assert_eq!(instance.get_result(), "New");
 
+// ensure that disabled items can't activate
+instance.set_result("".into());
+slint_testing::send_mouse_click(&instance, 100., 10.);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow));
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("\n"));
+assert_eq!(instance.get_result(), "");
+
 ```
 
 ```cpp
@@ -118,6 +133,16 @@ slint_testing::send_mouse_click(&instance, 10., 10.);
 slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::DownArrow);
 slint_testing::send_keyboard_string_sequence(&instance, "\n");
 assert_eq(instance.get_result(), "New");
+
+// ensure that disabled items can't activate
+instance.set_result("");
+slint_testing::send_mouse_click(&instance, 100., 10.);
+slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::DownArrow);
+slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::DownArrow);
+slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::DownArrow);
+slint_testing::send_keyboard_string_sequence(&instance, "\n");
+assert_eq(instance.get_result(), "");
+
 ```
 
 ```js
@@ -141,5 +166,14 @@ slintlib.private_api.send_mouse_click(instance, 10., 10.);
 slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
 slintlib.private_api.send_keyboard_string_sequence(instance, "\n");
 assert.equal(instance.result, "New");
+
+// ensure that disabled items can't activate
+instance.result = "";
+slintlib.private_api.send_mouse_click(instance, 100., 10.);
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
+slintlib.private_api.send_keyboard_string_sequence(instance, "\n");
+assert.equal(instance.result, "");
 
 */


### PR DESCRIPTION
By default it's enabled, of course. This property is not only added to `MenuItem`, but `Menu` as well - since they can be nested. It's also possible to select a disabled item, but it's hard to modify that since it's logic is written in Slint. You should be prevented from activating it with a tap or key press at least.

See #7791

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
