### PR TITLE
Upgrade cbindgen and use `unsafe(no_mangle)` attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,8 +135,7 @@ vtable = { version = "0.2", path = "helper_crates/vtable", default-features = fa
 
 by_address = { version = "1.0.4" }
 bytemuck = { version = "1.13.1" }
-# Not updated because of https://github.com/mozilla/cbindgen/issues/993
-cbindgen = { version = "0.26", default-features = false }
+cbindgen = { version = "0.29", default-features = false }
 cfg_aliases = { version = "0.2.0" }
 clap = { version = "4.0", features = ["derive", "wrap_help"] }
 clru = { version = "0.6.0" }

--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -34,7 +34,7 @@ pub use i_slint_backend_testing;
 #[cfg(feature = "slint-interpreter")]
 pub use slint_interpreter;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) {
     assert_eq!(
         core::mem::size_of::<Rc<dyn WindowAdapter>>(),
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) {
     core::ptr::write(out as *mut Rc<dyn WindowAdapter>, win);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_ensure_backend() {
     with_platform(|_b| {
         // Nothing to do, just make sure a backend was created
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn slint_ensure_backend() {
     .unwrap()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Enters the main event loop.
 pub extern "C" fn slint_run_event_loop(quit_on_last_window_closed: bool) {
     with_platform(|b| {
@@ -67,7 +67,7 @@ pub extern "C" fn slint_run_event_loop(quit_on_last_window_closed: bool) {
 }
 
 /// Will execute the given functor in the main thread
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_post_event(
     event: extern "C" fn(user_data: *mut c_void),
     user_data: *mut c_void,
@@ -94,13 +94,13 @@ pub unsafe extern "C" fn slint_post_event(
     .unwrap();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_quit_event_loop() {
     i_slint_core::api::quit_event_loop().unwrap();
 }
 
 #[cfg(feature = "std")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_register_font_from_path(
     win: *const WindowAdapterRcOpaque,
     path: &SharedString,
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn slint_register_font_from_path(
 }
 
 #[cfg(feature = "std")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_register_font_from_data(
     win: *const WindowAdapterRcOpaque,
     data: i_slint_core::slice::Slice<'static, u8>,
@@ -130,7 +130,7 @@ pub unsafe extern "C" fn slint_register_font_from_data(
     };
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_register_bitmap_font(
     win: *const WindowAdapterRcOpaque,
     font_data: &'static i_slint_core::graphics::BitmapFont,
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn slint_register_bitmap_font(
     window_adapter.renderer().register_bitmap_font(font_data);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_string_to_float(string: &SharedString, value: &mut f32) -> bool {
     match string.as_str().parse::<f32>() {
         Ok(v) => {
@@ -150,12 +150,12 @@ pub extern "C" fn slint_string_to_float(string: &SharedString, value: &mut f32) 
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_string_character_count(string: &SharedString) -> usize {
     unicode_segmentation::UnicodeSegmentation::graphemes(string.as_str(), true).count()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_string_to_usize(string: &SharedString, value: &mut usize) -> bool {
     match string.as_str().parse::<usize>() {
         Ok(v) => {
@@ -166,7 +166,7 @@ pub extern "C" fn slint_string_to_usize(string: &SharedString, value: &mut usize
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_debug(string: &SharedString) {
     i_slint_core::debug_log!("{string}");
 }
@@ -218,14 +218,14 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 #[cfg(feature = "esp-backtrace")]
 use esp_backtrace as _;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_set_xdg_app_id(_app_id: &SharedString) {
     #[cfg(feature = "i-slint-backend-selector")]
     i_slint_backend_selector::with_global_context(|ctx| ctx.set_xdg_app_id(_app_id.clone()))
         .unwrap();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_detect_operating_system(out: &mut SharedString) {
     *out = i_slint_core::detect_operating_system();
 }

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -97,27 +97,27 @@ impl WindowAdapter for CppWindowAdapter {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_window_properties_get_title(wp: &WindowProperties, out: &mut SharedString) {
     *out = wp.title();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_window_properties_get_background(wp: &WindowProperties, out: &mut Brush) {
     *out = wp.background();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_window_properties_get_fullscreen(wp: &WindowProperties) -> bool {
     wp.is_fullscreen()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_window_properties_get_minimized(wp: &WindowProperties) -> bool {
     wp.is_minimized()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_window_properties_get_maximized(wp: &WindowProperties) -> bool {
     wp.is_maximized()
 }
@@ -133,7 +133,7 @@ pub struct LayoutConstraintsReprC {
     pub has_max: bool,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_window_properties_get_layout_constraints(
     wp: &WindowProperties,
 ) -> LayoutConstraintsReprC {
@@ -150,7 +150,7 @@ pub extern "C" fn slint_window_properties_get_layout_constraints(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_window_adapter_new(
     user_data: WindowAdapterUserData,
     drop: unsafe extern "C" fn(WindowAdapterUserData),
@@ -286,7 +286,7 @@ unsafe impl Sync for CppEventLoopProxy {}
 
 // silent the warning depite `Clipboard` is a `#[non_exhaustive]` enum from another crate.
 #[allow(improper_ctypes_definitions)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_platform_register(
     user_data: PlatformUserData,
     drop: unsafe extern "C" fn(PlatformUserData),
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn slint_platform_register(
     i_slint_core::platform::set_platform(Box::new(p)).unwrap();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_windowrc_has_active_animations(
     handle: *const WindowAdapterRcOpaque,
 ) -> bool {
@@ -321,13 +321,13 @@ pub unsafe extern "C" fn slint_windowrc_has_active_animations(
     window_adapter.window().has_active_animations()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_platform_update_timers_and_animations() {
     i_slint_core::platform::update_timers_and_animations()
 }
 
 /// Returns the duration in millisecond until the next timer or `u64::MAX` if there is no pending timers
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_platform_duration_until_next_timer_update() -> u64 {
     i_slint_core::platform::duration_until_next_timer_update()
         .map_or(u64::MAX, |d| d.as_millis() as u64)
@@ -336,12 +336,12 @@ pub extern "C" fn slint_platform_duration_until_next_timer_update() -> u64 {
 #[repr(C)]
 pub struct PlatformTaskOpaque(*const c_void, *const c_void);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_platform_task_drop(event: PlatformTaskOpaque) {
     drop(Box::from_raw(core::mem::transmute::<PlatformTaskOpaque, *mut dyn FnOnce()>(event)));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_platform_task_run(event: PlatformTaskOpaque) {
     let f = Box::from_raw(core::mem::transmute::<PlatformTaskOpaque, *mut dyn FnOnce()>(event));
     f();
@@ -535,7 +535,7 @@ mod software_renderer {
         }
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_new(
         buffer_age: u32,
     ) -> SoftwareRendererOpaque {
@@ -549,12 +549,12 @@ mod software_renderer {
             as SoftwareRendererOpaque
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_drop(r: SoftwareRendererOpaque) {
         drop(Box::from_raw(r as *mut SoftwareRenderer));
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_render_rgb8(
         r: SoftwareRendererOpaque,
         buffer: *mut Rgb8Pixel,
@@ -567,7 +567,7 @@ mod software_renderer {
     }
 
     #[cfg(feature = "experimental")]
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_render_accel_rgb8(
         r: SoftwareRendererOpaque,
         buffer: *mut CppTargetPixelBuffer<Rgb8Pixel>,
@@ -577,7 +577,7 @@ mod software_renderer {
     }
 
     #[cfg(feature = "experimental")]
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_render_accel_rgb565(
         r: SoftwareRendererOpaque,
         buffer: *mut CppTargetPixelBuffer<Rgb565Pixel>,
@@ -586,7 +586,7 @@ mod software_renderer {
         unsafe { renderer.render_into_buffer(&mut *buffer) }
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_render_rgb565(
         r: SoftwareRendererOpaque,
         buffer: *mut u16,
@@ -659,7 +659,7 @@ mod software_renderer {
         }
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_render_by_line_rgb565(
         r: SoftwareRendererOpaque,
         process_line_fn: extern "C" fn(
@@ -677,7 +677,7 @@ mod software_renderer {
         renderer.render_by_line(processor)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_render_by_line_rgb8(
         r: SoftwareRendererOpaque,
         process_line_fn: extern "C" fn(
@@ -695,7 +695,7 @@ mod software_renderer {
         renderer.render_by_line(processor)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_set_rendering_rotation(
         r: SoftwareRendererOpaque,
         rotation: i32,
@@ -710,7 +710,7 @@ mod software_renderer {
         });
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_software_renderer_handle(
         r: SoftwareRendererOpaque,
     ) -> RendererPtr {
@@ -718,7 +718,7 @@ mod software_renderer {
         core::mem::transmute(r)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_software_renderer_region_to_rects(
         region: &PhysicalRegion,
         out: &mut SharedVector<IntRect>,
@@ -766,7 +766,7 @@ pub mod skia {
 
     type CppRawHandleOpaque = *const c_void;
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_new_raw_window_handle_win32(
         hwnd: *mut c_void,
         _hinstance: *mut c_void,
@@ -780,7 +780,7 @@ pub mod skia {
         Box::into_raw(Box::new(handle)) as CppRawHandleOpaque
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_new_raw_window_handle_x11_xcb(
         window: u32,
         visual_id: u32,
@@ -806,7 +806,7 @@ pub mod skia {
         Box::into_raw(Box::new(handle)) as CppRawHandleOpaque
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_new_raw_window_handle_x11_xlib(
         window: core::ffi::c_ulong,
         visual_id: core::ffi::c_ulong,
@@ -828,7 +828,7 @@ pub mod skia {
         Box::into_raw(Box::new(handle)) as CppRawHandleOpaque
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_new_raw_window_handle_wayland(
         surface: *mut c_void,
         display: *mut c_void,
@@ -845,7 +845,7 @@ pub mod skia {
         Box::into_raw(Box::new(handle)) as CppRawHandleOpaque
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_new_raw_window_handle_appkit(
         ns_view: *mut c_void,
         _ns_window: *mut c_void,
@@ -860,7 +860,7 @@ pub mod skia {
         Box::into_raw(Box::new(handle)) as CppRawHandleOpaque
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_raw_window_handle_drop(handle: CppRawHandleOpaque) {
         drop(Box::from_raw(handle as *mut CppRawHandle))
     }
@@ -868,7 +868,7 @@ pub mod skia {
     type SkiaRendererOpaque = *const c_void;
     type SkiaRenderer = i_slint_renderer_skia::SkiaRenderer;
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_skia_renderer_new(
         handle_opaque: CppRawHandleOpaque,
         size: IntSize,
@@ -887,18 +887,18 @@ pub mod skia {
         Box::into_raw(boxed_renderer) as SkiaRendererOpaque
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_skia_renderer_drop(r: SkiaRendererOpaque) {
         drop(Box::from_raw(r as *mut SkiaRenderer))
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_skia_renderer_render(r: SkiaRendererOpaque) {
         let r = &*(r as *const SkiaRenderer);
         r.render().unwrap();
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_skia_renderer_handle(r: SkiaRendererOpaque) -> RendererPtr {
         let r = (r as *const SkiaRenderer) as *const dyn Renderer;
         core::mem::transmute(r)

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -24,7 +24,7 @@ mod key_generated;
 
 #[cfg(no_qt)]
 mod ffi {
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_qt_get_widget(
         _: &i_slint_core::window::WindowAdapterRc,
     ) -> *mut std::ffi::c_void {

--- a/internal/backends/qt/qt_widgets/palette.rs
+++ b/internal/backends/qt/qt_widgets/palette.rs
@@ -182,13 +182,13 @@ impl i_slint_core::rtti::BuiltinGlobal for NativePalette {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_native_palette_init(self_: Pin<&NativePalette>) {
     self_.style_change_listener.set(core::ptr::null()); // because the C++ code don't initialize it
     self_.init_impl();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_native_palette_deinit(self_: Pin<&mut NativePalette>) {
     let scl = self_.style_change_listener.get();
     cpp!(unsafe [scl as "PaletteStyleChangeListener*"] { delete scl; });

--- a/internal/backends/qt/qt_widgets/stylemetrics.rs
+++ b/internal/backends/qt/qt_widgets/stylemetrics.rs
@@ -195,13 +195,13 @@ impl i_slint_core::rtti::BuiltinGlobal for NativeStyleMetrics {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_native_style_metrics_init(self_: Pin<&NativeStyleMetrics>) {
     self_.style_change_listener.set(core::ptr::null()); // because the C++ code don't initialize it
     self_.init_impl();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_native_style_metrics_deinit(self_: Pin<&mut NativeStyleMetrics>) {
     let scl = self_.style_change_listener.get();
     cpp!(unsafe [scl as "StyleChangeListener*"] { delete scl; });

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2674,7 +2674,7 @@ pub(crate) mod ffi {
 
     use super::QtWindow;
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_qt_get_widget(
         window_adapter: &i_slint_core::window::WindowAdapterRc,
     ) -> *mut c_void {

--- a/internal/backends/testing/ffi.rs
+++ b/internal/backends/testing/ffi.rs
@@ -17,12 +17,12 @@ impl ElementRoot for RootWrapper<'_> {
 
 impl super::Sealed for RootWrapper<'_> {}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_testing_init_backend() {
     crate::init_integration_test_with_mock_time();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_testing_element_visit_elements(
     root: &ItemTreeRc,
     user_data: *mut c_void,
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn slint_testing_element_visit_elements(
         .is_some()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_testing_element_find_by_accessible_label(
     root: &ItemTreeRc,
     label: &Slice<u8>,
@@ -46,7 +46,7 @@ pub extern "C" fn slint_testing_element_find_by_accessible_label(
     out.extend(ElementHandle::find_by_accessible_label(&RootWrapper(root), label))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_testing_element_find_by_element_id(
     root: &ItemTreeRc,
     element_id: &Slice<u8>,
@@ -56,7 +56,7 @@ pub extern "C" fn slint_testing_element_find_by_element_id(
     out.extend(ElementHandle::find_by_element_id(&RootWrapper(root), element_id));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_testing_element_find_by_element_type_name(
     root: &ItemTreeRc,
     type_name: &Slice<u8>,
@@ -66,7 +66,7 @@ pub extern "C" fn slint_testing_element_find_by_element_type_name(
     out.extend(ElementHandle::find_by_element_type_name(&RootWrapper(root), type_name));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_testing_element_id(
     element: &ElementHandle,
     out: &mut SharedString,
@@ -79,7 +79,7 @@ pub extern "C" fn slint_testing_element_id(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_testing_element_type_name(
     element: &ElementHandle,
     out: &mut SharedString,
@@ -92,7 +92,7 @@ pub extern "C" fn slint_testing_element_type_name(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_testing_element_bases(
     element: &ElementHandle,
     out: &mut SharedVector<SharedString>,

--- a/internal/core/callbacks.rs
+++ b/internal/core/callbacks.rs
@@ -91,14 +91,14 @@ pub(crate) mod ffi {
 
     /// Initialize the callback.
     /// slint_callback_drop must be called.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_callback_init(out: *mut CallbackOpaque) {
         assert_eq!(core::mem::size_of::<CallbackOpaque>(), core::mem::size_of::<Callback<()>>());
         core::ptr::write(out as *mut Callback<()>, Default::default());
     }
 
     /// Emit the callback
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_callback_call(
         sig: *const CallbackOpaque,
         arg: *const c_void,
@@ -115,7 +115,7 @@ pub(crate) mod ffi {
     /// Set callback handler.
     ///
     /// The binding has signature fn(user_data)
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_callback_set_handler(
         sig: *const CallbackOpaque,
         binding: extern "C" fn(user_data: *mut c_void, arg: *const c_void, ret: *mut c_void),
@@ -152,7 +152,7 @@ pub(crate) mod ffi {
     }
 
     /// Destroy callback
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_callback_drop(handle: *mut CallbackOpaque) {
         core::ptr::drop_in_place(handle as *mut Callback<()>);
     }

--- a/internal/core/date_time.rs
+++ b/internal/core/date_time.rs
@@ -79,22 +79,22 @@ mod ffi {
 
     use super::*;
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_date_time_use_24_hour_format() -> bool {
         use_24_hour_format()
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_date_time_month_day_count(month: u32, year: i32) -> i32 {
         month_day_count(month, year).unwrap_or(0)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_date_time_month_offset(month: u32, year: i32) -> i32 {
         month_offset(month, year)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_date_time_format_date(
         format: &SharedString,
         day: u32,
@@ -105,12 +105,12 @@ mod ffi {
         *out = format_date(format, day, month, year)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_date_time_date_now(d: &mut i32, m: &mut i32, y: &mut i32) {
         [*d, *m, *y] = date_now();
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_date_time_parse_date(
         date: &SharedString,
         format: &SharedString,

--- a/internal/core/graphics/color.rs
+++ b/internal/core/graphics/color.rs
@@ -500,22 +500,22 @@ pub(crate) mod ffi {
     #![allow(unsafe_code)]
     use super::*;
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_color_brighter(col: &Color, factor: f32, out: *mut Color) {
         core::ptr::write(out, col.brighter(factor))
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_color_darker(col: &Color, factor: f32, out: *mut Color) {
         core::ptr::write(out, col.darker(factor))
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_color_transparentize(col: &Color, factor: f32, out: *mut Color) {
         core::ptr::write(out, col.transparentize(factor))
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_color_mix(
         col1: &Color,
         col2: &Color,
@@ -525,12 +525,12 @@ pub(crate) mod ffi {
         core::ptr::write(out, col1.mix(col2, factor))
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_color_with_alpha(col: &Color, alpha: f32, out: *mut Color) {
         core::ptr::write(out, col.with_alpha(alpha))
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_color_to_hsva(
         col: &Color,
         h: &mut f32,
@@ -545,7 +545,7 @@ pub(crate) mod ffi {
         *a = hsv.alpha;
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_color_from_hsva(h: f32, s: f32, v: f32, a: f32) -> Color {
         Color::from_hsva(h, s, v, a)
     }

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1359,7 +1359,7 @@ pub(crate) mod ffi {
     }
 
     #[cfg(feature = "image-decoders")]
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_image_load_from_path(path: &SharedString, image: *mut Image) {
         core::ptr::write(
             image,
@@ -1368,7 +1368,7 @@ pub(crate) mod ffi {
     }
 
     #[cfg(feature = "std")]
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_image_load_from_embedded_data(
         data: Slice<'static, u8>,
         format: Slice<'static, u8>,
@@ -1377,12 +1377,12 @@ pub(crate) mod ffi {
         core::ptr::write(image, super::load_image_from_embedded_data(data, format));
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_image_size(image: &Image) -> IntSize {
         image.size()
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_image_path(image: &Image) -> Option<&SharedString> {
         match &image.0 {
             ImageInner::EmbeddedImage { cache_key, .. } => match cache_key {
@@ -1400,7 +1400,7 @@ pub(crate) mod ffi {
         }
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_image_from_embedded_textures(
         textures: &'static StaticTextures,
         image: *mut Image,
@@ -1408,13 +1408,13 @@ pub(crate) mod ffi {
         core::ptr::write(image, Image::from(ImageInner::StaticTextures(textures)));
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_image_compare_equal(image1: &Image, image2: &Image) -> bool {
         image1.eq(image2)
     }
 
     /// Call [`Image::set_nine_slice_edges`]
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_image_set_nine_slice_edges(
         image: &mut Image,
         top: u16,
@@ -1425,7 +1425,7 @@ pub(crate) mod ffi {
         image.set_nine_slice_edges(top, right, bottom, left);
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_image_to_rgb8(
         image: &Image,
         data: &mut SharedVector<Rgb8Pixel>,
@@ -1440,7 +1440,7 @@ pub(crate) mod ffi {
         })
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_image_to_rgba8(
         image: &Image,
         data: &mut SharedVector<Rgba8Pixel>,
@@ -1455,7 +1455,7 @@ pub(crate) mod ffi {
         })
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_image_to_rgba8_premultiplied(
         image: &Image,
         data: &mut SharedVector<Rgba8Pixel>,

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -397,7 +397,7 @@ pub(crate) mod ffi {
     #[allow(non_camel_case_types)]
     type c_void = ();
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// This function is used for the low-level C++ interface to allocate the backing vector for a shared path element array.
     pub unsafe extern "C" fn slint_new_path_elements(
         out: *mut c_void,
@@ -408,7 +408,7 @@ pub(crate) mod ffi {
         core::ptr::write(out as *mut crate::SharedVector<PathElement>, arr);
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// This function is used for the low-level C++ interface to allocate the backing vector for a shared path event array.
     pub unsafe extern "C" fn slint_new_path_events(
         out_events: *mut c_void,

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1184,7 +1184,7 @@ pub(crate) mod ffi {
     use core::ffi::c_void;
 
     /// Call init() on the ItemVTable of each item in the item array.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_register_item_tree(
         item_tree_rc: &ItemTreeRc,
         window_handle: *const crate::window::ffi::WindowAdapterRcOpaque,
@@ -1194,7 +1194,7 @@ pub(crate) mod ffi {
     }
 
     /// Free the backend graphics resources allocated in the item array.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_unregister_item_tree(
         component: ItemTreeRefPin,
         item_array: Slice<vtable::VOffset<u8, ItemVTable, vtable::AllowPin>>,
@@ -1212,7 +1212,7 @@ pub(crate) mod ffi {
     /// Expose `crate::item_tree::visit_item_tree` to C++
     ///
     /// Safety: Assume a correct implementation of the item_tree array
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_visit_item_tree(
         item_tree: &ItemTreeRc,
         item_tree_array: Slice<ItemTreeNode>,

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -78,10 +78,10 @@ type MenuEntryModel = crate::model::ModelRc<MenuEntry>;
 macro_rules! declare_item_vtable {
     (fn $getter:ident() -> $item_vtable_ty:ident for $item_ty:ty) => {
         ItemVTable_static! {
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub static $item_vtable_ty for $item_ty
         }
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn $getter() -> *const ItemVTable {
             use vtable::HasStaticVTable;
             <$item_ty>::static_vtable()
@@ -93,7 +93,7 @@ macro_rules! declare_item_vtable {
 macro_rules! declare_item_vtable {
     (fn $getter:ident() -> $item_vtable_ty:ident for $item_ty:ty) => {
         ItemVTable_static! {
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub static $item_vtable_ty for $item_ty
         }
     };
@@ -1460,7 +1460,7 @@ declare_item_vtable! {
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_contextmenu_close(
     s: Pin<&ContextMenu>,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
@@ -1473,7 +1473,7 @@ pub unsafe extern "C" fn slint_contextmenu_close(
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_contextmenu_is_open(
     s: Pin<&ContextMenu>,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
@@ -1672,7 +1672,7 @@ macro_rules! declare_builtin_structs {
 i_slint_common::for_each_builtin_structs!(declare_builtin_structs);
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_item_absolute_position(
     self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
     self_index: u32,

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -473,7 +473,7 @@ fn ensure_in_bound(flick: Pin<&Flickable>, p: LogicalPoint, flick_rc: &ItemRc) -
 /// This must be called using a non-null pointer pointing to a chunk of memory big enough to
 /// hold a FlickableDataBox
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_flickable_data_init(data: *mut FlickableDataBox) {
     core::ptr::write(data, FlickableDataBox::default());
 }
@@ -481,7 +481,7 @@ pub unsafe extern "C" fn slint_flickable_data_init(data: *mut FlickableDataBox) 
 /// # Safety
 /// This must be called using a non-null pointer pointing to an initialized FlickableDataBox
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_flickable_data_free(data: *mut FlickableDataBox) {
     core::ptr::drop_in_place(data);
 }

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -597,7 +597,7 @@ impl SwipeGestureHandler {
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_swipegesturehandler_cancel(
     s: Pin<&SwipeGestureHandler>,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1984,7 +1984,7 @@ fn next_word_boundary(text: &str, last_cursor_pos: usize) -> usize {
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_textinput_set_selection_offsets(
     text_input: Pin<&TextInput>,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
@@ -1999,7 +1999,7 @@ pub unsafe extern "C" fn slint_textinput_set_selection_offsets(
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_textinput_select_all(
     text_input: Pin<&TextInput>,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
@@ -2012,7 +2012,7 @@ pub unsafe extern "C" fn slint_textinput_select_all(
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_textinput_clear_selection(
     text_input: Pin<&TextInput>,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
@@ -2025,7 +2025,7 @@ pub unsafe extern "C" fn slint_textinput_clear_selection(
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_textinput_cut(
     text_input: Pin<&TextInput>,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
@@ -2038,7 +2038,7 @@ pub unsafe extern "C" fn slint_textinput_cut(
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_textinput_copy(
     text_input: Pin<&TextInput>,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
@@ -2051,7 +2051,7 @@ pub unsafe extern "C" fn slint_textinput_copy(
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_textinput_paste(
     text_input: Pin<&TextInput>,
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
@@ -2080,7 +2080,7 @@ pub fn slint_text_item_fontmetrics(
 }
 
 #[cfg(feature = "ffi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_cpp_text_item_fontmetrics(
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
     self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -734,7 +734,7 @@ pub(crate) mod ffi {
 
     use super::*;
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_solve_grid_layout(
         data: &GridLayoutData,
         result: &mut SharedVector<Coord>,
@@ -742,7 +742,7 @@ pub(crate) mod ffi {
         *result = super::solve_grid_layout(data)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_grid_layout_info(
         cells: Slice<GridLayoutCellData>,
         spacing: Coord,
@@ -751,7 +751,7 @@ pub(crate) mod ffi {
         super::grid_layout_info(cells, spacing, padding)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_solve_box_layout(
         data: &BoxLayoutData,
         repeater_indexes: Slice<u32>,
@@ -760,7 +760,7 @@ pub(crate) mod ffi {
         *result = super::solve_box_layout(data, repeater_indexes)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// Return the LayoutInfo for a BoxLayout with the given cells.
     pub extern "C" fn slint_box_layout_info(
         cells: Slice<BoxLayoutCellData>,
@@ -771,7 +771,7 @@ pub(crate) mod ffi {
         super::box_layout_info(cells, spacing, padding, alignment)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// Return the LayoutInfo for a BoxLayout with the given cells.
     pub extern "C" fn slint_box_layout_info_ortho(
         cells: Slice<BoxLayoutCellData>,
@@ -784,7 +784,7 @@ pub(crate) mod ffi {
     ///
     /// Safety: `cells` must be a pointer to a mutable array of cell data, the array must have at
     /// least `roles.len()` elements.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_reorder_dialog_button_layout(
         cells: *mut GridLayoutCellData,
         roles: Slice<DialogButtonRole>,

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -232,7 +232,7 @@ pub mod ffi {
     /// Create a `VBox::<MenuVTable>`` that wraps the [`ItemTreeRc`]
     ///
     /// Put the created VBox into the result pointer with std::ptr::write
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_menus_create_wrapper(
         menu_tree: &ItemTreeRc,
         result: *mut vtable::VBox<MenuVTable>,

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -13,13 +13,13 @@ pub struct PropertyHandleOpaque(PropertyHandle);
 
 /// Initialize the first pointer of the Property. Does not initialize the content.
 /// `out` is assumed to be uninitialized
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_init(out: *mut PropertyHandleOpaque) {
     core::ptr::write(out, PropertyHandleOpaque(PropertyHandle::default()));
 }
 
 /// To be called before accessing the value
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_update(handle: &PropertyHandleOpaque, val: *mut c_void) {
     let handle = Pin::new_unchecked(&handle.0);
     handle.update(val);
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn slint_property_update(handle: &PropertyHandleOpaque, va
 /// Mark the fact that the property was changed and that its binding need to be removed, and
 /// the dependencies marked dirty.
 /// To be called after the `value` has been changed
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_changed(
     handle: &PropertyHandleOpaque,
     value: *const c_void,
@@ -107,7 +107,7 @@ fn make_c_function_binding(
 ///  2. the box allocation within this binding
 /// It might be possible to reduce that by passing something with a
 /// vtable, so there is the need for less memory allocation.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_binding(
     handle: &PropertyHandleOpaque,
     binding: extern "C" fn(user_data: *mut c_void, pointer_to_value: *mut c_void),
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn slint_property_set_binding(
 /// Set a binding using an already allocated building holder
 ///
 //// (take ownership of the binding)
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_binding_internal(
     handle: &PropertyHandleOpaque,
     binding: *mut c_void,
@@ -142,25 +142,25 @@ pub unsafe extern "C" fn slint_property_set_binding_internal(
 }
 
 /// Returns whether the property behind this handle is marked as dirty
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_property_is_dirty(handle: &PropertyHandleOpaque) -> bool {
     handle.0.access(|binding| binding.is_some_and(|b| b.dirty.get()))
 }
 
 /// Marks the property as dirty and notifies dependencies.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_property_mark_dirty(handle: &PropertyHandleOpaque) {
     handle.0.mark_dirty()
 }
 
 /// Marks the property as dirty and notifies dependencies.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_property_set_constant(handle: &PropertyHandleOpaque) {
     handle.0.set_constant()
 }
 
 /// Destroy handle
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_drop(handle: *mut PropertyHandleOpaque) {
     core::ptr::drop_in_place(handle);
 }
@@ -194,7 +194,7 @@ fn c_set_animated_value<T: InterpolatedPropertyValue + Clone>(
 }
 
 /// Internal function to set up a property animation to the specified target value for an integer property.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_animated_value_int(
     handle: &PropertyHandleOpaque,
     from: i32,
@@ -205,7 +205,7 @@ pub unsafe extern "C" fn slint_property_set_animated_value_int(
 }
 
 /// Internal function to set up a property animation to the specified target value for a float property.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_animated_value_float(
     handle: &PropertyHandleOpaque,
     from: f32,
@@ -216,7 +216,7 @@ pub unsafe extern "C" fn slint_property_set_animated_value_float(
 }
 
 /// Internal function to set up a property animation to the specified target value for a color property.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_animated_value_color(
     handle: &PropertyHandleOpaque,
     from: Color,
@@ -227,7 +227,7 @@ pub unsafe extern "C" fn slint_property_set_animated_value_color(
 }
 
 /// Internal function to set up a property animation to the specified target value for a brush property.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_animated_value_brush(
     handle: &PropertyHandleOpaque,
     from: &Brush,
@@ -291,7 +291,7 @@ unsafe fn c_set_animated_binding<T: InterpolatedPropertyValue + Clone>(
 }
 
 /// Internal function to set up a property animation between values produced by the specified binding for an integer property.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_animated_binding_int(
     handle: &PropertyHandleOpaque,
     binding: extern "C" fn(*mut c_void, *mut core::ffi::c_int),
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn slint_property_set_animated_binding_int(
 }
 
 /// Internal function to set up a property animation between values produced by the specified binding for a float property.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_animated_binding_float(
     handle: &PropertyHandleOpaque,
     binding: extern "C" fn(*mut c_void, *mut f32),
@@ -335,7 +335,7 @@ pub unsafe extern "C" fn slint_property_set_animated_binding_float(
 }
 
 /// Internal function to set up a property animation between values produced by the specified binding for a color property.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_animated_binding_color(
     handle: &PropertyHandleOpaque,
     binding: extern "C" fn(*mut c_void, *mut Color),
@@ -357,7 +357,7 @@ pub unsafe extern "C" fn slint_property_set_animated_binding_color(
 }
 
 /// Internal function to set up a property animation between values produced by the specified binding for a brush property.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_animated_binding_brush(
     handle: &PropertyHandleOpaque,
     binding: extern "C" fn(*mut c_void, *mut Brush),
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn slint_property_set_animated_binding_brush(
 }
 
 /// Internal function to set up a state binding on a Property<StateInfo>.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_set_state_binding(
     handle: &PropertyHandleOpaque,
     binding: extern "C" fn(*mut c_void) -> i32,
@@ -427,14 +427,14 @@ static_assertions::assert_eq_size!(PropertyTrackerOpaque, PropertyTracker);
 /// Initialize the first pointer of the PropertyTracker.
 /// `out` is assumed to be uninitialized
 /// slint_property_tracker_drop need to be called after that
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_tracker_init(out: *mut PropertyTrackerOpaque) {
     core::ptr::write(out as *mut PropertyTracker, PropertyTracker::default());
 }
 
 /// Call the callback with the user data. Any properties access within the callback will be registered.
 /// Any currently evaluated bindings or property trackers will be notified if accessed properties are changed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_tracker_evaluate(
     handle: *const PropertyTrackerOpaque,
     callback: extern "C" fn(user_data: *mut c_void),
@@ -445,7 +445,7 @@ pub unsafe extern "C" fn slint_property_tracker_evaluate(
 
 /// Call the callback with the user data. Any properties access within the callback will be registered.
 /// Any currently evaluated bindings or property trackers will be not notified if accessed properties are changed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_tracker_evaluate_as_dependency_root(
     handle: *const PropertyTrackerOpaque,
     callback: extern "C" fn(user_data: *mut c_void),
@@ -455,7 +455,7 @@ pub unsafe extern "C" fn slint_property_tracker_evaluate_as_dependency_root(
         .evaluate_as_dependency_root(|| callback(user_data))
 }
 /// Query if the property tracker is dirty
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_tracker_is_dirty(
     handle: *const PropertyTrackerOpaque,
 ) -> bool {
@@ -463,25 +463,25 @@ pub unsafe extern "C" fn slint_property_tracker_is_dirty(
 }
 
 /// Destroy handle
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_property_tracker_drop(handle: *mut PropertyTrackerOpaque) {
     core::ptr::drop_in_place(handle as *mut PropertyTracker);
 }
 
 /// Construct a ChangeTracker
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_change_tracker_construct(ct: *mut ChangeTracker) {
     core::ptr::write(ct, ChangeTracker::default());
 }
 
 /// Drop a ChangeTracker
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_change_tracker_drop(ct: *mut ChangeTracker) {
     core::ptr::drop_in_place(ct);
 }
 
 /// initialize the change tracker
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_change_tracker_init(
     ct: &ChangeTracker,
     user_data: *mut c_void,
@@ -551,7 +551,7 @@ pub unsafe extern "C" fn slint_change_tracker_init(
 }
 
 /// return the current animation tick for the `animation-tick` function
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_animation_tick() -> u64 {
     crate::animations::animation_tick()
 }

--- a/internal/core/sharedvector.rs
+++ b/internal/core/sharedvector.rs
@@ -646,19 +646,19 @@ fn pop_test() {
 pub(crate) mod ffi {
     use super::*;
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// This function is used for the low-level C++ interface to allocate the backing vector of a SharedVector.
     pub unsafe extern "C" fn slint_shared_vector_allocate(size: usize, align: usize) -> *mut u8 {
         alloc::alloc::alloc(alloc::alloc::Layout::from_size_align(size, align).unwrap())
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// This function is used for the low-level C++ interface to deallocate the backing vector of a SharedVector
     pub unsafe extern "C" fn slint_shared_vector_free(ptr: *mut u8, size: usize, align: usize) {
         alloc::alloc::dealloc(ptr, alloc::alloc::Layout::from_size_align(size, align).unwrap())
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// This function is used for the low-level C++ interface to initialize the empty SharedVector.
     pub unsafe extern "C" fn slint_shared_vector_empty() -> *const u8 {
         &SHARED_NULL as *const _ as *const u8

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -410,7 +410,7 @@ pub(crate) mod ffi {
     #[allow(non_camel_case_types)]
     type c_char = u8;
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// Returns a nul-terminated pointer for this string.
     /// The returned value is owned by the string, and should not be used after any
     /// mutable function have been called on the string, and must not be freed.
@@ -422,20 +422,20 @@ pub(crate) mod ffi {
         }
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// Destroy the shared string
     pub unsafe extern "C" fn slint_shared_string_drop(ss: *const SharedString) {
         core::ptr::read(ss);
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// Increment the reference count of the string.
     /// The resulting structure must be passed to slint_shared_string_drop
     pub unsafe extern "C" fn slint_shared_string_clone(out: *mut SharedString, ss: &SharedString) {
         core::ptr::write(out, ss.clone())
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     /// Safety: bytes must be a valid utf-8 string of size len without null inside.
     /// The resulting structure must be passed to slint_shared_string_drop
     pub unsafe extern "C" fn slint_shared_string_from_bytes(
@@ -449,7 +449,7 @@ pub(crate) mod ffi {
 
     /// Create a string from a number.
     /// The resulting structure must be passed to slint_shared_string_drop
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_shared_string_from_number(out: *mut SharedString, n: f64) {
         let str = shared_string_from_number(n);
         core::ptr::write(out, str);
@@ -483,7 +483,7 @@ pub(crate) mod ffi {
         }
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_shared_string_from_number_fixed(
         out: &mut SharedString,
         n: f64,
@@ -534,7 +534,7 @@ pub(crate) mod ffi {
         assert_eq!(s.as_str(), "2.5");
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_shared_string_from_number_precision(
         out: &mut SharedString,
         n: f64,
@@ -609,7 +609,7 @@ pub(crate) mod ffi {
     /// Append some bytes to an existing shared string
     ///
     /// bytes must be a valid utf8 array of size `len`, without null bytes inside
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_shared_string_append(
         self_: &mut SharedString,
         bytes: *const c_char,
@@ -632,7 +632,7 @@ pub(crate) mod ffi {
         assert_eq!(s.as_str(), "Hello, world!");
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_shared_string_to_lowercase(
         out: &mut SharedString,
         ss: &SharedString,
@@ -650,7 +650,7 @@ pub(crate) mod ffi {
         assert_eq!(out.as_str(), "hello");
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_shared_string_to_uppercase(
         out: &mut SharedString,
         ss: &SharedString,

--- a/internal/core/tests.rs
+++ b/internal/core/tests.rs
@@ -13,7 +13,7 @@ use crate::platform::WindowEvent;
 /// Normally, the event loop update the time of the animation using
 /// real time, but in tests, it is more convenient to use the fake time.
 /// This function will add some milliseconds to the fake time
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_mock_elapsed_time(time_in_ms: u64) {
     let tick = crate::animations::CURRENT_ANIMATION_DRIVER.with(|driver| {
         let mut tick = driver.current_tick();
@@ -26,13 +26,13 @@ pub extern "C" fn slint_mock_elapsed_time(time_in_ms: u64) {
 }
 
 /// Return the current mocked time.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_get_mocked_time() -> u64 {
     crate::animations::CURRENT_ANIMATION_DRIVER.with(|driver| driver.current_tick()).as_millis()
 }
 
 /// Simulate a click on a position within the component.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_send_mouse_click(
     x: f32,
     y: f32,
@@ -48,7 +48,7 @@ pub extern "C" fn slint_send_mouse_click(
 }
 
 /// Simulate a character input event (pressed or released).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_send_keyboard_char(
     string: &crate::SharedString,
     pressed: bool,
@@ -64,7 +64,7 @@ pub extern "C" fn slint_send_keyboard_char(
 }
 
 /// Simulate a character input event.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn send_keyboard_string_sequence(
     sequence: &crate::SharedString,
     window_adapter: &crate::window::WindowAdapterRc,

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -454,7 +454,7 @@ pub(crate) mod ffi {
     /// A value of -1 for the timer id means a new timer is to be allocated.
     /// The (new) timer id is returned.
     /// The timer MUST be destroyed with slint_timer_destroy.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_start(
         id: usize,
         mode: TimerMode,
@@ -478,7 +478,7 @@ pub(crate) mod ffi {
     }
 
     /// Execute a callback with a delay in millisecond
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_singleshot(
         delay: u64,
         callback: extern "C" fn(*mut c_void),
@@ -490,7 +490,7 @@ pub(crate) mod ffi {
     }
 
     /// Stop a timer and free its raw data
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_destroy(id: usize) {
         if id == 0 {
             return;
@@ -500,7 +500,7 @@ pub(crate) mod ffi {
     }
 
     /// Stop a timer
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_stop(id: usize) {
         if id == 0 {
             return;
@@ -511,7 +511,7 @@ pub(crate) mod ffi {
     }
 
     /// Restart a repeated timer
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_restart(id: usize) {
         if id == 0 {
             return;
@@ -522,7 +522,7 @@ pub(crate) mod ffi {
     }
 
     /// Returns true if the timer is running; false otherwise.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_running(id: usize) -> bool {
         if id == 0 {
             return false;
@@ -534,7 +534,7 @@ pub(crate) mod ffi {
     }
 
     /// Returns the interval in milliseconds. 0 when the timer was never started.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_interval(id: usize) -> u64 {
         if id == 0 {
             return 0;

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -420,7 +420,7 @@ mod ffi {
     use crate::slice::Slice;
 
     /// Perform the translation and formatting.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_translate(
         to_translate: &mut SharedString,
         context: &SharedString,
@@ -434,13 +434,13 @@ mod ffi {
     }
 
     /// Mark all translated string as dirty to perform re-translation in case the language change
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_translations_mark_dirty() {
         mark_all_translations_dirty();
     }
 
     /// Safety: The slice must contain valid null-terminated utf-8 strings
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_translate_from_bundle(
         strs: Slice<*const core::ffi::c_char>,
         arguments: Slice<SharedString>,
@@ -465,7 +465,7 @@ mod ffi {
     /// (where indices[-1] is 0)
     ///
     /// Safety; the strs must be pointer to valid null-terminated utf-8 strings
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_translate_from_bundle_with_plural(
         strs: Slice<*const core::ffi::c_char>,
         indices: Slice<u32>,
@@ -500,7 +500,7 @@ mod ffi {
             .unwrap();
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_translate_set_bundled_languages(languages: Slice<Slice<'static, u8>>) {
         let languages = languages
             .iter()
@@ -509,7 +509,7 @@ mod ffi {
         set_bundled_languages(&languages);
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn slint_translate_select_bundled_translation(language: Slice<u8>) -> bool {
         let language = core::str::from_utf8(&language).unwrap();
         select_bundled_translation(language).is_ok()

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1468,7 +1468,7 @@ pub mod ffi {
     pub struct WindowAdapterRcOpaque(*const c_void, *const c_void);
 
     /// Releases the reference to the windowrc held by handle.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_drop(handle: *mut WindowAdapterRcOpaque) {
         assert_eq!(
             core::mem::size_of::<Rc<dyn WindowAdapter>>(),
@@ -1482,7 +1482,7 @@ pub mod ffi {
     }
 
     /// Releases the reference to the component window held by handle.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_clone(
         source: *const WindowAdapterRcOpaque,
         target: *mut WindowAdapterRcOpaque,
@@ -1496,7 +1496,7 @@ pub mod ffi {
     }
 
     /// Spins an event loop and renders the items of the provided component in this window.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_show(handle: *const WindowAdapterRcOpaque) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
 
@@ -1504,7 +1504,7 @@ pub mod ffi {
     }
 
     /// Spins an event loop and renders the items of the provided component in this window.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_hide(handle: *const WindowAdapterRcOpaque) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
         window_adapter.window().hide().unwrap();
@@ -1512,7 +1512,7 @@ pub mod ffi {
 
     /// Returns the visibility state of the window. This function can return false even if you previously called show()
     /// on it, for example if the user minimized the window.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_is_visible(
         handle: *const WindowAdapterRcOpaque,
     ) -> bool {
@@ -1521,7 +1521,7 @@ pub mod ffi {
     }
 
     /// Returns the window scale factor.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_get_scale_factor(
         handle: *const WindowAdapterRcOpaque,
     ) -> f32 {
@@ -1534,7 +1534,7 @@ pub mod ffi {
     }
 
     /// Sets the window scale factor, merely for testing purposes.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_scale_factor(
         handle: *const WindowAdapterRcOpaque,
         value: f32,
@@ -1544,7 +1544,7 @@ pub mod ffi {
     }
 
     /// Returns the text-input-focused property value.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_get_text_input_focused(
         handle: *const WindowAdapterRcOpaque,
     ) -> bool {
@@ -1557,7 +1557,7 @@ pub mod ffi {
     }
 
     /// Set the text-input-focused property.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_text_input_focused(
         handle: *const WindowAdapterRcOpaque,
         value: bool,
@@ -1567,7 +1567,7 @@ pub mod ffi {
     }
 
     /// Sets the focus item.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_focus_item(
         handle: *const WindowAdapterRcOpaque,
         focus_item: &ItemRc,
@@ -1578,7 +1578,7 @@ pub mod ffi {
     }
 
     /// Associates the window with the given component.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_component(
         handle: *const WindowAdapterRcOpaque,
         component: &ItemTreeRc,
@@ -1588,7 +1588,7 @@ pub mod ffi {
     }
 
     /// Show a popup and return its ID. The returned ID will always be non-zero.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_show_popup(
         handle: *const WindowAdapterRcOpaque,
         popup: &ItemTreeRc,
@@ -1608,7 +1608,7 @@ pub mod ffi {
     }
 
     /// Close the popup by the given ID.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_close_popup(
         handle: *const WindowAdapterRcOpaque,
         popup_id: NonZeroU32,
@@ -1618,7 +1618,7 @@ pub mod ffi {
     }
 
     /// C binding to the set_rendering_notifier() API of Window
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_rendering_notifier(
         handle: *const WindowAdapterRcOpaque,
         callback: extern "C" fn(
@@ -1673,7 +1673,7 @@ pub mod ffi {
     }
 
     /// C binding to the on_close_requested() API of Window
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_on_close_requested(
         handle: *const WindowAdapterRcOpaque,
         callback: extern "C" fn(user_data: *mut c_void) -> CloseRequestResponse,
@@ -1705,7 +1705,7 @@ pub mod ffi {
     }
 
     /// This function issues a request to the windowing system to redraw the contents of the window.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_request_redraw(handle: *const WindowAdapterRcOpaque) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
         window_adapter.request_redraw();
@@ -1713,7 +1713,7 @@ pub mod ffi {
 
     /// Returns the position of the window on the screen, in physical screen coordinates and including
     /// a window frame (if present).
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_position(
         handle: *const WindowAdapterRcOpaque,
         pos: &mut euclid::default::Point2D<i32>,
@@ -1725,7 +1725,7 @@ pub mod ffi {
     /// Sets the position of the window on the screen, in physical screen coordinates and including
     /// a window frame (if present).
     /// Note that on some windowing systems, such as Wayland, this functionality is not available.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_physical_position(
         handle: *const WindowAdapterRcOpaque,
         pos: &euclid::default::Point2D<i32>,
@@ -1737,7 +1737,7 @@ pub mod ffi {
     /// Sets the position of the window on the screen, in physical screen coordinates and including
     /// a window frame (if present).
     /// Note that on some windowing systems, such as Wayland, this functionality is not available.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_logical_position(
         handle: *const WindowAdapterRcOpaque,
         pos: &euclid::default::Point2D<f32>,
@@ -1748,7 +1748,7 @@ pub mod ffi {
 
     /// Returns the size of the window on the screen, in physical screen coordinates and excluding
     /// a window frame (if present).
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_size(handle: *const WindowAdapterRcOpaque) -> IntSize {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
         window_adapter.size().to_euclid().cast()
@@ -1756,7 +1756,7 @@ pub mod ffi {
 
     /// Resizes the window to the specified size on the screen, in physical pixels and excluding
     /// a window frame (if present).
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_physical_size(
         handle: *const WindowAdapterRcOpaque,
         size: &IntSize,
@@ -1767,7 +1767,7 @@ pub mod ffi {
 
     /// Resizes the window to the specified size on the screen, in physical pixels and excluding
     /// a window frame (if present).
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_logical_size(
         handle: *const WindowAdapterRcOpaque,
         size: &Size,
@@ -1777,7 +1777,7 @@ pub mod ffi {
     }
 
     /// Return whether the style is using a dark theme
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_color_scheme(
         handle: *const WindowAdapterRcOpaque,
     ) -> ColorScheme {
@@ -1788,7 +1788,7 @@ pub mod ffi {
     }
 
     /// Return whether the platform supports native menu bars
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_supports_native_menu_bar(
         handle: *const WindowAdapterRcOpaque,
     ) -> bool {
@@ -1797,7 +1797,7 @@ pub mod ffi {
     }
 
     /// Setup the native menu bar
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_setup_native_menu_bar(
         handle: *const WindowAdapterRcOpaque,
         vtable: NonNull<MenuVTable>,
@@ -1810,7 +1810,7 @@ pub mod ffi {
     }
 
     /// Return the default-font-size property of the WindowItem
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_default_font_size(
         handle: *const WindowAdapterRcOpaque,
     ) -> f32 {
@@ -1819,7 +1819,7 @@ pub mod ffi {
     }
 
     /// Dispatch a key pressed or release event
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_dispatch_key_event(
         handle: *const WindowAdapterRcOpaque,
         event_type: crate::input::KeyEventType,
@@ -1836,7 +1836,7 @@ pub mod ffi {
     }
 
     /// Dispatch a mouse event
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_dispatch_pointer_event(
         handle: *const WindowAdapterRcOpaque,
         event: crate::input::MouseEvent,
@@ -1846,7 +1846,7 @@ pub mod ffi {
     }
 
     /// Dispatch a window event
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_dispatch_event(
         handle: *const WindowAdapterRcOpaque,
         event: &crate::platform::WindowEvent,
@@ -1855,7 +1855,7 @@ pub mod ffi {
         window_adapter.window().dispatch_event(event.clone());
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_is_fullscreen(
         handle: *const WindowAdapterRcOpaque,
     ) -> bool {
@@ -1863,7 +1863,7 @@ pub mod ffi {
         window_adapter.window().is_fullscreen()
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_is_minimized(
         handle: *const WindowAdapterRcOpaque,
     ) -> bool {
@@ -1871,7 +1871,7 @@ pub mod ffi {
         window_adapter.window().is_minimized()
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_is_maximized(
         handle: *const WindowAdapterRcOpaque,
     ) -> bool {
@@ -1879,7 +1879,7 @@ pub mod ffi {
         window_adapter.window().is_maximized()
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_fullscreen(
         handle: *const WindowAdapterRcOpaque,
         value: bool,
@@ -1888,7 +1888,7 @@ pub mod ffi {
         window_adapter.window().set_fullscreen(value)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_minimized(
         handle: *const WindowAdapterRcOpaque,
         value: bool,
@@ -1897,7 +1897,7 @@ pub mod ffi {
         window_adapter.window().set_minimized(value)
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_set_maximized(
         handle: *const WindowAdapterRcOpaque,
         value: bool,
@@ -1907,7 +1907,7 @@ pub mod ffi {
     }
 
     /// Takes a snapshot of the window contents and returns it as RGBA8 encoded pixel buffer.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_take_snapshot(
         handle: *const WindowAdapterRcOpaque,
         data: &mut SharedVector<Rgba8Pixel>,

--- a/internal/interpreter/ffi.rs
+++ b/internal/interpreter/ffi.rs
@@ -12,48 +12,48 @@ use std::ffi::c_void;
 use vtable::VRef;
 
 /// Construct a new Value in the given memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_new() -> Box<Value> {
     Box::new(Value::default())
 }
 
 /// Construct a new Value in the given memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_clone(other: &Value) -> Box<Value> {
     Box::new(other.clone())
 }
 
 /// Destruct the value in that memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_destructor(val: Box<Value>) {
     drop(val);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_value_eq(a: &Value, b: &Value) -> bool {
     a == b
 }
 
 /// Construct a new Value in the given memory location as string
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_new_string(str: &SharedString) -> Box<Value> {
     Box::new(Value::String(str.clone()))
 }
 
 /// Construct a new Value in the given memory location as double
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_new_double(double: f64) -> Box<Value> {
     Box::new(Value::Number(double))
 }
 
 /// Construct a new Value in the given memory location as bool
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_new_bool(b: bool) -> Box<Value> {
     Box::new(Value::Bool(b))
 }
 
 /// Construct a new Value in the given memory location as array model
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_new_array_model(
     a: &SharedVector<Box<Value>>,
 ) -> Box<Value> {
@@ -62,25 +62,25 @@ pub unsafe extern "C" fn slint_interpreter_value_new_array_model(
 }
 
 /// Construct a new Value in the given memory location as Brush
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_new_brush(brush: &Brush) -> Box<Value> {
     Box::new(Value::Brush(brush.clone()))
 }
 
 /// Construct a new Value in the given memory location as Struct
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_new_struct(struc: &StructOpaque) -> Box<Value> {
     Box::new(Value::Struct(struc.as_struct().clone()))
 }
 
 /// Construct a new Value in the given memory location as image
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_new_image(img: &Image) -> Box<Value> {
     Box::new(Value::Image(img.clone()))
 }
 
 /// Construct a new Value containing a model in the given memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_new_model(
     model: NonNull<u8>,
     vtable: &ModelAdaptorVTable,
@@ -91,12 +91,12 @@ pub unsafe extern "C" fn slint_interpreter_value_new_model(
     )))))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_value_type(val: &Value) -> ValueType {
     val.value_type()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_value_to_string(val: &Value) -> Option<&SharedString> {
     match val {
         Value::String(v) => Some(v),
@@ -104,7 +104,7 @@ pub extern "C" fn slint_interpreter_value_to_string(val: &Value) -> Option<&Shar
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_value_to_number(val: &Value) -> Option<&f64> {
     match val {
         Value::Number(v) => Some(v),
@@ -112,7 +112,7 @@ pub extern "C" fn slint_interpreter_value_to_number(val: &Value) -> Option<&f64>
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_value_to_bool(val: &Value) -> Option<&bool> {
     match val {
         Value::Bool(v) => Some(v),
@@ -123,7 +123,7 @@ pub extern "C" fn slint_interpreter_value_to_bool(val: &Value) -> Option<&bool> 
 /// Extracts a `SharedVector<ValueOpaque>` out of the given value `val`, writes that into the
 /// `out` parameter and returns true; returns false if the value does not hold an extractable
 /// array.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_value_to_array(
     val: &Box<Value>,
     out: *mut SharedVector<Box<Value>>,
@@ -141,7 +141,7 @@ pub extern "C" fn slint_interpreter_value_to_array(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_value_to_brush(val: &Value) -> Option<&Brush> {
     match val {
         Value::Brush(b) => Some(b),
@@ -149,7 +149,7 @@ pub extern "C" fn slint_interpreter_value_to_brush(val: &Value) -> Option<&Brush
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_value_to_struct(val: &Value) -> *const StructOpaque {
     match val {
         Value::Struct(s) => s as *const Struct as *const StructOpaque,
@@ -157,7 +157,7 @@ pub extern "C" fn slint_interpreter_value_to_struct(val: &Value) -> *const Struc
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_value_to_image(val: &Value) -> Option<&Image> {
     match val {
         Value::Image(img) => Some(img),
@@ -186,13 +186,13 @@ impl StructOpaque {
 }
 
 /// Construct a new Struct in the given memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_struct_new(val: *mut StructOpaque) {
     std::ptr::write(val as *mut Struct, Struct::default())
 }
 
 /// Construct a new Struct in the given memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_struct_clone(
     other: &StructOpaque,
     val: *mut StructOpaque,
@@ -201,12 +201,12 @@ pub unsafe extern "C" fn slint_interpreter_struct_clone(
 }
 
 /// Destruct the struct in that memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_struct_destructor(val: *mut StructOpaque) {
     drop(std::ptr::read(val as *mut Struct))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_struct_get_field(
     stru: &StructOpaque,
     name: Slice<u8>,
@@ -218,7 +218,7 @@ pub extern "C" fn slint_interpreter_struct_get_field(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_struct_set_field<'a>(
     stru: &'a mut StructOpaque,
     name: Slice<u8>,
@@ -235,7 +235,7 @@ const _: [(); std::mem::size_of::<StructIteratorOpaque>()] =
 const _: [(); std::mem::align_of::<StructIteratorOpaque>()] =
     [(); std::mem::align_of::<StructIterator>()];
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_struct_iterator_destructor(
     val: *mut StructIteratorOpaque,
 ) {
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn slint_interpreter_struct_iterator_destructor(
 }
 
 /// Advance the iterator and return the next value, or a null pointer
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_struct_iterator_next<'a>(
     iter: &'a mut StructIteratorOpaque,
     k: &mut Slice<'a, u8>,
@@ -257,7 +257,7 @@ pub unsafe extern "C" fn slint_interpreter_struct_iterator_next<'a>(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_struct_make_iter(stru: &StructOpaque) -> StructIteratorOpaque {
     let ret_it: StructIterator = stru.as_struct().0.iter();
     unsafe {
@@ -268,7 +268,7 @@ pub extern "C" fn slint_interpreter_struct_make_iter(stru: &StructOpaque) -> Str
 }
 
 /// Get a property. Returns a null pointer if the property does not exist.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_instance_get_property(
     inst: &ErasedItemTreeBox,
     name: Slice<u8>,
@@ -284,7 +284,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_get_property(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_component_instance_set_property(
     inst: &ErasedItemTreeBox,
     name: Slice<u8>,
@@ -302,7 +302,7 @@ pub extern "C" fn slint_interpreter_component_instance_set_property(
 }
 
 /// Invoke a callback or function. Returns raw boxed value on success and null ptr on failure.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_instance_invoke(
     inst: &ErasedItemTreeBox,
     name: Slice<u8>,
@@ -348,7 +348,7 @@ impl CallbackUserData {
 
 /// Set a handler for the callback.
 /// The `callback` function must initialize the `ret` (the `ret` passed to the callback is initialized and is assumed initialized after the function)
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_instance_set_callback(
     inst: &ErasedItemTreeBox,
     name: Slice<u8>,
@@ -370,7 +370,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_set_callback(
 }
 
 /// Get a global property. Returns a raw boxed value on success; nullptr otherwise.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_instance_get_global_property(
     inst: &ErasedItemTreeBox,
     global: Slice<u8>,
@@ -390,7 +390,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_get_global_propert
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_component_instance_set_global_property(
     inst: &ErasedItemTreeBox,
     global: Slice<u8>,
@@ -413,7 +413,7 @@ pub extern "C" fn slint_interpreter_component_instance_set_global_property(
 }
 
 /// The `callback` function must initialize the `ret` (the `ret` passed to the callback is initialized and is assumed initialized after the function)
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_instance_set_global_callback(
     inst: &ErasedItemTreeBox,
     global: Slice<u8>,
@@ -438,7 +438,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_set_global_callbac
 }
 
 /// Invoke a global callback or function. Returns raw boxed value on success; nullptr otherwise.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_instance_invoke_global(
     inst: &ErasedItemTreeBox,
     global: Slice<u8>,
@@ -476,7 +476,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_invoke_global(
 }
 
 /// Show or hide
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn slint_interpreter_component_instance_show(
     inst: &ErasedItemTreeBox,
     is_visible: bool,
@@ -493,7 +493,7 @@ pub extern "C" fn slint_interpreter_component_instance_show(
 ///
 /// The out pointer must be uninitialized and must be destroyed with
 /// slint_windowrc_drop after usage
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_instance_window(
     inst: &ErasedItemTreeBox,
     out: *mut *const i_slint_core::window::ffi::WindowAdapterRcOpaque,
@@ -512,7 +512,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_window(
 ///
 /// The `out` must be uninitialized and is going to be initialized after the call
 /// and need to be destroyed with slint_interpreter_component_instance_destructor
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_instance_create(
     def: &ComponentDefinitionOpaque,
     out: *mut ComponentInstance,
@@ -520,7 +520,7 @@ pub unsafe extern "C" fn slint_interpreter_component_instance_create(
     std::ptr::write(out, def.as_component_definition().create().unwrap())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_instance_component_definition(
     inst: &ErasedItemTreeBox,
     component_definition_ptr: *mut ComponentDefinitionOpaque,
@@ -585,18 +585,18 @@ impl ModelNotifyOpaque {
 }
 
 /// Construct a new ModelNotifyNotify in the given memory region
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_model_notify_new(val: *mut ModelNotifyOpaque) {
     std::ptr::write(val as *mut ModelNotify, ModelNotify::default());
 }
 
 /// Destruct the value in that memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_model_notify_destructor(val: *mut ModelNotifyOpaque) {
     drop(std::ptr::read(val as *mut ModelNotify))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_model_notify_row_changed(
     notify: &ModelNotifyOpaque,
     row: usize,
@@ -604,7 +604,7 @@ pub unsafe extern "C" fn slint_interpreter_model_notify_row_changed(
     notify.as_model_notify().row_changed(row);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_model_notify_row_added(
     notify: &ModelNotifyOpaque,
     row: usize,
@@ -613,12 +613,12 @@ pub unsafe extern "C" fn slint_interpreter_model_notify_row_added(
     notify.as_model_notify().row_added(row, count);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_model_notify_reset(notify: &ModelNotifyOpaque) {
     notify.as_model_notify().reset();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_model_notify_row_removed(
     notify: &ModelNotifyOpaque,
     row: usize,
@@ -671,7 +671,7 @@ impl ComponentCompilerOpaque {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(deprecated)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_new(
     compiler: *mut ComponentCompilerOpaque,
@@ -681,14 +681,14 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_new(
     ))));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_destructor(
     compiler: *mut ComponentCompilerOpaque,
 ) {
     drop(Box::from_raw((*compiler).0.as_ptr()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_set_include_paths(
     compiler: &mut ComponentCompilerOpaque,
     paths: &SharedVector<SharedString>,
@@ -698,7 +698,7 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_set_include_paths(
         .set_include_paths(paths.iter().map(|path| path.as_str().into()).collect())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_set_style(
     compiler: &mut ComponentCompilerOpaque,
     style: Slice<u8>,
@@ -706,7 +706,7 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_set_style(
     compiler.as_component_compiler_mut().set_style(std::str::from_utf8(&style).unwrap().to_string())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_set_translation_domain(
     compiler: &mut ComponentCompilerOpaque,
     translation_domain: Slice<u8>,
@@ -716,7 +716,7 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_set_translation_do
         .set_translation_domain(std::str::from_utf8(&translation_domain).unwrap().to_string())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_get_style(
     compiler: &ComponentCompilerOpaque,
     style_out: &mut SharedString,
@@ -725,7 +725,7 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_get_style(
         compiler.as_component_compiler().style().map_or(SharedString::default(), |s| s.into());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_get_include_paths(
     compiler: &ComponentCompilerOpaque,
     paths: &mut SharedVector<SharedString>,
@@ -739,7 +739,7 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_get_include_paths(
     );
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_get_diagnostics(
     compiler: &ComponentCompilerOpaque,
     out_diags: &mut SharedVector<Diagnostic>,
@@ -764,7 +764,7 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_get_diagnostics(
     }));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_build_from_source(
     compiler: &mut ComponentCompilerOpaque,
     source_code: Slice<u8>,
@@ -783,7 +783,7 @@ pub unsafe extern "C" fn slint_interpreter_component_compiler_build_from_source(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_compiler_build_from_path(
     compiler: &mut ComponentCompilerOpaque,
     path: Slice<u8>,
@@ -833,7 +833,7 @@ impl ComponentDefinitionOpaque {
 }
 
 /// Construct a new Value in the given memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_clone(
     other: &ComponentDefinitionOpaque,
     def: *mut ComponentDefinitionOpaque,
@@ -842,7 +842,7 @@ pub unsafe extern "C" fn slint_interpreter_component_definition_clone(
 }
 
 /// Destruct the component definition in that memory location
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_destructor(
     val: *mut ComponentDefinitionOpaque,
 ) {
@@ -850,7 +850,7 @@ pub unsafe extern "C" fn slint_interpreter_component_definition_destructor(
 }
 
 /// Returns the list of properties of the component the component definition describes
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_properties(
     def: &ComponentDefinitionOpaque,
     props: &mut SharedVector<PropertyDescriptor>,
@@ -864,7 +864,7 @@ pub unsafe extern "C" fn slint_interpreter_component_definition_properties(
 }
 
 /// Returns the list of callback names of the component the component definition describes
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_callbacks(
     def: &ComponentDefinitionOpaque,
     callbacks: &mut SharedVector<SharedString>,
@@ -873,7 +873,7 @@ pub unsafe extern "C" fn slint_interpreter_component_definition_callbacks(
 }
 
 /// Returns the list of function names of the component the component definition describes
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_functions(
     def: &ComponentDefinitionOpaque,
     functions: &mut SharedVector<SharedString>,
@@ -882,7 +882,7 @@ pub unsafe extern "C" fn slint_interpreter_component_definition_functions(
 }
 
 /// Return the name of the component definition
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_name(
     def: &ComponentDefinitionOpaque,
     name: &mut SharedString,
@@ -891,7 +891,7 @@ pub unsafe extern "C" fn slint_interpreter_component_definition_name(
 }
 
 /// Returns a vector of strings with the names of all exported global singletons.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_globals(
     def: &ComponentDefinitionOpaque,
     names: &mut SharedVector<SharedString>,
@@ -901,7 +901,7 @@ pub unsafe extern "C" fn slint_interpreter_component_definition_globals(
 
 /// Returns a vector of the property descriptors of the properties of the specified publicly exported global
 /// singleton. Returns true if a global exists under the specified name; false otherwise.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_global_properties(
     def: &ComponentDefinitionOpaque,
     global_name: Slice<u8>,
@@ -923,7 +923,7 @@ pub unsafe extern "C" fn slint_interpreter_component_definition_global_propertie
 
 /// Returns a vector of the names of the callbacks of the specified publicly exported global
 /// singleton. Returns true if a global exists under the specified name; false otherwise.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_global_callbacks(
     def: &ComponentDefinitionOpaque,
     global_name: Slice<u8>,
@@ -942,7 +942,7 @@ pub unsafe extern "C" fn slint_interpreter_component_definition_global_callbacks
 
 /// Returns a vector of the names of the functions of the specified publicly exported global
 /// singleton. Returns true if a global exists under the specified name; false otherwise.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_interpreter_component_definition_global_functions(
     def: &ComponentDefinitionOpaque,
     global_name: Slice<u8>,


### PR DESCRIPTION
To be compatible with the 2024 edition, we need to wrap the `no_mangle` attribute in `unsafe()`.

The parsing for that in cbindgen was only added in the version 0.28, but we couldn't upgrade cbindgen before because of a regression in cbindgen 0.27 that prevented us from upgrading.
Now that cbindgen 0.29 is released with a fix, we can prepare for the 2024 edition
