### PR TITLE
Fix default-font-size not working with PopupWindow with the Qt backend

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2379,16 +2379,6 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
         Ok(())
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        let default_font_size = cpp!(unsafe[] -> i32 as "int" {
-            return QFontInfo(qApp->font()).pixelSize();
-        });
-        // Ideally this would return the value from another property with a binding that's updated
-        // as a FontChange event is received. This is relevant for the case of using the Qt backend
-        // with a non-native style.
-        LogicalLength::new(default_font_size as f32)
-    }
-
     fn free_graphics_resources(
         &self,
         component: ItemTreeRef,

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -235,10 +235,6 @@ impl RendererSealed for TestingWindow {
         Ok(())
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        LogicalLength::new(10.)
-    }
-
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>) {
         // No-op since TestingWindow is also the WindowAdapter
     }

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -116,8 +116,6 @@ pub trait RendererSealed {
         Err(crate::api::SetRenderingNotifierError::Unsupported)
     }
 
-    fn default_font_size(&self) -> LogicalLength;
-
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>);
 
     fn resize(&self, _size: crate::api::PhysicalSize) -> Result<(), PlatformError> {

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -883,10 +883,6 @@ impl RendererSealed for SoftwareRenderer {
         self::fonts::systemfonts::register_font_from_path(path)
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        self::fonts::DEFAULT_FONT_SIZE
-    }
-
     fn set_window_adapter(&self, window_adapter: &Rc<dyn WindowAdapter>) {
         *self.maybe_window_adapter.borrow_mut() = Some(Rc::downgrade(window_adapter));
         self.partial_rendering_state.clear_cache();

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -23,7 +23,7 @@ use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, SizeLengths};
 use crate::menus::MenuVTable;
 use crate::properties::{Property, PropertyTracker};
 use crate::renderer::Renderer;
-use crate::{Callback, Coord, SharedString};
+use crate::{Callback, SharedString};
 use alloc::boxed::Box;
 use alloc::rc::{Rc, Weak};
 use alloc::vec::Vec;
@@ -538,17 +538,6 @@ impl WindowInner {
         self.pinned_fields.window_properties_tracker.set_dirty(); // component changed, layout constraints for sure must be re-calculated
         let window_adapter = self.window_adapter();
         window_adapter.renderer().set_window_adapter(&window_adapter);
-        {
-            let component = ItemTreeRc::borrow_pin(component);
-            let root_item = component.as_ref().get_item_ref(0);
-            let window_item = ItemRef::downcast_pin::<crate::items::WindowItem>(root_item).unwrap();
-
-            let default_font_size_prop =
-                crate::items::WindowItem::FIELD_OFFSETS.default_font_size.apply_pin(window_item);
-            if default_font_size_prop.get().get() <= 0 as Coord {
-                default_font_size_prop.set(window_adapter.renderer().default_font_size());
-            }
-        }
         self.set_window_item_geometry(
             window_adapter.size().to_logical(self.scale_factor()).to_euclid(),
         );

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -427,10 +427,6 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         sharedfontdb::register_font_from_path(path)
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        self::fonts::DEFAULT_FONT_SIZE
-    }
-
     fn set_rendering_notifier(
         &self,
         callback: Box<dyn i_slint_core::api::RenderingNotifier>,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -899,10 +899,6 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         }
     }
 
-    fn default_font_size(&self) -> LogicalLength {
-        self::textlayout::DEFAULT_FONT_SIZE
-    }
-
     fn free_graphics_resources(
         &self,
         component: i_slint_core::item_tree::ItemTreeRef,


### PR DESCRIPTION
We had code on the window to reset the default-font-size property to the default from the renderer.
For the Qt backend, the PopupWindow being their own Window, this code was activated also for the PopupWindow's hidden default-font-size property, which caused all PopupWindow's font to not follow the default-font-size

Fixes #8855

