### PR TITLE
Live-Preview: Show "<click> unselect" only when selection exists

### DIFF
--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -240,11 +240,12 @@ export component PreviewView {
             unselect-area := TouchArea {
                 clicked => {
                     Api.unselect();
+                    StatusLineApi.help-text = "";
                 }
                 mouse-cursor: root.mode == DrawAreaMode.selecting ? MouseCursor.crosshair : MouseCursor.default;
 
                 changed has-hover => {
-                    if self.has-hover {
+                    if self.has-hover && root.selections.length > 0 {
                         StatusLineApi.help-text = "<click> unselect";
                     } else {
                          StatusLineApi.help-text = "";


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
