### PR TITLE
Set size of set on AccessKit container nodes

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -651,20 +651,12 @@ impl NodeCollection {
             .and_then(|s| s.parse::<usize>().ok())
         {
             node.set_position_in_set(position_in_set);
-            let mut item = item.clone();
-            while let Some(parent) = item.parent_item(ParentItemTraversalMode::StopAtPopups) {
-                if !parent.is_accessible() {
-                    item = parent;
-                    continue;
-                }
-                if let Some(size_of_set) = parent
-                    .accessible_string_property(AccessibleStringProperty::ItemCount)
-                    .and_then(|s| s.parse::<usize>().ok())
-                {
-                    node.set_size_of_set(size_of_set);
-                }
-                break;
-            }
+        }
+        if let Some(size_of_set) = item
+            .accessible_string_property(AccessibleStringProperty::ItemCount)
+            .and_then(|s| s.parse::<usize>().ok())
+        {
+            node.set_size_of_set(size_of_set);
         }
 
         let supported = item.supported_accessibility_actions();


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Was missing from #8152 

As discussed in #6975 