### PR TITLE
live-preview: Get better basic values for the property editor

### DIFF
--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -276,7 +276,7 @@ impl Expression {
         )
     }
 
-    fn from_expression_node(node: syntax_nodes::Expression, ctx: &mut LookupCtx) -> Self {
+    pub fn from_expression_node(node: syntax_nodes::Expression, ctx: &mut LookupCtx) -> Self {
         node.children_with_tokens()
             .find_map(|child| match child {
                 NodeOrToken::Node(node) => match node.kind() {

--- a/tools/lsp/preview/eval.rs
+++ b/tools/lsp/preview/eval.rs
@@ -5,22 +5,9 @@ use std::collections::HashMap;
 
 use smol_str::SmolStr;
 
-use i_slint_compiler::{expression_tree, langtype, parser::syntax_nodes};
+use i_slint_compiler::{expression_tree, langtype};
 use slint::Model;
 use slint_interpreter::{Value, ValueType};
-
-use crate::{common, util};
-
-/// Turns a `syntax_nodes::BindingExpression` into an `expression_tree::Expression`
-pub fn eval_binding_expression(
-    document_cache: &common::DocumentCache,
-    expression: syntax_nodes::BindingExpression,
-) -> Option<expression_tree::Expression> {
-    let e = expression.clone();
-    util::with_lookup_ctx(document_cache, e.clone().into(), |ctx| {
-        expression_tree::Expression::from_binding_expression_node(e.into(), ctx)
-    })
-}
 
 #[derive(Default)]
 struct EvalLocalContext {
@@ -621,7 +608,7 @@ fn handle_builtin_function(
             impl i_slint_core::translations::FormatArgs for StringModelWrapper {
                 type Output<'a> = slint::SharedString;
                 fn from_index(&self, index: usize) -> Option<slint::SharedString> {
-                    self.0.row_data(index).map(|x| x.try_into().unwrap())
+                    self.0.row_data(index).map(|x| x.try_into().unwrap_or_default())
                 }
             }
             Value::String(i_slint_core::translations::translate(

--- a/tools/lsp/preview/eval.rs
+++ b/tools/lsp/preview/eval.rs
@@ -138,7 +138,7 @@ fn eval_expression(
             Value::Void
         }
         Expression::ReadLocalVariable { name, .. } => {
-            local_context.local_variables.get(name).unwrap().clone()
+            local_context.local_variables.get(name).cloned().unwrap_or_default()
         }
         Expression::EasingCurve(curve) => Value::EasingCurve(match curve {
             expression_tree::EasingCurve::Linear => i_slint_core::animations::EasingCurve::Linear,
@@ -168,10 +168,12 @@ fn eval_expression(
             let angle = eval_expression(angle, local_context);
             Value::Brush(slint::Brush::LinearGradient(
                 i_slint_core::graphics::LinearGradientBrush::new(
-                    angle.try_into().unwrap(),
+                    angle.try_into().unwrap_or_default(),
                     stops.iter().map(|(color, stop)| {
-                        let color = eval_expression(color, local_context).try_into().unwrap();
-                        let position = eval_expression(stop, local_context).try_into().unwrap();
+                        let color =
+                            eval_expression(color, local_context).try_into().unwrap_or_default();
+                        let position =
+                            eval_expression(stop, local_context).try_into().unwrap_or_default();
                         i_slint_core::graphics::GradientStop { color, position }
                     }),
                 ),
@@ -180,8 +182,10 @@ fn eval_expression(
         Expression::RadialGradient { stops } => Value::Brush(slint::Brush::RadialGradient(
             i_slint_core::graphics::RadialGradientBrush::new_circle(stops.iter().map(
                 |(color, stop)| {
-                    let color = eval_expression(color, local_context).try_into().unwrap();
-                    let position = eval_expression(stop, local_context).try_into().unwrap();
+                    let color =
+                        eval_expression(color, local_context).try_into().unwrap_or_default();
+                    let position =
+                        eval_expression(stop, local_context).try_into().unwrap_or_default();
                     i_slint_core::graphics::GradientStop { color, position }
                 },
             )),
@@ -194,7 +198,7 @@ fn eval_expression(
             if local_context.return_value.is_none() {
                 local_context.return_value = Some(val);
             }
-            local_context.return_value.clone().unwrap()
+            local_context.return_value.clone().unwrap_or_default()
         }
         Expression::MinMax { ty: _, op, lhs, rhs } => {
             let Value::Number(lhs) = eval_expression(lhs, local_context) else {
@@ -246,85 +250,109 @@ fn handle_builtin_function(
 
     match f {
         BuiltinFunction::Mod => {
-            let mut to_num = |e| -> f64 { eval_expression(e, local_context).try_into().unwrap() };
+            let mut to_num =
+                |e| -> f64 { eval_expression(e, local_context).try_into().unwrap_or_default() };
             Value::Number(to_num(&arguments[0]).rem_euclid(to_num(&arguments[1])))
         }
         BuiltinFunction::Round => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.round())
         }
         BuiltinFunction::Ceil => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.ceil())
         }
         BuiltinFunction::Floor => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.floor())
         }
         BuiltinFunction::Sqrt => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.sqrt())
         }
         BuiltinFunction::Abs => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.abs())
         }
         BuiltinFunction::Sin => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.to_radians().sin())
         }
         BuiltinFunction::Cos => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.to_radians().cos())
         }
         BuiltinFunction::Tan => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.to_radians().tan())
         }
         BuiltinFunction::ASin => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.asin().to_degrees())
         }
         BuiltinFunction::ACos => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.acos().to_degrees())
         }
         BuiltinFunction::ATan => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.atan().to_degrees())
         }
         BuiltinFunction::ATan2 => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let y: f64 = eval_expression(&arguments[1], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let y: f64 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
             Value::Number(x.atan2(y).to_degrees())
         }
         BuiltinFunction::Log => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let y: f64 = eval_expression(&arguments[1], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let y: f64 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
             Value::Number(x.log(y))
         }
         BuiltinFunction::Ln => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.ln())
         }
         BuiltinFunction::Pow => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let y: f64 = eval_expression(&arguments[1], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let y: f64 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
             Value::Number(x.powf(y))
         }
         BuiltinFunction::Exp => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let x: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             Value::Number(x.exp())
         }
         BuiltinFunction::ToFixed => {
-            let n: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let digits: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
+            let n: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let digits: i32 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
             let digits: usize = digits.max(0) as usize;
             Value::String(i_slint_core::string::shared_string_from_number_fixed(n, digits))
         }
         BuiltinFunction::ToPrecision => {
-            let n: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let precision: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
+            let n: f64 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let precision: i32 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
             let precision: usize = precision.max(0) as usize;
             Value::String(i_slint_core::string::shared_string_from_number_precision(n, precision))
         }
@@ -526,10 +554,14 @@ fn handle_builtin_function(
             }
         }
         BuiltinFunction::Rgb => {
-            let r: i32 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let g: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
-            let b: i32 = eval_expression(&arguments[2], local_context).try_into().unwrap();
-            let a: f32 = eval_expression(&arguments[3], local_context).try_into().unwrap();
+            let r: i32 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let g: i32 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
+            let b: i32 =
+                eval_expression(&arguments[2], local_context).try_into().unwrap_or_default();
+            let a: f32 =
+                eval_expression(&arguments[3], local_context).try_into().unwrap_or_default();
             let r: u8 = r.clamp(0, 255) as u8;
             let g: u8 = g.clamp(0, 255) as u8;
             let b: u8 = b.clamp(0, 255) as u8;
@@ -537,30 +569,41 @@ fn handle_builtin_function(
             Value::Brush(slint::Brush::SolidColor(slint::Color::from_argb_u8(a, r, g, b)))
         }
         BuiltinFunction::Hsv => {
-            let h: f32 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let s: f32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
-            let v: f32 = eval_expression(&arguments[2], local_context).try_into().unwrap();
-            let a: f32 = eval_expression(&arguments[3], local_context).try_into().unwrap();
+            let h: f32 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let s: f32 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
+            let v: f32 =
+                eval_expression(&arguments[2], local_context).try_into().unwrap_or_default();
+            let a: f32 =
+                eval_expression(&arguments[3], local_context).try_into().unwrap_or_default();
             let a = (1. * a).clamp(0., 1.);
             Value::Brush(slint::Brush::SolidColor(slint::Color::from_hsva(h, s, v, a)))
         }
         BuiltinFunction::MonthDayCount => {
-            let m: u32 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let y: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
+            let m: u32 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let y: i32 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
             Value::Number(i_slint_core::date_time::month_day_count(m, y).unwrap_or(0) as f64)
         }
         BuiltinFunction::MonthOffset => {
-            let m: u32 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let y: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
+            let m: u32 =
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let y: i32 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
 
             Value::Number(i_slint_core::date_time::month_offset(m, y) as f64)
         }
         BuiltinFunction::FormatDate => {
             let f: slint::SharedString =
-                eval_expression(&arguments[0], local_context).try_into().unwrap();
-            let d: u32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
-            let m: u32 = eval_expression(&arguments[2], local_context).try_into().unwrap();
-            let y: i32 = eval_expression(&arguments[3], local_context).try_into().unwrap();
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
+            let d: u32 =
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
+            let m: u32 =
+                eval_expression(&arguments[2], local_context).try_into().unwrap_or_default();
+            let y: i32 =
+                eval_expression(&arguments[3], local_context).try_into().unwrap_or_default();
 
             Value::String(i_slint_core::date_time::format_date(&f, d, m, y))
         }
@@ -572,16 +615,16 @@ fn handle_builtin_function(
         ))),
         BuiltinFunction::ValidDate => {
             let d: slint::SharedString =
-                eval_expression(&arguments[0], local_context).try_into().unwrap();
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             let f: slint::SharedString =
-                eval_expression(&arguments[1], local_context).try_into().unwrap();
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
             Value::Bool(i_slint_core::date_time::parse_date(d.as_str(), f.as_str()).is_some())
         }
         BuiltinFunction::ParseDate => {
             let d: slint::SharedString =
-                eval_expression(&arguments[0], local_context).try_into().unwrap();
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             let f: slint::SharedString =
-                eval_expression(&arguments[1], local_context).try_into().unwrap();
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
 
             Value::Model(slint::ModelRc::new(
                 i_slint_core::date_time::parse_date(d.as_str(), f.as_str())
@@ -595,11 +638,11 @@ fn handle_builtin_function(
         }
         BuiltinFunction::Translate => {
             let original: slint::SharedString =
-                eval_expression(&arguments[0], local_context).try_into().unwrap();
+                eval_expression(&arguments[0], local_context).try_into().unwrap_or_default();
             let context: slint::SharedString =
-                eval_expression(&arguments[1], local_context).try_into().unwrap();
+                eval_expression(&arguments[1], local_context).try_into().unwrap_or_default();
             let domain: slint::SharedString =
-                eval_expression(&arguments[2], local_context).try_into().unwrap();
+                eval_expression(&arguments[2], local_context).try_into().unwrap_or_default();
             let args = eval_expression(&arguments[3], local_context);
             let Value::Model(args) = args else {
                 return Value::Void;
@@ -616,9 +659,9 @@ fn handle_builtin_function(
                 &context,
                 &domain,
                 &StringModelWrapper(args),
-                eval_expression(&arguments[4], local_context).try_into().unwrap(),
+                eval_expression(&arguments[4], local_context).try_into().unwrap_or_default(),
                 &slint::SharedString::try_from(eval_expression(&arguments[5], local_context))
-                    .unwrap(),
+                    .unwrap_or_default(),
             ))
         }
         BuiltinFunction::Use24HourFormat => {

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -438,13 +438,9 @@ fn map_value_and_type(
         let color_string = brushes::color_to_string(color);
         mapping.headers.push(mapping.name_prefix.clone());
         mapping.current_values.push(PropertyValue {
+            value_kind: kind,
             kind,
-            display_string: if kind == PropertyValueKind::Color {
-                color_string.clone()
-            } else {
-                SharedString::from("Solid Color")
-            },
-            value_string: color_string,
+            display_string: color_string.clone(),
             brush_kind: BrushKind::Solid,
             value_brush: slint::Brush::SolidColor(color),
             gradient_stops: Rc::new(VecModel::from(vec![GradientStop { color, position: 0.5 }]))
@@ -475,6 +471,7 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: get_value::<i32>(value).to_shared_string(),
                 kind: PropertyValueKind::Integer,
+                value_kind: PropertyValueKind::Integer,
                 value_int: get_value::<i32>(value),
                 code: get_code(value),
                 accessor_path: mapping.name_prefix.clone(),
@@ -486,9 +483,10 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Ms),
                 kind: PropertyValueKind::Float,
+                value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[Unit::Ms]),
-                value_int: 0,
+                visual_items: unit_model(&[Unit::S, Unit::Ms]),
+                value_int: 1,
                 code: get_code(value),
                 default_selection: 1,
                 accessor_path: mapping.name_prefix.clone(),
@@ -500,11 +498,20 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Phx),
                 kind: PropertyValueKind::Float,
+                value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[Unit::Phx]),
-                value_int: 0,
+                visual_items: unit_model(&[
+                    Unit::Px,
+                    Unit::Cm,
+                    Unit::Mm,
+                    Unit::In,
+                    Unit::Pt,
+                    Unit::Phx,
+                    Unit::Rem,
+                ]),
+                value_int: 5,
                 code: get_code(value),
-                default_selection: 0,
+                default_selection: 5,
                 accessor_path: mapping.name_prefix.clone(),
                 ..Default::default()
             });
@@ -514,8 +521,17 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Px),
                 kind: PropertyValueKind::Float,
+                value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[Unit::Px]),
+                visual_items: unit_model(&[
+                    Unit::Px,
+                    Unit::Cm,
+                    Unit::Mm,
+                    Unit::In,
+                    Unit::Pt,
+                    Unit::Phx,
+                    Unit::Rem,
+                ]),
                 value_int: 0,
                 code: get_code(value),
                 default_selection: 0,
@@ -528,11 +544,20 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Rem),
                 kind: PropertyValueKind::Float,
+                value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[Unit::Rem]),
-                value_int: 0,
+                visual_items: unit_model(&[
+                    Unit::Px,
+                    Unit::Cm,
+                    Unit::Mm,
+                    Unit::In,
+                    Unit::Pt,
+                    Unit::Phx,
+                    Unit::Rem,
+                ]),
+                value_int: 6,
                 code: get_code(value),
-                default_selection: 0,
+                default_selection: 6,
                 accessor_path: mapping.name_prefix.clone(),
                 ..Default::default()
             });
@@ -542,8 +567,9 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Deg),
                 kind: PropertyValueKind::Float,
+                value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
-                visual_items: unit_model(&[Unit::Deg]),
+                visual_items: unit_model(&[Unit::Deg, Unit::Grad, Unit::Turn, Unit::Rad]),
                 value_int: 0,
                 code: get_code(value),
                 default_selection: 0,
@@ -556,6 +582,7 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: slint::format!("{}{}", get_value::<f32>(value), Unit::Percent),
                 kind: PropertyValueKind::Float,
+                value_kind: PropertyValueKind::Float,
                 value_float: get_value::<f32>(value),
                 visual_items: unit_model(&[Unit::Percent]),
                 value_int: 0,
@@ -570,6 +597,7 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: slint::format!("\"{}\"", get_value::<SharedString>(value)),
                 kind: PropertyValueKind::String,
+                value_kind: PropertyValueKind::String,
                 value_string: get_value::<SharedString>(value),
                 code: get_code(value),
                 accessor_path: mapping.name_prefix.clone(),
@@ -595,6 +623,7 @@ fn map_value_and_type(
                     mapping.current_values.push(PropertyValue {
                         display_string: SharedString::from("Linear Gradient"),
                         kind: PropertyValueKind::Brush,
+                        value_kind: PropertyValueKind::Brush,
                         brush_kind: BrushKind::Linear,
                         value_float: lg.angle(),
                         value_brush: slint::Brush::LinearGradient(lg.clone()),
@@ -614,6 +643,7 @@ fn map_value_and_type(
                     mapping.current_values.push(PropertyValue {
                         display_string: SharedString::from("Radial Gradient"),
                         kind: PropertyValueKind::Brush,
+                        value_kind: PropertyValueKind::Brush,
                         brush_kind: BrushKind::Radial,
                         value_brush: slint::Brush::RadialGradient(rg.clone()),
                         gradient_stops: Rc::new(VecModel::from(
@@ -632,6 +662,7 @@ fn map_value_and_type(
                     mapping.current_values.push(PropertyValue {
                         display_string: SharedString::from("Unknown Brush"),
                         kind: PropertyValueKind::Code,
+                        value_kind: PropertyValueKind::Code,
                         value_string: SharedString::from("???"),
                         accessor_path: mapping.name_prefix.clone(),
                         code: get_code(value),
@@ -645,6 +676,7 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: get_value::<bool>(value).to_shared_string(),
                 kind: PropertyValueKind::Boolean,
+                value_kind: PropertyValueKind::Boolean,
                 value_bool: get_value::<bool>(value),
                 accessor_path: mapping.name_prefix.clone(),
                 code: get_code(value),
@@ -669,6 +701,7 @@ fn map_value_and_type(
                     enumeration.values[selected_value]
                 ),
                 kind: PropertyValueKind::Enum,
+                value_kind: PropertyValueKind::Enum,
                 value_string: enumeration.name.as_str().into(),
                 default_selection: i32::try_from(enumeration.default_value).unwrap_or_default(),
                 value_int: i32::try_from(selected_value).unwrap_or_default(),
@@ -753,6 +786,7 @@ fn map_value_and_type(
             mapping.current_values.push(PropertyValue {
                 display_string: "Unsupported type".into(),
                 kind: PropertyValueKind::Code,
+                value_kind: PropertyValueKind::Code,
                 value_string: "???".into(),
                 accessor_path: mapping.name_prefix.clone(),
                 code: get_code(value),
@@ -767,6 +801,7 @@ fn map_value_and_type(
 
     mapping.code_value = PropertyValue {
         kind: PropertyValueKind::Code,
+        value_kind: PropertyValueKind::Code,
         code: get_code(value),
         ..Default::default()
     };
@@ -776,7 +811,7 @@ pub fn map_value_and_type_to_property_value(
     ty: &langtype::Type,
     value: &Option<slint_interpreter::Value>,
     name_prefix: &str,
-) -> Option<PropertyValue> {
+) -> PropertyValue {
     let mut mapping =
         ValueMapping { name_prefix: SharedString::from(name_prefix), ..Default::default() };
 
@@ -786,15 +821,18 @@ pub fn map_value_and_type_to_property_value(
         || mapping.array_values.len() != 1
         || mapping.array_values[0].len() != 1
     {
-        Some(mapping.code_value)
+        mapping.code_value
     } else {
-        mapping.array_values.first().and_then(|av| av.first()).cloned()
+        mapping
+            .array_values
+            .first()
+            .and_then(|av| av.first())
+            .cloned()
+            .unwrap_or_else(|| mapping.code_value.clone())
     }
 }
 
-fn map_preview_data_to_property_value(
-    preview_data: &preview_data::PreviewData,
-) -> Option<PropertyValue> {
+fn map_preview_data_to_property_value(preview_data: &preview_data::PreviewData) -> PropertyValue {
     map_value_and_type_to_property_value(&preview_data.ty, &preview_data.value, "")
 }
 
@@ -894,7 +932,7 @@ fn get_property_value(container: SharedString, property_name: SharedString) -> P
                 property_name.as_str(),
             )
         })
-        .and_then(|pd| map_preview_data_to_property_value(&pd))
+        .map(|pd| map_preview_data_to_property_value(&pd))
         .unwrap_or_default()
 }
 
@@ -1074,7 +1112,7 @@ fn default_property_value(source: &PropertyValue) -> PropertyValue {
             pv.code = "false".into();
         }
         PropertyValueKind::Brush => {
-            pv.display_string = "Solid Color".into();
+            pv.display_string = "#00000000".into();
             pv.brush_kind = BrushKind::Solid;
             pv.value_brush = slint::Color::default().into();
             pv.code = "#00000000".into();
@@ -1408,7 +1446,7 @@ export component Tester {{
     ) {
         let (_, value) = validate_rp_impl(visibility, type_def, type_name, code, expected_data);
 
-        let pv = super::map_preview_data_to_property_value(&value).unwrap();
+        let pv = super::map_preview_data_to_property_value(&value);
         compare_pv(&pv, &expected_value);
 
         let (is_array, headers, values) = super::map_preview_data_to_property_value_table(&value);
@@ -1432,7 +1470,7 @@ export component Tester {{
     ) {
         let (_, value) = validate_rp_impl(visibility, type_def, type_name, code, expected_data);
 
-        let pv = super::map_preview_data_to_property_value(&value).unwrap();
+        let pv = super::map_preview_data_to_property_value(&value);
         compare_pv(
             &pv,
             &super::PropertyValue {
@@ -1501,7 +1539,16 @@ export component Tester {{
                 code: "100".into(),
                 kind: super::PropertyValueKind::Float,
                 value_float: 100.0,
-                visual_items: std::rc::Rc::new(VecModel::from(vec!["px".into()])).into(),
+                visual_items: std::rc::Rc::new(VecModel::from(vec![
+                    "px".into(),
+                    "cm".into(),
+                    "mm".into(),
+                    "in".into(),
+                    "pt".into(),
+                    "phx".into(),
+                    "rem".into(),
+                ]))
+                .into(),
                 ..Default::default()
             },
         );
@@ -1525,7 +1572,16 @@ export component Tester {{
                 code: "378".into(),
                 kind: super::PropertyValueKind::Float,
                 value_float: 378.0,
-                visual_items: std::rc::Rc::new(VecModel::from(vec!["px".into()])).into(),
+                visual_items: std::rc::Rc::new(VecModel::from(vec![
+                    "px".into(),
+                    "cm".into(),
+                    "mm".into(),
+                    "in".into(),
+                    "pt".into(),
+                    "phx".into(),
+                    "rem".into(),
+                ]))
+                .into(),
                 ..Default::default()
             },
         );
@@ -1549,8 +1605,10 @@ export component Tester {{
                 code: "100000".into(),
                 kind: super::PropertyValueKind::Float,
                 value_float: 100000.0,
-                visual_items: std::rc::Rc::new(VecModel::from(vec!["ms".into()])).into(),
+                visual_items: std::rc::Rc::new(VecModel::from(vec!["s".into(), "ms".into()]))
+                    .into(),
                 default_selection: 1,
+                value_int: 1,
                 ..Default::default()
             },
         );
@@ -1574,7 +1632,13 @@ export component Tester {{
                 code: "36000".into(),
                 kind: super::PropertyValueKind::Float,
                 value_float: 36000.0,
-                visual_items: std::rc::Rc::new(VecModel::from(vec!["deg".into()])).into(),
+                visual_items: std::rc::Rc::new(VecModel::from(vec![
+                    "deg".into(),
+                    "grad".into(),
+                    "turn".into(),
+                    "rad".into(),
+                ]))
+                .into(),
                 ..Default::default()
             },
         );
@@ -1619,7 +1683,6 @@ export component Tester {{
             },
             super::PropertyValue {
                 display_string: "#aabbccff".into(),
-                value_string: "#aabbccff".into(),
                 code: "\"#aabbccff\"".into(),
                 kind: super::PropertyValueKind::Color,
                 value_brush: slint::Brush::SolidColor(slint::Color::from_argb_u8(

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -131,7 +131,8 @@ export struct PropertyValue {
     display-string: string, // ALLWAYS, its a string description of what is there
     value-bool: bool, // boolean
     is-translatable: bool, // string
-    kind: PropertyValueKind,
+    kind: PropertyValueKind, // Defines what to display this as
+    value-kind: PropertyValueKind, // If kind == code, then this is the real kind of data
     brush-kind: BrushKind, // brush
     gradient-stops: [GradientStop], // brush
     value-brush: brush, // brush, color


### PR DESCRIPTION
Reuse the new eval code when collecting values, removing about 200 lines of code in total and bringing the property editor onto the same base as the palette. This gives somewhat better values and handles use of palette elements, too.

Fixes quite a few issues we had in the UI for brushes and palettes when used from the Property Editor.