### PR TITLE
Basic live-preview telemetry

### DIFF
--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -133,6 +133,9 @@ export function languageClientOptions(
 
 export function prepare_client(client: BaseLanguageClient) {
     client.registerFeature(new snippets.SnippetTextEditFeature());
+    client.onNotification(new NotificationType("telemetry/event"), (params) => {
+        console.log("Received telemetry event:", params);
+    });
 }
 
 // VSCode Plugin lifecycle related:

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -11,10 +11,9 @@ import * as wasm_preview from "./wasm_preview";
 import * as lsp_commands from "./lsp_commands";
 import * as snippets from "./snippets";
 
-import {
-    type BaseLanguageClient,
-    type LanguageClientOptions,
-    NotificationType,
+import type {
+    BaseLanguageClient,
+    LanguageClientOptions,
 } from "vscode-languageclient";
 
 export class ClientHandle {
@@ -150,12 +149,6 @@ export function activate(
 
     client.add_updater((cl) => {
         wasm_preview.initClientForPreview(context, cl);
-        cl?.onNotification(
-            new NotificationType("telemetry/event"),
-            (params: any) => {
-                handleTelemetryEvent(params.type, context.globalState);
-            },
-        );
     });
 
     vscode.workspace.onDidChangeConfiguration(async (ev) => {
@@ -265,30 +258,4 @@ async function maybeSendStartupTelemetryEvent(
     }
 
     telemetryLogger.logUsage("extension-activated", usageData);
-}
-
-function handleTelemetryEvent(
-    telemetryType: string,
-    globalState: vscode.Memento,
-) {
-    switch (telemetryType) {
-        case "preview_opened": {
-            const currentCount = globalState.get("preview_opened", 0);
-            globalState.update("preview_opened", currentCount + 1);
-            break;
-        }
-        case "property_changed": {
-            const currentCount = globalState.get("property_changed", 0);
-            globalState.update("property_changed", currentCount + 1);
-            break;
-        }
-        case "data_json_changed": {
-            const currentCount = globalState.get("data_json_changed", 0);
-            globalState.update("data_json_changed", currentCount + 1);
-            break;
-        }
-        default:
-            console.log("Received unknown telemetry event:", telemetryType);
-            break;
-    }
 }

--- a/editors/vscode/telemetry.json
+++ b/editors/vscode/telemetry.json
@@ -23,6 +23,23 @@
                 "purpose": "PerformanceAndHealth",
                 "comment": "The location of the panic in the slint-lsp code"
             }
+        },
+        "live-preview-stats": {
+            "preview_opened": {
+                "classification": "PublicNonPersonalData",
+                "purpose": "PerformanceAndHealth",
+                "comment": "Times the live preview has been opened"
+            },
+            "property_changed": {
+                "classification": "PublicNonPersonalData",
+                "purpose": "PerformanceAndHealth",
+                "comment": "Times a value in the property tab has been changed"
+            },
+            "data_json_changed": {
+                "classification": "PublicNonPersonalData",
+                "purpose": "PerformanceAndHealth",
+                "comment": "Times a property in the data tab has been changed"
+            }
         }
     },
     "commonProperties": {

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -1207,7 +1207,10 @@ fn set_json_preview_data(
     property_name: SharedString,
     json_string: SharedString,
 ) -> SharedString {
-    crate::preview::send_telemetry(&mut [("type".to_string(), serde_json::to_value("data_json_changed").unwrap())]);
+    crate::preview::send_telemetry(&mut [(
+        "type".to_string(), 
+        serde_json::to_value("data_json_changed").unwrap(),
+    )]);
 
     let property_name = (!property_name.is_empty()).then_some(property_name.to_string());
 

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -1207,6 +1207,8 @@ fn set_json_preview_data(
     property_name: SharedString,
     json_string: SharedString,
 ) -> SharedString {
+    crate::preview::send_telemetry(&mut [("type".to_string(), serde_json::to_value("data_json_changed").unwrap())]);
+
     let property_name = (!property_name.is_empty()).then_some(property_name.to_string());
 
     let json = match serde_json::from_str::<serde_json::Value>(json_string.as_ref()) {
@@ -1233,6 +1235,7 @@ fn set_json_preview_data(
     } else {
         SharedString::from("No preview loaded")
     }
+
 }
 
 fn update_properties(


### PR DESCRIPTION
Once an hour it will check if the live-preview was ever opened and if any properties were editied in the property tab, or any data tab data was updated. If nothing has changed it sends no data.