### PR TITLE
added draggable property to ScrollView, closes #2260

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
@@ -43,9 +43,9 @@ using for loops may be added in the future and is tracked in issue #407.
 Used to render the frame as disabled or enabled, but doesn't change behavior of the widget.
 </SlintProperty>
 
-### draggable
-<SlintProperty propName="draggable" typeName="bool" defaultValue="false" propertyVisibility="in">
-When true, the view can be scrolled by dragging.
+### mouse-drag
+<SlintProperty propName="mouse-drag" typeName="bool" defaultValue="false" propertyVisibility="in">
+When true, the view can be scrolled by dragging with the mouse.
 </SlintProperty>
 
 ### has-focus

--- a/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
@@ -44,7 +44,7 @@ Used to render the frame as disabled or enabled, but doesn't change behavior of 
 </SlintProperty>
 
 ### mouse-drag
-<SlintProperty propName="mouse-drag" typeName="bool" defaultValue="false" propertyVisibility="in">
+<SlintProperty propName="mouse-drag" typeName="bool" defaultValue="true for Material style, false for all others" propertyVisibility="in">
 When true, the view can be scrolled by dragging with the mouse.
 </SlintProperty>
 

--- a/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/scrollview.mdx
@@ -43,6 +43,11 @@ using for loops may be added in the future and is tracked in issue #407.
 Used to render the frame as disabled or enabled, but doesn't change behavior of the widget.
 </SlintProperty>
 
+### draggable
+<SlintProperty propName="draggable" typeName="bool" defaultValue="false" propertyVisibility="in">
+When true, the view can be scrolled by dragging.
+</SlintProperty>
+
 ### has-focus
 <SlintProperty propName="has-focus" typeName="bool" defaultValue="false" propertyVisibility="in-out">
 Used to render the frame as focused or unfocused, but doesn't change the behavior of the widget.

--- a/internal/compiler/widgets/cosmic/scrollview.slint
+++ b/internal/compiler/widgets/cosmic/scrollview.slint
@@ -92,7 +92,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
-    in property <bool> draggable <=> flickable.interactive;
+    in property <bool> mouse-drag <=> flickable.interactive;
 
     // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
     in-out property <bool> has-focus;

--- a/internal/compiler/widgets/cosmic/scrollview.slint
+++ b/internal/compiler/widgets/cosmic/scrollview.slint
@@ -92,6 +92,8 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
+    in property <bool> draggable <=> flickable.interactive;
+
     // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
     in-out property <bool> has-focus;
 

--- a/internal/compiler/widgets/cupertino/scrollview.slint
+++ b/internal/compiler/widgets/cupertino/scrollview.slint
@@ -100,7 +100,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
-    in property <bool> draggable <=> flickable.interactive;
+    in property <bool> mouse-drag <=> flickable.interactive;
 
     // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
     in-out property <bool> has-focus;

--- a/internal/compiler/widgets/cupertino/scrollview.slint
+++ b/internal/compiler/widgets/cupertino/scrollview.slint
@@ -100,6 +100,8 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
+    in property <bool> draggable <=> flickable.interactive;
+
     // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
     in-out property <bool> has-focus;
 

--- a/internal/compiler/widgets/fluent/scrollview.slint
+++ b/internal/compiler/widgets/fluent/scrollview.slint
@@ -145,6 +145,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
+    in property <bool> draggable <=> flickable.interactive;
 
     // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
     in-out property <bool> has-focus;

--- a/internal/compiler/widgets/fluent/scrollview.slint
+++ b/internal/compiler/widgets/fluent/scrollview.slint
@@ -145,7 +145,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
-    in property <bool> draggable <=> flickable.interactive;
+    in property <bool> mouse-drag <=> flickable.interactive;
 
     // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
     in-out property <bool> has-focus;

--- a/internal/compiler/widgets/material/scrollview.slint
+++ b/internal/compiler/widgets/material/scrollview.slint
@@ -104,7 +104,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
-    in property <bool> draggable <=> flickable.interactive;
+    in property <bool> mouse-drag <=> flickable.interactive;
 
     callback scrolled <=> flickable.flicked;
 

--- a/internal/compiler/widgets/material/scrollview.slint
+++ b/internal/compiler/widgets/material/scrollview.slint
@@ -104,6 +104,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> flickable.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> vertical-bar.policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> horizontal-bar.policy;
+    in property <bool> draggable <=> flickable.interactive;
 
     callback scrolled <=> flickable.flicked;
 
@@ -117,6 +118,7 @@ export component ScrollView {
     flickable := Flickable {
         x: 0;
         y: 0;
+        interactive: false;
         viewport-y <=> vertical-bar.value;
         viewport-x <=> horizontal-bar.value;
         width: parent.width - vertical-bar.width - 4px;

--- a/internal/compiler/widgets/material/scrollview.slint
+++ b/internal/compiler/widgets/material/scrollview.slint
@@ -118,7 +118,6 @@ export component ScrollView {
     flickable := Flickable {
         x: 0;
         y: 0;
-        interactive: false;
         viewport-y <=> vertical-bar.value;
         viewport-x <=> horizontal-bar.value;
         width: parent.width - vertical-bar.width - 4px;

--- a/internal/compiler/widgets/qt/internal-scrollview.slint
+++ b/internal/compiler/widgets/qt/internal-scrollview.slint
@@ -17,7 +17,7 @@ export component InternalScrollView {
     in property <bool> enabled <=> native.enabled;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> native.vertical-scrollbar-policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> native.horizontal-scrollbar-policy;
-    in property <bool> draggable <=> fli.interactive;
+    in property <bool> mouse-drag <=> fli.interactive;
 
     // Used by the StandardTableView
     out property <length> native-padding-left: native.native-padding-left;

--- a/internal/compiler/widgets/qt/internal-scrollview.slint
+++ b/internal/compiler/widgets/qt/internal-scrollview.slint
@@ -17,6 +17,7 @@ export component InternalScrollView {
     in property <bool> enabled <=> native.enabled;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> native.vertical-scrollbar-policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> native.horizontal-scrollbar-policy;
+    in property <bool> draggable <=> fli.interactive;
 
     // Used by the StandardTableView
     out property <length> native-padding-left: native.native-padding-left;

--- a/internal/compiler/widgets/qt/scrollview.slint
+++ b/internal/compiler/widgets/qt/scrollview.slint
@@ -14,7 +14,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> internal.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> internal.vertical-scrollbar-policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> internal.horizontal-scrollbar-policy;
-    in property <bool> draggable <=> internal.draggable;
+    in property <bool> mouse-drag <=> internal.draggable;
 
     callback scrolled <=> internal.scrolled;
 

--- a/internal/compiler/widgets/qt/scrollview.slint
+++ b/internal/compiler/widgets/qt/scrollview.slint
@@ -14,6 +14,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> internal.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> internal.vertical-scrollbar-policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> internal.horizontal-scrollbar-policy;
+    in property <bool> draggable <=> internal.draggable;
 
     callback scrolled <=> internal.scrolled;
 

--- a/internal/compiler/widgets/qt/scrollview.slint
+++ b/internal/compiler/widgets/qt/scrollview.slint
@@ -14,7 +14,7 @@ export component ScrollView {
     in-out property <length> viewport-y <=> internal.viewport-y;
     in property <ScrollBarPolicy> vertical-scrollbar-policy <=> internal.vertical-scrollbar-policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy <=> internal.horizontal-scrollbar-policy;
-    in property <bool> mouse-drag <=> internal.draggable;
+    in property <bool> mouse-drag <=> internal.mouse-drag;
 
     callback scrolled <=> internal.scrolled;
 


### PR DESCRIPTION
Adds a `draggable` property to ScrollView that binds to the `interactive` property of the internal Flickable. Should close #2260.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
