### PR TITLE
Add local variables, closes #2752

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
@@ -61,7 +61,7 @@ export component Example {
         let foo = 1;
         let foo = foo + 1;
 
-        debug(foo); // prints "1"
+        debug(foo); // prints "2"
 
         let foo = "hello world";
 

--- a/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
@@ -39,6 +39,37 @@ Functions can be annotated with the `pure` keyword.
 This indicates that the function does not cause any side effects.
 More details can be found in the <Link type="Purity" /> chapter.
 
+## Local Variables
+Functions can also have local variables, declared with the `let` keyword, similar to Rust, with an optional type annotation.
+For example:
+
+```slint
+export component Example {
+    function example() {
+        let foo: int = 1; // with type annotation
+        let bar = 2; // without type annotation
+    }
+}
+```
+
+Local variables are immutable and cannot be reassigned. But, shadowing (multiple variables with the same name) is permitted.
+For example:
+
+```slint
+export component Example {
+    function example() {
+        let foo = 1;
+        let foo = foo + 1;
+
+        debug(foo); // prints "1"
+
+        let foo = "hello world";
+
+        debug(foo); // prints "hello world"
+    }
+}
+```
+
 ## Calling Functions
 
 A function can be called without an element name (like a function call in other languages) or with

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -365,6 +365,7 @@ fn to_debug_string(
                     Expression::StructFieldAccess {
                         base: Box::new(Expression::ReadLocalVariable {
                             name: local_object.clone(),
+                            discriminator: None,
                             ty: ty.clone(),
                         }),
                         name: k.clone(),
@@ -389,7 +390,11 @@ fn to_debug_string(
             match string {
                 None => Expression::StringLiteral("{}".into()),
                 Some(string) => Expression::CodeBlock(vec![
-                    Expression::StoreLocalVariable { name: local_object, value: Box::new(expr) },
+                    Expression::StoreLocalVariable {
+                        name: local_object,
+                        discriminator: None,
+                        value: Box::new(expr),
+                    },
                     Expression::BinaryExpression {
                         lhs: Box::new(string),
                         op: '+',
@@ -402,6 +407,7 @@ fn to_debug_string(
             let local_object = "debug_enum";
             let mut v = vec![Expression::StoreLocalVariable {
                 name: local_object.into(),
+                discriminator: None,
                 value: Box::new(expr),
             }];
             let mut cond =
@@ -411,6 +417,7 @@ fn to_debug_string(
                     condition: Box::new(Expression::BinaryExpression {
                         lhs: Box::new(Expression::ReadLocalVariable {
                             name: local_object.into(),
+                            discriminator: None,
                             ty: ty.clone(),
                         }),
                         rhs: Box::new(Expression::EnumerationValue(EnumerationValue {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -12,7 +12,7 @@ use std::fmt::Write;
 use std::io::BufWriter;
 use std::sync::OnceLock;
 
-use smol_str::{format_smolstr, SmolStr, StrExt};
+use smol_str::{format_smolstr, SmolStr, StrExt, ToSmolStr};
 
 /// The configuration for the C++ code generator
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -3129,10 +3129,10 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             format!("slint::private_api::{}({})", ident(function), a.join(","))
         }
         Expression::FunctionParameterReference { index, .. } => format!("arg_{index}"),
-        Expression::StoreLocalVariable { name, value } => {
-            format!("auto {} = {};", ident(name), compile_expression(value, ctx))
+        Expression::StoreLocalVariable { name, discriminator, value } => {
+            format!("auto {}{} = {};", ident(name), discriminator.map_or(SmolStr::new(""), |d| d.to_smolstr()), compile_expression(value, ctx))
         }
-        Expression::ReadLocalVariable { name, .. } => ident(name).to_string(),
+        Expression::ReadLocalVariable { name, discriminator, .. } => format!("{}{}", ident(name), discriminator.map_or(SmolStr::new(""), |d| d.to_smolstr())),
         Expression::StructFieldAccess { base, name } => match base.ty(ctx) {
             Type::Struct(s)=> {
                 if s.name.is_none() {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2516,7 +2516,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             }
         }
 
-        Expression::StoreLocalVariable { name, value } => {
+        Expression::StoreLocalVariable { name, value, .. } => {
             let value = compile_expression(value, ctx);
             let name = ident(name);
             quote!(let #name = #value;)

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -34,6 +34,7 @@ pub enum Expression {
     /// Should be directly within a CodeBlock expression, and store the value of the expression in a local variable
     StoreLocalVariable {
         name: SmolStr,
+        discriminator: Option<usize>,
         value: Box<Expression>,
     },
 
@@ -41,6 +42,7 @@ pub enum Expression {
     /// with this name and this type before in one of the statement of an enclosing codeblock
     ReadLocalVariable {
         name: SmolStr,
+        discriminator: Option<usize>,
         ty: Type,
     },
 

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -253,7 +253,7 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
             Expression::BoolLiteral(x) => write!(f, "{x:?}"),
             Expression::PropertyReference(x) => write!(f, "{}", DisplayPropertyRef(x, ctx)),
             Expression::FunctionParameterReference { index } => write!(f, "arg_{index}"),
-            Expression::StoreLocalVariable { name, value } => {
+            Expression::StoreLocalVariable { name, value, .. } => {
                 write!(f, "{} = {}", name, e(value))
             }
             Expression::ReadLocalVariable { name, .. } => write!(f, "{name}"),

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -48,6 +48,9 @@ pub struct LookupCtx<'a> {
 
     /// The token currently processed
     pub current_token: Option<NodeOrToken>,
+
+    /// Local variables declared in the current scope.
+    pub local_variables: Vec<(SmolStr, Type)>,
 }
 
 impl<'a> LookupCtx<'a> {
@@ -62,6 +65,7 @@ impl<'a> LookupCtx<'a> {
             type_register,
             type_loader: None,
             current_token: None,
+            local_variables: Default::default(),
         }
     }
 
@@ -215,6 +219,26 @@ impl LookupObject for LookupResult {
             }
             LookupResult::Callable(..) => None,
         }
+    }
+}
+
+struct LocalVariableLookup;
+impl LookupObject for LocalVariableLookup {
+    fn for_each_entry<R>(
+        &self,
+        ctx: &LookupCtx,
+        f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
+    ) -> Option<R> {
+        // Reverse the local variables so that the last shadow is found first during lookup
+        for (name, ty) in ctx.local_variables.iter().rev() {
+            if let Some(r) = f(
+                &name,
+                Expression::ReadLocalVariable { name: name.clone(), ty: ty.clone() }.into(),
+            ) {
+                return Some(r);
+            }
+        }
+        None
     }
 }
 
@@ -830,16 +854,22 @@ impl LookupObject for BuiltinNamespaceLookup {
 
 pub fn global_lookup() -> impl LookupObject {
     (
-        ArgumentsLookup,
+        LocalVariableLookup,
         (
-            SpecialIdLookup,
+            ArgumentsLookup,
             (
-                IdLookup,
+                SpecialIdLookup,
                 (
-                    InScopeLookup,
+                    IdLookup,
                     (
-                        LookupType,
-                        (BuiltinNamespaceLookup, (ReturnTypeSpecificLookup, BuiltinFunctionLookup)),
+                        InScopeLookup,
+                        (
+                            LookupType,
+                            (
+                                BuiltinNamespaceLookup,
+                                (ReturnTypeSpecificLookup, BuiltinFunctionLookup),
+                            ),
+                        ),
                     ),
                 ),
             ),

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -367,7 +367,8 @@ declare_syntax! {
         /// the right-hand-side of a binding
         // Fixme: the test should be a or
         BindingExpression-> [ ?CodeBlock, ?Expression ],
-        CodeBlock-> [ *Expression, *ReturnStatement ],
+        CodeBlock-> [ *Expression, *LetStatement, *ReturnStatement ],
+        LetStatement -> [ DeclaredIdentifier, Expression ],
         ReturnStatement -> [ ?Expression ],
         // FIXME: the test should test that as alternative rather than several of them (but it can also be a literal)
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -368,7 +368,7 @@ declare_syntax! {
         // Fixme: the test should be a or
         BindingExpression-> [ ?CodeBlock, ?Expression ],
         CodeBlock-> [ *Expression, *LetStatement, *ReturnStatement ],
-        LetStatement -> [ DeclaredIdentifier, Expression ],
+        LetStatement -> [ DeclaredIdentifier, ?Type, Expression ],
         ReturnStatement -> [ ?Expression ],
         // FIXME: the test should test that as alternative rather than several of them (but it can also be a literal)
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,

--- a/internal/compiler/parser/statements.rs
+++ b/internal/compiler/parser/statements.rs
@@ -50,6 +50,11 @@ pub fn parse_statement(p: &mut impl Parser) -> bool {
         return true;
     }
 
+    if p.peek().as_str() == "let" {
+        parse_let_statement(p);
+        return true;
+    }
+
     parse_expression(p);
     if matches!(
         p.nth(0).kind(),
@@ -65,6 +70,24 @@ pub fn parse_statement(p: &mut impl Parser) -> bool {
         parse_expression(&mut *p);
     }
     p.test(SyntaxKind::Semicolon)
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,LetStatement
+/// let foo = 1;
+/// let bar = foo;
+/// ```
+fn parse_let_statement(p: &mut impl Parser) {
+    let mut p = p.start_node(SyntaxKind::LetStatement);
+    debug_assert_eq!(p.peek().as_str(), "let");
+    p.expect(SyntaxKind::Identifier); // "let"
+    {
+        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+        p.expect(SyntaxKind::Identifier);
+    }
+    p.expect(SyntaxKind::Equal);
+    parse_expression(&mut *p);
+    p.expect(SyntaxKind::Semicolon);
 }
 
 #[cfg_attr(test, parser_test)]

--- a/internal/compiler/parser/statements.rs
+++ b/internal/compiler/parser/statements.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use crate::parser::r#type::parse_type;
+
 use super::element::parse_code_block;
 use super::expressions::parse_expression;
 use super::prelude::*;
@@ -14,6 +16,9 @@ use super::prelude::*;
 /// if (true) { foo = bar; } else { bar = foo;  }
 /// return;
 /// if (true) { return 42; }
+/// let foo = 1;
+/// let bar = foo;
+/// let str: string = "hello world";
 /// ```
 pub fn parse_statement(p: &mut impl Parser) -> bool {
     if p.nth(0).kind() == SyntaxKind::RBrace {
@@ -76,6 +81,7 @@ pub fn parse_statement(p: &mut impl Parser) -> bool {
 /// ```test,LetStatement
 /// let foo = 1;
 /// let bar = foo;
+/// let str: string = "hello world";
 /// ```
 fn parse_let_statement(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::LetStatement);
@@ -85,6 +91,11 @@ fn parse_let_statement(p: &mut impl Parser) {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
         p.expect(SyntaxKind::Identifier);
     }
+
+    if p.test(SyntaxKind::Colon) {
+        parse_type(&mut *p);
+    }
+
     p.expect(SyntaxKind::Equal);
     parse_expression(&mut *p);
     p.expect(SyntaxKind::Semicolon);

--- a/internal/compiler/passes/deduplicate_property_read.rs
+++ b/internal/compiler/passes/deduplicate_property_read.rs
@@ -116,6 +116,7 @@ fn process_expression(expr: &mut Expression, old_state: &DedupPropState) {
             .into_iter()
             .map(|(name, nr)| Expression::StoreLocalVariable {
                 name,
+                discriminator: None,
                 value: Box::new(Expression::PropertyReference(nr)),
             })
             .collect::<Vec<_>>();
@@ -174,7 +175,7 @@ fn do_replacements(expr: &mut Expression, state: &DedupPropState) {
         Expression::PropertyReference(nr) => {
             if let Some(name) = state.get_mapping(nr) {
                 let ty = expr.ty();
-                *expr = Expression::ReadLocalVariable { name, ty };
+                *expr = Expression::ReadLocalVariable { name, discriminator: None, ty };
             }
         }
         Expression::BinaryExpression { lhs, rhs: _, op: '|' | '&' } => {

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -273,6 +273,7 @@ fn merge_explicit_constraints(
         let ty = expr.ty();
         let store = Expression::StoreLocalVariable {
             name: unique_name.clone(),
+            discriminator: None,
             value: Box::new(std::mem::take(expr)),
         };
         let Type::Struct(s) = &ty else { unreachable!() };
@@ -285,6 +286,7 @@ fn merge_explicit_constraints(
                     Expression::StructFieldAccess {
                         base: Expression::ReadLocalVariable {
                             name: unique_name.clone(),
+                            discriminator: None,
                             ty: ty.clone(),
                         }
                         .into(),
@@ -440,12 +442,14 @@ fn make_default_aspect_ratio_preserving_binding(
     } else {
         let implicit_size_var = Box::new(Expression::ReadLocalVariable {
             name: "image_implicit_size".into(),
+            discriminator: None,
             ty: BuiltinFunction::ImageSize.ty().return_type.clone(),
         });
 
         Expression::CodeBlock(vec![
             Expression::StoreLocalVariable {
                 name: "image_implicit_size".into(),
+                discriminator: None,
                 value: Box::new(Expression::FunctionCall {
                     function: BuiltinFunction::ImageSize.into(),
                     arguments: vec![Expression::PropertyReference(NamedReference::new(

--- a/internal/compiler/passes/lower_absolute_coordinates.rs
+++ b/internal/compiler/passes/lower_absolute_coordinates.rs
@@ -35,12 +35,14 @@ pub fn lower_absolute_coordinates(component: &Rc<Component>) {
 
         let parent_position_var = Box::new(Expression::ReadLocalVariable {
             name: "parent_position".into(),
+            discriminator: None,
             ty: point_type.clone().into(),
         });
 
         let binding = Expression::CodeBlock(vec![
             Expression::StoreLocalVariable {
                 name: "parent_position".into(),
+                discriminator: None,
                 value: Expression::FunctionCall {
                     function: BuiltinFunction::ItemAbsolutePosition.into(),
                     arguments: vec![Expression::ElementReference(Rc::downgrade(&elem))],

--- a/internal/compiler/passes/remove_return.rs
+++ b/internal/compiler/passes/remove_return.rs
@@ -214,9 +214,14 @@ fn continue_codeblock(
     );
     let load = Box::new(Expression::ReadLocalVariable {
         name: unique_name.clone(),
+        discriminator: None,
         ty: return_object.ty(),
     });
-    stmts.push(Expression::StoreLocalVariable { name: unique_name, value: return_object.into() });
+    stmts.push(Expression::StoreLocalVariable {
+        name: unique_name,
+        discriminator: None,
+        value: return_object.into(),
+    });
     stmts.push(Expression::Condition {
         condition: Expression::StructFieldAccess {
             base: load.clone(),
@@ -298,10 +303,17 @@ impl ExpressionResult {
                     "returned_expression{}",
                     COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                 );
-                let load =
-                    Box::new(Expression::ReadLocalVariable { name: name.clone(), ty: value.ty() });
+                let load = Box::new(Expression::ReadLocalVariable {
+                    name: name.clone(),
+                    discriminator: None,
+                    ty: value.ty(),
+                });
                 Expression::CodeBlock(vec![
-                    Expression::StoreLocalVariable { name, value: value.into() },
+                    Expression::StoreLocalVariable {
+                        name,
+                        discriminator: None,
+                        value: value.into(),
+                    },
                     Expression::Condition {
                         condition: Expression::StructFieldAccess {
                             base: load.clone(),
@@ -436,6 +448,7 @@ impl ExpressionResult {
                 let load = |field: &str| Expression::StructFieldAccess {
                     base: Box::new(Expression::ReadLocalVariable {
                         name: name.clone(),
+                        discriminator: None,
                         ty: value_ty.clone(),
                     }),
                     name: field.into(),
@@ -449,7 +462,11 @@ impl ExpressionResult {
                 });
                 ExpressionResult::ReturnObject {
                     value: Expression::CodeBlock(vec![
-                        Expression::StoreLocalVariable { name, value: value.into() },
+                        Expression::StoreLocalVariable {
+                            name,
+                            discriminator: None,
+                            value: value.into(),
+                        },
                         make_struct([condition, actual].into_iter().chain(ret.into_iter())),
                     ]),
                     has_value,
@@ -536,6 +553,7 @@ fn convert_struct(from: Expression, to: Type) -> Expression {
             Expression::StructFieldAccess {
                 base: Box::new(Expression::ReadLocalVariable {
                     name: var_name.clone(),
+                    discriminator: None,
                     ty: from_ty.clone(),
                 }),
                 name: key.clone(),
@@ -546,7 +564,11 @@ fn convert_struct(from: Expression, to: Type) -> Expression {
         new_values.insert(key.clone(), expression);
     }
     Expression::CodeBlock(vec![
-        Expression::StoreLocalVariable { name: var_name, value: Box::new(from) },
+        Expression::StoreLocalVariable {
+            name: var_name,
+            discriminator: None,
+            value: Box::new(from),
+        },
         Expression::Struct { values: new_values, ty: to },
     ])
 }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -46,6 +46,7 @@ fn resolve_expression(
             type_loader: Some(type_loader),
             current_token: None,
             local_variables: vec![],
+            next_local_variable_discriminator: 0,
         };
 
         let new_expr = match node.kind() {
@@ -239,9 +240,11 @@ impl Expression {
         let name = identifier_text(&node.DeclaredIdentifier()).unwrap_or_default();
         let value = Box::new(Self::from_expression_node(node.Expression(), ctx));
         
-        ctx.local_variables.push((name.clone(), value.ty()));
+        let discriminator = ctx.next_local_variable_discriminator;
+        ctx.local_variables.push((name.clone(), discriminator, value.ty()));
+        ctx.next_local_variable_discriminator += 1;
 
-        Expression::StoreLocalVariable { name, value }
+        Expression::StoreLocalVariable { name, discriminator: Some(discriminator), value }
     }
 
     fn from_return_statement(
@@ -1651,6 +1654,7 @@ fn resolve_two_way_bindings(
                                 type_loader: None,
                                 current_token: Some(node.clone().into()),
                                 local_variables: vec![],
+                                next_local_variable_discriminator: 0,
                             };
 
                             binding.expression = Expression::Invalid;

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -238,7 +238,15 @@ impl Expression {
 
     fn from_let_statement(node: syntax_nodes::LetStatement, ctx: &mut LookupCtx) -> Expression {
         let name = identifier_text(&node.DeclaredIdentifier()).unwrap_or_default();
-        let value = Box::new(Self::from_expression_node(node.Expression(), ctx));
+        let value = Self::from_expression_node(node.Expression(), ctx);
+        let ty = match node.Type() {
+            Some(ty) => {
+                type_from_node(ty, ctx.diag, ctx.type_register)
+            }
+            None => value.ty(),
+        };
+
+        let value = Box::new(value.maybe_convert_to(ty, &node, ctx.diag));
         
         let discriminator = ctx.next_local_variable_discriminator;
         ctx.local_variables.push((name.clone(), discriminator, value.ty()));

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -706,8 +706,9 @@ impl Snapshotter {
                     Weak::default()
                 },
             },
-            Expression::StoreLocalVariable { name, value } => Expression::StoreLocalVariable {
+            Expression::StoreLocalVariable { name, discriminator, value } => Expression::StoreLocalVariable {
                 name: name.clone(),
+                discriminator: discriminator.clone(),
                 value: Box::new(self.snapshot_expression(value)),
             },
             Expression::StructFieldAccess { base, name } => Expression::StructFieldAccess {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -325,7 +325,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         Expression::PathData(data)  => {
             Value::PathData(convert_path(data, local_context))
         }
-        Expression::StoreLocalVariable { name, value } => {
+        Expression::StoreLocalVariable { name, value, .. } => {
             let value = eval_expression(value, local_context);
             local_context.local_variables.insert(name.clone(), value);
             Value::Void

--- a/tests/cases/expr/let.slint
+++ b/tests/cases/expr/let.slint
@@ -1,0 +1,52 @@
+export component TestCase  {
+    public function test_simple() -> int {
+        let a = 1;
+
+        return a;
+    }
+
+    public function test_shadowing() -> int {
+        let a = 1;
+        let a = a + 1;
+
+        return a;
+    }
+
+    public function test_shadowing_scope() -> int {
+        let a = 1;
+
+        if (true) {
+            let a = a + 1;
+            
+            return a;
+        }
+
+        return a;
+    }
+
+    public function test_shadowing_different_type() -> string {
+        let a = 1;
+        let a = @tr("{}", a);
+
+        return a;
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.invoke_test_simple(), 1);
+assert_eq!(instance.invoke_test_shadowing(), 2);
+assert_eq!(instance.invoke_test_shadowing_scope(), 2);
+assert_eq!(instance.invoke_test_shadowing_different_type(), "1");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.invoke_test_simple(), 1);
+assert_eq(instance.invoke_test_shadowing(), 2);
+assert_eq(instance.invoke_test_shadowing_scope(), 2);
+assert_eq(instance.invoke_test_shadowing_different_type(), "1");
+```
+*/

--- a/tests/cases/expr/let.slint
+++ b/tests/cases/expr/let.slint
@@ -1,4 +1,4 @@
-export component TestCase  {
+export component TestCase {
     public function test_simple() -> int {
         let a = 1;
 
@@ -30,6 +30,18 @@ export component TestCase  {
 
         return a;
     }
+
+    public function test_type_annotation() -> int {
+        let a: int = 1;
+
+        return a;
+    }
+
+    public function test_type_annotation_conversion() -> int {
+        let a: int = 1.0;
+
+        return a;
+    }
 }
 
 /*
@@ -39,6 +51,8 @@ assert_eq!(instance.invoke_test_simple(), 1);
 assert_eq!(instance.invoke_test_shadowing(), 2);
 assert_eq!(instance.invoke_test_shadowing_scope(), 2);
 assert_eq!(instance.invoke_test_shadowing_different_type(), "1");
+assert_eq!(instance.invoke_test_type_annotation(), 1);
+assert_eq!(instance.invoke_test_type_annotation_conversion(), 1);
 ```
 
 ```cpp
@@ -48,5 +62,7 @@ assert_eq(instance.invoke_test_simple(), 1);
 assert_eq(instance.invoke_test_shadowing(), 2);
 assert_eq(instance.invoke_test_shadowing_scope(), 2);
 assert_eq(instance.invoke_test_shadowing_different_type(), "1");
+assert_eq(instance.invoke_test_type_annotation(), 1);
+assert_eq(instance.invoke_test_type_annotation_conversion(), 1);
 ```
 */

--- a/tests/cases/expr/let.slint
+++ b/tests/cases/expr/let.slint
@@ -24,8 +24,9 @@ export component TestCase {
         return a;
     }
 
-    public function test_shadowing_different_type() -> string {
+    public function test_shadowing_different_types() -> string {
         let a = 1;
+        let a: float = a + 1.0;
         let a = @tr("{}", a);
 
         return a;
@@ -50,7 +51,7 @@ let instance = TestCase::new().unwrap();
 assert_eq!(instance.invoke_test_simple(), 1);
 assert_eq!(instance.invoke_test_shadowing(), 2);
 assert_eq!(instance.invoke_test_shadowing_scope(), 2);
-assert_eq!(instance.invoke_test_shadowing_different_type(), "1");
+assert_eq!(instance.invoke_test_shadowing_different_types(), "2");
 assert_eq!(instance.invoke_test_type_annotation(), 1);
 assert_eq!(instance.invoke_test_type_annotation_conversion(), 1);
 ```
@@ -61,7 +62,7 @@ const TestCase &instance = *handle;
 assert_eq(instance.invoke_test_simple(), 1);
 assert_eq(instance.invoke_test_shadowing(), 2);
 assert_eq(instance.invoke_test_shadowing_scope(), 2);
-assert_eq(instance.invoke_test_shadowing_different_type(), "1");
+assert_eq(instance.invoke_test_shadowing_different_types(), "2");
 assert_eq(instance.invoke_test_type_annotation(), 1);
 assert_eq(instance.invoke_test_type_annotation_conversion(), 1);
 ```

--- a/tools/lsp/preview/eval.rs
+++ b/tools/lsp/preview/eval.rs
@@ -179,7 +179,7 @@ fn eval_expression(
                     .collect()
             })
         }
-        Expression::StoreLocalVariable { name, value } => {
+        Expression::StoreLocalVariable { name, value, .. } => {
             let value = eval_expression(value, local_context, None);
             local_context.local_variables.insert(name.clone(), value);
             Value::Void


### PR DESCRIPTION
Adds support for immutable local variables in .slint functions using a new `let` keyword with an optional type annotation:
```
let foo: int = 1; // with type annotation
let bar = 2; // without type annotation
```

Shadowing is allowed:
```
let foo = 1;
let foo = foo + 1;

debug(foo); // prints "2"

let foo = "hello world";

debug(foo); // prints "hello world"
```

Internally an extra discriminator field was added to the `StoreLocalVariable` and `ReadLocalVariable` expressions, so that shadowing support could be added in the C++ generator, as C++ does not support variable shadowing.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->