### PR TITLE
Flickable: reject Wheel events in the orthogonal direction

### DIFF
--- a/docs/astro/src/content/docs/reference/gestures/flickable.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/flickable.mdx
@@ -59,6 +59,12 @@ interacting with `TouchArea` elements:
    a `TouchArea`, then `Flickable` will flick immediately on pointer move events when the euclidean distance
    to the coordinates of the press event exceeds 8 logical pixels.
 
+## Wheel/Scroll Event Interaction
+
+The Flickable also supports scrolling with the mouse wheel and touchpad scroll gestures.
+It will scroll regardless of the `interactive` property.
+If the event is in a direction that for which the Flickable can scroll, the event will be intercepted.
+If the Flickable can't scroll in the direction of the event, the event will be forwarded to the parent.
 
 ## Properties
 

--- a/docs/astro/src/content/docs/reference/gestures/flickable.mdx
+++ b/docs/astro/src/content/docs/reference/gestures/flickable.mdx
@@ -61,9 +61,9 @@ interacting with `TouchArea` elements:
 
 ## Wheel/Scroll Event Interaction
 
-The Flickable also supports scrolling with the mouse wheel and touchpad scroll gestures.
+The `Flickable` also supports scrolling with the mouse wheel and touchpad scroll gestures.
 It will scroll regardless of the `interactive` property.
-If the event is in a direction that for which the Flickable can scroll, the event will be intercepted.
+If the `Flickable` can scroll in the event's direction, the event will be intercepted.
 If the Flickable can't scroll in the direction of the event, the event will be forwarded to the parent.
 
 ## Properties

--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -23,8 +23,7 @@ use crate::lengths::{
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use crate::window::WindowAdapter;
-use crate::Callback;
-use crate::Property;
+use crate::{Callback, Coord, Property};
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
@@ -385,10 +384,6 @@ impl FlickableData {
                 }
             }
             MouseEvent::Wheel { delta_x, delta_y, .. } => {
-                let old_pos = LogicalPoint::from_lengths(
-                    (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick).get(),
-                    (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick).get(),
-                );
                 let delta = if window_adapter.window().0.modifiers.get().shift()
                     && !cfg!(target_os = "macos")
                 {
@@ -397,6 +392,20 @@ impl FlickableData {
                 } else {
                     LogicalVector::new(*delta_x, *delta_y)
                 };
+
+                let geo = flick_rc.geometry();
+
+                if (delta.x == 0 as Coord && flick.viewport_height() <= geo.height_length())
+                    || (delta.y == 0 as Coord && flick.viewport_width() <= geo.width_length())
+                {
+                    // Scroll in a orthogonal direction than what is allowed by the flickable
+                    return InputEventResult::EventIgnored;
+                }
+
+                let old_pos = LogicalPoint::from_lengths(
+                    (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick).get(),
+                    (Flickable::FIELD_OFFSETS.viewport_y).apply_pin(flick).get(),
+                );
                 let new_pos = ensure_in_bound(flick, old_pos + delta, flick_rc);
 
                 let viewport_x = (Flickable::FIELD_OFFSETS.viewport_x).apply_pin(flick);

--- a/tests/cases/elements/flickable_in_flickable.slint
+++ b/tests/cases/elements/flickable_in_flickable.slint
@@ -121,4 +121,21 @@ assert_eq!(instance.get_outer_y(), old_outer_y);
 
 ```
 
+```rust
+// Wheel events
+use slint::{LogicalPosition, platform::WindowEvent };
+let instance = TestCase::new().unwrap();
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 0.0, delta_y: -50.0 });
+assert_eq!(instance.get_inner_x(), 0.);
+assert_eq!(instance.get_outer_y(), 50.);
+
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: -30.0, delta_y: 0.0 });
+assert_eq!(instance.get_inner_x(), 30.);
+assert_eq!(instance.get_outer_y(), 50.);
+
+instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 0.0, delta_y: 10.0 });
+assert_eq!(instance.get_inner_x(), 30.);
+assert_eq!(instance.get_outer_y(), 40.);
+```
+
 */


### PR DESCRIPTION
Fixes #8798

ChangeLog: Flickable forward wheel event in a orthogonal direction to their parent
