### PR TITLE
figma-inspector: added some UX to the revamped dialog

### DIFF
--- a/tools/figma-inspector/src/main.tsx
+++ b/tools/figma-inspector/src/main.tsx
@@ -6,7 +6,7 @@ import { getColorTheme, subscribeColorTheme } from "./utils/bolt-utils";
 import CodeSnippet from "./components/snippet/CodeSnippet";
 import { ExportType, useInspectorStore } from "./utils/store";
 import DialogFrame from "./components/DialogFrame.js";
-import { Button, Checkbox, DropdownMenu, Text } from "figma-kit";
+import { Text, Button, Checkbox, DropdownMenu } from "figma-kit";
 import "./main.css";
 
 export const App = () => {
@@ -102,33 +102,6 @@ export const App = () => {
                     />
                 </DialogFrame.Content>
                 <DialogFrame.Footer>
-                    <div className="border border-secondary  border-[var(--figma-color-bg-brand)]">
-                        <Text className="text-[var(--figma-color-bg-brand)]">
-                            Welcome to Figma
-                        </Text>
-                    </div>
-                    <DropdownMenu.Root>
-                        <DropdownMenu.Trigger asChild>
-                            <Button>Export</Button>
-                        </DropdownMenu.Trigger>
-                        <DropdownMenu.Content style={{}}>
-                            <DropdownMenu.Item
-                                onClick={() =>
-                                    exportFiles(ExportType.SeparateFiles)
-                                }
-                            >
-                                Separate Files…
-                            </DropdownMenu.Item>
-                            <DropdownMenu.Item
-                                onClick={() =>
-                                    exportFiles(ExportType.SingleFile)
-                                }
-                            >
-                                Single File…
-                            </DropdownMenu.Item>
-                        </DropdownMenu.Content>
-                    </DropdownMenu.Root>
-
                     <Checkbox.Root>
                         <Checkbox.Input
                             checked={useVariables}
@@ -136,6 +109,56 @@ export const App = () => {
                         />
                         <Checkbox.Label>Use Figma Variables</Checkbox.Label>
                     </Checkbox.Root>
+
+                    <DropdownMenu.Root>
+                        <DropdownMenu.Trigger asChild>
+                            <Button
+                                variant={
+                                    exportsAreCurrent ? "secondary" : "primary"
+                                }
+                                style={{
+                                    visibility: useVariables
+                                        ? "visible"
+                                        : "hidden",
+                                }}
+                            >
+                                Export
+                            </Button>
+                        </DropdownMenu.Trigger>
+                        <DropdownMenu.Content>
+                            <DropdownMenu.Item
+                                onClick={() =>
+                                    exportFiles(ExportType.SeparateFiles)
+                                }
+                            >
+                                Separate Files Per Collection…
+                            </DropdownMenu.Item>
+                            <DropdownMenu.Item
+                                onClick={() =>
+                                    exportFiles(ExportType.SingleFile)
+                                }
+                            >
+                                Single Design-Tokens File…
+                            </DropdownMenu.Item>
+                        </DropdownMenu.Content>
+                    </DropdownMenu.Root>
+                    <Text
+                        style={{
+                            color: exportsAreCurrent
+                                ? "var(--figma-color-text-disabled)"
+                                : "var(--figma-color-text-primary",
+                        }}
+                    >
+                        {useVariables ? (
+                            exportsAreCurrent ? (
+                                <em>Exports are current</em>
+                            ) : (
+                                "Either variables have changed or no export found"
+                            )
+                        ) : (
+                            ""
+                        )}
+                    </Text>
                 </DialogFrame.Footer>
             </DialogFrame>
         </>


### PR DESCRIPTION
tailwind has been added but the use case in storybook is still not functioning
this version is rebased on top of nigel's changes but uses figma variables to change the color of the text

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
