### PR TITLE
Skia: Delegate texture import to the surface trait

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -36,6 +36,7 @@ pub struct SkiaItemRenderer<'a> {
     pub canvas: &'a skia_safe::Canvas,
     pub scale_factor: ScaleFactor,
     pub window: &'a i_slint_core::api::Window,
+    surface: Option<&'a dyn crate::Surface>,
     state_stack: Vec<RenderState>,
     current_state: RenderState,
     image_cache: &'a ItemCache<Option<skia_safe::Image>>,
@@ -47,6 +48,7 @@ impl<'a> SkiaItemRenderer<'a> {
     pub fn new(
         canvas: &'a skia_safe::Canvas,
         window: &'a i_slint_core::api::Window,
+        surface: Option<&'a dyn crate::Surface>,
         image_cache: &'a ItemCache<Option<skia_safe::Image>>,
         path_cache: &'a ItemCache<Option<(Vector2D<f32, PhysicalPx>, skia_safe::Path)>>,
         box_shadow_cache: &'a mut SkiaBoxShadowCache,
@@ -55,6 +57,7 @@ impl<'a> SkiaItemRenderer<'a> {
             canvas,
             scale_factor: ScaleFactor::new(window.scale_factor()),
             window,
+            surface,
             state_stack: vec![],
             current_state: RenderState { alpha: 1.0, translation: Default::default() },
             image_cache,
@@ -194,6 +197,7 @@ impl<'a> SkiaItemRenderer<'a> {
                 if tiling != Default::default() { ImageFit::Preserve } else { item.image_fit() },
                 self.scale_factor,
                 self.canvas,
+                self.surface,
             )
             .and_then(|skia_image| {
                 let brush = item.colorize();
@@ -336,6 +340,7 @@ impl<'a> SkiaItemRenderer<'a> {
             let mut sub_renderer = SkiaItemRenderer::new(
                 canvas,
                 self.window,
+                self.surface,
                 self.image_cache,
                 self.path_cache,
                 self.box_shadow_cache,
@@ -939,6 +944,7 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
             ImageFit::Fill,
             self.scale_factor,
             self.canvas,
+            self.surface,
         );
 
         let skia_image = match skia_image {

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -570,6 +570,7 @@ impl SkiaRenderer {
         let mut skia_item_renderer = itemrenderer::SkiaItemRenderer::new(
             skia_canvas,
             window,
+            surface,
             &self.image_cache,
             &self.path_cache,
             &mut box_shadow_cache,
@@ -1038,6 +1039,14 @@ pub trait Surface {
 
     fn use_partial_rendering(&self) -> bool {
         false
+    }
+
+    fn import_opengl_texture(
+        &self,
+        _canvas: &skia_safe::Canvas,
+        _texture: &i_slint_core::graphics::BorrowedOpenGLTexture,
+    ) -> Option<skia_safe::Image> {
+        None
     }
 
     /// Implementations should return self to allow upcasting.


### PR DESCRIPTION
This makes it easier to keep cfg'ed code in the cfg' surfaces than cfg'ing in cached_image.rs :)

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
