### PR TITLE
backend selector: Prefer the winit backend over the default backend (…

### DIFF
--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -212,13 +212,11 @@ impl BackendSelector {
         }
 
         let backend_name = self.backend.as_deref().unwrap_or_else(|| {
+            // Only the winit backend supports graphics API requests right now, so prefer that over
+            // aborting.
             #[cfg(feature = "i-slint-backend-winit")]
-            {
-                // Only the winit backend supports graphics API requests right now, so prefer that over
-                // aborting.
-                if self.requested_graphics_api.is_some() {
-                    return "winit";
-                }
+            if self.requested_graphics_api.is_some() {
+                return "winit";
             }
             super::DEFAULT_BACKEND_NAME
         });

--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -211,7 +211,17 @@ impl BackendSelector {
             }
         }
 
-        let backend_name = self.backend.as_deref().unwrap_or(super::DEFAULT_BACKEND_NAME);
+        let backend_name = self.backend.as_deref().unwrap_or_else(|| {
+            #[cfg(feature = "i-slint-backend-winit")]
+            {
+                // Only the winit backend supports graphics API requests right now, so prefer that over
+                // aborting.
+                if self.requested_graphics_api.is_some() {
+                    return "winit";
+                }
+            }
+            super::DEFAULT_BACKEND_NAME
+        });
 
         let backend: Box<dyn i_slint_core::platform::Platform> = match backend_name {
             #[cfg(all(feature = "i-slint-backend-linuxkms", target_os = "linux"))]


### PR DESCRIPTION
…possibly Qt) of graphics APIs are requested

On Linux, if Qt is found, the qt backend is the default. This backend doesn't support selecting graphics APIs, thus the OpenGL and WGPU examples don't run out of the box. This patch fixes that by preferring winit.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
