### PR TITLE
Fix Typo in Support Comment for Async Usage in WGPU Renderer

### DIFF
--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -143,7 +143,7 @@ impl FemtoVGRenderer<WGPUBackend> {
                 i_slint_core::graphics::wgpu_24::WGPUConfiguration::Automatic(wgpu24_settings),
             )) => {
                 // wgpu uses async here, but the returned future is ready on first poll on all platforms except WASM,
-                // which we don't supoprt right now.
+                // which we don't support right now.
                 let instance = poll_once(async {
                     wgpu::util::new_instance_with_webgpu_detection(&wgpu::InstanceDescriptor {
                         backends: wgpu24_settings.backends,
@@ -157,7 +157,7 @@ impl FemtoVGRenderer<WGPUBackend> {
                 let surface = instance.create_surface(window_handle).unwrap();
 
                 // wgpu uses async here, but the returned future is ready on first poll on all platforms except WASM,
-                // which we don't supoprt right now.
+                // which we don't support right now.
                 let adapter = poll_once(async {
                     match wgpu::util::initialize_adapter_from_env(&instance, Some(&surface)) {
                         Some(adapter) => Some(adapter),
@@ -202,7 +202,7 @@ impl FemtoVGRenderer<WGPUBackend> {
                 let gles_minor_version = wgpu::Gles3MinorVersion::from_env().unwrap_or_default();
 
                 // wgpu uses async here, but the returned future is ready on first poll on all platforms except WASM,
-                // which we don't supoprt right now.
+                // which we don't support right now.
                 let instance = poll_once(async {
                     wgpu::util::new_instance_with_webgpu_detection(&wgpu::InstanceDescriptor {
                         backends,
@@ -221,7 +221,7 @@ impl FemtoVGRenderer<WGPUBackend> {
                 let surface = instance.create_surface(window_handle).unwrap();
 
                 // wgpu uses async here, but the returned future is ready on first poll on all platforms except WASM,
-                // which we don't supoprt right now.
+                // which we don't support right now.
                 let adapter = poll_once(async {
                     wgpu::util::initialize_adapter_from_env_or_default(&instance, Some(&surface))
                         .await


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the comments within the `femtovg/wgpu.rs` file. The word "support" was previously misspelled as "suport" in three locations. The comments clarify that async usage in wgpu is not currently supported except on WASM platforms. No functional code changes are included; this is a documentation/comment-only update to improve code clarity.