### PR TITLE
Replace some biome async linter supressions with an explicit fix

### DIFF
--- a/tools/slintpad/src/editor_widget.ts
+++ b/tools/slintpad/src/editor_widget.ts
@@ -392,7 +392,6 @@ export class EditorWidget extends Widget {
 
         this.clear_editors();
 
-        // biome-ignore lint/nursery/noFloatingPromises: <explanation>
         this.open_default_content();
     }
 
@@ -400,7 +399,7 @@ export class EditorWidget extends Widget {
         this.#tab_panel!.currentWidget = pane;
     }
 
-    private async open_default_content() {
+    private open_default_content() {
         const params = new URLSearchParams(window.location.search);
         const code = params.get("snippet");
         const load_url = params.get("load_url");
@@ -416,9 +415,10 @@ export class EditorWidget extends Widget {
             );
         }
         if (load_url) {
-            return await this.project_from_url(load_url);
+            void this.project_from_url(load_url);
+        } else {
+            void this.set_demo(load_demo ?? "");
         }
-        return await this.set_demo(load_demo ?? "");
     }
 
     private clear_editors() {
@@ -533,9 +533,7 @@ export class EditorWidget extends Widget {
 
         this.clear_editors();
 
-        return Promise.resolve(
-            (await this.open_tab_from_url(monaco.Uri.parse(uri)))[0],
-        );
+        return (await this.open_tab_from_url(monaco.Uri.parse(uri)))[0];
     }
 
     private async open_tab_from_url(

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -52,8 +52,7 @@ function create_settings_menu(): Menu {
         label: "Manage Github login",
         iconClass: "fa-brands fa-github",
         execute: () => {
-            // biome-ignore lint/nursery/noFloatingPromises: <explanation>
-            manage_github_access();
+            void manage_github_access();
         },
     });
 
@@ -75,8 +74,7 @@ function create_project_menu(
         mnemonic: 1,
         execute: () => {
             const url = prompt("Please enter the URL to open");
-            // biome-ignore lint/nursery/noFloatingPromises: <explanation>
-            editor.project_from_url(url);
+            void editor.project_from_url(url);
         },
     });
 

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -44,8 +44,7 @@ export class PreviewWidget extends Widget {
         this.title.caption = "Slint Viewer";
         this.title.closable = true;
 
-        // biome-ignore lint/nursery/noFloatingPromises: <explanation>
-        lsp.previewer(resource_url_mapper, style).then((p) => {
+        void lsp.previewer(resource_url_mapper, style).then((p) => {
             this.#previewer = p;
 
             // Give the UI some time to wire up the canvas so it can be found


### PR DESCRIPTION
We don't want to wait for these function calls.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
