### PR TITLE
Added Exp and Ln functions to Slint

### DIFF
--- a/docs/astro/src/content/docs/reference/global-functions/math.mdx
+++ b/docs/astro/src/content/docs/reference/global-functions/math.mdx
@@ -71,6 +71,10 @@ Takes a `value`, `minimum` and `maximum` and returns `maximum` if
 
 Return the log of the first value with a base of the second value
 
+### ln(float) -> float
+
+Return the natural log of the value. Same as log(e, x)
+
 ### min(T, T) -> T
 ### max(T, T) -> T
 
@@ -97,6 +101,9 @@ Square root
 
 Return the value of the first value raised to the second
 
+### exp(float, float) -> float
+
+Return the value of the e raised to the x
 
 ## Trigonometric Functions
 ### acos(float) -> angle

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -39,6 +39,7 @@ pub enum BuiltinFunction {
     ATan,
     ATan2,
     Log,
+    Ln,
     Pow,
     Exp,
     ToFixed,
@@ -175,8 +176,8 @@ declare_builtin_function_types!(
     ATan: (Type::Float32) -> Type::Angle,
     ATan2: (Type::Float32, Type::Float32) -> Type::Angle,
     Log: (Type::Float32, Type::Float32) -> Type::Float32,
-    Exp: (Type::Float32) -> Type::Float32,
     Pow: (Type::Float32, Type::Float32) -> Type::Float32,
+    Exp: (Type::Float32) -> Type::Float32,
     ToFixed: (Type::Float32, Type::Int32) -> Type::String,
     ToPrecision: (Type::Float32, Type::Int32) -> Type::String,
     SetFocusItem: (Type::ElementReference) -> Type::Void,
@@ -296,6 +297,7 @@ impl BuiltinFunction {
             | BuiltinFunction::ACos
             | BuiltinFunction::ASin
             | BuiltinFunction::Log
+            | BuiltinFunction::Ln
             | BuiltinFunction::Pow
             | BuiltinFunction::Exp
             | BuiltinFunction::ATan
@@ -374,6 +376,7 @@ impl BuiltinFunction {
             | BuiltinFunction::ACos
             | BuiltinFunction::ASin
             | BuiltinFunction::Log
+            | BuiltinFunction::Ln
             | BuiltinFunction::Pow
             | BuiltinFunction::Exp
             | BuiltinFunction::ATan

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -40,6 +40,7 @@ pub enum BuiltinFunction {
     ATan2,
     Log,
     Pow,
+    Exp,
     ToFixed,
     ToPrecision,
     SetFocusItem,
@@ -174,6 +175,7 @@ declare_builtin_function_types!(
     ATan: (Type::Float32) -> Type::Angle,
     ATan2: (Type::Float32, Type::Float32) -> Type::Angle,
     Log: (Type::Float32, Type::Float32) -> Type::Float32,
+    Exp: (Type::Float32) -> Type::Float32,
     Pow: (Type::Float32, Type::Float32) -> Type::Float32,
     ToFixed: (Type::Float32, Type::Int32) -> Type::String,
     ToPrecision: (Type::Float32, Type::Int32) -> Type::String,
@@ -295,6 +297,7 @@ impl BuiltinFunction {
             | BuiltinFunction::ASin
             | BuiltinFunction::Log
             | BuiltinFunction::Pow
+            | BuiltinFunction::Exp
             | BuiltinFunction::ATan
             | BuiltinFunction::ATan2
             | BuiltinFunction::ToFixed
@@ -372,6 +375,7 @@ impl BuiltinFunction {
             | BuiltinFunction::ASin
             | BuiltinFunction::Log
             | BuiltinFunction::Pow
+            | BuiltinFunction::Exp
             | BuiltinFunction::ATan
             | BuiltinFunction::ATan2
             | BuiltinFunction::ToFixed

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -176,6 +176,7 @@ declare_builtin_function_types!(
     ATan: (Type::Float32) -> Type::Angle,
     ATan2: (Type::Float32, Type::Float32) -> Type::Angle,
     Log: (Type::Float32, Type::Float32) -> Type::Float32,
+    Ln: (Type::Float32) -> Type::Float32,
     Pow: (Type::Float32, Type::Float32) -> Type::Float32,
     Exp: (Type::Float32) -> Type::Float32,
     ToFixed: (Type::Float32, Type::Int32) -> Type::String,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3520,6 +3520,10 @@ fn compile_builtin_function_call(
             ctx.generator_state.conditional_includes.cmath.set(true);
             format!("std::pow(({}), ({}))", a.next().unwrap(), a.next().unwrap())
         }
+        BuiltinFunction::Exp => {
+            ctx.generator_state.conditional_includes.cmath.set(true);
+            format!("std::exp({})", a.next().unwrap())
+        }
         BuiltinFunction::Sin => {
             ctx.generator_state.conditional_includes.cmath.set(true);
             format!("std::sin(({}) * {})", a.next().unwrap(), pi_180)

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3516,6 +3516,10 @@ fn compile_builtin_function_call(
             ctx.generator_state.conditional_includes.cmath.set(true);
             format!("std::log({}) / std::log({})", a.next().unwrap(), a.next().unwrap())
         }
+        BuiltinFunction::Ln => {
+            ctx.generator_state.conditional_includes.cmath.set(true);
+            format!("std::log({})", a.next().unwrap())
+        }
         BuiltinFunction::Pow => {
             ctx.generator_state.conditional_includes.cmath.set(true);
             format!("std::pow(({}), ({}))", a.next().unwrap(), a.next().unwrap())

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2996,6 +2996,7 @@ fn compile_builtin_function_call(
             let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
             quote!((#a1 as f64).log(#a2 as f64))
         }
+        BuiltinFunction::Ln => quote!((#(#a)* as f64).ln()),
         BuiltinFunction::Pow => {
             let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
             quote!((#a1 as f64).powf(#a2 as f64))

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3000,6 +3000,7 @@ fn compile_builtin_function_call(
             let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
             quote!((#a1 as f64).powf(#a2 as f64))
         }
+        BuiltinFunction::Exp => quote!((#(#a)* as f64).exp()),
         BuiltinFunction::ToFixed => {
             let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
             quote!(sp::shared_string_from_number_fixed(#a1 as f64, (#a2 as i32).max(0) as usize))

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -103,6 +103,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::ATan2 => 10,
         BuiltinFunction::Log => 10,
         BuiltinFunction::Pow => 10,
+        BuiltinFunction::Exp => 10,
         BuiltinFunction::ToFixed => ALLOC_COST,
         BuiltinFunction::ToPrecision => ALLOC_COST,
         BuiltinFunction::SetFocusItem | BuiltinFunction::ClearFocusItem => isize::MAX,

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -102,6 +102,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::ATan => 10,
         BuiltinFunction::ATan2 => 10,
         BuiltinFunction::Log => 10,
+        BuiltinFunction::Ln => 10,
         BuiltinFunction::Pow => 10,
         BuiltinFunction::Exp => 10,
         BuiltinFunction::ToFixed => ALLOC_COST,

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -751,7 +751,9 @@ impl LookupObject for MathFunctions {
             .or_else(|| f("atan2", b(BuiltinFunction::ATan2)))
             .or_else(|| f("log", b(BuiltinFunction::Log)))
             .or_else(|| f("exp", b(BuiltinFunction::Exp)))
+            .or_else(|| f("ln", b(BuiltinFunction::Ln)))
             .or_else(|| f("pow", b(BuiltinFunction::Pow)))
+            .or_else(|| f("exp", b(BuiltinFunction::Exp)))
     }
 }
 

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -750,6 +750,7 @@ impl LookupObject for MathFunctions {
             .or_else(|| f("atan", b(BuiltinFunction::ATan)))
             .or_else(|| f("atan2", b(BuiltinFunction::ATan2)))
             .or_else(|| f("log", b(BuiltinFunction::Log)))
+            .or_else(|| f("exp", b(BuiltinFunction::Exp)))
             .or_else(|| f("pow", b(BuiltinFunction::Pow)))
     }
 }

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -750,7 +750,6 @@ impl LookupObject for MathFunctions {
             .or_else(|| f("atan", b(BuiltinFunction::ATan)))
             .or_else(|| f("atan2", b(BuiltinFunction::ATan2)))
             .or_else(|| f("log", b(BuiltinFunction::Log)))
-            .or_else(|| f("exp", b(BuiltinFunction::Exp)))
             .or_else(|| f("ln", b(BuiltinFunction::Ln)))
             .or_else(|| f("pow", b(BuiltinFunction::Pow)))
             .or_else(|| f("exp", b(BuiltinFunction::Exp)))

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -486,6 +486,10 @@ fn call_builtin_function(
             let y: f64 = eval_expression(&arguments[1], local_context).try_into().unwrap();
             Value::Number(x.powf(y))
         }
+        BuiltinFunction::Exp => {
+            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            Value::Number(x.exp())
+        }
         BuiltinFunction::ToFixed => {
             let n: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
             let digits: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -481,6 +481,10 @@ fn call_builtin_function(
             let y: f64 = eval_expression(&arguments[1], local_context).try_into().unwrap();
             Value::Number(x.log(y))
         }
+        BuiltinFunction::Ln => {
+            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            Value::Number(x.ln())
+        }
         BuiltinFunction::Pow => {
             let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
             let y: f64 = eval_expression(&arguments[1], local_context).try_into().unwrap();

--- a/tests/cases/expr/exp.slint
+++ b/tests/cases/expr/exp.slint
@@ -1,0 +1,27 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+ TestCase := Rectangle {
+    property <float> t1: exp(0);
+    property <float> t2: exp(ln(4.0));
+}
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_t1(), 1.0);
+assert_eq(instance.get_t2(), 4.0);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_t1(), 1.0);
+assert_eq!(instance.get_t2(), 4.0);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.t1, 1);
+assert.equal(instance.t2, 4);
+```
+*/

--- a/tests/cases/expr/ln.slint
+++ b/tests/cases/expr/ln.slint
@@ -1,0 +1,27 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+ TestCase := Rectangle {
+    property <float> t1: ln(1);
+    property <float> t2: ln(exp(3));
+}
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_t1(), 0.0);
+assert_eq(instance.get_t2(), 3.0);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_t1(), 0.0);
+assert_eq!(instance.get_t2(), 3.0);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.t1, 0);
+assert.equal(instance.t2, 3);
+```
+*/


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

I felt these should be added, as they are already implemented in all used std math libraries, and it avoids developers defining e in their Slint code.

[exp_m1](https://doc.rust-lang.org/std/primitive.f64.html#method.exp_m1) and [ln_p1](https://doc.rust-lang.org/std/primitive.f64.html#method.ln_1p) would also be good addition for optimization, but I'll leave that up to the reviewers.

ChangeLog:

Added `Exp` function to Slint
Added `Ln` function to Slint
Added tests for `Exp` and `Ln`