### PR TITLE
Fix `ScrollView` scrollbar actions not triggering `scrolled` callback

### DIFF
--- a/internal/compiler/widgets/cosmic/scrollview.slint
+++ b/internal/compiler/widgets/cosmic/scrollview.slint
@@ -108,6 +108,13 @@ export component ScrollView {
         width: 100%;
         height: 100%;
 
+        changed viewport-x => {
+            root.scrolled();
+        }
+        changed viewport-y => {
+            root.scrolled();
+        }
+
         @children
     }
 

--- a/internal/compiler/widgets/cupertino/scrollview.slint
+++ b/internal/compiler/widgets/cupertino/scrollview.slint
@@ -118,6 +118,13 @@ export component ScrollView {
         width: parent.width - 4px;
         height: parent.height - 4px;
 
+        changed viewport-x => {
+            root.scrolled();
+        }
+        changed viewport-y => {
+            root.scrolled();
+        }
+
         @children
     }
 

--- a/internal/compiler/widgets/fluent/scrollview.slint
+++ b/internal/compiler/widgets/fluent/scrollview.slint
@@ -162,6 +162,13 @@ export component ScrollView {
         width: parent.width;
         height: parent.height;
 
+        changed viewport-x => {
+            root.scrolled();
+        }
+        changed viewport-y => {
+            root.scrolled();
+        }
+
         @children
     }
 

--- a/internal/compiler/widgets/material/scrollview.slint
+++ b/internal/compiler/widgets/material/scrollview.slint
@@ -119,6 +119,13 @@ export component ScrollView {
         width: parent.width - vertical-bar.width - 4px;
         height: parent.height - horizontal-bar.height - 4px;
 
+        changed viewport-x => {
+            root.scrolled();
+        }
+        changed viewport-y => {
+            root.scrolled();
+        }
+
         @children
     }
 

--- a/internal/compiler/widgets/qt/internal-scrollview.slint
+++ b/internal/compiler/widgets/qt/internal-scrollview.slint
@@ -50,6 +50,13 @@ export component InternalScrollView {
         interactive: false;
         viewport-y <=> native.vertical-value;
         viewport-x <=> native.horizontal-value;
+
+        changed viewport-x => {
+            root.scrolled();
+        }
+        changed viewport-y => {
+            root.scrolled();
+        }
     }
 }
 


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
