### PR TITLE
Fix miscompilation because of too-agressive optimization

### DIFF
--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -37,21 +37,8 @@ pub fn count_property_use(root: &CompilationUnit) {
     }
 
     root.for_each_sub_components(&mut |sc, ctx| {
-        // 2. the native items and bindings of used properties
-        for (pr, expr) in &sc.property_init {
-            match pr {
-                PropertyReference::Local { sub_component_path, property_index } => {
-                    let mut sc = sc;
-                    for i in sub_component_path {
-                        sc = &ctx.compilation_unit.sub_components[sc.sub_components[*i].ty];
-                    }
-                    if sc.properties[*property_index].use_count.get() == 0 {
-                        continue;
-                    }
-                }
-                PropertyReference::InNativeItem { .. } => {}
-                _ => unreachable!(),
-            }
+        // 2. the native items and bindings of properties
+        for (_, expr) in &sc.property_init {
             let c = expr.use_count.get();
             expr.use_count.set(c + 1);
             if c == 0 {

--- a/tests/cases/issues/issue_8144_optimized-used.slint
+++ b/tests/cases/issues/issue_8144_optimized-used.slint
@@ -1,0 +1,44 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+
+
+enum PaletteLevel { l1, l2, l3 }
+
+component Palette {
+   in property <PaletteLevel> palette-level;
+   in property <PaletteLevel> palette-level2;
+   out property <int> result : palette-level == PaletteLevel.l1 ? 45
+                                         : palette-level == PaletteLevel.l2 ? 89
+                                         :                                    32;
+   out property <int> result2 : palette-level2 == PaletteLevel.l1 ? 12
+                                         : palette-level2 == PaletteLevel.l2 ? 13
+                                         :                                    14;
+}
+
+
+export component TestCase inherits Window {
+    preferred-height: 300px;
+    preferred-width: 300px;
+    palette := Palette { palette-level: PaletteLevel.l2; palette-level2: PaletteLevel.l2; }
+
+    t := Text {
+        text: palette.result;
+        font-size: palette.result2 * 1px;
+    }
+    TouchArea {
+        clicked => {
+            result = t.text;
+        }
+    }
+    out property <string> result;
+}
+
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 101., 101.);
+assert_eq!(instance.get_result(), "89");
+```
+*/


### PR DESCRIPTION
We try to only visit the bindings of used property. The problem is that when we visit the element, not all properties have been marked as used, yet. We have a chicken and egg problem.

So just visit all bindings even for property we haven't reached. This is unfortunate that we have to do that, and we'd need a much deeper analysis to do this properly.

Fixes #8144
