### PR TITLE
figma-inspector: refactor to break out figma data acquisition

### DIFF
--- a/tools/figma-inspector/backend/code.ts
+++ b/tools/figma-inspector/backend/code.ts
@@ -5,6 +5,10 @@
 import { listenTS, dispatchTS } from "./utils/code-utils.js";
 import { generateSlintSnippet } from "./utils/property-parsing.js";
 import { exportFigmaVariablesToSeparateFiles } from "./utils/export-variables.js";
+import {
+    exportFigmaVariablesToJson,
+    exportFigmaVariablesToJsonString,
+} from "./utils/export-json.js";
 
 if (figma.editorType === "dev" && figma.mode === "codegen") {
     figma.codegen.on("generate", async ({ node }: { node: SceneNode }) => {
@@ -104,6 +108,31 @@ listenTS("exportToFiles", async (message) => {
     } catch (error) {
         console.error("Error exporting to files:", error);
         figma.notify("Failed to export to files", { error: true });
+    }
+});
+
+// JSON export handler for testing and debugging
+listenTS("exportToJson", async () => {
+    try {
+        const result = await exportFigmaVariablesToJson();
+        const jsonString = await exportFigmaVariablesToJsonString(2);
+
+        // Send JSON data to UI for testing/debugging
+        figma.ui.postMessage({
+            type: "exportedJson",
+            data: result.collections,
+            jsonString: jsonString,
+        });
+
+        figma.notify(
+            `Exported ${result.collections.length} collection(s) to JSON format`,
+        );
+    } catch (error) {
+        figma.ui.postMessage({
+            type: "exportJsonError",
+            error: String(error),
+        });
+        figma.notify("JSON export failed: " + String(error));
     }
 });
 

--- a/tools/figma-inspector/backend/utils/export-json.ts
+++ b/tools/figma-inspector/backend/utils/export-json.ts
@@ -1,0 +1,158 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+/**
+ * JSON export utilities for Figma variable collections
+ *
+ * This module provides JSON export functionality for testing and debugging.
+ * It uses the centralized data acquisition layer for consistency with other exporters.
+ */
+
+import {
+    acquireFigmaVariableData,
+    getVariablesForCollection,
+    type FigmaMode,
+} from "./figma-data-acquisition";
+
+export interface JsonVariableAlias {
+    type: "VARIABLE_ALIAS";
+    id: string;
+}
+
+export interface JsonVariable {
+    id: string;
+    name: string;
+    variableCollectionId: string;
+    resolvedType: "COLOR" | "FLOAT" | "STRING" | "BOOLEAN";
+    valuesByMode: Record<string, any>;
+    hiddenFromPublishing: boolean;
+    scopes: string[];
+}
+
+export interface JsonVariableCollection {
+    id: string;
+    name: string;
+    defaultModeId: string;
+    hiddenFromPublishing: boolean;
+    modes: FigmaMode[];
+    variables: JsonVariable[];
+}
+
+/**
+ * Export Figma variable collections to JSON format using the data acquisition layer
+ */
+export async function exportFigmaVariablesToJson(
+    includeInZip: boolean = false,
+): Promise<{
+    collections: JsonVariableCollection[];
+    shouldIncludeInZip: boolean;
+}> {
+    try {
+        // Use the centralized data acquisition
+        const figmaData = await acquireFigmaVariableData();
+        const jsonCollections: JsonVariableCollection[] = [];
+
+        for (const collection of figmaData.collections) {
+            const jsonCollection: JsonVariableCollection = {
+                id: collection.id,
+                name: collection.name,
+                defaultModeId: collection.defaultModeId,
+                hiddenFromPublishing: collection.hiddenFromPublishing,
+                modes: collection.modes,
+                variables: [],
+            };
+
+            // Get variables for this collection using the data acquisition utilities
+            const collectionVariables = getVariablesForCollection(
+                figmaData,
+                collection.id,
+            );
+
+            for (const variable of collectionVariables) {
+                const jsonVariable: JsonVariable = {
+                    id: variable.id,
+                    name: variable.name,
+                    variableCollectionId: variable.variableCollectionId,
+                    resolvedType: variable.resolvedType,
+                    valuesByMode: {},
+                    hiddenFromPublishing: variable.hiddenFromPublishing,
+                    scopes: variable.scopes,
+                };
+
+                // Process values by mode - preserve exact Figma structure
+                for (const [modeId, value] of Object.entries(
+                    variable.valuesByMode,
+                )) {
+                    jsonVariable.valuesByMode[modeId] = processVariableValue(
+                        value,
+                        variable.resolvedType,
+                    );
+                }
+
+                jsonCollection.variables.push(jsonVariable);
+            }
+
+            jsonCollections.push(jsonCollection);
+        }
+
+        return {
+            collections: jsonCollections,
+            shouldIncludeInZip: includeInZip,
+        };
+    } catch (error) {
+        console.error("Error exporting Figma variables to JSON:", error);
+        throw error;
+    }
+}
+
+/**
+ * Process a variable value to maintain exact Figma structure
+ */
+function processVariableValue(value: any, resolvedType: string): any {
+    // Handle variable aliases (references to other variables)
+    if (
+        typeof value === "object" &&
+        value &&
+        "type" in value &&
+        value.type === "VARIABLE_ALIAS"
+    ) {
+        return {
+            type: "VARIABLE_ALIAS",
+            id: value.id,
+        } as JsonVariableAlias;
+    }
+
+    // For all other values, preserve the exact structure that Figma provides
+    switch (resolvedType) {
+        case "COLOR":
+            if (typeof value === "object" && value && "r" in value) {
+                return {
+                    r: value.r,
+                    g: value.g,
+                    b: value.b,
+                    a: "a" in value ? value.a : 1,
+                };
+            }
+            break;
+        case "FLOAT":
+            return typeof value === "number" ? value : 0;
+        case "STRING":
+            return typeof value === "string" ? value : "";
+        case "BOOLEAN":
+            return typeof value === "boolean" ? value : false;
+    }
+
+    // Fallback: return the value as-is
+    return value;
+}
+
+/**
+ * Export collections to JSON string formatting
+ */
+export async function exportFigmaVariablesToJsonString(
+    indent: number = 2,
+    includeInZip: boolean = false,
+): Promise<string> {
+    const result = await exportFigmaVariablesToJson(includeInZip);
+    return JSON.stringify(result.collections, null, indent);
+}

--- a/tools/figma-inspector/backend/utils/export-variables.ts
+++ b/tools/figma-inspector/backend/utils/export-variables.ts
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import { rgbToHex } from "./property-parsing";
+import { exportFigmaVariablesToJsonString } from "./export-json";
+
+// Configuration flag for including JSON export in zip
+// Set to true to include raw Figma JSON data for testing/debugging
+const INCLUDE_JSON_IN_ZIP = true;
 
 /**
  * Helper to get the appropriate Slint type for a Figma variable type
@@ -997,9 +1002,6 @@ export async function exportFigmaVariablesToSeparateFiles(
                                 ) {
                                     value = varValue;
                                     foundModeId = varModeId;
-                                    console.log(
-                                        `Found mode name match: ${varModeId} -> ${modeName}`,
-                                    );
                                     break;
                                 }
                             }
@@ -1435,6 +1437,26 @@ export async function exportFigmaVariablesToSeparateFiles(
         } else {
             // Use individual files
             finalOutputFiles = generatedFiles;
+        }
+
+        // Add JSON export for testing/debugging (optional)
+        if (INCLUDE_JSON_IN_ZIP) {
+            try {
+                const jsonContent = await exportFigmaVariablesToJsonString(
+                    2,
+                    true,
+                );
+                finalOutputFiles.push({
+                    name: "figma-variables-debug.json",
+                    content: jsonContent,
+                });
+                console.log("JSON debug export included in zip");
+            } catch (jsonError) {
+                console.warn(
+                    "⚠️ Failed to include JSON debug export:",
+                    jsonError,
+                );
+            }
         }
 
         // Add README

--- a/tools/figma-inspector/backend/utils/figma-data-acquisition.ts
+++ b/tools/figma-inspector/backend/utils/figma-data-acquisition.ts
@@ -1,0 +1,170 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+/**
+ * Figma data acquisition utilities
+ *
+ * This module handles the acquisition of data from Figma APIs (both plugin and potentially REST API)
+ * and provides it in a structured format for various export formats (Slint, JSON, etc.)
+ *
+ * The separation allows for:
+ * - Reusing the same data acquisition logic across different exporters
+ * - Easy switching between plugin API and REST API in the future
+ * - Better testability by mocking this layer
+ * - Centralized batching and error handling
+ */
+
+export interface FigmaMode {
+    modeId: string;
+    name: string;
+}
+
+export interface FigmaCollection {
+    id: string;
+    name: string;
+    defaultModeId: string;
+    hiddenFromPublishing: boolean;
+    modes: FigmaMode[];
+    variableIds: string[];
+}
+
+export interface FigmaVariable {
+    id: string;
+    name: string;
+    variableCollectionId: string;
+    resolvedType: "COLOR" | "FLOAT" | "STRING" | "BOOLEAN";
+    valuesByMode: Record<string, any>;
+    hiddenFromPublishing: boolean;
+    scopes: string[];
+}
+
+export interface FigmaVariableData {
+    collections: FigmaCollection[];
+    variables: Map<string, FigmaVariable>;
+}
+
+/**
+ * Acquire all Figma variable data using the plugin API
+ *
+ * This function handles the core data acquisition process:
+ * - Fetches collections and their metadata
+ * - Batches variable requests for performance
+ * - Filters out invalid/empty variables
+ * - Returns structured data ready for processing by exporters
+ */
+export async function acquireFigmaVariableData(): Promise<FigmaVariableData> {
+    try {
+        // Get all variable collections
+        const rawCollections =
+            await figma.variables.getLocalVariableCollectionsAsync();
+        const collections: FigmaCollection[] = [];
+        const variables = new Map<string, FigmaVariable>();
+
+        // Process each collection
+        for (const rawCollection of rawCollections) {
+            // Convert to our standardized format
+            const collection: FigmaCollection = {
+                id: rawCollection.id,
+                name: rawCollection.name,
+                defaultModeId: rawCollection.defaultModeId,
+                hiddenFromPublishing: rawCollection.hiddenFromPublishing,
+                modes: rawCollection.modes.map((mode) => ({
+                    modeId: mode.modeId,
+                    name: mode.name,
+                })),
+                variableIds: [...rawCollection.variableIds], // Create a copy
+            };
+
+            // Process variables in batches for performance
+            const batchSize = 5;
+            for (
+                let i = 0;
+                i < rawCollection.variableIds.length;
+                i += batchSize
+            ) {
+                const batch = rawCollection.variableIds.slice(i, i + batchSize);
+                const batchPromises = batch.map((id) =>
+                    figma.variables.getVariableByIdAsync(id),
+                );
+                const batchResults = await Promise.all(batchPromises);
+
+                for (const variable of batchResults) {
+                    if (!variable) {
+                        continue;
+                    }
+
+                    // Skip variables with no values
+                    if (
+                        !variable.valuesByMode ||
+                        Object.keys(variable.valuesByMode).length === 0
+                    ) {
+                        continue;
+                    }
+
+                    // Store standardized variable data
+                    variables.set(variable.id, {
+                        id: variable.id,
+                        name: variable.name,
+                        variableCollectionId: variable.variableCollectionId,
+                        resolvedType: variable.resolvedType,
+                        valuesByMode: { ...variable.valuesByMode }, // Create a copy
+                        hiddenFromPublishing: variable.hiddenFromPublishing,
+                        scopes: [...(variable.scopes || [])], // Create a copy
+                    });
+                }
+
+                // Small delay to prevent overwhelming the API
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+
+            collections.push(collection);
+        }
+
+        return {
+            collections,
+            variables,
+        };
+    } catch (error) {
+        console.error("Error acquiring Figma variable data:", error);
+        throw error;
+    }
+}
+
+/**
+ * Get a variable by ID from acquired data
+ */
+export function getVariableById(
+    data: FigmaVariableData,
+    variableId: string,
+): FigmaVariable | undefined {
+    return data.variables.get(variableId);
+}
+
+/**
+ * Get all variables for a specific collection
+ */
+export function getVariablesForCollection(
+    data: FigmaVariableData,
+    collectionId: string,
+): FigmaVariable[] {
+    const collection = data.collections.find((c) => c.id === collectionId);
+    if (!collection) {
+        return [];
+    }
+
+    return collection.variableIds
+        .map((id) => data.variables.get(id))
+        .filter(
+            (variable): variable is FigmaVariable => variable !== undefined,
+        );
+}
+
+/**
+ * Get a collection by ID from acquired data
+ */
+export function getCollectionById(
+    data: FigmaVariableData,
+    collectionId: string,
+): FigmaCollection | undefined {
+    return data.collections.find((c) => c.id === collectionId);
+}

--- a/tools/figma-inspector/shared/universals.d.ts
+++ b/tools/figma-inspector/shared/universals.d.ts
@@ -25,6 +25,14 @@ export interface EventTS {
     generateSnippetRequest: { useVariables: boolean };
     nodeChanged;
     exportToFiles: { exportAsSingleFile: boolean };
+    exportToJson: Record<string, never>;
+    exportedJson: {
+        data: any[];
+        jsonString: string;
+    };
+    exportJsonError: {
+        error: string;
+    };
 
     // Resize-related messages
     resizeWindow: { width: number; height: number };

--- a/tools/figma-inspector/tests/data-acquisition.test.ts
+++ b/tools/figma-inspector/tests/data-acquisition.test.ts
@@ -1,0 +1,42 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { test, expect, vi, beforeEach } from "vitest";
+import { acquireFigmaVariableData } from "../backend/utils/figma-data-acquisition";
+
+// Mock the global figma object
+const mockFigma = {
+    variables: {
+        getLocalVariableCollectionsAsync: vi.fn(),
+        getVariableByIdAsync: vi.fn(),
+    },
+};
+
+// Set up global figma object
+(global as any).figma = mockFigma;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+test("data acquisition works with simple mock", async () => {
+    // Simple mock with no variables
+    const mockCollection = {
+        id: "collection1",
+        name: "Test",
+        defaultModeId: "mode1",
+        hiddenFromPublishing: false,
+        modes: [{ modeId: "mode1", name: "Default" }],
+        variableIds: [],
+    };
+
+    mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue([
+        mockCollection,
+    ]);
+
+    const result = await acquireFigmaVariableData();
+
+    expect(result.collections).toHaveLength(1);
+    expect(result.collections[0].name).toBe("Test");
+    expect(result.variables.size).toBe(0);
+});

--- a/tools/figma-inspector/tests/export-json.test.ts
+++ b/tools/figma-inspector/tests/export-json.test.ts
@@ -1,0 +1,79 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { test, expect, vi, beforeEach } from "vitest";
+import { exportFigmaVariablesToJson } from "../backend/utils/export-json";
+
+// Mock the global figma object
+const mockFigma = {
+    variables: {
+        getLocalVariableCollectionsAsync: vi.fn(),
+        getVariableByIdAsync: vi.fn(),
+    },
+};
+
+// Set up global figma object
+(global as any).figma = mockFigma;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+test("exports basic collection using data acquisition layer", async () => {
+    // Mock collection
+    const mockCollection = {
+        id: "collection1",
+        name: "Colors",
+        defaultModeId: "mode1",
+        hiddenFromPublishing: false,
+        modes: [{ modeId: "mode1", name: "Default" }],
+        variableIds: ["var1"],
+    };
+
+    // Mock variable
+    const mockVariable = {
+        id: "var1",
+        name: "primary",
+        variableCollectionId: "collection1",
+        resolvedType: "COLOR",
+        valuesByMode: {
+            mode1: { r: 1, g: 0, b: 0, a: 1 },
+        },
+        hiddenFromPublishing: false,
+        scopes: ["ALL_SCOPES"],
+    };
+
+    mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue([
+        mockCollection,
+    ]);
+    mockFigma.variables.getVariableByIdAsync.mockResolvedValue(mockVariable);
+
+    const result = await exportFigmaVariablesToJson();
+
+    expect(result.collections).toHaveLength(1);
+    expect(result.collections[0].name).toBe("Colors");
+    expect(result.collections[0].variables).toHaveLength(1);
+    expect(result.collections[0].variables[0].name).toBe("primary");
+});
+
+test("handles empty collections", async () => {
+    // Mock collection with no variables
+    const mockCollection = {
+        id: "collection1",
+        name: "Empty",
+        defaultModeId: "mode1",
+        hiddenFromPublishing: false,
+        modes: [{ modeId: "mode1", name: "Default" }],
+        variableIds: [],
+    };
+
+    mockFigma.variables.getLocalVariableCollectionsAsync.mockResolvedValue([
+        mockCollection,
+    ]);
+
+    const result = await exportFigmaVariablesToJson();
+
+    expect(result.collections).toHaveLength(1);
+    expect(result.collections[0].name).toBe("Empty");
+    expect(result.collections[0].variables).toHaveLength(0);
+});


### PR DESCRIPTION
under the export-variables.ts file there is a 
INCLUDE_JSON_IN_ZIP variable that is currently set to true.  this will export the json file in the same zip as the rest when set to true, but will not when set to false.  
I would like to make that less about changing the code and more about running. the plugin on a specific set of data but I don't know how to approach that as you did with pnpm (Ideally it would be a flag) 

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
