### PR TITLE
qt backend: Fix mouse up not being sent when pressing multiple buttons

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -183,7 +183,7 @@ cpp! {{
             if (!isMouseButtonDown && rust_window == this->rust_window) {
                 return;
             }
-            isMouseButtonDown = false;
+            isMouseButtonDown = event->button() != Qt::NoButton;
 
             int button = event->button();
             rust!(Slint_mouseReleaseEvent [rust_window: &QtWindow as "void*", pos: qttypes::QPoint as "QPoint", button: u32 as "int" ] {


### PR DESCRIPTION
Detect if a button is still pressed before deciding that no button is down.

Fixes #8335

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
