### PR TITLE
Bump Zed extension version for metadata update

### DIFF
--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "zed_slint"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -4,7 +4,7 @@
 id = "slint"
 name = "Slint"
 description = "Slint support for Zed"
-version = "0.0.7"
+version = "0.0.8"
 schema_version = 1
 authors = ["Luke. D Jones <luke@ljones.dev>"]
 repository = "https://gitlab.com/flukejones/zed-slint"


### PR DESCRIPTION
This PR bumps the version of the `Zed` extension in `editors/zed` to allow [zed-industries/extensions](https://github.com/zed-industries/extensions) to update its metadata pointer to the correct version of the `Slint` extension as discussed [here in this PR](https://github.com/zed-industries/extensions/pull/2982). 

Once this is merged, I will follow up with a version bump in the `extensions` repository to publish the updated `metadata`.
