### PR TITLE
regression when reducing sanitizers

### DIFF
--- a/tools/figma-inspector/backend/utils/export-variables.ts
+++ b/tools/figma-inspector/backend/utils/export-variables.ts
@@ -307,7 +307,7 @@ function createReferenceExpression(
 
     const propertyPath = targetPath
         .map((part) => sanitizePropertyName(part))
-        .join(".");
+        .join("/");
     const targetVariableModesMap =
         targetCollectionData.variables.get(propertyPath);
 
@@ -1017,7 +1017,7 @@ export async function exportFigmaVariablesToSeparateFiles(
             });
         }
 
-        // THEN process the variables for each collection
+        // process the variables for each collection
         for (const collection of variableCollections) {
             const collectionName = sanitizePropertyName(collection.name);
 


### PR DESCRIPTION
broke variable values due to separator inconsistency

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
