### PR TITLE
fix mistake in timer docs

### DIFF
--- a/docs/astro/src/content/docs/reference/timer.mdx
+++ b/docs/astro/src/content/docs/reference/timer.mdx
@@ -112,7 +112,7 @@ Timer {
 Start the timer (equivalent to setting `running` to true).
 
 ### stop()
-Stop the timer (equivalent to setting `running` to true).
+Stop the timer (equivalent to setting `running` to false).
 
 ### restart()
 Restarts the timer if it was previously started.


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

When I added the Timer methods to the docs I mistakenly wrote that start() and stop() would have the same effect when lowered.