### PR TITLE
figma-inspector: sanitizer was broken for some characters

### DIFF
--- a/tools/figma-inspector/backend/utils/export-variables.ts
+++ b/tools/figma-inspector/backend/utils/export-variables.ts
@@ -101,12 +101,41 @@ function formatVariableName(name: string): string {
     return sanitizedName;
 }
 
+
 export function sanitizePropertyName(name: string): string {
-    // Check if starts with a digit
-    if (/^\d/.test(name)) {
-        return `_${name}`;
+    // Handle names starting with "." - remove the dot
+    let sanitizedName = name.startsWith(".") ? name.substring(1) : name;
+
+    // Remove leading invalid chars AFTER initial dot check
+    sanitizedName = sanitizedName.replace(/^[_\-\.\(\)&]+/, "");
+
+    // If that made it empty, use a default
+    if (!sanitizedName || sanitizedName.trim() === "") {
+        sanitizedName = "property"; // Or handle as error?
     }
-    return name;
+
+    // Replace problematic characters BEFORE checking for leading digit
+    sanitizedName = sanitizedName
+        .replace(/&/g, "and") // Replace &
+        .replace(/\(/g, "_") // Replace ( with _
+        .replace(/\)/g, "_") // Replace ) with _
+        .replace(/[^a-zA-Z0-9_]/g, "_") // Replace other invalid chars (including -, +, :, etc.) with _
+        .replace(/__+/g, "_"); // Collapse multiple underscores
+
+    // Remove trailing underscores
+    sanitizedName = sanitizedName.replace(/_+$/, "");
+
+    // Check if starts with a digit AFTER other sanitization
+    if (/^\d/.test(sanitizedName)) {
+        return `_${sanitizedName}`;
+    }
+
+    // Ensure it's not empty again after trailing underscore removal
+    if (!sanitizedName || sanitizedName.trim() === "") {
+        return "property";
+    }
+
+    return sanitizedName.toLowerCase();
 }
 
 function sanitizeRowName(rowName: string): string {
@@ -175,7 +204,7 @@ function detectCycle(dependencies: Map<string, Set<string>>): boolean {
 export function extractHierarchy(name: string): string[] {
     // First try splitting by slashes (the expected format)
     if (name.includes("/")) {
-        return name.split("/").map((part) => formatVariableName(part));
+        return name.split("/").map((part) => sanitizePropertyName(part));
     }
 
     // Default case for simple names

--- a/tools/figma-inspector/backend/utils/export-variables.ts
+++ b/tools/figma-inspector/backend/utils/export-variables.ts
@@ -101,7 +101,6 @@ function formatVariableName(name: string): string {
     return sanitizedName;
 }
 
-
 export function sanitizePropertyName(name: string): string {
     // Handle names starting with "." - remove the dot
     let sanitizedName = name.startsWith(".") ? name.substring(1) : name;


### PR DESCRIPTION
there was a discrepancy between variable names and struct names because they were using different sanitizers

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
