### PR TITLE
vscode: Offer an option to set the Slint-lsp binary

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -163,6 +163,11 @@
             }
           },
           "description": "Map of paths in which the `import` statement for `@mylibrary` imports are looked up. This is an object such as `{\"mylibrary\": \"/path/to/library\"}`. Relative paths are resolved against the workspace root."
+        },
+        "slint.lspBinaryPath": {
+          "type": "string",
+          "default": "",
+          "description": "The path to the slint-lsp. Leave empty to use the packaged LSP"
         }
       }
     },


### PR DESCRIPTION
... which is disabled by default.

This might help with issues similar to #2577