### PR TITLE
live-preview: Add warning about missing panics doc to eval.rs

### DIFF
--- a/tools/lsp/fmt/tool.rs
+++ b/tools/lsp/fmt/tool.rs
@@ -128,6 +128,6 @@ fn visit_node(node: SyntaxNode, file: &mut impl Write) -> std::io::Result<()> {
         let mut writer = writer::FileWriter { file };
         fmt::format_document(doc, &mut writer)
     } else {
-        Err(std::io::Error::new(std::io::ErrorKind::Other, "Not a Document"))
+        Err(std::io::Error::other("Not a Document"))
     }
 }

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -453,12 +453,8 @@ pub fn filter_sort_selection_stack(
             SelectionStackFilter::Interactive => frame.is_interactive,
             SelectionStackFilter::Others => !frame.is_interactive && !frame.is_layout,
             SelectionStackFilter::LayoutsAndInteractive => frame.is_layout || frame.is_interactive,
-            SelectionStackFilter::LayoutsAndOthers => {
-                frame.is_layout || (!frame.is_layout && !frame.is_interactive)
-            }
-            SelectionStackFilter::InteractiveAndOthers => {
-                frame.is_interactive || (!frame.is_layout && !frame.is_interactive)
-            }
+            SelectionStackFilter::LayoutsAndOthers => frame.is_layout || !frame.is_interactive,
+            SelectionStackFilter::InteractiveAndOthers => frame.is_interactive || !frame.is_layout,
             SelectionStackFilter::Everything => true,
         }
     }

--- a/tools/lsp/preview/eval.rs
+++ b/tools/lsp/preview/eval.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+#![deny(clippy::missing_panics_doc)]
+
 use std::collections::HashMap;
 
 use smol_str::SmolStr;
@@ -202,16 +204,10 @@ fn eval_expression(
         }
         Expression::MinMax { ty: _, op, lhs, rhs } => {
             let Value::Number(lhs) = eval_expression(lhs, local_context) else {
-                return local_context
-                    .return_value
-                    .clone()
-                    .expect("minmax lhs expression did not evaluate to number");
+                return local_context.return_value.clone().unwrap_or_default();
             };
             let Value::Number(rhs) = eval_expression(rhs, local_context) else {
-                return local_context
-                    .return_value
-                    .clone()
-                    .expect("minmax rhs expression did not evaluate to number");
+                return local_context.return_value.clone().unwrap_or_default();
             };
             match op {
                 expression_tree::MinMaxOp::Min => Value::Number(lhs.min(rhs)),
@@ -222,7 +218,7 @@ fn eval_expression(
     }
 }
 
-/// Tries to evaluate a `syntax_nodes::BindingExpression` into an `slint_interpreter::Value`
+/// Tries to evaluate a `syntax_nodes::Expression` into an `slint_interpreter::Value`
 ///
 /// This has no access to any runtime information, so the evaluation is an approximation to the
 /// real value only.


### PR DESCRIPTION
That is supposed to help catch some cases where functions panic, but it missed the two `expect(...)` calls, so it is definitely not a complete solution.

I'd love to fuzz this, but AFAICT `rowan` does not support the `arbitrary` crate, so I can not have the fuzzer create random Expressions as input.

Fix the few clippy warnings in the LSP.