### PR TITLE
testing backend: Fix incorrect font metrics descent implementation

### DIFF
--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -181,7 +181,7 @@ impl RendererSealed for TestingWindow {
         let pixel_size = font_request.pixel_size.unwrap_or(LogicalLength::new(10.));
         i_slint_core::items::FontMetrics {
             ascent: pixel_size.get() * 0.7,
-            descent: pixel_size.get() * 0.3,
+            descent: -pixel_size.get() * 0.3,
             x_height: 3.,
             cap_height: 7.,
         }

--- a/tests/cases/text/font_size_propagation.slint
+++ b/tests/cases/text/font_size_propagation.slint
@@ -27,7 +27,7 @@ let factory = slint::ComponentFactory::new(move |ctx| {
     let e = spin_on::spin_on(compiler.build_from_source(
         r#"export component Inner inherits Window {
                 default-font-size: 34px;
-                preferred-height: t.font-metrics.ascent + t.font-metrics.descent;
+                preferred-height: t.font-metrics.ascent - t.font-metrics.descent;
                 t := Text {
                     text: "Hello 🌍";
                 }
@@ -39,7 +39,7 @@ let factory = slint::ComponentFactory::new(move |ctx| {
                         text: "Ok 🌍";
                     }
                     init => {
-                        popup-text-size = popup-text.font-metrics.ascent + popup-text.font-metrics.descent;
+                        popup-text-size = popup-text.font-metrics.ascent - popup-text.font-metrics.descent;
                     }
                 }
 


### PR DESCRIPTION
The value is usually negative, so it should be negative in our test as well.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
