### PR TITLE
Fix MenuBar on android

### DIFF
--- a/internal/compiler/widgets/common/menus.slint
+++ b/internal/compiler/widgets/common/menus.slint
@@ -166,7 +166,7 @@ export component MenuBarImpl {
     }
 
     context-menu := ContextMenuInternal {
-        // Only manual call to `show` should open the menu, and we shouldn't react to clicks
+        // Only manual calls to `show` should open the menu, and we shouldn't react to clicks.
         enabled: false;
         activated(entry) => { root.activated(entry); self.close(); }
         sub-menu(entry) => { root.sub-menu(entry); }

--- a/internal/compiler/widgets/common/menus.slint
+++ b/internal/compiler/widgets/common/menus.slint
@@ -166,6 +166,8 @@ export component MenuBarImpl {
     }
 
     context-menu := ContextMenuInternal {
+        // Only manual call to `show` should open the menu, and we shouldn't react to clicks
+        enabled: false;
         activated(entry) => { root.activated(entry); self.close(); }
         sub-menu(entry) => { root.sub-menu(entry); }
     }


### PR DESCRIPTION
The ContextMenuArea on android intercepts clicks to trigger on long clicks and this prevent the MenuBar's TouchArea to work properly

Fixes #8353
