### PR TITLE
live-preview: Simplify hide/show handling

### DIFF
--- a/tools/lsp/preview/wasm.rs
+++ b/tools/lsp/preview/wasm.rs
@@ -118,10 +118,6 @@ impl PreviewConnector {
 
     #[wasm_bindgen]
     pub fn show_ui(&self) -> Result<js_sys::Promise, JsValue> {
-        super::PREVIEW_STATE.with(|preview_state| {
-            let mut preview_state = preview_state.borrow_mut();
-            preview_state.ui_is_visible = true;
-        });
         invoke_from_event_loop_wrapped_in_promise(|instance| instance.show())
     }
 


### PR DESCRIPTION
Get rid of the `ui_is_visible` flag. That made more sense when it was in the contents cache wich allowed for multi-threaded access. When that changed, the flag moved next to `ui`, so it makes no sense to keep anymore.
