### PR TITLE
SLINT_TARGET_SOURCES sets target_include_directories using a generato…

### DIFF
--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -91,5 +91,5 @@ function(SLINT_TARGET_SOURCES target)
 
         target_sources(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h ${cpp_files})
     endforeach()
-    target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+    target_include_directories(${target} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 endfunction()


### PR DESCRIPTION
…r expression

This ensures that the binary directory path isn't exposed in the target's `INTERFACE_INCLUDE_DIRECTORIES`.

This prevents CMake errors when we `install` a target with generated Slint sources in the include directory:

```
[cmake] CMake Error in slint/cpp/CMakeLists.txt:
[cmake]   Target "slint-demo-cpp" INTERFACE_INCLUDE_DIRECTORIES property contains
[cmake]   path:
[cmake]
[cmake]     "/path/to/build/slint/cpp"
[cmake]
[cmake]   which is prefixed in the build directory.
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
