### PR TITLE
figma-inspector: corrected overwrite of reused modes 

### DIFF
--- a/tools/figma-inspector/backend/utils/export-variables.ts
+++ b/tools/figma-inspector/backend/utils/export-variables.ts
@@ -610,7 +610,7 @@ function generateStructsAndInstances(
                     name: sanitizedChildName,
                     type:
                         collectionData.modes.size > 1
-                            ? `mode${collectionData.modes.size}_${slintType}`
+                            ? `${collectionData.formattedName}_mode${collectionData.modes.size}_${slintType}`
                             : slintType,
                     isMultiMode: collectionData.modes.size > 1,
                 });
@@ -902,7 +902,7 @@ function generateStructsAndInstances(
             }
             // Root level property
             const slintType = instance.isMultiMode
-                ? `mode${collectionData.modes.size}_${instance.type}`
+                ? `${collectionData.formattedName}_mode${collectionData.modes.size}_${instance.type}`
                 : instance.type;
 
             if (instance.children && instance.children.size > 0) {
@@ -922,7 +922,7 @@ function generateStructsAndInstances(
             } else if (instance.modeData) {
                 const isRoot = indent === "    ";
                 const slintType = instance.isMultiMode
-                    ? `mode${collectionData.modes.size}_${instance.type}`
+                    ? `${collectionData.formattedName}_mode${collectionData.modes.size}_${instance.type}`
                     : instance.type;
                 // Root Value Instance
                 if (instance.isMultiMode) {
@@ -1930,7 +1930,7 @@ function generateSchemeStructs(
 
 function collectMultiModeStructs(
     node: VariableNode,
-    collectionData: { modes: Set<string> },
+    collectionData: { modes: Set<string>; formattedName: string },
     structDefinitions: string[],
 ) {
     if (collectionData.modes.size <= 1) {
@@ -1942,7 +1942,7 @@ function collectMultiModeStructs(
 
     // Generate a struct for each type regardless of whether it's used
     for (const slintType of allSlintTypes) {
-        const structName = `mode${collectionData.modes.size}_${slintType}`;
+        const structName = `${collectionData.formattedName}_mode${collectionData.modes.size}_${slintType}`;
 
         let structDef = `struct ${structName} {\n`;
         for (const mode of collectionData.modes) {
@@ -1961,7 +1961,7 @@ function collectMultiModeStructs(
                 // Skip if we already added this type
                 if (!allSlintTypes.includes(slintType)) {
                     // Add a struct for this additional type
-                    const structName = `mode${collectionData.modes.size}_${slintType}`;
+                    const structName = `${collectionData.formattedName}_mode${collectionData.modes.size}_${slintType}`;
 
                     let structDef = `struct ${structName} {\n`;
                     for (const mode of collectionData.modes) {

--- a/tools/figma-inspector/backend/utils/export-variables.ts
+++ b/tools/figma-inspector/backend/utils/export-variables.ts
@@ -543,7 +543,7 @@ interface PropertyInstance {
 function generateStructsAndInstances(
     variableTree: VariableNode,
     collectionName: string,
-    collectionData: any, // Using any for now, but ideally define a proper interface
+    collectionData: CollectionData, // using strict type interface
 ): {
     structs: string;
     instances: string;
@@ -1069,6 +1069,19 @@ function generateStructsAndInstances(
         instances: instancesCode,
     };
 }
+interface VariableModeData {
+    value: string;
+    type: string;
+    refId?: string;
+    comment?: string;
+}
+
+interface CollectionData {
+    name: string;
+    formattedName: string;
+    modes: Set<string>;
+    variables: Map<string, Map<string, VariableModeData>>;
+}
 
 // For Figma Plugin - Export function with hierarchical structure
 // Export each collection to a separate virtual file
@@ -1093,26 +1106,7 @@ export async function exportFigmaVariablesToSeparateFiles(
         const exportedFiles: Array<{ name: string; content: string }> = [];
 
         // First, initialize the collection structure for ALL collections
-        const collectionStructure = new Map<
-            string,
-            {
-                name: string;
-                formattedName: string;
-                modes: Set<string>;
-                variables: Map<
-                    string,
-                    Map<
-                        string,
-                        {
-                            value: string;
-                            type: string;
-                            refId?: string;
-                            comment?: string;
-                        }
-                    >
-                >;
-            }
-        >();
+        const collectionStructure = new Map<string, CollectionData>();
 
         // Build a global map of variable paths
         const variablePathsById = new Map<
@@ -1193,17 +1187,12 @@ export async function exportFigmaVariablesToSeparateFiles(
                             .get(collectionName)!
                             .variables.has(sanitizedRowName)
                     ) {
-                        collectionStructure.get(collectionName)!.variables.set(
-                            sanitizedRowName,
-                            new Map<
-                                string,
-                                {
-                                    value: string;
-                                    type: string;
-                                    refId?: string;
-                                }
-                            >(),
-                        );
+                        collectionStructure
+                            .get(collectionName)!
+                            .variables.set(
+                                sanitizedRowName,
+                                new Map<string, VariableModeData>(),
+                            );
                     }
 
                     // Process values for each mode


### PR DESCRIPTION
when combining collections, mode3_brush was too ambiguous.  
now using <collection>_mode3_brush 
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
