### PR TITLE
Prospective CI fix

### DIFF
--- a/.github/actions/install-skia-dependencies/action.yaml
+++ b/.github/actions/install-skia-dependencies/action.yaml
@@ -14,7 +14,7 @@ runs:
           shell: bash
         - name: Upgrade LLVM for Skia build on Windows
           if: runner.os == 'Windows'
-          run: choco upgrade llvm --version "19.1.7"
+          run: choco upgrade llvm --version "19.1.7" --allow-downgrade
           shell: bash
         # See https://github.com/ilammy/msvc-dev-cmd?tab=readme-ov-file#caveats
         - name: Remove GNU link.exe from GH actions


### PR DESCRIPTION
Error in CI:

```
Chocolatey v2.4.3
Upgrading the following packages:
llvm
By upgrading, you accept licenses for the packages.
A newer version of llvm (v20.1.7) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.

Chocolatey upgraded 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - llvm - A newer version of llvm (v20.1.7) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.
```
