### PR TITLE
Skia: Improve multi-window rendering resource consumption

### DIFF
--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -964,6 +964,7 @@ pub mod skia {
 
         let boxed_renderer: Box<SkiaRenderer> = Box::new(
             SkiaRenderer::new(
+                &i_slint_renderer_skia::SkiaSharedContext::default(),
                 handle.0.clone(),
                 handle.0.clone(),
                 PhysicalSize { width: size.width, height: size.height },

--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -3,6 +3,7 @@
 
 use i_slint_renderer_skia::skia_safe;
 use i_slint_renderer_skia::SkiaRenderer;
+use i_slint_renderer_skia::SkiaSharedContext;
 use slint::platform::software_renderer::{
     MinimalSoftwareWindow, PremultipliedRgbaColor, SoftwareRenderer, TargetPixel,
 };
@@ -72,9 +73,12 @@ struct SkiaTestWindow {
 impl SkiaTestWindow {
     fn new() -> Rc<Self> {
         let render_buffer = Rc::new(SkiaTestSoftwareBuffer::default());
-        let renderer = SkiaRenderer::new_with_surface(Box::new(
-            i_slint_renderer_skia::software_surface::SoftwareSurface::from(render_buffer.clone()),
-        ));
+        let renderer = SkiaRenderer::new_with_surface(
+            &SkiaSharedContext::default(),
+            Box::new(i_slint_renderer_skia::software_surface::SoftwareSurface::from(
+                render_buffer.clone(),
+            )),
+        );
         Rc::new_cyclic(|w: &Weak<Self>| Self {
             window: slint::Window::new(w.clone()),
             renderer,

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -15,7 +15,7 @@ use i_slint_core::platform::{
 use i_slint_core::timers::{Timer, TimerMode};
 use i_slint_core::window::{InputMethodRequest, WindowInner};
 use i_slint_core::{Property, SharedString};
-use i_slint_renderer_skia::SkiaRenderer;
+use i_slint_renderer_skia::{SkiaRenderer, SkiaSharedContext};
 use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -181,7 +181,7 @@ impl AndroidWindowAdapter {
         Rc::<Self>::new_cyclic(|w| Self {
             app,
             window: Window::new(w.clone()),
-            renderer: SkiaRenderer::default(),
+            renderer: SkiaRenderer::default(&SkiaSharedContext::default()),
             event_queue: Default::default(),
             pending_redraw: Default::default(),
             color_scheme,

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -8,8 +8,8 @@ use crate::drmoutput::DrmOutput;
 use i_slint_core::api::{PhysicalSize as PhysicalWindowSize, Window};
 use i_slint_core::item_rendering::{DirtyRegion, ItemRenderer};
 use i_slint_core::platform::PlatformError;
-use i_slint_renderer_skia::skia_safe;
 use i_slint_renderer_skia::SkiaRendererExt;
+use i_slint_renderer_skia::{skia_safe, SkiaRenderer, SkiaSharedContext};
 
 pub struct SkiaRendererAdapter {
     renderer: i_slint_renderer_skia::SkiaRenderer,
@@ -33,9 +33,10 @@ impl SkiaRendererAdapter {
         )?;
 
         let renderer = Box::new(Self {
-            renderer: i_slint_renderer_skia::SkiaRenderer::new_with_surface(Box::new(
-                skia_vk_surface,
-            )),
+            renderer: SkiaRenderer::new_with_surface(
+                &SkiaSharedContext::default(),
+                Box::new(skia_vk_surface),
+            ),
             // TODO: For vulkan we don't have a page flip event handling mechanism yet, so drive it with a timer.
             presenter: display.presenter,
             size: display.size,
@@ -67,9 +68,10 @@ impl SkiaRendererAdapter {
             )?;
 
         let renderer = Box::new(Self {
-            renderer: i_slint_renderer_skia::SkiaRenderer::new_with_surface(Box::new(
-                skia_gl_surface,
-            )),
+            renderer: SkiaRenderer::new_with_surface(
+                &SkiaSharedContext::default(),
+                Box::new(skia_gl_surface),
+            ),
             presenter: display.clone(),
             size,
         });
@@ -99,9 +101,10 @@ impl SkiaRendererAdapter {
         let size = i_slint_core::api::PhysicalSize::new(width, height);
 
         let renderer = Box::new(Self {
-            renderer: i_slint_renderer_skia::SkiaRenderer::new_with_surface(Box::new(
-                skia_software_surface,
-            )),
+            renderer: SkiaRenderer::new_with_surface(
+                &SkiaSharedContext::default(),
+                Box::new(skia_software_surface),
+            ),
             presenter: display.as_presenter(),
             size,
         });

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -98,16 +98,18 @@ cfg_if::cfg_if! {
     }
 }
 
-fn default_renderer_factory() -> Box<dyn WinitCompatibleRenderer> {
+fn default_renderer_factory(
+    shared_backend_data: &Rc<SharedBackendData>,
+) -> Box<dyn WinitCompatibleRenderer> {
     cfg_if::cfg_if! {
         if #[cfg(enable_skia_renderer)] {
-            renderer::skia::WinitSkiaRenderer::new_suspended()
+            renderer::skia::WinitSkiaRenderer::new_suspended(shared_backend_data)
         } else if #[cfg(feature = "renderer-femtovg-wgpu")] {
-            renderer::femtovg::WGPUFemtoVGRenderer::new_suspended()
+            renderer::femtovg::WGPUFemtoVGRenderer::new_suspended(shared_backend_data)
         } else if #[cfg(feature = "renderer-femtovg")] {
-            renderer::femtovg::GlutinFemtoVGRenderer::new_suspended()
+            renderer::femtovg::GlutinFemtoVGRenderer::new_suspended(shared_backend_data)
         } else if #[cfg(feature = "renderer-software")] {
-            renderer::sw::WinitSoftwareRenderer::new_suspended()
+            renderer::sw::WinitSoftwareRenderer::new_suspended(shared_backend_data)
         } else {
             compile_error!("Please select a feature to build with the winit backend: `renderer-femtovg`, `renderer-skia`, `renderer-skia-opengl`, `renderer-skia-vulkan` or `renderer-software`");
         }
@@ -136,7 +138,7 @@ fn try_create_window_with_fallback_renderer(
     .find_map(|renderer_factory| {
         WinitWindowAdapter::new(
             shared_backend_data.clone(),
-            renderer_factory(),
+            renderer_factory(&shared_backend_data),
             attrs.clone(),
             None,
             #[cfg(any(enable_accesskit, muda))]
@@ -354,6 +356,8 @@ impl BackendBuilder {
 }
 
 pub(crate) struct SharedBackendData {
+    #[cfg(enable_skia_renderer)]
+    skia_context: i_slint_renderer_skia::SkiaSharedContext,
     active_windows: RefCell<HashMap<winit::window::WindowId, Weak<WinitWindowAdapter>>>,
     #[cfg(not(target_arch = "wasm32"))]
     clipboard: std::cell::RefCell<clipboard::ClipboardPair>,
@@ -377,6 +381,8 @@ impl SharedBackendData {
                 .map_err(|display_err| PlatformError::OtherError(display_err.into()))?,
         );
         Ok(Self {
+            #[cfg(enable_skia_renderer)]
+            skia_context: i_slint_renderer_skia::SkiaSharedContext::default(),
             active_windows: Default::default(),
             #[cfg(not(target_arch = "wasm32"))]
             clipboard: RefCell::new(clipboard),
@@ -428,7 +434,7 @@ impl SharedBackendData {
 /// ```
 pub struct Backend {
     requested_graphics_api: Option<RequestedGraphicsAPI>,
-    renderer_factory_fn: fn() -> Box<dyn WinitCompatibleRenderer>,
+    renderer_factory_fn: fn(&Rc<SharedBackendData>) -> Box<dyn WinitCompatibleRenderer>,
     event_loop_state: std::cell::RefCell<Option<crate::event_loop::EventLoopState>>,
     shared_data: Rc<SharedBackendData>,
 
@@ -505,7 +511,7 @@ impl i_slint_core::platform::Platform for Backend {
 
         let adapter = WinitWindowAdapter::new(
             self.shared_data.clone(),
-            (self.renderer_factory_fn)(),
+            (self.renderer_factory_fn)(&self.shared_data),
             attrs.clone(),
             self.requested_graphics_api.clone(),
             #[cfg(any(enable_accesskit, muda))]

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::cell::Cell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use i_slint_core::renderer::Renderer;
@@ -24,7 +25,9 @@ pub struct GlutinFemtoVGRenderer {
 }
 
 impl GlutinFemtoVGRenderer {
-    pub fn new_suspended() -> Box<dyn WinitCompatibleRenderer> {
+    pub fn new_suspended(
+        _shared_backend_data: &Rc<crate::SharedBackendData>,
+    ) -> Box<dyn WinitCompatibleRenderer> {
         Box::new(Self { renderer: FemtoVGRenderer::new_suspended(), suspended: Cell::new(true) })
     }
 }
@@ -93,7 +96,9 @@ pub struct WGPUFemtoVGRenderer {
 
 #[cfg(all(feature = "renderer-femtovg-wgpu", not(target_family = "wasm")))]
 impl WGPUFemtoVGRenderer {
-    pub fn new_suspended() -> Box<dyn WinitCompatibleRenderer> {
+    pub fn new_suspended(
+        _shared_backend_data: &Rc<crate::SharedBackendData>,
+    ) -> Box<dyn WinitCompatibleRenderer> {
         Box::new(Self {
             renderer: FemtoVGRenderer::<i_slint_renderer_femtovg::wgpu::WGPUBackend>::new_suspended(
             ),

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -10,6 +10,7 @@ pub use i_slint_core::software_renderer::SoftwareRenderer;
 use i_slint_core::software_renderer::{PremultipliedRgbaColor, RepaintBufferType, TargetPixel};
 use i_slint_core::{graphics::RequestedGraphicsAPI, graphics::Rgb8Pixel};
 use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use super::WinitCompatibleRenderer;
@@ -68,7 +69,9 @@ impl TargetPixel for SoftBufferPixel {
 }
 
 impl WinitSoftwareRenderer {
-    pub fn new_suspended() -> Box<dyn WinitCompatibleRenderer> {
+    pub fn new_suspended(
+        _shared_backend_data: &Rc<crate::SharedBackendData>,
+    ) -> Box<dyn WinitCompatibleRenderer> {
         Box::new(Self {
             renderer: SoftwareRenderer::new(),
             _context: RefCell::new(None),

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -25,6 +25,8 @@ use windows::Win32::Graphics::Dxgi::{
 };
 use windows::Win32::System::Threading::{CreateEventW, WaitForSingleObjectEx, INFINITE};
 
+use crate::SkiaSharedContext;
+
 trait MapToPlatformError<T> {
     fn map_platform_error(self, msg: &str) -> std::result::Result<T, PlatformError>;
 }
@@ -255,6 +257,7 @@ pub struct D3DSurface {
 
 impl super::Surface for D3DSurface {
     fn new(
+        _shared_context: &SkiaSharedContext,
         window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
         _display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -4,7 +4,7 @@
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
 
@@ -65,12 +65,14 @@ cfg_if::cfg_if! {
 }
 
 fn create_default_surface(
+    context: &SkiaSharedContext,
     window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
     display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
     size: PhysicalWindowSize,
     requested_graphics_api: Option<RequestedGraphicsAPI>,
 ) -> Result<Box<dyn Surface>, PlatformError> {
     match DefaultSurface::new(
+        context,
         window_handle.clone(),
         display_handle.clone(),
         size,
@@ -83,8 +85,14 @@ fn create_default_surface(
                 "Failed to initialize Skia GPU renderer: {} . Falling back to software rendering",
                 err
             );
-            software_surface::SoftwareSurface::new(window_handle, display_handle, size, None)
-                .map(|r| Box::new(r) as Box<dyn Surface>)
+            software_surface::SoftwareSurface::new(
+                context,
+                window_handle,
+                display_handle,
+                size,
+                None,
+            )
+            .map(|r| Box::new(r) as Box<dyn Surface>)
         }
         #[cfg(not(skia_backend_software))]
         Err(err) => Err(err),
@@ -118,6 +126,22 @@ fn create_partial_renderer_state(
         .then(|| PartialRenderingState::default())
 }
 
+#[derive(Default)]
+struct SkiaSharedContextInner {
+    #[cfg(target_vendor = "apple")]
+    metal_context: OnceCell<metal_surface::SharedMetalContext>,
+    #[cfg(skia_backend_vulkan)]
+    vulkan_context: OnceCell<vulkan_surface::SharedVulkanContext>,
+}
+
+/// This data structure contains data that's intended to be shared across several instances of SkiaRenderer.
+/// For example, for Vulkan rendering, this shares the Vulkan instance.
+///
+/// Create an instance once and pass clones of it to the difference constructor functions, to ensure most
+/// efficient resource usage.
+#[derive(Clone, Default)]
+pub struct SkiaSharedContext(Rc<SkiaSharedContextInner>);
+
 /// Use the SkiaRenderer when implementing a custom Slint platform where you deliver events to
 /// Slint and want the scene to be rendered using Skia as underlying graphics library.
 pub struct SkiaRenderer {
@@ -129,6 +153,7 @@ pub struct SkiaRenderer {
     rendering_first_time: Cell<bool>,
     surface: RefCell<Option<Box<dyn Surface>>>,
     surface_factory: fn(
+        &SkiaSharedContext,
         window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
         display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
@@ -139,10 +164,11 @@ pub struct SkiaRenderer {
     dirty_region_debug_mode: DirtyRegionDebugMode,
     /// Tracking dirty regions indexed by buffer age - 1. More than 3 back buffers aren't supported, but also unlikely to happen.
     dirty_region_history: RefCell<[DirtyRegion; 3]>,
+    shared_context: SkiaSharedContext,
 }
 
-impl Default for SkiaRenderer {
-    fn default() -> Self {
+impl SkiaRenderer {
+    pub fn default(context: &SkiaSharedContext) -> Self {
         Self {
             maybe_window_adapter: Default::default(),
             rendering_notifier: Default::default(),
@@ -156,14 +182,13 @@ impl Default for SkiaRenderer {
             partial_rendering_state: create_partial_renderer_state(None),
             dirty_region_debug_mode: Default::default(),
             dirty_region_history: Default::default(),
+            shared_context: context.clone(),
         }
     }
-}
 
-impl SkiaRenderer {
     #[cfg(skia_backend_software)]
     /// Creates a new SkiaRenderer that will always use Skia's software renderer.
-    pub fn default_software() -> Self {
+    pub fn default_software(context: &SkiaSharedContext) -> Self {
         Self {
             maybe_window_adapter: Default::default(),
             rendering_notifier: Default::default(),
@@ -172,8 +197,13 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
             surface: Default::default(),
-            surface_factory: |window_handle, display_handle, size, requested_graphics_api| {
+            surface_factory: |context,
+                              window_handle,
+                              display_handle,
+                              size,
+                              requested_graphics_api| {
                 software_surface::SoftwareSurface::new(
+                    context,
                     window_handle,
                     display_handle,
                     size,
@@ -185,12 +215,13 @@ impl SkiaRenderer {
             partial_rendering_state: PartialRenderingState::default().into(),
             dirty_region_debug_mode: Default::default(),
             dirty_region_history: Default::default(),
+            shared_context: context.clone(),
         }
     }
 
     #[cfg(not(target_os = "ios"))]
     /// Creates a new SkiaRenderer that will always use Skia's OpenGL renderer.
-    pub fn default_opengl() -> Self {
+    pub fn default_opengl(context: &SkiaSharedContext) -> Self {
         Self {
             maybe_window_adapter: Default::default(),
             rendering_notifier: Default::default(),
@@ -199,8 +230,13 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
             surface: Default::default(),
-            surface_factory: |window_handle, display_handle, size, requested_graphics_api| {
+            surface_factory: |context,
+                              window_handle,
+                              display_handle,
+                              size,
+                              requested_graphics_api| {
                 opengl_surface::OpenGLSurface::new(
+                    context,
                     window_handle,
                     display_handle,
                     size,
@@ -212,12 +248,13 @@ impl SkiaRenderer {
             partial_rendering_state: create_partial_renderer_state(None),
             dirty_region_debug_mode: Default::default(),
             dirty_region_history: Default::default(),
+            shared_context: context.clone(),
         }
     }
 
     #[cfg(target_vendor = "apple")]
     /// Creates a new SkiaRenderer that will always use Skia's Metal renderer.
-    pub fn default_metal() -> Self {
+    pub fn default_metal(context: &SkiaSharedContext) -> Self {
         Self {
             maybe_window_adapter: Default::default(),
             rendering_notifier: Default::default(),
@@ -226,8 +263,13 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
             surface: Default::default(),
-            surface_factory: |window_handle, display_handle, size, requested_graphics_api| {
+            surface_factory: |context,
+                              window_handle,
+                              display_handle,
+                              size,
+                              requested_graphics_api| {
                 metal_surface::MetalSurface::new(
+                    context,
                     window_handle,
                     display_handle,
                     size,
@@ -239,12 +281,13 @@ impl SkiaRenderer {
             partial_rendering_state: create_partial_renderer_state(None),
             dirty_region_debug_mode: Default::default(),
             dirty_region_history: Default::default(),
+            shared_context: context.clone(),
         }
     }
 
     #[cfg(skia_backend_vulkan)]
     /// Creates a new SkiaRenderer that will always use Skia's Vulkan renderer.
-    pub fn default_vulkan() -> Self {
+    pub fn default_vulkan(context: &SkiaSharedContext) -> Self {
         Self {
             maybe_window_adapter: Default::default(),
             rendering_notifier: Default::default(),
@@ -253,8 +296,13 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
             surface: Default::default(),
-            surface_factory: |window_handle, display_handle, size, requested_graphics_api| {
+            surface_factory: |context,
+                              window_handle,
+                              display_handle,
+                              size,
+                              requested_graphics_api| {
                 vulkan_surface::VulkanSurface::new(
+                    context,
                     window_handle,
                     display_handle,
                     size,
@@ -266,12 +314,13 @@ impl SkiaRenderer {
             partial_rendering_state: create_partial_renderer_state(None),
             dirty_region_debug_mode: Default::default(),
             dirty_region_history: Default::default(),
+            shared_context: context.clone(),
         }
     }
 
     #[cfg(target_family = "windows")]
     /// Creates a new SkiaRenderer that will always use Skia's Direct3D renderer.
-    pub fn default_direct3d() -> Self {
+    pub fn default_direct3d(context: &SkiaSharedContext) -> Self {
         Self {
             maybe_window_adapter: Default::default(),
             rendering_notifier: Default::default(),
@@ -280,8 +329,13 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
             surface: Default::default(),
-            surface_factory: |window_handle, display_handle, size, requested_graphics_api| {
+            surface_factory: |context,
+                              window_handle,
+                              display_handle,
+                              size,
+                              requested_graphics_api| {
                 d3d_surface::D3DSurface::new(
+                    context,
                     window_handle,
                     display_handle,
                     size,
@@ -293,25 +347,28 @@ impl SkiaRenderer {
             partial_rendering_state: create_partial_renderer_state(None),
             dirty_region_debug_mode: Default::default(),
             dirty_region_history: Default::default(),
+            shared_context: context.clone(),
         }
     }
 
     /// Creates a new renderer is associated with the provided window adapter.
     pub fn new(
+        context: &SkiaSharedContext,
         window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
         display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
     ) -> Result<Self, PlatformError> {
-        Ok(Self::new_with_surface(create_default_surface(
-            window_handle,
-            display_handle,
-            size,
-            None,
-        )?))
+        Ok(Self::new_with_surface(
+            context,
+            create_default_surface(context, window_handle, display_handle, size, None)?,
+        ))
     }
 
     /// Creates a new renderer with the given surface trait implementation.
-    pub fn new_with_surface(surface: Box<dyn Surface + 'static>) -> Self {
+    pub fn new_with_surface(
+        context: &SkiaSharedContext,
+        surface: Box<dyn Surface + 'static>,
+    ) -> Self {
         let partial_rendering_state = create_partial_renderer_state(Some(surface.as_ref())).into();
         Self {
             maybe_window_adapter: Default::default(),
@@ -321,13 +378,14 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Cell::new(true),
             surface: RefCell::new(Some(surface)),
-            surface_factory: |_, _, _, _| {
+            surface_factory: |_, _, _, _, _| {
                 Err("Skia renderer constructed with surface does not support dynamic surface re-creation".into())
             },
             pre_present_callback: Default::default(),
             partial_rendering_state,
             dirty_region_debug_mode: Default::default(),
             dirty_region_history: Default::default(),
+            shared_context: context.clone(),
         }
     }
 
@@ -383,8 +441,13 @@ impl SkiaRenderer {
     ) -> Result<(), PlatformError> {
         // just in case
         self.suspend()?;
-        let surface =
-            (self.surface_factory)(window_handle, display_handle, size, requested_graphics_api)?;
+        let surface = (self.surface_factory)(
+            &self.shared_context,
+            window_handle,
+            display_handle,
+            size,
+            requested_graphics_api,
+        )?;
         self.set_surface(surface);
         Ok(())
     }
@@ -916,6 +979,7 @@ impl Drop for SkiaRenderer {
 pub trait Surface {
     /// Creates a new surface with the given window, display, and size.
     fn new(
+        shared_context: &SkiaSharedContext,
         window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
         display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -4,7 +4,9 @@
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
 
-use std::cell::{Cell, OnceCell, RefCell};
+#[cfg(any(target_vendor = "apple", skia_backend_vulkan))]
+use std::cell::OnceCell;
+use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
 
@@ -140,7 +142,7 @@ struct SkiaSharedContextInner {
 /// Create an instance once and pass clones of it to the difference constructor functions, to ensure most
 /// efficient resource usage.
 #[derive(Clone, Default)]
-pub struct SkiaSharedContext(Rc<SkiaSharedContextInner>);
+pub struct SkiaSharedContext(#[allow(dead_code)] Rc<SkiaSharedContextInner>);
 
 /// Use the SkiaRenderer when implementing a custom Slint platform where you deliver events to
 /// Slint and want the scene to be rendered using Skia as underlying graphics library.

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -19,6 +19,8 @@ use i_slint_core::{
     graphics::RequestedOpenGLVersion,
 };
 
+use crate::SkiaSharedContext;
+
 /// This surface type renders into the given window with OpenGL, using glutin and glow libraries.
 pub struct OpenGLSurface {
     fb_info: skia_safe::gpu::gl::FramebufferInfo,
@@ -30,6 +32,7 @@ pub struct OpenGLSurface {
 
 impl super::Surface for OpenGLSurface {
     fn new(
+        _shared_context: &SkiaSharedContext,
         window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
         display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -11,7 +11,7 @@ use std::num::NonZeroU32;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::PhysicalRect;
+use crate::{PhysicalRect, SkiaSharedContext};
 
 pub trait RenderBuffer {
     fn with_buffer(
@@ -114,6 +114,7 @@ pub struct SoftwareSurface {
 
 impl super::Surface for SoftwareSurface {
     fn new(
+        _shared_context: &SkiaSharedContext,
         window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
         display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         _size: PhysicalWindowSize,

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -19,6 +19,57 @@ use vulkano::swapchain::{Surface, Swapchain, SwapchainCreateInfo, SwapchainPrese
 use vulkano::sync::GpuFuture;
 use vulkano::{sync, Handle, Validated, VulkanError, VulkanLibrary, VulkanObject};
 
+use crate::SkiaSharedContext;
+
+pub struct SharedVulkanContext {
+    instance: Arc<Instance>,
+    // TODO: share also physical/logical device and queue, but their selection process is surface compatibility dependent.
+}
+
+impl super::SkiaSharedContextInner {
+    fn shared_vulkan_context(
+        &self,
+    ) -> Result<&SharedVulkanContext, i_slint_core::platform::PlatformError> {
+        if let Some(ctx) = self.vulkan_context.get() {
+            return Ok(ctx);
+        }
+        self.vulkan_context.set(SharedVulkanContext::new()?).ok();
+        Ok(self.vulkan_context.get().unwrap())
+    }
+}
+
+impl SharedVulkanContext {
+    fn new() -> Result<Self, i_slint_core::platform::PlatformError> {
+        let library = VulkanLibrary::new()
+            .map_err(|load_err| format!("Error loading vulkan library: {load_err}"))?;
+
+        let required_extensions = InstanceExtensions {
+            khr_surface: true,
+            mvk_macos_surface: true,
+            ext_metal_surface: true,
+            khr_wayland_surface: true,
+            khr_xlib_surface: true,
+            khr_xcb_surface: true,
+            khr_win32_surface: true,
+            khr_get_surface_capabilities2: true,
+            khr_get_physical_device_properties2: true,
+            ..InstanceExtensions::empty()
+        }
+        .intersection(library.supported_extensions());
+
+        let instance = Instance::new(
+            library.clone(),
+            InstanceCreateInfo {
+                flags: InstanceCreateFlags::ENUMERATE_PORTABILITY,
+                enabled_extensions: required_extensions,
+                ..Default::default()
+            },
+        )
+        .map_err(|instance_err| format!("Error creating Vulkan instance: {instance_err}"))?;
+        Ok(Self { instance })
+    }
+}
+
 /// This surface renders into the given window using Vulkan.
 pub struct VulkanSurface {
     gr_context: RefCell<skia_safe::gpu::DirectContext>,
@@ -158,6 +209,7 @@ impl VulkanSurface {
 
 impl super::Surface for VulkanSurface {
     fn new(
+        shared_context: &SkiaSharedContext,
         window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
         display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
         size: PhysicalWindowSize,
@@ -166,32 +218,8 @@ impl super::Surface for VulkanSurface {
         if requested_graphics_api.map_or(false, |api| api != RequestedGraphicsAPI::Vulkan) {
             return Err(format!("Requested non-Vulkan rendering with Vulkan renderer").into());
         }
-        let library = VulkanLibrary::new()
-            .map_err(|load_err| format!("Error loading vulkan library: {load_err}"))?;
 
-        let required_extensions = InstanceExtensions {
-            khr_surface: true,
-            mvk_macos_surface: true,
-            ext_metal_surface: true,
-            khr_wayland_surface: true,
-            khr_xlib_surface: true,
-            khr_xcb_surface: true,
-            khr_win32_surface: true,
-            khr_get_surface_capabilities2: true,
-            khr_get_physical_device_properties2: true,
-            ..InstanceExtensions::empty()
-        }
-        .intersection(library.supported_extensions());
-
-        let instance = Instance::new(
-            library.clone(),
-            InstanceCreateInfo {
-                flags: InstanceCreateFlags::ENUMERATE_PORTABILITY,
-                enabled_extensions: required_extensions,
-                ..Default::default()
-            },
-        )
-        .map_err(|instance_err| format!("Error creating Vulkan instance: {instance_err}"))?;
+        let instance = shared_context.0.shared_vulkan_context()?.instance.clone();
 
         let window_handle = window_handle
             .window_handle()

--- a/tools/docsnapper/headless.rs
+++ b/tools/docsnapper/headless.rs
@@ -5,7 +5,7 @@ use i_slint_core::api::PhysicalSize;
 use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::Renderer;
 use i_slint_core::window::{InputMethodRequest, WindowAdapter, WindowAdapterInternal};
-use i_slint_renderer_skia::SkiaRenderer;
+use i_slint_renderer_skia::{SkiaRenderer, SkiaSharedContext};
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -41,7 +41,7 @@ impl i_slint_core::platform::Platform for HeadlessBackend {
             size: Default::default(),
             ime_requests: Default::default(),
             mouse_cursor: Default::default(),
-            renderer: SkiaRenderer::default_software(),
+            renderer: SkiaRenderer::default_software(&SkiaSharedContext::default()),
         }))
     }
 


### PR DESCRIPTION
Share Vulkan instance as well as Metal device and command queue across windows.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
