### PR TITLE
lsp: Move `poll_once` into common

### DIFF
--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -819,7 +819,7 @@ pub fn workspace_edit_compiles(
     }) {
         diag = BuildDiagnostics::default(); // reset errors that might be due to missing changes elsewhere
 
-        let _ = preview::poll_once(document_cache.load_url(&u, None, c, &mut diag));
+        let _ = common::poll_once(document_cache.load_url(&u, None, c, &mut diag));
     }
 
     if diag.has_errors() {


### PR DESCRIPTION
.. to clean up `preview.rs` a bit.

The functionality is generic and could be used in both LSP and preview, so common with the other helper code seems appropriate.
