### PR TITLE
C++ Fix compilation of PopupWindow::show in changed callback

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3814,7 +3814,7 @@ fn compile_builtin_function_call(
                 let position = compile_expression(&popup.position.borrow(), &popup_ctx);
                 let close_policy = compile_expression(close_policy, ctx);
                 format!(
-                    "{window}.close_popup({component_access}->popup_id_{popup_index}); {component_access}->popup_id_{popup_index} = {window}.show_popup<{popup_window_id}>(&*({component_access}), [=](auto self) {{ return {position}; }}, {close_policy}, {{ {parent_component} }})"
+                    "{window}.close_popup({component_access}->popup_id_{popup_index}); {component_access}->popup_id_{popup_index} = {window}.template show_popup<{popup_window_id}>(&*({component_access}), [=](auto self) {{ return {position}; }}, {close_policy}, {{ {parent_component} }})"
                 )
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {arguments:?}")
@@ -3901,7 +3901,7 @@ fn compile_builtin_function_call(
             };
             format!(r"
                 {window}.close_popup({context_menu}.popup_id);
-                {context_menu}.popup_id = {window}.show_popup_menu<{popup_id}>({globals}, {position}, {{ {context_menu_rc} }}, [self](auto popup_menu) {{
+                {context_menu}.popup_id = {window}.template show_popup_menu<{popup_id}>({globals}, {position}, {{ {context_menu_rc} }}, [self](auto popup_menu) {{
                     auto parent_weak = self->self_weak;
                     auto self_ = self;
                     {init}

--- a/tests/cases/issues/issue_8710_popup_show_from_changed.slint
+++ b/tests/cases/issues/issue_8710_popup_show_from_changed.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// C++ code generation used to produce error for this test case
+
+export component AppWindow inherits Window {
+    in-out property<string> value;
+
+    changed value => {
+        popup.show();
+    }
+
+    popup := PopupWindow {}
+}
+


### PR DESCRIPTION
The window is dependent of an lambda `auto` parameter, so the `template` keyword is required in order to call show_popup

Fixes #8710 
