### PR TITLE
C++: generate a .zip for the package

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -577,7 +577,7 @@ jobs:
               run: |
                   ls -l
                   mkdir artifacts
-                  mv Slint-cpp-*-win64*.exe artifacts/
+                  mv Slint-cpp-*-win64* artifacts/
                   mv Slint-cpp-*.tar.gz artifacts/
                   mv slint-viewer-linux.tar.gz artifacts/
                   mv slint-viewer-armv7-unknown-linux-gnueabihf.tar.gz artifacts/

--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -495,6 +495,7 @@ if(EXISTS "${CMAKE_BINARY_DIR}/licenses")
 endif()
 
 if(WIN32)
+    set(CPACK_GENERATOR "NSIS;ZIP")
     if(MSVC)
         set(compiler_suffix "-MSVC")
     elseif(MINGW)


### PR DESCRIPTION
For #8665

(untested)

I'm not sure if we should really do this.