### PR TITLE
corelib: Fix overflow when spamming the TouchArea with clicks

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -519,7 +519,7 @@ impl ClickState {
                         && button == self.click_button.get()
                         && (position - self.click_position.get()).square_length() < 100 as _
                     {
-                        self.click_count.set(self.click_count.get() + 1);
+                        self.click_count.set(self.click_count.get().wrapping_add(1));
                         self.click_count_time_stamp.set(Some(instant_now));
                     } else {
                         self.restart(position, button);

--- a/tests/cases/elements/toucharea_doubleclick.slint
+++ b/tests/cases/elements/toucharea_doubleclick.slint
@@ -591,4 +591,22 @@ function double_click(x, y) {
 // assert.equal(instance.touch_double2, 1);
 // assert.equal(instance.touch_double3, 2);
 ```
+
+
+```rust
+// Issue #8552 : "spam" the touch area shouldn't cause overflow
+let instance = TestCase::new().unwrap();
+for _ in 0..600 {
+    slint_testing::send_mouse_click(&instance, 103.0, 103.0);
+    slint_testing::mock_elapsed_time(50);
+}
+
+assert_eq!(instance.get_touch1(), 0);
+assert_eq!(instance.get_touch2(), 600);
+assert_eq!(instance.get_touch3(), 0);
+assert_eq!(instance.get_touch_double1(), 0);
+assert_eq!(instance.get_touch_double2(), 300);
+assert_eq!(instance.get_touch_double3(), 0);
+```
+
 */


### PR DESCRIPTION
Fixes #8552

