### PR TITLE
Fixes for gradient stop re-ordering

### DIFF
--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -606,6 +606,7 @@ component GradientStopValue {
         delete-stop-ta := TouchArea {
             clicked => {
                 Api.remove-gradient-stop(PickerData.current-gradient-stops, stop-index);
+                PickerData.current-gradient-stops = Api.clone-gradient-stops(PickerData.current-gradient-stops);
             }
         }
 

--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -298,27 +298,24 @@ component GradientSlider {
     in property <length> end-limit;
     in property <length> parent-width;
     in property <bool> active;
+    property <bool> being-dragged <=> ta.pressed;
     property <length> slider-target-x;
     in-out property <int> stop-index;
     out property pressed <=> ta.pressed;
 
+    private property <int> previous-stop-index;
     in property <GradientStopIndexChanged> index-changed-data;
 
     callback index-changed(change: GradientStopIndexChanged);
 
     changed index-changed-data => {
-        if self.previous-stop-index == self.index-changed-data.start-index && self.stop-index == self.index-changed-data.end-index {
-            self.previous-stop-index = -1;
-            return;
-        }
-        if self.index-changed-data.start-index < self.stop-index && self.index-changed-data.end-index >= self.stop-index {
-            self.stop-index -= 1;
-        } else if self.index-changed-data.start-index > self.stop-index && self.index-changed-data.end-index <= self.stop-index {
-            self.stop-index += 1;
+        // is the new end index match? If so swap with the start-index
+        if !self.being-dragged {
+            if self.index-changed-data.end-index == self.stop-index {
+                self.stop-index = self.index-changed-data.start-index;
+            }
         }
     }
-
-    private property <int> previous-stop-index;
 
     width: 0;
     height: 0;
@@ -342,8 +339,8 @@ component GradientSlider {
 
                 if root.previous-stop-index != root.stop-index {
                     root.index-changed({ start-index: root.previous-stop-index, end-index: root.stop-index });
-                } else {
-                    root.previous-stop-index = -1;
+                    PickerData.current-stop-index = root.stop-index;
+                    previous-stop-index = root.stop-index;
                 }
             }
             clicked => {
@@ -351,6 +348,11 @@ component GradientSlider {
                     WindowManager.show-color-stop-picker();
                 }
                 block-clicked = false;
+            }
+            changed pressed => {
+                if self.pressed {
+                    PickerData.current-stop-index = stop-index;
+                }
             }
         }
 
@@ -369,6 +371,10 @@ component GradientSlider {
 
         ColorIndicator {
             color: PickerData.current-gradient-stops[stop-index].color;
+        }
+        Text {
+            color: black;
+            text: root.stop-index;
         }
     }
 }
@@ -681,12 +687,12 @@ component GradientPicker inherits SimpleColumn {
             property <GradientStopIndexChanged> index-changed;
 
             for i[index] in PickerData.current-gradient-stops: GradientSlider {
-                y: parent.height + 0px;
+                y: parent.height + (self.stop-index * 10px);
                 start-limit: 0;
                 end-limit: parent.width;
                 parent-width: parent.width;
                 stop-index: index;
-                active: index == PickerData.current-stop-index;
+                active: self.stop-index == PickerData.current-stop-index;
 
                 index-changed-data <=> parent.index-changed;
 

--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -330,10 +330,13 @@ component GradientSlider {
         background: active ? Styles.focused-color : EditorPalette.section-color;
         border-radius: 5px;
 
+        property <bool> block-clicked: false;
         ta := TouchArea {
             moved => {
                 slider-target-x = ((root.x + self.mouse-x - self.pressed-x) / 1px).round() * 1px;
-
+                if root.x != slider-target-x {
+                    block-clicked = true;
+                }
                 root.previous-stop-index = root.stop-index;
                 root.stop-index = Api.move-gradient-stop(PickerData.current-gradient-stops, stop-index, clamp(slider-target-x, root.start-limit, root.end-limit) / root.parent-width);
 
@@ -342,6 +345,12 @@ component GradientSlider {
                 } else {
                     root.previous-stop-index = -1;
                 }
+            }
+            clicked => {
+                if !block-clicked {
+                    WindowManager.show-color-stop-picker();
+                }
+                block-clicked = false;
             }
         }
 

--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -372,10 +372,6 @@ component GradientSlider {
         ColorIndicator {
             color: PickerData.current-gradient-stops[stop-index].color;
         }
-        Text {
-            color: black;
-            text: root.stop-index;
-        }
     }
 }
 
@@ -687,7 +683,7 @@ component GradientPicker inherits SimpleColumn {
             property <GradientStopIndexChanged> index-changed;
 
             for i[index] in PickerData.current-gradient-stops: GradientSlider {
-                y: parent.height + (self.stop-index * 10px);
+                y: parent.height;
                 start-limit: 0;
                 end-limit: parent.width;
                 parent-width: parent.width;

--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -622,6 +622,7 @@ component GradientPicker inherits SimpleColumn {
             current-index: PickerData.current-brush-kind == BrushKind.linear ? 0 : 1;
             selected(current-value) => {
                 PickerData.current-brush-kind = current-value == "Linear" ? BrushKind.linear : BrushKind.radial;
+                WindowManager.update-brush();
             }
 
         }

--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -672,7 +672,7 @@ component GradientPicker inherits SimpleColumn {
             property <GradientStopIndexChanged> index-changed;
 
             for i[index] in PickerData.current-gradient-stops: GradientSlider {
-                y: parent.height + 10px;
+                y: parent.height + 0px;
                 start-limit: 0;
                 end-limit: parent.width;
                 parent-width: parent.width;

--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -297,7 +297,7 @@ component GradientSlider {
     in property <length> start-limit;
     in property <length> end-limit;
     in property <length> parent-width;
-    in property <bool> active;
+    in property <bool> active: stop-index == PickerData.current-stop-index;
     property <bool> being-dragged <=> ta.pressed;
     property <length> slider-target-x;
     in-out property <int> stop-index;
@@ -692,7 +692,6 @@ component GradientPicker inherits SimpleColumn {
                 end-limit: parent.width;
                 parent-width: parent.width;
                 stop-index: index;
-                active: self.stop-index == PickerData.current-stop-index;
 
                 index-changed-data <=> parent.index-changed;
 
@@ -703,7 +702,6 @@ component GradientPicker inherits SimpleColumn {
                 changed pressed => {
                     if self.pressed {
                         root.clear-focus-panel();
-                        PickerData.current-stop-index = index;
                     }
                 }
             }


### PR DESCRIPTION
Potential fix for a set of complex gradient stop re-ordering interactions.

Previously when dragging a gradient stop past other stops the items did not re-order as expcected. The current focused stop did not update. Stops could stick to the dragging stop. Stop sliders could disapear from view. These should be fixed but need more manual testing.