### PR TITLE
doc: Extend Model::as_any() docs with a hint how to debug downcast fa…

### DIFF
--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -181,6 +181,7 @@ pub trait Model {
     ///     fn as_any(&self) -> &dyn core::any::Any { self }
     /// ```
     ///
+    /// ## Troubleshooting
     /// A common reason why the dowcast fails at run-time is because of a type-mismatch
     /// between the model created and the model downcasted. To debug this at compile time,
     /// try matching the model type used for the downcast explicitly at model creation time.


### PR DESCRIPTION
…ilures occuring at run-time with the help of compile time hints

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
