### PR TITLE
live-preview: Palette polish

### DIFF
--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1625,6 +1625,7 @@ fn set_selected_element(
     let element_node = selection.as_ref().and_then(|s| s.as_element_node());
     let notify_editor_about_selection_after_update =
         editor_notification == SelectionNotification::AfterUpdate;
+
     PREVIEW_STATE.with(move |preview_state| {
         let mut preview_state = preview_state.borrow_mut();
 
@@ -1684,6 +1685,9 @@ fn set_selected_element(
                         ))
                     })
                 {
+                    let palettes = ui::palette::collect_palette(&document_cache, &uri);
+                    ui::palette::set_palette(ui, palettes);
+
                     let in_layout = match parent_layout_kind {
                         ui::LayoutKind::None => properties::LayoutKind::None,
                         ui::LayoutKind::Horizontal => properties::LayoutKind::HorizontalBox,

--- a/tools/lsp/preview/ui/palette.rs
+++ b/tools/lsp/preview/ui/palette.rs
@@ -190,6 +190,12 @@ fn collect_palette_from_globals(
     values
 }
 
+fn is_css_color(code: slint::SharedString) -> bool {
+    let code = code.to_string();
+    let code = code.strip_prefix("Colors.").unwrap_or(&code);
+    i_slint_compiler::lookup::named_colors().contains_key(code)
+}
+
 fn filter_palettes(
     input: slint::ModelRc<ui::PaletteEntry>,
     pattern: slint::SharedString,
@@ -197,12 +203,6 @@ fn filter_palettes(
     let pattern = pattern.to_string();
     std::rc::Rc::new(slint::VecModel::from(filter_palettes_iter(&mut input.iter(), &pattern)))
         .into()
-}
-
-fn is_css_color(code: slint::SharedString) -> bool {
-    let code = code.to_string();
-    let code = code.strip_prefix("Colors.").unwrap_or(&code);
-    i_slint_compiler::lookup::named_colors().contains_key(code)
 }
 
 fn filter_palettes_iter(

--- a/tools/lsp/ui/components/widgets/floating-brush-picker-widget.slint
+++ b/tools/lsp/ui/components/widgets/floating-brush-picker-widget.slint
@@ -469,7 +469,7 @@ component ColorPicker inherits DraggablePanel {
     }
 
     if active-tab == PickerTab.css-color: CssColorPicker {
-        filter-text: "^Colors.";
+        filter-text: "^Colors. '%is_brush:yes ";
     }
 
     if active-tab == PickerTab.color && widget-mode == WidgetMode.edit: Button {
@@ -492,7 +492,7 @@ component ColorPicker inherits DraggablePanel {
     }
 
     if active-tab == PickerTab.globals: CssColorPicker {
-        property <string> filter-brush-and-color: "!^Colors. ";
+        property <string> filter-brush-and-color: "!^Colors. '%is_brush:yes ";
         property <string> filter-color-only: "!^Colors. '%kind:Color ";
         filter-text: picker-mode == BrushPropertyType.brush ? filter-brush-and-color : filter-color-only;
     }


### PR DESCRIPTION
A couple of small changes to address the issues raised in #8596.

This filters out non-brushes and refreshes palettes to those visible to the actual selected object.