### PR TITLE
WIP: Transition: Introduce in-out to allow writing symmetry animation

### DIFF
--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -235,7 +235,7 @@ module.exports = grammar({
 
     in_out_transition: ($) =>
       seq(
-        choice("in", "out"),
+        choice("in", "out", "in-out"),
         optional(seq($.expression, ":")),
         "{",
         repeat($.animate_statement),

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -414,7 +414,7 @@ declare_syntax! {
         StatePropertyChange -> [ QualifiedName, BindingExpression ],
         /// `transitions: [...]`
         Transitions -> [*Transition],
-        /// There is an identifier "in" or "out", the DeclaredIdentifier is the state name
+        /// There is an identifier "in", "out", "in-out", the DeclaredIdentifier is the state name
         Transition -> [?DeclaredIdentifier, *PropertyAnimation],
         /// Export a set of declared components by name
         ExportsList -> [ *ExportSpecifier, ?Component, *StructDeclaration, ?ExportModule, *EnumDeclaration ],

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -535,10 +535,10 @@ fn parse_state(p: &mut impl Parser) -> bool {
             SyntaxKind::Eof => return false,
             _ => {
                 if p.nth(1).kind() == SyntaxKind::LBrace
-                    && matches!(p.peek().as_str(), "in" | "out")
+                    && matches!(p.peek().as_str(), "in" | "out" | "in-out" | "in_out")
                 {
                     let mut p = p.start_node(SyntaxKind::Transition);
-                    p.consume(); // "in" or "out"
+                    p.consume(); // "in", "out" or "in-out"
                     p.expect(SyntaxKind::LBrace);
                     if !parse_transition_inner(&mut *p) {
                         return false;
@@ -562,7 +562,7 @@ fn parse_state(p: &mut impl Parser) -> bool {
 #[cfg_attr(test, parser_test)]
 /// ```test,Transitions
 /// transitions []
-/// transitions [in checked: {animate x { duration: 88ms; }} out checked: {animate x { duration: 88ms; }}]
+/// transitions [in checked: {animate x { duration: 88ms; }} out checked: {animate x { duration: 88ms; }} in-out checked: {animate x { duration: 88ms; }}]
 /// ```
 fn parse_transitions(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "transitions");
@@ -578,14 +578,15 @@ fn parse_transitions(p: &mut impl Parser) {
 /// in pressed : {}
 /// in pressed: { animate x { duration: 88ms; } }
 /// out pressed: { animate x { duration: 88ms; } }
+/// in-out pressed: { animate x { duration: 88ms; } }
 /// ```
 fn parse_transition(p: &mut impl Parser) -> bool {
-    if !matches!(p.peek().as_str(), "in" | "out") {
-        p.error("Expected 'in' or 'out' to declare a transition");
+    if !matches!(p.peek().as_str(), "in" | "out" | "in-out" | "in_out") {
+        p.error("Expected 'in', 'out', or 'in-out' to declare a transition");
         return false;
     }
     let mut p = p.start_node(SyntaxKind::Transition);
-    p.consume(); // "in" or "out"
+    p.consume(); // "in", "out" or "in-out"
     {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
         p.expect(SyntaxKind::Identifier);

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -511,7 +511,7 @@ fn duplicate_property_animation(
                 .iter()
                 .map(|a| TransitionPropertyAnimation {
                     state_id: a.state_id,
-                    is_out: a.is_out,
+                    direction: a.direction,
                     animation: duplicate_element_with_mapping(
                         &a.animation,
                         mapping,
@@ -568,7 +568,7 @@ fn duplicate_transition(
     priority_delta: i32,
 ) -> Transition {
     Transition {
-        is_out: t.is_out,
+        direction: t.direction,
         state_id: t.state_id.clone(),
         property_animations: t
             .property_animations

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -161,7 +161,7 @@ fn lower_transitions_in_element(
 
             let t = TransitionPropertyAnimation {
                 state_id: *state,
-                is_out: transition.is_out,
+                direction: transition.direction,
                 animation,
             };
             props.entry(p).or_insert_with(|| (span.clone(), vec![])).1.push(t);

--- a/internal/compiler/tests/syntax/basic/states_transitions.slint
+++ b/internal/compiler/tests/syntax/basic/states_transitions.slint
@@ -38,7 +38,10 @@ export TestCase := Rectangle {
             animate border { duration: 120ms; }
             animate color, text.text { duration: 300ms; }
 ///                        ^error{'text.text' is not a property that can be animated}
-
+        }
+        
+        in-out checked: {
+            animate color { duration: 100ms; }
         }
     ]
 

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -453,7 +453,7 @@ impl Snapshotter {
             .transitions
             .iter()
             .map(|t| object_tree::Transition {
-                is_out: t.is_out,
+                direction: t.direction,
                 state_id: t.state_id.clone(),
                 property_animations: t
                     .property_animations
@@ -570,7 +570,7 @@ impl Snapshotter {
                             .iter()
                             .map(|tpa| object_tree::TransitionPropertyAnimation {
                                 state_id: tpa.state_id,
-                                is_out: tpa.is_out,
+                                direction: tpa.direction,
                                 animation: self.create_and_snapshot_element(&tpa.animation),
                             })
                             .collect(),

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1420,8 +1420,10 @@ pub fn animation_for_property(
                     let state = eval::eval_expression(&state_ref, &mut context);
                     let state_info: i_slint_core::properties::StateInfo = state.try_into().unwrap();
                     for a in &animations {
-                        if (a.is_out && a.state_id == state_info.previous_state)
-                            || (!a.is_out && a.state_id == state_info.current_state)
+                        if (a.direction == i_slint_compiler::object_tree::TransitionDirection::Input && a.state_id == state_info.previous_state)
+                            || (a.direction == i_slint_compiler::object_tree::TransitionDirection::Output && a.state_id == state_info.current_state)
+                            || (a.direction == i_slint_compiler::object_tree::TransitionDirection::InOut && 
+                                (a.state_id == state_info.current_state || a.state_id == state_info.previous_state))
                         {
                             return (
                                 eval::new_struct_with_bindings(

--- a/tests/cases/properties/transitions2.slint
+++ b/tests/cases/properties/transitions2.slint
@@ -21,6 +21,13 @@ TestCase := Rectangle {
                 animate text1.foo { duration: 300ms; }
             }
         }
+
+        yyy when active_index == 3 : {
+            text1.foo: 9;
+            in-out {
+                animate text1.foo { duration: 300ms; }
+            }
+        }
     ]
 
     property<int> text1_foo: text1.foo;


### PR DESCRIPTION
I'd like to write `in-out` for transition when animations in `in` and `out` are same.

Current test status:
- [x] cargo test -p test-driver-interpreter
- [x] SLINT_TEST_FILTER=properties cargo test -p test-driver-rust
- [x] SLINT_TEST_FILTER=properties cargo test -p test-driver-cpp
- [ ] SLINT_TEST_FILTER=properties cargo test -p test-driver-nodejs

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
