### PR TITLE
Binding analysis: We shouldn't report binding loop based on base bindings

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -410,6 +410,7 @@ fn process_property(
         let element = prop.prop.element();
         if element.borrow().bindings.contains_key(prop.prop.name()) {
             analyze_binding(&prop, context, reverse_aliases, diag);
+            break;
         }
         let next = match &element.borrow().base_type {
             ElementType::Component(base) => {

--- a/internal/compiler/tests/syntax/analysis/binding_loop_popupwindow.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_popupwindow.slint
@@ -1,0 +1,21 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue #8889
+// There shouldn't be error or warnings in this case
+
+
+component MyPopup inherits PopupWindow {
+    property <length> first_column_width: 0.3 * root.width;
+
+    height: 400px;
+    width: 600px;
+
+    header := HorizontalLayout {
+        padding_left: root.first_column_width;
+    }
+}
+
+export component Test inherits Window {
+    popup := MyPopup { }
+}


### PR DESCRIPTION
In this case, there is an explicit binding in the PopupWindow::width, so we shouldn't continue and find loop based on the implicit bindings

Fixes #8889
