### PR TITLE
doc: Mention aarch64 as supported platform for Windows

### DIFF
--- a/docs/astro/src/content/docs/guide/platforms/desktop.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/desktop.mdx
@@ -14,10 +14,10 @@ are supported by their vendors at the time of a Slint version release.
 <Tabs syncKey="dev-platform">
 <TabItem label="Windows" icon="seti:windows">
 
-| Operating System | Architecture |
-| ---------------- | ------------ |
-| Windows 10       | x86-64       |
-| Windows 11       | x86-64       |
+| Operating System | Architecture    |
+| ---------------- | --------------- |
+| Windows 10       | x86-64          |
+| Windows 11       | x86-64, aarch64 |
 
 ### Handle the Console Window
 


### PR DESCRIPTION
Source: My windows dev environment is Windows ARM64, and after the release we're going to add ARM64 binaries.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
