### PR TITLE
slint crate: Replace early return with `no_run` tag on code fence

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -42,7 +42,7 @@ information about the generation functions and how to use them.
 
 This method combines your Rust code with the `.slint` design markup in one file, using a macro:
 
-```rust
+```rust,no_run
 slint::slint!{
     export component HelloWorld inherits Window {
         Text {
@@ -52,7 +52,6 @@ slint::slint!{
     }
 }
 fn main() {
-#   return; // Don't run a window in an example
     HelloWorld::new().unwrap().run().unwrap();
 }
 ```
@@ -472,7 +471,7 @@ pub mod wgpu_24 {
     //! ```
     //!
     //! `main.rs`:
-    //!```rust
+    //!```rust,no_run
     //!
     //! use slint::wgpu_24::wgpu;
     //! use wgpu::util::DeviceExt;
@@ -492,7 +491,6 @@ pub mod wgpu_24 {
     //!    }
     //!}
     //!fn main() -> Result<(), Box<dyn std::error::Error>> {
-    //!#   return Ok(()); // Don't run a window in an example
     //!    slint::BackendSelector::new()
     //!        .require_wgpu_24(slint::wgpu_24::WGPUConfiguration::default())
     //!        .select()?;


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
