### PR TITLE
Try to fix Mise rate limiting

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -23,6 +23,7 @@ jobs:
         timeout-minutes: 15
         env:
             CARGO_INCREMENTAL: false
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - uses: actions/checkout@v4
             - uses: jdx/mise-action@v2
@@ -36,6 +37,7 @@ jobs:
         timeout-minutes: 15
         env:
             CARGO_INCREMENTAL: false
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - uses: actions/checkout@v4
             - uses: jdx/mise-action@v2

--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -17,13 +17,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+    CARGO_INCREMENTAL: false
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
     format_fix:
         runs-on: ubuntu-24.04
         timeout-minutes: 15
-        env:
-            CARGO_INCREMENTAL: false
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - uses: actions/checkout@v4
             - uses: jdx/mise-action@v2
@@ -35,9 +36,6 @@ jobs:
     lint_typecheck:
         runs-on: ubuntu-24.04
         timeout-minutes: 15
-        env:
-            CARGO_INCREMENTAL: false
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - uses: actions/checkout@v4
             - uses: jdx/mise-action@v2


### PR DESCRIPTION
Some mise tasks never complete. Today the following warning showed up: 

mise WARN  GitHub API returned a 403 Forbidden error. This likely means you have exceeded the rate limit.
mise WARN  GITHUB_TOKEN is not set. This means mise is making unauthenticated requests to GitHub which have a lower rate limit.
To increase the rate limit, set the GITHUB_TOKEN environment variable to a GitHub personal access token.
Create a token at https://github.com/settings/tokens and set it as GITHUB_TOKEN in your environment.
You do not need to give this token any scopes.

Maybe this will fix the CI errors?