### PR TITLE
Prospective panic fix in the rust generated code

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -290,9 +290,9 @@ fn generate_public_component(
             pub fn new() -> core::result::Result<Self, slint::PlatformError> {
                 let inner = #inner_component_id::new()?;
                 #init_bundle_translations
-                #inner_component_id::user_init(sp::VRc::map(inner.clone(), |x| x));
                 // ensure that the window exist as this point so further call to window() don't panic
                 inner.globals.get().unwrap().window_adapter_ref()?;
+                #inner_component_id::user_init(sp::VRc::map(inner.clone(), |x| x));
                 core::result::Result::Ok(Self(inner))
             }
 


### PR DESCRIPTION
From the v1.11.0 crash reporter:
There is a panic in
`target/x86_64-unknown-linux-gnu/release/build/slint-lsp-8494405be069a534/out/main.rs:115729:64`
```
called `Result::unwrap()` on an `Err` value: Other("Could not initialize any renderer for LinuxKMS <REDACTED: user-file-path> from Skia renderer: Error opening device <REDACTED: user-file-path>: No such file or directory (os error 2)\\nError from FemtoVG renderer: Error reading DRM resource handles: Permission denied (os error 13)\\nError from Software renderer: Error opening device <REDACTED: user-file-path>: No such file or directory (os error 2)\\nNo renderers configured.")
```

That line in the generated file is in
```rs
115728   │          fn window_adapter_impl (& self) -> sp :: Rc < dyn sp :: WindowAdapter > {
115729   │              sp :: Rc :: clone (self . window_adapter_ref () . unwrap ()) }
```

Relevant backtrace:
```
6	"core::result::unwrap_failed"
7	"slint_lsp::preview::ui::slint_generatedPreviewUi::PreviewUi::new"
8	"slint_lsp::preview::ui::create_ui"
```

So the theory is that user_init need the window for some reason. (eg, could be needing the scale factor to conver sizes or some other things that needs the window)
So make sure we do the test before calling user_init
