### PR TITLE
Path: Add support for configuring the transform from viewbox to Path

### DIFF
--- a/docs/astro/src/content/docs/reference/elements/path.mdx
+++ b/docs/astro/src/content/docs/reference/elements/path.mdx
@@ -76,6 +76,12 @@ These four properties allow defining the position and size of the viewport of th
 If the `viewbox-width` or `viewbox-height` is less or equal than zero, the viewbox properties are
 ignored and instead the bounding rectangle of all path elements is used to define the view port.
 
+### fit-style
+<SlintProperty propName="fit-style" typeName="enum" enumName="PathFitStyle" defaultValue="min"/>
+
+This property defines how elements in a path's view box are transformed to fit into the Path's
+width and height. If no view box is defined, the implicit bounding rectangle becomes the view box.
+
 ### clip
 <SlintProperty propName="clip" typeName="bool" defaultValue="false"/>
  By default, when a path has a view box defined and the elements render

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -353,6 +353,25 @@ macro_rules! for_each_enums {
                 EndClosed,
             }
 
+            /// This enum defines how elements in a path's view box are transformed to fit into the Path's
+            /// width and height. If no view box is defined, the
+            /// implicit bounding rectangle becomes the view box.
+            #[non_exhaustive]
+            enum PathFitStyle {
+                /// Scale elements to fit into the Path element's
+                /// dimensions while preserving the aspect ratio,
+                /// avoiding overflow.
+                Min,
+                /// Scale elements to fit into the Path element's
+                /// dimensions while preserving the aspect ratio.
+                /// If the aspect ratio of the view box differs from
+                /// the aspect ratio of the Path, then the elements will overflow.
+                Max,
+                /// Scale elements horizontall and vertically to
+                /// fit exactly the Path's dimenions.
+                Stretch,
+            }
+
             /// This enum represents the different values for the `accessible-role` property, used to describe the
             /// role of an element in the context of assistive technology such as screen readers.
             #[non_exhaustive]

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -466,6 +466,7 @@ export component Path {
     in property <float> viewbox-y;
     in property <float> viewbox-width;
     in property <float> viewbox-height;
+    in property <PathFitStyle> fit-style;
     in property <bool> clip;
     in property <bool> anti-alias: true;
 

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -6,7 +6,7 @@ This module contains path related types and functions for the run-time library.
 */
 
 use crate::debug_log;
-use crate::items::PathEvent;
+use crate::items::{PathEvent, PathFitStyle};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use auto_enums::auto_enum;
@@ -248,14 +248,24 @@ impl PathDataIterator {
     /// Applies a transformation on the elements this iterator provides that tries to fit everything
     /// into the specified width/height, respecting the provided viewbox. If no viewbox is specified,
     /// the bounding rectangle of the path is used.
-    pub fn fit(&mut self, width: f32, height: f32, viewbox: Option<lyon_path::math::Box2D>) {
+    pub fn fit(
+        &mut self,
+        width: f32,
+        height: f32,
+        viewbox: Option<lyon_path::math::Box2D>,
+        style: PathFitStyle,
+    ) {
         if width > 0. || height > 0. {
             let viewbox =
                 viewbox.unwrap_or_else(|| lyon_algorithms::aabb::bounding_box(self.iter()));
             self.transform = lyon_algorithms::fit::fit_box(
                 &viewbox,
                 &lyon_path::math::Box2D::from_size(lyon_path::math::Size::new(width, height)),
-                lyon_algorithms::fit::FitStyle::Min,
+                match style {
+                    PathFitStyle::Min => lyon_algorithms::fit::FitStyle::Min,
+                    PathFitStyle::Max => lyon_algorithms::fit::FitStyle::Max,
+                    PathFitStyle::Stretch => lyon_algorithms::fit::FitStyle::Stretch,
+                },
             );
         }
     }

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -16,6 +16,7 @@ use crate::input::{
 };
 use crate::item_rendering::CachedRenderingData;
 
+use crate::items::PathFitStyle;
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalRect, LogicalSize, LogicalVector, RectLengths,
@@ -45,6 +46,7 @@ pub struct Path {
     pub viewbox_y: Property<f32>,
     pub viewbox_width: Property<f32>,
     pub viewbox_height: Property<f32>,
+    pub fit_style: Property<PathFitStyle>,
     pub clip: Property<bool>,
     pub anti_alias: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
@@ -163,7 +165,12 @@ impl Path {
             None
         };
 
-        elements_iter.fit(bounds_width.get() as _, bounds_height.get() as _, maybe_viewbox);
+        elements_iter.fit(
+            bounds_width.get() as _,
+            bounds_height.get() as _,
+            maybe_viewbox,
+            self.fit_style(),
+        );
         (offset, elements_iter).into()
     }
 }


### PR DESCRIPTION
By default, we preserve the aspect ratio, but this isn't quite always what's wanted. So the fit-style property permits configuring this.

Fixes #8853

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
