### PR TITLE
compiler: Fix identifier normalization function

### DIFF
--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -461,8 +461,15 @@ function loadSlint(loadData: LoadData): Object {
 
                 // globals
                 instance!.definition().globals.forEach((globalName) => {
-                    if (componentHandle[globalName] !== undefined) {
-                        console.warn("Duplicated property name " + globalName);
+                    const jsName = translateName(globalName);
+                    if (componentHandle[jsName] !== undefined) {
+                        console.warn(
+                            "Duplicated property name " +
+                                globalName +
+                                " (In JS: " +
+                                jsName +
+                                ")",
+                        );
                     } else {
                         const globalObject = Object.create({});
 
@@ -576,7 +583,7 @@ function loadSlint(loadData: LoadData): Object {
                                 }
                             });
 
-                        Object.defineProperty(componentHandle, globalName, {
+                        Object.defineProperty(componentHandle, jsName, {
                             get() {
                                 return globalObject;
                             },

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -510,7 +510,7 @@ impl ItemTreeDescription<'_> {
     > {
         let g = self.compiled_globals.as_ref().expect("Root component should have globals");
         g.exported_globals_by_name
-            .get(crate::normalize_identifier(name).as_ref())
+            .get(&crate::normalize_identifier(name))
             .and_then(|global_idx| g.compiled_globals.get(*global_idx))
             .map(|global| internal_properties_to_public(global.public_properties()))
     }

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -227,7 +227,7 @@ pub extern "C" fn slint_interpreter_struct_set_field<'a>(
     stru.as_struct_mut().set_field(std::str::from_utf8(&name).unwrap().into(), value.clone())
 }
 
-type StructIterator<'a> = std::collections::hash_map::Iter<'a, String, Value>;
+type StructIterator<'a> = std::collections::hash_map::Iter<'a, SmolStr, Value>;
 #[repr(C)]
 pub struct StructIteratorOpaque<'a>([usize; 5], std::marker::PhantomData<StructIterator<'a>>);
 const _: [(); std::mem::size_of::<StructIteratorOpaque>()] =
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_invoke(
     let comp = inst.unerase(guard);
     match comp.description().invoke(
         comp.borrow(),
-        &normalize_identifier_smolstr(std::str::from_utf8(&name).unwrap()),
+        &normalize_identifier(std::str::from_utf8(&name).unwrap()),
         args.as_slice(),
     ) {
         Ok(val) => Box::into_raw(Box::new(val)),
@@ -467,8 +467,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_invoke_global(
                     args.as_slice().iter().cloned().collect(),
                 )
             } else {
-                g.as_ref()
-                    .invoke_callback(&normalize_identifier_smolstr(callable_name), args.as_slice())
+                g.as_ref().invoke_callback(&normalize_identifier(callable_name), args.as_slice())
             }
         }) {
         Ok(val) => Box::into_raw(Box::new(val)),

--- a/internal/interpreter/json.rs
+++ b/internal/interpreter/json.rs
@@ -184,13 +184,13 @@ pub fn value_from_json(t: &langtype::Type, v: &serde_json::Value) -> Result<Valu
             langtype::Type::Struct(s) => Ok(crate::Struct(
                 obj.iter()
                     .map(|(k, v)| {
-                        let k = k.to_smolstr();
+                        let k = crate::api::normalize_identifier(k);
                         match s.fields.get(&k) {
-                            Some(t) => value_from_json(t, v).map(|v| (k.to_string(), v)),
+                            Some(t) => value_from_json(t, v).map(|v| (k, v)),
                             None => Err(format!("Found unknown field in struct: {k}")),
                         }
                     })
-                    .collect::<Result<HashMap<String, Value>, _>>()?,
+                    .collect::<Result<HashMap<smol_str::SmolStr, Value>, _>>()?,
             )
             .into()),
             _ => Err("Got a struct where none was expected".into()),
@@ -227,7 +227,7 @@ pub fn value_to_json(value: &Value) -> Result<serde_json::Value, String> {
 
         gradient += ")";
 
-        serde_json::Value::String(gradient.into())
+        serde_json::Value::String(gradient)
     }
 
     match value {

--- a/tests/cases/properties/dashes.slint
+++ b/tests/cases/properties/dashes.slint
@@ -1,10 +1,21 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
- Test-Case := Rectangle {
+struct __strange- {
+    _-indeed--: int,
+}
 
+export global _-Foo-- {
+    out property<int> _-foo-: 815;
+}
+
+Test-Case := Rectangle {
     property<length> property-x1: xxx-foo.border-width;
     property<length> property-x2: xxx_foo.border_width;
+
+    __-id- := Rectangle {
+        property<_-strange-> struct-property: { _-indeed--: 23 };
+    }
 
     xxx-foo := Rectangle {
         border-width: 42phx;
@@ -14,6 +25,8 @@
     property<int> hello--world: -hello-42 - 2; // -42 - 2 = -44
     property<int> this--has-6-slashes--: 42-hello--world; // 42 - -44  = 86
 
+    out property<int> _-test_property-: 42;
+    out property<int> __test_property2: _--id_.struct-property._-indeed--;
 }
 /*
 ```cpp
@@ -22,6 +35,10 @@ const Test_Case &instance = *handle;
 assert_eq(instance.get_property_x1(), 42);
 assert_eq(instance.get_property_x2(), 42);
 assert_eq(instance.get_this__has_6_slashes__(), 86);
+assert_eq(instance.get___test_property_(), 42);
+assert_eq(instance.get___test_property2(), 23);
+
+assert_eq(handle->global<__Foo__>().get___foo_(), 815);
 ```
 
 ```rust
@@ -29,6 +46,11 @@ let instance = Test_Case::new().unwrap();
 assert_eq!(instance.get_property_x1(), 42.);
 assert_eq!(instance.get_property_x2(), 42.);
 assert_eq!(instance.get_this__has_6_slashes__(), 86);
+assert_eq!(instance.get___test_property_(), 42);
+assert_eq!(instance.get___test_property2(), 23);
+
+let foo = instance.global::<__Foo__<'_>>();
+assert_eq!(foo.get___foo_(), 815);
 ```
 
 ```js
@@ -36,5 +58,9 @@ var instance = new slint.Test_Case({});
 assert.equal(instance.property_x1, 42);
 assert.equal(instance.property_x2, 42);
 assert.equal(instance.this__has_6_slashes__, 86);
+assert.equal(instance.__test_property_, 42);
+assert.equal(instance.__test_property2, 23);
+
+assert.equal(instance.__Foo__.__foo_, 815);
 ```
 */


### PR DESCRIPTION
`__1` is a valid identifier, which we normalized to `--1`, which is invalid.

This changes the normalization function to leave a `_` in the first position.

This is probably a bit slower than what we had before:-/