### PR TITLE
Make `CompilerConfiguration` `Clone`

### DIFF
--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -400,18 +400,6 @@ pub fn compile(path: impl AsRef<std::path::Path>) -> Result<(), CompileError> {
 ///     .with_style("material".into());
 /// slint_build::compile_with_config("ui/hello.slint", config).unwrap();
 /// ```
-/// 
-///
-/// or for multiple slint modules, use the [`glob`](https://docs.rs/glob/latest/glob/) crate:
-/// ```rust,no_run
-/// use glob::glob;
-/// let config =
-///     slint_build::CompilerConfiguration::new()
-///     .with_style("material".into());
-/// for module in glob("ui/*.slint").expect("Failed to find slint files") {
-        slint_build::compile_with_config(module.unwrap(), config.clone()).unwrap();
-/// }
-/// ```
 pub fn compile_with_config(
     relative_slint_file_path: impl AsRef<std::path::Path>,
     config: CompilerConfiguration,

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -400,6 +400,7 @@ pub fn compile(path: impl AsRef<std::path::Path>) -> Result<(), CompileError> {
 ///     .with_style("material".into());
 /// slint_build::compile_with_config("ui/hello.slint", config).unwrap();
 /// ```
+/// 
 ///
 /// or for multiple slint modules, use the [`glob`](https://docs.rs/glob/latest/glob/) crate:
 /// ```rust,no_run
@@ -408,7 +409,7 @@ pub fn compile(path: impl AsRef<std::path::Path>) -> Result<(), CompileError> {
 ///     slint_build::CompilerConfiguration::new()
 ///     .with_style("material".into());
 /// for module in glob("ui/*.slint").expect("Failed to find slint files") {
-///     slint_build::compile_with_config(module.unwrap(), config.clone()).unwrap();
+        slint_build::compile_with_config(module.unwrap(), config.clone()).unwrap();
 /// }
 /// ```
 pub fn compile_with_config(

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -400,7 +400,6 @@ pub fn compile(path: impl AsRef<std::path::Path>) -> Result<(), CompileError> {
 ///     .with_style("material".into());
 /// slint_build::compile_with_config("ui/hello.slint", config).unwrap();
 /// ```
-/// 
 ///
 /// or for multiple slint modules, use the [`glob`](https://docs.rs/glob/latest/glob/) crate:
 /// ```rust,no_run
@@ -409,7 +408,7 @@ pub fn compile(path: impl AsRef<std::path::Path>) -> Result<(), CompileError> {
 ///     slint_build::CompilerConfiguration::new()
 ///     .with_style("material".into());
 /// for module in glob("ui/*.slint").expect("Failed to find slint files") {
-        slint_build::compile_with_config(module.unwrap(), config.clone()).unwrap();
+///     slint_build::compile_with_config(module.unwrap(), config.clone()).unwrap();
 /// }
 /// ```
 pub fn compile_with_config(

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -400,6 +400,18 @@ pub fn compile(path: impl AsRef<std::path::Path>) -> Result<(), CompileError> {
 ///     .with_style("material".into());
 /// slint_build::compile_with_config("ui/hello.slint", config).unwrap();
 /// ```
+/// 
+///
+/// or for multiple slint modules, use the [`glob`](https://docs.rs/glob/latest/glob/) crate:
+/// ```rust,no_run
+/// use glob::glob;
+/// let config =
+///     slint_build::CompilerConfiguration::new()
+///     .with_style("material".into());
+/// for module in glob("ui/*.slint").expect("Failed to find slint files") {
+        slint_build::compile_with_config(module.unwrap(), config.clone()).unwrap();
+/// }
+/// ```
 pub fn compile_with_config(
     relative_slint_file_path: impl AsRef<std::path::Path>,
     config: CompilerConfiguration,

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -58,6 +58,7 @@ use std::path::Path;
 use i_slint_compiler::diagnostics::BuildDiagnostics;
 
 /// The structure for configuring aspects of the compilation of `.slint` markup files to Rust.
+#[derive(Clone)]
 pub struct CompilerConfiguration {
     config: i_slint_compiler::CompilerConfiguration,
 }


### PR DESCRIPTION
[edited based on comments from @ogoffart below ...]

This derives `Clone` for `CompilerConfiguration`.

The underlying inner `i_slint_compiler::CompilerConfiguration` is already Clone and this change does no harm.

My initial motivation was to allow for compiling multiple modules separately for the purpose of unit testing them individually. After taking a further look at how the compiler works and the generated output, this is "not simple".

Having Clone implemented in the upstream would make it much easier for me to work on this challenge within my own project and maybe provide a generic solution for optional consideration later, in case it is of value to others.