### PR TITLE
Home Automation: Highlight current tab

### DIFF
--- a/demos/home-automation/ui/components/mainView/mainScreen.slint
+++ b/demos/home-automation/ui/components/mainView/mainScreen.slint
@@ -49,6 +49,15 @@ export component PageButton inherits Rectangle {
     }
 }
 
+component PageButtonHighlighter {
+    Rectangle {
+        y: parent.height - parent.height * 15%;
+        width: parent.width * 50%;
+        height: 1px;
+        background: white;
+    }
+}
+
 export component MainScreen inherits Rectangle {
     property <int> internal-target-page: AppState.target-page;
     property <bool> transitioning: false;
@@ -273,11 +282,28 @@ export component MainScreen inherits Rectangle {
                     }
                 }
 
-                HorizontalLayout {
+                // We need to have two different highlighter because of #7999
+                if AppState.graphics-accelerator-available: PageButtonHighlighter {
+                    x: home.x + (tabs.spacing + self.width) * AppState.target-page;
+                    animate x {
+                        duration: Animation.transition-duration;
+                        easing: ease-in-out-sine;
+                    }
+                    width: AppState.orientation == Orientation.landscape ? 120px : 140px;
+                    height: 100%;
+                }
+
+                if !AppState.graphics-accelerator-available : PageButtonHighlighter {
+                    x: home.x + (tabs.spacing + self.width) * AppState.target-page;
+                    width: AppState.orientation == Orientation.landscape ? 120px : 140px;
+                    height: 100%;
+                }
+
+                tabs := HorizontalLayout {
                     alignment: center;
                     spacing: 0px;
                     y: AppState.graphics-accelerator-available ? 0 : -5px;
-                    PageButton {
+                    home := PageButton {
                         label: "Home";
                         target-page: 0;
                     }


### PR DESCRIPTION
It was highlighted with yellow underline. Does this rounded rect background work for current UI?

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
