### PR TITLE
Resurrected create_winit_window

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -645,6 +645,12 @@ pub trait WinitWindowAccessor: private::WinitWindowAccessorSealed {
         callback: impl FnMut(&i_slint_core::api::Window, &winit::event::WindowEvent) -> WinitWindowEventResult
             + 'static,
     );
+
+    /// Creates a non Slint aware window with winit
+    fn create_winit_window(
+        &self,
+        window_attributes: winit::window::WindowAttributes,
+    ) -> Result<winit::window::Window, winit::error::OsError>;
 }
 
 impl WinitWindowAccessor for i_slint_core::api::Window {
@@ -681,6 +687,23 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
                 .window_event_filter
                 .set(Some(Box::new(move |window, event| callback(window, event))));
         }
+    }
+
+    /// Creates a non Slint aware window with winit
+    fn create_winit_window(
+        &self,
+        window_attributes: winit::window::WindowAttributes,
+    ) -> Result<winit::window::Window, winit::error::OsError> {
+        i_slint_core::window::WindowInner::from_pub(self)
+            .window_adapter()
+            .internal(i_slint_core::InternalToken)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<WinitWindowAdapter>()
+            .unwrap()
+            .shared_backend_data
+            .with_event_loop(|eli| Ok(eli.create_window(window_attributes)))
+            .unwrap()
     }
 }
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -246,7 +246,7 @@ impl WinitWindowOrNone {
 /// GraphicsWindow is an implementation of the [WindowAdapter][`crate::eventloop::WindowAdapter`] trait. This is
 /// typically instantiated by entry factory functions of the different graphics back ends.
 pub struct WinitWindowAdapter {
-    shared_backend_data: Rc<SharedBackendData>,
+    pub shared_backend_data: Rc<SharedBackendData>,
     window: OnceCell<corelib::api::Window>,
     self_weak: Weak<Self>,
     pending_redraw: Cell<bool>,


### PR DESCRIPTION
With a previous PR, I added a hook to enable the creation of a winit window, which necessitated accessing the winit event loop (https://github.com/slint-ui/slint/pull/7227).  This hook was removed in `cd29bdd3677c0b03d87b200e2a810b9819978c35` because the Slint event loop was moved to `SharedBackendData`.

I'm very open to the possibility that this is not the correct change, perhaps due to one or more of the following
- Making `shared_backend_data` public
- The `unwrap()` calls
- The possibility that exposing `with_event_loop()` may be a better solution

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
