### PR TITLE
figma-inspector: missed using the values from old variable named mode…

### DIFF
--- a/tools/figma-inspector/backend/utils/export-variables.ts
+++ b/tools/figma-inspector/backend/utils/export-variables.ts
@@ -395,7 +395,10 @@ function generateStructsAndInstances(
                         >(),
                     };
 
-                    const rowNameKey = sanitizedChildName;
+                    const rowNameKey =
+                        childName === "mode" && hasRootModeVariable
+                            ? sanitizePropertyName("mode") // Use original "mode" for lookup
+                            : sanitizedChildName; // Use normal sanitized name for others
                     const resolvedVariableModesMap =
                         collectionData.variables.get(rowNameKey);
 


### PR DESCRIPTION
… when renaming to 'mode-var'
fixes bug caught by @NigelBreslaw in 
https://www.figma.com/community/file/1385659531316001292

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
