### PR TITLE
Prefer JS function over arrow functions

### DIFF
--- a/tools/figma-inspector/backend/utils/code-utils.ts
+++ b/tools/figma-inspector/backend/utils/code-utils.ts
@@ -5,25 +5,25 @@ import type { Message, PluginMessageEvent } from "../../src/globals";
 import type { EventTS } from "../../shared/universals";
 import { generateSlintSnippet } from "./property-parsing.js";
 
-export const dispatch = (data: any, origin = "*") => {
+export function dispatch(data: any, origin = "*") {
     figma.ui.postMessage(data, {
         origin,
     });
 };
 
-export const dispatchTS = <Key extends keyof EventTS>(
+export function dispatchTS <Key extends keyof EventTS>(
     event: Key,
     data: EventTS[Key],
     origin = "*",
-) => {
+) {
     dispatch({ type: event, ...data }, origin);
 };
 
-export const listenTS = <Key extends keyof EventTS>(
+export function listenTS <Key extends keyof EventTS>(
     eventName: Key,
     callback: (data: EventTS[Key] & { type: Key }) => any,
     listenOnce = false,
-) => {
+) {
     const func = (pluginMessage: any) => {
         if (pluginMessage && pluginMessage.type === eventName) {
             callback(pluginMessage);
@@ -35,11 +35,12 @@ export const listenTS = <Key extends keyof EventTS>(
 
     figma.ui.on("message", func);
 };
-export const getStore = async (key: string) => {
+
+export async function getStore(key: string) {
     const value = await figma.clientStorage.getAsync(key);
     return value;
 };
 
-export const setStore = async (key: string, value: string) => {
+export async function setStore(key: string, value: string) {
     await figma.clientStorage.setAsync(key, value);
 };

--- a/tools/figma-inspector/src/snippet/CodeSnippet.tsx
+++ b/tools/figma-inspector/src/snippet/CodeSnippet.tsx
@@ -21,7 +21,7 @@ import OnigurumaEngine from "shiki/wasm";
 import slintLang from "../../../../editors/vscode/slint.tmLanguage.json";
 
 let highlighter: HighlighterCore | null = null;
-const initHighlighter = async () => {
+async function initHighlighter() {
     highlighter = await createHighlighterCore({
         themes: [
             darkSlint as ThemeRegistration,
@@ -34,10 +34,7 @@ const initHighlighter = async () => {
 
 type HighlightTheme = "dark-slint" | "light-slint";
 
-export default function CodeSnippet({
-    code,
-    theme,
-}: { code: string; theme: HighlightTheme }) {
+export default function CodeSnippet({ code, theme,}: { code: string; theme: HighlightTheme }) {
     const [highlightedCode, setHighlightedCode] = useState<ReactNode | null>(
         null,
     );

--- a/tools/figma-inspector/src/utils/bolt-utils.ts
+++ b/tools/figma-inspector/src/utils/bolt-utils.ts
@@ -5,28 +5,28 @@ import { manifest } from "../../figma.config";
 import type { Message, PluginMessageEvent } from "../globals";
 import type { EventTS } from "../../shared/universals";
 
-export const dispatch = (msg: Message, global = false, origin = "*") => {
+export function dispatch(msg: Message, global = false, origin = "*") {
     const data: PluginMessageEvent = { pluginMessage: msg };
     if (!global) {
         data.pluginId = manifest.id;
     }
     parent.postMessage(data, origin);
-};
+}
 
-export const dispatchTS = <Key extends keyof EventTS>(
+export function dispatchTS<Key extends keyof EventTS>(
     event: Key, // Parameter name is 'event'
     data: EventTS[Key],
     global = false,
     origin = "*",
-) => {
+) {
     dispatch({ type: event, ...data }, global, origin);
-};
+}
 
-export const listenTS = <Key extends keyof EventTS>(
+export function listenTS<Key extends keyof EventTS>(
     eventName: Key,
     callback: (data: EventTS[Key]) => any,
     listenOnce = false,
-) => {
+) {
     const func = (event: MessageEvent<any>) => {
         // --- Check for pluginMessage existence ---
         if (event.data && event.data.pluginMessage) {
@@ -43,9 +43,9 @@ export const listenTS = <Key extends keyof EventTS>(
         }
     };
     window.addEventListener("message", func);
-};
+}
 
-export const getColorTheme = () => {
+export function getColorTheme(): "light" | "dark" {
     if (window?.matchMedia) {
         if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
             return "dark";
@@ -55,11 +55,11 @@ export const getColorTheme = () => {
         }
     }
     return "light";
-};
+}
 
-export const subscribeColorTheme = (
+export function subscribeColorTheme(
     callback: (mode: "light" | "dark") => void,
-) => {
+) {
     if (window?.matchMedia) {
         window
             .matchMedia("(prefers-color-scheme: dark)")
@@ -71,4 +71,4 @@ export const subscribeColorTheme = (
                 }
             });
     }
-};
+}

--- a/tools/figma-inspector/src/utils/utils.ts
+++ b/tools/figma-inspector/src/utils/utils.ts
@@ -38,9 +38,9 @@ export function writeTextToClipboard(str: string): boolean {
     return copySuccessful;
 }
 
-export const downloadZipFile = async (
+export async function downloadZipFile(
     files: Array<{ name: string; content: string }>,
-) => {
+) {
     try {
         if (!files || files.length === 0) {
             console.error("No files to zip!");
@@ -79,9 +79,9 @@ export const downloadZipFile = async (
             }, index * 100);
         });
     }
-};
+}
 
-const downloadFile = (filename: string, text: string) => {
+function downloadFile(filename: string, text: string) {
     const element = document.createElement("a");
     element.setAttribute(
         "href",
@@ -92,4 +92,4 @@ const downloadFile = (filename: string, text: string) => {
     document.body.appendChild(element);
     element.click();
     document.body.removeChild(element);
-};
+}


### PR DESCRIPTION
When defined seperatly traditional js function <name>(args): return are used as it makes it clear these are functions.

For in-line usage such as in event handlers (clicked={() => {}}) and Zustand state definitions (doSomething: () => {}) arrow functions are still used.