### PR TITLE
compiler: improve determinism of deduplicate_property_read

### DIFF
--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -151,6 +151,21 @@ impl Hash for NamedReference {
     }
 }
 
+impl PartialOrd for NamedReference {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for NamedReference {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.element()
+            .borrow()
+            .id
+            .cmp(&other.element().borrow().id)
+            .then(self.name().cmp(other.name()))
+    }
+}
+
 struct NamedReferenceInner {
     /// The element.
     element: Weak<RefCell<Element>>,

--- a/internal/compiler/passes/deduplicate_property_read.rs
+++ b/internal/compiler/passes/deduplicate_property_read.rs
@@ -8,7 +8,7 @@ use crate::langtype::Type;
 use crate::object_tree::*;
 use smol_str::{format_smolstr, SmolStr};
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 pub fn deduplicate_property_read(component: &Component) {
     visit_all_expressions(component, |expr, ty| {
@@ -28,7 +28,7 @@ struct ReadCount {
 
 #[derive(Default)]
 struct PropertyReadCounts {
-    counts: HashMap<NamedReference, ReadCount>,
+    counts: BTreeMap<NamedReference, ReadCount>,
     /// If at least one element of the map has duplicates
     has_duplicate: bool,
     /// if there is an assignment of a property we currently disable this optimization


### PR DESCRIPTION
We had a small problem with determinism of the property deduplication when multiple fields were deduplicated in a single function. (A similar commit is b2e7b0ec7d9bb566bf3a3f104831b677828ea322)

I'm a bit unsure about the soundness of the `Ord` implementation for `NamedReference`; it's derived from `fn map_nr` in the affected file.