### PR TITLE
TextMate Grammar: Add support from re-exports

### DIFF
--- a/editors/vscode/slint.tmLanguage.json
+++ b/editors/vscode/slint.tmLanguage.json
@@ -160,6 +160,17 @@
                             "include": "#comment"
                         }
                     ]
+                },
+                {
+                    "match": "\\s*(from)\\s*(\"[^\"]*\")\\s*;",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.other.from.slint"
+                        },
+                        "2": {
+                            "name": "string.quoted.double.export-path.slint"
+                        }
+                    }
                 }
             ]
         },

--- a/editors/vscode/tests/grammar/basic.slint
+++ b/editors/vscode/tests/grammar/basic.slint
@@ -62,6 +62,11 @@
 //            ^^ keyword.other.as.slint
 //               ^^^^^^^^ entity.name.type.export-list.slint
 //                        ^^^^^^^^^^ entity.name.type.export-list.slint
+  export { Foo } from "bar.slint";
+//^^^^^^ keyword.other.export.slint
+//         ^^^ entity.name.type.export-list.slint
+//               ^^^^ keyword.other.from.slint
+//                    ^^^^^^^^^^^ string.quoted.double.export-path.slint
   struct Foobar { }
 //^^^^^^ keyword.declaration.struct.slint
 //       ^^^^^^ entity.name.type.struct.slint


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
