### PR TITLE
live-preview: Fix stack overflow when there is a binding loop

### DIFF
--- a/tools/lsp/preview/ui/property_view.rs
+++ b/tools/lsp/preview/ui/property_view.rs
@@ -1230,4 +1230,30 @@ component Abc {
         assert_eq!(result.value_kind, ui::PropertyValueKind::Brush);
         assert_eq!(result.brush_kind, ui::BrushKind::Linear);
     }
+
+    #[test]
+    fn test_property_recursion() {
+        let result = property_conversion_test(
+            r#"export component Test { in property <int> test1 : test1 + 1; }"#,
+            0,
+        );
+
+        assert_eq!(result.value_kind, ui::PropertyValueKind::Integer);
+        assert_eq!(result.kind, ui::PropertyValueKind::Code);
+        assert_eq!(result.value_int, 0);
+        assert_eq!(result.code, "test1 + 1");
+
+        let result = property_conversion_test(
+            r#"export component Test {
+                in property <int> test1: test2;
+                in property <float> test2: test1;
+            }"#,
+            1,
+        );
+
+        assert_eq!(result.value_kind, ui::PropertyValueKind::Integer);
+        assert_eq!(result.kind, ui::PropertyValueKind::Integer);
+        assert_eq!(result.value_int, 0);
+        assert_eq!(result.code, "test2");
+    }
 }


### PR DESCRIPTION
Since the eval code might run before the binding analysis, we'd get a stack overflow if there is a loop.

Protect against that by having a limit of property call we can do.

Also we shouldn't re-use the same local variable and return value for a different property binding
