### PR TITLE
LSP: rename callback and functions

### DIFF
--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -64,6 +64,7 @@ pub fn goto_definition(
         }
         TokenInfo::LocalProperty(x) => goto_node(&x),
         TokenInfo::LocalCallback(x) => goto_node(&x),
+        TokenInfo::LocalFunction(x) => goto_node(&x),
         TokenInfo::IncompleteNamedReference(mut element_type, prop_name) => {
             while let ElementType::Component(com) = element_type {
                 if let Some(p) = com.root_element.borrow().property_declarations.get(&prop_name) {

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -52,7 +52,9 @@ pub fn get_tooltip(
             value: format!("![{0}]({0})", path.to_string_lossy()),
         },
         // Todo: this can happen when there is some syntax error
-        TokenInfo::LocalProperty(_) | TokenInfo::LocalCallback(_) => return None,
+        TokenInfo::LocalProperty(_) | TokenInfo::LocalCallback(_) | TokenInfo::LocalFunction(_) => {
+            return None
+        }
         TokenInfo::IncompleteNamedReference(el, name) => from_property_in_type(&el, &name)?,
     };
 


### PR DESCRIPTION
Closes #3958 (Most symbol could already be renamed, but that issue asked for callback as an usecase)

Also fix a few bugs in which too manu or too litle would be renamed when renaming properties

ChangeLog: allow to rename functions and callbacks