### PR TITLE
Home Automation: make lamp and overhead togglable

### DIFF
--- a/demos/home-automation/ui/components/general/fancySlider.slint
+++ b/demos/home-automation/ui/components/general/fancySlider.slint
@@ -51,6 +51,7 @@ export component FancySlider inherits Rectangle {
         width: 100%;
         height: 300%;
         y: parent.height / 2 - self.height / 2;
+        enabled: root.opacity > 0;
 
         clicked => {
             if self.mouse-x == initial-position {

--- a/demos/home-automation/ui/components/lamp.slint
+++ b/demos/home-automation/ui/components/lamp.slint
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
-import { Measurements, Colors, Style } from "../common.slint";
+import { Measurements, Colors, Style, Animation } from "../common.slint";
 import { FancySlider } from "general/fancySlider.slint";
 import { Control } from "control.slint";
 import { AppState } from "../appState.slint";
@@ -17,6 +17,16 @@ export component Lamp inherits Control {
         width: 100%;
         height: 100%;
 
+        property <bool> on: true;
+
+        TouchArea {
+            clicked => {
+                AppState.end-kiosk-mode();
+                tile.on = !tile.on;
+            }
+        }
+
+
         Rectangle {
             x: tile.width - self.width + 20px;
             width: 70%;
@@ -29,7 +39,11 @@ export component Lamp inherits Control {
             Image {
                 y: 0;
                 source: @image-url("../images/lamp/0024.png");
-                opacity: slider.value / 24;
+                opacity: tile.on ? slider.value / 24 * 0.8 + 0.2 : 0;
+                animate opacity {
+                    duration: 200ms;
+                    easing: ease-in-out-sine;
+                }
             }
         }
 
@@ -51,34 +65,15 @@ export component Lamp inherits Control {
                 width: root.width * 0.8;
                 icon: @image-url("../images/brightness.svg");
                 colorize-icon: Colors.black;
-            }
-        }
-    }
-    TouchArea {
-        clicked => {
-            AppState.end-kiosk-mode();
-            if self.mouse-x == slider.initial-position {
-                slider.anim-duration = 300ms;
-                slider.animated-value = (self.mouse-x / self.width) * (slider.maxValue - slider.minValue) + slider.minValue;
-            }
-        }
-        moved => {
-            if !slider.first-touch {
-                slider.first-touch = true;
-                slider.initial-position = self.mouse-x;
-                slider.initial-value = (self.mouse-x / self.width) * (slider.maxValue - slider.minValue) + slider.minValue;
-                slider.previous-value = slider.value;
-                slider.anim-duration = 0ms;
-            } else {
-                slider.change-value = ((self.mouse-x / self.width) * (slider.maxValue - slider.minValue) + slider.minValue) - slider.initial-value;
-                slider.value = Math.clamp(slider.previous-value + slider.change-value, slider.minValue, slider.maxValue);
-                slider.animated-value = slider.value;
-            }
-        }
-
-        changed pressed => {
-            if !self.pressed {
-                slider.first-touch = false;
+                states [
+                    on when !tile.on: {
+                        opacity: 0;
+                    }
+                ]
+                animate opacity {
+                    duration: Animation.transition-duration;
+                    easing: ease-in-out-sine;
+                }
             }
         }
     }

--- a/demos/home-automation/ui/components/overhead.slint
+++ b/demos/home-automation/ui/components/overhead.slint
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
-import { Palette, Measurements } from "../common.slint";
+import { Palette, Measurements, Animation } from "../common.slint";
 import { FancySlider } from "general/fancySlider.slint";
 import { HaText } from "general/haText.slint";
 import { Control } from "control.slint";
@@ -17,9 +17,11 @@ export component Overhead inherits Control {
         width: 100%;
         height: 100%;
 
+        property <bool> on: true;
+
         TouchArea {
             clicked => {
-                slider.toggle();
+                tile.on = !tile.on;
             }
         }
 
@@ -35,37 +37,19 @@ export component Overhead inherits Control {
                 color: Palette.overhead-foreground;
             }
 
-            slider := FancySlider {
+            FancySlider {
                 width: (root.height < Measurements.medium-height-tile) ? root.width - 0 - 18px : root.width * 0.8;
                 value: 0.0;
                 icon: @image-url("../images/brightness.svg");
-            }
-        }
-    }
-    TouchArea {
-        clicked => {
-            if self.mouse-x == slider.initial-position {
-                slider.anim-duration = 300ms;
-                slider.animated-value = (self.mouse-x / self.width) * (slider.maxValue - slider.minValue) + slider.minValue;
-            }
-        }
-        moved => {
-            if !slider.first-touch {
-                slider.first-touch = true;
-                slider.initial-position = self.mouse-x;
-                slider.initial-value = (self.mouse-x / self.width) * (slider.maxValue - slider.minValue) + slider.minValue;
-                slider.previous-value = slider.value;
-                slider.anim-duration = 0ms;
-            } else {
-                slider.change-value = ((self.mouse-x / self.width) * (slider.maxValue - slider.minValue) + slider.minValue) - slider.initial-value;
-                slider.value = Math.clamp(slider.previous-value + slider.change-value, slider.minValue, slider.maxValue);
-                slider.animated-value = slider.value;
-            }
-        }
-
-        changed pressed => {
-            if !self.pressed {
-                slider.first-touch = false;
+                states [
+                    on when !tile.on: {
+                        opacity: 0;
+                    }
+                ]
+                animate opacity {
+                    duration: Animation.transition-duration;
+                    easing: ease-in-out-sine;
+                }
             }
         }
     }


### PR DESCRIPTION
User would use them to control the state of lighting components mainly.

This partially reverts the commit 287a976bd0c5bd51b10431a7ebe7d29097228dde

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
