### PR TITLE
system-testing: Make the image format for snapshots configurable

### DIFF
--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -143,6 +143,7 @@ message RequestSetElementAccessibleValue {
 
 message RequestTakeSnapshot {
     Handle window_handle = 1;
+    string image_mime_type = 2;
 }
 
 message RequestElementClick {
@@ -251,7 +252,7 @@ message SetElementAccessibleValueResponse {
 }
 
 message TakeSnapshotResponse {
-    bytes window_contents_as_png = 1;
+    bytes window_contents_as_encoded_image = 1;
 }
 
 message ElementClickResponse {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -250,7 +250,9 @@ impl TestingClient {
             image::ExtendedColorType::Rgba8,
             format,
         )
-        .map_err(|encode_err| format!("error encoding png image after screenshot: {encode_err}"))?;
+        .map_err(|encode_err| {
+            format!("error encoding {image_mime_type} image after screenshot: {encode_err}")
+        })?;
         Ok(proto::TakeSnapshotResponse { window_contents_as_encoded_image })
     }
 

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -232,8 +232,16 @@ impl TestingClient {
             window.take_snapshot().map_err(|e| format!("Error grabbing window screenshot: {e}"))?;
         let mut window_contents_as_encoded_image: Vec<u8> = Vec::new();
         let mut cursor = std::io::Cursor::new(&mut window_contents_as_encoded_image);
-        let format =
-            image::ImageFormat::from_mime_type(image_mime_type).unwrap_or(image::ImageFormat::Png);
+        let format = if image_mime_type.is_empty() {
+            image::ImageFormat::Png
+        } else {
+            image::ImageFormat::from_mime_type(image_mime_type).ok_or_else(|| {
+                format!(
+                    "Unsupported image format {image_mime_type} requested for window snapshotting"
+                )
+            })?
+        };
+
         image::write_buffer_with_format(
             &mut cursor,
             buffer.as_bytes(),


### PR DESCRIPTION
Let the image crate pick an encoder by mime-type, otherwise fall back to png.

Renaming the field in the response is compatible, as only the tag numbers are encoded. Adding a field to the request is also compatible as every field is optional.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
