### PR TITLE
mise: Teach autofix to dedupe pnpm lock file

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -31,6 +31,10 @@ run = "taplo format"
 description = "Update pnpm lock file"
 run = "pnpm i --lockfile-only"
 
+["fix:pnpm:dedupe"]
+run = "pnpm dedupe"
+depends = ["prepare:pnpm-install"]
+
 ["fix:ts:format"]
 description = "Run pnpm format:fix"
 run = "pnpm run format:fix"
@@ -73,6 +77,8 @@ hide = true
 run = "pnpm install --frozen-lockfile"
 depends = ["fix:pnpm:lock"]
 
+
+
 ### CI
 
 ["ci:autofix:fix"]
@@ -85,6 +91,7 @@ depends = [
   "fix:text:trailing_spaces",
   "fix:toml:format",
   "fix:pnpm:lock",
+  "fix:pnpm:dedupe",
   "fix:ts:biome",
   "fix:ts:format",
 ]

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -78,7 +78,6 @@ run = "pnpm install --frozen-lockfile"
 depends = ["fix:pnpm:lock"]
 
 
-
 ### CI
 
 ["ci:autofix:fix"]

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -32,6 +32,7 @@ description = "Update pnpm lock file"
 run = "pnpm i --lockfile-only"
 
 ["fix:pnpm:dedupe"]
+description = "Run pnpm dedupe"
 run = "pnpm dedupe"
 depends = ["prepare:pnpm-install"]
 


### PR DESCRIPTION
Many dependencies in turn install their own copies of various npm packages such as esbuild and vite. This can cause issues where an exact version is needed but the wrong one gets used or a security fix fails to replace all versions of a certain package. 'pnpm dedupe' removes all the copies and just leaves the latest versions.