### PR TITLE
lsp: Fix indentation inconsistency and multi-word keyword completion repetition bug

### DIFF
--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -46,7 +46,7 @@ impl FormatState {
         }
         let mut new_line = String::from("\n");
         for _ in 0..self.indentation_level {
-            new_line += "    ";
+            new_line += "  ";
         }
         self.whitespace_to_add = Some(new_line);
     }


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

This PR:
1. Makes the formatter use 2 spaces instead of 4 to match the tree-sitter indentation
2. Fixes completion repetition on typing past the first word in a multi-word keyword (e.g. completing `in p` as opposed to `in ` results in `in in property` where it should result in `in property`)

The new function in `completion.rs` could probably be smaller which is why I'm opening this as a draft