### PR TITLE
interpreter: Recursively set the debug_handler on all components

### DIFF
--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -962,7 +962,7 @@ impl ComponentDefinition {
     #[cfg(feature = "internal")]
     pub fn set_debug_handler(
         &self,
-        handler: impl Fn(&Option<i_slint_compiler::diagnostics::SourceLocation>, &str) + 'static,
+        handler: impl Fn(Option<&i_slint_compiler::diagnostics::SourceLocation>, &str) + 'static,
         _: i_slint_core::InternalToken,
     ) {
         let handler = Rc::new(handler);

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -966,7 +966,7 @@ impl ComponentDefinition {
         _: i_slint_core::InternalToken,
     ) {
         generativity::make_guard!(guard);
-        let handler = Box::new(handler);
+        let handler = Rc::new(handler);
         *self.inner.unerase(guard).debug_handler.borrow_mut() = handler;
     }
     /// Creates a new instance of the component and returns a shared handle to it.

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -965,9 +965,10 @@ impl ComponentDefinition {
         handler: impl Fn(&Option<i_slint_compiler::diagnostics::SourceLocation>, &str) + 'static,
         _: i_slint_core::InternalToken,
     ) {
-        generativity::make_guard!(guard);
         let handler = Rc::new(handler);
-        *self.inner.unerase(guard).debug_handler.borrow_mut() = handler;
+
+        generativity::make_guard!(guard);
+        self.inner.unerase(guard).recursively_set_debug_handler(handler);
     }
     /// Creates a new instance of the component and returns a shared handle to it.
     pub fn create(&self) -> Result<ComponentInstance, PlatformError> {

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -703,6 +703,18 @@ impl ItemTreeDescription<'_> {
         let g = extra_data.globals.get().unwrap().get(global_name).clone();
         g.ok_or(())
     }
+
+    pub fn recursively_set_debug_handler(
+        &self,
+        handler: Rc<dyn Fn(&Option<i_slint_compiler::diagnostics::SourceLocation>, &str)>,
+    ) {
+        *self.debug_handler.borrow_mut() = handler.clone();
+
+        for r in &self.repeater {
+            generativity::make_guard!(guard);
+            r.unerase(guard).item_tree_to_repeat.recursively_set_debug_handler(handler.clone());
+        }
+    }
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -416,7 +416,7 @@ pub struct ItemTreeDescription<'id> {
         std::cell::OnceCell<Option<std::rc::Rc<i_slint_compiler::typeloader::TypeLoader>>>,
 
     pub(crate) debug_handler: std::cell::RefCell<
-        Rc<dyn Fn(&Option<i_slint_compiler::diagnostics::SourceLocation>, &str)>,
+        Rc<dyn Fn(Option<&i_slint_compiler::diagnostics::SourceLocation>, &str)>,
     >,
 }
 
@@ -706,7 +706,7 @@ impl ItemTreeDescription<'_> {
 
     pub fn recursively_set_debug_handler(
         &self,
-        handler: Rc<dyn Fn(&Option<i_slint_compiler::diagnostics::SourceLocation>, &str)>,
+        handler: Rc<dyn Fn(Option<&i_slint_compiler::diagnostics::SourceLocation>, &str)>,
     ) {
         *self.debug_handler.borrow_mut() = handler.clone();
 

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -416,7 +416,7 @@ pub struct ItemTreeDescription<'id> {
         std::cell::OnceCell<Option<std::rc::Rc<i_slint_compiler::typeloader::TypeLoader>>>,
 
     pub(crate) debug_handler: std::cell::RefCell<
-        Box<dyn Fn(&Option<i_slint_compiler::diagnostics::SourceLocation>, &str)>,
+        Rc<dyn Fn(&Option<i_slint_compiler::diagnostics::SourceLocation>, &str)>,
     >,
 }
 
@@ -1372,7 +1372,7 @@ pub(crate) fn generate_item_tree<'id>(
         type_loader: std::cell::OnceCell::new(),
         #[cfg(feature = "internal-highlight")]
         raw_type_loader: std::cell::OnceCell::new(),
-        debug_handler: std::cell::RefCell::new(Box::new(|_, text| {
+        debug_handler: std::cell::RefCell::new(Rc::new(|_, text| {
             i_slint_core::debug_log!("{text}")
         })),
     };

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -424,7 +424,7 @@ fn call_builtin_function(
             let to_print: SharedString =
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
             local_context.component_instance.description.debug_handler.borrow()(
-                source_location,
+                source_location.as_ref(),
                 &to_print,
             );
             Value::Void


### PR DESCRIPTION
This unbreaks things like this:

```slint
component Test {
    init => {
        debug("This shows up in the console");
    }
    if true: Rectangle {
        init() => {
            debug("This does *NOT* show up");
        }
    }
}
```
    
