### PR TITLE
MCU pico2: increase heap size

### DIFF
--- a/examples/mcu-board-support/pico2_st7789.rs
+++ b/examples/mcu-board-support/pico2_st7789.rs
@@ -28,7 +28,7 @@ mod rp_pico2;
 use rp_pico2::hal::{self, pac, prelude::*, timer::CopyableTimer0, Timer};
 use slint::platform::{software_renderer as renderer, PointerEventButton, WindowEvent};
 
-const HEAP_SIZE: usize = 200 * 1024;
+const HEAP_SIZE: usize = 400 * 1024;
 static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
 
 #[global_allocator]


### PR DESCRIPTION
400 kB would be alright because pico 2 has 520 KB on-chip SRAM

See https://github.com/slint-ui/slint/discussions/8477

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
