### PR TITLE
Fix UB when a change tracker gets deleted as a result of that change tracker evaluation

### DIFF
--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -147,17 +147,6 @@ pub(crate) mod dependency_tracker {
             self.0.get().is_null()
         }
 
-        /// Remove all the nodes from the list;
-        pub fn clear(self: Pin<&Self>) {
-            unsafe {
-                if let Some(n) = self.0.get().as_ref() {
-                    n.debug_assert_valid();
-                    n.prev.set(core::ptr::null());
-                }
-            }
-            self.0.set(core::ptr::null());
-        }
-
         pub unsafe fn drop(_self: *mut Self) {
             if let Some(next) = (*_self).0.get().as_ref() {
                 debug_assert_eq!(_self as *const _, next.prev.get() as *const _);
@@ -192,6 +181,22 @@ pub(crate) mod dependency_tracker {
                     node.debug_assert_valid();
                     next = node.next.get();
                     f(&node.binding);
+                }
+            }
+        }
+
+        /// Returns the first node of the list, if any
+        pub fn take_head(&self) -> Option<T>
+        where
+            T: Copy,
+        {
+            unsafe {
+                if let Some(node) = self.0.get().as_ref() {
+                    node.debug_assert_valid();
+                    node.remove();
+                    Some(node.binding)
+                } else {
+                    None
                 }
             }
         }

--- a/internal/core/properties/change_tracker.rs
+++ b/internal/core/properties/change_tracker.rs
@@ -103,6 +103,7 @@ impl ChangeTracker {
                 (inner.notify_fn)(&inner.data, &inner.value);
             }
             if !core::mem::replace(&mut inner.evaluating, false) {
+                // `drop` from the vtable was called while evaluating. Do it now.
                 core::mem::drop(Box::from_raw(_self));
             }
             BindingResult::KeepBinding


### PR DESCRIPTION
Don't drop the ChangeTracker's BindingHolder if it is currently being evaluated as we still need it later.

There was also a bug in DependencyListHead::clear as it was not properly updating all the field, and the use of for_each was problematic if nodes gets delete as we iterate.

Fixes #8741
