### PR TITLE
docs: improve "Bundled Translations"

### DIFF
--- a/docs/astro/src/content/docs/guide/development/translations.mdx
+++ b/docs/astro/src/content/docs/guide/development/translations.mdx
@@ -121,20 +121,6 @@ using a dedicated translation tool for working with them, such as the following:
 -   [Lokalize](https://userbase.kde.org/Lokalize)
 -   [Transifex](https://www.transifex.com/) (web interface)
 
-## Convert `.po` Files to `.mo` Files
-
-Convert the human readable `.po` files into machine-friendly `.mo` files, which are a binary representation
-that is more efficient to read by code.
-
-Use [Gettext](https://www.gnu.org/software/gettext/)'s `msgfmt` command line tool to convert `.po` files to `.mo`
-files:
-
-```sh
-msgfmt translation.po -o translation.mo
-```
-
-For bundled translations, no conversion is needed; `.po` files are embedded directly.
-
 ## Runtime Translations with Gettext
 
 Slint can use the [Gettext](https://www.gnu.org/software/gettext/) library to load translations at run-time.
@@ -160,6 +146,18 @@ Gettext expects translation files - called message catalogs - in following direc
 :::tip[Tip]
 Read the [Gettext documentation](https://www.gnu.org/software/gettext/manual/gettext.html#Locating-Catalogs) for more information.
 :::
+
+### Convert `.po` Files to `.mo` Files
+
+Convert the human readable `.po` files into machine-friendly `.mo` files, which are a binary representation
+that is more efficient to read by code.
+
+Use [Gettext](https://www.gnu.org/software/gettext/)'s `msgfmt` command line tool to convert `.po` files to `.mo`
+files:
+
+```sh
+msgfmt translation.po -o translation.mo
+```
 
 ### Select and Load Translations
 <Tabs syncKey="dev-language">
@@ -262,6 +260,7 @@ Use `slint_build::CompilerConfiguration`'s <LangRefLink lang="rust-slint-build" 
 ```rust
 let config = slint_build::CompilerConfiguration::new()
     .with_bundled_translations("path/to/translations");
+slint_build::compile_with_config("path/to/main-ui.slint", config).unwrap();
 ```
 
 The `<domain>` is the crate name.


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

1. Move section ```Convert `.po` Files to `.mo` Files``` to the next level below section ```Runtime Translations with Gettext```, because it has no relation to the "Bundled Translations" method.
2. Add `slint_build::compile_with_config()` function to "Bundling" section.