### PR TITLE
Fix time display in home automation demo

### DIFF
--- a/demos/home-automation/ui/components/mainView/mainScreen.slint
+++ b/demos/home-automation/ui/components/mainView/mainScreen.slint
@@ -140,7 +140,7 @@ export component MainScreen inherits Rectangle {
         if showing-time: HorizontalLayout {
             alignment: center;
             HaText {
-                text: Api.current-time.hour.mod(12);
+                text: Api.current-time.hour.mod(12) == 0 ? 12 : Api.current-time.hour.mod(12);
                 horizontal-alignment: center;
                 vertical-alignment: center;
                 color: Palette.info-foreground;
@@ -164,7 +164,7 @@ export component MainScreen inherits Rectangle {
             }
 
             HaText {
-                text: Api.current-time.hour > 12 ? " PM" : " AM";
+                text: Api.current-time.hour >= 12 ? " PM" : " AM";
                 horizontal-alignment: center;
                 vertical-alignment: center;
                 color: Palette.info-foreground;


### PR DESCRIPTION
Show 12 instead of 0 for noon/midnight and fix AM/PM logic

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
