### PR TITLE
correct 1.12.0 CHANGELOG release date year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All notable changes to this project are documented in this file.
  - Fixed potential crashes due to stack overflows on Windows.
  - live-preview: Lazily compute palette to speedup the UI.
 
-## [1.12.0] - 2026-06-16
+## [1.12.0] - 2025-06-16
 
 ### General
 


### PR DESCRIPTION
I was reading the CHANGELOG and was confused about the current year for a second, and then realized this needed to be updated 😂 

