### PR TITLE
live-preview: Improve filter UX

### DIFF
--- a/tools/lsp/ui/assets/search.svg
+++ b/tools/lsp/ui/assets/search.svg
@@ -1,1 +1,1 @@
-<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M15.25 0a8.25 8.25 0 0 0-6.18 13.72L1 22.88l1.12 1 8.05-9.12A8.251 8.251 0 1 0 15.25.01V0zm0 15a6.75 6.75 0 1 1 0-13.5 6.75 6.75 0 0 1 0 13.5z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m21 21-4.34-4.34"/><circle cx="11" cy="11" r="8"/></svg>

--- a/tools/lsp/ui/components/widgets/floating-brush-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-brush-picker-widget.slint
@@ -483,7 +483,9 @@ component ColorPicker inherits DraggablePanel {
     }
 
     if active-tab == PickerTab.globals: SvgColorPicker {
-        filter-text: "!^Colors.";
+        property <string> filter-brush-and-color: "!^Colors. ";
+        property <string> filter-color-only: "!^Colors. '%kind:Color ";
+        filter-text: picker-mode == BrushPropertyType.brush ? filter-brush-and-color : filter-color-only;
     }
 
     footer := Rectangle {

--- a/tools/lsp/ui/components/widgets/floating-brush-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-brush-picker-widget.slint
@@ -415,7 +415,7 @@ component ColorPicker inherits DraggablePanel {
     in-out property <BrushMode> brush-mode: color;
     property <PickerTab> active-tab: widget-mode == WidgetMode.color-stop ? PickerTab.color : PickerData.active-tab;
 
-    property <bool> show-palettes: PickerData.active-tab == PickerTab.color;
+    property <bool> show-recent: widget-mode == WidgetMode.color-stop || PickerData.active-tab == PickerTab.color;
 
     callback close <=> t-close.clicked;
 
@@ -472,9 +472,9 @@ component ColorPicker inherits DraggablePanel {
         }
     }
 
-    if show-palettes: VerticalSpacer { }
+    if show-recent: VerticalSpacer { }
 
-    if show-palettes: RecentColorPicker {
+    if show-recent: RecentColorPicker {
         recent-colors <=> Api.recent-colors;
     }
 

--- a/tools/lsp/ui/components/widgets/floating-brush-sections/svg-color-ui.slint
+++ b/tools/lsp/ui/components/widgets/floating-brush-sections/svg-color-ui.slint
@@ -67,8 +67,19 @@ component SearchBar {
         border-color: EditorPalette.text-color.with-alpha(0.1);
         border-radius: self.height / 2;
 
+        si := Rectangle {
+            x: 5px;
+            width: 18px;
+            opacity: 0.4;
+            Image {
+                width: 14px;
+                source: Icons.search;
+                colorize: EditorPalette.text-color;
+            }
+        }
+
         ti := TextInput {
-            x: EditorSizeSettings.standard-margin;
+            x: si.x + si.width + 5px;
             vertical-alignment: center;
             horizontal-alignment: left;
             font-family: "Inter";
@@ -81,7 +92,7 @@ component SearchBar {
         }
 
         Text {
-            x: EditorSizeSettings.standard-margin;
+            x: ti.x;
             text: "Search";
             horizontal-alignment: left;
             font-family: "Inter";


### PR DESCRIPTION
Filter out brush globals if the property only supports <color>.
Show a search icon in the search bar.