### PR TITLE
std-widgets: Fix warning from slint compiler

### DIFF
--- a/internal/compiler/widgets/fluent/menu.slint
+++ b/internal/compiler/widgets/fluent/menu.slint
@@ -43,7 +43,6 @@ export component MenuFrame inherits MenuFrameBase {
     drop-shadow-color: FluentPalette.shadow;
     drop-shadow-offset-y: 8px;
     drop-shadow-blur: 16px;
-    padding: 1px;
     layout-min-width: 280px;
 }
 
@@ -68,8 +67,6 @@ export component MenuItem {
             font-size: FluentFontSettings.body.font-size;
             font-weight: FluentFontSettings.body.font-weight;
             border-radius: 4px;
-            padding-left: 11px;
-            padding-right: 11px;
             spacing: 8px;
             sub-menu-icon: @image-url("_arrow_forward.svg");
             icon-size: 12px;


### PR DESCRIPTION
The slint compiler warns about

```
padding-left only has effect on layout elements
```

in the fluent style. Fix that by removing the useless padings.