### PR TITLE
Docs: fix copy/pasted string in docu for LineEdit's enabled property

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
@@ -31,7 +31,7 @@ a widget able to handle several lines of text.
 
 ### enabled
 <SlintProperty propName="enabled" typeName="bool" defaultValue="true">
-When false, nothing can be entered selecting text is still enabled as well as editing text programmatically.
+When false, nothing can be entered.
 </SlintProperty>
 
 ### font-size


### PR DESCRIPTION
Copying text in a disabled LineEdit isn't possible, that part of the sentence came from the docu for the read-only property.

In TextEdit, the docu for enabled only says this.
