### PR TITLE
Add `focus-policy` property to FocusScope

### DIFF
--- a/docs/astro/src/content/docs/reference/global-structs-enums.mdx
+++ b/docs/astro/src/content/docs/reference/global-structs-enums.mdx
@@ -20,6 +20,7 @@ import ColorScheme from "../../collections/enums/ColorScheme.md"
 import DialogButtonRole from "../../collections/enums/DialogButtonRole.md"
 import EventResult from "../../collections/enums/EventResult.md"
 import FillRule from "../../collections/enums/FillRule.md"
+import FocusPolicy from "../../collections/enums/FocusPolicy.md"
 import FocusReason from "../../collections/enums/FocusReason.md"
 import ImageFit from "../../collections/enums/ImageFit.md"
 import ImageHorizontalAlignment from "../../collections/enums/ImageHorizontalAlignment.md"
@@ -89,6 +90,9 @@ import TextWrap from "../../collections/enums/TextWrap.md"
 
 ### FillRule
 <FillRule />
+
+### FocusPolicy
+<FocusPolicy />
 
 ### FocusReason
 <FocusReason />

--- a/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
+++ b/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
@@ -47,6 +47,11 @@ Is `true` when the element has keyboard focus.
     child `FocusScope`s that were rejected, even if `enabled` is set to false.
 </SlintProperty>
 
+### focus-policy
+<SlintProperty propName="focus-policy" typeName="enum" enumName="FocusPolicy">
+The focus policy of the scope.
+</SlintProperty>
+
 ## Functions
 
 ### focus()

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -149,12 +149,12 @@ macro_rules! for_each_enums {
             /// This enum describes the different focus policies for a FocusScope
             #[non_exhaustive]
             enum FocusPolicy {
+                /// The FocusScope accepts focus from both tab navigation and pointer clicks
+                TabAndClick,
                 /// The FocusScope only accepts focus from tab navigation
                 TabOnly,
                 /// The FocusScope only accepts focus from pointer clicks
                 ClickOnly,
-                /// The FocusScope accepts focus from both tab navigation and pointer clicks
-                TabAndClick,
             }
 
             /// The enum reports what happened to the `PointerEventButton` in the event

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -146,6 +146,17 @@ macro_rules! for_each_enums {
                 WindowActivation,
             }
 
+            /// This enum describes the different focus policies for a FocusScope
+            #[non_exhaustive]
+            enum FocusPolicy {
+                /// The FocusScope only accepts focus from tab navigation
+                TabOnly,
+                /// The FocusScope only accepts focus from pointer clicks
+                ClickOnly,
+                /// The FocusScope accepts focus from both tab navigation and pointer clicks
+                TabAndClick,
+            }
+
             /// The enum reports what happened to the `PointerEventButton` in the event
             enum PointerEventKind {
                 /// The action was cancelled.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -134,6 +134,7 @@ export component TouchArea {
 
 export component FocusScope {
     in property <bool> enabled: true;
+    in property <FocusPolicy> focus-policy: FocusPolicy.tab-and-click;
     out property <bool> has-focus;
     callback key_pressed(event: KeyEvent) -> EventResult;
     callback key_released(event: KeyEvent) -> EventResult;

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -134,7 +134,7 @@ export component TouchArea {
 
 export component FocusScope {
     in property <bool> enabled: true;
-    in property <FocusPolicy> focus-policy: FocusPolicy.tab-and-click;
+    in property <FocusPolicy> focus-policy;
     out property <bool> has-focus;
     callback key_pressed(event: KeyEvent) -> EventResult;
     callback key_released(event: KeyEvent) -> EventResult;

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -53,6 +53,9 @@
     "float": {
         "href": "reference/primitive-types/#float"
     },
+    "FocusPolicy": {
+        "href": "reference/global-structs-enums/#focuspolicy"
+    },
     "FocusReason": {
         "href": "reference/global-structs-enums/#focusreason"
     },

--- a/tests/cases/focus/focus_policy.slint
+++ b/tests/cases/focus/focus_policy.slint
@@ -14,10 +14,6 @@ export component TestCase inherits Rectangle {
                 height: 100%;
                 background: red;
             }
-
-            focus-gained(reason) => {
-                debug("focused red");
-            }
         }
 
         fs2 := FocusScope {
@@ -27,10 +23,6 @@ export component TestCase inherits Rectangle {
                 height: 100%;
                 background: green;
             }
-
-            focus-gained(reason) => {
-                debug("focused green");
-            }
         }
 
         fs3 := FocusScope {
@@ -39,10 +31,6 @@ export component TestCase inherits Rectangle {
                 width: 100%;
                 height: 100%;
                 background: blue;
-            }
-
-            focus-gained(reason) => {
-                debug("focused blue");
             }
         }
     }

--- a/tests/cases/focus/focus_policy.slint
+++ b/tests/cases/focus/focus_policy.slint
@@ -1,0 +1,254 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Button, VerticalBox } from "std-widgets.slint";
+export component TestCase inherits Rectangle {
+    width: 400phx;
+    height: 400phx;
+
+    VerticalLayout {
+        fs1 := FocusScope {
+            focus-policy: FocusPolicy.tab-and-click;
+            Rectangle {
+                width: 100%;
+                height: 100%;
+                background: red;
+            }
+
+            focus-gained(reason) => {
+                debug("focused red");
+            }
+        }
+
+        fs2 := FocusScope {
+            focus-policy: FocusPolicy.tab-only;
+            Rectangle {
+                width: 100%;
+                height: 100%;
+                background: green;
+            }
+
+            focus-gained(reason) => {
+                debug("focused green");
+            }
+        }
+
+        fs3 := FocusScope {
+            focus-policy: FocusPolicy.click-only;
+            Rectangle {
+                width: 100%;
+                height: 100%;
+                background: blue;
+            }
+
+            focus-gained(reason) => {
+                debug("focused blue");
+            }
+        }
+    }
+
+    popup := PopupWindow { }
+
+    public function show-popup() {
+        popup.show();
+    }
+
+    public function focus-fs1() {
+        fs1.focus();
+    }
+
+    public function focus-fs2() {
+        fs2.focus();
+    }
+
+    public function focus-fs3() {
+        fs3.focus();
+    }
+
+    out property <bool> fs1-has-focus: fs1.has-focus;
+    out property <bool> fs2-has-focus: fs2.has-focus;
+    out property <bool> fs3-has-focus: fs3.has-focus;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+// initial tab into fs1
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert!(instance.get_fs1_has_focus());
+assert!(!instance.get_fs2_has_focus());
+assert!(!instance.get_fs3_has_focus());
+
+// tab to fs2
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert!(!instance.get_fs1_has_focus());
+assert!(instance.get_fs2_has_focus());
+assert!(!instance.get_fs3_has_focus());
+
+// skip fs3 and tab back to fs1
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert!(instance.get_fs1_has_focus());
+assert!(!instance.get_fs2_has_focus());
+assert!(!instance.get_fs3_has_focus());
+
+// click to focus fs3
+slint_testing::send_mouse_click(&instance, 5., 300.);
+assert!(!instance.get_fs1_has_focus());
+assert!(!instance.get_fs2_has_focus());
+assert!(instance.get_fs3_has_focus());
+
+// click to focus fs1
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_fs1_has_focus());
+assert!(!instance.get_fs2_has_focus());
+assert!(!instance.get_fs3_has_focus());
+
+// click shouldn't focus fs2
+slint_testing::send_mouse_click(&instance, 5., 200.);
+assert!(instance.get_fs1_has_focus());
+assert!(!instance.get_fs2_has_focus());
+assert!(!instance.get_fs3_has_focus());
+
+// opening a popup should still remove focus
+instance.invoke_show_popup();
+assert!(!instance.get_fs1_has_focus());
+assert!(!instance.get_fs2_has_focus());
+assert!(!instance.get_fs3_has_focus());
+
+// programmatic focus should still work too
+instance.invoke_focus_fs1();
+assert!(instance.get_fs1_has_focus());
+assert!(!instance.get_fs2_has_focus());
+assert!(!instance.get_fs3_has_focus());
+instance.invoke_focus_fs2();
+assert!(!instance.get_fs1_has_focus());
+assert!(instance.get_fs2_has_focus());
+assert!(!instance.get_fs3_has_focus());
+instance.invoke_focus_fs3();
+assert!(!instance.get_fs1_has_focus());
+assert!(!instance.get_fs2_has_focus());
+assert!(instance.get_fs3_has_focus());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+// initial tab into fs1
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert(instance.get_fs1_has_focus());
+assert(!instance.get_fs2_has_focus());
+assert(!instance.get_fs3_has_focus());
+
+// tab to fs2
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert(!instance.get_fs1_has_focus());
+assert(instance.get_fs2_has_focus());
+assert(!instance.get_fs3_has_focus());
+
+// skip fs3 and tab back to fs1
+slint_testing::send_keyboard_string_sequence(&instance, "\t");
+assert(instance.get_fs1_has_focus());
+assert(!instance.get_fs2_has_focus());
+assert(!instance.get_fs3_has_focus());
+
+// click to focus fs3
+slint_testing::send_mouse_click(&instance, 5., 300.);
+assert(!instance.get_fs1_has_focus());
+assert(!instance.get_fs2_has_focus());
+assert(instance.get_fs3_has_focus());
+
+// click to focus fs1
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert(instance.get_fs1_has_focus());
+assert(!instance.get_fs2_has_focus());
+assert(!instance.get_fs3_has_focus());
+
+// click shouldn't focus fs2
+slint_testing::send_mouse_click(&instance, 5., 200.);
+assert(instance.get_fs1_has_focus());
+assert(!instance.get_fs2_has_focus());
+assert(!instance.get_fs3_has_focus());
+
+// opening a popup should still remove focus
+instance.invoke_show_popup();
+assert(!instance.get_fs1_has_focus());
+assert(!instance.get_fs2_has_focus());
+assert(!instance.get_fs3_has_focus());
+
+// programmatic focus should still work too
+instance.invoke_focus_fs1();
+assert(instance.get_fs1_has_focus());
+assert(!instance.get_fs2_has_focus());
+assert(!instance.get_fs3_has_focus());
+instance.invoke_focus_fs2();
+assert(!instance.get_fs1_has_focus());
+assert(instance.get_fs2_has_focus());
+assert(!instance.get_fs3_has_focus());
+instance.invoke_focus_fs3();
+assert(!instance.get_fs1_has_focus());
+assert(!instance.get_fs2_has_focus());
+assert(instance.get_fs3_has_focus());
+```
+
+```js
+let instance = new slint.TestCase({});
+
+// initial tab into fs1
+slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
+assert(instance.fs1_has_focus);
+assert(!instance.fs2_has_focus);
+assert(!instance.fs3_has_focus);
+
+// tab to fs2
+slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
+assert(!instance.fs1_has_focus);
+assert(instance.fs2_has_focus);
+assert(!instance.fs3_has_focus);
+
+// skip fs3 and tab back to fs1
+slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
+assert(instance.fs1_has_focus);
+assert(!instance.fs2_has_focus);
+assert(!instance.fs3_has_focus);
+
+// click to focus fs3
+slintlib.private_api.send_mouse_click(instance, 5., 300.);
+assert(!instance.fs1_has_focus);
+assert(!instance.fs2_has_focus);
+assert(instance.fs3_has_focus);
+
+// click to focus fs1
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+assert(instance.fs1_has_focus);
+assert(!instance.fs2_has_focus);
+assert(!instance.fs3_has_focus);
+
+// click shouldn't focus fs2
+slintlib.private_api.send_mouse_click(instance, 5., 200.);
+assert(instance.fs1_has_focus);
+assert(!instance.fs2_has_focus);
+assert(!instance.fs3_has_focus);
+
+// opening a popup should still remove focus
+instance.show_popup();
+assert(!instance.fs1_has_focus);
+assert(!instance.fs2_has_focus);
+assert(!instance.fs3_has_focus);
+
+// programmatic focus should still work too
+instance.focus_fs1();
+assert(instance.fs1_has_focus);
+assert(!instance.fs2_has_focus);
+assert(!instance.fs3_has_focus);
+instance.focus_fs2();
+assert(!instance.fs1_has_focus);
+assert(instance.fs2_has_focus);
+assert(!instance.fs3_has_focus);
+instance.focus_fs3();
+assert(!instance.fs1_has_focus);
+assert(!instance.fs2_has_focus);
+assert(instance.fs3_has_focus);
+```
+*/


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Adds a new enum `FocusPolicy` for a property `focus-policy` on `FocusScope`, with variants for `TabOnly`, `ClickOnly` and `TabAndClick`. Notably, I did not add a policy for denying focus, as we already have the `enabled` property on `FocusScope`... maybe this should be deprecated in favor of a `Deny` variant?

Should close #3503.

The names I chose for the variants are not great in my opinion, definitely open to suggestions for changing these :sweat_smile:.
