### PR TITLE
core: Revert the change to use "C-unwind" calling convention

### DIFF
--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -24,12 +24,12 @@ mod svg;
 #[vtable::vtable]
 #[repr(C)]
 pub struct OpaqueImageVTable {
-    drop_in_place: extern "C-unwind" fn(VRefMut<OpaqueImageVTable>) -> Layout,
-    dealloc: extern "C-unwind" fn(&OpaqueImageVTable, ptr: *mut u8, layout: Layout),
+    drop_in_place: extern "C" fn(VRefMut<OpaqueImageVTable>) -> Layout,
+    dealloc: extern "C" fn(&OpaqueImageVTable, ptr: *mut u8, layout: Layout),
     /// Returns the image size
-    size: extern "C-unwind" fn(VRef<OpaqueImageVTable>) -> IntSize,
+    size: extern "C" fn(VRef<OpaqueImageVTable>) -> IntSize,
     /// Returns a cache key
-    cache_key: extern "C-unwind" fn(VRef<OpaqueImageVTable>) -> ImageCacheKey,
+    cache_key: extern "C" fn(VRef<OpaqueImageVTable>) -> ImageCacheKey,
 }
 
 #[cfg(feature = "svg")]

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -48,7 +48,7 @@ pub struct ItemTreeVTable {
     /// Visit the children of the item at index `index`.
     /// Note that the root item is at index 0, so passing 0 would visit the item under root (the children of root).
     /// If you want to visit the root item, you need to pass -1 as an index.
-    pub visit_children_item: extern "C-unwind" fn(
+    pub visit_children_item: extern "C" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         index: isize,
         order: TraversalOrder,
@@ -56,17 +56,17 @@ pub struct ItemTreeVTable {
     ) -> VisitChildrenResult,
 
     /// Return a reference to an item using the given index
-    pub get_item_ref: extern "C-unwind" fn(
+    pub get_item_ref: extern "C" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         index: u32,
     ) -> core::pin::Pin<VRef<ItemVTable>>,
 
     /// Return the range of indices below the dynamic `ItemTreeNode` at `index`
     pub get_subtree_range:
-        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>, index: u32) -> IndexRange,
+        extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, index: u32) -> IndexRange,
 
     /// Return the `ItemTreeRc` at `subindex` below the dynamic `ItemTreeNode` at `index`
-    pub get_subtree: extern "C-unwind" fn(
+    pub get_subtree: extern "C" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         index: u32,
         subindex: usize,
@@ -76,8 +76,7 @@ pub struct ItemTreeVTable {
     /// Return the item tree that is defined by this `ItemTree`.
     /// The return value is an item weak because it can be null if there is no parent.
     /// And the return value is passed by &mut because ItemWeak has a destructor
-    pub get_item_tree:
-        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>) -> Slice<ItemTreeNode>,
+    pub get_item_tree: extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>) -> Slice<ItemTreeNode>,
 
     /// Return the node this ItemTree is a part of in the parent ItemTree.
     ///
@@ -85,38 +84,34 @@ pub struct ItemTreeVTable {
     /// And the return value is passed by &mut because ItemWeak has a destructor
     /// Note that the returned value will typically point to a repeater node, which is
     /// strictly speaking not an Item at all!
-    pub parent_node:
-        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>, result: &mut ItemWeak),
+    pub parent_node: extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, result: &mut ItemWeak),
 
     /// This embeds this ItemTree into the item tree of another ItemTree
     ///
     /// Returns `true` if this ItemTree was embedded into the `parent`
     /// at `parent_item_tree_index`.
-    pub embed_component: extern "C-unwind" fn(
+    pub embed_component: extern "C" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         parent: &VWeak<ItemTreeVTable>,
         parent_item_tree_index: u32,
     ) -> bool,
 
     /// Return the index of the current subtree or usize::MAX if this is not a subtree
-    pub subtree_index: extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>) -> usize,
+    pub subtree_index: extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>) -> usize,
 
     /// Returns the layout info for the root of the ItemTree
-    pub layout_info:
-        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>, Orientation) -> LayoutInfo,
+    pub layout_info: extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, Orientation) -> LayoutInfo,
 
     /// Returns the item's geometry (relative to its parent item)
     pub item_geometry:
-        extern "C-unwind" fn(core::pin::Pin<VRef<ItemTreeVTable>>, item_index: u32) -> LogicalRect,
+        extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, item_index: u32) -> LogicalRect,
 
     /// Returns the accessible role for a given item
-    pub accessible_role: extern "C-unwind" fn(
-        core::pin::Pin<VRef<ItemTreeVTable>>,
-        item_index: u32,
-    ) -> AccessibleRole,
+    pub accessible_role:
+        extern "C" fn(core::pin::Pin<VRef<ItemTreeVTable>>, item_index: u32) -> AccessibleRole,
 
     /// Returns the accessible property via the `result`. Returns true if such a property exists.
-    pub accessible_string_property: extern "C-unwind" fn(
+    pub accessible_string_property: extern "C" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         item_index: u32,
         what: AccessibleStringProperty,
@@ -124,37 +119,37 @@ pub struct ItemTreeVTable {
     ) -> bool,
 
     /// Executes an accessibility action.
-    pub accessibility_action: extern "C-unwind" fn(
+    pub accessibility_action: extern "C" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         item_index: u32,
         action: &AccessibilityAction,
     ),
 
     /// Returns the supported accessibility actions.
-    pub supported_accessibility_actions: extern "C-unwind" fn(
+    pub supported_accessibility_actions: extern "C" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         item_index: u32,
     ) -> SupportedAccessibilityAction,
 
     /// Add the `ElementName::id` entries of the given item
-    pub item_element_infos: extern "C-unwind" fn(
+    pub item_element_infos: extern "C" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         item_index: u32,
         result: &mut SharedString,
     ) -> bool,
 
     /// Returns a Window, creating a fresh one if `do_create` is true.
-    pub window_adapter: extern "C-unwind" fn(
+    pub window_adapter: extern "C" fn(
         core::pin::Pin<VRef<ItemTreeVTable>>,
         do_create: bool,
         result: &mut Option<WindowAdapterRc>,
     ),
 
     /// in-place destructor (for VRc)
-    pub drop_in_place: unsafe extern "C-unwind" fn(VRefMut<ItemTreeVTable>) -> vtable::Layout,
+    pub drop_in_place: unsafe extern "C" fn(VRefMut<ItemTreeVTable>) -> vtable::Layout,
 
     /// dealloc function (for VRc)
-    pub dealloc: unsafe extern "C-unwind" fn(&ItemTreeVTable, ptr: *mut u8, layout: vtable::Layout),
+    pub dealloc: unsafe extern "C" fn(&ItemTreeVTable, ptr: *mut u8, layout: vtable::Layout),
 }
 
 #[cfg(test)]
@@ -1059,14 +1054,14 @@ pub struct ItemVisitorVTable {
     /// as the parent's ItemTree.
     /// `index` is to be used again in the visit_item_children function of the ItemTree (the one passed as parameter)
     /// and `item` is a reference to the item itself
-    visit_item: extern "C-unwind" fn(
+    visit_item: extern "C" fn(
         VRefMut<ItemVisitorVTable>,
         item_tree: &VRc<ItemTreeVTable, vtable::Dyn>,
         index: u32,
         item: Pin<VRef<ItemVTable>>,
     ) -> VisitChildrenResult,
     /// Destructor
-    drop: extern "C-unwind" fn(VRefMut<ItemVisitorVTable>),
+    drop: extern "C" fn(VRefMut<ItemVisitorVTable>),
 }
 
 /// Type alias to `vtable::VRefMut<ItemVisitorVTable>`
@@ -1226,7 +1221,7 @@ pub(crate) mod ffi {
         index: isize,
         order: TraversalOrder,
         visitor: VRefMut<ItemVisitorVTable>,
-        visit_dynamic: extern "C-unwind" fn(
+        visit_dynamic: extern "C" fn(
             base: *const c_void,
             order: TraversalOrder,
             visitor: vtable::VRefMut<ItemVisitorVTable>,

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -119,7 +119,7 @@ pub struct ItemVTable {
     /// This function is called by the run-time after the memory for the item
     /// has been allocated and initialized. It will be called before any user specified
     /// bindings are set.
-    pub init: extern "C-unwind" fn(core::pin::Pin<VRef<ItemVTable>>, my_item: &ItemRc),
+    pub init: extern "C" fn(core::pin::Pin<VRef<ItemVTable>>, my_item: &ItemRc),
 
     /// offset in bytes from the *const ItemImpl.
     /// isize::MAX  means None
@@ -128,7 +128,7 @@ pub struct ItemVTable {
     pub cached_rendering_data_offset: usize,
 
     /// We would need max/min/preferred size, and all layout info
-    pub layout_info: extern "C-unwind" fn(
+    pub layout_info: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         orientation: Orientation,
         window_adapter: &WindowAdapterRc,
@@ -139,7 +139,7 @@ pub struct ItemVTable {
     /// Then, depending on the return value, it is called for the children, and their children, then
     /// [`Self::input_event`] is called on the children, and finally [`Self::input_event`] is called
     /// on this item again.
-    pub input_event_filter_before_children: extern "C-unwind" fn(
+    pub input_event_filter_before_children: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
         window_adapter: &WindowAdapterRc,
@@ -147,28 +147,28 @@ pub struct ItemVTable {
     ) -> InputEventFilterResult,
 
     /// Handle input event for mouse and touch event
-    pub input_event: extern "C-unwind" fn(
+    pub input_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         MouseEvent,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> InputEventResult,
 
-    pub focus_event: extern "C-unwind" fn(
+    pub focus_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &FocusEvent,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> FocusEventResult,
 
-    pub key_event: extern "C-unwind" fn(
+    pub key_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         &KeyEvent,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> KeyEventResult,
 
-    pub render: extern "C-unwind" fn(
+    pub render: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
         backend: &mut ItemRendererRef,
         self_rc: &ItemRc,

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -27,12 +27,11 @@ use vtable::{VRef, VRefMut};
 #[repr(C)]
 pub struct MenuVTable {
     /// destructor
-    drop: extern "C-unwind" fn(VRefMut<MenuVTable>),
+    drop: extern "C" fn(VRefMut<MenuVTable>),
     /// Return the list of items for the sub menu (or the main menu of parent is None)
-    sub_menu:
-        extern "C-unwind" fn(VRef<MenuVTable>, Option<&MenuEntry>, &mut SharedVector<MenuEntry>),
+    sub_menu: extern "C" fn(VRef<MenuVTable>, Option<&MenuEntry>, &mut SharedVector<MenuEntry>),
     /// Handler when the menu entry is activated
-    activate: extern "C-unwind" fn(VRef<MenuVTable>, &MenuEntry),
+    activate: extern "C" fn(VRef<MenuVTable>, &MenuEntry),
 }
 
 struct ShadowTreeNode {

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -718,7 +718,7 @@ impl ItemTreeDescription<'_> {
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn visit_children_item(
+extern "C" fn visit_children_item(
     component: ItemTreeRefPin,
     index: isize,
     order: TraversalOrder,
@@ -1859,10 +1859,7 @@ pub fn get_repeater_by_name<'a, 'id>(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn layout_info(
-    component: ItemTreeRefPin,
-    orientation: Orientation,
-) -> LayoutInfo {
+extern "C" fn layout_info(component: ItemTreeRefPin, orientation: Orientation) -> LayoutInfo {
     generativity::make_guard!(guard);
     // This is fine since we can only be called with a component that with our vtable which is a ItemTreeDescription
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
@@ -1893,7 +1890,7 @@ extern "C-unwind" fn layout_info(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-unsafe extern "C-unwind" fn get_item_ref(component: ItemTreeRefPin, index: u32) -> Pin<ItemRef> {
+unsafe extern "C" fn get_item_ref(component: ItemTreeRefPin, index: u32) -> Pin<ItemRef> {
     let tree = get_item_tree(component);
     match &tree[index as usize] {
         ItemTreeNode::Item { item_array_index, .. } => {
@@ -1909,7 +1906,7 @@ unsafe extern "C-unwind" fn get_item_ref(component: ItemTreeRefPin, index: u32) 
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn get_subtree_range(component: ItemTreeRefPin, index: u32) -> IndexRange {
+extern "C" fn get_subtree_range(component: ItemTreeRefPin, index: u32) -> IndexRange {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     if index as usize >= instance_ref.description.repeater.len() {
@@ -1939,7 +1936,7 @@ extern "C-unwind" fn get_subtree_range(component: ItemTreeRefPin, index: u32) ->
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn get_subtree(
+extern "C" fn get_subtree(
     component: ItemTreeRefPin,
     index: u32,
     subtree_index: usize,
@@ -1978,7 +1975,7 @@ extern "C-unwind" fn get_subtree(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn get_item_tree(component: ItemTreeRefPin) -> Slice<ItemTreeNode> {
+extern "C" fn get_item_tree(component: ItemTreeRefPin) -> Slice<ItemTreeNode> {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     let tree = instance_ref.description.item_tree.as_slice();
@@ -1986,7 +1983,7 @@ extern "C-unwind" fn get_item_tree(component: ItemTreeRefPin) -> Slice<ItemTreeN
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn subtree_index(component: ItemTreeRefPin) -> usize {
+extern "C" fn subtree_index(component: ItemTreeRefPin) -> usize {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     if let Ok(value) = instance_ref.description.get_property(component, SPECIAL_PROPERTY_INDEX) {
@@ -1997,7 +1994,7 @@ extern "C-unwind" fn subtree_index(component: ItemTreeRefPin) -> usize {
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-unsafe extern "C-unwind" fn parent_node(component: ItemTreeRefPin, result: &mut ItemWeak) {
+unsafe extern "C" fn parent_node(component: ItemTreeRefPin, result: &mut ItemWeak) {
     generativity::make_guard!(guard);
     let instance_ref = InstanceRef::from_pin_ref(component, guard);
 
@@ -2037,7 +2034,7 @@ unsafe extern "C-unwind" fn parent_node(component: ItemTreeRefPin, result: &mut 
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-unsafe extern "C-unwind" fn embed_component(
+unsafe extern "C" fn embed_component(
     component: ItemTreeRefPin,
     parent_component: &ItemTreeWeak,
     parent_item_tree_index: u32,
@@ -2068,7 +2065,7 @@ unsafe extern "C-unwind" fn embed_component(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn item_geometry(component: ItemTreeRefPin, item_index: u32) -> LogicalRect {
+extern "C" fn item_geometry(component: ItemTreeRefPin, item_index: u32) -> LogicalRect {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
 
@@ -2091,7 +2088,7 @@ extern "C-unwind" fn item_geometry(component: ItemTreeRefPin, item_index: u32) -
 // silence the warning despite `AccessibleRole` is a `#[non_exhaustive]` enum from another crate.
 #[allow(improper_ctypes_definitions)]
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn accessible_role(component: ItemTreeRefPin, item_index: u32) -> AccessibleRole {
+extern "C" fn accessible_role(component: ItemTreeRefPin, item_index: u32) -> AccessibleRole {
     generativity::make_guard!(guard);
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     let nr = instance_ref.description.original_elements[item_index as usize]
@@ -2110,7 +2107,7 @@ extern "C-unwind" fn accessible_role(component: ItemTreeRefPin, item_index: u32)
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn accessible_string_property(
+extern "C" fn accessible_string_property(
     component: ItemTreeRefPin,
     item_index: u32,
     what: AccessibleStringProperty,
@@ -2140,7 +2137,7 @@ extern "C-unwind" fn accessible_string_property(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn accessibility_action(
+extern "C" fn accessibility_action(
     component: ItemTreeRefPin,
     item_index: u32,
     action: &AccessibilityAction,
@@ -2176,7 +2173,7 @@ extern "C-unwind" fn accessibility_action(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn supported_accessibility_actions(
+extern "C" fn supported_accessibility_actions(
     component: ItemTreeRefPin,
     item_index: u32,
 ) -> SupportedAccessibilityAction {
@@ -2199,7 +2196,7 @@ extern "C-unwind" fn supported_accessibility_actions(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn item_element_infos(
+extern "C" fn item_element_infos(
     component: ItemTreeRefPin,
     item_index: u32,
     result: &mut SharedString,
@@ -2214,7 +2211,7 @@ extern "C-unwind" fn item_element_infos(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-extern "C-unwind" fn window_adapter(
+extern "C" fn window_adapter(
     component: ItemTreeRefPin,
     do_create: bool,
     result: &mut Option<WindowAdapterRc>,
@@ -2229,9 +2226,7 @@ extern "C-unwind" fn window_adapter(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-unsafe extern "C-unwind" fn drop_in_place(
-    component: vtable::VRefMut<ItemTreeVTable>,
-) -> vtable::Layout {
+unsafe extern "C" fn drop_in_place(component: vtable::VRefMut<ItemTreeVTable>) -> vtable::Layout {
     let instance_ptr = component.as_ptr() as *mut Instance<'static>;
     let layout = (*instance_ptr).type_info().layout();
     dynamic_type::TypeInfo::drop_in_place(instance_ptr);
@@ -2239,11 +2234,7 @@ unsafe extern "C-unwind" fn drop_in_place(
 }
 
 #[cfg_attr(not(feature = "ffi"), i_slint_core_macros::remove_extern)]
-unsafe extern "C-unwind" fn dealloc(
-    _vtable: &ItemTreeVTable,
-    ptr: *mut u8,
-    layout: vtable::Layout,
-) {
+unsafe extern "C" fn dealloc(_vtable: &ItemTreeVTable, ptr: *mut u8, layout: vtable::Layout) {
     std::alloc::dealloc(ptr, layout.try_into().unwrap());
 }
 


### PR DESCRIPTION
This broke the build on zephyr

```
/usr/bin/ld: /home/runner/work/slint/slint/build/zephyr/NSI/home/runner/work/slint/slint/build/zephyr/zephyr.elf.loc_cpusw.o:(.data.DW.ref.rust_eh_personality[DW.ref.rust_eh_personality]+0x0): undefined reference to `rust_eh_personality'
```
