### PR TITLE
winit: Abort the event loop if creating a window failed

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -105,6 +105,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
         }
         if let Err(err) = self.shared_backend_data.create_inactive_windows(event_loop) {
             self.loop_error = Some(err);
+            event_loop.exit();
         }
     }
 


### PR DESCRIPTION
This was fatal in previous released and still should be fatal. Otherwise failure will result in a silent perceived hang, as the event loop continues to spin.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
