### PR TITLE
slint crate: Expose parts of the winit backend's previously private API

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -190,6 +190,18 @@ backend-android-activity-05 = [
 ## ```
 unstable-wgpu-24 = ["i-slint-core/unstable-wgpu-24", "i-slint-backend-selector/unstable-wgpu-24", "dep:wgpu-24"]
 
+## APIs guarded with this feature are *NOT* subject to the usual Slint API stability guarantees, because winit releases new major
+## versions more frequently than Slint. This feature as well as the APIs changed or removed in future minor releases of Slint, likely to be replaced
+## by a feature with a similar name but the winit version suffix being bumped.
+##
+## To avoid unintended compilation failures, we recommend to use the [tilde requirement](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements)
+## in your `Cargo.toml` when enabling this feature:
+##
+## ```toml
+## slint = { version = "~1.12", features = ["unstable-winit-030"] }
+## ```
+unstable-winit-030 = ["backend-winit", "dep:i-slint-backend-winit", "i-slint-backend-selector/unstable-winit-030"]
+
 [dependencies]
 i-slint-core = { workspace = true }
 slint-macros = { workspace = true }
@@ -211,6 +223,8 @@ raw-window-handle-06 = { workspace = true, optional = true }
 unicode-segmentation = { workspace = true }
 
 wgpu-24 = { workspace = true, optional = true }
+
+i-slint-backend-winit = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 # FemtoVG is disabled on android because it doesn't compile without setting RUST_FONTCONFIG_DLOPEN=on

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -553,5 +553,7 @@ pub mod winit_030 {
     //! Use the types and traits in this module in combination with other APIs to access additional window properties,
     //! create custom windows, or hook into the winit event loop.
 
-    pub use i_slint_backend_winit::{winit, WinitWindowAccessor, WinitWindowEventResult};
+    pub use i_slint_backend_winit::{
+        winit, EventLoopBuilder, SlintEvent, WinitWindowAccessor, WinitWindowEventResult,
+    };
 }

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -542,3 +542,16 @@ pub mod wgpu_24 {
     pub use i_slint_core::graphics::wgpu_24::*;
     pub use wgpu_24 as wgpu;
 }
+
+#[cfg(feature = "unstable-winit-030")]
+pub mod winit_030 {
+    //! Winit 0.30.x specific types and re-exports.
+    //!
+    //! *Note*: This module is behind a feature flag and may be removed or changed in future minor releases,
+    //!         as new major Winit releases become available.
+    //!
+    //! Use the types and traits in this module in combination with other APIs to access additional window properties,
+    //! create custom windows, or hook into the winit event loop.
+
+    pub use i_slint_backend_winit::{winit, WinitWindowAccessor, WinitWindowEventResult};
+}

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -552,6 +552,54 @@ pub mod winit_030 {
     //!
     //! Use the types and traits in this module in combination with other APIs to access additional window properties,
     //! create custom windows, or hook into the winit event loop.
+    //!
+    //! For example, use the [`WinitWindowAccessor`] to obtain access to the underling [`winit::window::Window`]:
+    //!
+    //! `Cargo.toml`:
+    //! ```toml
+    //! slint = { version = "~1.12", features = ["unstable-winit-030"] }
+    //! ```
+    //!
+    //! `main.rs`:
+    //! ```rust,no_run
+    //! // Bring winit and accessor traits into scope.
+    //! use slint::winit_030::{WinitWindowAccessor, winit};
+    //!
+    //! slint::slint!{
+    //!     import { VerticalBox, Button } from "std-widgets.slint";
+    //!     export component HelloWorld inherits Window {
+    //!         callback clicked;
+    //!         VerticalBox {
+    //!             Text {
+    //!                 text: "hello world";
+    //!                 color: green;
+    //!             }
+    //!             Button {
+    //!                 text: "Click me";
+    //!                 clicked => { root.clicked(); }
+    //!             }
+    //!         }
+    //!     }
+    //! }
+    //! fn main() -> Result<(), Box<dyn std::error::Error>> {
+    //!     // Make sure the winit backed is selected:
+    //!    slint::BackendSelector::new()
+    //!        .backend_name("winit".into())
+    //!        .select()?;
+    //!
+    //!     let app = HelloWorld::new()?;
+    //!     let app_weak = app.as_weak();
+    //!     app.on_clicked(move || {
+    //!         // access the winit window
+    //!         let app = app_weak.unwrap();
+    //!         app.window().with_winit_window(|winit_window: &winit::window::Window| {
+    //!             eprintln!("window id = {:#?}", winit_window.id());
+    //!         });
+    //!     });
+    //!     app.run()?;
+    //!     Ok(())
+    //! }
+    //! ```
 
     pub use i_slint_backend_winit::{
         winit, EventLoopBuilder, SlintEvent, WinitWindowAccessor, WinitWindowEventResult,

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -600,6 +600,8 @@ pub mod winit_030 {
     //!     Ok(())
     //! }
     //! ```
+    //! See also [`BackendSelector::with_winit_030_event_loop_builder()`](crate::BackendSelector::with_winit_030_event_loop_builder())
+    //! and [`BackendSelector::with_winit_030_window_attributes_hook()`](crate::BackendSelector::with_winit_030_window_attributes_hook()).
 
     pub use i_slint_backend_winit::{
         winit, EventLoopBuilder, SlintEvent, WinitWindowAccessor, WinitWindowEventResult,

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -56,6 +56,8 @@ unstable-wgpu-24 = [
   "i-slint-backend-winit?/unstable-wgpu-24",
 ]
 
+unstable-winit-030 = ["dep:i-slint-backend-winit"]
+
 # note that default enable the i-slint-backend-qt, but not its enable feature
 default = ["i-slint-backend-qt", "backend-winit"]
 

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -79,3 +79,6 @@ i-slint-backend-linuxkms = { workspace = true, features = ["default"], optional 
 
 [build-dependencies]
 i-slint-common = { workspace = true }
+
+[dev-dependencies]
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "backend-winit", "renderer-software", "unstable-winit-030"] }

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -56,7 +56,7 @@ unstable-wgpu-24 = [
   "i-slint-backend-winit?/unstable-wgpu-24",
 ]
 
-unstable-winit-030 = ["dep:i-slint-backend-winit"]
+unstable-winit-030 = ["i-slint-backend-winit"]
 
 # note that default enable the i-slint-backend-qt, but not its enable feature
 default = ["i-slint-backend-qt", "backend-winit"]

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -129,7 +129,7 @@ impl BackendSelector {
     ///
     /// ```rust,no_run
     /// let mut backend = slint::BackendSelector::new()
-    ///     .with_winit+window_attributes_hook(|attributes| attributes.with_content_protected(true))
+    ///     .with_winit_window_attributes_hook(|attributes| attributes.with_content_protected(true))
     ///     .select()
     ///     .unwrap();
     /// ```

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -34,6 +34,20 @@ pub struct BackendSelector {
     backend: Option<String>,
     renderer: Option<String>,
     selected: bool,
+    #[cfg(feature = "unstable-winit-030")]
+    winit_window_attributes_hook: Option<
+        Box<
+            dyn Fn(
+                i_slint_backend_winit::winit::window::WindowAttributes,
+            ) -> i_slint_backend_winit::winit::window::WindowAttributes,
+        >,
+    >,
+    #[cfg(feature = "unstable-winit-030")]
+    winit_event_loop_builder: Option<
+        i_slint_backend_winit::winit::event_loop::EventLoopBuilder<
+            i_slint_backend_winit::SlintUserEvent,
+        >,
+    >,
 }
 
 impl BackendSelector {
@@ -111,6 +125,51 @@ impl BackendSelector {
         self
     }
 
+    /// Configures this builder to use the specified winit hook that will be called before a Window is created.
+    ///
+    /// It can be used to adjust settings of window that will be created.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// let mut backend = slint::BackendSelector::new()
+    ///     .with_winit+window_attributes_hook(|attributes| attributes.with_content_protected(true))
+    ///     .select()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// *Note*: This function is behind a feature flag and may be removed or changed in future minor releases,
+    ///         as new major Winit releases become available.
+    #[must_use]
+    #[cfg(feature = "unstable-winit-030")]
+    pub fn with_winit_030_window_attributes_hook(
+        mut self,
+        hook: impl Fn(
+                i_slint_backend_winit::winit::window::WindowAttributes,
+            ) -> i_slint_backend_winit::winit::window::WindowAttributes
+            + 'static,
+    ) -> Self {
+        self.winit_window_attributes_hook = Some(Box::new(hook));
+        self
+    }
+
+    /// Configures this builder to use the specified winit event loop builder when creating the event
+    /// loop.
+    ///
+    /// *Note*: This function is behind a feature flag and may be removed or changed in future minor releases,
+    ///         as new major Winit releases become available.
+    #[must_use]
+    #[cfg(feature = "unstable-winit-030")]
+    pub fn with_winit_030_event_loop_builder(
+        mut self,
+        event_loop_builder: i_slint_backend_winit::winit::event_loop::EventLoopBuilder<
+            i_slint_backend_winit::SlintUserEvent,
+        >,
+    ) -> Self {
+        self.winit_event_loop_builder = Some(event_loop_builder);
+        self
+    }
+
     /// Adds the requirement that the selected renderer must match the given name. This is
     /// equivalent to setting the `SLINT_BACKEND=name` environment variable and requires
     /// that the corresponding renderer feature is enabled. For example, to select the Skia renderer,
@@ -165,6 +224,18 @@ impl BackendSelector {
 
                 let builder = match self.renderer.as_ref() {
                     Some(name) => builder.with_renderer_name(name),
+                    None => builder,
+                };
+
+                #[cfg(feature = "unstable-winit-030")]
+                let builder = match self.winit_window_attributes_hook {
+                    Some(hook) => builder.with_window_attributes_hook(hook),
+                    None => builder,
+                };
+
+                #[cfg(feature = "unstable-winit-030")]
+                let builder = match self.winit_event_loop_builder {
+                    Some(builder) => builder.with_event_loop_builder(builder),
                     None => builder,
                 };
 

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -222,14 +222,14 @@ impl BackendSelector {
                 };
 
                 #[cfg(feature = "unstable-winit-030")]
-                let builder = match self.winit_window_attributes_hook {
+                let builder = match self.winit_window_attributes_hook.take() {
                     Some(hook) => builder.with_window_attributes_hook(hook),
                     None => builder,
                 };
 
                 #[cfg(feature = "unstable-winit-030")]
-                let builder = match self.winit_event_loop_builder {
-                    Some(builder) => builder.with_event_loop_builder(builder),
+                let builder = match self.winit_event_loop_builder.take() {
+                    Some(event_loop_builder) => builder.with_event_loop_builder(event_loop_builder),
                     None => builder,
                 };
 

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -129,7 +129,7 @@ impl BackendSelector {
     ///
     /// ```rust,no_run
     /// let mut backend = slint::BackendSelector::new()
-    ///     .with_winit_window_attributes_hook(|attributes| attributes.with_content_protected(true))
+    ///     .with_winit_030_window_attributes_hook(|attributes| attributes.with_content_protected(true))
     ///     .select()
     ///     .unwrap();
     /// ```

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -43,11 +43,7 @@ pub struct BackendSelector {
         >,
     >,
     #[cfg(feature = "unstable-winit-030")]
-    winit_event_loop_builder: Option<
-        i_slint_backend_winit::winit::event_loop::EventLoopBuilder<
-            i_slint_backend_winit::SlintUserEvent,
-        >,
-    >,
+    winit_event_loop_builder: Option<i_slint_backend_winit::EventLoopBuilder>,
 }
 
 impl BackendSelector {
@@ -162,9 +158,7 @@ impl BackendSelector {
     #[cfg(feature = "unstable-winit-030")]
     pub fn with_winit_030_event_loop_builder(
         mut self,
-        event_loop_builder: i_slint_backend_winit::winit::event_loop::EventLoopBuilder<
-            i_slint_backend_winit::SlintUserEvent,
-        >,
+        event_loop_builder: i_slint_backend_winit::EventLoopBuilder,
     ) -> Self {
         self.winit_event_loop_builder = Some(event_loop_builder);
         self

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -19,7 +19,7 @@ use i_slint_core::SharedString;
 use i_slint_core::{properties::PropertyTracker, window::WindowAdapter};
 
 use super::WinitWindowAdapter;
-use crate::SlintUserEvent;
+use crate::SlintEvent;
 use winit::event_loop::EventLoopProxy;
 
 /// The AccessKit adapter tries to keep the given window adapter's item tree in sync with accesskit's node tree.
@@ -52,7 +52,7 @@ impl AccessKitAdapter {
     pub fn new(
         window_adapter_weak: Weak<WinitWindowAdapter>,
         winit_window: &winit::window::Window,
-        proxy: EventLoopProxy<SlintUserEvent>,
+        proxy: EventLoopProxy<SlintEvent>,
     ) -> Self {
         Self {
             inner: accesskit_winit::Adapter::with_event_loop_proxy(winit_window, proxy),
@@ -728,9 +728,9 @@ struct CachedNode {
     tracker: Pin<Box<PropertyTracker>>,
 }
 
-impl From<accesskit_winit::Event> for SlintUserEvent {
+impl From<accesskit_winit::Event> for SlintEvent {
     fn from(value: accesskit_winit::Event) -> Self {
-        SlintUserEvent(crate::event_loop::CustomEvent::Accesskit(value))
+        SlintEvent(crate::event_loop::CustomEvent::Accesskit(value))
     }
 }
 

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -9,7 +9,7 @@
 */
 use crate::drag_resize_window::{handle_cursor_move_for_resize, handle_resize};
 use crate::WinitWindowEventResult;
-use crate::{SharedBackendData, SlintUserEvent};
+use crate::{SharedBackendData, SlintEvent};
 use corelib::graphics::euclid;
 use corelib::input::{KeyEvent, KeyEventType, MouseEvent};
 use corelib::items::{ColorScheme, PointerEventButton};
@@ -26,13 +26,11 @@ use winit::event_loop::ActiveEventLoop;
 use winit::event_loop::ControlFlow;
 use winit::window::ResizeDirection;
 pub(crate) struct NotRunningEventLoop {
-    pub(crate) instance: winit::event_loop::EventLoop<SlintUserEvent>,
+    pub(crate) instance: winit::event_loop::EventLoop<SlintEvent>,
 }
 
 impl NotRunningEventLoop {
-    pub(crate) fn new(
-        mut builder: winit::event_loop::EventLoopBuilder<SlintUserEvent>,
-    ) -> Result<Self, PlatformError> {
+    pub(crate) fn new(mut builder: crate::EventLoopBuilder) -> Result<Self, PlatformError> {
         #[cfg(all(unix, not(target_vendor = "apple")))]
         {
             #[cfg(feature = "wayland")]
@@ -77,7 +75,7 @@ pub(crate) enum ActiveOrInactiveEventLoop<'a> {
     #[allow(unused)]
     Active(&'a ActiveEventLoop),
     #[allow(unused)]
-    Inactive(&'a winit::event_loop::EventLoop<SlintUserEvent>),
+    Inactive(&'a winit::event_loop::EventLoop<SlintEvent>),
 }
 
 pub(crate) trait EventLoopInterface {
@@ -175,7 +173,7 @@ impl EventLoopState {
     }
 }
 
-impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
+impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
     fn resumed(&mut self, active_event_loop: &ActiveEventLoop) {
         for (_, window_weak) in self.shared_backend_data.active_windows.borrow().iter() {
             if let Some(w) = window_weak.upgrade() {
@@ -462,7 +460,7 @@ impl winit::application::ApplicationHandler<SlintUserEvent> for EventLoopState {
         }
     }
 
-    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: SlintUserEvent) {
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: SlintEvent) {
         match event.0 {
             CustomEvent::UserEvent(user_callback) => user_callback(),
             CustomEvent::Exit => event_loop.exit(),

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use super::WinitWindowAdapter;
-use crate::SlintUserEvent;
+use crate::SlintEvent;
 use core::pin::Pin;
 use i_slint_core::items::MenuEntry;
 use i_slint_core::menus::MenuVTable;
@@ -36,13 +36,13 @@ impl MudaAdapter {
     pub fn setup(
         menubar: &vtable::VBox<MenuVTable>,
         winit_window: &Window,
-        proxy: EventLoopProxy<SlintUserEvent>,
+        proxy: EventLoopProxy<SlintEvent>,
         window_adapter_weak: Weak<WinitWindowAdapter>,
     ) -> Self {
         let menu = muda::Menu::new();
 
         muda::MenuEvent::set_event_handler(Some(move |e| {
-            let _ = proxy.send_event(SlintUserEvent(crate::event_loop::CustomEvent::Muda(e)));
+            let _ = proxy.send_event(SlintEvent(crate::event_loop::CustomEvent::Muda(e)));
         }));
 
         #[cfg(target_os = "windows")]

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -26,7 +26,7 @@ use corelib::items::{ColorScheme, MouseCursor};
 use corelib::items::{ItemRc, ItemRef};
 
 #[cfg(any(enable_accesskit, muda))]
-use crate::SlintUserEvent;
+use crate::SlintEvent;
 use crate::{SharedBackendData, WinitWindowEventResult};
 use corelib::api::PhysicalSize;
 use corelib::layout::Orientation;
@@ -278,7 +278,7 @@ pub struct WinitWindowAdapter {
     virtual_keyboard_helper: RefCell<Option<super::wasm_input_helper::WasmInputHelper>>,
 
     #[cfg(any(enable_accesskit, muda))]
-    event_loop_proxy: EventLoopProxy<SlintUserEvent>,
+    event_loop_proxy: EventLoopProxy<SlintEvent>,
 
     pub(crate) window_event_filter: Cell<
         Option<
@@ -310,7 +310,7 @@ impl WinitWindowAdapter {
         renderer: Box<dyn WinitCompatibleRenderer>,
         window_attributes: winit::window::WindowAttributes,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
-        #[cfg(any(enable_accesskit, muda))] proxy: EventLoopProxy<SlintUserEvent>,
+        #[cfg(any(enable_accesskit, muda))] proxy: EventLoopProxy<SlintEvent>,
         #[cfg(all(muda, target_os = "macos"))] muda_enable_default_menu_bar: bool,
     ) -> Result<Rc<Self>, PlatformError> {
         let self_rc = Rc::new_cyclic(|self_weak| Self {


### PR DESCRIPTION
Similar to the wgpu access, the `unstable-winit-030` feature exposes a `slint::winit_030` module, which in turn re-exports `winit` but also provides access to the `WinitWindowAccessor` trait. The `BackendSelector` is extended to provide a way to hook into window attribute creation as well as providing a custom event loop builder, similar to what `i_slint_backend_winit::BackendBuilder` provides.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
