### PR TITLE
Readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Slint** is an open-source declarative GUI toolkit for building native user interfaces for embedded systems, desktops, and mobile platforms.
 
-Write your UI once in `.slint`, a simple markup language. Connect it to logic written in Rust, C++, JavaScript, or Python.
+Write your UI once in `.slint`, a simple markup language. Connect it to business logic written in Rust, C++, JavaScript, or Python.
 
 ## Why Slint?
 
@@ -33,8 +33,8 @@ The name *Slint* is derived from our design goals:
 
 Beyond the design goals, here’s what makes Slint stand out:
 
-- **Design UI Independently**: Use a declarative language similar to separate your UI from business logic. Designers can work in parallel with developers.
-- **Tooling**: Including out editor integration and Live Preview & Editing to iterate quickly. We also have a Figma plugin.
+- **Independent UI Design**: Use a declarative language similar to separate your UI from business logic. Designers can work in parallel with developers.
+- **Tooling**: Iterate quickly with our Live Preview & editor integrations. Integrate from Figma with the [Slint To Figma plugin](https://www.figma.com/community/plugin/1474418299182276871/figma-to-slint).
 - **Stable APIs**: Slint follows a stable 1.x API. We evolve carefully without breaking your code.
 
 See what others have built: [#MadeWithSlint](https://madewithslint.com)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@
 [![REUSE status](https://api.reuse.software/badge/github.com/slint-ui/slint)](https://api.reuse.software/info/github.com/slint-ui/slint)
 [![Discussions](https://img.shields.io/github/discussions/slint-ui/slint)](https://github.com/slint-ui/slint/discussions)
 
-Slint is a declarative GUI toolkit to build native user interfaces for embedded,
-desktop, and mobile applications written in Rust, C++, JavaScript, or Python.
+**Slint** is an open-source declarative GUI toolkit for building native user interfaces for embedded systems, desktops, and mobile platforms.
+
+Write your UI once in `.slint`, a simple markup language. Connect it to logic written in Rust, C++, JavaScript, or Python.
+
+## Why Slint?
 
 The name *Slint* is derived from our design goals:
 
@@ -28,36 +31,15 @@ The name *Slint* is derived from our design goals:
     flexibility that only a native application can offer: Access full operating
     system APIs, utilize all CPU and GPU cores, connect to any peripheral.
 
-Visit [#MadeWithSlint](https://madewithslint.com) to view some of the projects
-using Slint. We invite you to use Slint and be part of its community.
+Beyond the design goals, here’s what makes Slint stand out:
 
-## Current Status
+- **Design UI Independently**: Use a declarative language similar to separate your UI from business logic. Designers can work in parallel with developers.
+- **Tooling**: Including out editor integration and Live Preview & Editing to iterate quickly. We also have a Figma plugin.
+- **Stable APIs**: Slint follows a stable 1.x API. We evolve carefully without breaking your code. 
 
-Slint is in active development. The state of support for each platform is as
-follows:
+See what others have built: [#MadeWithSlint](https://madewithslint.com)
 
-- **Embedded**: *Ready*. Slint is being used by customers in production on embedded
-    devices running embedded Linux and Windows. The Slint run-time requires less than
-    300KiB of RAM and can run on different processor architectures such as ARM Cortex M, ARM Cortex A, RISC-V, Intel x86, etc.
-    Refer to <https://slint.dev/supported-boards> for list of supported boards.
-- **Desktop**: *In Progress*. While Slint is a good fit on Windows, Linux and Mac,
-    we are working on improving the platform support in subsequent releases.
-- **Web**: *In Progress*. Slint apps can be compiled to WebAssembly and can run
-    in a web browser. As there are many other web frameworks, the web platform
-    is not one of our primary target platforms. The web support is currently
-    limited to demo purposes.
-- **Mobile**
-  - Android: *In Progress*. Track the progress of work here <https://github.com/slint-ui/slint/issues/46>.
-  - iOS: *Todo*. Support for iOS will commence after the initial support for Android is completed.
-
-### Accessibility
-
-Slint supports keyboard based navigation of many widgets, and user interfaces
-are scalable. The basic infrastructure for assistive technology like screen
-readers is in place. We're aware that more work is needed to get best-of-class
-support for users with special needs.
-
-## Demos
+## Examples
 
 ### Embedded
 
@@ -136,11 +118,7 @@ native code.
 The `.slint` files are compiled ahead of time. The expressions in the `.slint`
 are pure functions that the compiler can optimize. For example, the compiler
 could choose to "inline" properties and remove those that are constant or
-unchanged. In the future we hope to improve rendering time on low end devices by
-pre-processing images and text. The compiler could determine that a `Text` or an
-`Image` element is always on top of another `Image` in the same location.
-Consequently both elements could be rendered ahead of time into a single
-element, thus cutting down on rendering time.
+unchanged.
 
 The compiler uses the typical compiler phases of lexing, parsing, optimization,
 and finally code generation. It provides different back-ends for code generation
@@ -176,8 +154,6 @@ We have a few tools to help with the development of .slint files:
   working on it (when using the LSP preview is not possible).
 - [**SlintPad**](https://slintpad.com/), an online editor to try out .slint syntax
   without installing anything ([sources](./tools/slintpad)).
-- An [**updater**](./tools/updater) to convert the .slint files from
-  previous versions to newer versions.
 - A [**Figma to Slint**](https://www.figma.com/community/plugin/1474418299182276871/figma-to-slint) plugin.
 
 Please check our [Editors README](./editors/README.md) for tips on how to
@@ -196,10 +172,7 @@ See the [Slint licensing options on the website](https://slint.dev/pricing.html)
 ## Contributions
 
 We welcome your contributions: in the form of code, bug reports or feedback.
-
-- If you see an [RFC tag](https://github.com/slint-ui/slint/labels/rfc) on an
-  issue, feel free to chime in.
-- For contribution guidelines see [CONTRIBUTING.md](CONTRIBUTING.md).
+For contribution guidelines see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Beyond the design goals, here’s what makes Slint stand out:
 
 - **Design UI Independently**: Use a declarative language similar to separate your UI from business logic. Designers can work in parallel with developers.
 - **Tooling**: Including out editor integration and Live Preview & Editing to iterate quickly. We also have a Figma plugin.
-- **Stable APIs**: Slint follows a stable 1.x API. We evolve carefully without breaking your code. 
+- **Stable APIs**: Slint follows a stable 1.x API. We evolve carefully without breaking your code.
 
 See what others have built: [#MadeWithSlint](https://madewithslint.com)
 


### PR DESCRIPTION
 - Polish the wording of the intro
 - Remove the "current status" section. Slint has been stable for a long time and we don't need to put the keep that status in the readme
 - A few more wording updates or remove outdated contents
