### PR TITLE
figma-inspector: corrected some erroneous mode value logic

### DIFF
--- a/tools/figma-inspector/backend/utils/export-variables.ts
+++ b/tools/figma-inspector/backend/utils/export-variables.ts
@@ -68,8 +68,8 @@ export function sanitizePropertyName(name: string): string {
         .replace(/[^a-zA-Z0-9\-]/g, "-") // Replace non-alphanumeric chars (except hyphens) with hyphens
         .replace(/-+/g, "-"); // Collapse multiple hyphens to single hyphen
 
-    // Remove trailing hyphens
-    sanitizedName = sanitizedName.replace(/-+$/, "");
+    // Remove leading and trailing hyphens
+    sanitizedName = sanitizedName.replace(/^-+/, "").replace(/-+$/, "");
 
     // Check if starts with a digit AFTER other sanitization
     if (/^\d/.test(sanitizedName)) {


### PR DESCRIPTION
errors were coming out of 
https://www.figma.com/design/WrUbJ4SxCOIQEUtUW7Mj5m/Get-started-with-variables--Community-?node-id=85-2707&t=dhXSh8430B0RujUd-0

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
