### PR TITLE
WGPU: Add support for using WGPU textures in Slint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   'examples/memory',
   'examples/opengl_underlay',
   'examples/opengl_texture',
+  'examples/wgpu_texture',
   'examples/ffmpeg',
   'examples/gstreamer-player',
   'examples/plotter',

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -238,6 +238,8 @@ fn default_config() -> cbindgen::Config {
         // Disable any wasm guarded code in C++, too - so that there are no gaps in enums.
         ("target_arch = wasm32".into(), "SLINT_TARGET_WASM".into()),
         ("target_os = android".into(), "__ANDROID__".into()),
+        // Disable Rust WGPU specific API feature
+        ("feature = unstable-wgpu-24".into(), "SLINT_DISABLED_CODE".into()),
     ]
     .iter()
     .cloned()

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -176,6 +176,13 @@ backend-android-activity-05 = [
   "i-slint-backend-android-activity/aa-05",
 ]
 
+## Enable support for [WGPU](http://wgpu.rs) based rendering and expose WGPU based APIs based on WGPU version 24.x.
+##
+## Access to these APIS is valuable, but as WGPU releases new major versions frequently, this feature as well as the
+## APIs guarded with it are *NOT* subject to the usual Slint API stability guarantees. This will may be removed in future
+## minor releases of Slint, likely to be replaced by a feature with a similar name but the WGPU version suffix being bumped.
+unstable-wgpu-24 = ["i-slint-core/unstable-wgpu-24", "i-slint-backend-selector/unstable-wgpu-24"]
+
 [dependencies]
 i-slint-core = { workspace = true }
 slint-macros = { workspace = true }
@@ -220,4 +227,12 @@ bytemuck = { workspace = true }
 i-slint-backend-qt = { workspace = true, features = ["enable"], optional = true }
 
 [package.metadata.docs.rs]
-features = ["document-features", "log", "gettext", "renderer-software", "renderer-femtovg", "raw-window-handle-06"]
+features = [
+  "document-features",
+  "log",
+  "gettext",
+  "renderer-software",
+  "renderer-femtovg",
+  "raw-window-handle-06",
+  "unstable-wgpu-24",
+]

--- a/examples/wgpu_texture/Cargo.toml
+++ b/examples/wgpu_texture/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "wgpu_texture"
+version = "1.11.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition = "2021"
+build = "build.rs"
+license = "MIT"
+publish = false
+
+[[bin]]
+path = "main.rs"
+name = "wgpu_texture"
+
+[dependencies]
+slint = { path = "../../api/rs/slint", features = ["unstable-wgpu-24"] }
+wgpu-24 = { workspace = true, features = ["wgsl"] }
+bytemuck = { workspace = true }
+
+[build-dependencies]
+slint-build = { path = "../../api/rs/build" }

--- a/examples/wgpu_texture/README.md
+++ b/examples/wgpu_texture/README.md
@@ -1,0 +1,14 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
+# WGPU Texture Import Example
+
+This example application demonstrates how import a WGPU texture into a Slint scene:
+
+1. First a graphical effect is rendered using WGPU, into a texture.
+2. The texture is imported into a `slint::Image` and set on an `Image` element.
+3. A scene of Slint elements is rendered with the texture shown in the `Image`.
+
+This is implemented using the `set_rendering_notifier` function on the `slint::Window` type. It takes a callback as a parameter and that is invoked during different phases of the rendering. In this example the invocation during the setup phase is used to prepare the pipeline for WGPU rendering later. Then the `BeforeRendering` phase is used to render the graphical effect with WGPU into a texture. Then the texture is imported and Slint will render the scene of elements with the texture.
+
+Since the graphical effect is continuous, the code in the callback requests a redraw of the contents by calling `slint::Window::request_redraw()`.
+

--- a/examples/wgpu_texture/build.rs
+++ b/examples/wgpu_texture/build.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    slint_build::compile("scene.slint").unwrap();
+}

--- a/examples/wgpu_texture/scene.slint
+++ b/examples/wgpu_texture/scene.slint
@@ -1,0 +1,79 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Slider, GroupBox, HorizontalBox, VerticalBox, GridBox } from "std-widgets.slint";
+
+export component App inherits Window {
+    in property <image> texture <=> image.source;
+    out property <int> requested-texture-width: image.width/1phx;
+    out property <int> requested-texture-height: image.height/1phx;
+    out property <float> selected-red <=> red.value;
+    out property <float> selected-green <=> green.value;
+    out property <float> selected-blue <=> blue.value;
+
+    preferred-width: 500px;
+    preferred-height: 600px;
+    title: "Slint WGPU Texture Example";
+    icon: @image-url("../../logo/slint-logo-small-light.png");
+
+    VerticalBox {
+        Text {
+            text: "This text is rendered using Slint. The rotating cube below is rendered into an OpenGL texture.";
+            wrap: word-wrap;
+        }
+
+        image := Image {
+            preferred-width: 640px;
+            preferred-height: 640px;
+            min-width: 64px;
+            min-height: 64px;
+            width: 100%;
+            //height: 100%;
+        }
+
+        GroupBox {
+            title: "Cube Color Controls";
+
+            GridBox {
+                Row {
+                    Text {
+                        text: "Red:";
+                        vertical-alignment: center;
+                    }
+
+                    red := Slider {
+                        minimum: 0.1;
+                        maximum: 1.0;
+                        value: 0.2;
+                    }
+                }
+
+                Row {
+                    Text {
+                        text: "Green:";
+                        vertical-alignment: center;
+                    }
+
+                    green := Slider {
+                        minimum: 0.1;
+                        maximum: 1.0;
+                        value: 0.5;
+                    }
+                }
+
+                Row {
+                    Text {
+                        text: "Blue:";
+                        vertical-alignment: center;
+                    }
+
+                    blue := Slider {
+                        minimum: 0.1;
+                        maximum: 1.0;
+                        value: 0.9;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/wgpu_texture/shader.wgsl
+++ b/examples/wgpu_texture/shader.wgsl
@@ -1,0 +1,111 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) frag_position: vec2<f32>,
+};
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) vertex_index: u32
+) -> VertexOutput {
+    var output: VertexOutput;
+
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0,  3.0),
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>( 3.0, -1.0)
+    );
+
+    let pos = positions[vertex_index];
+    output.position = vec4<f32>(pos.x, -pos.y, 0.0, 1.0);
+    output.frag_position = pos;
+    return output;
+}
+
+struct Uniforms {
+    light_color_and_time: vec4<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> u: Uniforms;
+
+fn sdRoundBox(p: vec3<f32>, b: vec3<f32>, r: f32) -> f32 {
+    let q = abs(p) - b;
+    return length(max(q, vec3<f32>(0.0))) + min(max(q.x, max(q.y, q.z)), 0.0) - r;
+}
+
+fn rotateY(r: vec3<f32>, angle: f32) -> vec3<f32> {
+    let c = cos(angle);
+    let s = sin(angle);
+    let rotation_matrix = mat3x3<f32>(
+        vec3<f32>( c, 0.0,  s),
+        vec3<f32>(0.0, 1.0, 0.0),
+        vec3<f32>(-s, 0.0,  c)
+    );
+    return rotation_matrix * r;
+}
+
+fn rotateZ(r: vec3<f32>, angle: f32) -> vec3<f32> {
+    let c = cos(angle);
+    let s = sin(angle);
+    let rotation_matrix = mat3x3<f32>(
+        vec3<f32>( c, -s, 0.0),
+        vec3<f32>( s,  c, 0.0),
+        vec3<f32>(0.0, 0.0, 1.0)
+    );
+    return rotation_matrix * r;
+}
+
+// Distance from the scene
+fn scene(r: vec3<f32>) -> f32 {
+    let iTime = u.light_color_and_time.w;
+    let pos = rotateZ(rotateY(r + vec3<f32>(-1.0, -1.0, 4.0), iTime), iTime);
+    let cube = vec3<f32>(0.5, 0.5, 0.5);
+    let edge = 0.1;
+    return sdRoundBox(pos, cube, edge);
+}
+
+// https://iquilezles.org/articles/normalsSDF
+fn normal(pos: vec3<f32>) -> vec3<f32> {
+    let e = vec2<f32>(1.0, -1.0) * 0.5773;
+    let eps = 0.0005;
+    return normalize(
+        e.xyy * scene(pos + e.xyy * eps) +
+        e.yyx * scene(pos + e.yyx * eps) +
+        e.yxy * scene(pos + e.yxy * eps) +
+        e.xxx * scene(pos + e.xxx * eps)
+    );
+}
+
+fn render(fragCoord: vec2<f32>, light_color: vec3<f32>) -> vec4<f32> {
+    var color = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+
+    var camera = vec3<f32>(1.0, 2.0, 1.0);
+    var p = vec3<f32>(fragCoord.x, fragCoord.y + 1.0, -1.0);
+    var dir = normalize(p - camera);
+
+    var i = 0;
+    loop {
+        if (i >= 90) { break; }
+        let dist = scene(p);
+        if (dist < 0.0001) { break; }
+        p = p + dir * dist;
+        i = i + 1;
+    }
+
+    let surf_normal = normal(p);
+    let light_position = vec3<f32>(2.0, 4.0, -0.5);
+    var light = 7.0 + 2.0 * dot(surf_normal, light_position);
+    light = light / (0.2 * pow(length(light_position - p), 3.5));
+
+    return vec4<f32>(light * light_color, 1.0) * 2.0;
+}
+
+@fragment
+fn fs_main(@location(0) frag_position: vec2<f32>) -> @location(0) vec4<f32> {
+    let selected_light_color = u.light_color_and_time.xyz;
+    let r = vec2<f32>(0.5 * frag_position.x + 1.0, 0.5 - 0.5 * frag_position.y);
+    return render(r, selected_light_color);
+}

--- a/examples/wgpu_texture/shader.wgsl
+++ b/examples/wgpu_texture/shader.wgsl
@@ -24,12 +24,11 @@ fn vs_main(
     return output;
 }
 
-struct Uniforms {
+struct PushConstants {
     light_color_and_time: vec4<f32>,
 };
 
-@group(0) @binding(0)
-var<uniform> u: Uniforms;
+var<push_constant> pc: PushConstants;
 
 fn sdRoundBox(p: vec3<f32>, b: vec3<f32>, r: f32) -> f32 {
     let q = abs(p) - b;
@@ -60,7 +59,7 @@ fn rotateZ(r: vec3<f32>, angle: f32) -> vec3<f32> {
 
 // Distance from the scene
 fn scene(r: vec3<f32>) -> f32 {
-    let iTime = u.light_color_and_time.w;
+    let iTime = pc.light_color_and_time.w;
     let pos = rotateZ(rotateY(r + vec3<f32>(-1.0, -1.0, 4.0), iTime), iTime);
     let cube = vec3<f32>(0.5, 0.5, 0.5);
     let edge = 0.1;
@@ -105,7 +104,7 @@ fn render(fragCoord: vec2<f32>, light_color: vec3<f32>) -> vec4<f32> {
 
 @fragment
 fn fs_main(@location(0) frag_position: vec2<f32>) -> @location(0) vec4<f32> {
-    let selected_light_color = u.light_color_and_time.xyz;
+    let selected_light_color = pc.light_color_and_time.xyz;
     let r = vec2<f32>(0.5 * frag_position.x + 1.0, 0.5 - 0.5 * frag_position.y);
     return render(r, selected_light_color);
 }

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -50,6 +50,12 @@ raw-window-handle-06 = ["i-slint-core/raw-window-handle-06", "i-slint-backend-wi
 
 system-testing = ["i-slint-backend-testing/system-testing"]
 
+unstable-wgpu-24 = [
+  "i-slint-core/unstable-wgpu-24",
+  "i-slint-renderer-skia?/unstable-wgpu-24",
+  "i-slint-backend-winit?/unstable-wgpu-24",
+]
+
 # note that default enable the i-slint-backend-qt, but not its enable feature
 default = ["i-slint-backend-qt", "backend-winit"]
 

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -1,6 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+#![warn(missing_docs)]
+
+/*!
+This module contains types that are public and re-exported in the slint-rs as well as the slint-interpreter crate as public API,
+in particular the `BackendSelector` type.
+*/
+
 use alloc::boxed::Box;
 use alloc::{format, string::String};
 
@@ -86,6 +93,18 @@ impl BackendSelector {
     #[must_use]
     pub fn require_d3d(mut self) -> Self {
         self.requested_graphics_api = Some(RequestedGraphicsAPI::Direct3D);
+        self
+    }
+
+    /// Adds the requirement to the selector that the backend must render using [WGPU](http://wgpu.rs).
+    /// Use this when you integrate other WGPU-based renderers with a Slint UI.
+    ///
+    /// *Note*: This function is behind a feature flag and may be removed or changed in future minor releases,
+    ///         as new major WGPU releases become available.
+    #[cfg(feature = "unstable-wgpu-24")]
+    #[must_use]
+    pub fn require_wgpu_24(mut self) -> Self {
+        self.requested_graphics_api = Some(RequestedGraphicsAPI::WGPU24);
         self
     }
 

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -103,8 +103,11 @@ impl BackendSelector {
     ///         as new major WGPU releases become available.
     #[cfg(feature = "unstable-wgpu-24")]
     #[must_use]
-    pub fn require_wgpu_24(mut self) -> Self {
-        self.requested_graphics_api = Some(RequestedGraphicsAPI::WGPU24);
+    pub fn require_wgpu_24(
+        mut self,
+        configuration: i_slint_core::api::WGPU24Configuration,
+    ) -> Self {
+        self.requested_graphics_api = Some(RequestedGraphicsAPI::WGPU24(configuration));
         self
     }
 

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -54,6 +54,11 @@ renderer-software = [
 ]
 accessibility = ["dep:accesskit", "dep:accesskit_winit"]
 raw-window-handle-06 = ["i-slint-core/raw-window-handle-06"]
+unstable-wgpu-24 = [
+  "i-slint-core/unstable-wgpu-24",
+  "renderer-femtovg-wgpu",
+  "i-slint-renderer-femtovg/unstable-wgpu-24",
+]
 default = []
 
 [dependencies]

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -287,7 +287,7 @@ impl BackendBuilder {
             (Some("femtovg-wgpu"), maybe_graphics_api) => {
                 if !maybe_graphics_api.is_some_and(|_api| {
                     #[cfg(feature = "unstable-wgpu-24")]
-                    if matches!(_api, RequestedGraphicsAPI::WGPU24) {
+                    if matches!(_api, RequestedGraphicsAPI::WGPU24(..)) {
                         return true;
                     }
                     false
@@ -331,7 +331,7 @@ impl BackendBuilder {
                 }
             }
             #[cfg(feature = "unstable-wgpu-24")]
-            (None, Some(RequestedGraphicsAPI::WGPU24)) => {
+            (None, Some(RequestedGraphicsAPI::WGPU24(..))) => {
                 renderer::femtovg::WGPUFemtoVGRenderer::new_suspended
             }
             (None, Some(_requested_graphics_api)) => {

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -100,6 +100,10 @@ impl WinitSkiaRenderer {
                         )
                         .into());
                     }
+                    #[cfg(feature = "unstable-wgpu-24")]
+                    RequestedGraphicsAPI::WGPU24 => {
+                        return Err(format!("WGPU rendering is not supported by Skia").into());
+                    }
                 }
             }
             None => Ok(Self::new_suspended),

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -101,7 +101,7 @@ impl WinitSkiaRenderer {
                         .into());
                     }
                     #[cfg(feature = "unstable-wgpu-24")]
-                    RequestedGraphicsAPI::WGPU24 => {
+                    RequestedGraphicsAPI::WGPU24(..) => {
                         return Err(format!("WGPU rendering is not supported by Skia").into());
                     }
                 }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -63,6 +63,8 @@ raw-window-handle-06 = ["dep:raw-window-handle-06"]
 
 experimental = []
 
+unstable-wgpu-24 = ["dep:wgpu-24"]
+
 default = ["std", "unicode"]
 
 [dependencies]
@@ -113,6 +115,8 @@ chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 
 rustybuzz = { workspace = true, optional = true }
 fontdue = { workspace = true, optional = true }
+
+wgpu-24 = { workspace = true, optional = true }
 
 rustversion = { version = "1.0", optional = true }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -268,6 +268,20 @@ pub enum GraphicsAPI<'a> {
         /// `getContext` function on the HTML Canvas element.
         context_type: &'a str,
     },
+    /// The rendering is based on WGPU 24.x. Use the provided fields to submit commits to the provided
+    /// WGPU command queue.
+    ///
+    /// *Note*: This enum variant is behind a feature flag and may be removed or changed in future minor releases,
+    ///         as new major WGPU releases become available.
+    #[cfg(feature = "unstable-wgpu-24")]
+    WGPU24 {
+        /// The WGPU instance used for rendering.
+        instance: wgpu_24::Instance,
+        /// The WGPU device used for rendering.
+        device: wgpu_24::Device,
+        /// The WGPU queue for used for command submission.
+        queue: wgpu_24::Queue,
+    },
 }
 
 impl core::fmt::Debug for GraphicsAPI<'_> {
@@ -277,6 +291,8 @@ impl core::fmt::Debug for GraphicsAPI<'_> {
             GraphicsAPI::WebGL { context_type, .. } => {
                 write!(f, "GraphicsAPI::WebGL(context_type = {context_type})")
             }
+            #[cfg(feature = "unstable-wgpu-24")]
+            GraphicsAPI::WGPU24 { .. } => write!(f, "GraphicsAPI::WGPU24"),
         }
     }
 }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -16,6 +16,10 @@ use crate::window::{WindowAdapter, WindowInner};
 use alloc::boxed::Box;
 use alloc::string::String;
 
+mod graphics_selection;
+#[cfg(feature = "unstable-wgpu-24")]
+pub use graphics_selection::*;
+
 /// A position represented in the coordinate space of logical pixels. That is the space before applying
 /// a display device specific scale factor.
 #[derive(Debug, Default, Copy, Clone, PartialEq)]

--- a/internal/core/api/graphics_selection.rs
+++ b/internal/core/api/graphics_selection.rs
@@ -1,0 +1,88 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#![warn(missing_docs)]
+
+/*!
+This module contains types that are public and re-exported in the slint-rs as well as the slint-interpreter crate as public API,
+in particular the `BackendSelector` type, to configure the WGPU-based renderer(s).
+*/
+
+/// This data structure provides settings for initializing WGPU renderers.
+#[cfg(feature = "unstable-wgpu-24")]
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct WGPU24Settings {
+    /// The backends to use for the WGPU instance.
+    pub backends: wgpu_24::Backends,
+    /// The different options that are given to the selected backends.
+    pub backend_options: wgpu_24::BackendOptions,
+    /// The flags to fine-tune behaviour of the WGPU instance.
+    pub instance_flags: wgpu_24::InstanceFlags,
+
+    /// The power preference is used to influence the WGPU adapter selection.
+    pub power_preference: wgpu_24::PowerPreference,
+
+    /// The label for the device. This is used to identify the device in debugging tools.
+    pub device_label: Option<std::borrow::Cow<'static, str>>,
+    /// The required features for the device.
+    pub device_required_features: wgpu_24::Features,
+    /// The required limits for the device.
+    pub device_required_limits: wgpu_24::Limits,
+    /// The memory hints for the device.
+    pub device_memory_hints: wgpu_24::MemoryHints,
+}
+
+#[cfg(feature = "unstable-wgpu-24")]
+impl Default for WGPU24Settings {
+    fn default() -> Self {
+        let backends = wgpu_24::Backends::from_env().unwrap_or_default();
+        let dx12_shader_compiler = wgpu_24::Dx12Compiler::from_env().unwrap_or_default();
+        let gles_minor_version = wgpu_24::Gles3MinorVersion::from_env().unwrap_or_default();
+
+        Self {
+            backends,
+            backend_options: wgpu_24::BackendOptions {
+                dx12: wgpu_24::Dx12BackendOptions { shader_compiler: dx12_shader_compiler },
+                gl: wgpu_24::GlBackendOptions { gles_minor_version },
+            },
+            instance_flags: wgpu_24::InstanceFlags::from_build_config().with_env(),
+
+            power_preference: wgpu_24::PowerPreference::from_env().unwrap_or_default(),
+
+            device_label: None,
+            device_required_features: wgpu_24::Features::empty(),
+            device_required_limits: wgpu_24::Limits::downlevel_webgl2_defaults(),
+            device_memory_hints: wgpu_24::MemoryHints::MemoryUsage,
+        }
+    }
+}
+
+/// This enum describes the different ways to configure WGPU for rendering.
+#[cfg(feature = "unstable-wgpu-24")]
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum WGPU24Configuration {
+    /// Use `Manual` if you've initialized WGPU and want to supply the instance, adapter,
+    /// device, and queue for use.
+    Manual {
+        /// The WGPU instance to use.
+        instance: wgpu_24::Instance,
+        /// The WGPU adapter to use.
+        adapter: wgpu_24::Adapter,
+        /// The WGPU device to use.
+        device: wgpu_24::Device,
+        /// The WGPU queue to use.
+        queue: wgpu_24::Queue,
+    },
+    /// Use `Automatic` if you want to let Slint select the WGPU instance, adapter, and
+    /// device, but fine-tune aspects such as memory limits or features.
+    Automatic(WGPU24Settings),
+}
+
+#[cfg(feature = "unstable-wgpu-24")]
+impl Default for WGPU24Configuration {
+    fn default() -> Self {
+        Self::Automatic(WGPU24Settings::default())
+    }
+}

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -187,6 +187,9 @@ pub enum RequestedGraphicsAPI {
     Vulkan,
     /// Direct 3D
     Direct3D,
+    #[cfg(feature = "unstable-wgpu-24")]
+    /// WGPU 24.x
+    WGPU24,
 }
 
 impl TryFrom<RequestedGraphicsAPI> for RequestedOpenGLVersion {
@@ -203,6 +206,10 @@ impl TryFrom<RequestedGraphicsAPI> for RequestedOpenGLVersion {
             }
             RequestedGraphicsAPI::Direct3D => {
                 Err("Direct3D rendering is not supported with an OpenGL renderer".into())
+            }
+            #[cfg(feature = "unstable-wgpu-24")]
+            RequestedGraphicsAPI::WGPU24 => {
+                Err("WGPU 24.x rendering is not supported with an OpenGL renderer".into())
             }
         }
     }

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -177,7 +177,7 @@ pub enum RequestedOpenGLVersion {
 
 /// Internal enum specify which graphics API should be used, when
 /// the backend selector requests that from a built-in backend.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum RequestedGraphicsAPI {
     /// OpenGL (ES)
     OpenGL(RequestedOpenGLVersion),
@@ -189,7 +189,7 @@ pub enum RequestedGraphicsAPI {
     Direct3D,
     #[cfg(feature = "unstable-wgpu-24")]
     /// WGPU 24.x
-    WGPU24,
+    WGPU24(crate::api::WGPU24Configuration),
 }
 
 impl TryFrom<RequestedGraphicsAPI> for RequestedOpenGLVersion {
@@ -208,7 +208,7 @@ impl TryFrom<RequestedGraphicsAPI> for RequestedOpenGLVersion {
                 Err("Direct3D rendering is not supported with an OpenGL renderer".into())
             }
             #[cfg(feature = "unstable-wgpu-24")]
-            RequestedGraphicsAPI::WGPU24 => {
+            RequestedGraphicsAPI::WGPU24(..) => {
                 Err("WGPU 24.x rendering is not supported with an OpenGL renderer".into())
             }
         }

--- a/internal/core/graphics/image/cache.rs
+++ b/internal/core/graphics/image/cache.rs
@@ -28,6 +28,8 @@ impl clru::WeightScale<ImageCacheKey, ImageInner> for ImageWeightInBytes {
             #[cfg(not(target_arch = "wasm32"))]
             ImageInner::BorrowedOpenGLTexture(..) => 0, // Assume storage in GPU memory
             ImageInner::NineSlice(nine) => self.weight(_key, &nine.0),
+            #[cfg(feature = "unstable-wgpu-24")]
+            ImageInner::WGPUTexture(..) => 0, // The texture is imported from the application and will never reside in our cache.
         }
     }
 }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1456,6 +1456,8 @@ pub mod ffi {
     pub enum GraphicsAPI {
         /// The rendering is done using OpenGL.
         NativeOpenGL,
+        /// The rendering is done using APIs inaccessible from C++, such as WGPU.
+        Inaccessible,
     }
 
     #[allow(non_camel_case_types)]
@@ -1649,6 +1651,8 @@ pub mod ffi {
                 let cpp_graphics_api = match graphics_api {
                     crate::api::GraphicsAPI::NativeOpenGL { .. } => GraphicsAPI::NativeOpenGL,
                     crate::api::GraphicsAPI::WebGL { .. } => unreachable!(), // We don't support wasm with C++
+                    #[cfg(feature = "unstable-wgpu-24")]
+                    crate::api::GraphicsAPI::WGPU24 { .. } => GraphicsAPI::Inaccessible, // There is no C++ API for wgpu (maybe wgpu c in the future?)
                 };
                 (self.callback)(state, cpp_graphics_api, self.user_data)
             }

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -19,6 +19,7 @@ path = "lib.rs"
 default = []
 wgpu = ["wgpu-24"]
 wgpu-24 = ["dep:wgpu-24", "femtovg/wgpu"]
+unstable-wgpu-24 = ["wgpu-24"]
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["default", "box-shadow-cache", "shared-fontdb"] }

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -25,7 +25,7 @@ use i_slint_core::lengths::{
 };
 use i_slint_core::{Brush, Color, ImageInner, SharedString};
 
-use crate::images::OpenGLTextureImporter;
+use crate::images::TextureImporter;
 
 use super::images::{Texture, TextureCacheKey};
 use super::PhysicalSize;
@@ -36,7 +36,7 @@ type FemtovgBoxShadowCache<R> = BoxShadowCache<ItemGraphicsCacheEntry<R>>;
 pub use femtovg::Canvas;
 pub type CanvasRc<R> = Rc<RefCell<Canvas<R>>>;
 
-pub enum ItemGraphicsCacheEntry<R: femtovg::Renderer + OpenGLTextureImporter> {
+pub enum ItemGraphicsCacheEntry<R: femtovg::Renderer + TextureImporter> {
     Texture(Rc<Texture<R>>),
     ColorizedImage {
         // This original image Rc is kept here to keep the image in the shared image cache, so that
@@ -46,7 +46,7 @@ pub enum ItemGraphicsCacheEntry<R: femtovg::Renderer + OpenGLTextureImporter> {
     },
 }
 
-impl<R: femtovg::Renderer + OpenGLTextureImporter> Clone for ItemGraphicsCacheEntry<R> {
+impl<R: femtovg::Renderer + TextureImporter> Clone for ItemGraphicsCacheEntry<R> {
     fn clone(&self) -> Self {
         match self {
             Self::Texture(arg0) => Self::Texture(arg0.clone()),
@@ -58,7 +58,7 @@ impl<R: femtovg::Renderer + OpenGLTextureImporter> Clone for ItemGraphicsCacheEn
     }
 }
 
-impl<R: femtovg::Renderer + OpenGLTextureImporter> ItemGraphicsCacheEntry<R> {
+impl<R: femtovg::Renderer + TextureImporter> ItemGraphicsCacheEntry<R> {
     fn as_texture(&self) -> &Rc<Texture<R>> {
         match self {
             ItemGraphicsCacheEntry::Texture(image) => image,
@@ -81,7 +81,7 @@ struct State {
     current_render_target: femtovg::RenderTarget,
 }
 
-pub struct GLItemRenderer<'a, R: femtovg::Renderer + OpenGLTextureImporter> {
+pub struct GLItemRenderer<'a, R: femtovg::Renderer + TextureImporter> {
     graphics_cache: &'a ItemGraphicsCache<R>,
     texture_cache: &'a RefCell<super::images::TextureCache<R>>,
     box_shadow_cache: FemtovgBoxShadowCache<R>,
@@ -188,13 +188,13 @@ fn clip_path_for_rect_alike_item(
     rect_with_radius_to_path(clip_rect, radius)
 }
 
-impl<'a, R: femtovg::Renderer + OpenGLTextureImporter> GLItemRenderer<'a, R> {
+impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
     pub fn global_alpha_transparent(&self) -> bool {
         self.state.last().unwrap().global_alpha == 0.0
     }
 }
 
-impl<'a, R: femtovg::Renderer + OpenGLTextureImporter> ItemRenderer for GLItemRenderer<'a, R> {
+impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer<'a, R> {
     fn draw_rectangle(
         &mut self,
         rect: Pin<&dyn RenderRectangle>,
@@ -1111,7 +1111,7 @@ impl<'a, R: femtovg::Renderer + OpenGLTextureImporter> ItemRenderer for GLItemRe
     }
 }
 
-impl<'a, R: femtovg::Renderer + OpenGLTextureImporter> GLItemRenderer<'a, R> {
+impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
     pub(super) fn new(
         canvas: &CanvasRc<R>,
         graphics_cache: &'a ItemGraphicsCache<R>,

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -23,7 +23,7 @@ use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::RendererSealed;
 use i_slint_core::window::{WindowAdapter, WindowInner};
 use i_slint_core::Brush;
-use images::OpenGLTextureImporter;
+use images::TextureImporter;
 
 type PhysicalLength = euclid::Length<f32, PhysicalPx>;
 type PhysicalRect = euclid::Rect<f32, PhysicalPx>;
@@ -45,7 +45,7 @@ pub trait WindowSurface<R: femtovg::Renderer> {
 }
 
 pub trait GraphicsBackend {
-    type Renderer: femtovg::Renderer + OpenGLTextureImporter;
+    type Renderer: femtovg::Renderer + TextureImporter;
     type WindowSurface: WindowSurface<Self::Renderer>;
     const NAME: &'static str;
     fn new_suspended() -> Self;

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -24,6 +24,7 @@ x11 = ["glutin/x11", "glutin/glx", "softbuffer/x11", "softbuffer/x11-dlopen"]
 opengl = []
 vulkan = ["skia-safe/vulkan", "ash", "vulkano"]
 kms = ["softbuffer/kms"]
+unstable-wgpu-24 = ["i-slint-core/unstable-wgpu-24"]
 default = []
 
 [dependencies]

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -132,6 +132,8 @@ pub(crate) fn as_skia_image(
         ImageInner::NineSlice(n) => {
             as_skia_image(n.image(), target_size_fn, ImageFit::Preserve, scale_factor, canvas)
         }
+        #[cfg(feature = "unstable-wgpu-24")]
+        ImageInner::WGPUTexture(..) => None,
     }
 }
 

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -260,7 +260,9 @@ impl super::Surface for D3DSurface {
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
-        if requested_graphics_api.map_or(false, |api| api != RequestedGraphicsAPI::Direct3D) {
+        if requested_graphics_api
+            .map_or(false, |api| !matches!(api, RequestedGraphicsAPI::Direct3D))
+        {
             return Err(format!("Requested non-Direct3D rendering with Direct3D renderer").into());
         }
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -14,7 +14,8 @@ use i_slint_core::api::{
 };
 use i_slint_core::graphics::euclid::{self, Vector2D};
 use i_slint_core::graphics::rendering_metrics_collector::RenderingMetricsCollector;
-use i_slint_core::graphics::{BorderRadius, FontRequest, RequestedGraphicsAPI, SharedPixelBuffer};
+use i_slint_core::graphics::RequestedGraphicsAPI;
+use i_slint_core::graphics::{BorderRadius, FontRequest, SharedPixelBuffer};
 use i_slint_core::item_rendering::{DirtyRegion, ItemCache, ItemRenderer, PartialRenderingState};
 use i_slint_core::lengths::{
     LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PhysicalPx, ScaleFactor,

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -33,7 +33,7 @@ impl super::Surface for MetalSurface {
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
-        if requested_graphics_api.map_or(false, |api| api != RequestedGraphicsAPI::Metal) {
+        if requested_graphics_api.map_or(false, |api| !matches!(api, RequestedGraphicsAPI::Metal)) {
             return Err(format!("Requested non-Metal rendering with Metal renderer").into());
         }
 

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -11,13 +11,10 @@ use glutin::{
     prelude::*,
     surface::{SurfaceAttributesBuilder, WindowSurface},
 };
-use i_slint_core::graphics::RequestedGraphicsAPI;
+use i_slint_core::api::{GraphicsAPI, PhysicalSize as PhysicalWindowSize, Window};
+use i_slint_core::graphics::{RequestedGraphicsAPI, RequestedOpenGLVersion};
 use i_slint_core::item_rendering::DirtyRegion;
-use i_slint_core::{api::GraphicsAPI, platform::PlatformError};
-use i_slint_core::{
-    api::{PhysicalSize as PhysicalWindowSize, Window},
-    graphics::RequestedOpenGLVersion,
-};
+use i_slint_core::platform::PlatformError;
 
 /// This surface type renders into the given window with OpenGL, using glutin and glow libraries.
 pub struct OpenGLSurface {

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -163,7 +163,8 @@ impl super::Surface for VulkanSurface {
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {
-        if requested_graphics_api.map_or(false, |api| api != RequestedGraphicsAPI::Vulkan) {
+        if requested_graphics_api.map_or(false, |api| !matches!(api, RequestedGraphicsAPI::Vulkan))
+        {
             return Err(format!("Requested non-Vulkan rendering with Vulkan renderer").into());
         }
         let library = VulkanLibrary::new()

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -532,6 +532,7 @@ lazy_static! {
         ("\\.txt$", LicenseLocation::NoLicense),
         ("\\.ui$", LicenseLocation::NoLicense),
         ("\\.webp$", LicenseLocation::NoLicense),
+        ("\\.wgsl$", LicenseLocation::Tag(LicenseTagStyle::c_style_comment_style())),
         ("\\.xml$", LicenseLocation::NoLicense),
         ("\\.yaml$", LicenseLocation::Tag(LicenseTagStyle::shell_comment_style())),
         ("\\.yml$", LicenseLocation::Tag(LicenseTagStyle::shell_comment_style())),


### PR DESCRIPTION
This adds a `unstable-wgpu-24` feature that exposes WGPU types in the GraphicsAPI enum, adds `require_wgpu_24()` to the backend selector, and adds a conversion from `wgpu::Texture` to `slint::Image`.

The `require_wgpu_24()` function in the selector will be extended in the future (before the next release) to permit specifying additional aspects of the WGPU configuration.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
