### PR TITLE
live-preview: auto-clear log message after parsing

### DIFF
--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1402,17 +1402,17 @@ async fn reload_preview_impl(
 
     let loaded_component_name = compiled.as_ref().map(|c| c.name().to_string());
 
-    {
-        PREVIEW_STATE.with(|preview_state| {
-            let preview_state = preview_state.borrow_mut();
-
-            if let Some(ui) = &preview_state.ui {
-                ui::set_diagnostics(ui, &diagnostics);
+    PREVIEW_STATE.with_borrow_mut(|preview_state| {
+        if let Some(ui) = &preview_state.ui {
+            let api = ui.global::<ui::Api>();
+            if api.get_auto_clear_console() {
+                ui::log_messages::clear_log_messages_impl(ui);
             }
-        });
-        let diags = convert_diagnostics(&diagnostics, &source_file_versions.borrow());
-        notify_diagnostics(diags);
-    }
+            ui::set_diagnostics(ui, &diagnostics);
+        }
+    });
+    let diags = convert_diagnostics(&diagnostics, &source_file_versions.borrow());
+    notify_diagnostics(diags);
 
     update_preview_area(compiled, behavior, open_import_fallback, source_file_versions)?;
 

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -575,4 +575,5 @@ export global Api {
     // Console / LogMessages
     pure callback filter-log-messages(messages: [LogMessage], pattern: string) -> [LogMessage];
     callback clear-log-messages();
+    in-out property <bool> auto-clear-console: true;
 }

--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -185,7 +185,7 @@ export component ConsolePanel inherits SimpleColumn {
                 width: 6px;
             }
             Switch {
-                checked <=> WindowManager.auto-clear-console;
+                checked <=> Api.auto-clear-console;
             }
             Rectangle {
                 width: 10px;

--- a/tools/lsp/ui/windowglobal.slint
+++ b/tools/lsp/ui/windowglobal.slint
@@ -305,7 +305,6 @@ export global WindowManager {
     out property <PropertyInformation> current-property-information;
     in-out property <string> current-property-container-id;
     in-out property <PreviewData> current-preview-data;
-    in-out property <bool> auto-clear-console: true;
     property component-factory <=> Api.preview-data;
 
     property <string> possible_error;
@@ -321,12 +320,6 @@ export global WindowManager {
     callback update-brush-preview();
     callback show-color-stop-picker();
     callback hide-color-stop-picker();
-
-    changed component-factory => {
-        if auto-clear-console {
-            Api.clear-log-messages();
-        }
-    }
 
     show-floating-widget(property-information, element-information) => {
         widget-mode = WidgetMode.edit;


### PR DESCRIPTION
... instead of after the view was updated.

So that we don't see the errors prom a previous parse, and we don't miss the debug from init callback
