### PR TITLE
VS Code Extension: Fix syntax highlighting

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -59,7 +59,7 @@
       {
         "language": "slint",
         "scopeName": "source.slint",
-        "path": "../../docs/common/src/utils/slint.tmLanguage.json"
+        "path": "slint.tmLanguage.json"
       },
       {
         "injectTo": [

--- a/editors/vscode/slint.tmLanguage.json
+++ b/editors/vscode/slint.tmLanguage.json
@@ -1,0 +1,1 @@
+../../docs/common/src/utils/slint.tmLanguage.json


### PR DESCRIPTION
A relative path to outside the node package means the grammar file isn't accessible after packaging. Fortunately vsce resolves symlinks, so the use of a symlink files it.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
