### PR TITLE
Node.JS: Fixed panic when converting brushes to colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project are documented in this file.
 
  - Minimum Supported Rust Version (MSRV) is 1.85
 
+### Node.js API
+
+ - Fixed panic when attempting to convert brushes to colors.
+
 ## [1.12.1] - 2025-06-25
 
 ### General

--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -496,6 +496,17 @@ test("get/set brush properties", (t) => {
         t.deepEqual(ref_color.blue, 0);
         t.deepEqual(ref_color.alpha, 255);
     }
+
+    // ref is a brush, but setting to a color should not throw, but take the brush's color.
+    instance!.setProperty("ref-color", ref);
+    instance_ref = instance!.getProperty("ref-color");
+    if (t.true(instance_ref instanceof private_api.SlintBrush)) {
+        const ref_color = (instance_ref as private_api.SlintBrush).color;
+        t.deepEqual(ref_color.red, ref.color.red);
+        t.deepEqual(ref_color.green, ref.color.green);
+        t.deepEqual(ref_color.blue, ref.color.blue);
+        t.deepEqual(ref_color.alpha, ref.color.alpha);
+    }
 });
 
 test("get/set enum properties", (t) => {


### PR DESCRIPTION
The material components gallery would run `new ui.ListItem({...})` where one of the fields would be a default constructed brush, for which the "conversion" to a brush in Rust would fail because that case wasn't handled.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
