### PR TITLE
winit: Fix preferred window size not being taken into account when it…

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -604,6 +604,7 @@ impl WinitWindowAdapter {
                     self.resize_event(size)?;
                     Ok(true)
                 } else {
+                    self.pending_requested_size.set(size.into());
                     // None means that we'll get a `WindowEvent::Resized` later
                     Ok(false)
                 }
@@ -629,6 +630,7 @@ impl WinitWindowAdapter {
         if size.width > 0 && size.height > 0 {
             let physical_size = physical_size_to_slint(&size);
             self.size.set(physical_size);
+            self.pending_requested_size.set(None);
             let scale_factor = WindowInner::from_pub(self.window()).scale_factor();
             self.window().try_dispatch_event(WindowEvent::Resized {
                 size: physical_size.to_logical(scale_factor),


### PR DESCRIPTION
… changes multiple times between window creation and the resize event received from the window manager

In this phase between the window being resized and receiving the resize event, the pending_requested_size variable tracks the value to be used in adjust_window_size_to_satisfy_constraints. Unfortunately, it was never set.

Amends commit 1c73144b09d263ebe20cf5e7cf500e7d4d5ac3b5.

Fixes #8452

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
