### PR TITLE
Replace use of Rc<winit::window::Window> with Arc

### DIFF
--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -821,7 +821,7 @@ mod software_renderer {
 pub mod skia {
     use super::*;
     use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     struct RawHandlePair((RawWindowHandle, RawDisplayHandle));
 
@@ -843,11 +843,11 @@ pub mod skia {
         }
     }
 
-    struct CppRawHandle(Rc<RawHandlePair>);
+    struct CppRawHandle(Arc<RawHandlePair>);
 
     impl From<(RawWindowHandle, RawDisplayHandle)> for CppRawHandle {
         fn from(pair: (RawWindowHandle, RawDisplayHandle)) -> Self {
-            Self(Rc::new(RawHandlePair(pair)))
+            Self(Arc::new(RawHandlePair(pair)))
         }
     }
 

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -18,6 +18,7 @@ use i_slint_core::{Property, SharedString};
 use i_slint_renderer_skia::SkiaRenderer;
 use std::cell::Cell;
 use std::rc::Rc;
+use std::sync::Arc;
 
 struct LongPressDetection {
     _timer: Timer,
@@ -216,8 +217,8 @@ impl AndroidWindowAdapter {
                     }
 
                     self.renderer.set_window_handle(
-                        Rc::new(w),
-                        Rc::new(raw_window_handle::DisplayHandle::android()),
+                        Arc::new(w),
+                        Arc::new(raw_window_handle::DisplayHandle::android()),
                         size,
                         None,
                     )?;

--- a/internal/backends/linuxkms/display.rs
+++ b/internal/backends/linuxkms/display.rs
@@ -95,15 +95,15 @@ impl RenderingRotation {
     feature = "renderer-skia-opengl"
 ))]
 pub(crate) mod noop_presenter {
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     // Used when the underlying renderer/display takes care of the presentation to the display
     // and (hopefully) implements vsync.
     pub(crate) struct NoopPresenter {}
 
     impl NoopPresenter {
-        pub(crate) fn new() -> Rc<Self> {
-            Rc::new(Self {})
+        pub(crate) fn new() -> Arc<Self> {
+            Arc::new(Self {})
         }
     }
 

--- a/internal/backends/linuxkms/display/swdisplay.rs
+++ b/internal/backends/linuxkms/display/swdisplay.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use i_slint_core::platform::PlatformError;
 
@@ -15,7 +15,7 @@ pub trait SoftwareBufferDisplay {
             drm::buffer::DrmFourcc,
         ) -> Result<(), PlatformError>,
     ) -> Result<(), PlatformError>;
-    fn as_presenter(self: Rc<Self>) -> Rc<dyn super::Presenter>;
+    fn as_presenter(self: Arc<Self>) -> Arc<dyn super::Presenter>;
 }
 
 mod dumbbuffer;
@@ -23,7 +23,7 @@ mod linuxfb;
 
 pub fn new(
     device_opener: &crate::DeviceOpener,
-) -> Result<Rc<dyn SoftwareBufferDisplay>, PlatformError> {
+) -> Result<Arc<dyn SoftwareBufferDisplay>, PlatformError> {
     dumbbuffer::DumbBufferDisplay::new(device_opener)
         .or_else(|_| linuxfb::LinuxFBDisplay::new(device_opener))
 }

--- a/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
+++ b/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::drmoutput::DrmOutput;
 use drm::control::Device;
@@ -21,7 +21,7 @@ pub struct DumbBufferDisplay {
 impl DumbBufferDisplay {
     pub fn new(
         device_opener: &crate::DeviceOpener,
-    ) -> Result<Rc<dyn super::SoftwareBufferDisplay>, PlatformError> {
+    ) -> Result<Arc<dyn super::SoftwareBufferDisplay>, PlatformError> {
         let drm_output = DrmOutput::new(device_opener)?;
 
         //eprintln!("mode {}/{}", width, height);
@@ -45,7 +45,7 @@ impl DumbBufferDisplay {
         )?
         .into();
 
-        Ok(Rc::new(Self { drm_output, front_buffer, back_buffer, in_flight_buffer }))
+        Ok(Arc::new(Self { drm_output, front_buffer, back_buffer, in_flight_buffer }))
     }
 }
 
@@ -72,7 +72,7 @@ impl super::SoftwareBufferDisplay for DumbBufferDisplay {
             .and_then(|mut buffer| callback(buffer.as_mut(), age, format))
     }
 
-    fn as_presenter(self: Rc<Self>) -> Rc<dyn crate::display::Presenter> {
+    fn as_presenter(self: Arc<Self>) -> Arc<dyn crate::display::Presenter> {
         self
     }
 }

--- a/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
+++ b/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
@@ -3,7 +3,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::os::fd::AsRawFd;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use i_slint_core::platform::PlatformError;
 
@@ -12,7 +12,7 @@ pub struct LinuxFBDisplay {
     back_buffer: RefCell<Box<[u8]>>,
     width: u32,
     height: u32,
-    presenter: Rc<crate::display::noop_presenter::NoopPresenter>,
+    presenter: Arc<crate::display::noop_presenter::NoopPresenter>,
     first_frame: Cell<bool>,
     format: drm::buffer::DrmFourcc,
 }
@@ -20,7 +20,7 @@ pub struct LinuxFBDisplay {
 impl LinuxFBDisplay {
     pub fn new(
         device_opener: &crate::DeviceOpener,
-    ) -> Result<Rc<dyn super::SoftwareBufferDisplay>, PlatformError> {
+    ) -> Result<Arc<dyn super::SoftwareBufferDisplay>, PlatformError> {
         let mut last_err = None;
 
         for fbnum in 0..10 {
@@ -39,7 +39,7 @@ impl LinuxFBDisplay {
     fn new_with_path(
         device_opener: &crate::DeviceOpener,
         path: &std::path::Path,
-    ) -> Result<Rc<dyn super::SoftwareBufferDisplay>, PlatformError> {
+    ) -> Result<Arc<dyn super::SoftwareBufferDisplay>, PlatformError> {
         let fd = device_opener(path)?;
 
         let vinfo = unsafe {
@@ -93,7 +93,7 @@ impl LinuxFBDisplay {
 
         let back_buffer = RefCell::new(vec![0u8; size_bytes].into_boxed_slice());
 
-        Ok(Rc::new(Self {
+        Ok(Arc::new(Self {
             fb: RefCell::new(fb),
             back_buffer,
             width,
@@ -127,7 +127,7 @@ impl super::SoftwareBufferDisplay for LinuxFBDisplay {
         Ok(())
     }
 
-    fn as_presenter(self: Rc<Self>) -> Rc<dyn crate::display::Presenter> {
+    fn as_presenter(self: Arc<Self>) -> Arc<dyn crate::display::Presenter> {
         self.presenter.clone()
     }
 }

--- a/internal/backends/linuxkms/display/vulkandisplay.rs
+++ b/internal/backends/linuxkms/display/vulkandisplay.rs
@@ -9,7 +9,6 @@ use vulkano::instance::{Instance, InstanceCreateFlags, InstanceCreateInfo, Insta
 use vulkano::swapchain::Surface;
 use vulkano::VulkanLibrary;
 
-use std::rc::Rc;
 use std::sync::Arc;
 
 use super::Presenter;
@@ -19,7 +18,7 @@ pub struct VulkanDisplay {
     pub queue_family_index: u32,
     pub surface: Arc<Surface>,
     pub size: PhysicalWindowSize,
-    pub presenter: Rc<dyn Presenter>,
+    pub presenter: Arc<dyn Presenter>,
 }
 
 pub fn create_vulkan_display() -> Result<VulkanDisplay, PlatformError> {

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::display::RenderingRotation;
 use crate::drmoutput::DrmOutput;
@@ -51,7 +52,7 @@ impl SkiaRendererAdapter {
         device_opener: &crate::DeviceOpener,
     ) -> Result<Box<dyn crate::fullscreenwindowadapter::FullscreenRenderer>, PlatformError> {
         let drm_output = DrmOutput::new(device_opener)?;
-        let display = Rc::new(crate::display::gbmdisplay::GbmDisplay::new(drm_output)?);
+        let display = Arc::new(crate::display::gbmdisplay::GbmDisplay::new(drm_output)?);
 
         let (width, height) = display.drm_output.size();
         let size = i_slint_core::api::PhysicalSize::new(width, height);

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -1,7 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::display::RenderingRotation;
@@ -162,7 +161,7 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SkiaRendererAdapter 
     }
 }
 struct DrmDumbBufferAccess {
-    display: Rc<dyn crate::display::swdisplay::SoftwareBufferDisplay>,
+    display: Arc<dyn crate::display::swdisplay::SoftwareBufferDisplay>,
 }
 
 impl i_slint_renderer_skia::software_surface::RenderBuffer for DrmDumbBufferAccess {

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -14,7 +14,7 @@ use i_slint_renderer_skia::SkiaRendererExt;
 
 pub struct SkiaRendererAdapter {
     renderer: i_slint_renderer_skia::SkiaRenderer,
-    presenter: Rc<dyn crate::display::Presenter>,
+    presenter: Arc<dyn crate::display::Presenter>,
     size: PhysicalWindowSize,
 }
 

--- a/internal/backends/linuxkms/renderer/sw.rs
+++ b/internal/backends/linuxkms/renderer/sw.rs
@@ -7,14 +7,14 @@ use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
 use i_slint_core::platform::PlatformError;
 pub use i_slint_core::software_renderer::SoftwareRenderer;
 use i_slint_core::software_renderer::{PremultipliedRgbaColor, RepaintBufferType, TargetPixel};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::display::RenderingRotation;
 
 pub struct SoftwareRendererAdapter {
     renderer: SoftwareRenderer,
-    display: Rc<dyn crate::display::swdisplay::SoftwareBufferDisplay>,
-    presenter: Rc<dyn crate::display::Presenter>,
+    display: Arc<dyn crate::display::swdisplay::SoftwareBufferDisplay>,
+    presenter: Arc<dyn crate::display::Presenter>,
     size: PhysicalWindowSize,
 }
 

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -43,7 +43,7 @@ pub enum WinitWindowEventResult {
 }
 
 mod renderer {
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     use i_slint_core::{graphics::RequestedGraphicsAPI, platform::PlatformError};
 
@@ -62,7 +62,7 @@ mod renderer {
             event_loop: &dyn crate::event_loop::EventLoopInterface,
             window_attributes: winit::window::WindowAttributes,
             requested_graphics_api: Option<RequestedGraphicsAPI>,
-        ) -> Result<Rc<winit::window::Window>, PlatformError>;
+        ) -> Result<Arc<winit::window::Window>, PlatformError>;
 
         fn is_suspended(&self) -> bool;
     }

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::cell::Cell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use i_slint_core::renderer::Renderer;
 use i_slint_core::{graphics::RequestedGraphicsAPI, platform::PlatformError};
@@ -46,7 +46,7 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
         #[cfg_attr(target_arch = "wasm32", allow(unused_variables))] requested_graphics_api: Option<
             RequestedGraphicsAPI,
         >,
-    ) -> Result<Rc<winit::window::Window>, PlatformError> {
+    ) -> Result<Arc<winit::window::Window>, PlatformError> {
         #[cfg(not(target_arch = "wasm32"))]
         let (winit_window, opengl_context) = glcontext::OpenGLContext::new_context(
             window_attributes,
@@ -56,7 +56,7 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
 
         #[cfg(target_arch = "wasm32")]
         let winit_window =
-            Rc::new(event_loop.create_window(window_attributes).map_err(|winit_os_error| {
+            Arc::new(event_loop.create_window(window_attributes).map_err(|winit_os_error| {
                 PlatformError::from(format!(
                     "FemtoVG Renderer: Could not create winit window wrapper for DOM canvas: {}",
                     winit_os_error

--- a/internal/backends/winit/renderer/femtovg/glcontext.rs
+++ b/internal/backends/winit/renderer/femtovg/glcontext.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::{num::NonZeroU32, rc::Rc};
+use std::{num::NonZeroU32, sync::Arc};
 
 use glutin::{
     config::GlConfig,
@@ -16,7 +16,7 @@ use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 pub struct OpenGLContext {
     context: glutin::context::PossiblyCurrentContext,
     surface: glutin::surface::Surface<glutin::surface::WindowSurface>,
-    winit_window: Rc<winit::window::Window>,
+    winit_window: Arc<winit::window::Window>,
 }
 
 unsafe impl i_slint_renderer_femtovg::OpenGLInterface for OpenGLContext {
@@ -59,7 +59,7 @@ impl OpenGLContext {
         window_attributes: winit::window::WindowAttributes,
         event_loop: crate::event_loop::ActiveOrInactiveEventLoop<'_>,
         requested_opengl_version: Option<RequestedOpenGLVersion>,
-    ) -> Result<(Rc<winit::window::Window>, Self), PlatformError> {
+    ) -> Result<(Arc<winit::window::Window>, Self), PlatformError> {
         let config_template_builder = glutin::config::ConfigTemplateBuilder::new();
 
         // On macOS, there's only one GL config and that's initialized based on the values in the config template
@@ -247,7 +247,7 @@ impl OpenGLContext {
             )
             .ok();
 
-        let window = Rc::new(window);
+        let window = Arc::new(window);
 
         Ok((window.clone(), Self { context, surface, winit_window: window }))
     }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::cell::Cell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::winitwindowadapter::physical_size_to_slint;
 use i_slint_core::graphics::RequestedGraphicsAPI;
@@ -127,9 +127,9 @@ impl super::WinitCompatibleRenderer for WinitSkiaRenderer {
         event_loop: &dyn crate::event_loop::EventLoopInterface,
         window_attributes: winit::window::WindowAttributes,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
-    ) -> Result<Rc<winit::window::Window>, PlatformError> {
+    ) -> Result<Arc<winit::window::Window>, PlatformError> {
         let winit_window =
-            Rc::new(event_loop.create_window(window_attributes).map_err(|winit_os_error| {
+            Arc::new(event_loop.create_window(window_attributes).map_err(|winit_os_error| {
                 PlatformError::from(format!(
                     "Error creating native window for Skia rendering: {}",
                     winit_os_error

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -9,15 +9,17 @@ use i_slint_core::platform::PlatformError;
 pub use i_slint_core::software_renderer::SoftwareRenderer;
 use i_slint_core::software_renderer::{PremultipliedRgbaColor, RepaintBufferType, TargetPixel};
 use i_slint_core::{graphics::RequestedGraphicsAPI, graphics::Rgb8Pixel};
-use std::{cell::RefCell, rc::Rc};
+use std::cell::RefCell;
+use std::sync::Arc;
 
 use super::WinitCompatibleRenderer;
 
 pub struct WinitSoftwareRenderer {
     renderer: SoftwareRenderer,
-    _context: RefCell<Option<softbuffer::Context<Rc<winit::window::Window>>>>,
-    surface:
-        RefCell<Option<softbuffer::Surface<Rc<winit::window::Window>, Rc<winit::window::Window>>>>,
+    _context: RefCell<Option<softbuffer::Context<Arc<winit::window::Window>>>>,
+    surface: RefCell<
+        Option<softbuffer::Surface<Arc<winit::window::Window>, Arc<winit::window::Window>>>,
+    >,
 }
 
 #[repr(transparent)]
@@ -175,14 +177,14 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
         event_loop: &dyn crate::event_loop::EventLoopInterface,
         window_attributes: winit::window::WindowAttributes,
         _requested_graphics_api: Option<RequestedGraphicsAPI>,
-    ) -> Result<Rc<winit::window::Window>, PlatformError> {
+    ) -> Result<Arc<winit::window::Window>, PlatformError> {
         let winit_window =
             event_loop.create_window(window_attributes).map_err(|winit_os_error| {
                 PlatformError::from(format!(
                     "Error creating native window for software rendering: {winit_os_error}"
                 ))
             })?;
-        let winit_window = Rc::new(winit_window);
+        let winit_window = Arc::new(winit_window);
 
         let context = softbuffer::Context::new(winit_window.clone())
             .map_err(|e| format!("Error creating softbuffer context: {e}"))?;

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -9,6 +9,7 @@ use core::cell::{Cell, RefCell};
 use core::pin::Pin;
 use std::rc::Rc;
 use std::rc::Weak;
+use std::sync::Arc;
 
 #[cfg(target_arch = "wasm32")]
 use winit::platform::web::WindowExtWebSys;
@@ -123,7 +124,7 @@ fn window_is_resizable(
 
 enum WinitWindowOrNone {
     HasWindow {
-        window: Rc<winit::window::Window>,
+        window: Arc<winit::window::Window>,
         #[cfg(enable_accesskit)]
         accesskit_adapter: RefCell<crate::accesskit::AccessKitAdapter>,
         #[cfg(muda)]
@@ -133,7 +134,7 @@ enum WinitWindowOrNone {
 }
 
 impl WinitWindowOrNone {
-    fn as_window(&self) -> Option<Rc<winit::window::Window>> {
+    fn as_window(&self) -> Option<Arc<winit::window::Window>> {
         match self {
             Self::HasWindow { window, .. } => Some(window.clone()),
             Self::None { .. } => None,
@@ -370,7 +371,7 @@ impl WinitWindowAdapter {
     pub fn ensure_window(
         &self,
         event_loop: &dyn crate::event_loop::EventLoopInterface,
-    ) -> Result<Rc<winit::window::Window>, PlatformError> {
+    ) -> Result<Arc<winit::window::Window>, PlatformError> {
         #[allow(unused_mut)]
         let mut window_attributes = match &*self.winit_window_or_none.borrow() {
             WinitWindowOrNone::HasWindow { window, .. } => return Ok(window.clone()),
@@ -445,7 +446,7 @@ impl WinitWindowAdapter {
                 attributes.position = last_window_rc.outer_position().ok().map(|pos| pos.into());
                 *winit_window_or_none = WinitWindowOrNone::None(attributes.into());
 
-                if let Some(last_instance) = Rc::into_inner(last_window_rc) {
+                if let Some(last_instance) = Arc::into_inner(last_window_rc) {
                     self.shared_backend_data.unregister_window(last_instance.id());
                     drop(last_instance);
                 } else {
@@ -516,7 +517,7 @@ impl WinitWindowAdapter {
         Ok(())
     }
 
-    pub fn winit_window(&self) -> Option<Rc<winit::window::Window>> {
+    pub fn winit_window(&self) -> Option<Arc<winit::window::Window>> {
         self.winit_window_or_none.borrow().as_window()
     }
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1237,7 +1237,7 @@ impl WindowAdapterInternal for WinitWindowAdapter {
     #[cfg(feature = "raw-window-handle-06")]
     fn window_handle_06_rc(
         &self,
-    ) -> Result<Rc<dyn raw_window_handle::HasWindowHandle>, raw_window_handle::HandleError> {
+    ) -> Result<Arc<dyn raw_window_handle::HasWindowHandle>, raw_window_handle::HandleError> {
         self.winit_window_or_none
             .borrow()
             .as_window()
@@ -1247,7 +1247,7 @@ impl WindowAdapterInternal for WinitWindowAdapter {
     #[cfg(feature = "raw-window-handle-06")]
     fn display_handle_06_rc(
         &self,
-    ) -> Result<Rc<dyn raw_window_handle::HasDisplayHandle>, raw_window_handle::HandleError> {
+    ) -> Result<Arc<dyn raw_window_handle::HasDisplayHandle>, raw_window_handle::HandleError> {
         self.winit_window_or_none
             .borrow()
             .as_window()

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -215,20 +215,24 @@ pub trait WindowAdapterInternal {
     fn setup_menubar(&self, _menubar: vtable::VBox<MenuVTable>) {}
 
     /// Re-implement this to support exposing raw window handles (version 0.6).
-    #[cfg(feature = "raw-window-handle-06")]
+    #[cfg(all(feature = "std", feature = "raw-window-handle-06"))]
     fn window_handle_06_rc(
         &self,
-    ) -> Result<Rc<dyn raw_window_handle_06::HasWindowHandle>, raw_window_handle_06::HandleError>
-    {
+    ) -> Result<
+        std::sync::Arc<dyn raw_window_handle_06::HasWindowHandle>,
+        raw_window_handle_06::HandleError,
+    > {
         Err(raw_window_handle_06::HandleError::NotSupported)
     }
 
     /// Re-implement this to support exposing raw display handles (version 0.6).
-    #[cfg(feature = "raw-window-handle-06")]
+    #[cfg(all(feature = "std", feature = "raw-window-handle-06"))]
     fn display_handle_06_rc(
         &self,
-    ) -> Result<Rc<dyn raw_window_handle_06::HasDisplayHandle>, raw_window_handle_06::HandleError>
-    {
+    ) -> Result<
+        std::sync::Arc<dyn raw_window_handle_06::HasDisplayHandle>,
+        raw_window_handle_06::HandleError,
+    > {
         Err(raw_window_handle_06::HandleError::NotSupported)
     }
 

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -6,7 +6,7 @@ use i_slint_core::graphics::RequestedGraphicsAPI;
 use i_slint_core::item_rendering::DirtyRegion;
 use i_slint_core::platform::PlatformError;
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 use windows::core::Interface;
 use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_0;
 use windows::Win32::Graphics::Dxgi::Common::DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN;
@@ -255,8 +255,8 @@ pub struct D3DSurface {
 
 impl super::Surface for D3DSurface {
     fn new(
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        _display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        _display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -6,6 +6,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
+use std::sync::Arc;
 
 use i_slint_core::api::{
     GraphicsAPI, PhysicalSize as PhysicalWindowSize, RenderingNotifier, RenderingState,
@@ -64,8 +65,8 @@ cfg_if::cfg_if! {
 }
 
 fn create_default_surface(
-    window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-    display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+    window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+    display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
     size: PhysicalWindowSize,
     requested_graphics_api: Option<RequestedGraphicsAPI>,
 ) -> Result<Box<dyn Surface>, PlatformError> {
@@ -128,8 +129,8 @@ pub struct SkiaRenderer {
     rendering_first_time: Cell<bool>,
     surface: RefCell<Option<Box<dyn Surface>>>,
     surface_factory: fn(
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Box<dyn Surface>, PlatformError>,
@@ -297,8 +298,8 @@ impl SkiaRenderer {
 
     /// Creates a new renderer is associated with the provided window adapter.
     pub fn new(
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
     ) -> Result<Self, PlatformError> {
         Ok(Self::new_with_surface(create_default_surface(
@@ -375,8 +376,8 @@ impl SkiaRenderer {
     /// Reset the surface to the window given the window handle
     pub fn set_window_handle(
         &self,
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<(), PlatformError> {
@@ -915,8 +916,8 @@ impl Drop for SkiaRenderer {
 pub trait Surface {
     /// Creates a new surface with the given window, display, and size.
     fn new(
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, PlatformError>

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -13,7 +13,7 @@ use objc2_quartz_core::{CAMetalDrawable, CAMetalLayer};
 use skia_safe::gpu::mtl;
 
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// This surface renders into the given window using Metal. The provided display argument
 /// is ignored, as it has no meaning on macOS.
@@ -28,8 +28,8 @@ pub struct MetalSurface {
 
 impl super::Surface for MetalSurface {
     fn new(
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        _display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        _display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -1,9 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::cell::RefCell;
 use std::num::NonZeroU32;
-use std::rc::Rc;
+use std::{cell::RefCell, sync::Arc};
 
 use glutin::{
     config::GetGlConfig,
@@ -31,8 +30,8 @@ pub struct OpenGLSurface {
 
 impl super::Surface for OpenGLSurface {
     fn new(
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, PlatformError> {
@@ -155,8 +154,8 @@ impl super::Surface for OpenGLSurface {
 
 impl OpenGLSurface {
     pub fn new_with_config(
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
         requested_opengl_version: Option<RequestedOpenGLVersion>,
         config_builder: glutin::config::ConfigTemplateBuilder,

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -9,6 +9,7 @@ use i_slint_core::lengths::ScaleFactor;
 use std::cell::RefCell;
 use std::num::NonZeroU32;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::PhysicalRect;
 
@@ -31,11 +32,11 @@ pub trait RenderBuffer {
 }
 
 struct SoftbufferRenderBuffer {
-    _context: softbuffer::Context<Rc<dyn raw_window_handle::HasDisplayHandle>>,
+    _context: softbuffer::Context<Arc<dyn raw_window_handle::HasDisplayHandle>>,
     surface: RefCell<
         softbuffer::Surface<
-            Rc<dyn raw_window_handle::HasDisplayHandle>,
-            Rc<dyn raw_window_handle::HasWindowHandle>,
+            Arc<dyn raw_window_handle::HasDisplayHandle>,
+            Arc<dyn raw_window_handle::HasWindowHandle>,
         >,
     >,
 }
@@ -113,8 +114,8 @@ pub struct SoftwareSurface {
 
 impl super::Surface for SoftwareSurface {
     fn new(
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         _size: PhysicalWindowSize,
         _requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::cell::{Cell, RefCell};
-use std::rc::Rc;
 use std::sync::Arc;
 
 use i_slint_core::api::{PhysicalSize as PhysicalWindowSize, Window};

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -159,8 +159,8 @@ impl VulkanSurface {
 
 impl super::Surface for VulkanSurface {
     fn new(
-        window_handle: Rc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Rc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {


### PR DESCRIPTION
In preparation for wgpu usage, where the wgpu API requires the window handle to be send, i.e. Arc<dyn HasWindowHandle>.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
