### PR TITLE
CI: Fix espup install

### DIFF
--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -149,9 +149,10 @@ jobs:
               with:
                   old-ubuntu: true
             - uses: dtolnay/rust-toolchain@stable
+            - uses: cargo-bins/cargo-binstall@main
             - name: install espup
               run: |
-                  cargo install espup
+                  cargo binstall espup
                   espup install
                   rustup default esp
             - name: add esp toolchains to PATH


### PR DESCRIPTION
Build from source is broken after zip-rs dependency having been yanked. Try with binstall instead.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
