### PR TITLE
compiler: Reject comparison on unsupported types

### DIFF
--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -999,12 +999,11 @@ impl Expression {
 
         let expected_ty = match operator_class(op) {
             OperatorClass::ComparisonOp => {
-                let ty = Self::common_target_type_for_type_list([lhs.ty(), rhs.ty()].iter().cloned());
-                if !matches!(op, '=' | '!') && !ty.as_unit_product().is_some() && ty != Type::String {
-                    ctx.diag.push_error(
-                        format!("Values of type {ty} cannot be compared"),
-                        &node,
-                    );
+                let ty =
+                    Self::common_target_type_for_type_list([lhs.ty(), rhs.ty()].iter().cloned());
+                if !matches!(op, '=' | '!') && !ty.as_unit_product().is_some() && ty != Type::String
+                {
+                    ctx.diag.push_error(format!("Values of type {ty} cannot be compared"), &node);
                 }
                 ty
             }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -999,7 +999,14 @@ impl Expression {
 
         let expected_ty = match operator_class(op) {
             OperatorClass::ComparisonOp => {
-                Self::common_target_type_for_type_list([lhs.ty(), rhs.ty()].iter().cloned())
+                let ty = Self::common_target_type_for_type_list([lhs.ty(), rhs.ty()].iter().cloned());
+                if !matches!(op, '=' | '!') && !ty.as_unit_product().is_some() && ty != Type::String {
+                    ctx.diag.push_error(
+                        format!("Values of type {ty} cannot be compared"),
+                        &node,
+                    );
+                }
+                ty
             }
             OperatorClass::LogicalOp => Type::Bool,
             OperatorClass::ArithmeticOp => {

--- a/internal/compiler/tests/syntax/expressions/comparison_operator2.slint
+++ b/internal/compiler/tests/syntax/expressions/comparison_operator2.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component C  {
+
+    out property <bool> color-cmp: Colors.red > Colors.blue;
+    //                             ^error{Values of type color cannot be compared}
+    out property <bool> bool-cmp: true > false;
+    //                            ^error{Values of type bool cannot be compared}
+    out property <bool> string-cmp: "eee" > "ddd";
+    out property <bool> array-cmp: [45] < [45];
+    //                             ^error{Values of type \[float\] cannot be compared}
+    out property <bool> struct-cmp: { foo: 45 } <= { foo: 45 };
+    //                              ^error{Values of type \{ foo: float,\} cannot be compared}
+}

--- a/tests/cases/expr/comparison.slint
+++ b/tests/cases/expr/comparison.slint
@@ -13,6 +13,10 @@ TestCase := Rectangle {
 
     property<string> my_str: "hello";
     property<bool> t7: my_str == "hello";
+
+    property<bool> string-cmp: "fooa" < "foob";
+
+    out property <bool> test: t1 && !t2 && t3 && t4 && t5 && !t6 && t7 && string-cmp;
 }
 /*
 ```cpp
@@ -25,6 +29,9 @@ assert_eq(instance.get_t4(), true);
 assert_eq(instance.get_t5(), true);
 assert_eq(instance.get_t6(), false);
 assert_eq(instance.get_t7(), true);
+
+assert_eq(instance.get_string_cmp(), true);
+assert_eq(instance.get_test(), true);
 
 instance.set_hello(45);
 assert_eq(instance.get_t1(), true);
@@ -72,6 +79,9 @@ assert_eq!(instance.get_t5(), true);
 assert_eq!(instance.get_t6(), false);
 assert_eq!(instance.get_t7(), true);
 
+assert_eq!(instance.get_string_cmp(), true);
+assert_eq!(instance.get_test(), true);
+
 instance.set_hello(45);
 assert_eq!(instance.get_t1(), true);
 assert_eq!(instance.get_t2(), true);
@@ -115,6 +125,9 @@ assert.equal(instance.t4, true);
 assert.equal(instance.t5, true);
 assert.equal(instance.t6, false);
 assert.equal(instance.t7, true);
+
+assert.equal(instance.string_cmp, true);
+assert.equal(instance.test, true);
 
 instance.hello = 45;
 assert.equal(instance.t1, true);


### PR DESCRIPTION
The compiler was accepting the comparison of types such as color, or struct, and then later we'd get rust compilation error or interpreter panic.

Example seen in the crash reporter:
`internal/interpreter/eval.rs:257:35`
```
unsupported Value::Brush(SolidColor(Color { red: 0, green: 0, blue: 0, alpha: 0 })) ≤ Value::Brush(SolidColor(Color { red: 255, green: 0, blue: 0, alpha: 255 }))
```

Note that some code hapenned to compile with rust or C++. For example, comparison of bool, or anonymous struct (represented as tuples), or color represeted as int)
So technically this is a breaking change.
But this should be fine as this was not working in the interpreter and this is a bug fix.

ChangeLog: Slint compilation error for comparison of types that can't be compared with less or greater operator.
