### PR TITLE
renderer-skia: Update to skia-safe 0.86

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -66,7 +66,6 @@ jobs:
             - name: Downgrade cc and ring crate to work around https://github.com/slint-ui/slint/issues/6875
               run: |
                   cargo update -p ring --precise 0.17.9
-                  cargo update -p cc --precise 1.1.31
             - name: Fetch Yocto SDK
               run: |
                   # Fetch pre-built SDK built via populate_sdk for core-image-weston with setup from https://github.com/slint-ui/meta-slint/blob/main/.github/workflows/ci.yml

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -42,7 +42,7 @@ pin-weak = "1"
 scoped-tls-hkt = "0.1"
 raw-window-handle = { version = "0.6", features = ["std"] }
 
-skia-safe = { version = "0.84.0", features = ["textlayout", "gl"] }
+skia-safe = { version = "0.86.0", features = ["textlayout", "gl"] }
 glow = { workspace = true }
 unicode-segmentation = { workspace = true }
 
@@ -59,7 +59,7 @@ bytemuck = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 windows = { version = "0.61.1", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
-skia-safe = { version = "0.84.0", features = ["d3d"] }
+skia-safe = { version = "0.86.0", features = ["d3d"] }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc2 = { version = "0.6.0" }
@@ -68,11 +68,11 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = ["s
 objc2-quartz-core = { version = "0.3.0", default-features = false, features = ["std", "objc2-metal", "CALayer", "CAMetalLayer", "objc2-core-foundation"] }
 objc2-app-kit = { version = "0.3.0", default-features = false, features = ["std", "NSResponder", "NSView"] }
 objc2-core-foundation = { version = "0.3.0", default-features = false, features = ["CFCGTypes"] }
-skia-safe = { version = "0.84.0", features = ["metal"] }
+skia-safe = { version = "0.86.0", features = ["metal"] }
 raw-window-metal = "1.0"
 
 [target.'cfg(not(any(target_vendor = "apple", target_family = "windows")))'.dependencies]
-skia-safe = { version = "0.84.0", features = ["gl"] }
+skia-safe = { version = "0.86.0", features = ["gl"] }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }


### PR DESCRIPTION
This version syncs with Skia's milestone 137. See also https://github.com/rust-skia/rust-skia/releases/tag/0.86.0

Most relevant for us, this version compiles again with the latest cc crate when cross-compiling.

Fixes #6875
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
