### PR TITLE
live-preview: don't replace the native menu bar with the previewed one

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -79,9 +79,11 @@ pub enum BuiltinFunction {
     ColorScheme,
     SupportsNativeMenuBar,
     /// Setup the native menu bar, or the item-tree based menu bar
-    /// arguments ate: `(ref entries, ref sub-menu, ref activated, item_tree_root?)`
-    /// When there are 4 arguments, the last one is a reference to the MenuItem tree root (just like the entries in the [`Self::ShowPopupMenu`] call)
-    /// then the code will assign the callback handler and properties
+    /// arguments ate: `(ref entries, ref sub-menu, ref activated, item_tree_root?, no_native_menu_bar?)`
+    /// The two last arguments are only set if the menu is an item tree, in which case, `item_tree_root` is a reference
+    /// to the MenuItem tree root (just like the entries in the [`Self::ShowPopupMenu`] call), and `native_menu_bar` is
+    /// is a boolean literal that is true when we shouldn't try to setup the native menu bar.
+    /// If we have an item_tree_root, the code will assign the callback handler and properties on the non-native menubar as well
     SetupNativeMenuBar,
     Use24HourFormat,
     MonthDayCount,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3657,27 +3657,35 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::SetupNativeMenuBar => {
             let window = access_window_field(ctx);
-            if let [llr::Expression::PropertyReference(entries_r), llr::Expression::PropertyReference(sub_menu_r), llr::Expression::PropertyReference(activated_r), llr::Expression::NumberLiteral(tree_index)] = arguments {
+            if let [llr::Expression::PropertyReference(entries_r), llr::Expression::PropertyReference(sub_menu_r), llr::Expression::PropertyReference(activated_r), llr::Expression::NumberLiteral(tree_index), llr::Expression::BoolLiteral(no_native)] = arguments {
                 let current_sub_component = ctx.current_sub_component().unwrap();
                 let item_tree_id = ident(&ctx.compilation_unit.sub_components[current_sub_component.menu_item_trees[*tree_index as usize].root].name);
                 let access_entries = access_member(entries_r, ctx);
                 let access_sub_menu = access_member(sub_menu_r, ctx);
                 let access_activated = access_member(activated_r, ctx);
-                format!(r"
-                    if ({window}.supports_native_menu_bar()) {{
-                        auto item_tree = {item_tree_id}::create(self);
-                        auto item_tree_dyn = item_tree.into_dyn();
-                        vtable::VBox<slint::cbindgen_private::MenuVTable> box{{}};
-                        slint::cbindgen_private::slint_menus_create_wrapper(&item_tree_dyn, &box);
-                        slint::cbindgen_private::slint_windowrc_setup_native_menu_bar(&{window}.handle(), const_cast<slint::cbindgen_private::MenuVTable*>(box.vtable), box.instance);
-                        // The ownership of the VBox is transferred to slint_windowrc_setup_native_menu_bar
-                        box.instance = nullptr;
-                        box.vtable = nullptr;
-                    }} else {{
+                if *no_native {
+                    format!(r"{{
                         auto item_tree = {item_tree_id}::create(self);
                         auto item_tree_dyn = item_tree.into_dyn();
                         slint::private_api::setup_popup_menu_from_menu_item_tree(item_tree_dyn, {access_entries}, {access_sub_menu}, {access_activated});
                     }}")
+                } else {
+                    format!(r"
+                        if ({window}.supports_native_menu_bar()) {{
+                            auto item_tree = {item_tree_id}::create(self);
+                            auto item_tree_dyn = item_tree.into_dyn();
+                            vtable::VBox<slint::cbindgen_private::MenuVTable> box{{}};
+                            slint::cbindgen_private::slint_menus_create_wrapper(&item_tree_dyn, &box);
+                            slint::cbindgen_private::slint_windowrc_setup_native_menu_bar(&{window}.handle(), const_cast<slint::cbindgen_private::MenuVTable*>(box.vtable), box.instance);
+                            // The ownership of the VBox is transferred to slint_windowrc_setup_native_menu_bar
+                            box.instance = nullptr;
+                            box.vtable = nullptr;
+                        }} else {{
+                            auto item_tree = {item_tree_id}::create(self);
+                            auto item_tree_dyn = item_tree.into_dyn();
+                            slint::private_api::setup_popup_menu_from_menu_item_tree(item_tree_dyn, {access_entries}, {access_sub_menu}, {access_activated});
+                        }}")
+                }
             } else if let [entries, llr::Expression::PropertyReference(sub_menu), llr::Expression::PropertyReference(activated)] = arguments {
                 let entries = compile_expression(entries, ctx);
                 let sub_menu = access_member(sub_menu, ctx);

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -142,6 +142,9 @@ pub struct CompilerConfiguration {
     #[cfg(feature = "bundle-translations")]
     pub translation_path_bundle: Option<std::path::PathBuf>,
 
+    /// Do not generate the hook to create native menus
+    pub no_native_menu: bool,
+
     /// C++ namespace
     pub cpp_namespace: Option<String>,
 
@@ -227,6 +230,7 @@ impl CompilerConfiguration {
             accessibility: true,
             enable_experimental,
             translation_domain: None,
+            no_native_menu: false,
             cpp_namespace,
             debug_info,
             debug_hooks: None,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1101,7 +1101,7 @@ fn call_builtin_function(
             .into(),
         BuiltinFunction::SetupNativeMenuBar => {
             let component = local_context.component_instance;
-            if let [Expression::PropertyReference(entries_nr), Expression::PropertyReference(sub_menu_nr), Expression::PropertyReference(activated_nr), Expression::ElementReference(item_tree_root)] =
+            if let [Expression::PropertyReference(entries_nr), Expression::PropertyReference(sub_menu_nr), Expression::PropertyReference(activated_nr), Expression::ElementReference(item_tree_root), Expression::BoolLiteral(no_native)] =
                 arguments
             {
                 let menu_item_tree = item_tree_root
@@ -1115,7 +1115,7 @@ fn call_builtin_function(
                     crate::dynamic_item_tree::make_menu_item_tree(&menu_item_tree, &component);
 
                 if let Some(w) = component.window_adapter().internal(i_slint_core::InternalToken) {
-                    if w.supports_native_menu_bar() {
+                    if !no_native && w.supports_native_menu_bar() {
                         w.setup_menubar(vtable::VBox::new(menu_item_tree));
                         return Value::Void;
                     }

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1314,6 +1314,7 @@ async fn parse_source(
         cc.resource_url_mapper = resource_url_mapper();
     }
     cc.embed_resources = EmbedResourcesKind::ListAllResources;
+    cc.no_native_menu = true;
 
     if !style.is_empty() {
         cc.style = Some(style);


### PR DESCRIPTION
Always use the non-native one for the previewed component

