### PR TITLE
C++: Add clear() method to SharedString

### DIFF
--- a/api/cpp/include/slint_string.h
+++ b/api/cpp/include/slint_string.h
@@ -116,6 +116,9 @@ struct SharedString
                 == 0;
     }
 
+    /// Reset to an empty string
+    void clear() { *this = std::string_view("", 0); }
+
     /// Creates a new SharedString from the given number \a n. The string representation of the
     /// number uses a minimal formatting scheme: If \a n has no fractional part, the number will be
     /// formatted as an integer.

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -53,6 +53,14 @@ SCENARIO("SharedString API")
         REQUIRE(str.size() == 5);
     }
 
+    SECTION("clear")
+    {
+        str = "Hello";
+        str.clear();
+        REQUIRE(str.size() == 0);
+        REQUIRE(std::string_view(str.data()) == "");
+    }
+
     SECTION("to_lowercase")
     {
         str = "Hello";


### PR DESCRIPTION
A convenience method to reset to an empty string, like already known from `std::string`.

Instead of writing one of those:

```cpp
myString = slint::SharedString();
myString = "";  // Not ideal because it involves strlen()
```

This allows the more convenient variant:

```cpp
myString.clear();
```

I hope this is something worth to add?

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
