### PR TITLE
add option to create CompilerConfiguration with_debug_info

### DIFF
--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -190,6 +190,18 @@ impl CompilerConfiguration {
         Self { config }
     }
 
+    /// Configures the compiler to emit additional debug info when compiling Slint code.
+    /// 
+    /// This is the equivalent to setting `SLINT_EMIT_DEBUG_INFO=1` and using the `slint!()` macro 
+    /// and is primarily used by `i-slint-backend-testing`.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_debug_info(self) -> Self {
+        let mut config = self.config;
+        config.debug_info = true;
+        Self { config }
+    }
+
     /// Configures the compiler to use Signed Distance Field (SDF) encoding for fonts.
     ///
     /// This flag only takes effect when `embed_resources` is set to [`EmbedResourcesKind::EmbedForSoftwareRenderer`],

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -191,8 +191,8 @@ impl CompilerConfiguration {
     }
 
     /// Configures the compiler to emit additional debug info when compiling Slint code.
-    /// 
-    /// This is the equivalent to setting `SLINT_EMIT_DEBUG_INFO=1` and using the `slint!()` macro 
+    ///
+    /// This is the equivalent to setting `SLINT_EMIT_DEBUG_INFO=1` and using the `slint!()` macro
     /// and is primarily used by `i-slint-backend-testing`.
     #[doc(hidden)]
     #[must_use]

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -196,9 +196,9 @@ impl CompilerConfiguration {
     /// and is primarily used by `i-slint-backend-testing`.
     #[doc(hidden)]
     #[must_use]
-    pub fn with_debug_info(self) -> Self {
+    pub fn with_debug_info(self, enable: bool) -> Self {
         let mut config = self.config;
-        config.debug_info = true;
+        config.debug_info = enable;
         Self { config }
     }
 

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -10,7 +10,7 @@ use i_slint_core::window::WindowInner;
 use i_slint_core::SharedString;
 
 fn warn_missing_debug_info() {
-    i_slint_core::debug_log!("The use of the ElementHandle API requires the presence of debug info in Slint compiler generated code. Set the `SLINT_EMIT_DEBUG_INFO=1` environment variable at application build time")
+    i_slint_core::debug_log!("The use of the ElementHandle API requires the presence of debug info in Slint compiler generated code. Set the `SLINT_EMIT_DEBUG_INFO=1` environment variable at application build time or use `compile_with_config` and `with_debug_info`")
 }
 
 mod internal {

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -10,7 +10,7 @@ use i_slint_core::window::WindowInner;
 use i_slint_core::SharedString;
 
 fn warn_missing_debug_info() {
-    i_slint_core::debug_log!("The use of the ElementHandle API requires the presence of debug info in Slint compiler generated code. Set the `SLINT_EMIT_DEBUG_INFO=1` environment variable at application build time or use `compile_with_config` and `with_debug_info`")
+    i_slint_core::debug_log!("The use of the ElementHandle API requires the presence of debug info in Slint compiler generated code. Set the `SLINT_EMIT_DEBUG_INFO=1` environment variable at application build time or use `compile_with_config` and `with_debug_info` with `slint_build`'s `CompilerConfiguration`")
 }
 
 mod internal {


### PR DESCRIPTION
Using `i-slint-backend-testing` requires the environment variable `SLINT_EMIT_DEBUG_INFO=1` to be set when building the slint components.

When the components are created with the `slint!` macro this can be easily achieved via build.rs:
```rust
fn main() {
    // Set SLINT_EMIT_DEBUG_INFO=1 for tests, rust-analyzer, etc.
    if std::env::var("DEBUG") == Ok("true".to_string()) {
        println!("cargo:rustc-env=SLINT_EMIT_DEBUG_INFO=1");
    }
}
```

If the components are in dedicated `.slint` modules this becomes a lot tricker.

This PR adds the ability to build modules with debug info via build.rs:
```rust
fn main() {
    // Set SLINT_EMIT_DEBUG_INFO=1 for tests, rust-analyzer, etc.
    if std::env::var("DEBUG") == Ok("true".to_string()) {
        let config = slint_build::CompilerConfiguration::new().with_debug_info();
        slint_build::compile_with_config("src/tasks.slint", config).unwrap();
    }
}
```

The function is marked as `#[doc(hidden)]` for now, to avoid encouraging use of the internal testing backend.

I would be really grateful if you would consider including this small PR, the ability to directly test the UI and validate accessibility is absolutely amazing and unique - however unstable and unsupported the backend API may be ;)