### PR TITLE
LinuxKMS: Implement initial format negotiation for software display and renderer.

### DIFF
--- a/internal/backends/linuxkms/display/swdisplay.rs
+++ b/internal/backends/linuxkms/display/swdisplay.rs
@@ -21,12 +21,42 @@ pub trait SoftwareBufferDisplay {
 mod dumbbuffer;
 mod linuxfb;
 
+#[derive(Debug, Clone)]
+pub struct FormatNegotiation {
+    /// Formats supported by the renderer, in order of preference (best first)
+    pub renderer_formats: Vec<drm::buffer::DrmFourcc>,
+    /// Formats supported by the display backend
+    pub display_formats: Vec<drm::buffer::DrmFourcc>,
+}
+
+impl FormatNegotiation {
+    pub fn new(renderer_formats: &[drm::buffer::DrmFourcc]) -> Self {
+        Self { renderer_formats: renderer_formats.to_vec(), display_formats: Vec::new() }
+    }
+
+    pub fn negotiate(&self) -> Option<drm::buffer::DrmFourcc> {
+        for renderer_format in &self.renderer_formats {
+            if self.display_formats.contains(renderer_format) {
+                return Some(*renderer_format);
+            }
+        }
+        None
+    }
+
+    pub fn add_display_formats(&mut self, formats: &[drm::buffer::DrmFourcc]) {
+        self.display_formats.extend_from_slice(formats);
+    }
+}
+
 pub fn new(
     device_opener: &crate::DeviceOpener,
+    renderer_formats: &[drm::buffer::DrmFourcc],
 ) -> Result<Arc<dyn SoftwareBufferDisplay>, PlatformError> {
+    let mut negotiation = FormatNegotiation::new(renderer_formats);
+
     if std::env::var_os("SLINT_BACKEND_LINUXFB").is_some() {
-        return linuxfb::LinuxFBDisplay::new(device_opener);
+        return linuxfb::LinuxFBDisplay::new(device_opener, &mut negotiation);
     }
-    dumbbuffer::DumbBufferDisplay::new(device_opener)
-        .or_else(|_| linuxfb::LinuxFBDisplay::new(device_opener))
+    dumbbuffer::DumbBufferDisplay::new(device_opener, &mut negotiation)
+        .or_else(|_| linuxfb::LinuxFBDisplay::new(device_opener, &mut negotiation))
 }

--- a/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
+++ b/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
@@ -35,15 +35,10 @@ impl DumbBufferDisplay {
         let (depth, bpp) = pixel_format_params(format)
             .ok_or_else(|| format!("Cannot get depth and bpp for pixel format: {format:?}"))?;
 
-        let front_buffer: RefCell<DumbBuffer> = DumbBuffer::allocate(
-            &drm_output.drm_device,
-            drm_output.size(),
-            format,
-            depth,
-            bpp,
-        )
-        .map_err(|err| format!("Could not allocate drm dumb buffer: {err}"))?
-        .into();
+        let front_buffer: RefCell<DumbBuffer> =
+            DumbBuffer::allocate(&drm_output.drm_device, drm_output.size(), format, depth, bpp)
+                .map_err(|err| format!("Could not allocate drm dumb buffer: {err}"))?
+                .into();
 
         let back_buffer = DumbBuffer::allocate(
             &drm_output.drm_device,

--- a/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
+++ b/internal/backends/linuxkms/display/swdisplay/dumbbuffer.rs
@@ -130,12 +130,75 @@ struct DumbBuffer {
 /// Returns the pixel depth and bits-per-pixel values for a given DRM pixel format.
 fn pixel_format_params(format: drm::buffer::DrmFourcc) -> Option<(u32, u32)> {
     match format {
+        // 32-bit RGB formats
         drm::buffer::DrmFourcc::Xrgb8888 => Some((24, 32)),
         drm::buffer::DrmFourcc::Argb8888 => Some((32, 32)),
-        drm::buffer::DrmFourcc::Rgb565 => Some((16, 16)),
         drm::buffer::DrmFourcc::Xbgr8888 => Some((24, 32)),
         drm::buffer::DrmFourcc::Abgr8888 => Some((32, 32)),
-        // TODO: Add more formats
+        drm::buffer::DrmFourcc::Rgbx8888 => Some((24, 32)),
+        drm::buffer::DrmFourcc::Rgba8888 => Some((32, 32)),
+        drm::buffer::DrmFourcc::Bgrx8888 => Some((24, 32)),
+        drm::buffer::DrmFourcc::Bgra8888 => Some((32, 32)),
+
+        // 30-bit RGB formats (10 bits per channel)
+        drm::buffer::DrmFourcc::Xrgb2101010 => Some((30, 32)),
+        drm::buffer::DrmFourcc::Argb2101010 => Some((32, 32)),
+        drm::buffer::DrmFourcc::Xbgr2101010 => Some((30, 32)),
+        drm::buffer::DrmFourcc::Abgr2101010 => Some((32, 32)),
+        drm::buffer::DrmFourcc::Rgbx1010102 => Some((30, 32)),
+        drm::buffer::DrmFourcc::Rgba1010102 => Some((32, 32)),
+        drm::buffer::DrmFourcc::Bgrx1010102 => Some((30, 32)),
+        drm::buffer::DrmFourcc::Bgra1010102 => Some((32, 32)),
+
+        // 24-bit RGB formats
+        drm::buffer::DrmFourcc::Rgb888 => Some((24, 24)),
+        drm::buffer::DrmFourcc::Bgr888 => Some((24, 24)),
+
+        // 16-bit RGB formats
+        drm::buffer::DrmFourcc::Rgb565 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Bgr565 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Xrgb1555 => Some((15, 16)),
+        drm::buffer::DrmFourcc::Argb1555 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Xbgr1555 => Some((15, 16)),
+        drm::buffer::DrmFourcc::Abgr1555 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Rgbx5551 => Some((15, 16)),
+        drm::buffer::DrmFourcc::Rgba5551 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Bgrx5551 => Some((15, 16)),
+        drm::buffer::DrmFourcc::Bgra5551 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Xrgb4444 => Some((12, 16)),
+        drm::buffer::DrmFourcc::Argb4444 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Xbgr4444 => Some((12, 16)),
+        drm::buffer::DrmFourcc::Abgr4444 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Rgbx4444 => Some((12, 16)),
+        drm::buffer::DrmFourcc::Rgba4444 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Bgrx4444 => Some((12, 16)),
+        drm::buffer::DrmFourcc::Bgra4444 => Some((16, 16)),
+
+        // 8-bit indexed formats
+        drm::buffer::DrmFourcc::C8 => Some((8, 8)),
+
+        // YUV packed formats
+        drm::buffer::DrmFourcc::Yuyv => Some((16, 16)),
+        drm::buffer::DrmFourcc::Yvyu => Some((16, 16)),
+        drm::buffer::DrmFourcc::Uyvy => Some((16, 16)),
+        drm::buffer::DrmFourcc::Vyuy => Some((16, 16)),
+
+        // YUV planar formats
+        drm::buffer::DrmFourcc::Yuv420 => Some((12, 12)), // 4:2:0 = 8 + 2 + 2 = 12 bpp
+        drm::buffer::DrmFourcc::Yvu420 => Some((12, 12)),
+        drm::buffer::DrmFourcc::Yuv422 => Some((16, 16)), // 4:2:2 = 8 + 4 + 4 = 16 bpp
+        drm::buffer::DrmFourcc::Yvu422 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Yuv444 => Some((24, 24)), // 4:4:4 = 8 + 8 + 8 = 24 bpp
+        drm::buffer::DrmFourcc::Yvu444 => Some((24, 24)),
+
+        // NV formats (semi-planar YUV)
+        drm::buffer::DrmFourcc::Nv12 => Some((12, 12)),
+        drm::buffer::DrmFourcc::Nv21 => Some((12, 12)),
+        drm::buffer::DrmFourcc::Nv16 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Nv61 => Some((16, 16)),
+        drm::buffer::DrmFourcc::Nv24 => Some((24, 24)),
+        drm::buffer::DrmFourcc::Nv42 => Some((24, 24)),
+
         _ => None,
     }
 }

--- a/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
+++ b/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
@@ -260,19 +260,7 @@ impl super::SoftwareBufferDisplay for LinuxFBDisplay {
         let age = if self.first_frame.get() { 0 } else { 1 };
         self.first_frame.set(false);
 
-        match self.format {
-            drm::buffer::DrmFourcc::Xrgb8888 => {
-                // 32-bit format - no conversion needed
-                callback(self.back_buffer.borrow_mut().as_mut(), age, self.format)?;
-            }
-            drm::buffer::DrmFourcc::Rgb565 => {
-                // 16-bit format - ensure proper handling
-                callback(self.back_buffer.borrow_mut().as_mut(), age, self.format)?;
-            }
-            _ => {
-                return Err(PlatformError::Other("Unsupported pixel format".to_string()));
-            }
-        }
+        callback(self.back_buffer.borrow_mut().as_mut(), age, self.format)?;
 
         let mut fb = self.fb.borrow_mut();
         fb.as_mut().copy_from_slice(&self.back_buffer.borrow());

--- a/internal/backends/linuxkms/drmoutput.rs
+++ b/internal/backends/linuxkms/drmoutput.rs
@@ -252,6 +252,31 @@ impl DrmOutput {
         }
     }
 
+    pub fn get_supported_formats(&self) -> Result<Vec<drm::buffer::DrmFourcc>, PlatformError> {
+        // Try to get formats from the plane associated with our CRTC
+        if let Ok(plane_handles) = self.drm_device.plane_handles() {
+            for &plane_handle in &plane_handles {
+                if let Ok(plane) = self.drm_device.get_plane(plane_handle) {
+                    if plane.crtc() == Some(self.crtc) {
+                        let formats: Vec<drm::buffer::DrmFourcc> = plane
+                            .formats()
+                            .iter()
+                            .filter_map(|&format_u32| {
+                                drm::buffer::DrmFourcc::try_from(format_u32).ok()
+                            })
+                            .collect();
+
+                        if !formats.is_empty() {
+                            return Ok(formats);
+                        }
+                    }
+                }
+            }
+        }
+
+        Err(format!("No available formats found for current plane with CRTC {:?}", self.crtc).into())
+    }
+
     pub fn size(&self) -> (u32, u32) {
         let (width, height) = self.mode.size();
         (width as u32, height as u32)

--- a/internal/backends/linuxkms/drmoutput.rs
+++ b/internal/backends/linuxkms/drmoutput.rs
@@ -274,7 +274,8 @@ impl DrmOutput {
             }
         }
 
-        Err(format!("No available formats found for current plane with CRTC {:?}", self.crtc).into())
+        Err(format!("No available formats found for current plane with CRTC {:?}", self.crtc)
+            .into())
     }
 
     pub fn size(&self) -> (u32, u32) {

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -236,9 +236,7 @@ impl i_slint_renderer_skia::software_surface::RenderBuffer for DrmDumbBufferAcce
                 match format {
                     drm::buffer::DrmFourcc::Xrgb8888 => skia_safe::ColorType::BGRA8888,
 
-                    drm::buffer::DrmFourcc::Argb8888 => skia_safe::ColorType::RGBA8888,
-
-                    drm::buffer::DrmFourcc::Abgr8888 => skia_safe::ColorType::BGRA8888,
+                    drm::buffer::DrmFourcc::Argb8888 => skia_safe::ColorType::BGRA8888,
 
                     drm::buffer::DrmFourcc::Rgba8888 => skia_safe::ColorType::RGBA8888,
 

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -17,6 +17,46 @@ pub struct SkiaRendererAdapter {
     size: PhysicalWindowSize,
 }
 
+const SKIA_SUPPORTED_DRM_FOURCC_FORMATS: &[drm::buffer::DrmFourcc] = &[
+    // Preferred formats
+    drm::buffer::DrmFourcc::Xrgb8888,
+    // drm::buffer::DrmFourcc::Argb8888,
+    // drm::buffer::DrmFourcc::Bgra8888,
+    // drm::buffer::DrmFourcc::Rgba8888,
+    
+    // 16-bit formats
+    drm::buffer::DrmFourcc::Rgb565,
+    // drm::buffer::DrmFourcc::Bgr565,
+    
+    // // 4444 formats
+    // drm::buffer::DrmFourcc::Argb4444,
+    // drm::buffer::DrmFourcc::Abgr4444,
+    // drm::buffer::DrmFourcc::Rgba4444,
+    // drm::buffer::DrmFourcc::Bgra4444,
+    
+    // // Single channel formats
+    // drm::buffer::DrmFourcc::Gray8,
+    // drm::buffer::DrmFourcc::C8,
+    // drm::buffer::DrmFourcc::R8,
+    // drm::buffer::DrmFourcc::R16,
+    
+    // // Dual channel formats
+    // drm::buffer::DrmFourcc::Gr88,
+    // drm::buffer::DrmFourcc::Rg88,
+    // drm::buffer::DrmFourcc::Gr1616,
+    // drm::buffer::DrmFourcc::Rg1616,
+    
+    // // 10-bit formats
+    // drm::buffer::DrmFourcc::Xrgb2101010,
+    // drm::buffer::DrmFourcc::Argb2101010,
+    // drm::buffer::DrmFourcc::Abgr2101010,
+    // drm::buffer::DrmFourcc::Rgba1010102,
+    // drm::buffer::DrmFourcc::Bgra1010102,
+    // drm::buffer::DrmFourcc::Rgbx1010102,
+    // drm::buffer::DrmFourcc::Bgrx1010102,
+];
+
+
 impl SkiaRendererAdapter {
     #[cfg(feature = "renderer-skia-vulkan")]
     pub fn new_vulkan(
@@ -92,7 +132,7 @@ impl SkiaRendererAdapter {
     pub fn new_software(
         device_opener: &crate::DeviceOpener,
     ) -> Result<Box<dyn crate::fullscreenwindowadapter::FullscreenRenderer>, PlatformError> {
-        let display = crate::display::swdisplay::new(device_opener)?;
+        let display = crate::display::swdisplay::new(device_opener, SKIA_SUPPORTED_DRM_FOURCC_FORMATS)?;
 
         let skia_software_surface: i_slint_renderer_skia::software_surface::SoftwareSurface =
             DrmDumbBufferAccess { display: display.clone() }.into();
@@ -195,7 +235,54 @@ impl i_slint_renderer_skia::software_surface::RenderBuffer for DrmDumbBufferAcce
                 height,
                 match format {
                     drm::buffer::DrmFourcc::Xrgb8888 => skia_safe::ColorType::BGRA8888,
+
+                    drm::buffer::DrmFourcc::Argb8888 => skia_safe::ColorType::RGBA8888,
+
+                    drm::buffer::DrmFourcc::Abgr8888 => skia_safe::ColorType::BGRA8888,
+
+                    drm::buffer::DrmFourcc::Rgba8888 => skia_safe::ColorType::RGBA8888,
+
+                    drm::buffer::DrmFourcc::Bgra8888 => skia_safe::ColorType::BGRA8888,
+
                     drm::buffer::DrmFourcc::Rgb565 => skia_safe::ColorType::RGB565,
+
+                    drm::buffer::DrmFourcc::Bgr565 => skia_safe::ColorType::RGB565,
+
+                    drm::buffer::DrmFourcc::Argb4444 => skia_safe::ColorType::ARGB4444,
+
+                    drm::buffer::DrmFourcc::Abgr4444 => skia_safe::ColorType::ARGB4444,
+
+                    drm::buffer::DrmFourcc::Rgba4444 => skia_safe::ColorType::ARGB4444,
+
+                    drm::buffer::DrmFourcc::Bgra4444 => skia_safe::ColorType::ARGB4444,
+
+                    drm::buffer::DrmFourcc::C8 => skia_safe::ColorType::Gray8,
+
+                    drm::buffer::DrmFourcc::R8 => skia_safe::ColorType::R8UNorm,
+
+                    drm::buffer::DrmFourcc::R16 => skia_safe::ColorType::Unknown,
+
+                    drm::buffer::DrmFourcc::Gr88 => skia_safe::ColorType::R8G8UNorm,
+
+                    drm::buffer::DrmFourcc::Rg88 => skia_safe::ColorType::R8G8UNorm,
+
+                    drm::buffer::DrmFourcc::Gr1616 => skia_safe::ColorType::R16G16UNorm,
+
+                    drm::buffer::DrmFourcc::Rg1616 => skia_safe::ColorType::R16G16UNorm,
+
+                    drm::buffer::DrmFourcc::Xrgb2101010 => skia_safe::ColorType::RGB101010x,
+
+                    drm::buffer::DrmFourcc::Argb2101010 => skia_safe::ColorType::RGBA1010102,
+
+                    drm::buffer::DrmFourcc::Abgr2101010 => skia_safe::ColorType::BGRA1010102,
+
+                    drm::buffer::DrmFourcc::Rgba1010102 => skia_safe::ColorType::RGBA1010102,
+
+                    drm::buffer::DrmFourcc::Bgra1010102 => skia_safe::ColorType::BGRA1010102,
+
+                    drm::buffer::DrmFourcc::Rgbx1010102 => skia_safe::ColorType::RGB101010x,
+
+                    drm::buffer::DrmFourcc::Bgrx1010102 => skia_safe::ColorType::BGR101010x,
                     _ => {
                         return Err(format!(
                         "Unsupported frame buffer format {format} used with skia software renderer"

--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -23,29 +23,29 @@ const SKIA_SUPPORTED_DRM_FOURCC_FORMATS: &[drm::buffer::DrmFourcc] = &[
     // drm::buffer::DrmFourcc::Argb8888,
     // drm::buffer::DrmFourcc::Bgra8888,
     // drm::buffer::DrmFourcc::Rgba8888,
-    
+
     // 16-bit formats
     drm::buffer::DrmFourcc::Rgb565,
     // drm::buffer::DrmFourcc::Bgr565,
-    
+
     // // 4444 formats
     // drm::buffer::DrmFourcc::Argb4444,
     // drm::buffer::DrmFourcc::Abgr4444,
     // drm::buffer::DrmFourcc::Rgba4444,
     // drm::buffer::DrmFourcc::Bgra4444,
-    
+
     // // Single channel formats
     // drm::buffer::DrmFourcc::Gray8,
     // drm::buffer::DrmFourcc::C8,
     // drm::buffer::DrmFourcc::R8,
     // drm::buffer::DrmFourcc::R16,
-    
+
     // // Dual channel formats
     // drm::buffer::DrmFourcc::Gr88,
     // drm::buffer::DrmFourcc::Rg88,
     // drm::buffer::DrmFourcc::Gr1616,
     // drm::buffer::DrmFourcc::Rg1616,
-    
+
     // // 10-bit formats
     // drm::buffer::DrmFourcc::Xrgb2101010,
     // drm::buffer::DrmFourcc::Argb2101010,
@@ -55,7 +55,6 @@ const SKIA_SUPPORTED_DRM_FOURCC_FORMATS: &[drm::buffer::DrmFourcc] = &[
     // drm::buffer::DrmFourcc::Rgbx1010102,
     // drm::buffer::DrmFourcc::Bgrx1010102,
 ];
-
 
 impl SkiaRendererAdapter {
     #[cfg(feature = "renderer-skia-vulkan")]
@@ -132,7 +131,8 @@ impl SkiaRendererAdapter {
     pub fn new_software(
         device_opener: &crate::DeviceOpener,
     ) -> Result<Box<dyn crate::fullscreenwindowadapter::FullscreenRenderer>, PlatformError> {
-        let display = crate::display::swdisplay::new(device_opener, SKIA_SUPPORTED_DRM_FOURCC_FORMATS)?;
+        let display =
+            crate::display::swdisplay::new(device_opener, SKIA_SUPPORTED_DRM_FOURCC_FORMATS)?;
 
         let skia_software_surface: i_slint_renderer_skia::software_surface::SoftwareSurface =
             DrmDumbBufferAccess { display: display.clone() }.into();

--- a/internal/backends/linuxkms/renderer/sw.rs
+++ b/internal/backends/linuxkms/renderer/sw.rs
@@ -24,29 +24,29 @@ const SOFTWARE_RENDER_SUPPORTED_DRM_FOURCC_FORMATS: &[drm::buffer::DrmFourcc] = 
     // drm::buffer::DrmFourcc::Argb8888,
     // drm::buffer::DrmFourcc::Bgra8888,
     // drm::buffer::DrmFourcc::Rgba8888,
-    
+
     // 16-bit formats
     drm::buffer::DrmFourcc::Rgb565,
     // drm::buffer::DrmFourcc::Bgr565,
-    
+
     // // 4444 formats
     // drm::buffer::DrmFourcc::Argb4444,
     // drm::buffer::DrmFourcc::Abgr4444,
     // drm::buffer::DrmFourcc::Rgba4444,
     // drm::buffer::DrmFourcc::Bgra4444,
-    
+
     // // Single channel formats
     // drm::buffer::DrmFourcc::Gray8,
     // drm::buffer::DrmFourcc::C8,
     // drm::buffer::DrmFourcc::R8,
     // drm::buffer::DrmFourcc::R16,
-    
+
     // // Dual channel formats
     // drm::buffer::DrmFourcc::Gr88,
     // drm::buffer::DrmFourcc::Rg88,
     // drm::buffer::DrmFourcc::Gr1616,
     // drm::buffer::DrmFourcc::Rg1616,
-    
+
     // // 10-bit formats
     // drm::buffer::DrmFourcc::Xrgb2101010,
     // drm::buffer::DrmFourcc::Argb2101010,
@@ -106,7 +106,10 @@ impl SoftwareRendererAdapter {
     pub fn new(
         device_opener: &crate::DeviceOpener,
     ) -> Result<Box<dyn crate::fullscreenwindowadapter::FullscreenRenderer>, PlatformError> {
-        let display = crate::display::swdisplay::new(device_opener, SOFTWARE_RENDER_SUPPORTED_DRM_FOURCC_FORMATS)?;
+        let display = crate::display::swdisplay::new(
+            device_opener,
+            SOFTWARE_RENDER_SUPPORTED_DRM_FOURCC_FORMATS,
+        )?;
 
         let (width, height) = display.size();
         let size = i_slint_core::api::PhysicalSize::new(width, height);

--- a/internal/backends/linuxkms/renderer/sw.rs
+++ b/internal/backends/linuxkms/renderer/sw.rs
@@ -18,6 +18,45 @@ pub struct SoftwareRendererAdapter {
     size: PhysicalWindowSize,
 }
 
+const SOFTWARE_RENDER_SUPPORTED_DRM_FOURCC_FORMATS: &[drm::buffer::DrmFourcc] = &[
+    // Preferred formats
+    drm::buffer::DrmFourcc::Xrgb8888,
+    // drm::buffer::DrmFourcc::Argb8888,
+    // drm::buffer::DrmFourcc::Bgra8888,
+    // drm::buffer::DrmFourcc::Rgba8888,
+    
+    // 16-bit formats
+    drm::buffer::DrmFourcc::Rgb565,
+    // drm::buffer::DrmFourcc::Bgr565,
+    
+    // // 4444 formats
+    // drm::buffer::DrmFourcc::Argb4444,
+    // drm::buffer::DrmFourcc::Abgr4444,
+    // drm::buffer::DrmFourcc::Rgba4444,
+    // drm::buffer::DrmFourcc::Bgra4444,
+    
+    // // Single channel formats
+    // drm::buffer::DrmFourcc::Gray8,
+    // drm::buffer::DrmFourcc::C8,
+    // drm::buffer::DrmFourcc::R8,
+    // drm::buffer::DrmFourcc::R16,
+    
+    // // Dual channel formats
+    // drm::buffer::DrmFourcc::Gr88,
+    // drm::buffer::DrmFourcc::Rg88,
+    // drm::buffer::DrmFourcc::Gr1616,
+    // drm::buffer::DrmFourcc::Rg1616,
+    
+    // // 10-bit formats
+    // drm::buffer::DrmFourcc::Xrgb2101010,
+    // drm::buffer::DrmFourcc::Argb2101010,
+    // drm::buffer::DrmFourcc::Abgr2101010,
+    // drm::buffer::DrmFourcc::Rgba1010102,
+    // drm::buffer::DrmFourcc::Bgra1010102,
+    // drm::buffer::DrmFourcc::Rgbx1010102,
+    // drm::buffer::DrmFourcc::Bgrx1010102,
+];
+
 #[repr(transparent)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 struct DumbBufferPixelXrgb888(pub u32);
@@ -67,7 +106,7 @@ impl SoftwareRendererAdapter {
     pub fn new(
         device_opener: &crate::DeviceOpener,
     ) -> Result<Box<dyn crate::fullscreenwindowadapter::FullscreenRenderer>, PlatformError> {
-        let display = crate::display::swdisplay::new(device_opener)?;
+        let display = crate::display::swdisplay::new(device_opener, SOFTWARE_RENDER_SUPPORTED_DRM_FOURCC_FORMATS)?;
 
         let (width, height) = display.size();
         let size = i_slint_core::api::PhysicalSize::new(width, height);


### PR DESCRIPTION
Introduces initial support for surface format negotiation between the Linux KMS display backends (dumbbuffer, linuxfb) and the software renderers (Skia and Software). The negotiation logic prioritizes selecting a pixel format that is supported by both the renderer and the framebuffer, based on lists of supported DrmFourcc formats.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
