### PR TITLE
live-preview: Send telemetry to VSCode

### DIFF
--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -532,6 +532,8 @@ pub enum PreviewToLspMessage {
     SendWorkspaceEdit { label: Option<String>, edit: lsp_types::WorkspaceEdit },
     /// Pass a `ShowMessage` notification on to the editor
     SendShowMessage { message: lsp_types::ShowMessageParams },
+    /// Senf a telemetry event
+    TelemetryEvent(serde_json::Map<String, serde_json::Value>),
 }
 
 /// Information on the Element types available

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -581,6 +581,11 @@ async fn handle_preview_to_lsp_message(
             ctx.server_notifier
                 .send_notification::<lsp_types::notification::ShowMessage>(message)?;
         }
+        M::TelemetryEvent(object) => {
+            ctx.server_notifier.send_notification::<lsp_types::notification::TelemetryEvent>(
+                lsp_types::OneOf::Left(object),
+            )?
+        }
     }
     Ok(())
 }

--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -176,6 +176,10 @@ pub(super) fn open_ui_impl(preview_state: &mut PreviewState) -> Result<(), slint
         Some(ui) => ui,
         None => {
             let ui = super::ui::create_ui(default_style, experimental)?;
+            crate::preview::send_telemetry(&mut [(
+                "type".to_string(),
+                serde_json::to_value("preview_opened").unwrap(),
+            )]);
             preview_state.ui.insert(ui)
         }
     };

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -302,6 +302,14 @@ impl SlintServer {
                     .server_notifier
                     .send_notification::<lsp_types::notification::ShowMessage>(message);
             }
+            M::TelemetryEvent(object) => {
+                let _ = self
+                    .ctx
+                    .server_notifier
+                    .send_notification::<lsp_types::notification::TelemetryEvent>(
+                        lsp_types::OneOf::Left(object),
+                    );
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Send telemetry data from the live-preview to vscode.

It will process that data according to telemetry settings in VScode

This covers the part of getting the telemetry events to VSCode... We still need to get it recorded from there (which it may or may not do automatically).
