### PR TITLE
Add {} bracket support for % motion in Slint extension

### DIFF
--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "zed_slint"
-version = "0.0.9"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -4,7 +4,7 @@
 id = "slint"
 name = "Slint"
 description = "Slint support for Zed"
-version = "0.0.9"
+version = "0.1.0"
 schema_version = 1
 authors = ["Luke. D Jones <luke@ljones.dev>"]
 repository = "https://github.com/slint-ui/slint"

--- a/editors/zed/languages/slint/brackets.scm
+++ b/editors/zed/languages/slint/brackets.scm
@@ -3,3 +3,4 @@
 
 ("(" @open ")" @close)
 ("[" @open "]" @close)
+("{" @open "}" @close)


### PR DESCRIPTION
This PR adds support for **navigating** between `{}` curly braces using the `%` vim motion in `Zed`. Now, all `()`, `[]`, and `{}` pairs can be jumped between using `%` for better navigation in `Slint` files.