### PR TITLE
CMake 4.0 remove some deprecated code < 3.5

### DIFF
--- a/api/cpp/tests/CMakeLists.txt
+++ b/api/cpp/tests/CMakeLists.txt
@@ -4,7 +4,7 @@
 FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v2.13.8
+    GIT_TAG v3.8.0
 )
 
 FetchContent_MakeAvailable(Catch2)
@@ -13,7 +13,7 @@ find_package(Threads REQUIRED)
 
 macro(slint_test NAME)
     add_executable(test_${NAME} ${NAME}.cpp)
-    target_link_libraries(test_${NAME} PRIVATE Slint Catch2::Catch2)
+    target_link_libraries(test_${NAME} PRIVATE Slint Catch2::Catch2WithMain)
     target_compile_definitions(test_${NAME} PRIVATE
         SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"
     )

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -4,7 +4,7 @@
 #include <ranges>
 #include <chrono>
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <slint.h>
 

--- a/api/cpp/tests/eventloop.cpp
+++ b/api/cpp/tests/eventloop.cpp
@@ -4,7 +4,7 @@
 // cSpell: ignore singleshot
 
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <slint.h>
 #include <thread>

--- a/api/cpp/tests/interpreter.cpp
+++ b/api/cpp/tests/interpreter.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <slint.h>
 #include <slint-interpreter.h>

--- a/api/cpp/tests/models.cpp
+++ b/api/cpp/tests/models.cpp
@@ -4,7 +4,7 @@
 #include <chrono>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <slint.h>
 

--- a/api/cpp/tests/platform_eventloop.cpp
+++ b/api/cpp/tests/platform_eventloop.cpp
@@ -4,7 +4,7 @@
 // cSpell: ignore singleshot
 
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <slint-platform.h>
 #include <thread>

--- a/api/cpp/tests/properties.cpp
+++ b/api/cpp/tests/properties.cpp
@@ -3,7 +3,7 @@
 
 #include <chrono>
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <slint.h>
 #include <slint_image.h>

--- a/api/cpp/tests/testing.cpp
+++ b/api/cpp/tests/testing.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <slint.h>
 #include <slint-interpreter.h>

--- a/api/cpp/tests/window.cpp
+++ b/api/cpp/tests/window.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 
 #include <slint.h>
 #include <thread>

--- a/examples/todo/cpp/CMakeLists.txt
+++ b/examples/todo/cpp/CMakeLists.txt
@@ -17,6 +17,6 @@ target_link_libraries(todo PRIVATE todo_lib)
 
 if(SLINT_BUILD_TESTING AND SLINT_FEATURE_TESTING AND SLINT_FEATURE_EXPERIMENTAL)
     add_executable(test_todo_basic tests/test_todo_basic.cpp)
-    target_link_libraries(test_todo_basic PRIVATE Catch2::Catch2 todo_lib)
+    target_link_libraries(test_todo_basic PRIVATE Catch2::Catch2WithMain todo_lib)
     add_test(NAME test_todo_basic COMMAND test_todo_basic)
 endif()

--- a/examples/todo/cpp/tests/test_todo_basic.cpp
+++ b/examples/todo/cpp/tests/test_todo_basic.cpp
@@ -5,7 +5,7 @@
 #include "../app.h"
 
 #define CATCH_CONFIG_MAIN
-#include "catch2/catch.hpp"
+#include "catch2/catch_all.hpp"
 
 SCENARIO("Basic TEST")
 {


### PR DESCRIPTION
Catch2 old version still depend against cmake 3.0 + deprecated method.
Necessary to increase version otherwise when we try to compile
example with cmake 4.0 it will failed to configure it

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
