### PR TITLE
Allow trailing comma in import statements

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/file.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/file.mdx
@@ -292,10 +292,14 @@ export { MathLogic } // known as "MathLogic" when using native APIs to access gl
 The following syntax is supported for importing types:
 
 ```slint no-test
-import { export1 } from "module.slint";
-import { export1, export2 } from "module.slint";
-import { export1 as alias1 } from "module.slint";
-import { export1, export2 as alias2, /* ... */ } from "module.slint";
+import { MyButton } from "module.slint";
+import { MyButton, MySwitch } from "module.slint";
+import { MyButton as OtherButton } from "module.slint";
+import {
+    MyButton,
+    /* ... */,
+    MySwitch as OtherSwitch,
+} from "module.slint";
 ```
 
 The following syntax is supported for exporting types:

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -313,8 +313,11 @@ fn parse_import_specifier(p: &mut impl Parser) -> bool {
 #[cfg_attr(test, parser_test)]
 /// ```test,ImportIdentifierList
 /// { Type1 }
-/// { Type2, Type3 }
-/// { Type as Alias1, Type as AnotherAlias }
+/// { Type2, }
+/// { Type3, Type4 }
+/// { Type5, Type6, }
+/// { Type as Alias1, Type as AnotherAlias1 }
+/// { Type as Alias2, Type as AnotherAlias2, }
 /// {}
 /// ```
 fn parse_import_identifier_list(p: &mut impl Parser) -> bool {
@@ -322,23 +325,14 @@ fn parse_import_identifier_list(p: &mut impl Parser) -> bool {
     if !p.expect(SyntaxKind::LBrace) {
         return false;
     }
-    if p.test(SyntaxKind::RBrace) {
-        return true;
-    }
     loop {
+        if p.test(SyntaxKind::RBrace) {
+            return true;
+        }
         parse_import_identifier(&mut *p);
-        match p.nth(0).kind() {
-            SyntaxKind::RBrace => {
-                p.consume();
-                return true;
-            }
-            SyntaxKind::Comma => {
-                p.consume();
-            }
-            _ => {
-                p.error("Expected comma or brace");
-                return false;
-            }
+        if !p.test(SyntaxKind::Comma) && p.nth(0).kind() != SyntaxKind::RBrace {
+            p.error("Expected comma or brace");
+            return false;
         }
     }
 }

--- a/internal/compiler/tests/syntax/imports/import_parse_error6.slint
+++ b/internal/compiler/tests/syntax/imports/import_parse_error6.slint
@@ -1,0 +1,5 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { , SomeRect } from "../../typeloader/incpath/local_helper_type.slint";
+//       ^error{Syntax error: expected Identifier}

--- a/internal/compiler/tests/syntax/imports/import_parse_error7.slint
+++ b/internal/compiler/tests/syntax/imports/import_parse_error7.slint
@@ -1,0 +1,5 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { SomeRect SomeRect as OtherRect } from "../../typeloader/incpath/local_helper_type.slint";
+//                ^error{Expected comma or brace}

--- a/tests/cases/imports/external_globals_nameclash.slint
+++ b/tests/cases/imports/external_globals_nameclash.slint
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 //include_path: ../../helper_components
-import { UseGlobal, ExportedGlobal as FromExport } from "export_globals.slint";
+import {
+    UseGlobal,
+    ExportedGlobal as FromExport,
+} from "export_globals.slint";
 
 global NotExported := {
     property<int> abc: 1000;

--- a/tests/cases/imports/external_structs.slint
+++ b/tests/cases/imports/external_structs.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 //include_path: ../../helper_components
-import { UseStruct , ExportedStruct, ExportEnum } from "export_structs.slint";
+import { UseStruct , ExportedStruct, ExportEnum , } from "export_structs.slint";
 TestCase := Rectangle {
     property <ExportedStruct> exp: { d: 3001, e: {a: 2001} };
     u := UseStruct {

--- a/tests/cases/imports/external_type.slint
+++ b/tests/cases/imports/external_type.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 //include_path: ../../helper_components
-import { TestButton as RealButton } from "test_button.slint";
+import { TestButton as RealButton, } from "test_button.slint";
 import { ColorButton } from "../helper_components/test_button.slint";
 import { Button } from "std-widgets.slint";
 import { TestButton as ReExportedButton } from "re_export.slint";


### PR DESCRIPTION
Adding support for (optional) trailing commas like this:

```slint
import {
    Foo,
    Bar,
} from "foobar.slint";
```

This way it's more convenient to keep component imports nicely formatted and leads to smaller diffs when adding more components to the end of the import statement. See feature request #4922.

I've added an example to the documentation so one can see trailing commas are officially supported. But I renamed the imported types (e.g. `export1`) for consistency with other examples (e.g. `MyButton`). IMHO that makes the examples more expressive, but no strong opinion here...

Just let me know if anything (code, tests, docs) should be adjusted.

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
