### PR TITLE
Fix accessing the Platform global from within other globals

### DIFF
--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -123,7 +123,6 @@ pub async fn run_passes(
         );
         lower_states::lower_states(component, &doc.local_registry, diag);
         lower_text_input_interface::lower_text_input_interface(component);
-        lower_platform::lower_platform(component, type_loader);
         repeater_component::process_repeater_components(component);
         lower_popups::lower_popups(component, &doc.local_registry, diag);
         collect_init_code::collect_init_code(component);
@@ -212,6 +211,8 @@ pub async fn run_passes(
     unique_id::assign_unique_id(doc);
 
     doc.visit_all_used_components(|component| {
+        lower_platform::lower_platform(component, type_loader);
+
         // Don't perform the empty rectangle removal when debug info is requested, because the resulting
         // item tree ends up with a hierarchy where certain items have children that aren't child elements
         // but siblings or sibling children. We need a new data structure to perform a correct element tree

--- a/tests/cases/platform.slint
+++ b/tests/cases/platform.slint
@@ -4,6 +4,10 @@
 // Basic test for Platform.os and Platform.style-name. This is done in JS, as with Rust and C++ the style is fixed
 // to fluent.
 
+export global Info {
+    out property <string> style-name: Platform.style-name;
+}
+
 export component TestCase inherits Window {
     out property <string> os: {
         if Platform.os == OperatingSystemType.android {
@@ -22,7 +26,7 @@ export component TestCase inherits Window {
             "error"
         }
     }
-    out property <string> style-name: Platform.style-name;
+    out property <string> style-name: Info.style-name;
 }
 
 /*


### PR DESCRIPTION
The platform lowering pass was called before we collected globals, so visit_all_used_components never called the pass on any globals.

Fixes #8777

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
