### PR TITLE
Disable cut/paste action when textedit is disabled

### DIFF
--- a/internal/compiler/widgets/common/textedit-base.slint
+++ b/internal/compiler/widgets/common/textedit-base.slint
@@ -62,19 +62,32 @@ export component TextEditBase inherits Rectangle {
         Menu {
             MenuItem {
                 title: @tr("Cut");
-                activated => { text-input.cut(); }
+                enabled: root.enabled;
+                activated => {
+                    text-input.cut();
+                }
             }
+
             MenuItem {
                 title: @tr("Copy");
-                activated => { text-input.copy(); }
+                activated => {
+                    text-input.copy();
+                }
             }
+
             MenuItem {
                 title: @tr("Paste");
-                activated => { text-input.paste(); }
+                enabled: root.enabled;
+                activated => {
+                    text-input.paste();
+                }
             }
+
             MenuItem {
                 title: @tr("Select All");
-                activated => { text-input.select-all(); }
+                activated => {
+                    text-input.select-all();
+                }
             }
         }
 
@@ -123,7 +136,6 @@ export component TextEditBase inherits Rectangle {
                 }
             }
         }
-
     }
 
     placeholder := Text {


### PR DESCRIPTION
(Too bad that we can't hide these actions)

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
