### PR TITLE
Remove CompositionMode enum

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -331,7 +331,6 @@ fn gen_corelib(
         "SortOrder",
         "BitmapFont",
         "PhysicalRegion",
-        "CompositionMode",
     ]
     .iter()
     .chain(items.iter())

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -658,10 +658,6 @@ public:
     };
 
 #    ifdef SLINT_FEATURE_EXPERIMENTAL
-    /// This enum describes the how pixels from a source are merged with the pixels in a destination
-    /// image. This is a sub-set of the standard
-    /// [Porter-Duff](https://en.wikipedia.org/wiki/Alpha_compositing) modes.
-    using CompositionMode = cbindgen_private::CompositionMode;
     /// Representation of a texture to blend in the destination buffer.
     // (FIXME: this is currently opaque, but should be exposed)
     using DrawTextureArgs = cbindgen_private::DrawTextureArgs;
@@ -684,12 +680,6 @@ public:
         virtual std::span<PixelType> line_slice(std::size_t line_number) = 0;
         /// Returns the number of lines in the buffer. This is the height of the buffer in pixels.
         virtual std::size_t num_lines() = 0;
-
-        /// Fill a rectangle at the specified pixel coordinates with the given color. Return true
-        /// if the operation succeeded; false otherwise;
-        virtual bool fill_rectangle(int16_t x, int16_t y, int16_t width, int16_t height,
-                                    const RgbaColor<uint8_t> &premultiplied_color,
-                                    CompositionMode composition_mode) = 0;
 
         /// Draw a portion of provided texture to the specified pixel coordinates.
         /// Each pixel of the texture is to be blended with the given colorize color as well as the

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -224,21 +224,6 @@ impl From<RequestedOpenGLVersion> for RequestedGraphicsAPI {
     }
 }
 
-/// This enum describes the how pixels from a source are merged with the pixels in a destination image.
-/// This is a sub-set of the standard [Porter-Duff](https://en.wikipedia.org/wiki/Alpha_compositing) modes.
-#[repr(u8)]
-#[allow(dead_code)]
-#[derive(Default, Copy, Clone, Debug)]
-#[non_exhaustive]
-pub enum CompositionMode {
-    /// Only pixels from the source target are drawn.
-    Source,
-    /// The source is placed over the destination.
-    #[default]
-    SourceOver,
-    // TODO: maybe add more modes (e.g. xor, plus darker, etc.)
-}
-
 /// Internal module for use by cbindgen and the C++ platform API layer.
 #[cfg(feature = "ffi")]
 pub mod ffi {


### PR DESCRIPTION
It was used in the previous TargetPixelBuffer interface, but this is no longer the case
