### PR TITLE
live-preview: Cleanup and simplify preview.rs

### DIFF
--- a/tools/lsp/preview/native.rs
+++ b/tools/lsp/preview/native.rs
@@ -167,7 +167,9 @@ pub fn quit_ui_event_loop() {
         GUI_EVENT_LOOP_NOTIFIER.notify_one();
     }
 
-    close_ui();
+    let _ = i_slint_core::api::invoke_from_event_loop(move || {
+        close_ui();
+    });
 
     let _ = i_slint_core::api::quit_event_loop();
 
@@ -229,20 +231,13 @@ pub fn close_ui() {
         cache.ui_is_visible = false;
     }
 
-    i_slint_core::api::invoke_from_event_loop(move || {
-        super::PREVIEW_STATE.with(move |preview_state| {
-            let mut preview_state = preview_state.borrow_mut();
-            close_ui_impl(&mut preview_state)
-        });
-    })
-    .unwrap(); // TODO: Handle Error
-}
-
-fn close_ui_impl(preview_state: &mut PreviewState) {
-    let ui = preview_state.ui.take();
-    if let Some(ui) = ui {
-        ui.hide().unwrap();
-    }
+    super::PREVIEW_STATE.with(move |preview_state| {
+        let mut preview_state = preview_state.borrow_mut();
+        let ui = preview_state.ui.take();
+        if let Some(ui) = ui {
+            ui.hide().unwrap();
+        }
+    });
 }
 
 #[cfg(target_vendor = "apple")]

--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -118,10 +118,10 @@ impl PreviewConnector {
 
     #[wasm_bindgen]
     pub fn show_ui(&self) -> Result<js_sys::Promise, JsValue> {
-        {
-            let mut cache = super::CONTENT_CACHE.get_or_init(Default::default).lock().unwrap();
-            cache.ui_is_visible = true;
-        }
+        super::PREVIEW_STATE.with(|preview_state| {
+            let mut preview_state = preview_state.borrow_mut();
+            preview_state.ui_is_visible = true;
+        });
         invoke_from_event_loop_wrapped_in_promise(|instance| instance.show())
     }
 


### PR DESCRIPTION
The first patch makes the shutdown case run more code in the UI thread. This is necessary so that I can merge the ContentsCache and the PreviewState in the second patch.

There is more here that could be done as some of the merged state seems redundant now, but I will leave that for later.

Mid term I would love to get to a state where both the LSP and the live preview run in separate processes -- each (basically) single threaded. That should enable me to remove quite a bit of he startup synchronization code.
