### PR TITLE
WGPU: Clean up public API

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -178,10 +178,17 @@ backend-android-activity-05 = [
 
 ## Enable support for [WGPU](http://wgpu.rs) based rendering and expose WGPU based APIs based on WGPU version 24.x.
 ##
-## Access to these APIS is valuable, but as WGPU releases new major versions frequently, this feature as well as the
-## APIs guarded with it are *NOT* subject to the usual Slint API stability guarantees. This will may be removed in future
-## minor releases of Slint, likely to be replaced by a feature with a similar name but the WGPU version suffix being bumped.
-unstable-wgpu-24 = ["i-slint-core/unstable-wgpu-24", "i-slint-backend-selector/unstable-wgpu-24"]
+## APIs guarded with this feature are *NOT* subject to the usual Slint API stability guarantees, because WGPU releases new major
+## versions frequently. This feature as well as the APIs changed or removed in future minor releases of Slint, likely to be replaced
+## by a feature with a similar name but the WGPU version suffix being bumped.
+##
+## To avoid unintended compilation failures, we recommend to use the [tilde requirement](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements)
+## in your `Cargo.toml` when enabling this feature:
+##
+## ```toml
+## slint = { version = "~1.12", features = ["unstable-wgpu-24"] }
+## ```
+unstable-wgpu-24 = ["i-slint-core/unstable-wgpu-24", "i-slint-backend-selector/unstable-wgpu-24", "dep:wgpu-24"]
 
 [dependencies]
 i-slint-core = { workspace = true }
@@ -202,6 +209,8 @@ log = { workspace = true, optional = true }
 raw-window-handle-06 = { workspace = true, optional = true }
 
 unicode-segmentation = { workspace = true }
+
+wgpu-24 = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 # FemtoVG is disabled on android because it doesn't compile without setting RUST_FONTCONFIG_DLOPEN=on

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -443,3 +443,102 @@ mod compile_fail_tests;
 
 #[cfg(doc)]
 pub mod docs;
+
+#[cfg(feature = "unstable-wgpu-24")]
+pub mod wgpu_24 {
+    //! WGPU 24.x specific types and re-exports.
+    //!
+    //! *Note*: This module is behind a feature flag and may be removed or changed in future minor releases,
+    //!         as new major WGPU releases become available.
+    //!
+    //! Use the types in this module in combination with other APIs to integrate external, WGPU-based rendering engines
+    //! into a UI with Slint.
+    //!
+    //! First, ensure that WGPU is used for rendering with Slint by using [`slint::BackendSelector::require_wgpu_24()`](i_slint_backend_selector::api::BackendSelector::require_wgpu_24()).
+    //! This function accepts a pre-configured WGPU setup or configuration hints such as required features or memory limits.
+    //!
+    //! For rendering, it's crucial that you're using the same [`wgpu::Device`] and [`wgpu::Queue`] for allocating textures or submitting commands as Slint. Obtain the same queue
+    //! by either using [`WGPUConfiguration::Manual`] to make Slint use an existing WGPU configuration, or use [`slint::Window::set_rendering_notifier()`](i_slint_core::api::Window::set_rendering_notifier())
+    //! to let Slint invoke a callback that provides access device, queue, etc. in [`slint::GraphicsAPI::WGPU24`](i_slint_core::api::GraphicsAPI::WGPU24).
+    //!
+    //! To integrate rendering content into a scene shared with a Slint UI, use either [`slint::Window::set_rendering_notifier()`](i_slint_core::api::Window::set_rendering_notifier()) to render an underlay
+    //! or overlay, or integrate externally produced [`wgpu::Texture`]s using [`slint::Image::try_from<wgpu::Texture>()`](i_slint_core::graphics::Image::try_from).
+    //!
+    //! The following example allocates a [`wgpu::Texture`] and, for the sake of simplicity in this documentation, fills with green as color, and then proceeds to set it as a `slint::Image` in the scene.
+    //!
+    //! `Cargo.toml`:
+    //! ```toml
+    //! slint = { version = "~1.12", features = ["unstable-wgpu-24"] }
+    //! ```
+    //!
+    //! `main.rs`:
+    //!```rust
+    //!
+    //! use slint::wgpu_24::wgpu;
+    //! use wgpu::util::DeviceExt;
+    //!
+    //!slint::slint!{
+    //!    export component HelloWorld inherits Window {
+    //!        preferred-width: 320px;
+    //!        preferred-height: 300px;
+    //!        in-out property <image> app-texture;
+    //!        VerticalLayout {
+    //!            Text {
+    //!                text: "hello world";
+    //!                color: green;
+    //!            }
+    //!            Image { source: root.app-texture; }
+    //!        }
+    //!    }
+    //!}
+    //!fn main() -> Result<(), Box<dyn std::error::Error>> {
+    //!#   return Ok(()); // Don't run a window in an example
+    //!    slint::BackendSelector::new()
+    //!        .require_wgpu_24(slint::wgpu_24::WGPUConfiguration::default())
+    //!        .select()?;
+    //!    let app = HelloWorld::new()?;
+    //!
+    //!    let app_weak = app.as_weak();
+    //!
+    //!    app.window().set_rendering_notifier(move |state, graphics_api| {
+    //!        let (Some(app), slint::RenderingState::RenderingSetup, slint::GraphicsAPI::WGPU24{ device, queue, ..}) = (app_weak.upgrade(), state, graphics_api) else {
+    //!            return;
+    //!        };
+    //!
+    //!        let mut pixels = slint::SharedPixelBuffer::<slint::Rgba8Pixel>::new(320, 200);
+    //!        pixels.make_mut_slice().fill(slint::Rgba8Pixel {
+    //!            r: 0,
+    //!            g: 255,
+    //!            b :0,
+    //!            a: 255,
+    //!        });
+    //!
+    //!        let texture = device.create_texture_with_data(queue,
+    //!            &wgpu::TextureDescriptor {
+    //!                label: None,
+    //!                size: wgpu::Extent3d { width: 320, height: 200, depth_or_array_layers: 1 },
+    //!                mip_level_count: 1,
+    //!                sample_count: 1,
+    //!                dimension: wgpu::TextureDimension::D2,
+    //!                format: wgpu::TextureFormat::Rgba8Unorm,
+    //!                usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+    //!                view_formats: &[],
+    //!            },
+    //!            wgpu::util::TextureDataOrder::default(),
+    //!            pixels.as_bytes(),
+    //!        );
+    //!
+    //!        let imported_image = slint::Image::try_from(texture).unwrap();
+    //!
+    //!        app.set_app_texture(imported_image);
+    //!    })?;
+    //!
+    //!    app.run()?;
+    //!
+    //!    Ok(())
+    //!}
+    //!```
+    //!
+    pub use i_slint_core::graphics::wgpu_24::*;
+    pub use wgpu_24 as wgpu;
+}

--- a/examples/wgpu_texture/Cargo.toml
+++ b/examples/wgpu_texture/Cargo.toml
@@ -16,7 +16,6 @@ name = "wgpu_texture"
 
 [dependencies]
 slint = { path = "../../api/rs/slint", features = ["unstable-wgpu-24"] }
-wgpu-24 = { workspace = true, features = ["wgsl"] }
 bytemuck = { workspace = true }
 
 [build-dependencies]

--- a/examples/wgpu_texture/main.rs
+++ b/examples/wgpu_texture/main.rs
@@ -3,7 +3,7 @@
 
 slint::include_modules!();
 
-use wgpu_24 as wgpu;
+use slint::wgpu_24::{wgpu, WGPUConfiguration, WGPUSettings};
 
 struct DemoRenderer {
     device: wgpu::Device,
@@ -140,12 +140,12 @@ impl DemoRenderer {
 }
 
 fn main() {
-    let mut wgpu_settings = slint::WGPU24Settings::default();
+    let mut wgpu_settings = WGPUSettings::default();
     wgpu_settings.device_required_features = wgpu::Features::PUSH_CONSTANTS;
     wgpu_settings.device_required_limits.max_push_constant_size = 16;
 
     slint::BackendSelector::new()
-        .require_wgpu_24(slint::WGPU24Configuration::Automatic(wgpu_settings))
+        .require_wgpu_24(WGPUConfiguration::Automatic(wgpu_settings))
         .select()
         .expect("Unable to create Slint backend with WGPU based renderer");
 

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -105,7 +105,7 @@ impl BackendSelector {
     #[must_use]
     pub fn require_wgpu_24(
         mut self,
-        configuration: i_slint_core::api::WGPU24Configuration,
+        configuration: i_slint_core::graphics::wgpu_24::WGPUConfiguration,
     ) -> Self {
         self.requested_graphics_api = Some(RequestedGraphicsAPI::WGPU24(configuration));
         self

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -16,10 +16,6 @@ use crate::window::{WindowAdapter, WindowInner};
 use alloc::boxed::Box;
 use alloc::string::String;
 
-mod graphics_selection;
-#[cfg(feature = "unstable-wgpu-24")]
-pub use graphics_selection::*;
-
 /// A position represented in the coordinate space of logical pixels. That is the space before applying
 /// a display device specific scale factor.
 #[derive(Debug, Default, Copy, Clone, PartialEq)]

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -56,6 +56,9 @@ pub mod boxshadowcache;
 pub mod border_radius;
 pub use border_radius::*;
 
+#[cfg(feature = "unstable-wgpu-24")]
+pub mod wgpu_24;
+
 /// CachedGraphicsData allows the graphics backend to store an arbitrary piece of data associated with
 /// an item, which is typically computed by accessing properties. The dependency_tracker is used to allow
 /// for a lazy computation. Typically, back ends store either compute intensive data or handles that refer to
@@ -189,7 +192,7 @@ pub enum RequestedGraphicsAPI {
     Direct3D,
     #[cfg(feature = "unstable-wgpu-24")]
     /// WGPU 24.x
-    WGPU24(crate::api::WGPU24Configuration),
+    WGPU24(wgpu_24::WGPUConfiguration),
 }
 
 impl TryFrom<RequestedGraphicsAPI> for RequestedOpenGLVersion {

--- a/internal/core/graphics/wgpu_24.rs
+++ b/internal/core/graphics/wgpu_24.rs
@@ -9,10 +9,9 @@ in particular the `BackendSelector` type, to configure the WGPU-based renderer(s
 */
 
 /// This data structure provides settings for initializing WGPU renderers.
-#[cfg(feature = "unstable-wgpu-24")]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-pub struct WGPU24Settings {
+pub struct WGPUSettings {
     /// The backends to use for the WGPU instance.
     pub backends: wgpu_24::Backends,
     /// The different options that are given to the selected backends.
@@ -33,8 +32,7 @@ pub struct WGPU24Settings {
     pub device_memory_hints: wgpu_24::MemoryHints,
 }
 
-#[cfg(feature = "unstable-wgpu-24")]
-impl Default for WGPU24Settings {
+impl Default for WGPUSettings {
     fn default() -> Self {
         let backends = wgpu_24::Backends::from_env().unwrap_or_default();
         let dx12_shader_compiler = wgpu_24::Dx12Compiler::from_env().unwrap_or_default();
@@ -59,10 +57,9 @@ impl Default for WGPU24Settings {
 }
 
 /// This enum describes the different ways to configure WGPU for rendering.
-#[cfg(feature = "unstable-wgpu-24")]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-pub enum WGPU24Configuration {
+pub enum WGPUConfiguration {
     /// Use `Manual` if you've initialized WGPU and want to supply the instance, adapter,
     /// device, and queue for use.
     Manual {
@@ -77,12 +74,11 @@ pub enum WGPU24Configuration {
     },
     /// Use `Automatic` if you want to let Slint select the WGPU instance, adapter, and
     /// device, but fine-tune aspects such as memory limits or features.
-    Automatic(WGPU24Settings),
+    Automatic(WGPUSettings),
 }
 
-#[cfg(feature = "unstable-wgpu-24")]
-impl Default for WGPU24Configuration {
+impl Default for WGPUConfiguration {
     fn default() -> Self {
-        Self::Automatic(WGPU24Settings::default())
+        Self::Automatic(WGPUSettings::default())
     }
 }

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -125,14 +125,19 @@ impl FemtoVGRenderer<WGPUBackend> {
         let (instance, adapter, device, queue, surface) = match requested_graphics_api {
             #[cfg(feature = "unstable-wgpu-24")]
             Some(RequestedGraphicsAPI::WGPU24(
-                i_slint_core::api::WGPU24Configuration::Manual { instance, adapter, device, queue },
+                i_slint_core::graphics::wgpu_24::WGPUConfiguration::Manual {
+                    instance,
+                    adapter,
+                    device,
+                    queue,
+                },
             )) => {
                 let surface = instance.create_surface(window_handle).unwrap();
                 (instance, adapter, device, queue, surface)
             }
             #[cfg(feature = "unstable-wgpu-24")]
             Some(RequestedGraphicsAPI::WGPU24(
-                i_slint_core::api::WGPU24Configuration::Automatic(wgpu24_settings),
+                i_slint_core::graphics::wgpu_24::WGPUConfiguration::Automatic(wgpu24_settings),
             )) => {
                 // wgpu uses async here, but the returned future is ready on first poll on all platforms except WASM,
                 // which we don't supoprt right now.


### PR DESCRIPTION
- Create a `slint::wgpu_24` module
- Re-export `wgpu` in it
- Place the WGPU config types used by the `BackendSelector::require_wgpu_24` function in it, and remove the 24 infix.

As an upside, this also adds the feature guard to the docs at least for the `wgpu_24` module.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
