### PR TITLE
slint-compiler: Guess output format from file extension if not present

### DIFF
--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -73,6 +73,7 @@ function(SLINT_TARGET_SOURCES target)
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h ${cpp_files}
             COMMAND ${SLINT_COMPILER_ENV} $<TARGET_FILE:Slint::slint-compiler> ${_SLINT_ABSOLUTE}
+                -f cpp
                 -o ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.h
                 --depfile ${CMAKE_CURRENT_BINARY_DIR}/${_SLINT_BASE_NAME}.d
                 --style ${_SLINT_STYLE}

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -44,8 +44,8 @@ enum Embedding {
 struct Cli {
     /// Set the output format for generated code.
     /// Possible values: 'cpp' for C++ code or 'rust' for Rust code.
-    #[arg(short = 'f', long = "format", default_value = "cpp")]
-    format: generator::OutputFormat,
+    #[arg(short = 'f', long = "format")]
+    format: Option<generator::OutputFormat>,
 
     /// Specify include paths for imported .slint files or image resources.
     /// This is used for including external .slint files or image resources referenced by '@image-url'.
@@ -121,7 +121,12 @@ fn main() -> std::io::Result<()> {
         std::process::exit(-1);
     }
 
-    let mut format = args.format.clone();
+    let mut format = args.format.clone().unwrap_or_else(|| {
+        match std::path::Path::new(&args.output).extension().and_then(|ext| ext.to_str()) {
+            Some("rs") => generator::OutputFormat::Rust,
+            _ => generator::OutputFormat::Cpp(Default::default()),
+        }
+    });
 
     if args.cpp_namespace.is_some() {
         if !matches!(format, generator::OutputFormat::Cpp(..)) {


### PR DESCRIPTION
This is more intuitive that the C++ default, especially in light of additional output languages in the future.

To be on the safe side, this also passes the explicit -f cpp on the CMake side.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
