### PR TITLE
NOT FUNCTIONAL:  `muda` context menu support

### DIFF
--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -209,7 +209,7 @@ pub mod re_exports {
     pub use i_slint_core::lengths::{
         logical_position_to_api, LogicalLength, LogicalPoint, LogicalRect,
     };
-    pub use i_slint_core::menus::{Menu, MenuFromItemTree, MenuVTable};
+    pub use i_slint_core::menus::{ContextMenuFromItemTree, Menu, MenuFromItemTree, MenuVTable};
     pub use i_slint_core::model::*;
     pub use i_slint_core::properties::{
         set_state_binding, ChangeTracker, Property, PropertyTracker, StateInfo,

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -39,7 +39,7 @@ pub enum CustomEvent {
     #[cfg(enable_accesskit)]
     Accesskit(accesskit_winit::Event),
     #[cfg(muda)]
-    Muda(muda::MenuEvent),
+    Muda(muda::MenuEvent, MudaType),
 }
 
 impl std::fmt::Debug for CustomEvent {
@@ -52,9 +52,16 @@ impl std::fmt::Debug for CustomEvent {
             #[cfg(enable_accesskit)]
             Self::Accesskit(a) => write!(f, "AccessKit({a:?})"),
             #[cfg(muda)]
-            Self::Muda(e) => write!(f, "Muda({e:?})"),
+            Self::Muda(e, mt) => write!(f, "Muda({e:?},{mt:?})"),
         }
     }
+}
+
+#[cfg(muda)]
+#[derive(Clone, Copy, Debug)]
+pub enum MudaType {
+    Menubar,
+    Context,
 }
 
 pub struct EventLoopState {
@@ -427,7 +434,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                 event_loop.set_control_flow(ControlFlow::Poll);
             }
             #[cfg(muda)]
-            CustomEvent::Muda(event) => {
+            CustomEvent::Muda(event, muda_type) => {
                 if let Some((window, eid)) = event.id().0.split_once('|').and_then(|(w, e)| {
                     Some((
                         self.shared_backend_data
@@ -435,7 +442,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                         e.parse::<usize>().ok()?,
                     ))
                 }) {
-                    window.muda_event(eid);
+                    window.muda_event(eid, muda_type);
                 };
             }
         }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2764,7 +2764,8 @@ fn compile_builtin_function_call(
             }
         }
         BuiltinFunction::ShowPopupMenu => {
-            let [Expression::PropertyReference(context_menu_ref), entries, position] = arguments
+            let [Expression::PropertyReference(context_menu_ref), entries, position, Expression::BoolLiteral(no_native)] =
+                arguments
             else {
                 panic!("internal error: invalid args to ShowPopupMenu {arguments:?}")
             };
@@ -2855,7 +2856,7 @@ fn compile_builtin_function_call(
                     let entries = #entries;
                     {
                         let _self = popup_instance_vrc.as_pin_ref();
-                        #access_entries.set(entries);
+                        #access_entries.set(entries.clone());
                         #fw_sub_menu
                         #fw_activated
                         let self_weak = parent_weak.clone();
@@ -2868,22 +2869,37 @@ fn compile_builtin_function_call(
                 }
             };
             let context_menu = context_menu.unwrap();
+
+            let native_impl = if *no_native {
+                quote!()
+            } else {
+                quote!(if sp::WindowInner::from_pub(#window_adapter_tokens.window()).supports_native_menu_bar() {
+                    sp::WindowInner::from_pub(#window_adapter_tokens.window()).show_context_menu(sp::VBox::new(popup_instance_menu), #position);
+                } else)
+            };
+
             quote!({
                 let position = #position;
                 let popup_instance = #popup_id::new(_self.globals.get().unwrap().clone()).unwrap();
                 let popup_instance_vrc = sp::VRc::map(popup_instance.clone(), |x| x);
-                let parent_weak = _self.self_weak.get().unwrap().clone();
-                #init_popup
-                #close_popup
-                let id = sp::WindowInner::from_pub(#window_adapter_tokens.window()).show_popup(
-                    &sp::VRc::into_dyn(popup_instance.into()),
-                    position,
-                    sp::PopupClosePolicy::CloseOnClickOutside,
-                    #context_menu_rc,
-                    true, // is_menu
-                );
-                #context_menu.popup_id.set(Some(id));
-                #popup_id::user_init(popup_instance_vrc);
+                {
+                    let parent_weak = _self.self_weak.get().unwrap().clone();
+                    #init_popup
+                    let popup_instance_menu = sp::ContextMenuFromItemTree::new(sp::VRc::into_dyn(popup_instance.clone()), entries.clone());
+                    #native_impl
+                    /* else */ {
+                        #close_popup
+                        let id = sp::WindowInner::from_pub(#window_adapter_tokens.window()).show_popup(
+                            &sp::VRc::into_dyn(popup_instance.into()),
+                            position,
+                            sp::PopupClosePolicy::CloseOnClickOutside,
+                            #context_menu_rc,
+                            true, // is_menu
+                        );
+                        #context_menu.popup_id.set(Some(id));
+                        #popup_id::user_init(popup_instance_vrc);
+                    }
+                }
             })
         }
         BuiltinFunction::SetSelectionOffsets => {
@@ -3107,7 +3123,7 @@ fn compile_builtin_function_call(
                 };
 
                 quote!({
-                    let menu_item_tree_instance = #item_tree_id::new(_self.self_weak.get().unwrap().clone()).unwrap();
+                    let menu_item_tree_instance = #item_tree_id::new(_self.self_weak.get().unwrap().clone()).unwrap(); // BLGAG
                     let menu_item_tree = sp::MenuFromItemTree::new(sp::VRc::into_dyn(menu_item_tree_instance));
                     #native_impl
                     /*else*/ {

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -153,6 +153,7 @@ pub async fn lower_menus(
 
     let mut has_menu = false;
     let mut has_menubar = false;
+    let no_native_menu = type_loader.compiler_config.no_native_menu;
 
     doc.visit_all_used_components(|component| {
         recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
@@ -160,7 +161,7 @@ pub async fn lower_menus(
                 has_menubar |= process_window(elem, &useful_menu_component, type_loader.compiler_config.no_native_menu, diag);
             }
             if matches!(&elem.borrow().builtin_type(), Some(b) if matches!(b.name.as_str(), "ContextMenuArea" | "ContextMenuInternal")) {
-                has_menu |= process_context_menu(elem, &useful_menu_component, diag);
+                has_menu |= process_context_menu(elem, &useful_menu_component, diag, no_native_menu);
             }
         })
     });
@@ -169,7 +170,8 @@ pub async fn lower_menus(
         recurse_elem_including_sub_components_no_borrow(&menubar_impl, &(), &mut |elem, _| {
             if matches!(&elem.borrow().builtin_type(), Some(b) if matches!(b.name.as_str(), "ContextMenuArea" | "ContextMenuInternal"))
             {
-                has_menu |= process_context_menu(elem, &useful_menu_component, diag);
+                has_menu |=
+                    process_context_menu(elem, &useful_menu_component, diag, no_native_menu);
             }
         });
     }
@@ -197,7 +199,7 @@ pub async fn lower_menus(
         recurse_elem_including_sub_components_no_borrow(&popup_menu_impl, &(), &mut |elem, _| {
             if matches!(&elem.borrow().builtin_type(), Some(b) if matches!(b.name.as_str(), "ContextMenuArea" | "ContextMenuInternal"))
             {
-                process_context_menu(elem, &useful_menu_component, diag);
+                process_context_menu(elem, &useful_menu_component, diag, no_native_menu);
             }
         });
         doc.popup_menu_impl = popup_menu_impl.into();
@@ -208,6 +210,7 @@ fn process_context_menu(
     context_menu_elem: &ElementRc,
     components: &UsefulMenuComponents,
     diag: &mut BuildDiagnostics,
+    no_native_menu: bool,
 ) -> bool {
     let is_internal = matches!(&context_menu_elem.borrow().base_type, ElementType::Builtin(b) if b.name == "ContextMenuInternal");
 
@@ -303,6 +306,7 @@ fn process_context_menu(
                 index: 0,
                 ty: crate::typeregister::logical_point_type(),
             },
+            Expression::BoolLiteral(no_native_menu),
         ],
         source_location,
     };

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -217,6 +217,13 @@ pub trait WindowAdapterInternal {
 
     fn setup_menubar(&self, _menubar: vtable::VBox<MenuVTable>) {}
 
+    fn show_context_menu(
+        &self,
+        _context_menu: vtable::VBox<MenuVTable>,
+        _position: LogicalPosition,
+    ) {
+    }
+
     /// Re-implement this to support exposing raw window handles (version 0.6).
     #[cfg(all(feature = "std", feature = "raw-window-handle-06"))]
     fn window_handle_06_rc(
@@ -1147,6 +1154,17 @@ impl WindowInner {
     pub fn setup_menubar(&self, menubar: vtable::VBox<MenuVTable>) {
         if let Some(x) = self.window_adapter().internal(crate::InternalToken) {
             x.setup_menubar(menubar);
+        }
+    }
+
+    /// Show a native context menu
+    pub fn show_context_menu(
+        &self,
+        context_menu: vtable::VBox<MenuVTable>,
+        position: LogicalPosition,
+    ) {
+        if let Some(x) = self.window_adapter().internal(crate::InternalToken) {
+            x.show_context_menu(context_menu, position);
         }
     }
 


### PR DESCRIPTION
This represents the better part of a day of trying to implement native context menu support with `muda`.  I've been able to get a context menu to appear, with the following caveats:
- Only the Rust code generator is supported
- Only Windows is supported
- Menu activation is `todo!()`
- Root menu items seem to display a subitem whether they have items or not

I've been finding it challenging navigating the Slint object model, particularly in the context of code generation, and I'm sure in some cases I'm overlooking simpler solutions.  So I was hoping that I could get some feedback (perhaps what objects I need to "lock on to") about how to pull this over the finish line.

Thanks in advance, I'm really looking forward to having a native context menu in Slint!

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
