### PR TITLE
TextInput: Fix stale cursor/anchor offsets and undo panic when text changes externally

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -336,6 +336,7 @@ fn default_config() -> cbindgen::Config {
     config.export = cbindgen::ExportConfig {
         rename: [
             ("Callback".into(), "private_api::CallbackHelper".into()),
+            ("ChangeTracker".into(), "private_api::ChangeTracker".into()),
             ("VoidArg".into(), "void".into()),
             ("FocusReasonArg".into(), "FocusReason".into()),
             ("StringArg".into(), "slint::SharedString".into()),
@@ -525,6 +526,8 @@ fn gen_corelib(
         "slint_property_listener_scope_is_dirty",
         "PropertyTrackerOpaque",
         "CallbackOpaque",
+        "ChangeTracker",
+        "ChangeTrackerOpaque",
         "WindowAdapterRc",
         "VoidArg",
         "StringArg",
@@ -917,11 +920,6 @@ fn gen_corelib(
         .body
         .insert("Flickable".to_owned(), "    inline Flickable(); inline ~Flickable();".into());
     config.export.pre_body.insert("FlickableDataBox".to_owned(), "struct FlickableData;".into());
-    config
-        .export
-        .body
-        .insert("TextInput".to_owned(), "    inline TextInput(); inline ~TextInput();".into());
-    config.export.pre_body.insert("TextInputDataBox".to_owned(), "struct TextInputData;".into());
     config.export.body.insert(
         "SystemTrayIcon".to_owned(),
         "    inline SystemTrayIcon(); inline ~SystemTrayIcon();".into(),

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -917,6 +917,11 @@ fn gen_corelib(
         .body
         .insert("Flickable".to_owned(), "    inline Flickable(); inline ~Flickable();".into());
     config.export.pre_body.insert("FlickableDataBox".to_owned(), "struct FlickableData;".into());
+    config
+        .export
+        .body
+        .insert("TextInput".to_owned(), "    inline TextInput(); inline ~TextInput();".into());
+    config.export.pre_body.insert("TextInputDataBox".to_owned(), "struct TextInputData;".into());
     config.export.body.insert(
         "SystemTrayIcon".to_owned(),
         "    inline SystemTrayIcon(); inline ~SystemTrayIcon();".into(),

--- a/api/cpp/include/private/slint_properties.h
+++ b/api/cpp/include/private/slint_properties.h
@@ -7,10 +7,6 @@
 
 namespace slint::cbindgen_private {
 struct PropertyAnimation;
-struct ChangeTracker
-{
-    void *inner;
-};
 }
 
 #include "private/slint_properties_internal.h"
@@ -458,7 +454,7 @@ struct ChangeTracker
     }
 
 private:
-    cbindgen_private::ChangeTracker inner;
+    cbindgen_private::ChangeTrackerOpaque inner;
 };
 
 } // namespace slint::private_api

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -575,6 +575,15 @@ cbindgen_private::Flickable::~Flickable()
     slint_flickable_data_free(&data);
 }
 
+cbindgen_private::TextInput::TextInput()
+{
+    slint_textinput_data_init(&data);
+}
+cbindgen_private::TextInput::~TextInput()
+{
+    slint_textinput_data_free(&data);
+}
+
 cbindgen_private::SystemTrayIcon::SystemTrayIcon()
 {
     slint_system_tray_icon_data_init(&data);

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -575,15 +575,6 @@ cbindgen_private::Flickable::~Flickable()
     slint_flickable_data_free(&data);
 }
 
-cbindgen_private::TextInput::TextInput()
-{
-    slint_textinput_data_init(&data);
-}
-cbindgen_private::TextInput::~TextInput()
-{
-    slint_textinput_data_free(&data);
-}
-
 cbindgen_private::SystemTrayIcon::SystemTrayIcon()
 {
     slint_system_tray_icon_data_init(&data);

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -30,7 +30,7 @@ use crate::rtti::*;
 use crate::string::string_to_float;
 use crate::window::{InputMethodProperties, InputMethodRequest, WindowAdapter, WindowInner};
 use crate::{Callback, Coord, Property, SharedString, SharedVector};
-use alloc::{rc::Rc, string::String};
+use alloc::{boxed::Box, rc::Rc, string::String};
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
 use core::pin::Pin;
@@ -771,10 +771,62 @@ pub struct TextInput {
     pressed: Cell<u8>,
     undo_items: Cell<SharedVector<UndoItem>>,
     redo_items: Cell<SharedVector<UndoItem>>,
+    data: TextInputDataBox,
+}
+
+#[derive(Default)]
+pub struct TextInputData {
+    /// Mirror of `text` as of the last internal edit. Used by the change handler installed
+    /// in `init` to tell internal edits apart from external assignments to the public `text`
+    /// property, so that only the latter realign the cursor/anchor offsets and undo stack.
+    internal_text: Cell<SharedString>,
+    /// Runs `align_to_text` whenever `text` is assigned externally (see issues #331 and #9024).
+    text_change_tracker: crate::properties::ChangeTracker,
+}
+
+#[repr(C)]
+/// Wraps the internal data structure for the TextInput
+pub struct TextInputDataBox(core::ptr::NonNull<TextInputData>);
+
+impl Default for TextInputDataBox {
+    fn default() -> Self {
+        TextInputDataBox(Box::leak(Box::<TextInputData>::default()).into())
+    }
+}
+impl Drop for TextInputDataBox {
+    fn drop(&mut self) {
+        // Safety: the self.0 was constructed from a Box::leak in TextInputDataBox::default
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
+    }
+}
+impl core::ops::Deref for TextInputDataBox {
+    type Target = TextInputData;
+    fn deref(&self) -> &Self::Target {
+        // Safety: initialized in TextInputDataBox::default
+        unsafe { self.0.as_ref() }
+    }
 }
 
 impl Item for TextInput {
-    fn init(self: Pin<&Self>, _self_rc: &ItemRc) {}
+    fn init(self: Pin<&Self>, self_rc: &ItemRc) {
+        // Seed the mirror so the change handler doesn't treat the initial text as external.
+        self.data.internal_text.set(self.text());
+        self.data.text_change_tracker.init_delayed(
+            self_rc.downgrade(),
+            |self_weak| {
+                self_weak
+                    .upgrade()
+                    .and_then(|rc| rc.downcast::<TextInput>())
+                    .map(|text_input| text_input.as_pin_ref().text())
+                    .unwrap_or_default()
+            },
+            |self_weak, new_text| {
+                let Some(self_rc) = self_weak.upgrade() else { return };
+                let Some(text_input) = self_rc.downcast::<TextInput>() else { return };
+                text_input.as_pin_ref().align_to_text(new_text, &self_rc);
+            },
+        );
+    }
 
     fn deinit(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>) {
         if self.has_focus() {
@@ -1084,7 +1136,7 @@ impl Item for TextInput {
                     kind: UndoItemKind::TextInsert,
                 });
 
-                self.as_ref().text.set(text.into());
+                self.as_ref().set_text_internal(text.into());
                 let new_cursor_pos = (insert_pos + event.key_event.text.len()) as i32;
                 self.as_ref().anchor_position_byte_offset.set(new_cursor_pos);
                 self.set_cursor_position(
@@ -1201,7 +1253,7 @@ impl Item for TextInput {
                             let mut text = String::from(self.text());
                             let cursor_position = self.cursor_position(&text);
                             text.insert_str(cursor_position, &preedit_text);
-                            self.text.set(text.into());
+                            self.set_text_internal(text.into());
                             let new_pos = (cursor_position + preedit_text.len()) as i32;
                             self.anchor_position_byte_offset.set(new_pos);
                             self.set_cursor_position(
@@ -1613,6 +1665,47 @@ impl TextInput {
         new_cursor_pos != last_cursor_pos
     }
 
+    /// Set `text` from an internal edit, keeping the `internal_text` mirror in sync so the
+    /// change handler doesn't mistake this edit for an external assignment.
+    fn set_text_internal(self: Pin<&Self>, text: SharedString) {
+        self.data.internal_text.set(text.clone());
+        self.text.set(text);
+    }
+
+    /// Called by the change handler when the public `text` property changes. If the new text
+    /// differs from our `internal_text` mirror, the change came from outside (the application
+    /// assigned `text` directly), so realign all derived state to the new text: clamp the
+    /// cursor and anchor offsets to valid boundaries (issue #331) and clear the undo/redo
+    /// stacks, whose positions refer to the now-replaced text (issue #9024).
+    fn align_to_text(self: Pin<&Self>, new_text: &SharedString, self_rc: &ItemRc) {
+        let previous_text = self.data.internal_text.replace(new_text.clone());
+        if previous_text == *new_text {
+            // Produced by an internal edit: `set_text_internal` already kept the mirror in sync,
+            // so the offsets and undo stack are consistent with `new_text`. Nothing to realign.
+            return;
+        }
+
+        self.undo_items.set(Default::default());
+        self.redo_items.set(Default::default());
+
+        let old_cursor = self.cursor_position_byte_offset();
+        let clamped_cursor = safe_byte_offset(old_cursor, new_text) as i32;
+        let clamped_anchor = safe_byte_offset(self.anchor_position_byte_offset(), new_text) as i32;
+        self.anchor_position_byte_offset.set(clamped_anchor);
+
+        if let Some(window_adapter) = self_rc.window_adapter() {
+            self.set_cursor_position(
+                clamped_cursor,
+                true,
+                TextChangeNotify::TriggerCallbacks,
+                &window_adapter,
+                self_rc,
+            );
+        } else {
+            self.cursor_position_byte_offset.set(clamped_cursor);
+        }
+    }
+
     pub fn set_cursor_position(
         self: Pin<&Self>,
         new_position: i32,
@@ -1692,7 +1785,7 @@ impl TextInput {
         };
 
         let text = [text.split_at(anchor).0, text.split_at(cursor).1].concat();
-        self.text.set(text.into());
+        self.set_text_internal(text.into());
         self.anchor_position_byte_offset.set(anchor as i32);
 
         self.add_undo_item(UndoItem {
@@ -1822,7 +1915,7 @@ impl TextInput {
         });
 
         let cursor_pos = cursor_pos + text_to_insert.len();
-        self.text.set(text.into());
+        self.set_text_internal(text.into());
         self.anchor_position_byte_offset.set(cursor_pos as i32);
         self.set_cursor_position(
             cursor_pos as i32,
@@ -2120,7 +2213,7 @@ impl TextInput {
                 let text: String = self.text().into();
                 let text = [text.split_at(last.pos).0, text.split_at(last.pos + last.text.len()).1]
                     .concat();
-                self.text.set(text.into());
+                self.set_text_internal(text.into());
 
                 self.anchor_position_byte_offset.set(last.anchor as i32);
                 self.set_cursor_position(
@@ -2134,7 +2227,7 @@ impl TextInput {
             UndoItemKind::TextRemove => {
                 let mut text: String = self.text().into();
                 text.insert_str(last.pos, &last.text);
-                self.text.set(text.into());
+                self.set_text_internal(text.into());
 
                 self.anchor_position_byte_offset.set(last.anchor as i32);
                 self.set_cursor_position(
@@ -2164,7 +2257,7 @@ impl TextInput {
             UndoItemKind::TextInsert => {
                 let mut text: String = self.text().into();
                 text.insert_str(last.pos, &last.text);
-                self.text.set(text.into());
+                self.set_text_internal(text.into());
 
                 self.anchor_position_byte_offset.set(last.anchor as i32);
                 self.set_cursor_position(
@@ -2179,7 +2272,7 @@ impl TextInput {
                 let text: String = self.text().into();
                 let text = [text.split_at(last.pos).0, text.split_at(last.pos + last.text.len()).1]
                     .concat();
-                self.text.set(text.into());
+                self.set_text_internal(text.into());
 
                 self.anchor_position_byte_offset.set(last.anchor as i32);
                 self.set_cursor_position(
@@ -2435,5 +2528,24 @@ pub unsafe extern "C" fn slint_cpp_text_item_fontmetrics(
         let self_rc = ItemRc::new(self_component.clone(), self_index);
         let self_ref = self_rc.borrow();
         slint_text_item_fontmetrics(window_adapter, self_ref, &self_rc)
+    }
+}
+
+/// # Safety
+/// This must be called using a non-null pointer pointing to a chunk of memory big enough to
+/// hold a TextInputDataBox
+#[cfg(feature = "ffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_textinput_data_init(data: *mut TextInputDataBox) {
+    unsafe { core::ptr::write(data, TextInputDataBox::default()) };
+}
+
+/// # Safety
+/// This must be called using a non-null pointer pointing to an initialized TextInputDataBox
+#[cfg(feature = "ffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_textinput_data_free(data: *mut TextInputDataBox) {
+    unsafe {
+        core::ptr::drop_in_place(data);
     }
 }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -30,7 +30,7 @@ use crate::rtti::*;
 use crate::string::string_to_float;
 use crate::window::{InputMethodProperties, InputMethodRequest, WindowAdapter, WindowInner};
 use crate::{Callback, Coord, Property, SharedString, SharedVector};
-use alloc::{boxed::Box, rc::Rc, string::String};
+use alloc::{rc::Rc, string::String};
 use const_field_offset::FieldOffsets;
 use core::cell::Cell;
 use core::pin::Pin;
@@ -771,11 +771,6 @@ pub struct TextInput {
     pressed: Cell<u8>,
     undo_items: Cell<SharedVector<UndoItem>>,
     redo_items: Cell<SharedVector<UndoItem>>,
-    data: TextInputDataBox,
-}
-
-#[derive(Default)]
-pub struct TextInputData {
     /// Mirror of `text` as of the last internal edit. Used by the change handler installed
     /// in `init` to tell internal edits apart from external assignments to the public `text`
     /// property, so that only the latter realign the cursor/anchor offsets and undo stack.
@@ -784,34 +779,11 @@ pub struct TextInputData {
     text_change_tracker: crate::properties::ChangeTracker,
 }
 
-#[repr(C)]
-/// Wraps the internal data structure for the TextInput
-pub struct TextInputDataBox(core::ptr::NonNull<TextInputData>);
-
-impl Default for TextInputDataBox {
-    fn default() -> Self {
-        TextInputDataBox(Box::leak(Box::<TextInputData>::default()).into())
-    }
-}
-impl Drop for TextInputDataBox {
-    fn drop(&mut self) {
-        // Safety: the self.0 was constructed from a Box::leak in TextInputDataBox::default
-        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
-    }
-}
-impl core::ops::Deref for TextInputDataBox {
-    type Target = TextInputData;
-    fn deref(&self) -> &Self::Target {
-        // Safety: initialized in TextInputDataBox::default
-        unsafe { self.0.as_ref() }
-    }
-}
-
 impl Item for TextInput {
     fn init(self: Pin<&Self>, self_rc: &ItemRc) {
         // Seed the mirror so the change handler doesn't treat the initial text as external.
-        self.data.internal_text.set(self.text());
-        self.data.text_change_tracker.init_delayed(
+        self.internal_text.set(self.text());
+        self.text_change_tracker.init_delayed(
             self_rc.downgrade(),
             |self_weak| {
                 self_weak
@@ -1668,7 +1640,7 @@ impl TextInput {
     /// Set `text` from an internal edit, keeping the `internal_text` mirror in sync so the
     /// change handler doesn't mistake this edit for an external assignment.
     fn set_text_internal(self: Pin<&Self>, text: SharedString) {
-        self.data.internal_text.set(text.clone());
+        self.internal_text.set(text.clone());
         self.text.set(text);
     }
 
@@ -1678,7 +1650,7 @@ impl TextInput {
     /// cursor and anchor offsets to valid boundaries (issue #331) and clear the undo/redo
     /// stacks, whose positions refer to the now-replaced text (issue #9024).
     fn align_to_text(self: Pin<&Self>, new_text: &SharedString, self_rc: &ItemRc) {
-        let previous_text = self.data.internal_text.replace(new_text.clone());
+        let previous_text = self.internal_text.replace(new_text.clone());
         if previous_text == *new_text {
             // Produced by an internal edit: `set_text_internal` already kept the mirror in sync,
             // so the offsets and undo stack are consistent with `new_text`. Nothing to realign.
@@ -2528,24 +2500,5 @@ pub unsafe extern "C" fn slint_cpp_text_item_fontmetrics(
         let self_rc = ItemRc::new(self_component.clone(), self_index);
         let self_ref = self_rc.borrow();
         slint_text_item_fontmetrics(window_adapter, self_ref, &self_rc)
-    }
-}
-
-/// # Safety
-/// This must be called using a non-null pointer pointing to a chunk of memory big enough to
-/// hold a TextInputDataBox
-#[cfg(feature = "ffi")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_textinput_data_init(data: *mut TextInputDataBox) {
-    unsafe { core::ptr::write(data, TextInputDataBox::default()) };
-}
-
-/// # Safety
-/// This must be called using a non-null pointer pointing to an initialized TextInputDataBox
-#[cfg(feature = "ffi")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_textinput_data_free(data: *mut TextInputDataBox) {
-    unsafe {
-        core::ptr::drop_in_place(data);
     }
 }

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1375,6 +1375,20 @@ fn safe_byte_offset(unsafe_byte_offset: i32, text: &str) -> usize {
     text.ceil_char_boundary(unsafe_byte_offset as usize)
 }
 
+/// Like [`safe_byte_offset`], but additionally snaps the result up to a grapheme cluster
+/// boundary. Used when realigning the cursor/anchor to text that was replaced externally, so
+/// they never land inside a multi-codepoint grapheme (e.g. an emoji with a skin-tone modifier
+/// or a base character followed by a combining mark), matching how cursor movement treats a
+/// grapheme cluster as indivisible.
+fn safe_grapheme_boundary_offset(unsafe_byte_offset: i32, text: &str) -> usize {
+    let offset = safe_byte_offset(unsafe_byte_offset, text);
+    let mut grapheme_cursor = unicode_segmentation::GraphemeCursor::new(offset, text.len(), true);
+    match grapheme_cursor.is_boundary(text, 0) {
+        Ok(true) => offset,
+        _ => grapheme_cursor.next_boundary(text, 0).ok().flatten().unwrap_or(text.len()),
+    }
+}
+
 /// This struct holds the fields needed for rendering a TextInput item after applying any
 /// on-going composition. This way the renderer's don't have to duplicate the code for extracting
 /// and applying the pre-edit text, cursor placement within, etc.
@@ -1661,8 +1675,9 @@ impl TextInput {
         self.redo_items.set(Default::default());
 
         let old_cursor = self.cursor_position_byte_offset();
-        let clamped_cursor = safe_byte_offset(old_cursor, new_text) as i32;
-        let clamped_anchor = safe_byte_offset(self.anchor_position_byte_offset(), new_text) as i32;
+        let clamped_cursor = safe_grapheme_boundary_offset(old_cursor, new_text) as i32;
+        let clamped_anchor =
+            safe_grapheme_boundary_offset(self.anchor_position_byte_offset(), new_text) as i32;
         self.anchor_position_byte_offset.set(clamped_anchor);
 
         if let Some(window_adapter) = self_rc.window_adapter() {

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -496,27 +496,37 @@ pub unsafe extern "C" fn slint_property_tracker_drop(handle: *mut PropertyTracke
     unsafe { core::ptr::drop_in_place(handle as *mut PropertyTracker) };
 }
 
+#[repr(C)]
+/// Opaque type representing the ChangeTracker
+pub struct ChangeTrackerOpaque {
+    _inner: *const c_void,
+}
+
+static_assertions::assert_eq_align!(ChangeTrackerOpaque, ChangeTracker);
+static_assertions::assert_eq_size!(ChangeTrackerOpaque, ChangeTracker);
+
 /// Construct a ChangeTracker
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_change_tracker_construct(ct: *mut ChangeTracker) {
-    unsafe { core::ptr::write(ct, ChangeTracker::default()) };
+pub unsafe extern "C" fn slint_change_tracker_construct(ct: *mut ChangeTrackerOpaque) {
+    unsafe { core::ptr::write(ct as *mut ChangeTracker, ChangeTracker::default()) };
 }
 
 /// Drop a ChangeTracker
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_change_tracker_drop(ct: *mut ChangeTracker) {
-    unsafe { core::ptr::drop_in_place(ct) };
+pub unsafe extern "C" fn slint_change_tracker_drop(ct: *mut ChangeTrackerOpaque) {
+    unsafe { core::ptr::drop_in_place(ct as *mut ChangeTracker) };
 }
 
 /// initialize the change tracker
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_change_tracker_init(
-    ct: &ChangeTracker,
+    ct: &ChangeTrackerOpaque,
     user_data: *mut c_void,
     drop_user_data: extern "C" fn(user_data: *mut c_void),
     eval_fn: extern "C" fn(user_data: *mut c_void) -> bool,
     notify_fn: extern "C" fn(user_data: *mut c_void),
 ) {
+    let ct = unsafe { &*(ct as *const ChangeTrackerOpaque as *const ChangeTracker) };
     #[allow(non_camel_case_types)]
     struct C_ChangeTrackerInner {
         user_data: *mut c_void,
@@ -622,7 +632,7 @@ mod ffi_change_tracker_leak_test {
         let ct = ChangeTracker::default();
         unsafe {
             slint_change_tracker_init(
-                &ct,
+                &*(&ct as *const ChangeTracker as *const ChangeTrackerOpaque),
                 &state as *const EvalState as *mut c_void,
                 drop_fn,
                 eval_fn,

--- a/tests/cases/text/issue_9024_undo_after_text_set.slint
+++ b/tests/cases/text/issue_9024_undo_after_text_set.slint
@@ -1,0 +1,70 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for issue #9024: setting `text` programmatically used to leave the
+// undo/redo stack pointing into the now-replaced text, so a subsequent undo panicked
+// with "byte index out of bounds". Setting `text` externally must clear the undo stack
+// (and re-clamp the cursor/anchor, see issue #331).
+
+component TestCase inherits Window {
+    width: 100phx;
+    height: 100phx;
+    ti := TextInput {
+        cursor-position-changed => { root.cursor_changed_count += 1; }
+    }
+
+    in-out property <string> test_text <=> ti.text;
+    in-out property <int> test_cursor_pos: ti.cursor_position_byte_offset;
+    in-out property <int> test_anchor_pos: ti.anchor_position_byte_offset;
+    in-out property <bool> input_focused: ti.has_focus;
+    out property <int> cursor_changed_count;
+
+    callback do_undo();
+    do_undo => { ti.undo(); }
+    callback do_redo();
+    do_redo => { ti.redo(); }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_input_focused());
+
+// Type some text, which records undo items and leaves the cursor at the end.
+slint_testing::send_keyboard_string_sequence(&instance, "Hello");
+assert_eq!(instance.get_test_text(), "Hello");
+assert_eq!(instance.get_test_cursor_pos(), 5);
+
+// Replace the text programmatically with a shorter string, as an application would.
+let cursor_changed_count = instance.get_cursor_changed_count();
+instance.set_test_text("Yo".into());
+slint_testing::mock_elapsed_time(0);
+
+// Issue #331: the cursor and anchor are re-clamped to the new (shorter) length.
+assert_eq!(instance.get_test_cursor_pos(), 2);
+assert_eq!(instance.get_test_anchor_pos(), 2);
+// The (delayed) re-clamp reports the new position via cursor-position-changed.
+assert!(instance.get_cursor_changed_count() > cursor_changed_count);
+
+// Issue #9024: the undo stack referenced the old text; undo must now be a no-op
+// rather than panicking, because the external assignment cleared the history.
+instance.invoke_do_undo();
+assert_eq!(instance.get_test_text(), "Yo");
+instance.invoke_do_redo();
+assert_eq!(instance.get_test_text(), "Yo");
+
+// Editing still works and builds a fresh, consistent undo history.
+slint_testing::send_keyboard_string_sequence(&instance, "!");
+assert_eq!(instance.get_test_text(), "Yo!");
+instance.invoke_do_undo();
+assert_eq!(instance.get_test_text(), "Yo");
+
+// Clearing the text entirely and then undoing must not panic either.
+instance.set_test_text("".into());
+slint_testing::mock_elapsed_time(0);
+assert_eq!(instance.get_test_cursor_pos(), 0);
+instance.invoke_do_undo();
+assert_eq!(instance.get_test_text(), "");
+```
+*/

--- a/tests/cases/text/issue_9024_undo_after_text_set.slint
+++ b/tests/cases/text/issue_9024_undo_after_text_set.slint
@@ -26,6 +26,49 @@ component TestCase inherits Window {
 }
 
 /*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert(instance.get_input_focused());
+
+// Type some text, which records undo items and leaves the cursor at the end.
+slint_testing::send_keyboard_string_sequence(&instance, "Hello");
+assert_eq(instance.get_test_text(), "Hello");
+assert_eq(instance.get_test_cursor_pos(), 5);
+
+// Replace the text programmatically with a shorter string, as an application would.
+auto cursor_changed_count = instance.get_cursor_changed_count();
+instance.set_test_text("Yo");
+slint_testing::mock_elapsed_time(0);
+
+// Issue #331: the cursor and anchor are re-clamped to the new (shorter) length.
+assert_eq(instance.get_test_cursor_pos(), 2);
+assert_eq(instance.get_test_anchor_pos(), 2);
+// The (delayed) re-clamp reports the new position via cursor-position-changed.
+assert(instance.get_cursor_changed_count() > cursor_changed_count);
+
+// Issue #9024: the undo stack referenced the old text; undo must now be a no-op
+// rather than panicking, because the external assignment cleared the history.
+instance.invoke_do_undo();
+assert_eq(instance.get_test_text(), "Yo");
+instance.invoke_do_redo();
+assert_eq(instance.get_test_text(), "Yo");
+
+// Editing still works and builds a fresh, consistent undo history.
+slint_testing::send_keyboard_string_sequence(&instance, "!");
+assert_eq(instance.get_test_text(), "Yo!");
+instance.invoke_do_undo();
+assert_eq(instance.get_test_text(), "Yo");
+
+// Clearing the text entirely and then undoing must not panic either.
+instance.set_test_text("");
+slint_testing::mock_elapsed_time(0);
+assert_eq(instance.get_test_cursor_pos(), 0);
+instance.invoke_do_undo();
+assert_eq(instance.get_test_text(), "");
+```
+
 ```rust
 let instance = TestCase::new().unwrap();
 slint_testing::send_mouse_click(&instance, 5., 5.);

--- a/tests/cases/text/text_change.slint
+++ b/tests/cases/text/text_change.slint
@@ -32,7 +32,10 @@ assert_eq!(instance.get_text(), "Yo");
 slint_testing::send_keyboard_string_sequence(&instance, "Hello Again");
 assert_eq!(instance.get_text(), "YoHello Again");
 instance.set_text("Yo".into());
-// Issue #331: assert_eq!(instance.get_test_cursor_pos(), 2);
+// Issue #331: setting `text` externally re-clamps the cursor to the new (shorter) length.
+// The realignment runs in a change handler, so pump them before observing the offset.
+slint_testing::mock_elapsed_time(0);
+assert_eq!(instance.get_test_cursor_pos(), 2);
 slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
 assert_eq!(instance.get_test_cursor_pos(), 1);
 ```

--- a/tests/cases/text/text_set_unicode.slint
+++ b/tests/cases/text/text_set_unicode.slint
@@ -1,0 +1,141 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Coverage for re-clamping the cursor/anchor when `text` is set externally (issues #331/#9024),
+// with multi-byte and multi-codepoint input. A stale byte offset must be snapped to a grapheme
+// cluster boundary so it never lands inside a multi-byte character or in the middle of a
+// grapheme (e.g. an emoji with a skin-tone modifier), and the undo stack must be reset so an
+// undo after an external assignment is a no-op rather than panicking.
+
+// cspell:ignore héllo wörld
+
+component TestCase inherits Window {
+    width: 100phx;
+    height: 100phx;
+    ti := TextInput { }
+
+    in-out property <string> test_text <=> ti.text;
+    out property <int> test_cursor_pos: ti.cursor_position_byte_offset;
+    out property <int> test_anchor_pos: ti.anchor_position_byte_offset;
+    out property <bool> input_focused: ti.has_focus;
+
+    callback set_selection_offsets(int, int);
+    set_selection_offsets(start, end) => { ti.set-selection-offsets(start, end); }
+    callback do_undo();
+    do_undo => { ti.undo(); }
+    callback do_redo();
+    do_redo => { ti.redo(); }
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+// --- Case 1: a stale offset that lands inside a multi-codepoint grapheme snaps past it ---
+// "👍🏽" is a single grapheme of two codepoints (8 bytes); byte offset 4 is a valid char
+// boundary but sits in the middle of the grapheme. A codepoint-only clamp would leave the
+// cursor at 4; snapping to the grapheme boundary moves it to 8.
+instance.set_test_text("ab");
+slint_testing::mock_elapsed_time(0);
+instance.invoke_set_selection_offsets(2, 2);
+assert_eq(instance.get_test_cursor_pos(), 2);
+instance.set_test_text("👍🏽");
+slint_testing::mock_elapsed_time(0);
+assert_eq(instance.get_test_cursor_pos(), 8);
+assert_eq(instance.get_test_anchor_pos(), 8);
+
+// --- Case 2: cursor in the middle, shrink past it; cursor and anchor clamp independently ---
+// "héllo" has the 2-byte 'é' at bytes 1..3, so offsets 0,1,3,4,5,6 are valid.
+instance.set_test_text("héllo");
+slint_testing::mock_elapsed_time(0);
+instance.invoke_set_selection_offsets(1, 4);
+assert_eq(instance.get_test_anchor_pos(), 1);
+assert_eq(instance.get_test_cursor_pos(), 4);
+// "hö" is 3 bytes; the anchor at 1 stays valid, the cursor at 4 clamps to the new end (3).
+instance.set_test_text("hö");
+slint_testing::mock_elapsed_time(0);
+assert_eq(instance.get_test_anchor_pos(), 1);
+assert_eq(instance.get_test_cursor_pos(), 3);
+
+// --- Case 3: undo after an external set, with multi-byte undo offsets (issue #9024) ---
+// Start from an empty field so the click-positioned caret is deterministic across backends.
+instance.set_test_text("");
+slint_testing::mock_elapsed_time(0);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert(instance.get_input_focused());
+// Typing records undo items whose byte offsets exceed the character count ('ö' is 2 bytes).
+slint_testing::send_keyboard_string_sequence(&instance, "wörld");
+assert_eq(instance.get_test_text(), "wörld");
+assert_eq(instance.get_test_cursor_pos(), 6);
+// Replace externally with a shorter multi-byte string.
+instance.set_test_text("yö");
+slint_testing::mock_elapsed_time(0);
+assert_eq(instance.get_test_cursor_pos(), 3);
+// The undo stack referenced the old text; undo/redo must be no-ops rather than panicking.
+instance.invoke_do_undo();
+assert_eq(instance.get_test_text(), "yö");
+instance.invoke_do_redo();
+assert_eq(instance.get_test_text(), "yö");
+// Editing still works and builds a fresh, consistent history.
+slint_testing::send_keyboard_string_sequence(&instance, "!");
+assert_eq(instance.get_test_text(), "yö!");
+instance.invoke_do_undo();
+assert_eq(instance.get_test_text(), "yö");
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+
+// --- Case 1: a stale offset that lands inside a multi-codepoint grapheme snaps past it ---
+// "👍🏽" is a single grapheme of two codepoints (8 bytes); byte offset 4 is a valid char
+// boundary but sits in the middle of the grapheme. A codepoint-only clamp would leave the
+// cursor at 4; snapping to the grapheme boundary moves it to 8.
+instance.set_test_text("ab".into());
+slint_testing::mock_elapsed_time(0);
+instance.invoke_set_selection_offsets(2, 2);
+assert_eq!(instance.get_test_cursor_pos(), 2);
+instance.set_test_text("👍🏽".into());
+slint_testing::mock_elapsed_time(0);
+assert_eq!(instance.get_test_cursor_pos(), 8);
+assert_eq!(instance.get_test_anchor_pos(), 8);
+
+// --- Case 2: cursor in the middle, shrink past it; cursor and anchor clamp independently ---
+// "héllo" has the 2-byte 'é' at bytes 1..3, so offsets 0,1,3,4,5,6 are valid.
+instance.set_test_text("héllo".into());
+slint_testing::mock_elapsed_time(0);
+instance.invoke_set_selection_offsets(1, 4);
+assert_eq!(instance.get_test_anchor_pos(), 1);
+assert_eq!(instance.get_test_cursor_pos(), 4);
+// "hö" is 3 bytes; the anchor at 1 stays valid, the cursor at 4 clamps to the new end (3).
+instance.set_test_text("hö".into());
+slint_testing::mock_elapsed_time(0);
+assert_eq!(instance.get_test_anchor_pos(), 1);
+assert_eq!(instance.get_test_cursor_pos(), 3);
+
+// --- Case 3: undo after an external set, with multi-byte undo offsets (issue #9024) ---
+// Start from an empty field so the click-positioned caret is deterministic across backends.
+instance.set_test_text("".into());
+slint_testing::mock_elapsed_time(0);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_input_focused());
+// Typing records undo items whose byte offsets exceed the character count ('ö' is 2 bytes).
+slint_testing::send_keyboard_string_sequence(&instance, "wörld");
+assert_eq!(instance.get_test_text(), "wörld");
+assert_eq!(instance.get_test_cursor_pos(), 6);
+// Replace externally with a shorter multi-byte string.
+instance.set_test_text("yö".into());
+slint_testing::mock_elapsed_time(0);
+assert_eq!(instance.get_test_cursor_pos(), 3);
+// The undo stack referenced the old text; undo/redo must be no-ops rather than panicking.
+instance.invoke_do_undo();
+assert_eq!(instance.get_test_text(), "yö");
+instance.invoke_do_redo();
+assert_eq!(instance.get_test_text(), "yö");
+// Editing still works and builds a fresh, consistent history.
+slint_testing::send_keyboard_string_sequence(&instance, "!");
+assert_eq!(instance.get_test_text(), "yö!");
+instance.invoke_do_undo();
+assert_eq!(instance.get_test_text(), "yö");
+```
+*/


### PR DESCRIPTION
When `text` is assigned programmatically, the cursor and anchor byte offsets were left stale (reporting wrong values, #331) and the undo/redo stack kept positions into the replaced text, causing an out-of-bounds panic on undo (#9024).

`TextInput` now keeps an internal mirror of the text and installs a change handler on the `text` property. On an external assignment it re-clamps the cursor and anchor offsets to the new text and clears the undo/redo history; internal edits route through a helper that keeps the mirror in sync so they aren't mistaken for external changes. The realignment also emits `cursor-position-changed`.

Fixes #331
Fixes #9024