### PR TITLE
live-preview: Have a handler for `debug(...)` in slint code

### DIFF
--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -957,6 +957,15 @@ pub struct ComponentDefinition {
 }
 
 impl ComponentDefinition {
+    /// Set a `debug(...)` handler
+    pub fn set_debug_handler(
+        &self,
+        handler: Rc<dyn Fn(&Option<i_slint_compiler::diagnostics::SourceLocation>, &str)>,
+        _: i_slint_core::InternalToken,
+    ) {
+        generativity::make_guard!(guard);
+        *self.inner.unerase(guard).debug_handler.borrow_mut() = handler;
+    }
     /// Creates a new instance of the component and returns a shared handle to it.
     pub fn create(&self) -> Result<ComponentInstance, PlatformError> {
         generativity::make_guard!(guard);

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -414,6 +414,10 @@ pub struct ItemTreeDescription<'id> {
     #[cfg(feature = "internal-highlight")]
     pub(crate) raw_type_loader:
         std::cell::OnceCell<Option<std::rc::Rc<i_slint_compiler::typeloader::TypeLoader>>>,
+
+    pub(crate) debug_handler: std::cell::RefCell<
+        Rc<dyn Fn(&Option<i_slint_compiler::diagnostics::SourceLocation>, &str)>,
+    >,
 }
 
 #[derive(Clone, derive_more::From)]
@@ -1379,6 +1383,9 @@ pub(crate) fn generate_item_tree<'id>(
         type_loader: std::cell::OnceCell::new(),
         #[cfg(feature = "internal-highlight")]
         raw_type_loader: std::cell::OnceCell::new(),
+        debug_handler: std::cell::RefCell::new(Rc::new(|_, text| {
+            i_slint_core::debug_log!("{text}")
+        })),
     };
 
     Rc::new(t)

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -204,7 +204,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
             }
             v
         }
-        Expression::FunctionCall { function, arguments, source_location: _ } => match &function {
+        Expression::FunctionCall { function, arguments, source_location } => match &function {
             Callable::Function(nr) => {
                 let is_item_member = nr.element().borrow().native_class().is_some_and(|n| n.properties.contains_key(nr.name()));
                 if is_item_member {
@@ -218,7 +218,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 let args = arguments.iter().map(|e| eval_expression(e, local_context)).collect::<Vec<_>>();
                 invoke_callback(&ComponentInstance::InstanceRef(local_context.component_instance), &nr.element(), nr.name(), &args).unwrap()
             }
-            Callable::Builtin(f) => call_builtin_function(f.clone(), arguments, local_context),
+            Callable::Builtin(f) => call_builtin_function(f.clone(), arguments, local_context, source_location),
         }
         Expression::SelfAssignment { lhs, rhs, op, .. } => {
             let rhs = eval_expression(rhs, local_context);
@@ -406,6 +406,7 @@ fn call_builtin_function(
     f: BuiltinFunction,
     arguments: &[Expression],
     local_context: &mut EvalLocalContext,
+    source_location: &Option<i_slint_compiler::diagnostics::SourceLocation>,
 ) -> Value {
     match f {
         BuiltinFunction::GetWindowScaleFactor => Value::Number(
@@ -422,7 +423,10 @@ fn call_builtin_function(
         BuiltinFunction::Debug => {
             let to_print: SharedString =
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
-            corelib::debug_log!("{}", to_print);
+            local_context.component_instance.description.debug_handler.borrow()(
+                source_location,
+                &to_print,
+            );
             Value::Void
         }
         BuiltinFunction::Mod => {

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -28,6 +28,37 @@ slint::include_modules!();
 
 pub type PropertyDeclarations = HashMap<SmolStr, PropertyDeclaration>;
 
+pub fn append_debug_log_message(
+    ui: &PreviewUi,
+    location: Option<(lsp_types::Url, usize, usize)>,
+    message: &str,
+) {
+    let api = ui.global::<Api>();
+
+    let log_model = api.get_log_output();
+    let Some(log_model) = log_model.as_any().downcast_ref::<VecModel<LogMessage>>() else {
+        return;
+    };
+
+    let location = location
+        .map(|(url, line, column)| (url.to_shared_string(), line, column))
+        .unwrap_or_default();
+
+    log_model.push(LogMessage {
+        file_url: location.0,
+        line: location.1 as i32,
+        column: location.2 as i32,
+        message: message.into(),
+        level: LogMessageLevel::Debug,
+    });
+}
+
+pub fn clear_debug_log(ui: &PreviewUi) {
+    let api = ui.global::<Api>();
+
+    api.set_log_output(Rc::new(VecModel::default()).into());
+}
+
 pub fn create_ui(style: String, experimental: bool) -> Result<PreviewUi, PlatformError> {
     let ui = PreviewUi::new()?;
 

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -223,6 +223,20 @@ export struct PaletteEntry {
     value: PropertyValue,
 }
 
+export enum LogMessageLevel {
+    Debug,
+    Warning,
+    Error,
+}
+
+export struct LogMessage {
+    file_url: string,
+    line: int,
+    column: int,
+    message: string,
+    level: LogMessageLevel,
+}
+
 export global Api {
     // # Properties
     // ## General preview state:
@@ -253,6 +267,9 @@ export global Api {
     in-out property <string> current-style;
     // control, but command on macOS
     in-out property <string> control-key-name: "control";
+
+    // ## Log Output
+    in-out property <[LogMessage]> log-output;
 
     // ## Drawing Area
     // Borders around things

--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -1,0 +1,27 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { TextEdit, ScrollView } from "std-widgets.slint";
+import { Api, LogMessageLevel } from "../api.slint";
+
+export component ConsolePanel {
+    ScrollView {
+        height: Api.log-output.length == 0 ? 0px : 100px;
+
+        VerticalLayout {
+            for lm in Api.log-output: Rectangle {
+                height: 30px;
+
+                Text {
+                    text: lm.message;
+                    color: lm.level == LogMessageLevel.Debug ? Colors.black : Colors.red;
+                }
+                if !lm.file_url.is-empty: TouchArea {
+                    clicked => {
+                        Api.show-document(lm.file-url, lm.line, lm.column);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -19,6 +19,7 @@ import { ColorPickerView } from "components/widgets/floating-brush-picker-widget
 import { TableEditorView } from "components/spreadsheet-dialog.slint";
 import "./assets/Inter-VariableFont.ttf";
 import "./assets/SourceCodePro-Medium.ttf";
+import { ConsolePanel } from "components/console-panel.slint";
 
 export { Api }
 
@@ -145,6 +146,8 @@ export component PreviewUi inherits Window {
                     }
 
                 }
+
+                ConsolePanel { }
 
                 StatusLine { }
             }


### PR DESCRIPTION
Allow to have a handler for `debug(...)` in slint code when running in the interpreter.

When the live-preview is active, print the debug output prefixed with "DEBUG>" and show the debug messages in the UI.

This makes it unnecessary to ask people to look at the console in Slintpad.