### PR TITLE
windows: Use a default stack size of 10MB

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,3 +19,10 @@ rustflags = [
   "-C",
   "target-feature=+s32c1i",
 ]
+
+[target.x86_64-pc-windows-msvc]
+# Increase default stack size to match Linux
+rustflags = ["-C", "link-arg=/STACK:10000000"]
+[target.aarch64-pc-windows-msvc]
+# Increase default stack size to match Linux
+rustflags = ["-C", "link-arg=/STACK:10000000"]

--- a/docs/astro/src/content/docs/guide/platforms/desktop.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/desktop.mdx
@@ -63,6 +63,25 @@ your Python script.
 </TabItem>
 
 </Tabs>
+
+### Rust: Stack Overflows
+
+When developing Rust applications on Windows, you might sooner or later observe the program aborting with `STATUS_STACK_OVERFLOW`,
+especially in debug builds. This is a known issue that's a combination of a high demand for stack space and MSVC defaulting to
+a stack size for the main thread that's significantly smaller compared to other operating systems.
+
+This is fixed by configuring the linker. Create a [`.cargo\config.toml`](https://doc.rust-lang.org/cargo/reference/config.html#configuration)
+file in your project (note the `.cargo` sub-directory) with the following contents:
+
+```toml
+[target.x86_64-pc-windows-msvc]
+# Increase default stack size to match Linux
+rustflags = ["-C", "link-arg=/STACK:10000000"]
+[target.aarch64-pc-windows-msvc]
+# Increase default stack size to match Linux
+rustflags = ["-C", "link-arg=/STACK:10000000"]
+```
+
 </TabItem>
 <TabItem label="macOS" icon="apple">
 


### PR DESCRIPTION
This matches Linux and avoids annoying stack overflows, especially when running our own demos (see printerdemo).

This is now also documented for our users.

Fixes #4586

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
