### PR TITLE
Android: use `android-build` dev dependency; small fixes

### DIFF
--- a/internal/backends/android-activity/Cargo.toml
+++ b/internal/backends/android-activity/Cargo.toml
@@ -33,6 +33,9 @@ jni = { version = "0.21", features = ["invocation"] }
 ndk-08 = { package = "ndk", version = "0.8.0", optional = true, features = ["rwh_06"] }
 ndk-09 = { package = "ndk", version = "0.9.0", optional = true, features = ["rwh_06"], default-features = false }
 
+[build-dependencies]
+android-build = "0.1.2"
+
 [package.metadata.docs.rs]
 targets = ["aarch64-linux-android", "armv7-linux-androideabi", "i686-linux-android", "x86_64-linux-android"]
 features = ["native-activity", "aa-06"]

--- a/internal/backends/android-activity/build.rs
+++ b/internal/backends/android-activity/build.rs
@@ -1,120 +1,75 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use std::env;
 use std::path::PathBuf;
-use std::process::Command;
-use std::{env, fs};
+
+use android_build::{Dexer, JavaBuild};
 
 fn main() {
-    // unit test: `#[test]` fn are not run in build.rs, so we need to call it manually
-    test_parse_version();
-
     if !env::var("TARGET").unwrap().contains("android") {
         return;
     }
+    let release_mode = env::var("PROFILE").as_ref().map(|s| s.as_str()) == Ok("release");
 
-    let out_dir: PathBuf = env::var_os("OUT_DIR").unwrap().into();
+    // This is the only Java source file
+    let java_src = "SlintAndroidJavaHelper.java";
+    let java_src_path = format!("java/{java_src}");
 
     let slint_path: PathBuf = ["dev", "slint", "android-activity"].iter().collect();
-    let java_class = "SlintAndroidJavaHelper.java";
 
-    let mut out_class = out_dir.clone();
-    out_class.push("java");
-    out_class.push(slint_path);
+    let out_dir: PathBuf = env::var_os("OUT_DIR").unwrap().into();
+    let mut out_class_dir = out_dir.clone();
+    out_class_dir.push("java");
+    out_class_dir.push(slint_path);
 
-    let android_home =
-        PathBuf::from(env_var("ANDROID_HOME").or_else(|_| env_var("ANDROID_SDK_ROOT")).expect(
-            "Please set the ANDROID_HOME environment variable to the path of the Android SDK",
-        ));
-
-    let classpath = find_latest_version(android_home.join("platforms"), "android.jar")
-        .expect("No Android platforms found");
-
-    // Try to locate javac and java
-    let javac_java = env_var("JAVA_HOME")
-        .map(|home| PathBuf::from(home).join("bin"))
-        .map(|bin| (bin.join("javac"), bin.join("java")));
-    let (javac_path, java_path) = if let Ok(ref javac_java) = javac_java {
-        (javac_java.0.to_str().unwrap(), javac_java.1.to_str().unwrap())
-    } else {
-        ("javac", "java")
-    };
-
-    let handle_java_err = |err: std::io::Error| {
-        if err.kind() == std::io::ErrorKind::NotFound {
-            panic!("Could not locate the java compiler. Please ensure that the JAVA_HOME environment variable is set correctly.")
-        } else {
-            panic!("Could not run {javac_path}: {err}")
-        }
-    };
-
-    // Check version
-    let o = Command::new(&javac_path).arg("-version").output().unwrap_or_else(handle_java_err);
-    if !o.status.success() {
-        panic!("Failed to get javac version: {}", String::from_utf8_lossy(&o.stderr));
+    if out_class_dir.try_exists().unwrap_or(false) {
+        let _ = std::fs::remove_dir_all(&out_class_dir);
     }
-    let mut version_output = String::from_utf8_lossy(&o.stdout);
-    if version_output.is_empty() {
-        // old version of java used stderr
-        version_output = String::from_utf8_lossy(&o.stderr);
-    }
-    let java_ver = parse_javac_version_output(&version_output);
-    if java_ver < 8 {
-        panic!("The detected Java version is too old. The minimum required version is Java 8. Your Java version: {version_output:?} (parsed as {java_ver})")
-    }
+    std::fs::create_dir_all(&out_class_dir)
+        .unwrap_or_else(|e| panic!("Cannot create output directory {out_class_dir:?} - {e}"));
 
-    std::fs::create_dir_all(&out_class)
-        .unwrap_or_else(|e| panic!("Cannot create output directory {out_class:?} - {e}"));
+    let android_jar = android_build::android_jar(None).expect("No Android platforms found");
 
-    // Compile the Java file into a .class file
-    let o = Command::new(&javac_path)
-        .arg(format!("java/{java_class}"))
-        .arg("-d")
-        .arg(out_class.as_os_str())
-        .arg("-classpath")
-        .arg(&classpath)
-        .args(if java_ver != 8 { &["--release", "8"] } else { &[] as &[&str] })
-        .args(&["-encoding", "UTF-8"])
+    // Compile the Java file into .class files
+    let o = JavaBuild::new()
+        .file(&java_src_path)
+        .class_path(&android_jar)
+        .classes_out_dir(&out_class_dir)
+        .java_source_version(8)
+        .java_target_version(8)
+        .debug_info(android_build::DebugInfo {
+            line_numbers: !release_mode,
+            variables: !release_mode,
+            source_files: !release_mode,
+        })
+        .command()
+        .unwrap_or_else(|e| panic!("Could not generate the java compiler command: {e}"))
+        .args(["-encoding", "UTF-8"])
         .output()
-        .unwrap_or_else(handle_java_err);
+        .unwrap_or_else(|e| panic!("Could not run the java compiler: {e}"));
 
     if !o.status.success() {
         panic!("Java compilation failed: {}", String::from_utf8_lossy(&o.stderr));
     }
 
-    // Convert the .class file into a .dex file
-    let d8_path = find_latest_version(android_home.join("build-tools"), "lib")
-        .map(|path| path.join("d8.jar"))
-        .expect("d8 tool not found");
-
-    // collect all the *.class files
-    let classes = fs::read_dir(&out_class)
+    let o = Dexer::new()
+        .android_jar(&android_jar)
+        .class_path(&out_class_dir)
+        .collect_classes(&out_class_dir)
         .unwrap()
-        .filter_map(Result::ok)
-        .filter(|entry| entry.path().extension() == Some(std::ffi::OsStr::new("class")))
-        .map(|entry| entry.path())
-        .collect::<Vec<_>>();
-
-    let o = Command::new(&java_path)
-        // class path of D8 itself
-        .arg("-classpath")
-        .arg(&d8_path)
-        .arg("com.android.tools.r8.D8")
-        // class path of D8's input
-        .arg("--classpath")
-        .arg(&out_class)
-        .args(&classes)
-        .arg("--output")
-        .arg(out_dir.as_os_str())
-        // workaround for the DexClassLoader in Android 7.x
-        .arg("--min-api")
-        .arg("20")
+        .release(release_mode)
+        .android_min_api(20) // disable multidex for single dex file output
+        .out_dir(out_dir)
+        .command()
+        .unwrap_or_else(|e| panic!("Could not generate the D8 command: {e}"))
         .output()
-        .unwrap_or_else(|err| panic!("Error running {d8_path:?}: {err}"));
+        .unwrap_or_else(|e| panic!("Error running D8: {e}"));
 
     if !o.status.success() {
         eprintln!("Dex conversion failed: {}", String::from_utf8_lossy(&o.stderr));
-
+        let javac = android_build::javac().unwrap();
+        let java_ver = android_build::check_javac_version(&javac).unwrap();
         if java_ver >= 21 {
             eprintln!("WARNING: JDK version 21 is known to cause an error with older android SDK");
             eprintln!("See https://github.com/slint-ui/slint/issues/4973");
@@ -123,42 +78,5 @@ fn main() {
         panic!("Dex conversion failed");
     }
 
-    println!("cargo:rerun-if-changed=java/{java_class}");
-}
-
-fn parse_javac_version_output(version_output: &str) -> i32 {
-    let version = version_output
-        .split_whitespace()
-        .nth(1)
-        .and_then(|v| v.split('-').next())
-        .unwrap_or_default();
-    let mut java_ver: i32 = version.split('.').next().unwrap_or("0").parse().unwrap_or(0);
-    if java_ver == 1 {
-        // Before java 9, the version was something like javac 1.8
-        java_ver = version.split('.').nth(1).unwrap_or("0").parse().unwrap_or(0);
-    }
-    java_ver
-}
-
-//#[test] doesn't work in build.rs so it is called from main. Impact on build time should be negligible
-fn test_parse_version() {
-    assert_eq!(parse_javac_version_output("javac 1.8.0_292"), 8);
-    assert_eq!(parse_javac_version_output("javac 17.0.13"), 17);
-    assert_eq!(parse_javac_version_output("javac 21.0.5"), 21);
-    assert_eq!(parse_javac_version_output("javac 24-ea"), 24);
-    assert_eq!(parse_javac_version_output("error"), 0);
-    assert_eq!(parse_javac_version_output("javac error"), 0);
-}
-
-fn env_var(var: &str) -> Result<String, env::VarError> {
-    println!("cargo:rerun-if-env-changed={var}");
-    env::var(var)
-}
-
-fn find_latest_version(base: PathBuf, arg: &str) -> Option<PathBuf> {
-    fs::read_dir(base)
-        .ok()?
-        .filter_map(|entry| Some(entry.ok()?.path().join(arg)))
-        .filter(|path| path.exists())
-        .max()
+    println!("cargo:rerun-if-changed={java_src_path}");
 }

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -49,69 +49,33 @@ fn load_java_helper(app: &AndroidApp) -> Result<jni::objects::GlobalRef, jni::er
             &[JValue::Object(&dex_buffer), JValue::Object(&parent_class_loader)],
         )?
     } else {
-        // writes the dex data into the application internal storage
-        let dex_data_len = dex_data.len() as i32;
-        let dex_byte_array = env.byte_array_from_slice(dex_data).unwrap();
+        let code_cache_path = {
+            let dir = env
+                .call_method(&native_activity, "getCodeCacheDir", "()Ljava/io/File;", &[])?
+                .l()?;
+            let path =
+                env.call_method(&dir, "getAbsolutePath", "()Ljava/lang/String;", &[])?.l()?;
+            jni_get_string(&path, &mut env)
+                .map(|s| s.to_string_lossy().into_owned())
+                .map(std::path::PathBuf::from)?
+        };
+        let dex_name = env!("CARGO_CRATE_NAME").to_string() + ".dex";
+        let dex_file_path = code_cache_path.join(dex_name);
+        std::fs::write(&dex_file_path, dex_data).unwrap(); // Note: this panics on failure
+        let dex_file_path = env.new_string(&dex_file_path.as_os_str().to_string_lossy())?;
 
-        let dex_dir = env.new_string("dex")?;
-        let dex_dir_path = env
-            .call_method(
-                &native_activity,
-                "getDir",
-                "(Ljava/lang/String;I)Ljava/io/File;",
-                &[JValue::Object(&dex_dir), JValue::from(0 as jint)],
-            )?
-            .l()?;
-        let dex_name = env.new_string(env!("CARGO_CRATE_NAME").to_string() + ".dex")?;
-        let dex_path = env.new_object(
-            "java/io/File",
-            "(Ljava/io/File;Ljava/lang/String;)V",
-            &[JValue::Object(&dex_dir_path), JValue::Object(&dex_name)],
-        )?;
-        let dex_path =
-            env.call_method(dex_path, "getAbsolutePath", "()Ljava/lang/String;", &[])?.l()?;
+        let oats_dir_path = code_cache_path.join("oats");
+        let _ = std::fs::create_dir(&oats_dir_path);
+        let oats_dir_path = env.new_string(&oats_dir_path.as_os_str().to_string_lossy())?;
 
-        // prepares the folder for optimized dex generated while creating `DexClassLoader`
-        let out_dex_dir = env.new_string("outdex")?;
-        let out_dex_dir_path = env
-            .call_method(
-                &native_activity,
-                "getDir",
-                "(Ljava/lang/String;I)Ljava/io/File;",
-                &[JValue::Object(&out_dex_dir), JValue::from(0 as jint)],
-            )?
-            .l()?;
-        let out_dex_dir_path = env
-            .call_method(&out_dex_dir_path, "getAbsolutePath", "()Ljava/lang/String;", &[])?
-            .l()?;
-
-        // writes the dex data
-        let write_stream = env.new_object(
-            "java/io/FileOutputStream",
-            "(Ljava/lang/String;)V",
-            &[(&dex_path).into()],
-        )?;
-        env.call_method(
-            &write_stream,
-            "write",
-            "([BII)V",
-            &[
-                JValue::Object(&dex_byte_array),
-                JValue::from(0 as jint),
-                JValue::from(dex_data_len as jint),
-            ],
-        )?;
-        env.call_method(&write_stream, "close", "()V", &[])?;
-
-        // loads the dex file
         env.new_object(
             "dalvik/system/DexClassLoader",
             "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;)V",
             &[
-                JValue::Object(&dex_path),
-                JValue::Object(&out_dex_dir_path),
-                JValue::Object(&JObject::null()),
-                JValue::Object(&parent_class_loader),
+                (&dex_file_path).into(),
+                (&oats_dir_path).into(),
+                (&JObject::null()).into(),
+                (&parent_class_loader).into(),
             ],
         )?
     };
@@ -366,10 +330,22 @@ extern "system" fn Java_SlintAndroidJavaHelper_updateText(
             adaptor.show_cursor_handles.set(false);
             let runtime_window = i_slint_core::window::WindowInner::from_pub(&adaptor.window);
             let event = if preedit_start != preedit_end {
-                let adjust = |pos| if pos <= preedit_start { pos } else if pos >= preedit_end { pos - preedit_end + preedit_start } else { preedit_start } as i32;
+                let adjust = |pos| {
+                    if pos <= preedit_start {
+                        pos
+                    } else if pos >= preedit_end {
+                        preedit_start + (pos - preedit_end)
+                    } else {
+                        preedit_start
+                    }
+                } as i32;
                 i_slint_core::input::KeyEvent {
                     event_type: i_slint_core::input::KeyEventType::UpdateComposition,
-                    text: i_slint_core::format!( "{}{}", &text[..preedit_start], &text[preedit_end..]),
+                    text: i_slint_core::format!(
+                        "{}{}",
+                        &text[..preedit_start],
+                        &text[preedit_end..]
+                    ),
                     preedit_text: text[preedit_start..preedit_end].into(),
                     preedit_selection: Some(0..(preedit_end - preedit_start) as i32),
                     replacement_range: Some(i32::MIN..i32::MAX),
@@ -537,6 +513,7 @@ fn jni_get_string<'e, 'a>(
     use jni::errors::{Error::*, JniError};
 
     let string_class = env.find_class("java/lang/String")?;
+    let string_class = env.auto_local(string_class);
     let obj_class = env.get_object_class(obj)?;
     let obj_class = env.auto_local(obj_class);
     if !env.is_assignable_from(string_class, obj_class)? {


### PR DESCRIPTION
Closes <https://github.com/slint-ui/slint/issues/7829>; solves <https://github.com/slint-ui/slint/issues/7203#issuecomment-2616113738>; simplifies dex loading procedure for older Android versions.
