### PR TITLE
VS Code: For the per-element help URLs, use snapshots.slint.dev for l…

### DIFF
--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -300,7 +300,7 @@ function helpBaseUrl(context: vscode.ExtensionContext): string {
     ) {
         return "https://snapshots.slint.dev/master/docs/slint/reference/";
     } else {
-        return `https://docs.slint.dev/${context.extension.packageJSON.version}/docs/slint/reference/`;
+        return `https://releases.slint.dev/${context.extension.packageJSON.version}/docs/slint/reference/`;
     }
 }
 

--- a/editors/vscode/src/common.ts
+++ b/editors/vscode/src/common.ts
@@ -177,7 +177,7 @@ export function activate(
     const command = vscode.commands.registerCommand(
         "slint.openHelp",
         (word) => {
-            const helpUrl = getHelpUrlForElement(word);
+            const helpUrl = getHelpUrlForElement(context, word);
             if (helpUrl) {
                 vscode.env.openExternal(vscode.Uri.parse(helpUrl));
             }
@@ -191,7 +191,7 @@ export function activate(
                 const range = document.getWordRangeAtPosition(position);
                 const word = document.getText(range);
 
-                if (getHelpUrlForElement(word)) {
+                if (getHelpUrlForElement(context, word)) {
                     const commandUri = vscode.Uri.parse(
                         `command:slint.openHelp?${encodeURIComponent(JSON.stringify([word]))}`,
                     );
@@ -293,9 +293,21 @@ async function maybeSendStartupTelemetryEvent(
     telemetryLogger.logUsage("extension-activated", usageData);
 }
 
-const HELP_URL = "https://snapshots.slint.dev/master/docs/slint/reference/";
+function helpBaseUrl(context: vscode.ExtensionContext): string {
+    if (
+        context.extensionMode === vscode.ExtensionMode.Development ||
+        context.extension.packageJSON.name.endsWith("-nightly")
+    ) {
+        return "https://snapshots.slint.dev/master/docs/slint/reference/";
+    } else {
+        return `https://docs.slint.dev/${context.extension.packageJSON.version}/docs/slint/reference/`;
+    }
+}
 
-function getHelpUrlForElement(elementName: string): string | null {
+function getHelpUrlForElement(
+    context: vscode.ExtensionContext,
+    elementName: string,
+): string | null {
     const elementPaths: Record<string, string> = {
         // elements
         Image: "elements/image",
@@ -352,5 +364,5 @@ function getHelpUrlForElement(elementName: string): string | null {
     };
 
     const path = elementPaths[elementName];
-    return path ? `${HELP_URL}${path}/` : null;
+    return path ? `${helpBaseUrl(context)}${path}/` : null;
 }


### PR DESCRIPTION
…ocal and nightly builds, and use docs.slint.dev/$version for everything else

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
