### PR TITLE
Teach autofix CI to update an outdated PNPM lockfile

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -27,6 +27,10 @@ run = "cargo fmt --all"
 description = "Run taplo format"
 run = "taplo format"
 
+["fix:pnpm:lock"]
+description = "Update pnpm lock file"
+run = "pnpm i --lockfile-only"
+
 ["fix:ts:format"]
 description = "Run pnpm format:fix"
 run = "pnpm run format:fix"
@@ -67,6 +71,7 @@ depends = ["prepare:pnpm-install"]
 ["prepare:pnpm-install"]
 hide = true
 run = "pnpm install --frozen-lockfile"
+depends = ["fix:pnpm:lock"]
 
 ### CI
 
@@ -79,6 +84,7 @@ depends = [
   "fix:rust:format",
   "fix:text:trailing_spaces",
   "fix:toml:format",
+  "fix:pnpm:lock",
   "fix:ts:biome",
   "fix:ts:format",
 ]


### PR DESCRIPTION
Forgetting to push an updated pnpm lock file is a common issue when working with any of the npm package based projects. This teaches autofix to update it and allow the rest of the CI run to proceed.