### PR TITLE
Add predicates for array filtering

### DIFF
--- a/api/cpp/include/slint_models.h
+++ b/api/cpp/include/slint_models.h
@@ -47,6 +47,36 @@ long int model_length(const std::shared_ptr<M> &model)
     }
 }
 
+template<typename M, typename P>
+bool model_any(const std::shared_ptr<M> &model, P predicate)
+{
+    long int count = model_length(model);
+
+    for (long int i = 0; i < count; ++i) {
+        auto data = access_array_index(model, i);
+        if (predicate(data)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+template<typename M, typename P>
+bool model_all(const std::shared_ptr<M> &model, P predicate)
+{
+    long int count = model_length(model);
+
+    for (long int i = 0; i < count; ++i) {
+        auto data = access_array_index(model, i);
+        if (!predicate(data)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 } // namespace private_api
 
 /// \rst

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -290,7 +290,8 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
         | Type::Easing
         | Type::PathData
         | Type::LayoutCache
-        | Type::ElementReference => Err(napi::Error::from_reason("reason")),
+        | Type::ElementReference
+        | Type::Predicate => Err(napi::Error::from_reason("reason")),
     }
 }
 

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -315,7 +315,8 @@ fn to_debug_string(
         | Type::ElementReference
         | Type::LayoutCache
         | Type::Model
-        | Type::PathData => {
+        | Type::PathData
+        | Type::Predicate => {
             diag.push_error("Cannot debug this expression".into(), node);
             Expression::Invalid
         }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -77,6 +77,7 @@ pub enum BuiltinFunction {
     ImageSize,
     ArrayLength,
     ArrayAny,
+    ArrayAll,
     Rgb,
     Hsv,
     ColorScheme,
@@ -241,6 +242,7 @@ declare_builtin_function_types!(
     })),
     ArrayLength: (Type::Model) -> Type::Int32,
     ArrayAny: (Type::Model, Type::Predicate) -> Type::Bool,
+    ArrayAll: (Type::Model, Type::Predicate) -> Type::Bool,
     Rgb: (Type::Int32, Type::Int32, Type::Int32, Type::Float32) -> Type::Color,
     Hsv: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
     ColorScheme: () -> Type::Enumeration(
@@ -362,6 +364,7 @@ impl BuiltinFunction {
             BuiltinFunction::StopTimer => false,
             BuiltinFunction::RestartTimer => false,
             BuiltinFunction::ArrayAny => true,
+            BuiltinFunction::ArrayAll => true,
         }
     }
 
@@ -439,6 +442,7 @@ impl BuiltinFunction {
             BuiltinFunction::StopTimer => false,
             BuiltinFunction::RestartTimer => false,
             BuiltinFunction::ArrayAny => true,
+            BuiltinFunction::ArrayAll => true,
         }
     }
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4014,6 +4014,7 @@ fn compile_builtin_function_call(
                 panic!("internal error: invalid args to RetartTimer {arguments:?}")
             }
         }
+        BuiltinFunction::ArrayAny => todo!(),
     }
 }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3520,6 +3520,12 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 None => format!("slint::private_api::translate_from_bundle(slint_translation_bundle_{string_index}, {args})"),
             }
         },
+        Expression::Predicate { arg_name, expression } => {
+            let arg = ident(arg_name);
+            let expr = compile_expression(expression, ctx);
+
+            format!("[&](auto {arg}) -> bool {{ return {expr}; }}")
+        },
     }
 }
 
@@ -4014,7 +4020,12 @@ fn compile_builtin_function_call(
                 panic!("internal error: invalid args to RetartTimer {arguments:?}")
             }
         }
-        BuiltinFunction::ArrayAny => todo!(),
+        BuiltinFunction::ArrayAny => {
+            format!("slint::private_api::model_any({}, {})", a.next().unwrap(), a.next().unwrap())
+        },
+        BuiltinFunction::ArrayAll => {
+            format!("slint::private_api::model_all({}, {})", a.next().unwrap(), a.next().unwrap())
+        },
     }
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2680,6 +2680,13 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
 
             }
         },
+        Expression::Predicate { arg_name, expression } => {
+            let arg_name = ident(arg_name);
+            let expression = compile_expression(expression, ctx);
+            quote! {
+                |#arg_name| {#expression}
+            }
+        },
     }
 }
 
@@ -3258,6 +3265,17 @@ fn compile_builtin_function_call(
                 panic!("internal error: invalid args to RetartTimer {arguments:?}")
             }
         }
+        BuiltinFunction::ArrayAny => {
+            if let [_, Expression::Predicate { .. }] = arguments {
+                let arr_expression = a.next().unwrap();
+                let predicate_expression = a.next().unwrap();
+                quote!(match #arr_expression { x => {
+                    x.iter().any(#predicate_expression)
+                }})
+            } else {
+                panic!("internal error: invalid args to ArrayAny {arguments:?}")
+            }
+        },
     }
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3275,7 +3275,18 @@ fn compile_builtin_function_call(
             } else {
                 panic!("internal error: invalid args to ArrayAny {arguments:?}")
             }
-        },
+        }
+        BuiltinFunction::ArrayAll => {
+            if let [_, Expression::Predicate { .. }] = arguments {
+                let arr_expression = a.next().unwrap();
+                let predicate_expression = a.next().unwrap();
+                quote!(match #arr_expression { x => {
+                    x.iter().all(#predicate_expression)
+                }})
+            } else {
+                panic!("internal error: invalid args to ArrayAll {arguments:?}")
+            }
+        }
     }
 }
 

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -180,7 +180,7 @@ impl Display for Type {
             }
             Type::ElementReference => write!(f, "element ref"),
             Type::LayoutCache => write!(f, "layout cache"),
-            Type::Predicate => todo!(),
+            Type::Predicate => write!(f, "predicate"),
         }
     }
 }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -64,6 +64,7 @@ pub enum Type {
 
     /// This is a `SharedArray<f32>`
     LayoutCache,
+    Predicate,
 }
 
 impl core::cmp::PartialEq for Type {
@@ -104,6 +105,7 @@ impl core::cmp::PartialEq for Type {
             Type::UnitProduct(a) => matches!(other, Type::UnitProduct(b) if a == b),
             Type::ElementReference => matches!(other, Type::ElementReference),
             Type::LayoutCache => matches!(other, Type::LayoutCache),
+            Type::Predicate => matches!(other, Type::Predicate),
         }
     }
 }
@@ -178,6 +180,7 @@ impl Display for Type {
             }
             Type::ElementReference => write!(f, "element ref"),
             Type::LayoutCache => write!(f, "layout cache"),
+            Type::Predicate => todo!(),
         }
     }
 }
@@ -314,6 +317,7 @@ impl Type {
             Type::UnitProduct(_) => None,
             Type::ElementReference => None,
             Type::LayoutCache => None,
+            Type::Predicate => None,
         }
     }
 

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -205,6 +205,11 @@ pub enum Expression {
         /// The `n` value to use for the plural form if it is a plural form
         plural: Option<Box<Expression>>,
     },
+
+    Predicate {
+        arg_name: SmolStr,
+        expression: Box<Expression>,
+    }
 }
 
 impl Expression {
@@ -217,7 +222,8 @@ impl Expression {
             | Type::InferredProperty
             | Type::InferredCallback
             | Type::ElementReference
-            | Type::LayoutCache => return None,
+            | Type::LayoutCache
+            | Type::Predicate => return None,
             Type::Float32
             | Type::Duration
             | Type::Int32
@@ -320,6 +326,7 @@ impl Expression {
             Self::MinMax { ty, .. } => ty.clone(),
             Self::EmptyComponentFactory => Type::ComponentFactory,
             Self::TranslationReference { .. } => Type::String,
+            Self::Predicate { .. } => Type::Predicate,
         }
     }
 }
@@ -408,6 +415,9 @@ macro_rules! visit_impl {
                 if let Some(plural) = plural {
                     $visitor(plural);
                 }
+            }
+            Expression::Predicate { expression, .. } => {
+                $visitor(expression);
             }
         }
     };

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -209,7 +209,7 @@ pub enum Expression {
     Predicate {
         arg_name: SmolStr,
         expression: Box<Expression>,
-    }
+    },
 }
 
 impl Expression {

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -254,6 +254,10 @@ pub fn lower_expression(
         },
         tree_Expression::EmptyComponentFactory => llr_Expression::EmptyComponentFactory,
         tree_Expression::DebugHook { expression, .. } => lower_expression(expression, ctx),
+        tree_Expression::Predicate { arg_name, expression } => llr_Expression::Predicate {
+            arg_name: arg_name.clone(),
+            expression: Box::new(lower_expression(expression, ctx)),
+        },
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -155,6 +155,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::StopTimer => 10,
         BuiltinFunction::RestartTimer => 10,
         BuiltinFunction::ArrayAny => isize::MAX,
+        BuiltinFunction::ArrayAll => isize::MAX,
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -70,6 +70,7 @@ fn expression_cost(exp: &Expression, ctx: &EvaluationContext) -> isize {
         Expression::MinMax { .. } => 10,
         Expression::EmptyComponentFactory => 10,
         Expression::TranslationReference { .. } => PROPERTY_ACCESS_COST + 2 * ALLOC_COST,
+        Expression::Predicate { expression, .. } => expression_cost(expression, ctx),
     };
 
     exp.visit(|e| cost = cost.saturating_add(expression_cost(e, ctx)));
@@ -153,6 +154,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::StartTimer => 10,
         BuiltinFunction::StopTimer => 10,
         BuiltinFunction::RestartTimer => 10,
+        BuiltinFunction::ArrayAny => isize::MAX,
     }
 }
 

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -368,6 +368,7 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                     ),
                 }
             }
+            Expression::Predicate { .. } => todo!(),
         }
     }
 }

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -289,7 +289,9 @@ impl LookupObject for PredicateArgumentsLookup {
     ) -> Option<R> {
         // we reverse the types here so that the most recently added predicate argument is the first one for shadowing purposes
         // this is done in case someone does `arr.any(x => x.any(x => x > 0))`... why anyone would do this is beyond me though
-        for (name, ty) in ctx.predicate_arguments.iter().zip(ctx.predicate_argument_types.iter().rev()) {
+        for (name, ty) in
+            ctx.predicate_arguments.iter().zip(ctx.predicate_argument_types.iter().rev())
+        {
             if let Some(r) =
                 f(name, Expression::ReadLocalVariable { name: name.clone(), ty: ty.clone() }.into())
             {

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -284,10 +284,9 @@ impl LookupObject for PredicateArgumentsLookup {
         f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
     ) -> Option<R> {
         for (name, ty) in ctx.predicate_arguments.iter().zip(ctx.predicate_argument_types.iter()) {
-            if let Some(r) = f(
-                name,
-                Expression::ReadLocalVariable { name: name.clone(), ty: ty.clone() }.into(),
-            ) {
+            if let Some(r) =
+                f(name, Expression::ReadLocalVariable { name: name.clone(), ty: ty.clone() }.into())
+            {
                 return Some(r);
             }
         }
@@ -1105,6 +1104,7 @@ impl LookupObject for ArrayExpression<'_> {
             f(&SmolStr::new_static("length"), function_call(BuiltinFunction::ArrayLength))
         })
         .or_else(|| f(&SmolStr::new_static("any"), member_function(BuiltinFunction::ArrayAny)))
+        .or_else(|| f(&SmolStr::new_static("all"), member_function(BuiltinFunction::ArrayAll)))
     }
 }
 

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -59,6 +59,9 @@ pub struct LookupCtx<'a> {
     /// A stack of predicate arguments
     /// Theoretically a predicate could include another predicate, so this is a stack
     pub predicate_arguments: Vec<SmolStr>,
+
+    /// A flag that indicates if predicates are currently allowed (currently only inside a function argument)
+    pub predicates_allowed: bool,
 }
 
 impl<'a> LookupCtx<'a> {
@@ -76,6 +79,7 @@ impl<'a> LookupCtx<'a> {
             local_variables: Default::default(),
             predicate_arguments: Default::default(),
             predicate_argument_types: Default::default(),
+            predicates_allowed: false,
         }
     }
 

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -283,7 +283,9 @@ impl LookupObject for PredicateArgumentsLookup {
         ctx: &LookupCtx,
         f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
     ) -> Option<R> {
-        for (name, ty) in ctx.predicate_arguments.iter().zip(ctx.predicate_argument_types.iter()) {
+        // we reverse the types here so that the most recently added predicate argument is the first one for shadowing purposes
+        // this is done in case someone does `arr.any(x => x.any(x => x > 0))`... why anyone would do this is beyond me though
+        for (name, ty) in ctx.predicate_arguments.iter().zip(ctx.predicate_argument_types.iter().rev()) {
             if let Some(r) =
                 f(name, Expression::ReadLocalVariable { name: name.clone(), ty: ty.clone() }.into())
             {

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -374,7 +374,7 @@ declare_syntax! {
         Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
                        ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtGradient, ?AtTr,
-                       ?MemberAccess ],
+                       ?MemberAccess, ?Predicate ],
         /// Concatenate the Expressions to make a string (usually expended from a template string)
         StringTemplate -> [*Expression],
         /// `@image-url("foo.png")`
@@ -449,6 +449,8 @@ declare_syntax! {
         EnumValue -> [],
         /// `@rust-attr(...)`
         AtRustAttr -> [],
+        /// `|x| x > 0`
+        Predicate -> [DeclaredIdentifier, Expression],
     }
 }
 

--- a/internal/compiler/parser/expressions.rs
+++ b/internal/compiler/parser/expressions.rs
@@ -30,7 +30,7 @@ use super::prelude::*;
 /// array[index]
 /// {object:42}
 /// "foo".bar.something().something.xx({a: 1.foo}.a)
-/// |x| x > 0
+/// x => x > 0
 /// ```
 pub fn parse_expression(p: &mut impl Parser) -> bool {
     p.peek(); // consume the whitespace so they aren't part of the Expression node
@@ -59,7 +59,11 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
     let mut possible_range = false;
     match p.nth(0).kind() {
         SyntaxKind::Identifier => {
-            parse_qualified_name(&mut *p);
+            if p.nth(1).kind() == SyntaxKind::FatArrow {
+                parse_predicate(&mut *p);
+            } else {
+                parse_qualified_name(&mut *p);
+            }
         }
         SyntaxKind::StringLiteral => {
             if p.nth(0).as_str().ends_with('{') {
@@ -89,9 +93,6 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
         }
         SyntaxKind::At => {
             parse_at_keyword(&mut *p);
-        }
-        SyntaxKind::Pipe => {
-            parse_predicate(&mut *p);
         }
         _ => {
             p.error("invalid expression");
@@ -233,20 +234,19 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
 
 #[cfg_attr(test, parser_test)]
 /// ```test
-/// |x| x > 0
-/// |y| y == 42
-/// |z| true
+/// x => x > 0
+/// y => y == 42
+/// z => true
 /// ```
 fn parse_predicate(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::Predicate);
-    p.expect(SyntaxKind::Pipe);
 
     {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
         p.expect(SyntaxKind::Identifier);
     }
 
-    p.expect(SyntaxKind::Pipe);
+    p.expect(SyntaxKind::FatArrow);
 
     parse_expression(&mut *p);
 }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1292,10 +1292,18 @@ impl Expression {
         let arg_name = node.DeclaredIdentifier().to_smolstr();
 
         ctx.predicate_arguments.push(arg_name.clone());
-        let expression = Box::new(Expression::from_expression_node(node.Expression(), ctx));
+        let expression = Expression::from_expression_node(node.Expression(), ctx);
+        let ty = expression.ty();
+        if ty != Type::Bool {
+            ctx.diag.push_error(
+                format!("Predicate expression must be of type bool, but is {}", ty),
+                &node.Expression(),
+            );
+        }
+
         ctx.predicate_arguments.pop();
 
-        Expression::Predicate { arg_name, expression }
+        Expression::Predicate { arg_name, expression: Box::new(expression) }
     }
 
     fn from_string_template_node(

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -895,13 +895,15 @@ impl Expression {
             return Self::Invalid;
         };
 
-        // dirty hack to supply the type of the predicate argument for array member functions, 
-        // we check if we are dealing with an array builtin, then we push the type to the context, 
+        // dirty hack to supply the type of the predicate argument for array member functions,
+        // we check if we are dealing with an array builtin, then we push the type to the context,
         // to be popped at the end of this function after all the predicate's expression is resolved
         let mut should_pop_predicate_args = false;
         match &function {
             LookupResultCallable::MemberFunction { base, member, .. } => match **member {
-                LookupResultCallable::Callable(Callable::Builtin(BuiltinFunction::ArrayAny)) => {
+                LookupResultCallable::Callable(Callable::Builtin(
+                    BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll,
+                )) => {
                     let ty = match base.ty() {
                         Type::Array(ty) => (*ty).clone(),
                         _ => unreachable!(),

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -884,13 +884,17 @@ impl Expression {
 
         let Some(function) = function else {
             // Check sub expressions anyway
-            // sub_expr.count();
+            sub_expr.for_each(|n| {
+                Self::from_expression_node(n.clone(), ctx);
+            });
             assert!(ctx.diag.has_errors());
             return Self::Invalid;
         };
         let LookupResult::Callable(function) = function else {
             // Check sub expressions anyway
-            // sub_expr.count();
+            sub_expr.for_each(|n| {
+                Self::from_expression_node(n.clone(), ctx);
+            });
             ctx.diag.push_error("The expression is not a function".into(), &node);
             return Self::Invalid;
         };

--- a/internal/compiler/tests/syntax/expressions/predicates.slint
+++ b/internal/compiler/tests/syntax/expressions/predicates.slint
@@ -3,7 +3,7 @@
 
 export component Test inherits Window {
     property <[int]> ints: [1, 2, 3, 4, 5];
-
+    
     if x => x > 0 : Rectangle {}
 //     ^error{Predicate expressions are not permitted outside of array builtin function arguments}
 

--- a/internal/compiler/tests/syntax/expressions/predicates.slint
+++ b/internal/compiler/tests/syntax/expressions/predicates.slint
@@ -1,0 +1,37 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Test inherits Window {
+    property <[int]> ints: [1, 2, 3, 4, 5];
+
+    if x => x > 0 : Rectangle {}
+//     ^error{Predicate expressions are not permitted outside of array builtin function arguments}
+
+    init => {
+        ints.any(1);
+//               ^error{Cannot convert float to predicate}
+        ints.all(1);
+//               ^error{Cannot convert float to predicate}
+
+        ints.any(x => 1);
+//                    ^error{Predicate expression must be of type bool, but is float}
+        ints.all(x => 1);
+//                    ^error{Predicate expression must be of type bool, but is float}
+
+        ints.any(x => x);
+//                    ^error{Predicate expression must be of type bool, but is int}
+        ints.all(x => x);
+//                    ^error{Predicate expression must be of type bool, but is int}
+
+        debug(x => x > 0);
+//            ^error{Predicate expressions are not permitted outside of array builtin function arguments}
+    
+        y => y > 0;
+//      ^error{Predicate expressions are not permitted outside of array builtin function arguments}
+    }
+
+    TouchArea {
+        clicked => x => x > 0;
+//                 ^error{Predicate expressions are not permitted outside of array builtin function arguments}
+    }
+}

--- a/internal/compiler/tests/syntax/expressions/predicates.slint
+++ b/internal/compiler/tests/syntax/expressions/predicates.slint
@@ -3,7 +3,7 @@
 
 export component Test inherits Window {
     property <[int]> ints: [1, 2, 3, 4, 5];
-    
+
     if x => x > 0 : Rectangle {}
 //     ^error{Predicate expressions are not permitted outside of array builtin function arguments}
 
@@ -25,7 +25,7 @@ export component Test inherits Window {
 
         debug(x => x > 0);
 //            ^error{Predicate expressions are not permitted outside of array builtin function arguments}
-    
+
         y => y > 0;
 //      ^error{Predicate expressions are not permitted outside of array builtin function arguments}
     }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1260,7 +1260,8 @@ pub(crate) fn generate_item_tree<'id>(
             | Type::Model
             | Type::PathData
             | Type::UnitProduct(_)
-            | Type::ElementReference => panic!("bad type {ty:?}"),
+            | Type::ElementReference
+            | Type::Predicate => panic!("bad type {ty:?}"),
         })
     }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -412,8 +412,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         Expression::Predicate { arg_name, expression } => {
             let arg_name = arg_name.clone();
             let expression = expression.clone();
-            let predicate: Rc<RefCell<dyn Fn(&mut EvalLocalContext<'_, '_>, &Value) -> Value + 'static>> =
-                Rc::new(RefCell::new(move |local_context: &mut EvalLocalContext<'_, '_>, value: &Value| {
+            let predicate =    Rc::new(RefCell::new(move |local_context: &mut EvalLocalContext<'_, '_>, value: &Value| {
                     local_context.local_variables.insert(arg_name.clone(), value.clone());
                     eval_expression(&expression, local_context)
                 }));

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -408,6 +408,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
         }
         Expression::EmptyComponentFactory => Value::ComponentFactory(Default::default()),
         Expression::DebugHook { expression, .. } => eval_expression(expression, local_context),
+        Expression::Predicate { arg_name, expression } => todo!(),
     }
 }
 
@@ -1368,6 +1369,8 @@ fn call_builtin_function(
                 panic!("internal error: argument to RestartTimer must be an element")
             }
         }
+        BuiltinFunction::ArrayAny => todo!(),
+        BuiltinFunction::ArrayAll => todo!(),
     }
 }
 
@@ -1658,7 +1661,8 @@ fn check_value_type(value: &Value, ty: &Type) -> bool {
         | Type::InferredCallback
         | Type::Callback { .. }
         | Type::Function { .. }
-        | Type::ElementReference => panic!("not valid property type"),
+        | Type::ElementReference
+        | Type::Predicate => panic!("not valid property type"),
         Type::Float32 => matches!(value, Value::Number(_)),
         Type::Int32 => matches!(value, Value::Number(_)),
         Type::String => matches!(value, Value::String(_)),
@@ -1986,7 +1990,8 @@ pub fn default_value_for_type(ty: &Type) -> Value {
         Type::InferredProperty
         | Type::InferredCallback
         | Type::ElementReference
-        | Type::Function { .. } => {
+        | Type::Function { .. }
+        | Type::Predicate => {
             panic!("There can't be such property")
         }
     }

--- a/tests/cases/models/array_predicates.slint
+++ b/tests/cases/models/array_predicates.slint
@@ -15,25 +15,39 @@ export component TestCase {
         { name: "Charlie", age: 35 },
         { name: "Diana", age: 28 }
     ];
+    property <[[Person]]> groups: [
+        [{ name: "Alice", age: 30 }, { name: "Bob", age: 25 }],
+        [{ name: "Charlie", age: 35 }, { name: "Diana", age: 28 }],
+        [{ name: "Evan", age: 22 }, { name: "Fiona", age: 27 }]
+    ];
 
     out property <bool> test: self.ints.all(
     
     
-    x => x > 0) && !self.ints.all(
-    x => x > 1) && !self.ints.any(
-    x => x == 0) && self.ints.any(
-    x => x == 5) && self.ints.any(
-    x => x < 5) && self.strings.all(
-    s => s.character-count > 0) && !self.strings.all(
-    s => s.is-empty) && self.strings.any(
-    s => s == "hello") && !self.strings.any(
-    s => s == "test") && !self.strings.any(
-    s => s.is-empty) && self.people.all(
-    p => p.age > 20) && !self.people.all(
-    p => p.age < 30) && self.people.any(
-    p => p.name == "Alice") && !self.people.any(
-    p => p.name == "Evan") && self.people.any(
-    p => p.age < 30);
+    x
+    => x > 0) && !self.ints.all(x => x > 1
+    ) && !self.ints.any(x => x == 0
+    ) && self.ints.any(x => x == 5
+    ) && self.ints.any(x => x < 5
+    ) && self.strings.all(s => s.character-count > 0
+    ) && !self.strings.all(s => s.is-empty
+    ) && self.strings.any(s => s == "hello"
+    ) && !self.strings.any(s => s == "test"
+    ) && !self.strings.any(s => s.is-empty
+    ) && self.people.all(p => p.age > 20
+    ) && !self.people.all(p => p.age < 30
+    ) && self.people.any(p => p.name == "Alice"
+    ) && !self.people.any(p => p.name == "Evan"
+    ) && self.people.any(p => p.age < 30
+    ) && self.groups.all(p => p.all(p
+    => p.age > 20)) && !self.groups.all(p => p.all(p
+    => p.age < 30)) && self.groups.all(p => p.any(p
+    => p.age >= 25)) && !self.groups.any(p => p.all(p
+    => p.name == "Alice")) && self.groups.any(p => p.all(p
+    => p.name.character-count > 4)) && self.groups.any(p => p.any(p
+    => p.name.character-count == 7));
+
+    // with the groups here we are also testing arg shadowing when nested predicate args have the same name
 }
 
 /*

--- a/tests/cases/models/array_predicates.slint
+++ b/tests/cases/models/array_predicates.slint
@@ -21,31 +21,47 @@ export component TestCase {
         [{ name: "Evan", age: 22 }, { name: "Fiona", age: 27 }]
     ];
 
-    out property <bool> test: self.ints.all(
-    
-    
-    x
-    => x > 0) && !self.ints.all(x => x > 1
-    ) && !self.ints.any(x => x == 0
-    ) && self.ints.any(x => x == 5
-    ) && self.ints.any(x => x < 5
-    ) && self.strings.all(s => s.character-count > 0
-    ) && !self.strings.all(s => s.is-empty
-    ) && self.strings.any(s => s == "hello"
-    ) && !self.strings.any(s => s == "test"
-    ) && !self.strings.any(s => s.is-empty
-    ) && self.people.all(p => p.age > 20
-    ) && !self.people.all(p => p.age < 30
-    ) && self.people.any(p => p.name == "Alice"
-    ) && !self.people.any(p => p.name == "Evan"
-    ) && self.people.any(p => p.age < 30
-    ) && self.groups.all(p => p.all(p
-    => p.age > 20)) && !self.groups.all(p => p.all(p
-    => p.age < 30)) && self.groups.all(p => p.any(p
-    => p.age >= 25)) && !self.groups.any(p => p.all(p
-    => p.name == "Alice")) && self.groups.any(p => p.all(p
-    => p.name.character-count > 4)) && self.groups.any(p => p.any(p
-    => p.name.character-count == 7));
+    out property <bool> test: {
+        // test that predicate args shadow outer variables regardless of type
+        let x = "hello world";
+        let s = 42;
+        let p = 42px;
+
+        let ints = self.ints.all(x
+
+        => x > 0
+        ) && !self.ints.all(x => x > 1
+        ) && !self.ints.any(x => x == 0
+        ) && self.ints.any(x => x == 5
+        ) && self.ints.any(x => x < 5
+        );
+        
+        let strings = self.strings.all(s => s.character-count > 0
+        ) && !self.strings.all(s => s.is-empty
+        ) && self.strings.any(s => s == "hello"
+        ) && !self.strings.any(s => s == "test"
+        ) && !self.strings.any(s => s.is-empty
+        );
+        
+        let people = self.people.all(p => p.age > 20
+        ) && !self.people.all(p => p.age < 30
+        ) && self.people.any(p => p.name == "Alice"
+        ) && !self.people.any(p => p.name == "Evan"
+        ) && self.people.any(p => p.age < 30
+        );
+        
+        let groups = self.groups.all(p => p.all(p
+        => p.age > 20)) && !self.groups.all(p => p.all(p
+        => p.age < 30)) && self.groups.all(p => p.any(p
+        => p.age >= 25)) && !self.groups.any(p => p.all(p
+        => p.name == "Alice")) && self.groups.any(p => p.all(p
+        => p.name.character-count > 4)) && self.groups.any(p => p.any(p
+        => p.name.character-count == 7));
+        
+        let shadowing = x == "hello world" && s == 42 && p == 42px;
+
+        ints && strings && people && groups && shadowing
+    }
 
     // with the groups here we are also testing arg shadowing when nested predicate args have the same name
 }

--- a/tests/cases/models/array_predicates.slint
+++ b/tests/cases/models/array_predicates.slint
@@ -1,0 +1,59 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+struct Person {
+    name: string,
+    age: int,
+}
+
+export component TestCase {
+    property <[int]> ints: [1, 2, 3, 4, 5];
+    property <[string]> strings: ["hello", "world", "foo", "bar"];
+    property <[Person]> people: [
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 25 },
+        { name: "Charlie", age: 35 },
+        { name: "Diana", age: 28 }
+    ];
+
+    out property <bool> test: self.ints.all(
+    
+    
+    |x| x > 0) && !self.ints.all(
+    |x| x > 1) && !self.ints.any(
+    |x| x == 0) && self.ints.any(
+    |x| x == 5) && self.ints.any(
+    |x| x < 5) && self.strings.all(
+    |s| s.character-count > 0) && !self.strings.all(
+    |s| s.is-empty) && self.strings.any(
+    |s| s == "hello") && !self.strings.any(
+    |s| s == "test") && !self.strings.any(
+    |s| s.is-empty) && self.people.all(
+    |p| p.age > 20) && !self.people.all(
+    |p| p.age < 30) && self.people.any(
+    |p| p.name == "Alice") && !self.people.any(
+    |p| p.name == "Evan") && self.people.any(
+    |p| p.age < 30);
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+
+assert(instance.test);
+```
+*/

--- a/tests/cases/models/array_predicates.slint
+++ b/tests/cases/models/array_predicates.slint
@@ -19,21 +19,21 @@ export component TestCase {
     out property <bool> test: self.ints.all(
     
     
-    |x| x > 0) && !self.ints.all(
-    |x| x > 1) && !self.ints.any(
-    |x| x == 0) && self.ints.any(
-    |x| x == 5) && self.ints.any(
-    |x| x < 5) && self.strings.all(
-    |s| s.character-count > 0) && !self.strings.all(
-    |s| s.is-empty) && self.strings.any(
-    |s| s == "hello") && !self.strings.any(
-    |s| s == "test") && !self.strings.any(
-    |s| s.is-empty) && self.people.all(
-    |p| p.age > 20) && !self.people.all(
-    |p| p.age < 30) && self.people.any(
-    |p| p.name == "Alice") && !self.people.any(
-    |p| p.name == "Evan") && self.people.any(
-    |p| p.age < 30);
+    x => x > 0) && !self.ints.all(
+    x => x > 1) && !self.ints.any(
+    x => x == 0) && self.ints.any(
+    x => x == 5) && self.ints.any(
+    x => x < 5) && self.strings.all(
+    s => s.character-count > 0) && !self.strings.all(
+    s => s.is-empty) && self.strings.any(
+    s => s == "hello") && !self.strings.any(
+    s => s == "test") && !self.strings.any(
+    s => s.is-empty) && self.people.all(
+    p => p.age > 20) && !self.people.all(
+    p => p.age < 30) && self.people.any(
+    p => p.name == "Alice") && !self.people.any(
+    p => p.name == "Evan") && self.people.any(
+    p => p.age < 30);
 }
 
 /*

--- a/tests/cases/models/array_predicates.slint
+++ b/tests/cases/models/array_predicates.slint
@@ -35,21 +35,21 @@ export component TestCase {
         ) && self.ints.any(x => x == 5
         ) && self.ints.any(x => x < 5
         );
-        
+
         let strings = self.strings.all(s => s.character-count > 0
         ) && !self.strings.all(s => s.is-empty
         ) && self.strings.any(s => s == "hello"
         ) && !self.strings.any(s => s == "test"
         ) && !self.strings.any(s => s.is-empty
         );
-        
+
         let people = self.people.all(p => p.age > 20
         ) && !self.people.all(p => p.age < 30
         ) && self.people.any(p => p.name == "Alice"
         ) && !self.people.any(p => p.name == "Evan"
         ) && self.people.any(p => p.age < 30
         );
-        
+
         let groups = self.groups.all(p => p.all(p
         => p.age > 20)) && !self.groups.all(p => p.all(p
         => p.age < 30)) && self.groups.all(p => p.any(p
@@ -57,7 +57,7 @@ export component TestCase {
         => p.name == "Alice")) && self.groups.any(p => p.all(p
         => p.name.character-count > 4)) && self.groups.any(p => p.any(p
         => p.name.character-count == 7));
-        
+
         let shadowing = x == "hello world" && s == 42 && p == 42px;
 
         ints && strings && people && groups && shadowing

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2229,7 +2229,7 @@ export component MainWindow2 inherits Rectangle {
         );
     }
 
-        #[test]
+    #[test]
     fn nested_predicate() {
         assert_formatting(
             "component X { property <[[int]]> arr: [[1, 2, 3, 4, 5]]; function foo() { arr.any(x     =>   x.all(y   => y   ==  7     )      ); } }",


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Added a predicate type made with rust-style closure syntax (`|x| x == 10`). Hardcoded as an 80% solution specifically for use with the array type. To try this out I’ve added array member functions for `any` and `all`, along with an accompanying test.

To resolve the predicate argument type, this uses a hardcoded hack on function call resolution. Not sure if this is acceptable, let me know.

The main goal of this is to work towards closing #1328, which will require additional work for inferring a return type on the built in function. But, this also could be added as-is, or with a lowering pass to close #4801.

Implementation here is incomplete (missing interpreter impl) and likely buggy, just pushing now for feedback.
