### PR TITLE
Update C++ MSRV

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -22,7 +22,7 @@ if (NOT Corrosion_FOUND)
 endif (NOT Corrosion_FOUND)
 
 list(PREPEND CMAKE_MODULE_PATH ${Corrosion_SOURCE_DIR}/cmake)
-find_package(Rust 1.82 REQUIRED MODULE)
+find_package(Rust 1.85 REQUIRED MODULE)
 
 option(BUILD_SHARED_LIBS "Build Slint as shared library" ON)
 option(SLINT_FEATURE_COMPILER "Enable support for compiling .slint files to C++ ahead of time" ON)

--- a/api/cpp/docs/cmake.md
+++ b/api/cpp/docs/cmake.md
@@ -49,7 +49,7 @@ In the next section you will learn how to use the installed library in your appl
 First you need to install the prerequisites:
 
 * Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). If you already
-  have Rust installed, make sure that it's at least version 1.82 or newer. You can check which version you have installed
+  have Rust installed, make sure that it's at least version 1.85 or newer. You can check which version you have installed
   by running `rustc --version`. Once this is done, you should have the `rustc` compiler and the `cargo` build system installed in your path.
 
 You can either choose to compile Slint from source along with your application or include Slint as an external CMake package.

--- a/api/cpp/docs/mcu/generic.md
+++ b/api/cpp/docs/mcu/generic.md
@@ -9,7 +9,7 @@ following generic instructions on what's needed to compile and use Slint.
 ## Prerequisites
 
 * Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). If you already
-  have Rust installed, make sure that it's at least version 1.82 or newer. You can check which version you have installed
+  have Rust installed, make sure that it's at least version 1.85 or newer. You can check which version you have installed
   by running `rustc --version`. Once this is done, you should have the `rustc` compiler and the `cargo` build system installed in your path.
 
 * A C++ cross-compiler compiler that supports C++20.


### PR DESCRIPTION
Because some crate in our examples are using the edition2024 resolver with no way to remove them without removing the exmaples from the workspace, this means that effectively the C++ build which needs to run the cargo metadata on the workspace, doens't build anymore with the rust MSRV

ChangeLog: C++: requires Rust 1.85
