### PR TITLE
Flickable: the clip detection shouldn't activate when something holds the grab

### DIFF
--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -116,7 +116,9 @@ impl Item for Flickable {
                 || pos.x_length() > geometry.width_length()
                 || pos.y_length() > geometry.height_length()
             {
-                return InputEventFilterResult::Intercept;
+                if !self.data.inner.borrow().pressed_time.is_some() {
+                    return InputEventFilterResult::Intercept;
+                }
             }
         }
         if !self.interactive() && !matches!(event, MouseEvent::Wheel { .. }) {

--- a/tests/cases/elements/flickable3.slint
+++ b/tests/cases/elements/flickable3.slint
@@ -27,16 +27,30 @@ TestCase := Window {
     x: 250phx;
     width: 250phx;
     viewport-width: 800phx;
+    y: 0;
+    height: 300phx;
 
     t2 := TouchArea {
       width: 50phx;
       Rectangle { background: parent.has-hover ? green: yellow; }
+      pointer-event(event) => {
+        if event.kind == PointerEventKind.cancel {
+            root.pointer-events += "C";
+        } else if event.kind == PointerEventKind.down {
+            root.pointer-events += "D(" + self.mouse-y/1px + ")";
+        } else if event.kind == PointerEventKind.up {
+            root.pointer-events += "U(" + self.mouse-y/1px + ")";
+        } else if event.kind == PointerEventKind.move {
+            root.pointer-events += "M(" + self.mouse-y/1px + ")";
+        }
+        }
     }
   }
 
   out property<bool> t1-has-hover: t1.has-hover;
   out property<bool> t1sec-has-hover: t1sec.has-hover;
   out property<bool> t2-has-hover: t2.has-hover;
+  out property <string> pointer-events;
 
   in-out property f1_pos <=> f1.viewport_y;
 }
@@ -89,6 +103,30 @@ slint_testing::mock_elapsed_time(100);
 assert_eq!(instance.get_f1_pos(), -60.0);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(30.0, 25.0) });
 assert_eq!(instance.get_f1_pos(), -60.0);
+```
+
+```rust
+// Test pointer event of the inner touch area
+use slint::{platform::WindowEvent, LogicalPosition, platform::PointerEventButton};
+let instance = TestCase::new().unwrap();
+
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(255.0, 25.0) });
+assert_eq!(instance.get_t2_has_hover(), true);
+assert_eq!(instance.get_pointer_events(), "M(25)");
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(255.0, 28.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_t2_has_hover(), true);
+assert_eq!(instance.get_pointer_events(), "M(25)D(28)");
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(255.0, 30.0) });
+assert_eq!(instance.get_pointer_events(), "M(25)D(28)M(30)");
+slint_testing::mock_elapsed_time(200);
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(255.0, 350.0) });
+assert_eq!(instance.get_pointer_events(), "M(25)D(28)M(30)M(350)");
+slint_testing::mock_elapsed_time(100);
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(255.0, 380.0), button: PointerEventButton::Left });
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_pointer_events(), "M(25)D(28)M(30)M(350)U(380)");
+
 ```
 
 


### PR DESCRIPTION
Otherwise the inner elements stops receiving event once the mouse gets outside of the flickable.


As discussed here: https://chat.slint.dev/public/pl/doetihff3f8wd8przne9zc75oc

> If your slider is inside a Flickable, the pointer events stop when you drag outside the flickable:  [Demo](https://slintpad.com/?snippet=import+%7B+Slider+%7D+from+%22std-widgets.slint%22%3B%0A%0Aexport+component+Demo+inherits+Window+%7B%0A++++width%3A+400px%3B%0A++++height%3A+300px%3B%0A%0A++++background%3A+%23eee%3B%0A%0A++++Flickable+%7B%0A++++++++width%3A+300px%3B%0A++++++++height%3A+150px%3B%0A%0A++++++++Rectangle+%7B%0A++++++++++++background%3A+%23999%3B%0A++++++++%7D%0A%0A++++++++Slider+%7B%0A++++++++++++width%3A+150px%3B%0A++++++++++++minimum%3A+0%3B%0A++++++++++++maximum%3A+100%3B%0A++++++++%7D%0A++++%7D%0A%7D&style=native)
