### PR TITLE
Python: Smaller cleanups

### DIFF
--- a/api/python/Cargo.toml
+++ b/api/python/Cargo.toml
@@ -46,7 +46,7 @@ i-slint-backend-selector = { workspace = true }
 i-slint-core = { workspace = true }
 slint-interpreter = { workspace = true, features = ["default", "display-diagnostics", "internal"] }
 i-slint-compiler = { workspace = true }
-pyo3 = { version = "0.24", features = ["extension-module", "indexmap", "chrono", "abi3-py310"] }
+pyo3 = { version = "0.25", features = ["extension-module", "indexmap", "chrono", "abi3-py310"] }
 indexmap = { version = "2.1.0" }
 chrono = "0.4"
 spin_on = { workspace = true }

--- a/api/python/models.rs
+++ b/api/python/models.rs
@@ -155,7 +155,7 @@ impl i_slint_core::model::Model for PyModelShared {
 }
 
 impl PyModelShared {
-    pub fn rust_into_js_model<'py>(
+    pub fn rust_into_py_model<'py>(
         model: &ModelRc<slint_interpreter::Value>,
         py: Python<'py>,
     ) -> Option<Bound<'py, PyAny>> {

--- a/api/python/value.rs
+++ b/api/python/value.rs
@@ -10,20 +10,8 @@ use std::collections::HashMap;
 
 #[gen_stub_pyclass]
 pub struct PyValue(pub slint_interpreter::Value);
-struct PyValueRef<'a>(&'a slint_interpreter::Value);
 
 impl<'py> IntoPyObject<'py> for PyValue {
-    type Target = PyAny;
-    type Output = Bound<'py, Self::Target>;
-    type Error = PyErr;
-
-    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        // Share the conversion code below that operates on the reference
-        PyValueRef(&self.0).into_pyobject(py)
-    }
-}
-
-impl<'a, 'py> IntoPyObject<'py> for PyValueRef<'a> {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
     type Error = PyErr;

--- a/api/python/value.rs
+++ b/api/python/value.rs
@@ -26,7 +26,7 @@ impl<'py> IntoPyObject<'py> for PyValue {
                 crate::image::PyImage::from(image).into_bound_py_any(py)
             }
             slint_interpreter::Value::Model(model) => {
-                crate::models::PyModelShared::rust_into_js_model(model, py).map_or_else(
+                crate::models::PyModelShared::rust_into_py_model(model, py).map_or_else(
                     || crate::models::ReadOnlyRustModel::from(model).into_bound_py_any(py),
                     |m| Ok(m),
                 )


### PR DESCRIPTION
- Upgrade to latest PyO3 release
- Remove dead code
- Rename helper function for clarity