### PR TITLE
Fix pnpm missing script permissions

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -31,7 +31,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4.1.0
               with:
-                version: 10.9.0
+                version: 10.10.0
             - name: Set up rgb crate rustdoc link
               run: |
                   rgb_version=`grep 'rgb = '  internal/core/Cargo.toml | sed 's/^.*"\(.*\)"/\1/'`

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
               id: node-install
             - uses: pnpm/action-setup@v4.1.0
               with:
-                version: 10.9.0
+                version: 10.10.0
             - uses: ./.github/actions/setup-rust
               with:
                   key: x-napi-v2-${{ steps.node-install.outputs.node-version }} # the cache key consists of a manually bumpable version and the node version, as the cached rustc artifacts contain linking information where to find node.lib, which is in a versioned directory.
@@ -354,7 +354,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4.1.0
               with:
-                version: 10.9.0
+                version: 10.10.0
             - uses: Swatinem/rust-cache@v2
               with:
                 key: "vsce_1" # increment this to bust the cache if needed
@@ -682,7 +682,7 @@ jobs:
               id: node-install
             - uses: pnpm/action-setup@v4.1.0
               with:
-                version: 10.9.0
+                version: 10.10.0
             - name: Run pnpm install
               working-directory: tools/figma-inspector
               run: pnpm install --frozen-lockfile

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -238,7 +238,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4.1.0
               with:
-                version: 10.9.0
+                version: 10.10.0
             - name: Install GNU Sed
               run: brew install gnu-sed
             - uses: actions/setup-node@v4
@@ -320,7 +320,7 @@ jobs:
               id: node-install
             - uses: pnpm/action-setup@v4.1.0
               with:
-                version: 10.9.0
+                version: 10.10.0
             - name: Run pnpm install
               working-directory: tools/figma-inspector
               run: pnpm install --frozen-lockfile

--- a/.github/workflows/wasm_editor_and_interpreter.yaml
+++ b/.github/workflows/wasm_editor_and_interpreter.yaml
@@ -23,7 +23,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4.1.0
               with:
-                version: 10.9.0
+                version: 10.10.0
             - uses: actions/setup-node@v4
               with:
                 node-version: 20
@@ -61,7 +61,7 @@ jobs:
                 node-version: 20
             - uses: pnpm/action-setup@v4.1.0
               with:
-                version: 10.9.0
+                version: 10.10.0
             - name: Download wasm_lsp Artifacts
               uses: actions/download-artifact@v4
               with:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
       "@babel/helpers@<7.26.10": ">=7.26.10"
     },
     "onlyBuiltDependencies": [
-      "esbuild"
+      "@biomejs/biome",
+      "esbuild",
+      "sharp"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,8 @@
     "lint:fix": "pnpm --stream -r lint:fix",
     "type-check": "pnpm --stream -r type-check"
   },
-  "packageManager": "pnpm@10.9.0",
+  "packageManager": "pnpm@10.10.0",
   "pnpm": {
-    "overrides": {
-      "@babel/runtime@<7.26.10": ">=7.26.10",
-      "@babel/helpers@<7.26.10": ">=7.26.10"
-    },
     "onlyBuiltDependencies": [
       "@biomejs/biome",
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@babel/runtime@<7.26.10': '>=7.26.10'
-  '@babel/helpers@<7.26.10': '>=7.26.10'
-
 importers:
 
   .: {}


### PR DESCRIPTION
Bump to the newest pnpm.
Add some missing script permissions for Biome and Sharp.
Remove some old security override fix that is no longer needed as the packages were properly fixed.