### PR TITLE
Move Palette.style-name to internal protected StyleMetrics.style-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ All notable changes to this project are documented in this file.
  - Fix horizontal tab stretch with material
  - scrollview: fixed scrollthumb size on small sizes (#7809)
  - MenuBar reacts to hover event when the menu is open (#7822)
- - Added `Palette.style-name` property
  - Added `MenuSeparator` sub-element in `Menu` (#7790)
  - Added `MenuItem::enabled`
 

--- a/docs/astro/src/content/docs/reference/std-widgets/style.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/style.mdx
@@ -75,21 +75,6 @@ export component Example inherits Window {
 }
 ```
 
-In situations where the specific property is not available you can detect the style via `Palette.style-name`.
-
-```slint playground
-import { Palette } from "std-widgets.slint";
-
-export component Example inherits Window {
-    Rectangle {
-        border-radius: Palette.style-name == "fluent" ? 4px : 2px;
-        border-width: Palette.style-name == "fluent" ? 2px : 1px;
-        border-color: Palette.border;
-        background: Palette.background;
-    }
-}
-```
-
 ## Previewing Designs With `slint-viewer`
 
 Select the style either by setting the `SLINT_STYLE` environment variable, or by passing the style name with the `--style` argument:

--- a/internal/backends/qt/qt_widgets/palette.rs
+++ b/internal/backends/qt/qt_widgets/palette.rs
@@ -30,7 +30,6 @@ struct PaletteStyleChangeListener : QWidget {
 #[pin]
 #[pin_drop]
 pub struct NativePalette {
-    pub style_name: Property<SharedString>,
     pub background: Property<Brush>,
     pub foreground: Property<Brush>,
     pub alternate_background: Property<Brush>,
@@ -55,7 +54,6 @@ impl const_field_offset::PinnedDrop for NativePalette {
 impl NativePalette {
     pub fn new() -> Pin<Rc<Self>> {
         Rc::pin(NativePalette {
-            style_name: Default::default(),
             background: Default::default(),
             alternate_background: Default::default(),
             alternate_foreground: Default::default(),

--- a/internal/backends/qt/qt_widgets/stylemetrics.rs
+++ b/internal/backends/qt/qt_widgets/stylemetrics.rs
@@ -49,6 +49,8 @@ pub struct NativeStyleMetrics {
     // Tab Bar metrics:
     pub tab_bar_alignment: Property<LayoutAlignment>,
 
+    pub style_name: Property<SharedString>,
+
     pub style_change_listener: core::cell::Cell<*const u8>,
 }
 
@@ -75,6 +77,7 @@ impl NativeStyleMetrics {
             placeholder_color_disabled: Default::default(),
             dark_color_scheme: Default::default(),
             tab_bar_alignment: Default::default(),
+            style_name: Default::default(),
             style_change_listener: core::cell::Cell::new(core::ptr::null()),
         })
     }

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -699,12 +699,13 @@ export global NativeStyleMetrics {
     // Tab Bar metrics:
     out property <LayoutAlignment> tab-bar-alignment;
 
+    out property <string> style-name: "qt";
+
     //-is_non_item_type
     //-is_internal
 }
 
 export global NativePalette {
-    out property <string> style-name: "qt";
     out property <brush> background;
     out property <brush> foreground;
     out property <brush> alternate-background;

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -502,7 +502,7 @@ pub fn check_deprecated_stylemetrics(
         && !name.starts_with("layout-"))
     .then(|| format!("Palette.{name}"))
     .map_or(StyleMetricsPropertyUse::Acceptable, |msg| {
-        if !ctx.type_register.expose_internal_types && is_style_metrics_prop && name == "style-name"
+        if is_style_metrics_prop && name == "style-name"
         {
             StyleMetricsPropertyUse::Unacceptable
         } else {

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -502,8 +502,7 @@ pub fn check_deprecated_stylemetrics(
         && !name.starts_with("layout-"))
     .then(|| format!("Palette.{name}"))
     .map_or(StyleMetricsPropertyUse::Acceptable, |msg| {
-        if is_style_metrics_prop && name == "style-name"
-        {
+        if is_style_metrics_prop && name == "style-name" {
             StyleMetricsPropertyUse::Unacceptable
         } else {
             StyleMetricsPropertyUse::Deprecated(msg)

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -471,15 +471,17 @@ impl LookupObject for ElementRc {
     }
 }
 
+/// This enum describes the result of checking the use of a property of the StyleMetrics object.
 pub enum StyleMetricsPropertyUse {
+    /// The property is acceptable for use.
     Acceptable,
+    /// The property is acceptable fo use, but it is deprecated. The string provides the name of the
+    /// property that should be used instead.
     Deprecated(String),
+    /// The property is not acceptable for use, it is internal.
     Unacceptable,
 }
 
-/// Returns Some() if name is a deprecated style metrics property.
-/// Returns None if the property is acceptable for regular use.
-/// Returns Err(()) if the property should not be accessible.
 pub fn check_deprecated_stylemetrics(
     elem: &ElementRc,
     ctx: &LookupCtx<'_>,

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -412,10 +412,16 @@ impl LookupObject for ElementRc {
         f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
     ) -> Option<R> {
         for (name, prop) in &self.borrow().property_declarations {
+            let deprecated = match check_deprecated_stylemetrics(self, ctx, name) {
+                StyleMetricsPropertyUse::Acceptable => None,
+                StyleMetricsPropertyUse::Deprecated(msg) => Some(msg),
+                StyleMetricsPropertyUse::Unacceptable => continue, // Skip from lookup
+            };
+
             let r = expression_from_reference(
                 NamedReference::new(self, name.clone()),
                 &prop.property_type,
-                check_deprecated_stylemetrics(self, ctx, name),
+                deprecated,
             );
             if let Some(r) = f(name, r) {
                 return Some(r);
@@ -448,8 +454,12 @@ impl LookupObject for ElementRc {
                 || lookup_result.property_visibility != PropertyVisibility::Private)
         {
             let deprecated = (lookup_result.resolved_name != name.as_str())
-                .then(|| lookup_result.resolved_name.to_string())
-                .or_else(|| check_deprecated_stylemetrics(self, ctx, name));
+                .then(|| Some(lookup_result.resolved_name.to_string()))
+                .or_else(|| match check_deprecated_stylemetrics(self, ctx, name) {
+                    StyleMetricsPropertyUse::Acceptable => Some(None),
+                    StyleMetricsPropertyUse::Deprecated(msg) => Some(Some(msg)),
+                    StyleMetricsPropertyUse::Unacceptable => None,
+                })?;
             Some(expression_from_reference(
                 NamedReference::new(self, lookup_result.resolved_name.to_smolstr()),
                 &lookup_result.property_type,
@@ -461,17 +471,29 @@ impl LookupObject for ElementRc {
     }
 }
 
+pub enum StyleMetricsPropertyUse {
+    Acceptable,
+    Deprecated(String),
+    Unacceptable,
+}
+
+/// Returns Some() if name is a deprecated style metrics property.
+/// Returns None if the property is acceptable for regular use.
+/// Returns Err(()) if the property should not be accessible.
 pub fn check_deprecated_stylemetrics(
     elem: &ElementRc,
     ctx: &LookupCtx<'_>,
     name: &SmolStr,
-) -> Option<String> {
+) -> StyleMetricsPropertyUse {
     let borrow = elem.borrow();
+
+    let is_style_metrics_prop = matches!(
+        borrow.enclosing_component.upgrade().unwrap().id.as_str(),
+        "StyleMetrics" | "NativeStyleMetrics"
+    );
+
     (!ctx.type_register.expose_internal_types
-        && matches!(
-            borrow.enclosing_component.upgrade().unwrap().id.as_str(),
-            "StyleMetrics" | "NativeStyleMetrics"
-        )
+        && is_style_metrics_prop
         && borrow
             .debug
             .first()
@@ -479,6 +501,14 @@ pub fn check_deprecated_stylemetrics(
             .map_or(true, |x| x.path().starts_with("builtin:"))
         && !name.starts_with("layout-"))
     .then(|| format!("Palette.{name}"))
+    .map_or(StyleMetricsPropertyUse::Acceptable, |msg| {
+        if !ctx.type_register.expose_internal_types && is_style_metrics_prop && name == "style-name"
+        {
+            StyleMetricsPropertyUse::Unacceptable
+        } else {
+            StyleMetricsPropertyUse::Deprecated(msg)
+        }
+    })
 }
 
 fn expression_from_reference(

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1423,6 +1423,27 @@ fn continue_lookup_within_element(
     let lookup_result = elem.borrow().lookup_property(&prop_name);
     let local_to_component = lookup_result.is_local_to_component && ctx.is_local_element(elem);
 
+    let err = |ctx: &mut LookupCtx, extra: &str| {
+        let what = match &elem.borrow().base_type {
+            ElementType::Global => {
+                let global = elem.borrow().enclosing_component.upgrade().unwrap();
+                assert!(global.is_global());
+                format!("'{}'", global.id)
+            }
+            ElementType::Component(c) => format!("Element '{}'", c.id),
+            ElementType::Builtin(b) => format!("Element '{}'", b.name),
+            ElementType::Native(_) => unreachable!("the native pass comes later"),
+            ElementType::Error => {
+                assert!(ctx.diag.has_errors());
+                return;
+            }
+        };
+        ctx.diag.push_error(
+            format!("{} does not have a property '{}'{}", what, second.text(), extra),
+            &second,
+        );
+    };
+
     if lookup_result.property_type.is_property_type() {
         if !local_to_component && lookup_result.property_visibility == PropertyVisibility::Private {
             ctx.diag.push_error(format!("The property '{}' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components", second.text()), &second);
@@ -1440,10 +1461,17 @@ fn continue_lookup_within_element(
                 &lookup_result.resolved_name,
                 &second,
             );
-        } else if let Some(deprecated) =
-            crate::lookup::check_deprecated_stylemetrics(elem, ctx, &prop_name)
-        {
-            ctx.diag.push_property_deprecation_warning(&prop_name, &deprecated, &second);
+        } else {
+            match crate::lookup::check_deprecated_stylemetrics(elem, ctx, &prop_name) {
+                crate::lookup::StyleMetricsPropertyUse::Acceptable => {}
+                crate::lookup::StyleMetricsPropertyUse::Deprecated(deprecated) => {
+                    ctx.diag.push_property_deprecation_warning(&prop_name, &deprecated, &second)
+                }
+                crate::lookup::StyleMetricsPropertyUse::Unacceptable => {
+                    err(ctx, "");
+                    return None;
+                }
+            }
         }
         let prop = Expression::PropertyReference(NamedReference::new(
             elem,
@@ -1493,26 +1521,6 @@ fn continue_lookup_within_element(
             LookupResult::from(callable).into()
         }
     } else {
-        let mut err = |extra: &str| {
-            let what = match &elem.borrow().base_type {
-                ElementType::Global => {
-                    let global = elem.borrow().enclosing_component.upgrade().unwrap();
-                    assert!(global.is_global());
-                    format!("'{}'", global.id)
-                }
-                ElementType::Component(c) => format!("Element '{}'", c.id),
-                ElementType::Builtin(b) => format!("Element '{}'", b.name),
-                ElementType::Native(_) => unreachable!("the native pass comes later"),
-                ElementType::Error => {
-                    assert!(ctx.diag.has_errors());
-                    return;
-                }
-            };
-            ctx.diag.push_error(
-                format!("{} does not have a property '{}'{}", what, second.text(), extra),
-                &second,
-            );
-        };
         if let Some(minus_pos) = second.text().find('-') {
             // Attempt to recover if the user wanted to write "-"
             if elem
@@ -1521,11 +1529,11 @@ fn continue_lookup_within_element(
                 .property_type
                 != Type::Invalid
             {
-                err(". Use space before the '-' if you meant a subtraction");
+                err(ctx, ". Use space before the '-' if you meant a subtraction");
                 return None;
             }
         }
-        err("");
+        err(ctx, "");
         None
     }
 }

--- a/internal/compiler/tests/syntax/lookup/deprecated_property.slint
+++ b/internal/compiler/tests/syntax/lookup/deprecated_property.slint
@@ -33,6 +33,10 @@ export Xxx := Rectangle {
 
         background = StyleMetrics.window-background;
 //                                ^warning{The property 'window-background' has been deprecated. Please use 'Palette.window-background' instead}
+
+        // Not really a deprecation test, but handled in the same function :)
+        debug(StyleMetrics.style-name);
+//                         ^error{'StyleMetrics' does not have a property 'style-name'}
     }
 
 }

--- a/internal/compiler/widgets/cosmic/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic/std-widgets-impl.slint
@@ -10,7 +10,7 @@ export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
 import { CosmicPalette } from "styling.slint";
 
-export global StyleMetrics  {
+export global StyleMetrics {
     out property <length> layout-spacing: 8px;
     out property <length> layout-padding: 8px;
     out property <length> text-cursor-width: 1px;
@@ -21,10 +21,10 @@ export global StyleMetrics  {
     out property <color> textedit-background-disabled: CosmicPalette.control-disabled;
     out property <color> textedit-text-color-disabled: CosmicPalette.text-disabled;
     out property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
+    out property <string> style-name: "cosmic";
 }
 
 export global Palette {
-    out property <string> style-name: "cosmic";
     out property <brush> background: CosmicPalette.background;
     out property <brush> foreground: CosmicPalette.foreground;
     out property <brush> alternate-background: CosmicPalette.alternate-background;

--- a/internal/compiler/widgets/cupertino/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino/std-widgets-impl.slint
@@ -8,7 +8,7 @@ export { LineEdit } from "lineedit.slint";
 import { CupertinoPalette } from "styling.slint";
 export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
-export global StyleMetrics  {
+export global StyleMetrics {
     out property <length> layout-spacing: 10px;
     out property <length> layout-padding: 12px;
     out property <length> text-cursor-width: 1px;
@@ -19,10 +19,10 @@ export global StyleMetrics  {
     out property <color> textedit-background-disabled: CupertinoPalette.tertiary-control-background;
     out property <color> textedit-text-color-disabled: CupertinoPalette.foreground-secondary;
     out property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
+    out property <string> style-name: "cupertino";
 }
 
 export global Palette {
-    out property <string> style-name: "cupertino";
     out property <brush> background: CupertinoPalette.background;
     out property <brush> foreground: CupertinoPalette.foreground;
     out property <brush> alternate-background: CupertinoPalette.alternate-background;

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -8,7 +8,7 @@ export { LineEdit } from "lineedit.slint";
 import { FluentPalette } from "styling.slint";
 export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
-export global StyleMetrics  {
+export global StyleMetrics {
     out property <length> layout-spacing: 8px;
     out property <length> layout-padding: 8px;
     out property <length> text-cursor-width: 1px;
@@ -19,10 +19,10 @@ export global StyleMetrics  {
     out property <color> textedit-background-disabled: FluentPalette.control-disabled;
     out property <color> textedit-text-color-disabled: FluentPalette.text-disabled;
     out property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
+    out property <string> style-name: "fluent";
 }
 
 export global Palette {
-    out property <string> style-name: "fluent";
     out property <brush> background: FluentPalette.background;
     out property <brush> foreground: FluentPalette.foreground;
     out property <brush> alternate-background: FluentPalette.alternate-background;

--- a/internal/compiler/widgets/material/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material/std-widgets-impl.slint
@@ -11,7 +11,7 @@ export { ListItem } from "components.slint";
 export { LineEdit } from "lineedit.slint";
 export { MenuBarItem, MenuBar, MenuFrame, MenuItem } from "menu.slint";
 
-export global StyleMetrics  {
+export global StyleMetrics {
     out property <length> layout-spacing: 16px;
     out property <length> layout-padding: 16px;
     out property <length> text-cursor-width: 2px;
@@ -24,10 +24,10 @@ export global StyleMetrics  {
     out property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
     out property <string> default-font-family: "Roboto";
     out property <color> window-background: MaterialPalette.background;
+    out property <string> style-name: "material";
 }
 
 export global Palette {
-    out property <string> style-name: "material";
     out property <brush> background: MaterialPalette.background;
     out property <brush> foreground: MaterialPalette.foreground;
     out property <brush> alternate-background: MaterialPalette.alternate-background;

--- a/tools/lsp/ui/components/widgets/inline-brush-widget.slint
+++ b/tools/lsp/ui/components/widgets/inline-brush-widget.slint
@@ -8,6 +8,7 @@ import { EditorSpaceSettings, EditorSizeSettings, EditorPalette } from "../../co
 import { WindowManager } from "../../windowglobal.slint";
 import { ColorIndicator, GradientIndicator, FakeShadowText, PickerTextInput } from "brush-helpers.slint";
 import { BrushPropertyType } from "../../properties-state.slint";
+import { StyleMetrics } from "std-widgets.slint";
 
 component FocusBorder inherits Rectangle {
     in property <bool> has-focus;
@@ -32,10 +33,10 @@ component CustomLineEdit {
     out property <brush> fluent-control-input-active: Palette.color-scheme == ColorScheme.dark ? #1E1E1EB3 : #FFFFFF;
 
     width: 100px;
-    height: Palette.style-name == "cupertino" ? 22px : Palette.style-name == "fluent" ? 32px : 33px;
+    height: StyleMetrics.style-name == "cupertino" ? 22px : StyleMetrics.style-name == "fluent" ? 32px : 33px;
 
     FocusBorder {
-        visible: Palette.style-name == "cupertino";
+        visible: StyleMetrics.style-name == "cupertino";
         x: (parent.width - self.width) / 2;
         y: (parent.height - self.height) / 2;
         width: parent.width + 6px;
@@ -46,8 +47,8 @@ component CustomLineEdit {
     background := Rectangle {
         background: Palette.control-background;
         border-width: 1px;
-        border-color: Palette.style-name == "fluent" ? fluent-text-control-border : Palette.border;
-        border-radius: Palette.style-name == "fluent" ? 4px : 0px;
+        border-color: StyleMetrics.style-name == "fluent" ? fluent-text-control-border : Palette.border;
+        border-radius: StyleMetrics.style-name == "fluent" ? 4px : 0px;
 
         focus-border := Rectangle {
             x: parent.border-radius;
@@ -60,7 +61,7 @@ component CustomLineEdit {
     @children
 
     states [
-        focused when root.has-focus && Palette.style-name == "fluent": {
+        focused when root.has-focus && StyleMetrics.style-name == "fluent": {
             background.background: fluent-control-input-active;
             background.border-color: Palette.border;
             focus-border.background: Palette.accent-background;


### PR DESCRIPTION
This is only exposed when internal types are exposed (such as in the lsp).

The plan is to make this public under a new name/global after the release.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
