### PR TITLE
C++: Fix opengl_texture example

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -99,7 +99,7 @@ define_cargo_dependent_feature(backend-winit-x11 "Enable support for the winit c
 define_cargo_dependent_feature(backend-winit-wayland "Enable support for the winit create to interact only with the wayland windowing system on Unix. Enable this option and turn off SLINT_FEATURE_BACKEND_WINIT for a smaller build with just wayland support." OFF "NOT SLINT_FEATURE_FREESTANDING")
 
 define_cargo_dependent_feature(renderer-femtovg "Enable support for the OpenGL ES 2.0 based FemtoVG rendering engine." ON "NOT SLINT_FEATURE_FREESTANDING")
-define_cargo_dependent_feature(renderer-femtovg-wgpu "Enable support for the WGPU based FemtoVG rendering engine." ON "NOT SLINT_FEATURE_FREESTANDING")
+define_cargo_dependent_feature(renderer-femtovg-wgpu "Enable support for the WGPU based FemtoVG rendering engine." OFF "NOT SLINT_FEATURE_FREESTANDING")
 define_cargo_dependent_feature(renderer-skia "Enable support for the Skia based rendering engine." OFF "NOT SLINT_FEATURE_FREESTANDING")
 define_cargo_dependent_feature(renderer-skia-opengl "Enable support for the Skia based rendering engine with its OpenGL backend." OFF "NOT SLINT_FEATURE_FREESTANDING")
 define_cargo_dependent_feature(renderer-skia-vulkan "Enable support for the Skia based rendering engine with its Vulkan backend." OFF "NOT SLINT_FEATURE_FREESTANDING")

--- a/examples/opengl_texture/main.cpp
+++ b/examples/opengl_texture/main.cpp
@@ -382,7 +382,7 @@ int main()
         if (*error == slint::SetRenderingNotifierError::Unsupported) {
             fprintf(stderr,
                     "This example requires the use of a GL renderer. Please run with the "
-                    "environment variable SLINT_BACKEND=winit set.\n");
+                    "environment variable SLINT_BACKEND=winit-femtovg set.\n");
         } else {
             fprintf(stderr, "Unknown error calling set_rendering_notifier\n");
         }

--- a/examples/opengl_underlay/main.cpp
+++ b/examples/opengl_underlay/main.cpp
@@ -170,7 +170,7 @@ int main()
         if (*error == slint::SetRenderingNotifierError::Unsupported) {
             fprintf(stderr,
                     "This example requires the use of a GL renderer. Please run with the "
-                    "environment variable SLINT_BACKEND=winit set.\n");
+                    "environment variable SLINT_BACKEND=winit-femtovg set.\n");
         } else {
             fprintf(stderr, "Unknown error calling set_rendering_notifier\n");
         }


### PR DESCRIPTION
- Fix the erroneously default of enabling the WPGU FemtoVG renderer for C++
- Improve advice for C++ OpenGL examples to explicitly select the FemtoVG GL renderer

Fixes #8901

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
