### PR TITLE
Clip FF from hex colors

### DIFF
--- a/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-color-picker-widget.slint
@@ -276,7 +276,11 @@ component ColorModeColorAndApply {
             width: 100px;
             text: "Apply";
             clicked => {
-                WindowManager.apply-current-value(Api.color-to-data(PickerData.current-color).text);
+                if PickerData.current-color.to-hsv().alpha == 1 {
+                    WindowManager.apply-current-value("#\{Api.color-to-data(PickerData.current-color).short-text}")
+                } else {
+                    WindowManager.apply-current-value(Api.color-to-data(PickerData.current-color).text);
+                }
             }
         }
     }

--- a/tools/lsp/ui/components/widgets/inline-brush-widget.slint
+++ b/tools/lsp/ui/components/widgets/inline-brush-widget.slint
@@ -128,7 +128,11 @@ component InlineColor {
                         if self.text.character-count > 6 {
                             hsv-color.alpha = Api.string-to-color("#\{self.text}").to-hsv().alpha;
                         }
-                        root.set-color-binding(Api.color-to-data(hsv(hsv-color.hue, hsv-color.saturation, hsv-color.value, hsv-color.alpha)).text);
+                        if hsv-color.alpha == 1 {
+                            root.set-color-binding("#\{Api.color-to-data(hsv(hsv-color.hue, hsv-color.saturation, hsv-color.value, hsv-color.alpha)).short-text}");
+                        } else {
+                            root.set-color-binding(Api.color-to-data(hsv(hsv-color.hue, hsv-color.saturation, hsv-color.value, hsv-color.alpha)).text);
+                        }
                     } else {
                         self.text = Api.color-to-data(root.current-color).short-text.to-uppercase();
                     }
@@ -166,7 +170,11 @@ component InlineColor {
                 horizontal-alignment: right;
                 accepted => {
                     self.text = clamp(self.text.to-float(), 0, 100);
-                    root.set-color-binding(Api.color-to-data(hsv(root.current-color.to-hsv().hue, root.current-color.to-hsv().saturation, root.current-color.to-hsv().value, self.text.to-float() / 100)).text);
+                    if self.text == "100" {
+                        root.set-color-binding("#\{Api.color-to-data(hsv(root.current-color.to-hsv().hue, root.current-color.to-hsv().saturation, root.current-color.to-hsv().value, 1)).short-text}");
+                    } else {
+                        root.set-color-binding(Api.color-to-data(hsv(root.current-color.to-hsv().hue, root.current-color.to-hsv().saturation, root.current-color.to-hsv().value, self.text.to-float() / 100)).text);
+                    }
                     self.clear-focus();
                 }
                 edited => {


### PR DESCRIPTION
Although technically Slint hex colors are #RGBA values, it's common to not see the alpha when its 100% i.e. FF. So a color in code would look like #d1d1d1 and not #d1d1d1ff. However any hex color created by the live-preview components always shows the alpha even if it's 100%.

This change clips the FF from the values create via Slint code. However brush stops are created via Rust and need a separate fix.