### PR TITLE
Node.js: Fix support for loadFile() with an URL on Windows

### DIFF
--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -13,7 +13,13 @@ const dirname = path.dirname(
 
 // loadFile api
 test("loadFile", (t) => {
-    const demo = loadFile(path.join(dirname, "resources/test.slint")) as any;
+    // Test the URL variant here, to ensure that it works (esp. on Windows)
+    const demo = loadFile(
+        new URL(
+            "resources/test.slint",
+            import.meta.url.replace("build", "__test__"),
+        ),
+    ) as any;
     const test = new demo.Test();
     t.is(test.check, "Test");
 

--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -16,6 +16,8 @@ export { ArrayModel } from "./models";
 
 import { Diagnostic } from "../rust-module.cjs";
 
+import { fileURLToPath } from "node:url";
+
 /**
  *  Represents a two-dimensional point.
  */
@@ -626,7 +628,8 @@ export function loadFile(
     filePath: string | URL,
     options?: LoadFileOptions,
 ): Object {
-    const pathname = filePath instanceof URL ? filePath.pathname : filePath;
+    const pathname =
+        filePath instanceof URL ? fileURLToPath(filePath) : filePath;
     return loadSlint({
         fileData: { filePath: pathname, options },
         from: "file",
@@ -948,7 +951,7 @@ export namespace private_api {
  * ````
  */
 export function initTranslations(domain: string, path: string | URL) {
-    const pathname = path instanceof URL ? path.pathname : path;
+    const pathname = path instanceof URL ? fileURLToPath(path) : path;
     napi.initTranslations(domain, pathname);
 }
 


### PR DESCRIPTION
We recommend the use of `loadFile(new URL("...", import.metal.url))`,
but this never worked on Windows, because we're not using the API
the Node.js docs even recommend to correctly covert to a local path on Windows.

Fixes #8209