### PR TITLE
Created an accessor for the Qt backend to access a window's `QWidget`

### DIFF
--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -311,3 +311,21 @@ impl i_slint_core::platform::Platform for Backend {
         core::time::Duration::from_millis(duration_ms as u64)
     }
 }
+
+/// This helper trait can be used to obtain access to a pointer to a QtWidget for a given
+/// [`slint::Window`](slint:rust:slint/struct.window).")]
+#[cfg(not(no_qt))]
+pub trait QtWidgetAccessor {
+    fn qt_widget_ptr(&self) -> Option<std::ptr::NonNull<()>>;
+}
+
+#[cfg(not(no_qt))]
+impl QtWidgetAccessor for i_slint_core::api::Window {
+    fn qt_widget_ptr(&self) -> Option<std::ptr::NonNull<()>> {
+        i_slint_core::window::WindowInner::from_pub(self)
+            .window_adapter()
+            .internal(i_slint_core::InternalToken)
+            .and_then(|wa| wa.as_any().downcast_ref::<qt_window::QtWindow>())
+            .map(qt_window::QtWindow::widget_ptr)
+    }
+}

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1713,7 +1713,7 @@ impl QtWindow {
     }
 
     /// Return the QWidget*
-    fn widget_ptr(&self) -> NonNull<()> {
+    pub fn widget_ptr(&self) -> NonNull<()> {
         unsafe { std::mem::transmute_copy::<QWidgetPtr, NonNull<_>>(&self.widget_ptr) }
     }
 


### PR DESCRIPTION
This is a hook for the Qt backend that provides the ability to access the `QWidget` for a window, similar to how the `winit` back end supports accessing the `winit` `Window` object

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
