### PR TITLE
live-preview: Disentangle threads

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -16,7 +16,7 @@
 "aqua:sharkdp/fd" = "10.2.0"
 "rust" = { version = "stable", profile = "default" }
 node = "20"
-pnpm = "10.10.0"
+pnpm = "10.11.0"
 taplo = "0.9.3"
 "ubi:rustwasm/wasm-pack" = "0.13.1"
 


### PR DESCRIPTION
Make sure all code in preview is actually running in the UI thread. For WASM this is a NOOP, as we have just one thread there anyway.

For the native side, we need to handle all lsp to preview messages in the UI thread. This is a bit trickier than it sounds: We do not want to bring up the UI thread fully till the UI needs to be shown.

So we reuse the machanism used to switch between WASM preview and native preview in VSCode:

We listen for a `ShowPreview` message and if the event loop is not up, we bring it up and send a `RequestState` to the LSP. That will respond with all the data we need and repeat its `ShowPreview` rerquest afterwards.
