### PR TITLE
live-preview: Do not send TextEdits that do not change anything

### DIFF
--- a/tools/lsp/common/text_edit.rs
+++ b/tools/lsp/common/text_edit.rs
@@ -225,11 +225,15 @@ impl TextEditor {
     }
 
     pub fn finalize(self) -> Option<(String, TextOffsetAdjustments, (usize, usize))> {
-        (!self.adjustments.is_empty()).then_some((
-            self.contents,
-            self.adjustments,
-            self.original_offset_range,
-        ))
+        if self.source_file.source() == Some(&self.contents) {
+            None
+        } else {
+            (!self.adjustments.is_empty()).then_some((
+                self.contents,
+                self.adjustments,
+                self.original_offset_range,
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
They get ignored by the editor (rightfully so), while the live preview will wait for the new source code, blocking all further edits.

Not a regression, as this has been in for a while now, but definitely a brown paper bag issue.

Thanks to @NigelBreslaw for figuring this out.

