### PR TITLE
live-reload of .slint file for rust compiled app

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,13 +94,18 @@ jobs:
               with:
                   toolchain: ${{ matrix.rust_version }}
                   key: x-v3
-            - name: Run tests (not qt)
+            - name: Run tests
               run:  cargo test --verbose --all-features --workspace ${{ matrix.extra_args }} ${{ matrix.maybe_exclude_bevy }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python -- --skip=_qt::t
               env:
                   SLINT_CREATE_SCREENSHOTS: 1
               shell: bash
             - name: Run tests (qt)
               run: cargo test --verbose --all-features --workspace ${{ matrix.extra_args }} ${{ matrix.maybe_exclude_bevy }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python --bin test-driver-rust -- _qt --test-threads=1
+              shell: bash
+            - name: live-reload test
+              env:
+                SLINT_LIVE_RELOAD: 1
+              run: cargo test --verbose --features=build-time,slint/live-reload -p test-driver-rust -- --skip=_qt::t
               shell: bash
             - name: Archive screenshots after failed tests
               if: ${{ failure() }}

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -442,6 +442,7 @@ pub fn compile_with_config(
     println!("cargo:rerun-if-env-changed=SLINT_ASSET_SECTION");
     println!("cargo:rerun-if-env-changed=SLINT_EMBED_RESOURCES");
     println!("cargo:rerun-if-env-changed=SLINT_EMIT_DEBUG_INFO");
+    println!("cargo:rerun-if-env-changed=SLINT_LIVE_RELOAD");
 
     println!(
         "cargo:rustc-env=SLINT_INCLUDE_GENERATED={}",

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -83,6 +83,19 @@ raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/ra
 ## AVIF, BMP, DDS, Farbfeld, GIF, HDR, ICO, JPEG, EXR, PNG, PNM, QOI, TGA, TIFF, WebP.
 image-default-formats = ["i-slint-core/image-default-formats"]
 
+## Enable the live reload feature
+##
+## Enable this feature to reload the .slint files at runtime and reload it whenever the files are modified on disk.
+## For this feature to work, it's also required to set the `SLINT_LIVE_RELOAD` environment variable during
+## application compilation.
+##
+## This is a feature for debugging and development. It's not recommended to add this feature to your Cargo.toml.
+## Instead, use the `--features` command line argument like so when building your app:
+## ```bash
+## SLINT_LIVE_RELOAD=1 cargo build --features slint/live-reload
+## ```
+live-reload = ["dep:slint-interpreter"]
+
 #! ### Backends
 
 #! Slint needs a backend that will act as liaison between Slint and the OS.
@@ -207,6 +220,7 @@ i-slint-core = { workspace = true }
 slint-macros = { workspace = true }
 i-slint-backend-selector = { workspace = true }
 i-slint-core-macros = { workspace = true }
+slint-interpreter = { workspace = true, optional = true, default-features = false, features = ["display-diagnostics", "compat-1-2", "internal-live-reload"] }
 
 const-field-offset = { version = "0.1.2", path = "../../../helper_crates/const-field-offset" }
 document-features = { version = "0.2.0", optional = true }

--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -93,7 +93,7 @@ pub mod generated_code {
 
     impl ComponentHandle for SampleComponent {
         #[doc(hidden)]
-        type Inner = SampleComponent;
+        type WeakInner = ();
 
         /// Returns a new weak pointer.
         fn as_weak(&self) -> Weak<Self> {
@@ -106,9 +106,7 @@ pub mod generated_code {
         }
 
         #[doc(hidden)]
-        fn from_inner(
-            _: vtable::VRc<crate::private_unstable_api::re_exports::ItemTreeVTable, Self::Inner>,
-        ) -> Self {
+        fn upgrade_from_weak_inner(_: &Self::WeakInner) -> Option<Self> {
             unimplemented!();
         }
 

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -234,4 +234,7 @@ pub mod re_exports {
     pub use pin_weak::rc::PinWeak;
     pub use unicode_segmentation::UnicodeSegmentation;
     pub use vtable::{self, *};
+
+    #[cfg(feature = "live-reload")]
+    pub use slint_interpreter::live_reload;
 }

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -24,6 +24,8 @@ pub mod cpp;
 
 #[cfg(feature = "rust")]
 pub mod rust;
+#[cfg(feature = "rust")]
+pub mod rust_live_reload;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum OutputFormat {

--- a/internal/compiler/generator/rust_live_reload.rs
+++ b/internal/compiler/generator/rust_live_reload.rs
@@ -1,0 +1,469 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use super::rust::{ident, rust_primitive_type};
+use crate::langtype::{Struct, Type};
+use crate::llr;
+use crate::object_tree::Document;
+use crate::CompilerConfiguration;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+/// Generate the rust code for the given component.
+pub fn generate(
+    doc: &Document,
+    compiler_config: &CompilerConfiguration,
+) -> std::io::Result<TokenStream> {
+    let (structs_and_enums_ids, inner_module) =
+        super::rust::generate_types(&doc.used_types.borrow().structs_and_enums);
+
+    let type_value_conversions =
+        generate_value_conversions(&doc.used_types.borrow().structs_and_enums);
+
+    let llr = crate::llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config)?;
+
+    if llr.public_components.is_empty() {
+        return Ok(Default::default());
+    }
+
+    let main_file = doc
+        .node
+        .as_ref()
+        .ok_or_else(|| std::io::Error::other("Cannot determine path of the main file"))?
+        .source_file
+        .path()
+        .to_string_lossy();
+
+    let public_components = llr
+        .public_components
+        .iter()
+        .map(|p| generate_public_component(p, compiler_config, &main_file));
+
+    let globals = llr
+        .globals
+        .iter_enumerated()
+        .filter(|(_, glob)| glob.must_generate())
+        .map(|(_, glob)| generate_global(glob, &llr));
+    let globals_ids = llr.globals.iter().filter(|glob| glob.exported).flat_map(|glob| {
+        std::iter::once(ident(&glob.name)).chain(glob.aliases.iter().map(|x| ident(x)))
+    });
+    let compo_ids = llr.public_components.iter().map(|c| ident(&c.name));
+
+    let named_exports = super::rust::generate_named_exports(&doc.exports);
+    // The inner module was meant to be internal private, but projects have been reaching into it
+    // so we can't change the name of this module
+    let generated_mod = doc
+        .last_exported_component()
+        .map(|c| format_ident!("slint_generated{}", ident(&c.id)))
+        .unwrap_or_else(|| format_ident!("slint_generated"));
+
+    Ok(quote! {
+        mod #generated_mod {
+            #inner_module
+            #(#globals)*
+            #(#public_components)*
+            #type_value_conversions
+        }
+        #[allow(unused_imports)]
+        pub use #generated_mod::{#(#compo_ids,)* #(#structs_and_enums_ids,)* #(#globals_ids,)* #(#named_exports,)*};
+        #[allow(unused_imports)]
+        pub use slint::{ComponentHandle as _, Global as _, ModelExt as _};
+    })
+}
+
+fn generate_public_component(
+    llr: &llr::PublicComponent,
+    compiler_config: &CompilerConfiguration,
+    main_file: &str,
+) -> TokenStream {
+    let public_component_id = ident(&llr.name);
+    let component_name = llr.name.as_str();
+
+    let mut property_and_callback_accessors: Vec<TokenStream> = vec![];
+    for p in &llr.public_properties {
+        let prop_name = p.name.as_str();
+        let prop_ident = ident(&p.name);
+
+        if let Type::Callback(callback) = &p.ty {
+            let callback_args =
+                callback.args.iter().map(|a| rust_primitive_type(a).unwrap()).collect::<Vec<_>>();
+            let return_type = rust_primitive_type(&callback.return_type).unwrap();
+            let args_name =
+                (0..callback.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
+            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            property_and_callback_accessors.push(quote!(
+                #[allow(dead_code)]
+                pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
+                    self.0.invoke(#prop_name, &[#(#args_name.into(),)*])
+                        .unwrap_or_else(|e| panic!("Cannot invoke callback {}::{}: {e}", #component_name, #prop_name))
+                        .try_into().expect("Invalid return type")
+                }
+            ));
+            let on_ident = format_ident!("on_{}", prop_ident);
+            property_and_callback_accessors.push(quote!(
+                #[allow(dead_code)]
+                pub fn #on_ident(&self, f: impl FnMut(#(#callback_args),*) -> #return_type + 'static) {
+                    let f = ::core::cell::RefCell::new(f);
+                    self.0.set_callback(#prop_name, move |values| {
+                        let [#(#args_name,)*] = values else { panic!("invalid number of argument for callback {}::{}", #component_name, #prop_name) };
+                        (*f.borrow_mut())(#(#args_name.clone().try_into().unwrap_or_else(|_| panic!("invalid argument for callback {}::{}", #component_name, #prop_name)),)*).into()
+                    }).unwrap_or_else(|e| panic!("Cannot set callback {}::{}: {e}", #component_name, #prop_name))
+                }
+            ));
+        } else if let Type::Function(function) = &p.ty {
+            let callback_args =
+                function.args.iter().map(|a| rust_primitive_type(a).unwrap()).collect::<Vec<_>>();
+            let return_type = rust_primitive_type(&function.return_type).unwrap();
+            let args_name =
+                (0..function.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
+            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            property_and_callback_accessors.push(quote!(
+                #[allow(dead_code)]
+                pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
+                    self.0.invoke(#prop_name, &[#(#args_name.into(),)*])
+                        .unwrap_or_else(|e| panic!("Cannot invoke callback {}::{}: {e}", #component_name, #prop_name))
+                        .try_into().expect("Invalid return type")
+                }
+            ));
+        } else {
+            let rust_property_type = rust_primitive_type(&p.ty).unwrap();
+            let convert_to_value = convert_to_value_fn(&p.ty);
+            let convert_from_value = convert_from_value_fn(&p.ty);
+
+            let getter_ident = format_ident!("get_{}", prop_ident);
+            property_and_callback_accessors.push(quote!(
+                #[allow(dead_code)]
+                pub fn #getter_ident(&self) -> #rust_property_type {
+                    #[allow(unused_imports)]
+                    #convert_from_value(
+                        self.0.get_property(#prop_name)
+                            .unwrap_or_else(|e| panic!("Cannot get property {}::{} - {e}", #component_name, #prop_name))
+                    ).expect("Invalid property type")
+                }
+            ));
+
+            let setter_ident = format_ident!("set_{}", prop_ident);
+            if !p.read_only {
+                property_and_callback_accessors.push(quote!(
+                    #[allow(dead_code)]
+                    pub fn #setter_ident(&self, value: #rust_property_type) {
+                        self.0.set_property(#prop_name, #convert_to_value(value))
+                            .unwrap_or_else(|e| panic!("Cannot set property {}::{} - {e}", #component_name, #prop_name));
+                    }
+                ));
+            } else {
+                property_and_callback_accessors.push(quote!(
+                    #[allow(dead_code)] fn #setter_ident(&self, _read_only_property : ()) { }
+                ));
+            }
+        }
+    }
+
+    let include_paths = compiler_config.include_paths.iter().map(|p| p.to_string_lossy());
+    let library_paths = compiler_config.library_paths.iter().map(|(n, p)| {
+        let p = p.to_string_lossy();
+        quote!((#n.to_string(), #p.into()))
+    });
+    let style = compiler_config.style.iter();
+
+    quote!(
+        pub struct #public_component_id(slint_interpreter::ComponentInstance);
+
+        impl #public_component_id {
+            pub fn new() -> sp::Result<Self, slint::PlatformError> {
+                let mut compiler = slint_interpreter::Compiler::default();
+                compiler.set_include_paths([#(#include_paths.into()),*].into_iter().collect());
+                compiler.set_library_paths([#(#library_paths.into()),*].into_iter().collect());
+                #(compiler.set_style(#style.to_string());)*
+
+                let mut future = ::core::pin::pin!(compiler.build_from_path(#main_file));
+                let mut cx = ::std::task::Context::from_waker(::std::task::Waker::noop());
+                let ::std::task::Poll::Ready(result) = ::std::future::Future::poll(future.as_mut(), &mut cx) else { unreachable!("Compiler returned Pending") };
+                result.print_diagnostics();
+                assert!(!result.has_errors(), "Was not able to compile the file");
+                let definition = result.component(#component_name).expect("Cannot open component");
+                let instance = definition.create()?;
+                sp::Ok(Self(instance))
+            }
+
+            #(#property_and_callback_accessors)*
+        }
+
+        impl slint::ComponentHandle for #public_component_id {
+            type WeakInner = slint_interpreter::Weak<slint_interpreter::ComponentInstance>;
+            fn as_weak(&self) -> slint_interpreter::Weak<Self> {
+                slint::Weak::new(slint_interpreter::ComponentHandle::as_weak(&self.0))
+            }
+
+            fn clone_strong(&self) -> Self {
+                Self(slint::ComponentHandle::clone_strong(&self.0))
+            }
+
+            fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> sp::Option<Self> {
+                sp::Some(Self(inner.upgrade()?))
+            }
+
+            fn run(&self) -> ::core::result::Result<(), slint::PlatformError> {
+                slint::ComponentHandle::run(&self.0)
+            }
+
+            fn show(&self) -> ::core::result::Result<(), slint::PlatformError> {
+                slint::ComponentHandle::show(&self.0)
+            }
+
+            fn hide(&self) -> ::core::result::Result<(), slint::PlatformError> {
+                slint::ComponentHandle::hide(&self.0)
+            }
+
+            fn window(&self) -> &slint::Window {
+                slint::ComponentHandle::window(&self.0)
+            }
+
+            fn global<'a, T: slint::Global<'a, Self>>(&'a self) -> T {
+                T::get(&self)
+            }
+        }
+
+        /// This is needed for the the internal tests  (eg `slint_testing::send_keyboard_string_sequence`)
+        impl<X> ::core::convert::From<#public_component_id> for sp::VRc<sp::ItemTreeVTable, X>
+            where Self : ::core::convert::From<sp::live_reload::ComponentInstance>
+        {
+            fn from(value: #public_component_id) -> Self {
+                Self::from(slint::ComponentHandle::clone_strong(value.0.borrow().instance()))
+            }
+        }
+
+    )
+}
+
+fn generate_global(global: &llr::GlobalComponent, root: &llr::CompilationUnit) -> TokenStream {
+    if !global.exported {
+        return quote!();
+    }
+    let global_name = global.name.as_str();
+    let mut property_and_callback_accessors: Vec<TokenStream> = vec![];
+    for p in &global.public_properties {
+        let prop_name = p.name.as_str();
+        let prop_ident = ident(&p.name);
+
+        if let Type::Callback(callback) = &p.ty {
+            let callback_args =
+                callback.args.iter().map(|a| rust_primitive_type(a).unwrap()).collect::<Vec<_>>();
+            let return_type = rust_primitive_type(&callback.return_type).unwrap();
+            let args_name =
+                (0..callback.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
+            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            property_and_callback_accessors.push(quote!(
+                #[allow(dead_code)]
+                pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
+                    self.0.invoke_global(#global_name, #prop_name, &[#(#args_name.into(),)*])
+                        .unwrap_or_else(|e| panic!("Cannot invoke callback {}::{}: {e}", #global_name, #prop_name))
+                        .try_into().expect("Invalid return type")
+                }
+            ));
+            let on_ident = format_ident!("on_{}", prop_ident);
+            property_and_callback_accessors.push(quote!(
+                #[allow(dead_code)]
+                pub fn #on_ident(&self, f: impl FnMut(#(#callback_args),*) -> #return_type + 'static) {
+                    let f = ::core::cell::RefCell::new(f);
+                    self.0.set_global_callback(#global_name, #prop_name, move |values| {
+                        let [#(#args_name,)*] = values else { panic!("invalid number of argument for callback {}::{}", #global_name, #prop_name) };
+                        (*f.borrow_mut())(#(#args_name.clone().try_into().unwrap_or_else(|_| panic!("invalid argument for callback {}::{}", #global_name, #prop_name)),)*).into()
+                    }).unwrap_or_else(|e| panic!("Cannot set callback {}::{}: {e}", #global_name, #prop_name))
+                }
+            ));
+        } else if let Type::Function(function) = &p.ty {
+            let callback_args =
+                function.args.iter().map(|a| rust_primitive_type(a).unwrap()).collect::<Vec<_>>();
+            let return_type = rust_primitive_type(&function.return_type).unwrap();
+            let args_name =
+                (0..function.args.len()).map(|i| format_ident!("arg_{}", i)).collect::<Vec<_>>();
+            let caller_ident = format_ident!("invoke_{}", prop_ident);
+            property_and_callback_accessors.push(quote!(
+                #[allow(dead_code)]
+                pub fn #caller_ident(&self, #(#args_name : #callback_args,)*) -> #return_type {
+                    self.0.invoke_global(#global_name, #prop_name, &[#(#args_name.into(),)*])
+                        .unwrap_or_else(|e| panic!("Cannot invoke callback {}::{}: {e}", #global_name, #prop_name))
+                        .try_into().expect("Invalid return type")
+                }
+            ));
+        } else {
+            let rust_property_type = rust_primitive_type(&p.ty).unwrap();
+            let convert_to_value = convert_to_value_fn(&p.ty);
+            let convert_from_value = convert_from_value_fn(&p.ty);
+
+            let getter_ident = format_ident!("get_{}", prop_ident);
+            property_and_callback_accessors.push(quote!(
+                #[allow(dead_code)]
+                pub fn #getter_ident(&self) -> #rust_property_type {
+                    #convert_from_value(
+                        self.0.get_global_property(#global_name, #prop_name)
+                            .unwrap_or_else(|e| panic!("Cannot get property {}::{} - {e}", #global_name, #prop_name))
+                    ).expect("Invalid property type")
+                }
+            ));
+
+            let setter_ident = format_ident!("set_{}", prop_ident);
+            if !p.read_only {
+                property_and_callback_accessors.push(quote!(
+                    #[allow(dead_code)]
+                    pub fn #setter_ident(&self, value: #rust_property_type) {
+                        self.0.set_global_property(#global_name, #prop_name, #convert_to_value(value))
+                            .unwrap_or_else(|e| panic!("Cannot set property {}::{} - {e}", #global_name, #prop_name));
+                    }
+                ));
+            } else {
+                property_and_callback_accessors.push(quote!(
+                    #[allow(dead_code)] fn #setter_ident(&self, _read_only_property : ()) { }
+                ));
+            }
+        }
+    }
+
+    let public_component_id = ident(&global.name);
+    let aliases = global.aliases.iter().map(|name| ident(name));
+    let getters = root.public_components.iter().map(|c| {
+        let root_component_id = ident(&c.name);
+        quote! {
+            impl<'a> slint::Global<'a, #root_component_id> for #public_component_id<'a> {
+                fn get(component: &'a #root_component_id) -> Self {
+                    Self(&component.0)
+                }
+            }
+        }
+    });
+
+    quote!(
+        #[allow(unused)]
+        pub struct #public_component_id<'a>(&'a slint_interpreter::ComponentInstance);
+
+        impl<'a> #public_component_id<'a> {
+            #(#property_and_callback_accessors)*
+        }
+        #(pub type #aliases<'a> = #public_component_id<'a>;)*
+        #(#getters)*
+    )
+}
+
+/// returns a function that converts the type to a Value.
+/// Normally, that would simply be `xxx.into()`, but for anonymous struct, we need an explicit conversion
+fn convert_to_value_fn(ty: &Type) -> TokenStream {
+    match ty {
+        Type::Struct(s) if s.name.is_none() => {
+            // anonymous struct is mapped to a tuple
+            let names = s.fields.keys().map(|k| k.as_str()).collect::<Vec<_>>();
+            let fields = names.iter().map(|k| ident(k)).collect::<Vec<_>>();
+            quote!((|(#(#fields,)*)| {
+                slint_interpreter::Value::Struct([#((#names.to_string(), slint_interpreter::Value::from(#fields)),)*].into_iter().collect())
+            }))
+        }
+        Type::Array(a) if matches!(a.as_ref(), Type::Struct(s) if s.name.is_none()) => {
+            let conf_fn = convert_to_value_fn(a.as_ref());
+            quote!((|model: sp::ModelRc<_>| -> slint_interpreter::Value {
+                slint_interpreter::Value::Model(sp::ModelRc::new(model.map(#conf_fn)))
+            }))
+        }
+        _ => quote!(::core::convert::From::from),
+    }
+}
+
+/// Returns a function that converts a Value to the type.
+/// Normally, that would simply be `xxx.try_into()`, but for anonymous struct, we need an explicit conversion
+fn convert_from_value_fn(ty: &Type) -> TokenStream {
+    match ty {
+        Type::Struct(s) if s.name.is_none() => {
+            let names = s.fields.keys().map(|k| k.as_str()).collect::<Vec<_>>();
+            // anonymous struct is mapped to a tuple
+            quote!((|v: slint_interpreter::Value| -> sp::Result<_, ()> {
+                let slint_interpreter::Value::Struct(s) = v else { return sp::Err(()) };
+                sp::Ok((#(s.get_field(#names).ok_or(())?.clone().try_into().map_err(|_|())?,)*))
+            }))
+        }
+        Type::Array(a) if matches!(a.as_ref(), Type::Struct(s) if s.name.is_none()) => {
+            let conf_fn = convert_from_value_fn(a.as_ref());
+            quote!((|v: slint_interpreter::Value| -> sp::Result<_, ()> {
+                let slint_interpreter::Value::Model(model) = v else { return sp::Err(()) };
+                sp::Ok(sp::ModelRc::new(model.map(|x| #conf_fn(x).unwrap_or_default())))
+            }))
+        }
+        _ => quote!(::core::convert::TryFrom::try_from),
+    }
+}
+
+fn generate_value_conversions(used_types: &[Type]) -> TokenStream {
+    let r = used_types
+        .iter()
+        .filter_map(|ty| match ty {
+            Type::Struct(s) => match s.as_ref() {
+                Struct { fields, name: Some(name), node: Some(_), .. } => {
+                    let ty = ident(name);
+                    let convert_to_value = fields.values().map(convert_to_value_fn);
+                    let convert_from_value = fields.values().map(convert_from_value_fn);
+                    let field_names = fields.keys().map(|k| k.as_str()).collect::<Vec<_>>();
+                    let fields = field_names.iter().map(|k| ident(k)).collect::<Vec<_>>();
+                    Some(quote!{
+                        impl From<#ty> for slint_interpreter::Value {
+                            fn from(_value: #ty) -> Self {
+                                Self::Struct([#((#field_names.to_string(), #convert_to_value(_value.#fields)),)*].into_iter().collect())
+                            }
+                        }
+                        impl TryFrom<slint_interpreter::Value> for #ty {
+                            type Error = ();
+                            fn try_from(v: slint_interpreter::Value) -> sp::Result<Self, ()> {
+                                match v {
+                                    slint_interpreter::Value::Struct(_x) => {
+                                        sp::Ok(Self {
+                                            #(#fields: #convert_from_value(_x.get_field(#field_names).ok_or(())?.clone()).map_err(|_|())?,)*
+                                        })
+                                    }
+                                    _ => sp::Err(()),
+                                }
+                            }
+                        }
+                    })
+                }
+                _ => None,
+            },
+            Type::Enumeration(en) => {
+                let name = en.name.as_str();
+                let ty = ident(&en.name);
+                let vals = en.values.iter().map(|v| ident(&crate::generator::to_pascal_case(v))).collect::<Vec<_>>();
+                let val_names = en.values.iter().map(|v| v.as_str()).collect::<Vec<_>>();
+
+                Some(quote!{
+                    impl From<#ty> for slint_interpreter::Value {
+                        fn from(v: #ty) -> Self {
+                            fn to_string(v: #ty) -> String {
+                                match v {
+                                    #(#ty::#vals => #val_names.to_string(),)*
+                                }
+                            }
+                            Self::EnumerationValue(#name.to_owned(), to_string(v))
+                        }
+                    }
+                    impl TryFrom<slint_interpreter::Value> for #ty {
+                        type Error = ();
+                        fn try_from(v: slint_interpreter::Value) -> sp::Result<Self, ()> {
+                            match v {
+                                slint_interpreter::Value::EnumerationValue(enumeration, value) => {
+                                    if enumeration != #name {
+                                        return sp::Err(());
+                                    }
+                                    fn from_str(value: &str) -> sp::Result<#ty, ()> {
+                                        match value {
+                                            #(#val_names => Ok(#ty::#vals),)*
+                                            _ => sp::Err(()),
+                                        }
+                                    }
+                                    from_str(value.as_str()).map_err(|_| ())
+                                }
+                                _ => sp::Err(()),
+                            }
+                        }
+                    }
+                })
+            },
+            _ => None,
+        });
+    quote!(#(#r)*)
+}

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -11,7 +11,6 @@ This module contains types that are public and re-exported in the slint-rs as we
 pub use crate::future::*;
 use crate::graphics::{Rgba8Pixel, SharedPixelBuffer};
 use crate::input::{KeyEventType, MouseEvent};
-use crate::item_tree::ItemTreeVTable;
 use crate::window::{WindowAdapter, WindowInner};
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -759,9 +758,9 @@ pub trait Global<'a, Component> {
 ///
 /// This trait is implemented by the [generated component](index.html#generated-components)
 pub trait ComponentHandle {
-    /// The type of the generated component.
+    /// The internal Inner type for `Weak<Self>::inner`.
     #[doc(hidden)]
-    type Inner;
+    type WeakInner: Clone + Default;
     /// Returns a new weak pointer.
     fn as_weak(&self) -> Weak<Self>
     where
@@ -773,7 +772,9 @@ pub trait ComponentHandle {
 
     /// Internal function used when upgrading a weak reference to a strong one.
     #[doc(hidden)]
-    fn from_inner(_: vtable::VRc<ItemTreeVTable, Self::Inner>) -> Self;
+    fn upgrade_from_weak_inner(_: &Self::WeakInner) -> Option<Self>
+    where
+        Self: Sized;
 
     /// Convenience function for [`crate::Window::show()`](struct.Window.html#method.show).
     /// This shows the window on the screen and maintains an extra strong reference while
@@ -820,7 +821,7 @@ mod weak_handle {
     /// as the one it has been created from.
     /// This is useful to use with [`invoke_from_event_loop()`] or [`Self::upgrade_in_event_loop()`].
     pub struct Weak<T: ComponentHandle> {
-        inner: vtable::VWeak<ItemTreeVTable, T::Inner>,
+        inner: T::WeakInner,
         #[cfg(feature = "std")]
         thread: std::thread::ThreadId,
     }
@@ -828,7 +829,7 @@ mod weak_handle {
     impl<T: ComponentHandle> Default for Weak<T> {
         fn default() -> Self {
             Self {
-                inner: vtable::VWeak::default(),
+                inner: T::WeakInner::default(),
                 #[cfg(feature = "std")]
                 thread: std::thread::current().id(),
             }
@@ -847,9 +848,9 @@ mod weak_handle {
 
     impl<T: ComponentHandle> Weak<T> {
         #[doc(hidden)]
-        pub fn new(rc: &vtable::VRc<ItemTreeVTable, T::Inner>) -> Self {
+        pub fn new(inner: T::WeakInner) -> Self {
             Self {
-                inner: vtable::VRc::downgrade(rc),
+                inner,
                 #[cfg(feature = "std")]
                 thread: std::thread::current().id(),
             }
@@ -868,7 +869,7 @@ mod weak_handle {
             if std::thread::current().id() != self.thread {
                 return None;
             }
-            self.inner.upgrade().map(T::from_inner)
+            T::upgrade_from_weak_inner(&self.inner)
         }
 
         /// Convenience function that returns a new strongly referenced component if
@@ -883,12 +884,13 @@ mod weak_handle {
                     "Trying to upgrade a Weak from a different thread than the one it belongs to"
                 );
             }
-            T::from_inner(self.inner.upgrade().expect("The Weak doesn't hold a valid component"))
+            T::upgrade_from_weak_inner(&self.inner)
+                .expect("The Weak doesn't hold a valid component")
         }
 
         /// A helper function to allow creation on `component_factory::Component` from
         /// a `ComponentHandle`
-        pub(crate) fn inner(&self) -> vtable::VWeak<ItemTreeVTable, T::Inner> {
+        pub(crate) fn inner(&self) -> T::WeakInner {
             self.inner.clone()
         }
 

--- a/internal/core/component_factory.rs
+++ b/internal/core/component_factory.rs
@@ -50,12 +50,12 @@ pub struct ComponentFactory(Option<ComponentFactoryInner>);
 
 impl ComponentFactory {
     /// Create a new `ComponentFactory`
-    pub fn new<T: ComponentHandle + 'static>(
+    pub fn new<
+        X: vtable::HasStaticVTable<ItemTreeVTable> + 'static,
+        T: ComponentHandle<WeakInner = vtable::VWeak<ItemTreeVTable, X>> + 'static,
+    >(
         factory: impl Fn(FactoryContext) -> Option<T> + 'static,
-    ) -> Self
-    where
-        T::Inner: vtable::HasStaticVTable<ItemTreeVTable> + 'static,
-    {
+    ) -> Self {
         let factory = Box::new(factory) as Box<dyn Fn(FactoryContext) -> Option<T> + 'static>;
 
         Self(Some(ComponentFactoryInner(Rc::new(move |ctx| -> Option<ItemTreeRc> {

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -130,6 +130,9 @@ internal-highlight = []
 # NOTE: this is not a semver compatible feature
 internal-json = ["dep:serde_json"]
 
+# (internal)
+internal-live-reload = ["dep:notify", "display-diagnostics"]
+
 
 [dependencies]
 i-slint-compiler = { workspace = true }
@@ -151,6 +154,8 @@ raw-window-handle-06 = { workspace = true, optional = true }
 itertools = { workspace = true }
 smol_str = { workspace = true }
 unicode-segmentation = { workspace = true }
+
+notify = { version = "8.0.0", default-features = false, features = ["macos_kqueue"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 i-slint-backend-winit = { workspace = true }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1536,23 +1536,21 @@ impl ComponentInstance {
 }
 
 impl ComponentHandle for ComponentInstance {
-    type Inner = crate::dynamic_item_tree::ErasedItemTreeBox;
+    type WeakInner = vtable::VWeak<ItemTreeVTable, crate::dynamic_item_tree::ErasedItemTreeBox>;
 
     fn as_weak(&self) -> Weak<Self>
     where
         Self: Sized,
     {
-        Weak::new(&self.inner)
+        Weak::new(vtable::VRc::downgrade(&self.inner))
     }
 
     fn clone_strong(&self) -> Self {
         Self { inner: self.inner.clone() }
     }
 
-    fn from_inner(
-        inner: vtable::VRc<i_slint_core::item_tree::ItemTreeVTable, Self::Inner>,
-    ) -> Self {
-        Self { inner }
+    fn upgrade_from_weak_inner(inner: &Self::WeakInner) -> Option<Self> {
+        Some(Self { inner: inner.upgrade()? })
     }
 
     fn show(&self) -> Result<(), PlatformError> {

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -88,6 +88,8 @@ mod global_component;
 pub mod highlight;
 #[cfg(feature = "internal-json")]
 pub mod json;
+#[cfg(feature = "internal-live-reload")]
+pub mod live_reload;
 mod value_model;
 
 #[doc(inline)]

--- a/internal/interpreter/live_reload.rs
+++ b/internal/interpreter/live_reload.rs
@@ -1,0 +1,299 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! This is an internal module that contains the [`LiveReloadingComponent`] struct.
+
+use crate::dynamic_item_tree::WindowOptions;
+use core::cell::RefCell;
+use core::task::Waker;
+use i_slint_core::api::{ComponentHandle, PlatformError};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+//re-export for the generated code:
+pub use crate::{Compiler, ComponentInstance, Value};
+
+/// This struct is used to compile and instantiate a component from a .slint file on disk.
+/// The file is watched for changes and the component is recompiled and instantiated
+pub struct LiveReloadingComponent {
+    // because new_cyclic cannot return error, we need to initialize the instance after
+    instance: Option<ComponentInstance>,
+    compiler: Compiler,
+    file_name: PathBuf,
+    component_name: String,
+    properties: HashMap<String, Value>,
+    callbacks: HashMap<String, Rc<dyn Fn(&[Value]) -> Value + 'static>>,
+}
+
+impl LiveReloadingComponent {
+    /// Compile and instantiate a component from the specified .slint file and component.
+    pub fn new(
+        mut compiler: Compiler,
+        file_name: PathBuf,
+        component_name: String,
+    ) -> Result<Rc<RefCell<Self>>, PlatformError> {
+        let self_rc = Rc::<RefCell<Self>>::new_cyclic(move |self_weak| {
+            let watcher = Watcher::new(self_weak.clone());
+            if watcher.lock().unwrap().watcher.is_some() {
+                let watcher_clone = watcher.clone();
+                compiler.set_file_loader(move |path| {
+                    watcher_clone.lock().unwrap().watch(path);
+                    Box::pin(async { None })
+                });
+                watcher.lock().unwrap().watch(&file_name);
+            }
+            RefCell::new(Self {
+                instance: None,
+                compiler,
+                file_name,
+                component_name,
+                properties: Default::default(),
+                callbacks: Default::default(),
+            })
+        });
+
+        let mut self_mut = self_rc.borrow_mut();
+        let result = {
+            let mut future =
+                core::pin::pin!(self_mut.compiler.build_from_path(&self_mut.file_name));
+            let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+            let std::task::Poll::Ready(result) =
+                std::future::Future::poll(future.as_mut(), &mut cx)
+            else {
+                unreachable!("Compiler returned Pending")
+            };
+            result
+        };
+        #[cfg(feature = "display-diagnostics")]
+        result.print_diagnostics();
+        assert!(
+            !result.has_errors(),
+            "Was not able to compile the file {}. \n{:?}",
+            self_mut.file_name.display(),
+            result.diagnostics
+        );
+        let definition = result.component(&self_mut.component_name).expect("Cannot open component");
+        let instance = definition.create()?;
+        eprintln!(
+            "Loaded component {} from {}",
+            self_mut.component_name,
+            self_mut.file_name.display()
+        );
+        self_mut.instance = Some(instance);
+        drop(self_mut);
+        Ok(self_rc)
+    }
+
+    /// Reload the component from the .slint file.
+    /// If there is an error, it won't actually reload.
+    /// Return false in case of errors
+    pub fn reload(&mut self) -> bool {
+        let result = {
+            let mut future = core::pin::pin!(self.compiler.build_from_path(&self.file_name));
+            let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+            let std::task::Poll::Ready(result) =
+                std::future::Future::poll(future.as_mut(), &mut cx)
+            else {
+                unreachable!("Compiler returned Pending")
+            };
+            result
+        };
+        #[cfg(feature = "display-diagnostics")]
+        result.print_diagnostics();
+        if result.has_errors() {
+            return false;
+        }
+
+        if let Some(definition) = result.component(&self.component_name) {
+            let window_adapter =
+                i_slint_core::window::WindowInner::from_pub(self.instance().window())
+                    .window_adapter();
+            match definition.create_with_options(WindowOptions::UseExistingWindow(window_adapter)) {
+                Ok(instance) => {
+                    self.instance = Some(instance);
+                }
+                Err(e) => {
+                    eprintln!("Error while creating the component: {e}");
+                    return false;
+                }
+            }
+        } else {
+            eprintln!("Component {} not found", self.component_name);
+            return false;
+        }
+
+        // Set the properties
+        for (name, value) in self.properties.iter() {
+            if let Some((global, prop)) = name.split_once('.') {
+                self.instance()
+                    .set_global_property(global, prop, value.clone())
+                    .unwrap_or_else(|e| panic!("Cannot set property {name}: {e}"));
+            } else {
+                self.instance()
+                    .set_property(name, value.clone())
+                    .unwrap_or_else(|e| panic!("Cannot set property {name}: {e}"));
+            }
+        }
+        for (name, callback) in self.callbacks.iter() {
+            let callback = callback.clone();
+            if let Some((global, prop)) = name.split_once('.') {
+                self.instance()
+                    .set_global_callback(global, prop, move |args| callback(args))
+                    .unwrap_or_else(|e| panic!("Cannot set callback {name}: {e}"));
+            } else {
+                self.instance()
+                    .set_callback(name, move |args| callback(args))
+                    .unwrap_or_else(|e| panic!("Cannot set callback {name}: {e}"));
+            }
+        }
+
+        eprintln!("Reloaded component {} from {}", self.component_name, self.file_name.display());
+
+        true
+    }
+
+    /// Return the instance
+    pub fn instance(&self) -> &ComponentInstance {
+        &self.instance.as_ref().expect("always set after Self is created from Rc::new_cyclic")
+    }
+
+    /// Set a property and remember its value for when the component is reloaded
+    pub fn set_property(&mut self, name: &str, value: Value) {
+        self.properties.insert(name.into(), value.clone());
+        self.instance()
+            .set_property(&name, value)
+            .unwrap_or_else(|e| panic!("Cannot set property {name}: {e}"))
+    }
+
+    /// Forward to get_property
+    pub fn get_property(&self, name: &str) -> Value {
+        self.instance()
+            .get_property(&name)
+            .unwrap_or_else(|e| panic!("Cannot get property {name}: {e}"))
+    }
+
+    /// Forward to invoke
+    pub fn invoke(&self, name: &str, args: &[Value]) -> Value {
+        self.instance()
+            .invoke(name, args)
+            .unwrap_or_else(|e| panic!("Cannot invoke callback {name}: {e}"))
+    }
+
+    /// Forward to set_callback
+    pub fn set_callback(&mut self, name: &str, callback: Rc<dyn Fn(&[Value]) -> Value + 'static>) {
+        self.callbacks.insert(name.into(), callback.clone());
+        self.instance()
+            .set_callback(&name, move |args| callback(args))
+            .unwrap_or_else(|e| panic!("Cannot set callback {name}: {e}"));
+    }
+
+    /// forward to set_global_property
+    pub fn set_global_property(&mut self, global_name: &str, name: &str, value: Value) {
+        self.properties.insert(format!("{global_name}.{name}"), value.clone());
+        self.instance()
+            .set_global_property(global_name, name, value)
+            .unwrap_or_else(|e| panic!("Cannot set property {global_name}::{name}: {e}"))
+    }
+
+    /// forward to get_global_property
+    pub fn get_global_property(&self, global_name: &str, name: &str) -> Value {
+        self.instance()
+            .get_global_property(global_name, name)
+            .unwrap_or_else(|e| panic!("Cannot get property {global_name}::{name}: {e}"))
+    }
+
+    /// Forward to invoke_global
+    pub fn invoke_global(&self, global_name: &str, name: &str, args: &[Value]) -> Value {
+        self.instance()
+            .invoke_global(global_name, name, args)
+            .unwrap_or_else(|e| panic!("Cannot invoke callback {global_name}::{name}: {e}"))
+    }
+
+    /// Forward to set_global_callback
+    pub fn set_global_callback(
+        &mut self,
+        global_name: &str,
+        name: &str,
+        callback: Rc<dyn Fn(&[Value]) -> Value + 'static>,
+    ) {
+        self.callbacks.insert(format!("{global_name}.{name}"), callback.clone());
+        self.instance()
+            .set_global_callback(global_name, name, move |args| callback(args))
+            .unwrap_or_else(|e| panic!("Cannot set callback {global_name}::{name}: {e}"));
+    }
+}
+
+enum WatcherState {
+    Starting,
+    /// The file system watcher notified the main thread of a change
+    Changed,
+    /// The main thread is waiting for the next event
+    Waiting(Waker),
+}
+
+struct Watcher {
+    // (wouldn't need to be an option if new_cyclic() could return errors)
+    watcher: Option<notify::RecommendedWatcher>,
+    state: WatcherState,
+}
+
+impl Watcher {
+    fn new(component_weak: std::rc::Weak<RefCell<LiveReloadingComponent>>) -> Arc<Mutex<Self>> {
+        let arc = Arc::new(Mutex::new(Self { state: WatcherState::Starting, watcher: None }));
+
+        let watcher_weak = Arc::downgrade(&arc);
+        let result = crate::spawn_local(std::future::poll_fn(move |cx| {
+            let (Some(instance), Some(watcher)) =
+                (component_weak.upgrade(), watcher_weak.upgrade())
+            else {
+                // When the instance is dropped, we can stop this future
+                return std::task::Poll::Ready(());
+            };
+            let state = std::mem::replace(
+                &mut watcher.lock().unwrap().state,
+                WatcherState::Waiting(cx.waker().clone()),
+            );
+            if matches!(state, WatcherState::Changed) {
+                instance.borrow_mut().reload();
+            };
+            std::task::Poll::Pending
+        }));
+
+        // no event loop, no need to start a watcher
+        if !result.is_ok() {
+            return arc;
+        }
+
+        let watcher_weak = Arc::downgrade(&arc);
+        arc.lock().unwrap().watcher =
+            notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
+                use notify::EventKind as K;
+                let Ok(event) = event else { return };
+                let Some(watcher) = watcher_weak.upgrade() else { return };
+                if matches!(event.kind, K::Modify(_) | K::Create(_)) {
+                    if let WatcherState::Waiting(waker) =
+                        std::mem::replace(&mut watcher.lock().unwrap().state, WatcherState::Changed)
+                    {
+                        waker.wake();
+                    }
+                }
+            })
+            .ok();
+        arc
+    }
+
+    fn watch(&mut self, path: &Path) {
+        let Some(watcher) = self.watcher.as_mut() else { return };
+        notify::Watcher::watch(watcher, path, notify::RecursiveMode::NonRecursive).unwrap_or_else(
+            |err| match err.kind {
+                notify::ErrorKind::PathNotFound => {
+                    // Editors can save the file by first removing the old file and then renaming the new file to the final name.
+                    // Ignore the error if the file doesn't exist
+                }
+                _ => eprintln!("Warning: error while watching {}: {:?}", path.display(), err),
+            },
+        );
+    }
+}

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -5,6 +5,8 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 fn main() -> std::io::Result<()> {
+    let live_reload = std::env::var("SLINT_LIVE_RELOAD").is_ok();
+
     let mut generated_file = BufWriter::new(std::fs::File::create(
         Path::new(&std::env::var_os("OUT_DIR").unwrap()).join("generated.rs"),
     )?);
@@ -19,8 +21,18 @@ fn main() -> std::io::Result<()> {
         let source = std::fs::read_to_string(&testcase.absolute_path)?;
         let ignored = if testcase.is_ignored("rust") {
             "#[ignore = \"testcase ignored for rust\"]"
-        } else if cfg!(not(feature = "build-time")) && source.contains("//bundle-translations") {
+        } else if (cfg!(not(feature = "build-time")) || live_reload)
+            && source.contains("//bundle-translations")
+        {
             "#[ignore = \"translation bundle not working with the macro\"]"
+        } else if live_reload && source.contains("ComponentContainer") {
+            "#[ignore = \"ComponentContainer doesn't work with the interpreter\"]"
+        } else if live_reload && source.contains("#3464") {
+            "#[ignore = \"issue #3464 not fixed with the interpreter\"]"
+        } else if live_reload && module_name.contains("widgets_menubar") {
+            "#[ignore = \"issue #8454 causes crashes\"]"
+        } else if live_reload && module_name.contains("write_to_model") {
+            "#[ignore = \"Interpreted model don't forward to underlying models for anonymous structs\"]"
         } else {
             ""
         };
@@ -58,7 +70,9 @@ fn main() -> std::io::Result<()> {
 
     // By default resources are embedded. The WASM example builds provide test coverage for that. This switch
     // provides test coverage for the non-embedding case, compiling tests without embedding the images.
-    println!("cargo:rustc-env=SLINT_EMBED_RESOURCES=false");
+    if !live_reload {
+        println!("cargo:rustc-env=SLINT_EMBED_RESOURCES=false");
+    }
 
     //Make sure to use a consistent style
     println!("cargo:rustc-env=SLINT_STYLE=fluent");


### PR DESCRIPTION
This will generate API that calls the interpreter behind the scene.
And it will set a file system watcher so reload automatically

Can be tested by running an app like so:

```
SLINT_LIVE_RELOAD=1 cargo run -p gallery --features=slint/live-reload
```

`SLINT_LIVE_RELOAD=1` is needed at build time so the rust compiler generate the right thing, the `slint/live-reload` feature will be used to enable the runtime for the live-reloading


 - Since only the public API needs to be compiled by the rust compiler, the rust compilation is faster.
 - The automatic reloading feature works Ok, but can lead to unexpected states. But the application can still be restarted without compiling.
 - If the interface changes in an incompatible way (deleted properties or callback or to incompatible types) then the app will panic.

Rust part of #4128
