### PR TITLE
(Figma-plugin) Editing a property should update the snippet in design view

### DIFF
--- a/tools/figma-inspector/backend/utils/property-parsing.ts
+++ b/tools/figma-inspector/backend/utils/property-parsing.ts
@@ -335,10 +335,9 @@ async function getVariablePathString(
 ): Promise<string | null> {
     const variable = await figma.variables.getVariableByIdAsync(variableId);
     if (variable) {
-        const collection =
-            await figma.variables.getVariableCollectionByIdAsync(
-                variable.variableCollectionId,
-            );
+        const collection = await figma.variables.getVariableCollectionByIdAsync(
+            variable.variableCollectionId,
+        );
         if (collection) {
             const globalName = formatStructName(collection.name);
             const pathParts = extractHierarchy(variable.name);

--- a/tools/figma-inspector/shared/universals.d.ts
+++ b/tools/figma-inspector/shared/universals.d.ts
@@ -23,5 +23,6 @@ export interface EventTS {
 
     checkVariableChanges: Record<string, never>;
     generateSnippetRequest: { useVariables: boolean };
+    nodeChanged;
     exportToFiles: { exportAsSingleFile: boolean };
 }

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -49,6 +49,12 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
             });
         });
 
+        listenTS("nodeChanged", () => {
+            dispatchTS("generateSnippetRequest", {
+                useVariables: get().useVariables,
+            });
+        })
+
         listenTS("exportedFiles", (res) => {
             get().exportFilesHandler(res.files);
         });

--- a/tools/figma-inspector/src/utils/store.ts
+++ b/tools/figma-inspector/src/utils/store.ts
@@ -53,7 +53,7 @@ export const useInspectorStore = create<StoreState>()((set, get) => ({
             dispatchTS("generateSnippetRequest", {
                 useVariables: get().useVariables,
             });
-        })
+        });
 
         listenTS("exportedFiles", (res) => {
             get().exportFilesHandler(res.files);


### PR DESCRIPTION
In Figma dev-mode once you select an item in Figma it shows the slint snippet. If you then change any properties on the selected item the snippet updates. This is because the dev-mode automatically detects those changes and requests an update.

In the design view the api is different. The 'selection changed' event is used to show the initial snippet but subsequent changes will not be detected untill the user selects another item and then reselects the changed one. This PR adds a listener to the currently selected item to react to the NodeChanged event and update the snippet.

This PR also tidies up some dead async code. There were try catch blocks on code that according to the figma api docs never throw exceptions. Plus a few awaits on non async functions.