### PR TITLE
Implement Debug for Platform error

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -1032,7 +1032,6 @@ impl std::error::Error for EventLoopError {}
 /// use slint::platform::PlatformError;
 /// PlatformError::from(format!("Could not load resource {}", 1234));
 /// ```
-#[derive(Debug)]
 #[non_exhaustive]
 pub enum PlatformError {
     /// No default platform was selected, or no platform could be initialized.
@@ -1061,6 +1060,12 @@ pub enum PlatformError {
 impl From<PlatformError> for wasm_bindgen::JsValue {
     fn from(err: PlatformError) -> wasm_bindgen::JsValue {
         wasm_bindgen::JsError::from(err).into()
+    }
+}
+
+impl core::fmt::Debug for PlatformError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
With the same message as Display to have more meaningful errors in panic from `unwrap()`

CC #8412

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
