### PR TITLE
WGPU: Make WGPU24 variant of GraphicsAPI non-exhaustive

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -541,7 +541,6 @@ pub mod wgpu_24 {
     //!```
     //!
     pub use i_slint_core::graphics::wgpu_24::*;
-    pub use wgpu_24 as wgpu;
 }
 
 #[cfg(feature = "unstable-winit-030")]

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -277,6 +277,7 @@ pub enum GraphicsAPI<'a> {
     ///
     /// See also the [`slint::wgpu_24`](slint:rust:slint/wgpu_24) module.
     #[cfg(feature = "unstable-wgpu-24")]
+    #[non_exhaustive]
     WGPU24 {
         /// The WGPU instance used for rendering.
         instance: wgpu_24::Instance,

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -224,6 +224,17 @@ impl From<RequestedOpenGLVersion> for RequestedGraphicsAPI {
     }
 }
 
+/// Private API exposed to just the renderers to create GraphicsAPI instance with
+/// non-exhaustive enum variant.
+#[cfg(feature = "unstable-wgpu-24")]
+pub fn create_graphics_api_wgpu_24(
+    instance: wgpu_24::wgpu::Instance,
+    device: wgpu_24::wgpu::Device,
+    queue: wgpu_24::wgpu::Queue,
+) -> crate::api::GraphicsAPI<'static> {
+    crate::api::GraphicsAPI::WGPU24 { instance, device, queue }
+}
+
 /// Internal module for use by cbindgen and the C++ platform API layer.
 #[cfg(feature = "ffi")]
 pub mod ffi {

--- a/internal/core/graphics/wgpu_24.rs
+++ b/internal/core/graphics/wgpu_24.rs
@@ -8,6 +8,8 @@ This module contains types that are public and re-exported in the slint-rs as we
 in particular the `BackendSelector` type, to configure the WGPU-based renderer(s).
 */
 
+pub use wgpu_24 as wgpu;
+
 /// This data structure provides settings for initializing WGPU renderers.
 #[derive(Clone, Debug)]
 #[non_exhaustive]

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -82,7 +82,9 @@ impl GraphicsBackend for WGPUBackend {
         let device = self.device.borrow().clone();
         let queue = self.queue.borrow().clone();
         if let (Some(instance), Some(device), Some(queue)) = (instance, device, queue) {
-            Ok(callback(Some(i_slint_core::api::GraphicsAPI::WGPU24 { instance, device, queue })))
+            Ok(callback(Some(i_slint_core::graphics::create_graphics_api_wgpu_24(
+                instance, device, queue,
+            ))))
         } else {
             Ok(callback(None))
         }


### PR DESCRIPTION
This way we can add the surface texture in a future release without breaking compatibility.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
