### PR TITLE
codegen: Don't generate unused struct

### DIFF
--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -237,6 +237,8 @@ pub async fn run_passes(
     });
 
     remove_unused_properties::remove_unused_properties(doc);
+    // collect globals once more: After optimizations we might have less globals
+    collect_globals::collect_globals(doc, diag);
     collect_structs_and_enums::collect_structs_and_enums(doc);
 
     doc.visit_all_used_components(|component| {
@@ -244,9 +246,6 @@ pub async fn run_passes(
             generate_item_indices::generate_item_indices(component);
         }
     });
-
-    // collect globals once more: After optimizations we might have less globals
-    collect_globals::collect_globals(doc, diag);
 
     embed_images::embed_images(
         doc,

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -15,7 +15,7 @@ fn main() -> std::io::Result<()> {
         if module_name.starts_with(|c: char| !c.is_ascii_alphabetic()) {
             module_name.insert(0, '_');
         }
-        writeln!(generated_file, "#[path=\"{module_name}.rs\"] mod r#{module_name};")?;
+        writeln!(generated_file, "#[path=\"{module_name}.rs\"] pub mod r#{module_name};")?;
         let source = std::fs::read_to_string(&testcase.absolute_path)?;
         let ignored = if testcase.is_ignored("rust") {
             "#[ignore = \"testcase ignored for rust\"]"


### PR DESCRIPTION
This fixes a warning in nightly rust which has been better at detecting unused struct

```
error: struct `TextStyle` is never constructed
  --> /home/runner/work/slint/slint/target/debug/build/slint-lsp-da851cbad8b87459/out/main.rs:78:66
   |
78 |      # [derive (Default , PartialEq , Debug , Clone)] pub struct r#TextStyle {
   |                                                                  ^^^^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`
```

Where TextStyle is only used in some globals whose properties are fully inlined. So first do the pass that removed unused global, and then the pass that remove unused struct
