### PR TITLE
Fix build on QNX

### DIFF
--- a/internal/common/Cargo.toml
+++ b/internal/common/Cargo.toml
@@ -30,4 +30,7 @@ cfg-if = { version = "1", optional = true }
 libloading = { version = "0.8.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-fontdb = { workspace = true, optional = true, default-features = true }
+fontdb = { workspace = true, optional = true, features = ["std", "fs", "fontconfig"] }
+
+[target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "nto")))'.dependencies]
+fontdb = { workspace = true, optional = true, features = ["memmap"] }


### PR DESCRIPTION
- The memmap2 dependecy doesn't compile on QNX, so disable fontdb's memmap feature on QNX (besides WASM)
- Assume the availability of the Noto Sans font from the fonts system package

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
