### PR TITLE
Introduce `Platform.style-name` and `Platform.os`

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -91,6 +91,13 @@ inline void debug(const SharedString &str)
     cbindgen_private::slint_debug(&str);
 }
 
+inline SharedString detect_operating_system()
+{
+    SharedString result;
+    cbindgen_private::slint_detect_operating_system(&result);
+    return result;
+}
+
 } // namespace private_api
 
 namespace cbindgen_private {

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -224,3 +224,8 @@ pub unsafe extern "C" fn slint_set_xdg_app_id(_app_id: &SharedString) {
     i_slint_backend_selector::with_global_context(|ctx| ctx.set_xdg_app_id(_app_id.clone()))
         .unwrap();
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn slint_detect_operating_system(out: &mut SharedString) {
+    *out = i_slint_core::detect_operating_system();
+}

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -190,6 +190,7 @@ pub mod re_exports {
     pub use i_slint_core::api::LogicalPosition;
     pub use i_slint_core::callbacks::Callback;
     pub use i_slint_core::date_time::*;
+    pub use i_slint_core::detect_operating_system;
     pub use i_slint_core::graphics::*;
     pub use i_slint_core::input::{
         key_codes::Key, FocusEvent, InputEventResult, KeyEvent, KeyEventResult, KeyboardModifiers,

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -292,6 +292,10 @@ export default defineConfig({
                                             },
                                         ],
                                     },
+                                    {
+                                        label: "Platform Namespace",
+                                        slug: "reference/global-namespaces/platform",
+                                    },
                                 ],
                             },
                             {

--- a/docs/astro/src/content/docs/reference/global-namespaces/platform.mdx
+++ b/docs/astro/src/content/docs/reference/global-namespaces/platform.mdx
@@ -11,6 +11,31 @@ The **Platform** namespace contains properties that help deal with platform spec
 
 ## Properties
 
+### os
+<SlintProperty propName="os" typeName="string">
+The name of the operating system. Possible values are:
+
+| Operating System | Value     |
+|------------------|-----------|
+| Windows          | `windows` |
+| macOS            | `macos`   |
+| Linux            | `linux`   |
+| Android          | `android` |
+| iOS              | `ios`     |
+
+If the operating system is none of the above, the value of this property is the empty string.
+
+:::note{Note}
+When running in a web browser, the value of this property is computed at run-time by querying the web browser's navigator properties.
+:::
+
+:::note{Note}
+When Slint is ported to new operating systems in the future, this table will be extended.
+:::
+
+</SlintProperty>
+
+
 ### style-name
 <SlintProperty propName="style-name" typeName="string">
 The name of the currently selected <Link type="StyleWidgets" label="widget style"/>. Some widget

--- a/docs/astro/src/content/docs/reference/global-namespaces/platform.mdx
+++ b/docs/astro/src/content/docs/reference/global-namespaces/platform.mdx
@@ -1,0 +1,20 @@
+---
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+title: Platform
+description: Platform Namespace
+---
+
+import SlintProperty  from '/src/components/SlintProperty.astro';
+import Link from '/src/components/Link.astro';
+
+The **Platform** namespace contains properties that help deal with platform specific differences.
+
+## Properties
+
+### style-name
+<SlintProperty propName="style-name" typeName="string">
+The name of the currently selected <Link type="StyleWidgets" label="widget style"/>. Some widget
+styles have dark and light variant suffixes, such as `fluent-light`. This property contains the
+style name without the suffix. Use <Link type="Palette" label="Palette"/>'s `color-scheme` to
+determine the currently used scheme.
+</SlintProperty>

--- a/docs/astro/src/content/docs/reference/std-widgets/style.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/style.mdx
@@ -75,6 +75,21 @@ export component Example inherits Window {
 }
 ```
 
+In situations where the specific property is not available you can detect the style via `Platform.style-name`.
+
+```slint playground
+import { Palette } from "std-widgets.slint";
+
+export component Example inherits Window {
+    Rectangle {
+        border-radius: Platform.style-name == "fluent" ? 4px : 2px;
+        border-width: Platform.style-name == "fluent" ? 2px : 1px;
+        border-color: Palette.border;
+        background: Palette.background;
+    }
+}
+```
+
 ## Previewing Designs With `slint-viewer`
 
 Select the style either by setting the `SLINT_STYLE` environment variable, or by passing the style name with the `--style` argument:

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -699,8 +699,6 @@ export global NativeStyleMetrics {
     // Tab Bar metrics:
     out property <LayoutAlignment> tab-bar-alignment;
 
-    out property <string> style-name: "qt";
-
     //-is_non_item_type
     //-is_internal
 }

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -513,6 +513,11 @@ export global TextInputInterface {
     in property <bool> text-input-focused;
 }
 
+export global Platform {
+    out property <string> os;
+    out property <string> style-name;
+}
+
 export component NativeButton {
     in property <string> text;
     in property <image> icon;

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -103,6 +103,7 @@ pub enum BuiltinFunction {
     RegisterBitmapFont,
     Translate,
     UpdateTimers,
+    DetectOperatingSystem,
 }
 
 #[derive(Debug, Clone)]
@@ -259,6 +260,7 @@ declare_builtin_function_types!(
     Translate: (Type::String, Type::String, Type::String, Type::Array(Type::String.into())) -> Type::String,
     Use24HourFormat: () -> Type::Bool,
     UpdateTimers: () -> Type::Void,
+    DetectOperatingSystem: () -> Type::String,
 );
 
 impl BuiltinFunction {
@@ -345,6 +347,7 @@ impl BuiltinFunction {
             BuiltinFunction::Translate => false,
             BuiltinFunction::Use24HourFormat => false,
             BuiltinFunction::UpdateTimers => false,
+            BuiltinFunction::DetectOperatingSystem => true,
         }
     }
 
@@ -417,6 +420,7 @@ impl BuiltinFunction {
             BuiltinFunction::Translate => true,
             BuiltinFunction::Use24HourFormat => true,
             BuiltinFunction::UpdateTimers => false,
+            BuiltinFunction::DetectOperatingSystem => true,
         }
     }
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3970,6 +3970,10 @@ fn compile_builtin_function_call(
         BuiltinFunction::UpdateTimers => {
             "self->update_timers()".into()
         }
+        BuiltinFunction::DetectOperatingSystem => {
+            format!("slint::private_api::detect_operating_system()")
+        }
+
     }
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3224,6 +3224,9 @@ fn compile_builtin_function_call(
         BuiltinFunction::UpdateTimers => {
             quote!(_self.update_timers())
         }
+        BuiltinFunction::DetectOperatingSystem => {
+            quote!(sp::detect_operating_system())
+        }
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -149,6 +149,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::Translate => 2 * ALLOC_COST + PROPERTY_ACCESS_COST,
         BuiltinFunction::Use24HourFormat => 2 * ALLOC_COST + PROPERTY_ACCESS_COST,
         BuiltinFunction::UpdateTimers => 10,
+        BuiltinFunction::DetectOperatingSystem => 10,
     }
 }
 

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -114,6 +114,7 @@ pub enum BuiltinNamespace {
     Colors,
     Math,
     Key,
+    Platform,
     SlintInternal,
 }
 
@@ -192,6 +193,7 @@ impl LookupObject for LookupResult {
             }
             LookupResult::Namespace(BuiltinNamespace::Math) => MathFunctions.for_each_entry(ctx, f),
             LookupResult::Namespace(BuiltinNamespace::Key) => KeysLookup.for_each_entry(ctx, f),
+            LookupResult::Namespace(BuiltinNamespace::Platform) => Platform.for_each_entry(ctx, f),
             LookupResult::Namespace(BuiltinNamespace::SlintInternal) => {
                 SlintInternal.for_each_entry(ctx, f)
             }
@@ -208,6 +210,7 @@ impl LookupObject for LookupResult {
             }
             LookupResult::Namespace(BuiltinNamespace::Math) => MathFunctions.lookup(ctx, name),
             LookupResult::Namespace(BuiltinNamespace::Key) => KeysLookup.lookup(ctx, name),
+            LookupResult::Namespace(BuiltinNamespace::Platform) => Platform.lookup(ctx, name),
             LookupResult::Namespace(BuiltinNamespace::SlintInternal) => {
                 SlintInternal.lookup(ctx, name)
             }
@@ -412,16 +415,10 @@ impl LookupObject for ElementRc {
         f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
     ) -> Option<R> {
         for (name, prop) in &self.borrow().property_declarations {
-            let deprecated = match check_deprecated_stylemetrics(self, ctx, name) {
-                StyleMetricsPropertyUse::Acceptable => None,
-                StyleMetricsPropertyUse::Deprecated(msg) => Some(msg),
-                StyleMetricsPropertyUse::Unacceptable => continue, // Skip from lookup
-            };
-
             let r = expression_from_reference(
                 NamedReference::new(self, name.clone()),
                 &prop.property_type,
-                deprecated,
+                check_deprecated_stylemetrics(self, ctx, name),
             );
             if let Some(r) = f(name, r) {
                 return Some(r);
@@ -454,12 +451,8 @@ impl LookupObject for ElementRc {
                 || lookup_result.property_visibility != PropertyVisibility::Private)
         {
             let deprecated = (lookup_result.resolved_name != name.as_str())
-                .then(|| Some(lookup_result.resolved_name.to_string()))
-                .or_else(|| match check_deprecated_stylemetrics(self, ctx, name) {
-                    StyleMetricsPropertyUse::Acceptable => Some(None),
-                    StyleMetricsPropertyUse::Deprecated(msg) => Some(Some(msg)),
-                    StyleMetricsPropertyUse::Unacceptable => None,
-                })?;
+                .then(|| lookup_result.resolved_name.to_string())
+                .or_else(|| check_deprecated_stylemetrics(self, ctx, name));
             Some(expression_from_reference(
                 NamedReference::new(self, lookup_result.resolved_name.to_smolstr()),
                 &lookup_result.property_type,
@@ -471,31 +464,17 @@ impl LookupObject for ElementRc {
     }
 }
 
-/// This enum describes the result of checking the use of a property of the StyleMetrics object.
-pub enum StyleMetricsPropertyUse {
-    /// The property is acceptable for use.
-    Acceptable,
-    /// The property is acceptable fo use, but it is deprecated. The string provides the name of the
-    /// property that should be used instead.
-    Deprecated(String),
-    /// The property is not acceptable for use, it is internal.
-    Unacceptable,
-}
-
 pub fn check_deprecated_stylemetrics(
     elem: &ElementRc,
     ctx: &LookupCtx<'_>,
     name: &SmolStr,
-) -> StyleMetricsPropertyUse {
+) -> Option<String> {
     let borrow = elem.borrow();
-
-    let is_style_metrics_prop = matches!(
-        borrow.enclosing_component.upgrade().unwrap().id.as_str(),
-        "StyleMetrics" | "NativeStyleMetrics"
-    );
-
     (!ctx.type_register.expose_internal_types
-        && is_style_metrics_prop
+        && matches!(
+            borrow.enclosing_component.upgrade().unwrap().id.as_str(),
+            "StyleMetrics" | "NativeStyleMetrics"
+        )
         && borrow
             .debug
             .first()
@@ -503,13 +482,6 @@ pub fn check_deprecated_stylemetrics(
             .map_or(true, |x| x.path().starts_with("builtin:"))
         && !name.starts_with("layout-"))
     .then(|| format!("Palette.{name}"))
-    .map_or(StyleMetricsPropertyUse::Acceptable, |msg| {
-        if is_style_metrics_prop && name == "style-name" {
-            StyleMetricsPropertyUse::Unacceptable
-        } else {
-            StyleMetricsPropertyUse::Deprecated(msg)
-        }
-    })
 }
 
 fn expression_from_reference(
@@ -806,6 +778,28 @@ impl LookupObject for SlintInternal {
     }
 }
 
+struct Platform;
+impl LookupObject for Platform {
+    fn for_each_entry<R>(
+        &self,
+        ctx: &LookupCtx,
+        f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
+    ) -> Option<R> {
+        let mut f = |n, e: LookupResult| f(&SmolStr::new_static(n), e);
+        None.or_else(|| {
+            let style = ctx
+                .type_loader
+                .map(|tl| {
+                    tl.resolved_style.strip_suffix("-dark").unwrap_or_else(|| {
+                        tl.resolved_style.strip_suffix("-light").unwrap_or(&tl.resolved_style)
+                    })
+                })
+                .unwrap_or_default();
+            f("style-name", Expression::StringLiteral(style.into()).into())
+        })
+    }
+}
+
 struct ColorFunctions;
 impl LookupObject for ColorFunctions {
     fn for_each_entry<R>(
@@ -847,6 +841,7 @@ impl LookupObject for BuiltinNamespaceLookup {
         None.or_else(|| f("Colors", LookupResult::Namespace(BuiltinNamespace::Colors)))
             .or_else(|| f("Math", LookupResult::Namespace(BuiltinNamespace::Math)))
             .or_else(|| f("Key", LookupResult::Namespace(BuiltinNamespace::Key)))
+            .or_else(|| f("Platform", LookupResult::Namespace(BuiltinNamespace::Platform)))
             .or_else(|| {
                 if ctx.type_register.expose_internal_types {
                     f("SlintInternal", LookupResult::Namespace(BuiltinNamespace::SlintInternal))

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -114,7 +114,6 @@ pub enum BuiltinNamespace {
     Colors,
     Math,
     Key,
-    Platform,
     SlintInternal,
 }
 
@@ -193,7 +192,6 @@ impl LookupObject for LookupResult {
             }
             LookupResult::Namespace(BuiltinNamespace::Math) => MathFunctions.for_each_entry(ctx, f),
             LookupResult::Namespace(BuiltinNamespace::Key) => KeysLookup.for_each_entry(ctx, f),
-            LookupResult::Namespace(BuiltinNamespace::Platform) => Platform.for_each_entry(ctx, f),
             LookupResult::Namespace(BuiltinNamespace::SlintInternal) => {
                 SlintInternal.for_each_entry(ctx, f)
             }
@@ -210,7 +208,6 @@ impl LookupObject for LookupResult {
             }
             LookupResult::Namespace(BuiltinNamespace::Math) => MathFunctions.lookup(ctx, name),
             LookupResult::Namespace(BuiltinNamespace::Key) => KeysLookup.lookup(ctx, name),
-            LookupResult::Namespace(BuiltinNamespace::Platform) => Platform.lookup(ctx, name),
             LookupResult::Namespace(BuiltinNamespace::SlintInternal) => {
                 SlintInternal.lookup(ctx, name)
             }
@@ -778,28 +775,6 @@ impl LookupObject for SlintInternal {
     }
 }
 
-struct Platform;
-impl LookupObject for Platform {
-    fn for_each_entry<R>(
-        &self,
-        ctx: &LookupCtx,
-        f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
-    ) -> Option<R> {
-        let mut f = |n, e: LookupResult| f(&SmolStr::new_static(n), e);
-        None.or_else(|| {
-            let style = ctx
-                .type_loader
-                .map(|tl| {
-                    tl.resolved_style.strip_suffix("-dark").unwrap_or_else(|| {
-                        tl.resolved_style.strip_suffix("-light").unwrap_or(&tl.resolved_style)
-                    })
-                })
-                .unwrap_or_default();
-            f("style-name", Expression::StringLiteral(style.into()).into())
-        })
-    }
-}
-
 struct ColorFunctions;
 impl LookupObject for ColorFunctions {
     fn for_each_entry<R>(
@@ -841,7 +816,6 @@ impl LookupObject for BuiltinNamespaceLookup {
         None.or_else(|| f("Colors", LookupResult::Namespace(BuiltinNamespace::Colors)))
             .or_else(|| f("Math", LookupResult::Namespace(BuiltinNamespace::Math)))
             .or_else(|| f("Key", LookupResult::Namespace(BuiltinNamespace::Key)))
-            .or_else(|| f("Platform", LookupResult::Namespace(BuiltinNamespace::Platform)))
             .or_else(|| {
                 if ctx.type_register.expose_internal_types {
                     f("SlintInternal", LookupResult::Namespace(BuiltinNamespace::SlintInternal))

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -32,6 +32,7 @@ mod lower_accessibility;
 mod lower_component_container;
 mod lower_layout;
 mod lower_menus;
+mod lower_platform;
 mod lower_popups;
 mod lower_property_to_element;
 mod lower_shadows;
@@ -121,6 +122,7 @@ pub async fn run_passes(
         );
         lower_states::lower_states(component, &doc.local_registry, diag);
         lower_text_input_interface::lower_text_input_interface(component);
+        lower_platform::lower_platform(component, type_loader);
         repeater_component::process_repeater_components(component);
         lower_popups::lower_popups(component, &doc.local_registry, diag);
         collect_init_code::collect_init_code(component);

--- a/internal/compiler/passes/lower_platform.rs
+++ b/internal/compiler/passes/lower_platform.rs
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Pass lower the access to the global Platform to constants and builtin function calls.
+
+use crate::expression_tree::{BuiltinFunction, Expression};
+use crate::object_tree::{visit_all_expressions, Component};
+use std::rc::Rc;
+
+pub fn lower_platform(component: &Rc<Component>, type_loader: &mut crate::typeloader::TypeLoader) {
+    visit_all_expressions(component, |e, _| {
+        e.visit_recursive_mut(&mut |e| match e {
+            Expression::PropertyReference(nr)
+                if nr.element().borrow().builtin_type().is_some_and(|bt| bt.name == "Platform") =>
+            {
+                if nr.name() == "os" {
+                    *e = Expression::FunctionCall {
+                        function: BuiltinFunction::DetectOperatingSystem.into(),
+                        arguments: vec![],
+                        source_location: None,
+                    };
+                } else if nr.name() == "style-name" {
+                    let style =
+                        type_loader.resolved_style.strip_suffix("-dark").unwrap_or_else(|| {
+                            type_loader
+                                .resolved_style
+                                .strip_suffix("-light")
+                                .unwrap_or(&type_loader.resolved_style)
+                        });
+                    *e = Expression::StringLiteral(style.into()).into();
+                }
+            }
+
+            _ => {}
+        })
+    })
+}

--- a/internal/compiler/tests/syntax/lookup/deprecated_property.slint
+++ b/internal/compiler/tests/syntax/lookup/deprecated_property.slint
@@ -33,10 +33,6 @@ export Xxx := Rectangle {
 
         background = StyleMetrics.window-background;
 //                                ^warning{The property 'window-background' has been deprecated. Please use 'Palette.window-background' instead}
-
-        // Not really a deprecation test, but handled in the same function :)
-        debug(StyleMetrics.style-name);
-//                         ^error{'StyleMetrics' does not have a property 'style-name'}
     }
 
 }

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -195,7 +195,7 @@ impl Snapshotter {
             all_documents,
             global_type_registry: self.snapshot_type_register(&type_loader.global_type_registry),
             compiler_config: type_loader.compiler_config.clone(),
-            style: type_loader.style.clone(),
+            resolved_style: type_loader.resolved_style.clone(),
         })
     }
 
@@ -840,7 +840,9 @@ impl Snapshotter {
 pub struct TypeLoader {
     pub global_type_registry: Rc<RefCell<TypeRegister>>,
     pub compiler_config: CompilerConfiguration,
-    style: String,
+    /// The style that was specified in the compiler configuration, but resolved. So "native" for example is resolved to the concrete
+    /// style.
+    pub resolved_style: String,
     all_documents: LoadedDocuments,
 }
 
@@ -868,7 +870,7 @@ impl TypeLoader {
         let myself = Self {
             global_type_registry,
             compiler_config,
-            style: style.clone(),
+            resolved_style: style.clone(),
             all_documents: Default::default(),
         };
 
@@ -1528,7 +1530,7 @@ impl TypeLoader {
             .chain(
                 (file_to_import == "std-widgets.slint"
                     || referencing_file.is_some_and(|x| x.starts_with("builtin:/")))
-                .then(|| format!("builtin:/{}", self.style).into()),
+                .then(|| format!("builtin:/{}", self.resolved_style).into()),
             )
             .find_map(|include_dir| {
                 let candidate = crate::pathutils::join(&include_dir, Path::new(file_to_import))?;

--- a/internal/compiler/widgets/cosmic/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cosmic/std-widgets-impl.slint
@@ -21,7 +21,6 @@ export global StyleMetrics {
     out property <color> textedit-background-disabled: CosmicPalette.control-disabled;
     out property <color> textedit-text-color-disabled: CosmicPalette.text-disabled;
     out property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
-    out property <string> style-name: "cosmic";
 }
 
 export global Palette {

--- a/internal/compiler/widgets/cupertino/std-widgets-impl.slint
+++ b/internal/compiler/widgets/cupertino/std-widgets-impl.slint
@@ -19,7 +19,6 @@ export global StyleMetrics {
     out property <color> textedit-background-disabled: CupertinoPalette.tertiary-control-background;
     out property <color> textedit-text-color-disabled: CupertinoPalette.foreground-secondary;
     out property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
-    out property <string> style-name: "cupertino";
 }
 
 export global Palette {

--- a/internal/compiler/widgets/fluent/std-widgets-impl.slint
+++ b/internal/compiler/widgets/fluent/std-widgets-impl.slint
@@ -19,7 +19,6 @@ export global StyleMetrics {
     out property <color> textedit-background-disabled: FluentPalette.control-disabled;
     out property <color> textedit-text-color-disabled: FluentPalette.text-disabled;
     out property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
-    out property <string> style-name: "fluent";
 }
 
 export global Palette {

--- a/internal/compiler/widgets/material/std-widgets-impl.slint
+++ b/internal/compiler/widgets/material/std-widgets-impl.slint
@@ -24,7 +24,6 @@ export global StyleMetrics {
     out property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
     out property <string> default-font-family: "Roboto";
     out property <color> window-background: MaterialPalette.background;
-    out property <string> style-name: "material";
 }
 
 export global Palette {

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -107,6 +107,9 @@
     "NumericTypes": {
         "href": "reference/primitive-types/#numeric-types"
     },
+    "Palette": {
+        "href": "reference/std-widgets/overview/#palette-properties"
+    },
     "Path": {
         "href": "reference/elements/path/"
     },

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -122,7 +122,7 @@ gettext-rs = { version = "0.7.1", optional = true, features = ["gettext-system"]
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2" }
-web-sys = { workspace = true, features = ["HtmlImageElement"] }
+web-sys = { workspace = true, features = ["HtmlImageElement", "Navigator"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fontdb = { workspace = true, optional = true, default-features = true }

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -98,3 +98,46 @@ pub type Coord = i32;
 /// This type is not exported from the public API crate, so function having this
 /// parameter cannot be called from the public API without naming it
 pub struct InternalToken;
+
+#[cfg(not(target_family = "wasm"))]
+pub fn detect_operating_system() -> SharedString {
+    let os = if cfg!(target_os = "android") {
+        "android"
+    } else if cfg!(target_os = "ios") {
+        "ios"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else {
+        ""
+    };
+    os.into()
+}
+
+#[cfg(target_family = "wasm")]
+pub fn detect_operating_system() -> SharedString {
+    let mut user_agent =
+        web_sys::window().and_then(|w| w.navigator().user_agent().ok()).unwrap_or_default();
+    user_agent.make_ascii_lowercase();
+    let mut platform =
+        web_sys::window().and_then(|w| w.navigator().platform().ok()).unwrap_or_default();
+    platform.make_ascii_lowercase();
+
+    if user_agent.contains("ipad") || user_agent.contains("iphone") {
+        "ios"
+    } else if user_agent.contains("android") {
+        "android"
+    } else if platform.starts_with("mac") {
+        "macos"
+    } else if platform.starts_with("win") {
+        "windows"
+    } else if platform.starts_with("linux") {
+        "linux"
+    } else {
+        ""
+    }
+    .into()
+}

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1336,6 +1336,7 @@ fn call_builtin_function(
             crate::dynamic_item_tree::update_timers(local_context.component_instance);
             Value::Void
         }
+        BuiltinFunction::DetectOperatingSystem => i_slint_core::detect_operating_system().into(),
     }
 }
 

--- a/tests/cases/platform.slint
+++ b/tests/cases/platform.slint
@@ -1,0 +1,33 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Basic test for Platform.os and Platform.style-name. This is done in JS, as with Rust and C++ the style is fixed
+// to fluent.
+
+export component TestCase inherits Window {
+    out property <string> os: Platform.os;
+    out property <string> style-name: Platform.style-name;
+}
+
+/*
+```js
+let instance = new slint.TestCase({});
+let os = instance.os;
+let style_name = instance.style_name;
+console.log(style_name);
+
+const { platform } = require('node:process');
+if (platform === 'win32') {
+    assert.strictEqual(os, "windows");
+    assert.strictEqual(style_name, "fluent");
+} else if (platform === 'darwin') {
+    assert.strictEqual(os, "macos");
+    assert.strictEqual(style_name, "cupertino");
+} else if (platform === 'linux') {
+    assert.strictEqual(os, "linux");
+    assert(style_name == "qt" || style_name == "fluent");
+} else {
+    throw new Error("Unknown platform for this test: " + platform);
+}
+```
+*/

--- a/tools/lsp/ui/components/widgets/widget-helpers.slint
+++ b/tools/lsp/ui/components/widgets/widget-helpers.slint
@@ -26,10 +26,10 @@ export component CustomLineEdit {
     out property <brush> fluent-control-input-active: Palette.color-scheme == ColorScheme.dark ? #1E1E1EB3 : #FFFFFF;
 
     width: 100px;
-    height: StyleMetrics.style-name == "cupertino" ? 22px : StyleMetrics.style-name == "fluent" ? 32px : 33px;
+    height: Platform.style-name == "cupertino" ? 22px : Platform.style-name == "fluent" ? 32px : 33px;
 
     FocusBorder {
-        visible: StyleMetrics.style-name == "cupertino";
+        visible: Platform.style-name == "cupertino";
         x: (parent.width - self.width) / 2;
         y: (parent.height - self.height) / 2;
         width: parent.width + 6px;
@@ -40,8 +40,8 @@ export component CustomLineEdit {
     background := Rectangle {
         background: Palette.control-background;
         border-width: 1px;
-        border-color: StyleMetrics.style-name == "fluent" ? fluent-text-control-border : Palette.border;
-        border-radius: StyleMetrics.style-name == "fluent" ? 4px : 0px;
+        border-color: Platform.style-name == "fluent" ? fluent-text-control-border : Palette.border;
+        border-radius: Platform.style-name == "fluent" ? 4px : 0px;
 
         focus-border := Rectangle {
             x: parent.border-radius;
@@ -54,7 +54,7 @@ export component CustomLineEdit {
     @children
 
     states [
-        focused when root.has-focus && StyleMetrics.style-name == "fluent": {
+        focused when root.has-focus && Platform.style-name == "fluent": {
             background.background: fluent-control-input-active;
             background.border-color: Palette.border;
             focus-border.background: Palette.accent-background;


### PR DESCRIPTION
This replaces the previously hidden `StyleMetrics.style-name` that was only accessible for internal use, introduced in #8200.

Additionally, this introduces `Platform.os`.