### PR TITLE
Compiler: Fix changed callback on private global properties

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -789,10 +789,14 @@ pub fn generate(
         }),
     ));
 
+    let mut init_global = vec![];
+
     for (idx, glob) in llr.globals.iter_enumerated() {
+        let name = format_smolstr!("global_{}", concatenate_ident(&glob.name));
         let ty = if glob.is_builtin {
             format_smolstr!("slint::cbindgen_private::{}", glob.name)
         } else if glob.must_generate() {
+            init_global.push(format!("{name}->init();"));
             generate_global(&mut file, &conditional_includes, idx, glob, &llr);
             file.definitions.extend(glob.aliases.iter().map(|name| {
                 Declaration::TypeAlias(TypeAlias {
@@ -809,12 +813,24 @@ pub fn generate(
             Access::Public,
             Declaration::Var(Var {
                 ty: format_smolstr!("std::shared_ptr<{}>", ty),
-                name: format_smolstr!("global_{}", concatenate_ident(&glob.name)),
+                name,
                 init: Some(format!("std::make_shared<{ty}>(this)")),
                 ..Default::default()
             }),
         ));
     }
+
+    globals_struct.members.push((
+        Access::Public,
+        Declaration::Function(Function {
+            name: globals_struct.name.clone(),
+            is_constructor_or_destructor: true,
+            signature: "()".into(),
+            statements: Some(init_global),
+            ..Default::default()
+        }),
+    ));
+
     file.declarations.push(Declaration::Struct(globals_struct));
 
     if let Some(popup_menu) = &llr.popup_menu {
@@ -2581,7 +2597,7 @@ fn generate_global(
         ));
     }
 
-    let mut init = vec!["(void)this->globals;".into()];
+    let mut init = vec![];
     let ctx = EvaluationContext::new_global(
         root,
         global_idx,
@@ -2625,8 +2641,17 @@ fn generate_global(
             name: ident(&global.name),
             signature: "(const class SharedGlobals *globals)".into(),
             is_constructor_or_destructor: true,
-            statements: Some(init),
+            statements: Some(vec![]),
             constructor_member_initializers: vec!["globals(globals)".into()],
+            ..Default::default()
+        }),
+    ));
+    global_struct.members.push((
+        Access::Private,
+        Declaration::Function(Function {
+            name: ident("init"),
+            signature: "() -> void".into(),
+            statements: Some(init),
             ..Default::default()
         }),
     ));
@@ -2638,6 +2663,7 @@ fn generate_global(
             ..Default::default()
         }),
     ));
+    global_struct.friends.push(SmolStr::new_static("SharedGlobals"));
 
     generate_public_api_for_properties(
         &mut global_struct.members,

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -122,11 +122,19 @@ pub fn count_property_use(root: &CompilationUnit) {
         }
     });
 
-    // TODO: only visit used function
     for (idx, g) in root.globals.iter_enumerated() {
         let ctx = EvaluationContext::new_global(root, idx, ());
+        // TODO: only visit used function
         for f in &g.functions {
             f.code.visit_property_references(&ctx, &mut visit_property);
+        }
+
+        for (p, e) in &g.change_callbacks {
+            visit_property(
+                &PropertyReference::Local { sub_component_path: vec![], property_index: *p },
+                &ctx,
+            );
+            e.borrow().visit_property_references(&ctx, &mut visit_property);
         }
     }
 

--- a/tests/cases/properties/changes.slint
+++ b/tests/cases/properties/changes.slint
@@ -7,6 +7,9 @@ export global Glob {
     changed v => {
         r += "|" + v;
     }
+
+    private property <int> other: v;
+    changed other => { r += "=" + v }
 }
 
 
@@ -165,7 +168,7 @@ assert_eq!(instance.get_result(), "||sub2(124)root2(124)sub(790)root(790)");
 instance.global::<Glob<'_>>().set_v(88);
 assert_eq!(instance.global::<Glob<'_>>().get_r(), "");
 slint_testing::mock_elapsed_time(100);
-assert_eq!(instance.global::<Glob<'_>>().get_r(), "|88");
+assert_eq!(instance.global::<Glob<'_>>().get_r(), "=88|88");
 ```
 
 ```cpp
@@ -211,7 +214,7 @@ assert_eq(instance.get_result(), "||sub2(124)root2(124)sub(790)root(790)");
 instance.global<Glob>().set_v(88);
 assert_eq(instance.global<Glob>().get_r(), "");
 slint_testing::mock_elapsed_time(100);
-assert_eq(instance.global<Glob>().get_r(), "|88");
+assert_eq(instance.global<Glob>().get_r(), "=88|88");
 ```
 
 ```js
@@ -251,7 +254,7 @@ assert.equal(instance.result, "||sub2(124)root2(124)sub(790)root(790)");
 instance.Glob.v = 88;
 assert.equal(instance.Glob.r, "");
 slintlib.private_api.mock_elapsed_time(100);
-assert.equal(instance.Glob.r, "|88");
+assert.equal(instance.Glob.r, "=88|88");
 ```
 
 */


### PR DESCRIPTION
The code would fail to compile because the property would not be seen as used and would be removed, but not the change callback.

Fixes #8269

Also fix a segfault in the added test because it will initialize the change callback (and therefore query the properties) because the SharedGlobal structure is fully initialized.
So we must only initialize the change callback on global after the SharedGlobal is fully initialized


