### PR TITLE
Compilation error with empty enums

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -146,7 +146,7 @@ impl Document {
             let en =
                 Enumeration { name: name.clone(), values, default_value: 0, node: Some(n.clone()) };
             if en.values.is_empty() {
-                diag.push_error("Enum must have at least one value".into(), &n);
+                diag.push_error("Enums must have at least one value".into(), &n);
             }
 
             let ty = Type::Enumeration(Rc::new(en));

--- a/internal/compiler/tests/syntax/basic/enums.slint
+++ b/internal/compiler/tests/syntax/basic/enums.slint
@@ -20,7 +20,7 @@ enum Xyz {
 
 
    enum Empty {}
-// ^error{Enum must have at least one value}
+// ^error{Enums must have at least one value}
 
 export component Test {
     property<Empty> empty;


### PR DESCRIPTION
Technically a breaking change, although code generation was very likely to panic.

Fixes #8743

ChangeLog: Enum without value cause compilation errors (instead of panics)
