### PR TITLE
Experimental Drag&Drop support

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -373,6 +373,7 @@ if (SLINT_BUILD_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_sharedvector_internal.h
         ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_string_internal.h
         ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_timer_internal.h
+        ${CMAKE_CURRENT_BINARY_DIR}/generated_include/slint_events_internal.h
     )
 
     if(SLINT_FEATURE_INTERPRETER)

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -119,6 +119,7 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
     writeln!(structs_priv, "// This file is auto-generated from {}", file!())?;
     writeln!(structs_priv, "#include \"slint_builtin_structs.h\"")?;
     writeln!(structs_priv, "#include \"slint_enums_internal.h\"")?;
+    writeln!(structs_priv, "#include \"slint_point.h\"")?;
     writeln!(structs_priv, "namespace slint::cbindgen_private {{")?;
     writeln!(structs_priv, "enum class KeyEventType : uint8_t;")?;
     macro_rules! struct_file {
@@ -218,6 +219,7 @@ fn default_config() -> cbindgen::Config {
             ("FocusReasonArg".into(), "FocusReason".into()),
             ("KeyEventArg".into(), "KeyEvent".into()),
             ("PointerEventArg".into(), "PointerEvent".into()),
+            ("DropEventArg".into(), "DropEvent".into()),
             ("PointerScrollEventArg".into(), "PointerScrollEvent".into()),
             ("PointArg".into(), "slint::LogicalPosition".into()),
             ("FloatArg".into(), "float".into()),
@@ -286,6 +288,8 @@ fn gen_corelib(
         "Rectangle",
         "BasicBorderRectangle",
         "BorderRectangle",
+        "DragArea",
+        "DropArea",
         "ImageItem",
         "ClippedImage",
         "TouchArea",
@@ -368,7 +372,6 @@ fn gen_corelib(
         "Property",
         "Slice",
         "Timer",
-        "TimerMode",
         "PropertyHandleOpaque",
         "Callback",
         "slint_property_listener_scope_evaluate",
@@ -377,6 +380,7 @@ fn gen_corelib(
         "CallbackOpaque",
         "WindowAdapterRc",
         "VoidArg",
+        "DropEventArg",
         "FocusReasonArg",
         "KeyEventArg",
         "PointerEventArg",
@@ -385,29 +389,6 @@ fn gen_corelib(
         "Point",
         "MenuEntryModel",
         "MenuEntryArg",
-        "slint_color_brighter",
-        "slint_color_darker",
-        "slint_color_transparentize",
-        "slint_color_mix",
-        "slint_color_with_alpha",
-        "slint_color_to_hsva",
-        "slint_color_from_hsva",
-        "slint_image_size",
-        "slint_image_path",
-        "slint_image_load_from_path",
-        "slint_image_load_from_embedded_data",
-        "slint_image_from_embedded_textures",
-        "slint_image_compare_equal",
-        "slint_image_set_nine_slice_edges",
-        "slint_image_to_rgb8",
-        "slint_image_to_rgba8",
-        "slint_image_to_rgba8_premultiplied",
-        "slint_timer_start",
-        "slint_timer_singleshot",
-        "slint_timer_destroy",
-        "slint_timer_stop",
-        "slint_timer_restart",
-        "slint_timer_running",
         "Coord",
         "LogicalRect",
         "LogicalPoint",
@@ -483,15 +464,9 @@ fn gen_corelib(
         .iter()
         .map(|s| s.to_string())
         .collect();
-        tmp.export.exclude = config
-            .export
-            .exclude
-            .iter()
-            .filter(|exclusion| !tmp.export.include.iter().any(|inclusion| inclusion == *exclusion))
-            .cloned()
-            .collect();
         tmp
     };
+    config.export.exclude.extend(timer_config.export.include.iter().cloned());
     cbindgen::Builder::new()
         .with_config(timer_config)
         .with_src(crate_dir.join("timers.rs"))
@@ -499,7 +474,7 @@ fn gen_corelib(
         .context("Unable to generate bindings for slint_timer_internal.h")?
         .write_to_file(include_dir.join("slint_timer_internal.h"));
 
-    for (rust_types, extra_excluded_types, internal_header, prelude) in [
+    for (rust_types, internal_header, prelude) in [
         (
             vec![
                 "ImageInner",
@@ -521,7 +496,6 @@ fn gen_corelib(
                 "StaticTextures",
                 "BorrowedOpenGLTextureOrigin"
             ],
-            vec!["Color"],
             "slint_image_internal.h",
             "namespace slint::cbindgen_private { struct ParsedSVG{}; struct HTMLImage{}; using namespace vtable; namespace types{ struct NineSliceImage{}; } }",
         ),
@@ -532,22 +506,31 @@ fn gen_corelib(
             "slint_color_with_alpha",
             "slint_color_to_hsva",
             "slint_color_from_hsva",],
-            vec![],
             "slint_color_internal.h",
             "",
         ),
         (
-            vec!["PathData", "PathElement", "slint_new_path_elements", "slint_new_path_events"],
-            vec![],
+            vec!["PathData", "PathElement", "slint_new_path_elements", "slint_new_path_events", "Point"],
             "slint_pathdata_internal.h",
-            "",
+            "#include \"slint_sharedvector.h\"\n#include \"slint_point.h\"",
         ),
         (
             vec!["Brush", "LinearGradient", "GradientStop", "RadialGradient"],
-            vec!["Color"],
             "slint_brush_internal.h",
             "",
         ),
+        (
+            vec!["MouseEvent"],
+            "slint_events_internal.h",
+            "#include \"slint_point.h\"
+            namespace slint::cbindgen_private {
+                struct KeyEvent; struct PointerEvent;
+                struct Rect;
+                using LogicalRect = Rect;
+                using LogicalPoint = Point2D<float>;
+                using LogicalLength = float;
+            }",
+        )
     ]
     .iter()
     {
@@ -591,32 +574,14 @@ fn gen_corelib(
             "slint_windowrc_is_minimized",
             "slint_windowrc_is_maximized",
             "slint_windowrc_take_snapshot",
-            "slint_new_path_elements",
-            "slint_new_path_events",
-            "slint_color_brighter",
-            "slint_color_darker",
-            "slint_color_transparentize",
-            "slint_color_mix",
-            "slint_color_with_alpha",
-            "slint_color_to_hsva",
-            "slint_color_from_hsva",
-            "slint_image_size",
-            "slint_image_path",
-            "slint_image_load_from_path",
-            "slint_image_load_from_embedded_data",
-            "slint_image_set_nine_slice_edges",
-            "slint_image_to_rgb8",
-            "slint_image_to_rgba8",
-            "slint_image_to_rgba8_premultiplied",
-            "slint_image_from_embedded_textures",
-            "slint_image_compare_equal",
         ]
-        .iter()
-        .filter(|exclusion| !rust_types.iter().any(|inclusion| inclusion == *exclusion))
-        .chain(extra_excluded_types.iter())
-        .chain(public_exported_types.iter())
+        .into_iter()
+        .chain(config.export.exclude.iter().map(|s| s.as_str()))
+        .filter(|exclusion| !rust_types.iter().any(|inclusion| inclusion == exclusion))
         .map(|s| s.to_string())
         .collect();
+
+        config.export.exclude.extend(rust_types.iter().map(|s| s.to_string()));
 
         special_config.enumeration = cbindgen::EnumConfig {
             derive_tagged_enum_copy_assignment: true,
@@ -646,7 +611,7 @@ fn gen_corelib(
             .with_src(crate_dir.join("graphics/image.rs"))
             .with_src(crate_dir.join("graphics/image/cache.rs"))
             .with_src(crate_dir.join("animations.rs"))
-            //            .with_src(crate_dir.join("input.rs"))
+            .with_src(crate_dir.join("input.rs"))
             .with_src(crate_dir.join("item_rendering.rs"))
             .with_src(crate_dir.join("window.rs"))
             .with_include("slint_enums_internal.h")
@@ -759,6 +724,7 @@ fn gen_corelib(
         .with_include("slint_point.h")
         .with_include("slint_timer.h")
         .with_include("slint_builtin_structs_internal.h")
+        .with_include("slint_events_internal.h")
         .with_after_include(
             r"
 namespace slint {
@@ -766,17 +732,14 @@ namespace slint {
     namespace cbindgen_private {
         using slint::private_api::WindowAdapterRc;
         using namespace vtable;
-        struct KeyEvent; struct PointerEvent;
         using private_api::Property;
         using private_api::PathData;
         using private_api::Point;
-        struct Rect;
-        using LogicalRect = Rect;
-        using LogicalPoint = Point2D<float>;
-        using LogicalLength = float;
         struct ItemTreeVTable;
         struct ItemVTable;
         using types::IntRect;
+        using types::Size;
+        using types::MouseEvent;
     }
     template<typename ModelData> class Model;
 }",

--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -499,12 +499,8 @@ public:
     void dispatch_pointer_press_event(LogicalPosition pos, PointerEventButton button)
     {
         private_api::assert_main_thread();
-        using slint::cbindgen_private::MouseEvent;
-        MouseEvent event { .tag = MouseEvent::Tag::Pressed,
-                           .pressed = MouseEvent::Pressed_Body { .position = { pos.x, pos.y },
-                                                                 .button = button,
-                                                                 .click_count = 0 } };
-        inner.dispatch_pointer_event(event);
+        inner.dispatch_pointer_event(
+                slint::cbindgen_private::MouseEvent::Pressed({ pos.x, pos.y }, button, 0));
     }
     /// Dispatches a pointer or mouse release event to the scene.
     ///
@@ -516,12 +512,8 @@ public:
     void dispatch_pointer_release_event(LogicalPosition pos, PointerEventButton button)
     {
         private_api::assert_main_thread();
-        using slint::cbindgen_private::MouseEvent;
-        MouseEvent event { .tag = MouseEvent::Tag::Released,
-                           .released = MouseEvent::Released_Body { .position = { pos.x, pos.y },
-                                                                   .button = button,
-                                                                   .click_count = 0 } };
-        inner.dispatch_pointer_event(event);
+        inner.dispatch_pointer_event(
+                slint::cbindgen_private::MouseEvent::Released({ pos.x, pos.y }, button, 0));
     }
     /// Dispatches a pointer exit event to the scene.
     ///
@@ -532,9 +524,7 @@ public:
     void dispatch_pointer_exit_event()
     {
         private_api::assert_main_thread();
-        using slint::cbindgen_private::MouseEvent;
-        MouseEvent event { .tag = MouseEvent::Tag::Exit, .moved = {} };
-        inner.dispatch_pointer_event(event);
+        inner.dispatch_pointer_event(slint::cbindgen_private::MouseEvent::Exit());
     }
 
     /// Dispatches a pointer move event to the scene.
@@ -546,10 +536,7 @@ public:
     void dispatch_pointer_move_event(LogicalPosition pos)
     {
         private_api::assert_main_thread();
-        using slint::cbindgen_private::MouseEvent;
-        MouseEvent event { .tag = MouseEvent::Tag::Moved,
-                           .moved = MouseEvent::Moved_Body { .position = { pos.x, pos.y } } };
-        inner.dispatch_pointer_event(event);
+        inner.dispatch_pointer_event(slint::cbindgen_private::MouseEvent::Moved({ pos.x, pos.y }));
     }
 
     /// Dispatches a scroll (or wheel) event to the scene.
@@ -563,12 +550,8 @@ public:
     void dispatch_pointer_scroll_event(LogicalPosition pos, float delta_x, float delta_y)
     {
         private_api::assert_main_thread();
-        using slint::cbindgen_private::MouseEvent;
-        MouseEvent event { .tag = MouseEvent::Tag::Wheel,
-                           .wheel = MouseEvent::Wheel_Body { .position = { pos.x, pos.y },
-                                                             .delta_x = delta_x,
-                                                             .delta_y = delta_y } };
-        inner.dispatch_pointer_event(event);
+        inner.dispatch_pointer_event(
+                slint::cbindgen_private::MouseEvent::Wheel({ pos.x, pos.y }, delta_x, delta_y));
     }
 
     /// Set the logical size of this window after a resize event

--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -224,7 +224,7 @@ public:
     void dispatch_pointer_event(const cbindgen_private::MouseEvent &event)
     {
         private_api::assert_main_thread();
-        cbindgen_private::slint_windowrc_dispatch_pointer_event(&inner, event);
+        cbindgen_private::slint_windowrc_dispatch_pointer_event(&inner, &event);
     }
 
     /// Registers a font by the specified path. The path must refer to an existing

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -237,7 +237,7 @@ impl Item for NativeButton {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -247,7 +247,7 @@ impl Item for NativeButton {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
@@ -262,7 +262,7 @@ impl Item for NativeButton {
         let was_pressed = self.pressed();
 
         Self::FIELD_OFFSETS.pressed.apply_pin(self).set(match event {
-            MouseEvent::Pressed { button, .. } => button == PointerEventButton::Left,
+            MouseEvent::Pressed { button, .. } => *button == PointerEventButton::Left,
             MouseEvent::Exit | MouseEvent::Released { .. } => false,
             MouseEvent::Moved { .. } => {
                 return if was_pressed {
@@ -275,7 +275,8 @@ impl Item for NativeButton {
         });
         if let MouseEvent::Released { position, .. } = event {
             let geo = self_rc.geometry();
-            if LogicalRect::new(LogicalPoint::default(), geo.size).contains(position) && was_pressed
+            if LogicalRect::new(LogicalPoint::default(), geo.size).contains(*position)
+                && was_pressed
             {
                 self.activate();
             }

--- a/internal/backends/qt/qt_widgets/button.rs
+++ b/internal/backends/qt/qt_widgets/button.rs
@@ -272,6 +272,9 @@ impl Item for NativeButton {
                 }
             }
             MouseEvent::Wheel { .. } => return InputEventResult::EventIgnored,
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+                return InputEventResult::EventIgnored
+            }
         });
         if let MouseEvent::Released { position, .. } = event {
             let geo = self_rc.geometry();

--- a/internal/backends/qt/qt_widgets/checkbox.rs
+++ b/internal/backends/qt/qt_widgets/checkbox.rs
@@ -67,7 +67,7 @@ impl Item for NativeCheckBox {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -77,7 +77,7 @@ impl Item for NativeCheckBox {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
@@ -89,8 +89,8 @@ impl Item for NativeCheckBox {
         }
         if let MouseEvent::Released { position, button, .. } = event {
             let geo = self_rc.geometry();
-            if button == PointerEventButton::Left
-                && LogicalRect::new(LogicalPoint::default(), geo.size).contains(position)
+            if *button == PointerEventButton::Left
+                && LogicalRect::new(LogicalPoint::default(), geo.size).contains(*position)
             {
                 Self::FIELD_OFFSETS.checked.apply_pin(self).set(!self.checked());
                 Self::FIELD_OFFSETS.toggled.apply_pin(self).call(&())

--- a/internal/backends/qt/qt_widgets/combobox.rs
+++ b/internal/backends/qt/qt_widgets/combobox.rs
@@ -52,7 +52,7 @@ impl Item for NativeComboBox {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -62,7 +62,7 @@ impl Item for NativeComboBox {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
@@ -193,7 +193,7 @@ impl Item for NativeComboBoxPopup {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -202,7 +202,7 @@ impl Item for NativeComboBoxPopup {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {

--- a/internal/backends/qt/qt_widgets/groupbox.rs
+++ b/internal/backends/qt/qt_widgets/groupbox.rs
@@ -161,7 +161,7 @@ impl Item for NativeGroupBox {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -170,7 +170,7 @@ impl Item for NativeGroupBox {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -93,7 +93,7 @@ impl Item for NativeLineEdit {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -102,7 +102,7 @@ impl Item for NativeLineEdit {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {

--- a/internal/backends/qt/qt_widgets/listviewitem.rs
+++ b/internal/backends/qt/qt_widgets/listviewitem.rs
@@ -80,7 +80,7 @@ impl Item for NativeStandardListViewItem {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -89,7 +89,7 @@ impl Item for NativeStandardListViewItem {
 
     fn input_event(
         self: Pin<&Self>,
-        _event: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {

--- a/internal/backends/qt/qt_widgets/progress_indicator.rs
+++ b/internal/backends/qt/qt_widgets/progress_indicator.rs
@@ -72,7 +72,7 @@ impl Item for NativeProgressIndicator {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -81,7 +81,7 @@ impl Item for NativeProgressIndicator {
 
     fn input_event(
         self: Pin<&Self>,
-        _event: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -225,6 +225,7 @@ impl Item for NativeScrollView {
                     }
                     InputEventResult::EventAccepted
                 }
+                MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
             };
             self.data.set(data);
             result

--- a/internal/backends/qt/qt_widgets/scrollview.rs
+++ b/internal/backends/qt/qt_widgets/scrollview.rs
@@ -105,7 +105,7 @@ impl Item for NativeScrollView {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -114,7 +114,7 @@ impl Item for NativeScrollView {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -149,7 +149,7 @@ impl Item for NativeSlider {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -159,7 +159,7 @@ impl Item for NativeSlider {
     #[allow(clippy::unnecessary_cast)] // MouseEvent uses Coord
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
@@ -248,7 +248,7 @@ impl Item for NativeSlider {
                 InputEventResult::EventAccepted
             }
             MouseEvent::Pressed { button, .. } | MouseEvent::Released { button, .. } => {
-                debug_assert_ne!(button, PointerEventButton::Left);
+                debug_assert_ne!(*button, PointerEventButton::Left);
                 InputEventResult::EventIgnored
             }
         };

--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -251,6 +251,7 @@ impl Item for NativeSlider {
                 debug_assert_ne!(*button, PointerEventButton::Left);
                 InputEventResult::EventIgnored
             }
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
         };
         data.active_controls = new_control;
 

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -224,6 +224,7 @@ impl Item for NativeSpinBox {
 
                     true
                 }
+                MouseEvent::DragMove(..) | MouseEvent::Drop(..) => false,
             };
         data.active_controls = new_control;
         if changed {

--- a/internal/backends/qt/qt_widgets/spinbox.rs
+++ b/internal/backends/qt/qt_widgets/spinbox.rs
@@ -123,7 +123,7 @@ impl Item for NativeSpinBox {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -132,7 +132,7 @@ impl Item for NativeSpinBox {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
@@ -178,7 +178,7 @@ impl Item for NativeSpinBox {
                 }
                 MouseEvent::Released { button, .. } => {
                     data.pressed = false;
-                    let left_button = button == PointerEventButton::Left;
+                    let left_button = *button == PointerEventButton::Left;
                     if new_control == cpp!(unsafe []->u32 as "int" { return QStyle::SC_SpinBoxUp;})
                         && enabled
                         && left_button
@@ -206,14 +206,14 @@ impl Item for NativeSpinBox {
                 }
                 MouseEvent::Moved { .. } => false,
                 MouseEvent::Wheel { delta_y, .. } => {
-                    if delta_y > 0. {
+                    if *delta_y > 0. {
                         let v = self.value();
                         if v < self.maximum() {
                             let new_val = v + step_size;
                             self.value.set(new_val);
                             Self::FIELD_OFFSETS.edited.apply_pin(self).call(&(new_val,));
                         }
-                    } else if delta_y < 0. {
+                    } else if *delta_y < 0. {
                         let v = self.value();
                         if v > self.minimum() {
                             let new_val = v - step_size;

--- a/internal/backends/qt/qt_widgets/tableheadersection.rs
+++ b/internal/backends/qt/qt_widgets/tableheadersection.rs
@@ -61,7 +61,7 @@ impl Item for NativeTableHeaderSection {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -70,7 +70,7 @@ impl Item for NativeTableHeaderSection {
 
     fn input_event(
         self: Pin<&Self>,
-        _event: MouseEvent,
+        _event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -237,7 +237,7 @@ impl Item for NativeTabWidget {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -246,7 +246,7 @@ impl Item for NativeTabWidget {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
@@ -422,7 +422,7 @@ impl Item for NativeTab {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -431,7 +431,7 @@ impl Item for NativeTab {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &i_slint_core::items::ItemRc,
     ) -> InputEventResult {
@@ -441,7 +441,7 @@ impl Item for NativeTab {
         }
 
         Self::FIELD_OFFSETS.pressed.apply_pin(self).set(match event {
-            MouseEvent::Pressed { button, .. } => button == PointerEventButton::Left,
+            MouseEvent::Pressed { button, .. } => *button == PointerEventButton::Left,
             MouseEvent::Exit | MouseEvent::Released { .. } => false,
             MouseEvent::Moved { .. } => {
                 return if self.pressed() {
@@ -455,8 +455,8 @@ impl Item for NativeTab {
         let click_on_press = cpp!(unsafe [] -> bool as "bool" {
             return qApp->style()->styleHint(QStyle::SH_TabBar_SelectMouseType, nullptr, nullptr) == QEvent::MouseButtonPress;
         });
-        if matches!(event, MouseEvent::Released { button, .. } if !click_on_press && button == PointerEventButton::Left)
-            || matches!(event, MouseEvent::Pressed { button, .. } if click_on_press && button == PointerEventButton::Left)
+        if matches!(event, MouseEvent::Released { button: PointerEventButton::Left, .. } if !click_on_press)
+            || matches!(event, MouseEvent::Pressed { button: PointerEventButton::Left, .. } if click_on_press)
         {
             WindowInner::from_pub(window_adapter.window()).set_focus_item(
                 self_rc,

--- a/internal/backends/qt/qt_widgets/tabwidget.rs
+++ b/internal/backends/qt/qt_widgets/tabwidget.rs
@@ -451,6 +451,9 @@ impl Item for NativeTab {
                 }
             }
             MouseEvent::Wheel { .. } => return InputEventResult::EventIgnored,
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+                return InputEventResult::EventIgnored
+            }
         });
         let click_on_press = cpp!(unsafe [] -> bool as "bool" {
             return qApp->style()->styleHint(QStyle::SH_TabBar_SelectMouseType, nullptr, nullptr) == QEvent::MouseButtonPress;

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -115,6 +115,21 @@ macro_rules! for_each_builtin_structs {
                 }
             }
 
+            /// This structure is passed to the callbacks of the `DropArea` element
+            struct DropEvent {
+                @name = "slint::private_api::DropEvent"
+                export {
+                    /// The mime type of the data being dragged
+                    mime_type: SharedString,
+                    /// The data being dragged
+                    data: SharedString,
+                    /// The current mouse position in coordinates of the `DropArea` element
+                    position: LogicalPosition,
+                }
+                private {
+                }
+            }
+
             /// Represents an item in a StandardListView and a StandardTableView.
             #[non_exhaustive]
             struct StandardListViewItem {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -186,6 +186,22 @@ export component SwipeGestureHandler {
     //-default_size_binding:expands_to_parent_geometry
 }
 
+export component DragArea {
+    in property <bool> enabled: true;
+    //out property <bool> dragging;
+    in property <string> mime-type;
+    in property <string> data;
+    //-default_size_binding:expands_to_parent_geometry
+
+}
+export component DropArea {
+    in property <bool> enabled: true;
+    callback can-drop(event: DropEvent) -> bool;
+    callback dropped(event: DropEvent);
+    out property <bool> contains-drag;
+    //-default_size_binding:expands_to_parent_geometry
+}
+
 component MenuItem {
     in property <string> title;
     callback activated();

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -408,6 +408,7 @@ impl TypeRegister {
             ($pub_type:ident, SharedString) => { Type::String };
             ($pub_type:ident, Image) => { Type::Image };
             ($pub_type:ident, Coord) => { Type::LogicalLength };
+            ($pub_type:ident, LogicalPosition) => { logical_point_type() };
             ($pub_type:ident, KeyboardModifiers) => { $pub_type.clone() };
             ($pub_type:ident, $_:ident) => {
                 BUILTIN.with(|e| Type::Enumeration(e.enums.$pub_type.clone()))
@@ -547,8 +548,12 @@ impl TypeRegister {
     pub fn builtin() -> Rc<RefCell<Self>> {
         let mut register = Self::builtin_internal();
 
-        register.elements.remove("ComponentContainer");
-        register.types.remove("component-factory");
+        register.elements.remove("ComponentContainer").unwrap();
+        register.types.remove("component-factory").unwrap();
+
+        register.elements.remove("DragArea").unwrap();
+        register.elements.remove("DropArea").unwrap();
+        register.types.remove("DropEvent").unwrap(); // Also removed in xtask/src/slintdocs.rs
 
         Rc::new(RefCell::new(register))
     }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -20,6 +20,7 @@ When adding an item or a property, it needs to be kept in sync with different pl
 #![allow(non_upper_case_globals)]
 #![allow(missing_docs)] // because documenting each property of items is redundant
 
+use crate::api::LogicalPosition;
 use crate::graphics::{Brush, Color, FontRequest};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEventResult,
@@ -32,6 +33,7 @@ use crate::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalRect, LogicalSize, LogicalVector, PointLengths,
     RectLengths,
 };
+pub use crate::menus::MenuItem;
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use crate::window::{WindowAdapter, WindowAdapterRc, WindowInner};
@@ -54,9 +56,10 @@ mod input_items;
 pub use input_items::*;
 mod image;
 pub use self::image::*;
+mod drag_n_drop;
+pub use drag_n_drop::*;
 #[cfg(feature = "std")]
 mod path;
-pub use crate::menus::MenuItem;
 #[cfg(feature = "std")]
 pub use path::*;
 
@@ -70,7 +73,7 @@ pub type KeyEventArg = (KeyEvent,);
 type FocusReasonArg = (FocusReason,);
 type PointerEventArg = (PointerEvent,);
 type PointerScrollEventArg = (PointerScrollEvent,);
-type PointArg = (crate::api::LogicalPosition,);
+type PointArg = (LogicalPosition,);
 type MenuEntryArg = (MenuEntry,);
 type MenuEntryModel = crate::model::ModelRc<MenuEntry>;
 
@@ -1047,6 +1050,14 @@ declare_item_vtable! {
     fn slint_get_FlickableVTable() -> FlickableVTable for Flickable
 }
 
+declare_item_vtable! {
+    fn slint_get_DragAreaVTable() -> DragAreaVTable for DragArea
+}
+
+declare_item_vtable! {
+    fn slint_get_DropAreaVTable() -> DropAreaVTable for DropArea
+}
+
 /// The implementation of the `PropertyAnimation` element
 #[repr(C)]
 #[derive(FieldOffsets, SlintElement, Clone, Debug)]
@@ -1349,7 +1360,7 @@ impl Item for ContextMenu {
         }
         match event {
             MouseEvent::Pressed { position, button: PointerEventButton::Right, .. } => {
-                self.show.call(&(crate::api::LogicalPosition::from_euclid(position),));
+                self.show.call(&(LogicalPosition::from_euclid(*position),));
                 InputEventResult::EventAccepted
             }
             #[cfg(target_os = "android")]

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -141,7 +141,7 @@ pub struct ItemVTable {
     /// on this item again.
     pub input_event_filter_before_children: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
-        MouseEvent,
+        &MouseEvent,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> InputEventFilterResult,
@@ -149,7 +149,7 @@ pub struct ItemVTable {
     /// Handle input event for mouse and touch event
     pub input_event: extern "C" fn(
         core::pin::Pin<VRef<ItemVTable>>,
-        MouseEvent,
+        &MouseEvent,
         window_adapter: &WindowAdapterRc,
         self_rc: &ItemRc,
     ) -> InputEventResult,
@@ -211,7 +211,7 @@ impl Item for Empty {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -220,7 +220,7 @@ impl Item for Empty {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -303,7 +303,7 @@ impl Item for Rectangle {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -312,7 +312,7 @@ impl Item for Rectangle {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -404,7 +404,7 @@ impl Item for BasicBorderRectangle {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -413,7 +413,7 @@ impl Item for BasicBorderRectangle {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -518,7 +518,7 @@ impl Item for BorderRectangle {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -527,7 +527,7 @@ impl Item for BorderRectangle {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -647,7 +647,7 @@ impl Item for Clip {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -667,7 +667,7 @@ impl Item for Clip {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -759,7 +759,7 @@ impl Item for Opacity {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -768,7 +768,7 @@ impl Item for Opacity {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -877,7 +877,7 @@ impl Item for Layer {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -886,7 +886,7 @@ impl Item for Layer {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -970,7 +970,7 @@ impl Item for Rotate {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -979,7 +979,7 @@ impl Item for Rotate {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -1115,7 +1115,7 @@ impl Item for WindowItem {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -1124,7 +1124,7 @@ impl Item for WindowItem {
 
     fn input_event(
         self: Pin<&Self>,
-        _event: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -1331,7 +1331,7 @@ impl Item for ContextMenu {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -1340,7 +1340,7 @@ impl Item for ContextMenu {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -1356,6 +1356,7 @@ impl Item for ContextMenu {
             MouseEvent::Pressed { position, button: PointerEventButton::Left, .. } => {
                 let timer = crate::timers::Timer::default();
                 let self_weak = _self_rc.downgrade();
+                let position = *position;
                 timer.start(
                     crate::timers::TimerMode::SingleShot,
                     WindowInner::from_pub(_window_adapter.window())
@@ -1365,7 +1366,7 @@ impl Item for ContextMenu {
                     move || {
                         let Some(self_rc) = self_weak.upgrade() else { return };
                         let Some(self_) = self_rc.downcast::<ContextMenu>() else { return };
-                        self_.show.call(&(crate::api::LogicalPosition::from_euclid(position),));
+                        self_.show.call(&(LogicalPosition::from_euclid(position),));
                     },
                 );
                 self.long_press_timer.set(Some(timer));
@@ -1515,7 +1516,7 @@ impl Item for BoxShadow {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -1524,7 +1525,7 @@ impl Item for BoxShadow {
 
     fn input_event(
         self: Pin<&Self>,
-        _event: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {

--- a/internal/core/items/component_container.rs
+++ b/internal/core/items/component_container.rs
@@ -182,7 +182,7 @@ impl Item for ComponentContainer {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -191,7 +191,7 @@ impl Item for ComponentContainer {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {

--- a/internal/core/items/drag_n_drop.rs
+++ b/internal/core/items/drag_n_drop.rs
@@ -1,0 +1,312 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use super::{
+    DropEvent, Item, ItemConsts, ItemRc, MouseCursor, PointerEventButton, RenderingResult,
+};
+use crate::input::{
+    FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, KeyEvent,
+    KeyEventResult, MouseEvent,
+};
+use crate::item_rendering::{CachedRenderingData, ItemRenderer};
+use crate::layout::{LayoutInfo, Orientation};
+use crate::lengths::{LogicalPoint, LogicalRect, LogicalSize};
+#[cfg(feature = "rtti")]
+use crate::rtti::*;
+use crate::window::WindowAdapter;
+use crate::{Callback, Property, SharedString};
+use alloc::rc::Rc;
+use const_field_offset::FieldOffsets;
+use core::cell::Cell;
+use core::pin::Pin;
+use i_slint_core_macros::*;
+
+pub type DropEventArg = (DropEvent,);
+
+#[repr(C)]
+#[derive(FieldOffsets, Default, SlintElement)]
+#[pin]
+/// The implementation of the `DragArea` element
+pub struct DragArea {
+    pub enabled: Property<bool>,
+    pub mime_type: Property<SharedString>,
+    pub data: Property<SharedString>,
+    pressed: Cell<bool>,
+    pressed_position: Cell<LogicalPoint>,
+    pub cached_rendering_data: CachedRenderingData,
+}
+
+impl Item for DragArea {
+    fn init(self: Pin<&Self>, _self_rc: &ItemRc) {}
+
+    fn layout_info(
+        self: Pin<&Self>,
+        _: Orientation,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> LayoutInfo {
+        LayoutInfo { stretch: 1., ..LayoutInfo::default() }
+    }
+
+    fn input_event_filter_before_children(
+        self: Pin<&Self>,
+        event: &MouseEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> InputEventFilterResult {
+        if !self.enabled() {
+            self.cancel();
+            return InputEventFilterResult::ForwardAndIgnore;
+        }
+
+        match event {
+            MouseEvent::Pressed { position, button: PointerEventButton::Left, .. } => {
+                self.pressed_position.set(*position);
+                self.pressed.set(true);
+                InputEventFilterResult::ForwardAndInterceptGrab
+            }
+            MouseEvent::Exit => {
+                self.cancel();
+                InputEventFilterResult::ForwardAndIgnore
+            }
+            MouseEvent::Released { button: PointerEventButton::Left, .. } => {
+                self.pressed.set(false);
+                InputEventFilterResult::ForwardAndIgnore
+            }
+
+            MouseEvent::Moved { position } => {
+                if !self.pressed.get() {
+                    InputEventFilterResult::ForwardEvent
+                } else {
+                    let pressed_pos = self.pressed_position.get();
+                    let dx = (position.x - pressed_pos.x).abs();
+                    let dy = (position.y - pressed_pos.y).abs();
+                    let threshold = super::flickable::DISTANCE_THRESHOLD.get();
+                    if dy > threshold || dx > threshold {
+                        InputEventFilterResult::Intercept
+                    } else {
+                        InputEventFilterResult::ForwardAndInterceptGrab
+                    }
+                }
+            }
+            MouseEvent::Wheel { .. } => InputEventFilterResult::ForwardAndIgnore,
+            // Not the left button
+            MouseEvent::Pressed { .. } | MouseEvent::Released { .. } => {
+                InputEventFilterResult::ForwardAndIgnore
+            }
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+                InputEventFilterResult::ForwardAndIgnore
+            }
+        }
+    }
+
+    fn input_event(
+        self: Pin<&Self>,
+        event: &MouseEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> InputEventResult {
+        match event {
+            MouseEvent::Pressed { .. } => InputEventResult::EventAccepted,
+            MouseEvent::Exit => {
+                self.cancel();
+                InputEventResult::EventIgnored
+            }
+            MouseEvent::Released { .. } => {
+                self.cancel();
+                InputEventResult::EventIgnored
+            }
+            MouseEvent::Moved { position } => {
+                if !self.pressed.get() || !self.enabled() {
+                    return InputEventResult::EventIgnored;
+                }
+                let pressed_pos = self.pressed_position.get();
+                let dx = (position.x - pressed_pos.x).abs();
+                let dy = (position.y - pressed_pos.y).abs();
+                let threshold = super::flickable::DISTANCE_THRESHOLD.get();
+                let start_drag = dx > threshold || dy > threshold;
+                if start_drag {
+                    self.pressed.set(false);
+                    InputEventResult::StartDrag
+                } else {
+                    InputEventResult::EventAccepted
+                }
+            }
+            MouseEvent::Wheel { .. } => InputEventResult::EventIgnored,
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
+        }
+    }
+
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> KeyEventResult {
+        KeyEventResult::EventIgnored
+    }
+
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> FocusEventResult {
+        FocusEventResult::FocusIgnored
+    }
+
+    fn render(
+        self: Pin<&Self>,
+        _: &mut &mut dyn ItemRenderer,
+        _self_rc: &ItemRc,
+        _size: LogicalSize,
+    ) -> RenderingResult {
+        RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect(
+        self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        mut geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry.size = LogicalSize::zero();
+        geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
+}
+
+impl ItemConsts for DragArea {
+    const cached_rendering_data_offset: const_field_offset::FieldOffset<
+        DragArea,
+        CachedRenderingData,
+    > = DragArea::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
+}
+
+impl DragArea {
+    fn cancel(self: Pin<&Self>) {
+        self.pressed.set(false)
+    }
+}
+
+#[repr(C)]
+#[derive(FieldOffsets, Default, SlintElement)]
+#[pin]
+/// The implementation of the `DropArea` element
+pub struct DropArea {
+    pub enabled: Property<bool>,
+    pub contains_drag: Property<bool>,
+    pub can_drop: Callback<DropEventArg, bool>,
+    pub dropped: Callback<DropEventArg>,
+
+    pub cached_rendering_data: CachedRenderingData,
+}
+
+impl Item for DropArea {
+    fn init(self: Pin<&Self>, _self_rc: &ItemRc) {}
+
+    fn layout_info(
+        self: Pin<&Self>,
+        _: Orientation,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> LayoutInfo {
+        LayoutInfo { stretch: 1., ..LayoutInfo::default() }
+    }
+
+    fn input_event_filter_before_children(
+        self: Pin<&Self>,
+        _: &MouseEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> InputEventFilterResult {
+        InputEventFilterResult::ForwardEvent
+    }
+
+    fn input_event(
+        self: Pin<&Self>,
+        event: &MouseEvent,
+        window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> InputEventResult {
+        if !self.enabled() {
+            return InputEventResult::EventIgnored;
+        }
+        match event {
+            MouseEvent::DragMove(event) => {
+                let r = Self::FIELD_OFFSETS.can_drop.apply_pin(self).call(&(event.clone(),));
+                if r {
+                    self.contains_drag.set(true);
+                    if let Some(window_adapter) = window_adapter.internal(crate::InternalToken) {
+                        window_adapter.set_mouse_cursor(MouseCursor::Copy);
+                    }
+                    InputEventResult::EventAccepted
+                } else {
+                    self.contains_drag.set(false);
+                    InputEventResult::EventIgnored
+                }
+            }
+            MouseEvent::Drop(event) => {
+                self.contains_drag.set(false);
+                Self::FIELD_OFFSETS.dropped.apply_pin(self).call(&(event.clone(),));
+                InputEventResult::EventAccepted
+            }
+            MouseEvent::Exit => {
+                self.contains_drag.set(false);
+                InputEventResult::EventIgnored
+            }
+            _ => InputEventResult::EventIgnored,
+        }
+    }
+
+    fn key_event(
+        self: Pin<&Self>,
+        _: &KeyEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> KeyEventResult {
+        KeyEventResult::EventIgnored
+    }
+
+    fn focus_event(
+        self: Pin<&Self>,
+        _: &FocusEvent,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+    ) -> FocusEventResult {
+        FocusEventResult::FocusIgnored
+    }
+
+    fn render(
+        self: Pin<&Self>,
+        _: &mut &mut dyn ItemRenderer,
+        _self_rc: &ItemRc,
+        _size: LogicalSize,
+    ) -> RenderingResult {
+        RenderingResult::ContinueRenderingChildren
+    }
+
+    fn bounding_rect(
+        self: core::pin::Pin<&Self>,
+        _window_adapter: &Rc<dyn WindowAdapter>,
+        _self_rc: &ItemRc,
+        mut geometry: LogicalRect,
+    ) -> LogicalRect {
+        geometry.size = LogicalSize::zero();
+        geometry
+    }
+
+    fn clips_children(self: core::pin::Pin<&Self>) -> bool {
+        false
+    }
+}
+
+impl ItemConsts for DropArea {
+    const cached_rendering_data_offset: const_field_offset::FieldOffset<
+        DropArea,
+        CachedRenderingData,
+    > = DropArea::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
+}

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -313,6 +313,9 @@ impl FlickableData {
             MouseEvent::Pressed { .. } | MouseEvent::Released { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+                InputEventFilterResult::ForwardAndIgnore
+            }
         }
     }
 
@@ -406,6 +409,7 @@ impl FlickableData {
                 }
                 InputEventResult::EventAccepted
             }
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
         }
     }
 

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -106,7 +106,7 @@ impl Item for Flickable {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -128,7 +128,7 @@ impl Item for Flickable {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -253,13 +253,13 @@ impl FlickableData {
     fn handle_mouse_filter(
         &self,
         flick: Pin<&Flickable>,
-        event: MouseEvent,
+        event: &MouseEvent,
         flick_rc: &ItemRc,
     ) -> InputEventFilterResult {
         let mut inner = self.inner.borrow_mut();
         match event {
             MouseEvent::Pressed { position, button: PointerEventButton::Left, .. } => {
-                inner.pressed_pos = position;
+                inner.pressed_pos = *position;
                 inner.pressed_time = Some(crate::animations::current_tick());
                 inner.pressed_viewport_pos = LogicalPoint::from_lengths(
                     (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick).get(),
@@ -288,7 +288,7 @@ impl FlickableData {
                         }
                         // Check if the mouse was moved more than the DISTANCE_THRESHOLD in a
                         // direction in which the flickable can flick
-                        let diff = position - inner.pressed_pos;
+                        let diff = *position - inner.pressed_pos;
                         let geo = flick_rc.geometry();
                         let w = geo.width_length();
                         let h = geo.height_length();
@@ -319,7 +319,7 @@ impl FlickableData {
     fn handle_mouse(
         &self,
         flick: Pin<&Flickable>,
-        event: MouseEvent,
+        event: &MouseEvent,
         window_adapter: &Rc<dyn WindowAdapter>,
         flick_rc: &ItemRc,
     ) -> InputEventResult {
@@ -340,7 +340,7 @@ impl FlickableData {
             }
             MouseEvent::Moved { position } => {
                 if inner.pressed_time.is_some() {
-                    let new_pos = inner.pressed_viewport_pos + (position - inner.pressed_pos);
+                    let new_pos = inner.pressed_viewport_pos + (*position - inner.pressed_pos);
                     let x = (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick);
                     let y = (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick);
                     let should_capture = || {
@@ -390,9 +390,9 @@ impl FlickableData {
                     && !cfg!(target_os = "macos")
                 {
                     // Shift invert coordinate for the purpose of scrolling. But not on macOs because there the OS already take care of the change
-                    LogicalVector::new(delta_y, delta_x)
+                    LogicalVector::new(*delta_y, *delta_x)
                 } else {
-                    LogicalVector::new(delta_x, delta_y)
+                    LogicalVector::new(*delta_x, *delta_y)
                 };
                 let new_pos = ensure_in_bound(flick, old_pos + delta, flick_rc);
 
@@ -412,7 +412,7 @@ impl FlickableData {
     fn mouse_released(
         inner: &mut FlickableDataInner,
         flick: Pin<&Flickable>,
-        event: MouseEvent,
+        event: &MouseEvent,
         flick_rc: &ItemRc,
     ) {
         if let (Some(pressed_time), Some(pos)) = (inner.pressed_time, event.position()) {

--- a/internal/core/items/image.rs
+++ b/internal/core/items/image.rs
@@ -66,7 +66,7 @@ impl Item for ImageItem {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -75,7 +75,7 @@ impl Item for ImageItem {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -217,7 +217,7 @@ impl Item for ClippedImage {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -226,7 +226,7 @@ impl Item for ClippedImage {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -202,6 +202,7 @@ impl Item for TouchArea {
                     }
                 }
             }
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
         }
     }
 
@@ -487,6 +488,9 @@ impl Item for SwipeGestureHandler {
             MouseEvent::Pressed { .. } | MouseEvent::Released { .. } => {
                 InputEventFilterResult::ForwardAndIgnore
             }
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => {
+                InputEventFilterResult::ForwardAndIgnore
+            }
         }
     }
 
@@ -539,6 +543,7 @@ impl Item for SwipeGestureHandler {
                 InputEventResult::GrabMouse
             }
             MouseEvent::Wheel { .. } => InputEventResult::EventIgnored,
+            MouseEvent::DragMove(..) | MouseEvent::Drop(..) => InputEventResult::EventIgnored,
         }
     }
 

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -67,7 +67,7 @@ impl Item for TouchArea {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -99,7 +99,7 @@ impl Item for TouchArea {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -116,13 +116,13 @@ impl Item for TouchArea {
         match event {
             MouseEvent::Pressed { position, button, .. } => {
                 self.grabbed.set(true);
-                if button == PointerEventButton::Left {
+                if *button == PointerEventButton::Left {
                     Self::FIELD_OFFSETS.pressed_x.apply_pin(self).set(position.x_length());
                     Self::FIELD_OFFSETS.pressed_y.apply_pin(self).set(position.y_length());
                     Self::FIELD_OFFSETS.pressed.apply_pin(self).set(true);
                 }
                 Self::FIELD_OFFSETS.pointer_event.apply_pin(self).call(&(PointerEvent {
-                    button,
+                    button: *button,
                     kind: PointerEventKind::Down,
                     modifiers: window_adapter.window().0.modifiers.get().into(),
                 },));
@@ -144,8 +144,8 @@ impl Item for TouchArea {
 
             MouseEvent::Released { button, position, click_count } => {
                 let geometry = self_rc.geometry();
-                if button == PointerEventButton::Left
-                    && LogicalRect::new(LogicalPoint::default(), geometry.size).contains(position)
+                if *button == PointerEventButton::Left
+                    && LogicalRect::new(LogicalPoint::default(), geometry.size).contains(*position)
                     && self.pressed()
                 {
                     Self::FIELD_OFFSETS.clicked.apply_pin(self).call(&());
@@ -155,11 +155,11 @@ impl Item for TouchArea {
                 }
 
                 self.grabbed.set(false);
-                if button == PointerEventButton::Left {
+                if *button == PointerEventButton::Left {
                     Self::FIELD_OFFSETS.pressed.apply_pin(self).set(false);
                 }
                 Self::FIELD_OFFSETS.pointer_event.apply_pin(self).call(&(PointerEvent {
-                    button,
+                    button: *button,
                     kind: PointerEventKind::Up,
                     modifiers: window_adapter.window().0.modifiers.get().into(),
                 },));
@@ -181,10 +181,12 @@ impl Item for TouchArea {
             }
             MouseEvent::Wheel { delta_x, delta_y, .. } => {
                 let modifiers = window_adapter.window().0.modifiers.get().into();
-                let r = Self::FIELD_OFFSETS
-                    .scroll_event
-                    .apply_pin(self)
-                    .call(&(PointerScrollEvent { delta_x, delta_y, modifiers },));
+                let r =
+                    Self::FIELD_OFFSETS.scroll_event.apply_pin(self).call(&(PointerScrollEvent {
+                        delta_x: *delta_x,
+                        delta_y: *delta_y,
+                        modifiers,
+                    },));
                 if self.grabbed.get() {
                     InputEventResult::GrabMouse
                 } else {
@@ -282,7 +284,7 @@ impl Item for FocusScope {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -291,7 +293,7 @@ impl Item for FocusScope {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -425,7 +427,7 @@ impl Item for SwipeGestureHandler {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -441,7 +443,7 @@ impl Item for SwipeGestureHandler {
                 Self::FIELD_OFFSETS
                     .pressed_position
                     .apply_pin(self)
-                    .set(crate::lengths::logical_position_to_api(position));
+                    .set(crate::lengths::logical_position_to_api(*position));
                 self.pressed.set(true);
                 InputEventFilterResult::DelayForwarding(
                     super::flickable::FORWARD_DELAY.as_millis() as _
@@ -490,7 +492,7 @@ impl Item for SwipeGestureHandler {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -504,7 +506,7 @@ impl Item for SwipeGestureHandler {
                 if !self.pressed.get() && !self.swiping() {
                     return InputEventResult::EventIgnored;
                 }
-                self.current_position.set(crate::lengths::logical_position_to_api(position));
+                self.current_position.set(crate::lengths::logical_position_to_api(*position));
                 self.pressed.set(false);
                 if self.swiping() {
                     Self::FIELD_OFFSETS.swiping.apply_pin(self).set(false);
@@ -518,7 +520,7 @@ impl Item for SwipeGestureHandler {
                 if !self.pressed.get() {
                     return InputEventResult::EventIgnored;
                 }
-                self.current_position.set(crate::lengths::logical_position_to_api(position));
+                self.current_position.set(crate::lengths::logical_position_to_api(*position));
                 if !self.swiping() {
                     let pressed_pos = self.pressed_position();
                     let dx = position.x - pressed_pos.x as Coord;

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -18,8 +18,7 @@ use crate::item_rendering::CachedRenderingData;
 
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{
-    LogicalBorderRadius, LogicalLength, LogicalRect, LogicalSize, LogicalVector, PointLengths,
-    RectLengths,
+    LogicalBorderRadius, LogicalLength, LogicalRect, LogicalSize, LogicalVector, RectLengths,
 };
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
@@ -65,27 +64,16 @@ impl Item for Path {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        event: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
-        self_rc: &ItemRc,
+        _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
-        if let Some(pos) = event.position() {
-            let geometry = self_rc.geometry();
-            if self.clip()
-                && (pos.x < 0 as _
-                    || pos.y < 0 as _
-                    || pos.x_length() > geometry.width_length()
-                    || pos.y_length() > geometry.height_length())
-            {
-                return InputEventFilterResult::Intercept;
-            }
-        }
         InputEventFilterResult::ForwardAndIgnore
     }
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -83,7 +83,7 @@ impl Item for ComplexText {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -92,7 +92,7 @@ impl Item for ComplexText {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -245,7 +245,7 @@ impl Item for SimpleText {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -254,7 +254,7 @@ impl Item for SimpleText {
 
     fn input_event(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -574,7 +574,7 @@ impl Item for TextInput {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: MouseEvent,
+        _: &MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> InputEventFilterResult {
@@ -583,7 +583,7 @@ impl Item for TextInput {
 
     fn input_event(
         self: Pin<&Self>,
-        event: MouseEvent,
+        event: &MouseEvent,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> InputEventResult {
@@ -593,7 +593,7 @@ impl Item for TextInput {
         match event {
             MouseEvent::Pressed { position, button: PointerEventButton::Left, click_count } => {
                 let clicked_offset =
-                    self.byte_offset_for_position(position, window_adapter, self_rc) as i32;
+                    self.byte_offset_for_position(*position, window_adapter, self_rc) as i32;
                 self.as_ref().pressed.set((click_count % 3) + 1);
 
                 if !window_adapter.window().0.modifiers.get().shift() {
@@ -630,7 +630,7 @@ impl Item for TextInput {
             }
             MouseEvent::Released { position, button: PointerEventButton::Middle, .. } => {
                 let clicked_offset =
-                    self.byte_offset_for_position(position, window_adapter, self_rc) as i32;
+                    self.byte_offset_for_position(*position, window_adapter, self_rc) as i32;
                 self.as_ref().anchor_position_byte_offset.set(clicked_offset);
                 self.set_cursor_position(
                     clicked_offset,
@@ -655,7 +655,7 @@ impl Item for TextInput {
                 let pressed = self.as_ref().pressed.get();
                 if pressed > 0 {
                     let clicked_offset =
-                        self.byte_offset_for_position(position, window_adapter, self_rc) as i32;
+                        self.byte_offset_for_position(*position, window_adapter, self_rc) as i32;
                     self.set_cursor_position(
                         clicked_offset,
                         true,

--- a/internal/core/menus.rs
+++ b/internal/core/menus.rs
@@ -162,7 +162,7 @@ impl crate::items::Item for MenuItem {
 
     fn input_event_filter_before_children(
         self: Pin<&Self>,
-        _: crate::input::MouseEvent,
+        _: &crate::input::MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> crate::input::InputEventFilterResult {
@@ -171,7 +171,7 @@ impl crate::items::Item for MenuItem {
 
     fn input_event(
         self: Pin<&Self>,
-        _: crate::input::MouseEvent,
+        _: &crate::input::MouseEvent,
         _window_adapter: &Rc<dyn WindowAdapter>,
         _self_rc: &ItemRc,
     ) -> crate::input::InputEventResult {

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -50,6 +50,7 @@ macro_rules! declare_ValueType_2 {
             crate::api::LogicalPosition,
             crate::items::FontMetrics,
             crate::items::MenuEntry,
+            crate::items::DropEvent,
             crate::model::ModelRc<crate::items::MenuEntry>,
             $(crate::items::$Name,)*
         ];

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -647,7 +647,7 @@ impl WindowInner {
         });
 
         mouse_input_state = if let Some(mut event) =
-            crate::input::handle_mouse_grab(event, &window_adapter, &mut mouse_input_state)
+            crate::input::handle_mouse_grab(&event, &window_adapter, &mut mouse_input_state)
         {
             let mut item_tree = self.component.borrow().upgrade();
             let mut offset = LogicalPoint::default();
@@ -697,7 +697,7 @@ impl WindowInner {
                 event.translate(-offset.to_vector());
                 let mut new_input_state = crate::input::process_mouse_input(
                     root,
-                    event,
+                    &event,
                     &window_adapter,
                     mouse_input_state,
                 );
@@ -1862,10 +1862,10 @@ pub mod ffi {
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_dispatch_pointer_event(
         handle: *const WindowAdapterRcOpaque,
-        event: crate::input::MouseEvent,
+        event: &crate::input::MouseEvent,
     ) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        window_adapter.window().0.process_mouse_input(event);
+        window_adapter.window().0.process_mouse_input(event.clone());
     }
 
     /// Dispatch a window event

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -997,6 +997,8 @@ fn generate_rtti() -> HashMap<&'static str, Rc<ItemRTTI>> {
             rtti_for::<Rotate>(),
             rtti_for::<Opacity>(),
             rtti_for::<Layer>(),
+            rtti_for::<DragArea>(),
+            rtti_for::<DropArea>(),
             rtti_for::<ContextMenu>(),
             rtti_for::<MenuItem>(),
         ]

--- a/tests/cases/elements/dragarea_droparea.slint
+++ b/tests/cases/elements/dragarea_droparea.slint
@@ -1,0 +1,100 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 200px;
+    in-out property <string> result;
+    out property <bool> contains-drag <=> da.contains-drag;
+    VerticalLayout {
+        Rectangle {
+            background: inner_touch_area.has-hover ? yellow : red;
+            DragArea {
+                mime-type: "text/plain";
+                data: "Hello World";
+
+                inner_touch_area := TouchArea {
+                    x: 50px;
+                    width: 50px;
+                    clicked => { result += "InnerClicked;"; }
+                }
+            }
+        }
+        Rectangle {
+            background: da.contains-drag ? green : blue;
+            da := DropArea {
+                can-drop(event) => {
+                    debug("can-drop", event);
+                    true
+                }
+                dropped(event) => {
+                    result += "D[" + event.data + "];";
+                    debug("dropped", event);
+                }
+            }
+        }
+    }
+}
+
+
+/*
+```rust
+use slint::{platform::WindowEvent, LogicalPosition, platform::PointerEventButton};
+
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_result(), "");
+
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(20.0, 25.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_result(), "");
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(21.0, 40.0) });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_result(), "");
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(22.0, 120.0) });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_contains_drag(), true);
+assert_eq!(instance.get_result(), "");
+
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(22.0, 120.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_result(), "D[Hello World];");
+assert_eq!(instance.get_contains_drag(), false);
+
+instance.set_result("".into());
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(51.0, 50.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_result(), "");
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(52.0, 50.0) });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_result(), "");
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(52.0, 50.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_result(), "InnerClicked;");
+assert_eq!(instance.get_contains_drag(), false);
+
+instance.set_result("".into());
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(51.0, 15.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_result(), "");
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(58.0, 40.0) });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_result(), "");
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(58.0, 120.0) });
+assert_eq!(instance.get_contains_drag(), true);
+assert_eq!(instance.get_result(), "");
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(58.0, 20.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(20);
+assert_eq!(instance.get_contains_drag(), false);
+assert_eq!(instance.get_result(), "");
+```
+
+*/

--- a/tools/lsp/ui/components/expandable-listview.slint
+++ b/tools/lsp/ui/components/expandable-listview.slint
@@ -61,36 +61,27 @@ component HeaderItemTemplate {
 }
 
 component ItemTemplate {
+    in property <ComponentItem> data;
     in property <bool> enabled: true;
     in property <string> text;
     in property <bool> can-drop-here;
     in property <length> offset;
-    out property <length> absolute-mouse-x: touch-area.mouse-x - touch-area.x + touch-area.absolute-position.x;
-    out property <length> absolute-mouse-y: touch-area.mouse-y - touch-area.y + touch-area.absolute-position.y;
     out property <bool> pressed <=> touch-area.pressed;
 
     callback clicked <=> touch-area.clicked;
-    callback pointer-event <=> touch-area.pointer-event;
 
     min-width: content-layer.min-width;
     min-height: max(EditorSizeSettings.item-height, content-layer.min-height);
 
-    touch-area := TouchArea {
-        states [
-            dragging-no-drop when self.pressed && !root.can-drop-here: {
-                mouse-cursor: MouseCursor.no-drop;
-            }
-            dragging-can-drop when self.pressed && root.can-drop-here: {
-                mouse-cursor: MouseCursor.copy;
-            }
-            normal when !self.pressed: {
-                mouse-cursor: MouseCursor.default;
-            }
-        ]
+    DragArea {
+        mime-type: "application/x-slint-component";
+        data: data.index;
 
-        changed has-hover => {
-            if self.has-hover {
-                StatusLineApi.help-text = @tr("Drag onto canvas to add {}", text);
+        touch-area := TouchArea {
+            changed has-hover => {
+                if self.has-hover {
+                    StatusLineApi.help-text = @tr("Drag onto canvas to add {}", text);
+                }
             }
         }
     }
@@ -120,10 +111,6 @@ export component ExpandableListView inherits ScrollView {
     in property <[ComponentListItem]> known-components;
 
     in property <bool> preview-is-current;
-    in property <length> preview-area-position-x;
-    in property <length> preview-area-position-y;
-    in property <length> preview-area-width;
-    in property <length> preview-area-height;
     in-out property <ComponentItem> visible-component: {
         name: "",
         defined-at: "",
@@ -132,11 +119,8 @@ export component ExpandableListView inherits ScrollView {
         is-currently-shown: false,
     };
 
-    pure callback can-drop(index: int, x: length, y: length, on-drop-area: bool) -> bool;
-    callback drop(index: int, x: length, y: length);
     callback show-preview-for(name: string, defined-at: string);
 
-    property <bool> preview-visible: preview-area-width > 0px && preview-area-height > 0px;
     property <length> list-spacing: 10px;
 
     VerticalLayout {
@@ -149,23 +133,11 @@ export component ExpandableListView inherits ScrollView {
 
             if header-item.open: VerticalLayout {
                 for ci[index] in cli.components: ItemTemplate {
-                    property <length> drop-x: self.absolute-mouse-x - root.preview-area-position-x;
-                    property <length> drop-y: self.absolute-mouse-y - root.preview-area-position-y;
-                    property <bool> on-drop-area:
-                            drop-x >= 0 && drop-x <= root.preview-area-width && drop-y >= 0 && drop-y <= root.preview-area-height;
-                    property <ComponentItem> data: ci;
-
-                    can-drop-here: root.preview-is-current && !self.data.is-currently-shown && root.can-drop(self.data.index, drop-x, drop-y, on-drop-area);
-                    enabled: root.preview-visible;
+                    data: ci;
                     text: ci.name;
                     offset: header-item.offset;
                     height: self.min-height;
 
-                    pointer-event(event) => {
-                        if self.can-drop-here && event.kind == PointerEventKind.up && event.button == PointerEventButton.left {
-                            root.drop(self.data.index, drop-x, drop-y);
-                        }
-                    }
 
                     init() => {
                         root.visible-component = ci;

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -93,20 +93,7 @@ export component PreviewUi inherits Window {
                         known-components: Api.known-components;
 
                         preview-area-is-current: preview.preview-is-current;
-                        preview-area-position-x: preview.preview-area-position-x;
-                        preview-area-position-y: preview.preview-area-position-y;
-                        preview-area-width: preview.preview-area-width;
-                        preview-area-height: preview.preview-area-height;
-
                         visible-component: root.visible-component;
-
-                        can-drop(index, x, y, on-drop-area) => {
-                            Api.can-drop(index, x, y, on-drop-area);
-                        }
-
-                        drop(index, x, y) => {
-                            Api.drop(index, x, y);
-                        }
 
                         show-preview-for(name, defined-at) => {
                             Api.show-preview-for(name, defined-at);

--- a/tools/lsp/ui/views/library-view.slint
+++ b/tools/lsp/ui/views/library-view.slint
@@ -11,15 +11,9 @@ export component LibraryView {
     in property <[ComponentListItem]> known-components <=> component-list-view.known-components;
 
     in property <bool> preview-area-is-current <=> component-list-view.preview-is-current;
-    in property <length> preview-area-position-x <=> component-list-view.preview-area-position-x;
-    in property <length> preview-area-position-y <=> component-list-view.preview-area-position-y;
-    in property <length> preview-area-width <=> component-list-view.preview-area-width;
-    in property <length> preview-area-height <=> component-list-view.preview-area-height;
 
     in-out property <ComponentItem> visible-component <=> component-list-view.visible-component;
 
-    pure callback can-drop <=> component-list-view.can-drop;
-    callback drop <=> component-list-view.drop;
     callback show-preview-for <=> component-list-view.show-preview-for;
 
     width: EditorSizeSettings.side-bar-width;

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -200,11 +200,6 @@ export component PreviewView {
     out property <bool> preview-visible: preview-area-container.has-component;
     out property <DrawAreaMode> mode: uninitialized;
 
-    out property <length> preview-area-position-x: preview-area-container.absolute-position.x;
-    out property <length> preview-area-position-y: preview-area-container.absolute-position.y;
-    out property <length> preview-area-width: preview-visible ? preview-area-container.width : 0px;
-    out property <length> preview-area-height: preview-visible ? preview-area-container.height : 0px;
-
     preferred-height: max(max(preview-area-container.preferred-height, preview-area-container.min-height) + 2 * scroll-view.border, 10 * scroll-view.border);
     preferred-width: max(max(preview-area-container.preferred-width, preview-area-container.min-width) + 2 * scroll-view.border, 10 * scroll-view.border);
 
@@ -407,9 +402,21 @@ export component PreviewView {
                     }
                 }
 
+                DropArea {
+                    can-drop(event) => {
+                        if event.mime-type != "application/x-slint-component" {
+                            return false;
+                        }
+                        return Api.can-drop(event.data.to-float(), event.position.x, event.position.y, true);
+                    }
+                    dropped(event) => {
+                        Api.drop(event.data.to-float(), event.position.x, event.position.y);
+                    }
+                }
+
                 selection-popup := SelectionPopup {
-                    preview-width: root.preview-area-width;
-                    preview-height: root.preview-area-height;
+                    preview-width: preview-area-container.width;
+                    preview-height: preview-area-container.height;
                     x: 0px;
                     y: 0px;
                     max-popup-height: root.height * 0.9;

--- a/xtask/src/slintdocs.rs
+++ b/xtask/src/slintdocs.rs
@@ -213,8 +213,10 @@ pub fn extract_builtin_structs() -> std::collections::BTreeMap<String, StructDoc
 
     // `StateInfo` should not be in the documentation, so remove it again
     structs.remove("StateInfo");
-    // Experimental type
+    // Internal type
     structs.remove("MenuEntry");
+    // Experimental type
+    structs.remove("DropEvent");
 
     structs
 }


### PR DESCRIPTION
Add a `DragArea` and `DropArea` elements.
It is currently gated as experimental.

Use it in the live-preview for the drag&drop between the component library and the preview.

CC https://github.com/slint-ui/slint/issues/1967