### PR TITLE
interpreter: Remove normalization in builtin enum conversion

### DIFF
--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -338,10 +338,7 @@ macro_rules! declare_value_enum_conversion {
     ($( $(#[$enum_doc:meta])* enum $Name:ident { $($body:tt)* })*) => { $(
         impl From<i_slint_core::items::$Name> for Value {
             fn from(v: i_slint_core::items::$Name) -> Self {
-                Value::EnumerationValue(
-                    stringify!($Name).to_owned(),
-                    i_slint_compiler::parser::normalize_identifier(v.to_string().trim_start_matches("r#")).to_string(),
-                )
+                Value::EnumerationValue(stringify!($Name).to_owned(), v.to_string())
             }
         }
         impl TryFrom<Value> for i_slint_core::items::$Name {
@@ -353,14 +350,7 @@ macro_rules! declare_value_enum_conversion {
                         if enumeration != stringify!($Name) {
                             return Err(());
                         }
-
-                        <i_slint_core::items::$Name>::from_str(value.as_str())
-                            .or_else(|_| {
-                                let norm = i_slint_compiler::parser::normalize_identifier(value.as_str());
-                                <i_slint_core::items::$Name>::from_str(&norm)
-                                    .or_else(|_| <i_slint_core::items::$Name>::from_str(&format!("r#{}", norm)))
-                            })
-                            .map_err(|_| ())
+                        i_slint_core::items::$Name::from_str(value.as_str()).map_err(|_| ())
                     }
                     _ => Err(()),
                 }


### PR DESCRIPTION
Once upon a time, the enum were written in snake case in the .rs file, but since ac4f3e97adfe939b77c66fa954accd12baf30128, they are written in camel case, and the strenum crate takes care of moving that to kebab case, which match our normalization, so there is no need to normalize more.

The de-normalization was actually broken since
63f7533dc907c134bb2c081927d9e6008a3bfab6 which changed a de-normalization into a normalization for the TryFrom<Value>
