### PR TITLE
Menu: Add icon property

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -14,6 +14,9 @@ fn enums(path: &Path) -> anyhow::Result<()> {
     );
     writeln!(enums_priv, "#pragma once")?;
     writeln!(enums_priv, "// This file is auto-generated from {}", file!())?;
+    writeln!(enums_priv, "#include <slint_properties.h>")?;
+    writeln!(enums_priv, "#include <slint_color.h>")?;
+    writeln!(enums_priv, "#include <slint_image.h>")?;
     writeln!(enums_priv, "#include \"slint_enums.h\"")?;
     writeln!(enums_priv, "namespace slint::cbindgen_private {{")?;
     let mut enums_pub = BufWriter::new(

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -14,9 +14,6 @@ fn enums(path: &Path) -> anyhow::Result<()> {
     );
     writeln!(enums_priv, "#pragma once")?;
     writeln!(enums_priv, "// This file is auto-generated from {}", file!())?;
-    writeln!(enums_priv, "#include <slint_properties.h>")?;
-    writeln!(enums_priv, "#include <slint_color.h>")?;
-    writeln!(enums_priv, "#include <slint_image.h>")?;
     writeln!(enums_priv, "#include \"slint_enums.h\"")?;
     writeln!(enums_priv, "namespace slint::cbindgen_private {{")?;
     let mut enums_pub = BufWriter::new(
@@ -123,6 +120,7 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
     writeln!(structs_priv, "#include \"slint_builtin_structs.h\"")?;
     writeln!(structs_priv, "#include \"slint_enums_internal.h\"")?;
     writeln!(structs_priv, "#include \"slint_point.h\"")?;
+    writeln!(structs_priv, "#include \"slint_image.h\"")?;
     writeln!(structs_priv, "namespace slint::cbindgen_private {{")?;
     writeln!(structs_priv, "enum class KeyEventType : uint8_t;")?;
     macro_rules! struct_file {
@@ -500,7 +498,7 @@ fn gen_corelib(
                 "BorrowedOpenGLTextureOrigin"
             ],
             "slint_image_internal.h",
-            "namespace slint::cbindgen_private { struct ParsedSVG{}; struct HTMLImage{}; using namespace vtable; namespace types{ struct NineSliceImage{}; } }",
+            "#include \"slint_color.h\"\nnamespace slint::cbindgen_private { struct ParsedSVG{}; struct HTMLImage{}; using namespace vtable; namespace types{ struct NineSliceImage{}; } }",
         ),
         (
             vec!["Color", "slint_color_brighter", "slint_color_darker",

--- a/api/cpp/include/slint_color.h
+++ b/api/cpp/include/slint_color.h
@@ -4,9 +4,6 @@
 #pragma once
 
 #include "slint_color_internal.h"
-#include "slint_properties.h"
-
-#include <stdint.h>
 
 namespace slint {
 
@@ -284,18 +281,5 @@ RgbaColor<float> Color::to_argb_float() const
 {
     return RgbaColor<float>(*this);
 }
-
-namespace private_api {
-
-template<>
-inline void
-Property<Color>::set_animated_value(const Color &new_value,
-                                    const cbindgen_private::PropertyAnimation &animation_data) const
-{
-    cbindgen_private::slint_property_set_animated_value_color(&inner, value, new_value,
-                                                              &animation_data);
-}
-
-} // namespace private_api
 
 } // namespace slint

--- a/api/cpp/include/slint_properties.h
+++ b/api/cpp/include/slint_properties.h
@@ -212,6 +212,15 @@ Property<float>::set_animated_value(const float &new_value,
                                                               &animation_data);
 }
 
+template<>
+inline void
+Property<Color>::set_animated_value(const Color &new_value,
+                                    const cbindgen_private::PropertyAnimation &animation_data) const
+{
+    cbindgen_private::slint_property_set_animated_value_color(&inner, value, new_value,
+                                                              &animation_data);
+}
+
 template<typename F>
 void set_state_binding(const Property<StateInfo> &property, F binding)
 {

--- a/docs/astro/src/content/docs/reference/window/contextmenuarea.mdx
+++ b/docs/astro/src/content/docs/reference/window/contextmenuarea.mdx
@@ -51,6 +51,11 @@ This is the label of the menu as written in the menu bar or in the parent menu.
 When disabled, the `Menu` can be selected but not activated.
 </SlintProperty>
 
+### icon
+<SlintProperty propName="icon" typeName="image">
+The icon shown next to the title when in a parent menu.
+</SlintProperty>
+
 ## `MenuItem`
 
 A `MenuItem` represents a single menu entry. It must be a child of a `Menu` element.
@@ -67,6 +72,11 @@ The title shown for this menu item.
 
 <SlintProperty propName="enabled" typeName="bool" defaultValue="true">
 When disabled, the `MenuItem` can be selected but not activated.
+</SlintProperty>
+
+### icon
+<SlintProperty propName="icon" typeName="image">
+The icon shown next to the title.
 </SlintProperty>
 
 ### Callbacks of `MenuItem`

--- a/examples/gallery/gallery.slint
+++ b/examples/gallery/gallery.slint
@@ -28,6 +28,8 @@ export component App inherits Window {
                 title: @tr("MenuBar" => "Save As");
                 for x in 10: MenuItem { title: @tr("MenuBar" => "Name {}", x+1);  }
             }
+            MenuSeparator {}
+            MenuItem { title: @tr("MenuBar" => "MenuItem with Icon"); icon: @image-url("thumbsup.png"); }
         }
         Menu {
             title: @tr("MenuBar" => "Edit");

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -89,7 +89,21 @@ impl MudaAdapter {
                 Box::new(muda::PredefinedMenuItem::separator())
             } else if !entry.has_sub_menu && depth != 0 {
                 // the top level always has a sub menu regardless of entry.has_sub_menu
-                Box::new(muda::MenuItem::with_id(id.clone(), &entry.title, entry.enabled, None))
+                let icon = entry
+                    .icon
+                    .to_rgba8()
+                    .map(|rgba| {
+                        muda::Icon::from_rgba(rgba.as_bytes().to_vec(), rgba.width(), rgba.height())
+                            .ok()
+                    })
+                    .flatten();
+                Box::new(muda::IconMenuItem::with_id(
+                    id.clone(),
+                    &entry.title,
+                    entry.enabled,
+                    icon,
+                    None,
+                ))
             } else {
                 let sub_menu = muda::Submenu::with_id(id.clone(), &entry.title, entry.enabled);
                 if depth < 15 {

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -204,8 +204,8 @@ macro_rules! for_each_builtin_structs {
                 export {
                     /// The text of the menu entry
                     title: SharedString,
-                    // /// the icon associated with the menu entry
-                    // icon: Image,
+                    /// the icon associated with the menu entry
+                    icon: Image,
                     /// an opaque id that can be used to identify the menu entry
                     id: SharedString,
                     // keyboard_shortcut: KeySequence,

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -206,6 +206,7 @@ component MenuItem {
     in property <string> title;
     callback activated();
     in property <bool> enabled: true;
+    in property <image> icon;
     //-disallow_global_types_as_child_elements
     //-is_non_item_type
 }
@@ -218,6 +219,7 @@ component MenuSeparator {
 component Menu {
     in property <string> title;
     in property <bool> enabled: true;
+    in property <image> icon;
     MenuItem {}
     MenuSeparator {}
     Menu {}

--- a/internal/compiler/widgets/common/menu-base.slint
+++ b/internal/compiler/widgets/common/menu-base.slint
@@ -123,6 +123,15 @@ export component MenuItemBase {
                 padding-left: root.padding-left;
                 padding-right: root.padding-right;
 
+                spacing: 10px;
+
+                Image {
+                    width: root.icon-size;
+                    y: (parent.height - self.height) / 2;
+                    source: entry.icon;
+                    accessible-role: none;
+                }
+
                 label := Text {
                     text: entry.title;
                     color: root.default-foreground;

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -21,7 +21,7 @@ When adding an item or a property, it needs to be kept in sync with different pl
 #![allow(missing_docs)] // because documenting each property of items is redundant
 
 use crate::api::LogicalPosition;
-use crate::graphics::{Brush, Color, FontRequest};
+use crate::graphics::{Brush, Color, FontRequest, Image};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEventResult,
     KeyEventType, MouseEvent,

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -4,6 +4,7 @@
 // for MenuVTable_static
 #![allow(unsafe_code)]
 
+use crate::graphics::Image;
 use crate::item_rendering::CachedRenderingData;
 use crate::item_tree::{ItemTreeRc, ItemWeak, VisitChildrenResult};
 use crate::items::{ItemRc, ItemRef, MenuEntry, VoidArg};
@@ -87,11 +88,12 @@ impl MenuFromItemTree {
                     let children = self.update_shadow_tree_recursive(&item);
                     let has_sub_menu = !children.is_empty();
                     let enabled = menu_item.enabled();
+                    let icon = menu_item.icon();
                     self.item_cache.borrow_mut().insert(
                         id.clone(),
                         ShadowTreeNode { item: ItemRc::downgrade(&item), children },
                     );
-                    result.push(MenuEntry { title, id, has_sub_menu, is_separator, enabled });
+                    result.push(MenuEntry { title, id, has_sub_menu, is_separator, enabled, icon });
                 }
                 VisitChildrenResult::CONTINUE
             };
@@ -146,6 +148,7 @@ pub struct MenuItem {
     pub title: Property<SharedString>,
     pub activated: Callback<VoidArg>,
     pub enabled: Property<bool>,
+    pub icon: Property<Image>,
 }
 
 impl crate::items::Item for MenuItem {


### PR DESCRIPTION
This adds an icon that is displayed to the left of the title, and is also shown for Menus are inside of a parent menu.

![image](https://github.com/user-attachments/assets/116df471-abaf-44fe-bcf2-606384e919ba)

Closes #7791

<!--
- [X] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [X] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
