### PR TITLE
Fix most of "unnecessary parentheses", "unnecessary trailing semicolon" and "unused `std::result::Result`" lints in the generated code

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2351,8 +2351,14 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             }})
         }
         Expression::CodeBlock(sub) => {
-            let map = sub.iter().map(|e| compile_expression_no_parenthesis(e, ctx));
-            quote!({ #(#map);* })
+            let mut body = TokenStream::new();
+            for (i, e) in sub.iter().enumerate() {
+                body.extend(compile_expression_no_parenthesis(e, ctx));
+                if i + 1 < sub.len() && !matches!(e, Expression::StoreLocalVariable{..}) {
+                    body.extend(quote!(;));
+                }
+            }
+            quote!({ #body })
         }
         Expression::PropertyAssignment { property, value } => {
             let value = compile_expression(value, ctx);

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1172,8 +1172,8 @@ fn generate_sub_component(
                     tree_index: u32, tree_index_of_first_child: u32) {
                 #![allow(unused)]
                 let _self = self_rc.as_pin_ref();
-                _self.self_weak.set(sp::VRcMapped::downgrade(&self_rc));
-                _self.globals.set(globals);
+                let _ = _self.self_weak.set(sp::VRcMapped::downgrade(&self_rc));
+                let _ = _self.globals.set(globals);
                 _self.tree_index.set(tree_index);
                 _self.tree_index_of_first_child.set(tree_index_of_first_child);
                 #(#init)*
@@ -1493,7 +1493,7 @@ fn generate_global(
             }
             fn init(self: ::core::pin::Pin<sp::Rc<Self>>, globals: &sp::Rc<SharedGlobals>) {
                 #![allow(unused)]
-                self.globals.set(sp::Rc::downgrade(globals));
+                let _ = self.globals.set(sp::Rc::downgrade(globals));
                 let self_rc = self;
                 let _self = self_rc.as_ref();
                 #(#init)*


### PR DESCRIPTION
Recently we noticed a slowdown of our build times of our relatively large slint files when we started using many many conditionals in functions.
Even incremental builds where we only changed a single string literal in an unrelated rust source file takes a minute to build, when a few months ago it took only seconds.

I checked what `rustc` was spending its time on, and it turns out it was busy generating tons and tons of `unused_paren` lints. Now this lint is `#[allow]`-ed in the module, but I assume that `allow` only comes into play when printing the lints, they are still generated during compilation.
(The callstack is roughly `rustc_lint::unused::UnusedDelimLint::emit_unused_delims` <= `rustc_interface::passes::**early_lint_checks**` <= `rustc_ast_lowering::lower_to_hir`)

Another symptom of this is `looking_for_entry_point` taking a lot of time when printed by `RUSTFLAGS=-Ztime-passes`

We think the solution is that `slint` should generate code with these lints in the first place, instead of just `allow`ing them. With the changes in the PR, our incremental builds take only seconds again.

This PR is a somewhat quick-n-dirty fix for the above problems, I'd be glad to hear how else this (not adding parentheses around expressions, depending on the context) could be tackled.
