### PR TITLE
Use Zustand to handle state and simplify Main.tsx

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      zustand:
+        specifier: 5.0.3
+        version: 5.0.3(@types/react@19.1.2)(react@19.1.0)
     devDependencies:
       '@figma/plugin-typings':
         specifier: 1.110.0
@@ -4890,6 +4893,24 @@ packages:
 
   zod@3.24.3:
     resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+
+  zustand@5.0.3:
+    resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -10364,5 +10385,10 @@ snapshots:
       zod: 3.24.3
 
   zod@3.24.3: {}
+
+  zustand@5.0.3(@types/react@19.1.2)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.1.2
+      react: 19.1.0
 
   zwitch@2.0.4: {}

--- a/tools/figma-inspector/package.json
+++ b/tools/figma-inspector/package.json
@@ -21,23 +21,24 @@
   },
   "devDependencies": {
     "@figma/plugin-typings": "1.110.0",
+    "@types/jszip": "3.4.0",
     "@types/node": "20.16.10",
     "@types/react": "19.1.2",
     "@types/react-dom": "19.1.2",
     "@vitejs/plugin-react": "4.4.1",
     "cross-env": "7.0.3",
+    "jszip": "3.10.1",
     "shiki": "3.3.0",
     "typescript": "5.8.3",
     "vite": "6.3.3",
     "vite-figma-plugin": "0.0.24",
     "vite-plugin-singlefile": "2.2.0",
-    "vitest": "3.1.2",
-    "@types/jszip": "3.4.0",
-    "jszip": "3.10.1"
+    "vitest": "3.1.2"
   },
   "dependencies": {
     "html-react-parser": "5.2.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "zustand": "5.0.3"
   }
 }

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -5,9 +5,7 @@ import {
     useEffect,
     useState,
     useCallback,
-    useRef,
-    type ReactNode,
-    use,
+    useRef
 } from "react";
 import JSZip from "jszip";
 import {
@@ -16,7 +14,6 @@ import {
     getColorTheme,
     subscribeColorTheme,
 } from "./utils/bolt-utils";
-import { copyToClipboard } from "./utils/utils.js";
 import CodeSnippet from "./snippet/CodeSnippet";
 import "./main.css";
 import { useInspectorStore } from "./utils/store";
@@ -39,7 +36,7 @@ const downloadFile = (filename: string, text: string) => {
 export const App = () => {
     const [exportsAreCurrent, setExportsAreCurrent] = useState(false);
 
-    const { title, slintSnippet, initializeEventListeners } = useInspectorStore();
+    const { title, slintSnippet, copyToClipboard, initializeEventListeners } = useInspectorStore();
 
     const [exportedFiles, setExportedFiles] = useState<
         Array<{ name: string; content: string }>
@@ -322,10 +319,10 @@ export const App = () => {
             >
                 <span
                     id="copy-icon"
-                    onClick={() => copyToClipboard(slintSnippet)}
+                    onClick={() => copyToClipboard()}
                     onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") {
-                            copyToClipboard(slintSnippet);
+                            copyToClipboard();
                         }
                     }}
                     className="copy-icon"

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -9,7 +9,6 @@ import {
 } from "react";
 import {
     dispatchTS,
-    listenTS,
     getColorTheme,
     subscribeColorTheme,
 } from "./utils/bolt-utils";
@@ -25,7 +24,7 @@ export const App = () => {
         exportsAreCurrent, exportedFiles, title, slintSnippet,
         useVariables, exportAsSingleFile, menuOpen,
         copyToClipboard, initializeEventListeners, setUseVariables,
-        setExportsAreCurrent, setExportedFiles, setExportAsSingleFile,
+        setExportsAreCurrent, setExportAsSingleFile,
         setMenuOpen, toggleMenu, exportFiles
     } = useInspectorStore();
 
@@ -112,47 +111,6 @@ export const App = () => {
             dispatchTS("monitorVariableChanges", { enabled: false });
         };
     }, []);
-
-    // Export files handler
-    useEffect(() => {
-        const exportFilesHandler = async (res: any) => {
-            // Make the handler async
-            if (res.files && Array.isArray(res.files) && res.files.length > 0) {
-                // Ensure files exist
-                setExportedFiles(res.files);
-
-                // Mark exports as current
-                setExportsAreCurrent(true);
-
-                //  Automatically trigger download
-                await downloadZipFile(res.files); // Call downloadZipFile with the received files
-                //  End automatic download
-            } else {
-                console.error("Invalid or empty files data received:", res);
-                // Reset state if files are invalid/empty after an export attempt
-                setExportedFiles([]);
-                setExportsAreCurrent(false); // Mark as not current if export failed to produce files
-            }
-        };
-
-        // Register the handler with listenTS
-        listenTS("exportedFiles", exportFilesHandler);
-
-        // Also add direct message listener as backup
-        const directHandler = (event: MessageEvent) => {
-            if (
-                event.data.pluginMessage &&
-                event.data.pluginMessage.type === "exportedFiles"
-            ) {
-                exportFilesHandler(event.data.pluginMessage); // Call the same async handler
-            }
-        };
-
-        window.addEventListener("message", directHandler);
-        return () => window.removeEventListener("message", directHandler);
-    }, []);
-
-
 
     const buttonStyle: React.CSSProperties = {
         border: `none`,

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -20,19 +20,15 @@ import { downloadZipFile } from "./utils/utils.js";
 
 
 export const App = () => {
-    const [exportsAreCurrent, setExportsAreCurrent] = useState(false);
 
     const {
-        title, slintSnippet, useVariables,
-        copyToClipboard, initializeEventListeners, setUseVariables
+        exportsAreCurrent, exportedFiles, title, slintSnippet, 
+        useVariables, exportAsSingleFile,
+        copyToClipboard, initializeEventListeners, setUseVariables, setExportsAreCurrent,
+        setExportedFiles, setExportAsSingleFile
     } = useInspectorStore();
 
-    const [exportedFiles, setExportedFiles] = useState<
-        Array<{ name: string; content: string }>
-    >([]);
     const [lightOrDarkMode, setLightOrDarkMode] = useState(getColorTheme());
-    // State for the export format toggle
-    const [exportAsSingleFile, setExportAsSingleFile] = useState(false); // Default to multiple files
     //  Add state for dropdown visibility
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const menuRef = useRef<HTMLDivElement>(null); // Ref for the menu
@@ -74,6 +70,7 @@ export const App = () => {
             document.removeEventListener("mousedown", handleClickOutside);
         };
     }, [isMenuOpen]); // Re-run effect when isMenuOpen changes
+
     const handleCheckboxChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement>) => {
             const checked = event.target.checked;

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -7,6 +7,7 @@ import {
     useCallback,
     useRef,
     type ReactNode,
+    use,
 } from "react";
 import JSZip from "jszip";
 import {
@@ -18,6 +19,8 @@ import {
 import { copyToClipboard } from "./utils/utils.js";
 import CodeSnippet from "./snippet/CodeSnippet";
 import "./main.css";
+import { useInspectorStore } from "./utils/store";
+
 
 // Add file download functionality
 const downloadFile = (filename: string, text: string) => {
@@ -35,8 +38,9 @@ const downloadFile = (filename: string, text: string) => {
 
 export const App = () => {
     const [exportsAreCurrent, setExportsAreCurrent] = useState(false);
-    const [title, setTitle] = useState("");
-    const [slintProperties, setSlintProperties] = useState("");
+
+    const { title, slintSnippet, initializeEventListeners } = useInspectorStore();
+
     const [exportedFiles, setExportedFiles] = useState<
         Array<{ name: string; content: string }>
     >([]);
@@ -58,10 +62,7 @@ export const App = () => {
     }, [exportAsSingleFile]);
     const [useVariables, setUseVariables] = useState(false); // Default to false
 
-    listenTS("updatePropertiesCallback", (res) => {
-        setTitle(res.title);
-        setSlintProperties(res.slintSnippet || "");
-    });
+
 
     useEffect(() => {
         const handleSelectionChange = () => {
@@ -123,6 +124,7 @@ export const App = () => {
 
     // Theme handling
     useEffect(() => {
+        initializeEventListeners();
         subscribeColorTheme((mode) => {
             setLightOrDarkMode(mode);
         });
@@ -320,10 +322,10 @@ export const App = () => {
             >
                 <span
                     id="copy-icon"
-                    onClick={() => copyToClipboard(slintProperties)}
+                    onClick={() => copyToClipboard(slintSnippet)}
                     onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") {
-                            copyToClipboard(slintProperties);
+                            copyToClipboard(slintSnippet);
                         }
                     }}
                     className="copy-icon"
@@ -385,7 +387,7 @@ export const App = () => {
                 }}
             >
                 <CodeSnippet
-                    code={slintProperties || "// Select a component to inspect"}
+                    code={slintSnippet || "// Select a component to inspect"}
                     theme={
                         lightOrDarkMode === "dark"
                             ? "dark-slint"

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -22,31 +22,20 @@ import { downloadZipFile } from "./utils/utils.js";
 export const App = () => {
 
     const {
-        exportsAreCurrent, exportedFiles, title, slintSnippet, 
-        useVariables, exportAsSingleFile,
-        copyToClipboard, initializeEventListeners, setUseVariables, setExportsAreCurrent,
-        setExportedFiles, setExportAsSingleFile
+        exportsAreCurrent, exportedFiles, title, slintSnippet,
+        useVariables, exportAsSingleFile, menuOpen,
+        copyToClipboard, initializeEventListeners, setUseVariables,
+        setExportsAreCurrent, setExportedFiles, setExportAsSingleFile,
+        setMenuOpen, toggleMenu, exportFiles
     } = useInspectorStore();
 
     const [lightOrDarkMode, setLightOrDarkMode] = useState(getColorTheme());
-    //  Add state for dropdown visibility
-    const [isMenuOpen, setIsMenuOpen] = useState(false);
     const menuRef = useRef<HTMLDivElement>(null); // Ref for the menu
     const buttonRef = useRef<HTMLButtonElement>(null); // Ref for the button
-    const toggleMenu = useCallback(() => {
-        setIsMenuOpen((prev) => !prev);
-    }, []);
-    const handleExportClick = useCallback(() => {
-        setExportedFiles([]);
-        setExportsAreCurrent(false);
-        dispatchTS("exportToFiles", { exportAsSingleFile: exportAsSingleFile });
-        setIsMenuOpen(false); // Close menu after clicking export
-    }, [exportAsSingleFile]);
-
 
     useEffect(() => {
         // Only add listener if menu is open
-        if (!isMenuOpen) {
+        if (!menuOpen) {
             return;
         }
 
@@ -58,7 +47,7 @@ export const App = () => {
                 buttonRef.current && // Also check the button ref
                 !buttonRef.current.contains(event.target as Node)
             ) {
-                setIsMenuOpen(false); // Close the menu
+                setMenuOpen(false); // Close the menu
             }
         };
 
@@ -69,16 +58,7 @@ export const App = () => {
         return () => {
             document.removeEventListener("mousedown", handleClickOutside);
         };
-    }, [isMenuOpen]); // Re-run effect when isMenuOpen changes
-
-    const handleCheckboxChange = useCallback(
-        (event: React.ChangeEvent<HTMLInputElement>) => {
-            const checked = event.target.checked;
-            setExportAsSingleFile(checked);
-            // Keep menu open when checkbox is toggled
-        },
-        [useVariables],
-    );
+    }, [menuOpen]); // Re-run effect when isMenuOpen changes
 
 
     // Theme handling
@@ -188,8 +168,8 @@ export const App = () => {
         cursor: "pointer",
         position: "relative",
         textAlign: "center",
-        opacity: isMenuOpen ? 0.6 : 1,
-        pointerEvents: isMenuOpen ? "none" : "auto",
+        opacity: menuOpen ? 0.6 : 1,
+        pointerEvents: menuOpen ? "none" : "auto",
     };
 
     const menuStyle: React.CSSProperties = {
@@ -207,7 +187,7 @@ export const App = () => {
         padding: "5px 0",
         marginTop: "2px",
         justifyContent: "center",
-        display: isMenuOpen ? "block" : "none",
+        display: menuOpen ? "block" : "none",
     };
 
     const menuItemStyle: React.CSSProperties = {
@@ -327,7 +307,7 @@ export const App = () => {
                 )}
 
                 {/* --- Dropdown Menu --- */}
-                {isMenuOpen && (
+                {menuOpen && (
                     <div
                         ref={menuRef}
                         style={menuStyle}
@@ -347,7 +327,7 @@ export const App = () => {
                             <input
                                 type="checkbox"
                                 checked={exportAsSingleFile}
-                                onChange={handleCheckboxChange}
+                                onChange={(e) => setExportAsSingleFile(e.target.checked)}
                                 style={{
                                     marginRight: "8px",
                                     cursor: "pointer",
@@ -369,10 +349,10 @@ export const App = () => {
                         <div
                             role="button" // Semantics
                             tabIndex={0} // Make focusable
-                            onClick={handleExportClick}
+                            onClick={exportFiles}
                             onKeyDown={(e) => {
                                 if (e.key === "Enter" || e.key === " ") {
-                                    handleExportClick();
+                                    exportFiles();
                                 }
                             }} // Keyboard accessibility
                             style={{ ...menuItemStyle, padding: "8px 12px" }}

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -1,11 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import {
-    useEffect,
-    useState,
-    useRef
-} from "react";
+import { useEffect, useState, useRef } from "react";
 import {
     dispatchTS,
     getColorTheme,
@@ -16,15 +12,23 @@ import "./main.css";
 import { useInspectorStore } from "./utils/store";
 import { downloadZipFile } from "./utils/utils.js";
 
-
 export const App = () => {
-
     const {
-        exportsAreCurrent, exportedFiles, title, slintSnippet,
-        useVariables, exportAsSingleFile, menuOpen,
-        copyToClipboard, initializeEventListeners, setUseVariables,
-        setExportsAreCurrent, setExportAsSingleFile,
-        setMenuOpen, toggleMenu, exportFiles
+        exportsAreCurrent,
+        exportedFiles,
+        title,
+        slintSnippet,
+        useVariables,
+        exportAsSingleFile,
+        menuOpen,
+        copyToClipboard,
+        initializeEventListeners,
+        setUseVariables,
+        setExportsAreCurrent,
+        setExportAsSingleFile,
+        setMenuOpen,
+        toggleMenu,
+        exportFiles,
     } = useInspectorStore();
 
     const [lightOrDarkMode, setLightOrDarkMode] = useState(getColorTheme());
@@ -57,7 +61,6 @@ export const App = () => {
             document.removeEventListener("mousedown", handleClickOutside);
         };
     }, [menuOpen]); // Re-run effect when isMenuOpen changes
-
 
     // Theme handling
     useEffect(() => {
@@ -219,7 +222,9 @@ export const App = () => {
                             <input
                                 type="checkbox"
                                 checked={useVariables}
-                                onChange={(e) => setUseVariables(e.target.checked)}
+                                onChange={(e) =>
+                                    setUseVariables(e.target.checked)
+                                }
                                 style={{
                                     marginRight: "4px",
                                     cursor: "pointer",
@@ -274,8 +279,8 @@ export const App = () => {
                         <label
                             style={{ ...menuItemStyle, cursor: "pointer" }}
                             onMouseEnter={(e) =>
-                            (e.currentTarget.style.backgroundColor =
-                                menuItemHoverStyle.backgroundColor!)
+                                (e.currentTarget.style.backgroundColor =
+                                    menuItemHoverStyle.backgroundColor!)
                             }
                             onMouseLeave={(e) =>
                                 (e.currentTarget.style.backgroundColor = "")
@@ -284,7 +289,9 @@ export const App = () => {
                             <input
                                 type="checkbox"
                                 checked={exportAsSingleFile}
-                                onChange={(e) => setExportAsSingleFile(e.target.checked)}
+                                onChange={(e) =>
+                                    setExportAsSingleFile(e.target.checked)
+                                }
                                 style={{
                                     marginRight: "8px",
                                     cursor: "pointer",
@@ -314,8 +321,8 @@ export const App = () => {
                             }} // Keyboard accessibility
                             style={{ ...menuItemStyle, padding: "8px 12px" }}
                             onMouseEnter={(e) =>
-                            (e.currentTarget.style.backgroundColor =
-                                menuItemHoverStyle.backgroundColor!)
+                                (e.currentTarget.style.backgroundColor =
+                                    menuItemHoverStyle.backgroundColor!)
                             }
                             onMouseLeave={(e) =>
                                 (e.currentTarget.style.backgroundColor = "")
@@ -353,7 +360,7 @@ export const App = () => {
                             transition: "all 0.3s ease",
                             opacity: exportsAreCurrent ? "1" : "0.5",
                         }}
-                    // disabled={!exportsAreCurrent}
+                        // disabled={!exportsAreCurrent}
                     >
                         <span style={{ marginRight: "8px" }}>
                             {exportsAreCurrent ? "📦" : "⚠️"}

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -36,7 +36,10 @@ const downloadFile = (filename: string, text: string) => {
 export const App = () => {
     const [exportsAreCurrent, setExportsAreCurrent] = useState(false);
 
-    const { title, slintSnippet, copyToClipboard, initializeEventListeners } = useInspectorStore();
+    const {
+        title, slintSnippet, useVariables,
+        copyToClipboard, initializeEventListeners, setUseVariables
+    } = useInspectorStore();
 
     const [exportedFiles, setExportedFiles] = useState<
         Array<{ name: string; content: string }>
@@ -57,7 +60,6 @@ export const App = () => {
         dispatchTS("exportToFiles", { exportAsSingleFile: exportAsSingleFile });
         setIsMenuOpen(false); // Close menu after clicking export
     }, [exportAsSingleFile]);
-    const [useVariables, setUseVariables] = useState(false); // Default to false
 
 
 
@@ -107,17 +109,7 @@ export const App = () => {
         },
         [useVariables],
     );
-    // Update the handleUseVariables handler
-    const handleUseVariables = useCallback(
-        (event: React.ChangeEvent<HTMLInputElement>) => {
-            const checked = event.target.checked;
-            // Update the state
-            setUseVariables(checked);
-            // Request a new snippet from the backend with the updated preference
-            dispatchTS("generateSnippetRequest", { useVariables: checked });
-        },
-        [],
-    );
+
 
     // Theme handling
     useEffect(() => {
@@ -364,7 +356,7 @@ export const App = () => {
                             <input
                                 type="checkbox"
                                 checked={useVariables}
-                                onChange={handleUseVariables}
+                                onChange={(e) => setUseVariables(e.target.checked)}
                                 style={{
                                     marginRight: "4px",
                                     cursor: "pointer",
@@ -419,8 +411,8 @@ export const App = () => {
                         <label
                             style={{ ...menuItemStyle, cursor: "pointer" }}
                             onMouseEnter={(e) =>
-                                (e.currentTarget.style.backgroundColor =
-                                    menuItemHoverStyle.backgroundColor!)
+                            (e.currentTarget.style.backgroundColor =
+                                menuItemHoverStyle.backgroundColor!)
                             }
                             onMouseLeave={(e) =>
                                 (e.currentTarget.style.backgroundColor = "")
@@ -459,8 +451,8 @@ export const App = () => {
                             }} // Keyboard accessibility
                             style={{ ...menuItemStyle, padding: "8px 12px" }}
                             onMouseEnter={(e) =>
-                                (e.currentTarget.style.backgroundColor =
-                                    menuItemHoverStyle.backgroundColor!)
+                            (e.currentTarget.style.backgroundColor =
+                                menuItemHoverStyle.backgroundColor!)
                             }
                             onMouseLeave={(e) =>
                                 (e.currentTarget.style.backgroundColor = "")
@@ -498,7 +490,7 @@ export const App = () => {
                             transition: "all 0.3s ease",
                             opacity: exportsAreCurrent ? "1" : "0.5",
                         }}
-                        // disabled={!exportsAreCurrent}
+                    // disabled={!exportsAreCurrent}
                     >
                         <span style={{ marginRight: "8px" }}>
                             {exportsAreCurrent ? "📦" : "⚠️"}

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -4,7 +4,6 @@
 import {
     useEffect,
     useState,
-    useCallback,
     useRef
 } from "react";
 import {

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -48,19 +48,6 @@ export const App = () => {
     }, [exportAsSingleFile]);
 
 
-
-    useEffect(() => {
-        const handleSelectionChange = () => {
-            // Request snippet update using the current state of useVariables
-            dispatchTS("generateSnippetRequest", {
-                useVariables: useVariables,
-            });
-        };
-        listenTS("selectionChangedInFigma", handleSelectionChange);
-
-        // Also request initial snippet on component mount
-        dispatchTS("generateSnippetRequest", { useVariables: useVariables });
-    }, [useVariables]);
     useEffect(() => {
         // Only add listener if menu is open
         if (!isMenuOpen) {

--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -7,7 +7,6 @@ import {
     useCallback,
     useRef
 } from "react";
-import JSZip from "jszip";
 import {
     dispatchTS,
     listenTS,
@@ -17,21 +16,8 @@ import {
 import CodeSnippet from "./snippet/CodeSnippet";
 import "./main.css";
 import { useInspectorStore } from "./utils/store";
+import { downloadZipFile } from "./utils/utils.js";
 
-
-// Add file download functionality
-const downloadFile = (filename: string, text: string) => {
-    const element = document.createElement("a");
-    element.setAttribute(
-        "href",
-        "data:text/plain;charset=utf-8," + encodeURIComponent(text),
-    );
-    element.setAttribute("download", filename);
-    element.style.display = "none";
-    document.body.appendChild(element);
-    element.click();
-    document.body.removeChild(element);
-};
 
 export const App = () => {
     const [exportsAreCurrent, setExportsAreCurrent] = useState(false);
@@ -202,51 +188,7 @@ export const App = () => {
         return () => window.removeEventListener("message", directHandler);
     }, []);
 
-    // Create the functions with access to dispatchTS
-    const downloadZipFile = async (
-        files: Array<{ name: string; content: string }>,
-    ) => {
-        try {
-            if (!files || files.length === 0) {
-                console.error("No files to zip!");
-                return;
-            }
 
-            // Create a new JSZip instance directly (using the import)
-            const zip = new JSZip();
-
-            // Add each file to the zip with debug logging
-            files.forEach((file) => {
-                zip.file(file.name, file.content);
-            });
-
-            // Generate the zip
-            const content = await zip.generateAsync({ type: "blob" });
-
-            // Create download link
-            const element = document.createElement("a");
-            element.href = URL.createObjectURL(content);
-            element.download = "figma-collections.zip";
-            document.body.appendChild(element);
-            element.click();
-            document.body.removeChild(element);
-
-            // Clean up
-            URL.revokeObjectURL(element.href);
-        } catch (error) {
-            console.error("Error creating ZIP file:", error);
-
-            // Fallback to individual downloads if ZIP creation fails
-            alert(
-                "Couldn't create ZIP file. Downloading files individually...",
-            );
-            files.forEach((file, index) => {
-                setTimeout(() => {
-                    downloadFile(file.name, file.content);
-                }, index * 100);
-            });
-        }
-    };
 
     const buttonStyle: React.CSSProperties = {
         border: `none`,

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -1,21 +1,34 @@
 import { create } from "zustand";
-import { listenTS } from "./bolt-utils";
+import { dispatchTS, listenTS } from "./bolt-utils";
+import { writeTextToClipboard } from "./utils.js";
 
 interface StoreState {
     title: string;
     slintSnippet: string;
     setTitle: (title: string) => void;
     initializeEventListeners: () => void;
+    copyToClipboard: () => Promise<void>;
 }
 
-export const useInspectorStore = create<StoreState>()((set) => ({
+export const useInspectorStore = create<StoreState>()((set, get) => ({
     title: "",
     slintSnippet: "",
     setTitle: (title) => set({ title }),
     initializeEventListeners: () => {
-
         listenTS("updatePropertiesCallback", (res) => {
             set({ title: res.title, slintSnippet: res.slintSnippet || "" });
         });
+    },
+    copyToClipboard: async () => {
+        try {
+            writeTextToClipboard(get().slintSnippet);
+            dispatchTS("copyToClipboard", {
+                result: true,
+            });
+        } catch (error) {
+            dispatchTS("copyToClipboard", {
+                result: false,
+            });
+        }
     },
 }));

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -1,3 +1,5 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
 import { create } from "zustand";
 import { dispatchTS, listenTS } from "./bolt-utils";
 import { writeTextToClipboard } from "./utils.js";

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -56,7 +56,7 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
 
     copyToClipboard: async () => {
         try {
-            writeTextToClipboard(get().slintSnippet);
+            await writeTextToClipboard(get().slintSnippet);
             dispatchTS("copyToClipboard", {
                 result: true,
             });

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -25,6 +25,10 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
         listenTS("updatePropertiesCallback", (res) => {
             set({ title: res.title, slintSnippet: res.slintSnippet || "" });
         });
+
+        listenTS("selectionChangedInFigma", () => {
+            dispatchTS("generateSnippetRequest", { useVariables: get().useVariables });
+        });
     },
 
     copyToClipboard: async () => {

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -8,16 +8,27 @@ interface StoreState {
     title: string;
     slintSnippet: string;
     useVariables: boolean;
+    exportsAreCurrent: boolean;
+    exportedFiles: Array<{ name: string; content: string }>;
+    exportAsSingleFile: boolean;
     setTitle: (title: string) => void;
     initializeEventListeners: () => void;
     copyToClipboard: () => Promise<void>;
     setUseVariables: (useVariables: boolean) => void;
+    setExportsAreCurrent: (exportsAreCurrent: boolean) => void;
+    setExportedFiles: (
+        exportedFiles: Array<{ name: string; content: string }>,
+    ) => void;
+    setExportAsSingleFile: (exportAsSingleFile: boolean) => void;
 }
 
 export const useInspectorStore = create<StoreState>()((set, get) => ({
     title: "",
     slintSnippet: "",
     useVariables: false,
+    exportsAreCurrent: false,
+    exportedFiles: [],
+    exportAsSingleFile: false,
 
     setTitle: (title) => set({ title }),
 
@@ -47,5 +58,17 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
     setUseVariables: (useVariables) => {
         set({ useVariables })
         dispatchTS("generateSnippetRequest", { useVariables });
+    },
+
+    setExportsAreCurrent: (exportsAreCurrent) => {
+        set({ exportsAreCurrent })
+    },
+
+    setExportedFiles: (exportedFiles) => {
+        set({ exportedFiles })
+    },
+
+    setExportAsSingleFile: (exportAsSingleFile) => {
+        set({ exportAsSingleFile })
     },
 }));

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -52,6 +52,9 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
         listenTS("exportedFiles", (res) => {
             get().exportFilesHandler(res.files);
         });
+
+        // On first run check to see if anything is currently selected and show a snippet.
+        dispatchTS("generateSnippetRequest", { useVariables: get().useVariables });
     },
 
     copyToClipboard: () => {

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -11,6 +11,7 @@ interface StoreState {
     exportsAreCurrent: boolean;
     exportedFiles: Array<{ name: string; content: string }>;
     exportAsSingleFile: boolean;
+    menuOpen: boolean;
     setTitle: (title: string) => void;
     initializeEventListeners: () => void;
     copyToClipboard: () => Promise<void>;
@@ -20,6 +21,9 @@ interface StoreState {
         exportedFiles: Array<{ name: string; content: string }>,
     ) => void;
     setExportAsSingleFile: (exportAsSingleFile: boolean) => void;
+    setMenuOpen: (menuOpen: boolean) => void;
+    toggleMenu: () => void;
+    exportFiles: () => void;
 }
 
 export const useInspectorStore = create<StoreState>()((set, get) => ({
@@ -29,6 +33,7 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
     exportsAreCurrent: false,
     exportedFiles: [],
     exportAsSingleFile: false,
+    menuOpen: false,
 
     setTitle: (title) => set({ title }),
 
@@ -70,5 +75,18 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
 
     setExportAsSingleFile: (exportAsSingleFile) => {
         set({ exportAsSingleFile })
+    },
+
+    setMenuOpen: (menuOpen) => {
+        set({ menuOpen })
+    },
+
+    toggleMenu: () => {
+        set({ menuOpen: !get().menuOpen })
+    },
+
+    exportFiles: () => {
+        set({ exportedFiles: [], exportsAreCurrent: false, menuOpen: false });
+        dispatchTS("exportToFiles", { exportAsSingleFile: get().exportAsSingleFile });
     },
 }));

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -27,6 +27,7 @@ interface StoreState {
 }
 
 export const useInspectorStore = create<StoreState>()((set, get) => ({
+    // Default store values
     title: "",
     slintSnippet: "",
     useVariables: false,

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -49,7 +49,6 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
             });
         });
 
-
         listenTS("exportedFiles", (res) => {
             get().exportFilesHandler(res.files);
         });
@@ -101,7 +100,6 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
             set({ exportedFiles: files, exportsAreCurrent: true });
 
             await downloadZipFile(files);
-
         } else {
             console.error("Invalid or empty files data received:", files);
             set({ exportedFiles: [], exportsAreCurrent: false }); // Mark as not current if export failed to produce files

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -5,20 +5,26 @@ import { writeTextToClipboard } from "./utils.js";
 interface StoreState {
     title: string;
     slintSnippet: string;
+    useVariables: boolean;
     setTitle: (title: string) => void;
     initializeEventListeners: () => void;
     copyToClipboard: () => Promise<void>;
+    setUseVariables: (useVariables: boolean) => void;
 }
 
 export const useInspectorStore = create<StoreState>()((set, get) => ({
     title: "",
     slintSnippet: "",
+    useVariables: false,
+
     setTitle: (title) => set({ title }),
+
     initializeEventListeners: () => {
         listenTS("updatePropertiesCallback", (res) => {
             set({ title: res.title, slintSnippet: res.slintSnippet || "" });
         });
     },
+
     copyToClipboard: async () => {
         try {
             writeTextToClipboard(get().slintSnippet);
@@ -30,5 +36,10 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
                 result: false,
             });
         }
+    },
+
+    setUseVariables: (useVariables) => {
+        set({ useVariables })
+        dispatchTS("generateSnippetRequest", { useVariables });
     },
 }));

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { listenTS } from "./bolt-utils";
+
+interface StoreState {
+    title: string;
+    slintSnippet: string;
+    setTitle: (title: string) => void;
+    initializeEventListeners: () => void;
+}
+
+export const useInspectorStore = create<StoreState>()((set) => ({
+    title: "",
+    slintSnippet: "",
+    setTitle: (title) => set({ title }),
+    initializeEventListeners: () => {
+
+        listenTS("updatePropertiesCallback", (res) => {
+            set({ title: res.title, slintSnippet: res.slintSnippet || "" });
+        });
+    },
+}));

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -14,7 +14,7 @@ interface StoreState {
     menuOpen: boolean;
     setTitle: (title: string) => void;
     initializeEventListeners: () => void;
-    copyToClipboard: () => Promise<void>;
+    copyToClipboard: () => void;
     setUseVariables: (useVariables: boolean) => void;
     setExportsAreCurrent: (exportsAreCurrent: boolean) => void;
     setExportAsSingleFile: (exportAsSingleFile: boolean) => void;
@@ -54,13 +54,14 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
         });
     },
 
-    copyToClipboard: async () => {
-        try {
-            await writeTextToClipboard(get().slintSnippet);
+    copyToClipboard: () => {
+        const success = writeTextToClipboard(get().slintSnippet);
+
+        if (success) {
             dispatchTS("copyToClipboard", {
                 result: true,
             });
-        } catch (error) {
+        } else {
             dispatchTS("copyToClipboard", {
                 result: false,
             });

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -54,7 +54,9 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
         });
 
         // On first run check to see if anything is currently selected and show a snippet.
-        dispatchTS("generateSnippetRequest", { useVariables: get().useVariables });
+        dispatchTS("generateSnippetRequest", {
+            useVariables: get().useVariables,
+        });
     },
 
     copyToClipboard: () => {

--- a/tools/figma-inspector/src/utils/utils.ts
+++ b/tools/figma-inspector/src/utils/utils.ts
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
-import { dispatchTS } from "./bolt-utils.js";
+import JSZip from "jszip";
 
 export function writeTextToClipboard(str: string) {
     const prevActive = document.activeElement;
@@ -32,3 +32,59 @@ export function writeTextToClipboard(str: string) {
         }
     }
 }
+
+export const downloadZipFile = async (
+    files: Array<{ name: string; content: string }>,
+) => {
+    try {
+        if (!files || files.length === 0) {
+            console.error("No files to zip!");
+            return;
+        }
+
+        // Create a new JSZip instance directly (using the import)
+        const zip = new JSZip();
+
+        // Add each file to the zip with debug logging
+        files.forEach((file) => {
+            zip.file(file.name, file.content);
+        });
+
+        // Generate the zip
+        const content = await zip.generateAsync({ type: "blob" });
+
+        // Create download link
+        const element = document.createElement("a");
+        element.href = URL.createObjectURL(content);
+        element.download = "figma-collections.zip";
+        document.body.appendChild(element);
+        element.click();
+        document.body.removeChild(element);
+
+        // Clean up
+        URL.revokeObjectURL(element.href);
+    } catch (error) {
+        console.error("Error creating ZIP file:", error);
+
+        // Fallback to individual downloads if ZIP creation fails
+        alert("Couldn't create ZIP file. Downloading files individually...");
+        files.forEach((file, index) => {
+            setTimeout(() => {
+                downloadFile(file.name, file.content);
+            }, index * 100);
+        });
+    }
+};
+
+const downloadFile = (filename: string, text: string) => {
+    const element = document.createElement("a");
+    element.setAttribute(
+        "href",
+        "data:text/plain;charset=utf-8," + encodeURIComponent(text),
+    );
+    element.setAttribute("download", filename);
+    element.style.display = "none";
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+};

--- a/tools/figma-inspector/src/utils/utils.ts
+++ b/tools/figma-inspector/src/utils/utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 import JSZip from "jszip";
 
-export function writeTextToClipboard(str: string) {
+export function writeTextToClipboard(str: string): boolean {
     const prevActive = document.activeElement;
     const textArea = document.createElement("textarea");
 
@@ -17,20 +17,25 @@ export function writeTextToClipboard(str: string) {
     textArea.focus();
     textArea.select();
 
+    let copySuccessful = false;
+
     try {
         const successful = document.execCommand("copy");
         if (!successful) {
             throw new Error("Copy command failed");
+        } else {
+            copySuccessful = true;
         }
     } catch (e: unknown) {
         const errorMessage = e instanceof Error ? e.message : String(e);
-        throw new Error("Failed to copy text: " + errorMessage);
+        console.error("Failed to copy text: " + errorMessage);
     } finally {
         textArea.remove();
         if (prevActive && prevActive instanceof HTMLElement) {
             prevActive.focus();
         }
     }
+    return copySuccessful;
 }
 
 export const downloadZipFile = async (

--- a/tools/figma-inspector/src/utils/utils.ts
+++ b/tools/figma-inspector/src/utils/utils.ts
@@ -32,16 +32,3 @@ export function writeTextToClipboard(str: string) {
         }
     }
 }
-
-export async function copyToClipboard(slintProperties: string) {
-    try {
-        await writeTextToClipboard(slintProperties);
-        dispatchTS("copyToClipboard", {
-            result: true,
-        });
-    } catch (error) {
-        dispatchTS("copyToClipboard", {
-            result: false,
-        });
-    }
-}


### PR DESCRIPTION
This adds the Zustand state library to simplify react state handling.

It allows all the listening to the Figma side of the plugin to be moved inside it. This inturn allows quite a bit of logic to also move over to the store.ts file and start to leave Main.tsx to only describe the UI.