### PR TITLE
More idiomatic Vec duplication in memory tiles example/tutorial

### DIFF
--- a/docs/astro/src/content/code/main_game_logic_in_rust.rs
+++ b/docs/astro/src/content/code/main_game_logic_in_rust.rs
@@ -10,7 +10,7 @@ fn main() {
     // Fetch the tiles from the model
     let mut tiles: Vec<TileData> = main_window.get_memory_tiles().iter().collect();
     // Duplicate them to ensure that we have pairs
-    tiles.extend(tiles.clone());
+    tiles.extend_from_within(..);
 
     // Randomly mix the tiles
     use rand::seq::SliceRandom;

--- a/docs/astro/src/content/code/main_tiles_from_rust.rs
+++ b/docs/astro/src/content/code/main_tiles_from_rust.rs
@@ -11,7 +11,7 @@ fn main() {
     // Fetch the tiles from the model
     let mut tiles: Vec<TileData> = main_window.get_memory_tiles().iter().collect();
     // Duplicate them to ensure that we have pairs
-    tiles.extend(tiles.clone());
+    tiles.extend_from_within(..);
 
     // Randomly mix the tiles
     use rand::seq::SliceRandom;

--- a/examples/memory/main.rs
+++ b/examples/memory/main.rs
@@ -22,7 +22,7 @@ pub fn main() {
     let main_window = MainWindow::new().unwrap();
 
     let mut tiles: Vec<TileData> = main_window.get_memory_tiles().iter().collect();
-    tiles.extend(tiles.clone());
+    tiles.extend_from_within(..);
 
     use rand::seq::SliceRandom;
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
Use a better idiom for duplicating the vector contents in the tutorial code. Overall effect is minor but since the Rust standard library provides a means of doing this without doing a manual clone, it seems better to use that.