### PR TITLE
examples: Do not fail `todo` example test

### DIFF
--- a/examples/todo/rust/lib.rs
+++ b/examples/todo/rust/lib.rs
@@ -170,7 +170,7 @@ impl SerializedState {
 
 #[test]
 fn press_add_adds_one_todo() {
-    if std::env::var_os("SLINT_EMIT_DEBUG_INFO").unwrap_or_default() != "1" {
+    if option_env!("SLINT_EMIT_DEBUG_INFO").unwrap_or_default() != "1" {
         println!("This test needs to be build with `SLINT_EMIT_DEBUG_INFO=1` in the environment");
         return;
     }

--- a/examples/todo/rust/lib.rs
+++ b/examples/todo/rust/lib.rs
@@ -170,6 +170,10 @@ impl SerializedState {
 
 #[test]
 fn press_add_adds_one_todo() {
+    if std::env::var_os("SLINT_EMIT_DEBUG_INFO").unwrap_or_default() != "1" {
+        println!("This test needs to be build with `SLINT_EMIT_DEBUG_INFO=1` in the environment");
+        return;
+    }
     i_slint_backend_testing::init_no_event_loop();
     use i_slint_backend_testing::{ElementHandle, ElementQuery};
     let state = init();


### PR DESCRIPTION
... when `SLINT_EMIT_DEBUG_INFO` is not set.
