### PR TITLE
POC for letting VScode open the browser help for basic elements

### DIFF
--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -204,10 +204,7 @@ export function activate(
                 if (getHelpUrlForElement(word)) {
                     vscode.commands.executeCommand("slint.openHelp");
                     // This code ensures an underline appears when CTRL is held down.
-                    return new vscode.Location(
-                        document.uri,
-                        new vscode.Position(0, 0),
-                    );
+                    return new vscode.Location(document.uri, position);
                 }
 
                 return null;

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -306,7 +306,6 @@ async function maybeSendStartupTelemetryEvent(
 const HELP_URL = "https://docs.slint.dev/latest/docs/slint/reference/";
 
 function getHelpUrlForElement(elementName: string): string | null {
-
     const helpMapping: { [key: string]: string } = {
         // elements
         Image: `${HELP_URL}elements/image/`,

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -306,35 +306,32 @@ async function maybeSendStartupTelemetryEvent(
 const HELP_URL = "https://docs.slint.dev/latest/docs/slint/reference/";
 
 function getHelpUrlForElement(elementName: string): string | null {
-    const helpMapping: { [key: string]: string } = {
+    const elementPaths: Record<string, string> = {
         // elements
-        Image: `${HELP_URL}elements/image/`,
-        Path: `${HELP_URL}elements/path/`,
-        Text: `${HELP_URL}elements/text/`,
-        Rectangle: `${HELP_URL}elements/rectangle/`,
-
+        Image: "elements/image",
+        Path: "elements/path",
+        Text: "elements/text",
+        Rectangle: "elements/rectangle",
         // gestures
-        Flickable: `${HELP_URL}gestures/flickable/`,
-        SwipeGestureHandler: `${HELP_URL}gestures/swipegesturehandler/`,
-        TouchArea: `${HELP_URL}gestures/toucharea/`,
-
+        Flickable: "gestures/flickable",
+        SwipeGestureHandler: "gestures/swipegesturehandler",
+        TouchArea: "gestures/toucharea",
         // keyboard-input
-        FocusScope: `${HELP_URL}keyboard-input/focusscope/`,
-        TextInput: `${HELP_URL}keyboard-input/textinput/`,
-        TextInputInterface: `${HELP_URL}keyboard-input/textinputinterface/`,
-
+        FocusScope: "keyboard-input/focusscope",
+        TextInput: "keyboard-input/textinput",
+        TextInputInterface: "keyboard-input/textinputinterface",
         // layouts
-        GridLayout: `${HELP_URL}layouts/gridlayout/`,
-        HorizontalLayout: `${HELP_URL}layouts/horizontallayout/`,
-        VerticalLayout: `${HELP_URL}layouts/verticallayout/`,
-
+        GridLayout: "layouts/gridlayout",
+        HorizontalLayout: "layouts/horizontallayout",
+        VerticalLayout: "layouts/verticallayout",
         // window
-        ContextMenuArea: `${HELP_URL}window/contextmenuarea/`,
-        Dialog: `${HELP_URL}window/dialog/`,
-        MenuBar: `${HELP_URL}window/menubar/`,
-        PopupWindow: `${HELP_URL}window/popupwindow/`,
-        Window: `${HELP_URL}window/window/`,
+        ContextMenuArea: "window/contextmenuarea",
+        Dialog: "window/dialog",
+        MenuBar: "window/menubar",
+        PopupWindow: "window/popupwindow",
+        Window: "window/window",
     };
 
-    return helpMapping[elementName] || null;
+    const path = elementPaths[elementName];
+    return path ? `${HELP_URL}${path}/` : null;
 }

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -293,7 +293,7 @@ async function maybeSendStartupTelemetryEvent(
     telemetryLogger.logUsage("extension-activated", usageData);
 }
 
-const HELP_URL = "https://docs.slint.dev/latest/docs/slint/reference/";
+const HELP_URL = "https://snapshots.slint.dev/master/docs/slint/reference/";
 
 function getHelpUrlForElement(elementName: string): string | null {
     const elementPaths: Record<string, string> = {


### PR DESCRIPTION
This allows the user to CTRL/CMD click on a basic element like 'Rectangle' or 'Text' and have the browser be opened to the correct help page.

There are many other ways this type of functionality could be done and probably in ways any editor using the Slint LSP can take advantage of. VScode also has multiple types of help, including the on-hover inline help system. But these all require more effort to support, including generating the right markdown files or teaching the LSP about the help. While this simple tweak gives a bit of extra help access to VScode users right away.