### PR TITLE
figma-inspector: Restore type safety for message interface

### DIFF
--- a/tools/figma-inspector/backend/code.ts
+++ b/tools/figma-inspector/backend/code.ts
@@ -99,11 +99,10 @@ figma.on("selectionchange", () => {
     }
 });
 
-listenTS("exportToFiles", async (payload: { exportAsSingleFile?: boolean }) => {
-    const shouldExportAsSingleFile = payload?.exportAsSingleFile ?? false;
+listenTS("exportToFiles", async (message) => {
     try {
         const files = await exportFigmaVariablesToSeparateFiles(
-            shouldExportAsSingleFile,
+            message.exportAsSingleFile,
         );
 
         // Send to UI for downloading

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -59,7 +59,7 @@ export const App = () => {
     const [useVariables, setUseVariables] = useState(false); // Default to false
 
     listenTS("updatePropertiesCallback", (res) => {
-        setTitle(res.title || "");
+        setTitle(res.title);
         setSlintProperties(res.slintSnippet || "");
     });
 

--- a/tools/figma-inspector/src/utils/bolt-utils.ts
+++ b/tools/figma-inspector/src/utils/bolt-utils.ts
@@ -24,8 +24,7 @@ export const dispatchTS = <Key extends keyof EventTS>(
 
 export const listenTS = <Key extends keyof EventTS>(
     eventName: Key,
-    // --- Adjust callback type to expect the whole message ---
-    callback: (data: any) => any, // Use 'any' for simplicity or define a more specific type
+    callback: (data: EventTS[Key]) => any,
     listenOnce = false,
 ) => {
     const func = (event: MessageEvent<any>) => {
@@ -33,10 +32,10 @@ export const listenTS = <Key extends keyof EventTS>(
         if (event.data && event.data.pluginMessage) {
             const pluginMessage = event.data.pluginMessage;
 
-            // --- Check for 'type' property instead of 'event' ---
             if (pluginMessage.type === eventName) {
-                // --- Pass the whole pluginMessage object to the callback ---
-                callback(pluginMessage);
+                // We've verified the type, so we can safely cast
+                const eventData = pluginMessage as EventTS[Key];
+                callback(eventData);
                 if (listenOnce) {
                     window.removeEventListener("message", func);
                 }


### PR DESCRIPTION
listenTS's callback should only receive the data structures that match the event.

Also tidy up a few other event listener callbacks.