### PR TITLE
Skia: Add support for rendering with WGPU

### DIFF
--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -756,6 +756,10 @@ pub mod skia {
         }
     }
 
+    /// Safety: This is only needed for the Skia renderer when using WGPU, which isn't supported for C++.
+    unsafe impl std::marker::Send for RawHandlePair {}
+    unsafe impl std::marker::Sync for RawHandlePair {}
+
     struct CppRawHandle(Arc<RawHandlePair>);
 
     impl From<(RawWindowHandle, RawDisplayHandle)> for CppRawHandle {

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -218,7 +218,7 @@ impl AndroidWindowAdapter {
 
                     self.renderer.set_window_handle(
                         Arc::new(w),
-                        Arc::new(raw_window_handle::DisplayHandle::android()),
+                        Arc::new(DummyDisplayHandle),
                         size,
                         None,
                     )?;
@@ -855,5 +855,16 @@ fn map_key_code(code: android_activity::input::Keycode) -> Option<SharedString> 
         Keycode::ThumbsDown => None,
         Keycode::ProfileSwitch => None,
         _ => None,
+    }
+}
+
+/// A dummy display handle that's Send + Sync. Required by wgpu, but harmless as
+/// raw_window_handel::AndroidDisplayHandle is an empty struct.
+struct DummyDisplayHandle;
+impl raw_window_handle::HasDisplayHandle for DummyDisplayHandle {
+    fn display_handle(
+        &self,
+    ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
+        Ok(raw_window_handle::DisplayHandle::android())
     }
 }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -74,6 +74,16 @@ impl WinitSkiaRenderer {
         }))
     }
 
+    #[cfg(feature = "unstable-wgpu-26")]
+    pub fn new_wgpu_26_suspended(
+        shared_backend_data: &Rc<crate::SharedBackendData>,
+    ) -> Result<Box<dyn super::WinitCompatibleRenderer>, PlatformError> {
+        Ok(Box::new(Self {
+            renderer: SkiaRenderer::default_wgpu_26(&shared_backend_data.skia_context),
+            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+        }))
+    }
+
     pub fn factory_for_graphics_api(
         requested_graphics_api: Option<&RequestedGraphicsAPI>,
     ) -> Result<
@@ -120,7 +130,7 @@ impl WinitSkiaRenderer {
                     }
                     #[cfg(feature = "unstable-wgpu-26")]
                     RequestedGraphicsAPI::WGPU26(..) => {
-                        return Err(format!("WGPU rendering is not supported by Skia").into());
+                        return Ok(Self::new_wgpu_26_suspended);
                     }
                 }
             }

--- a/internal/core/graphics/wgpu_26.rs
+++ b/internal/core/graphics/wgpu_26.rs
@@ -210,7 +210,7 @@ pub fn any_wgpu26_adapters_with_gpu(requested_graphics_api: Option<RequestedGrap
 pub fn init_instance_adapter_device_queue_surface(
     window_handle: Box<dyn wgpu::WindowHandle + 'static>,
     requested_graphics_api: Option<RequestedGraphicsAPI>,
-    backends_to_avoid: Option<wgpu::Backends>,
+    backends_to_avoid: wgpu::Backends,
 ) -> Result<
     (
         wgpu_26::Instance,
@@ -232,16 +232,11 @@ pub fn init_instance_adapter_device_queue_surface(
             (instance, adapter, device, queue, surface)
         }
         Some(RequestedGraphicsAPI::WGPU26(api::WGPUConfiguration::Automatic(wgpu26_settings))) => {
-            let mut backends = wgpu26_settings.backends;
-            if let Some(backends_to_avoid) = backends_to_avoid {
-                backends.remove(backends_to_avoid);
-            }
-
             // wgpu uses async here, but the returned future is ready on first poll on all platforms except WASM,
             // which we don't support right now.
             let instance = poll_once(async {
                 wgpu::util::new_instance_with_webgpu_detection(&wgpu::InstanceDescriptor {
-                    backends,
+                    backends: wgpu26_settings.backends & !backends_to_avoid,
                     flags: wgpu26_settings.instance_flags,
                     backend_options: wgpu26_settings.backend_options,
                     memory_budget_thresholds: wgpu26_settings.instance_memory_budget_thresholds,
@@ -291,11 +286,7 @@ pub fn init_instance_adapter_device_queue_surface(
             (instance, adapter, device, queue, surface)
         }
         None => {
-            let mut backends = wgpu::Backends::from_env().unwrap_or_default();
-            if let Some(backends_to_avoid) = backends_to_avoid {
-                backends.remove(backends_to_avoid);
-            }
-
+            let backends = wgpu::Backends::from_env().unwrap_or_default() & !backends_to_avoid;
             let dx12_shader_compiler = wgpu::Dx12Compiler::from_env().unwrap_or_default();
             let gles_minor_version = wgpu::Gles3MinorVersion::from_env().unwrap_or_default();
 

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -133,6 +133,7 @@ impl FemtoVGRenderer<WGPUBackend> {
             i_slint_core::graphics::wgpu_26::init_instance_adapter_device_queue_surface(
                 window_handle,
                 requested_graphics_api,
+                None,
             )?;
 
         let mut surface_config =

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -133,7 +133,8 @@ impl FemtoVGRenderer<WGPUBackend> {
             i_slint_core::graphics::wgpu_26::init_instance_adapter_device_queue_surface(
                 window_handle,
                 requested_graphics_api,
-                None,
+                /* rendering artifacts :( */
+                wgpu::Backends::GL,
             )?;
 
         let mut surface_config =

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -22,9 +22,16 @@ path = "lib.rs"
 wayland = ["glutin/wayland", "softbuffer/wayland", "softbuffer/wayland-dlopen"]
 x11 = ["glutin/x11", "glutin/glx", "softbuffer/x11", "softbuffer/x11-dlopen"]
 opengl = []
-vulkan = ["skia-safe/vulkan", "ash", "vulkano"]
+vulkan = ["skia-safe/vulkan", "dep:ash", "vulkano"]
 kms = ["softbuffer/kms"]
-unstable-wgpu-26 = ["i-slint-core/unstable-wgpu-26"]
+unstable-wgpu-26 = [
+  "i-slint-core/unstable-wgpu-26",
+  "dep:wgpu-26",
+  "dep:spin_on",
+  "dep:metal",
+  "dep:foreign-types",
+  "dep:ash",
+]
 default = []
 
 [dependencies]
@@ -49,6 +56,9 @@ unicode-segmentation = { workspace = true }
 ash = { version = "^0.38.0", optional = true }
 vulkano = { version = "0.35.0", optional = true, default-features = false }
 
+wgpu-26 = { workspace = true, optional = true }
+spin_on = { version = "0.1", optional = true }
+
 [target.'cfg(any(not(target_vendor = "apple"), target_os = "macos"))'.dependencies]
 glutin = { workspace = true, default-features = false, features = ["egl", "wgl"] }
 
@@ -59,7 +69,11 @@ bytemuck = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 windows = { version = "0.61.1", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
+windows_58 = { package = "windows", version = "0.58.0", features = ["Win32", "Win32_System_Com", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common", "Win32_System_Threading", "Win32_Security"] }
+windows-core = { package = "windows-core", version = "0.61.0" }
+windows-core_58 = { package = "windows-core", version = "0.58.0" }
 skia-safe = { version = "0.87", features = ["d3d"] }
+wgpu-26 = { workspace = true, optional = true, features = ["dx12"] }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc2 = { version = "0.6.0" }
@@ -71,8 +85,13 @@ objc2-core-foundation = { version = "0.3.0", default-features = false, features 
 skia-safe = { version = "0.87", features = ["metal"] }
 raw-window-metal = "1.0"
 
+metal = { version = "0.31", optional = true }
+foreign-types = { version = "0.5.0", optional = true }
+wgpu-26 = { workspace = true, optional = true, features = ["metal"] }
+
 [target.'cfg(not(any(target_vendor = "apple", target_family = "windows")))'.dependencies]
-skia-safe = { version = "0.87", features = ["gl"] }
+skia-safe = { version = "0.87", features = ["gl", "vulkan"] }
+wgpu-26 = { workspace = true, optional = true, features = ["vulkan"] }
 
 [build-dependencies]
 cfg_aliases = { workspace = true }

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -101,7 +101,9 @@ pub(crate) fn as_skia_image(
             surface,
         ),
         #[cfg(feature = "unstable-wgpu-26")]
-        ImageInner::WGPUTexture(..) => None,
+        ImageInner::WGPUTexture(any_wgpu_texture) => {
+            surface.and_then(|surface| surface.import_wgpu_texture(canvas, any_wgpu_texture))
+        }
     }
 }
 

--- a/internal/renderers/skia/d3d_surface.rs
+++ b/internal/renderers/skia/d3d_surface.rs
@@ -258,8 +258,8 @@ pub struct D3DSurface {
 impl super::Surface for D3DSurface {
     fn new(
         _shared_context: &SkiaSharedContext,
-        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
-        _display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+        _display_handle: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {

--- a/internal/renderers/skia/metal_surface.rs
+++ b/internal/renderers/skia/metal_surface.rs
@@ -60,8 +60,8 @@ pub struct MetalSurface {
 impl super::Surface for MetalSurface {
     fn new(
         shared_context: &SkiaSharedContext,
-        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
-        _display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+        _display_handle: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -30,8 +30,8 @@ pub struct OpenGLSurface {
 impl super::Surface for OpenGLSurface {
     fn new(
         _shared_context: &SkiaSharedContext,
-        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, PlatformError> {
@@ -47,14 +47,6 @@ impl super::Surface for OpenGLSurface {
 
     fn name(&self) -> &'static str {
         "opengl"
-    }
-
-    fn supports_graphics_api() -> bool {
-        true
-    }
-
-    fn supports_graphics_api_with_self(&self) -> bool {
-        true
     }
 
     fn with_graphics_api(&self, callback: &mut dyn FnMut(GraphicsAPI<'_>)) {

--- a/internal/renderers/skia/software_surface.rs
+++ b/internal/renderers/skia/software_surface.rs
@@ -32,11 +32,11 @@ pub trait RenderBuffer {
 }
 
 struct SoftbufferRenderBuffer {
-    _context: softbuffer::Context<Arc<dyn raw_window_handle::HasDisplayHandle>>,
+    _context: softbuffer::Context<Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>>,
     surface: RefCell<
         softbuffer::Surface<
-            Arc<dyn raw_window_handle::HasDisplayHandle>,
-            Arc<dyn raw_window_handle::HasWindowHandle>,
+            Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
+            Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
         >,
     >,
 }
@@ -115,8 +115,8 @@ pub struct SoftwareSurface {
 impl super::Surface for SoftwareSurface {
     fn new(
         _shared_context: &SkiaSharedContext,
-        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
         _size: PhysicalWindowSize,
         _requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {

--- a/internal/renderers/skia/vulkan_surface.rs
+++ b/internal/renderers/skia/vulkan_surface.rs
@@ -210,8 +210,8 @@ impl VulkanSurface {
 impl super::Surface for VulkanSurface {
     fn new(
         shared_context: &SkiaSharedContext,
-        window_handle: Arc<dyn raw_window_handle::HasWindowHandle>,
-        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle>,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
         size: PhysicalWindowSize,
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Self, i_slint_core::platform::PlatformError> {

--- a/internal/renderers/skia/wgpu_26_surface.rs
+++ b/internal/renderers/skia/wgpu_26_surface.rs
@@ -45,7 +45,12 @@ impl super::Surface for WGPUSurface {
             i_slint_core::graphics::wgpu_26::init_instance_adapter_device_queue_surface(
                 Box::new(WindowAndDisplayHandle(window_handle, display_handle)),
                 requested_graphics_api,
-                if cfg!(target_os = "windows") { Some(wgpu::Backends::VULKAN) } else { None },
+                wgpu::Backends::GL /* we're not mapping that to skia because we can't save/restore state */
+                    .union(if cfg!(target_os = "windows") {
+                        wgpu::Backends::VULKAN
+                    } else {
+                        wgpu::Backends::empty()
+                    }),
             )?;
 
         let mut surface_config =

--- a/internal/renderers/skia/wgpu_26_surface.rs
+++ b/internal/renderers/skia/wgpu_26_surface.rs
@@ -45,6 +45,7 @@ impl super::Surface for WGPUSurface {
             i_slint_core::graphics::wgpu_26::init_instance_adapter_device_queue_surface(
                 Box::new(WindowAndDisplayHandle(window_handle, display_handle)),
                 requested_graphics_api,
+                if cfg!(target_os = "windows") { Some(wgpu::Backends::VULKAN) } else { None },
             )?;
 
         let mut surface_config =

--- a/internal/renderers/skia/wgpu_26_surface.rs
+++ b/internal/renderers/skia/wgpu_26_surface.rs
@@ -1,0 +1,283 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use i_slint_core::api::{GraphicsAPI, PhysicalSize as PhysicalWindowSize, Window};
+use i_slint_core::graphics::RequestedGraphicsAPI;
+use i_slint_core::item_rendering::DirtyRegion;
+use i_slint_core::platform::PlatformError;
+
+use std::cell::RefCell;
+use std::sync::Arc;
+
+use wgpu_26 as wgpu;
+
+use crate::SkiaSharedContext;
+
+#[cfg(target_family = "windows")]
+mod dx12;
+#[cfg(target_vendor = "apple")]
+mod metal;
+#[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+mod vulkan;
+
+/// This surface renders into the given window using Metal. The provided display argument
+/// is ignored, as it has no meaning on macOS.
+pub struct WGPUSurface {
+    gr_context: RefCell<skia_safe::gpu::DirectContext>,
+    instance: wgpu::Instance,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    surface_config: RefCell<wgpu::SurfaceConfiguration>,
+    surface: wgpu::Surface<'static>,
+    textures_to_transition_for_sampling: RefCell<Vec<wgpu::Texture>>,
+    backend: Backend,
+}
+
+impl super::Surface for WGPUSurface {
+    fn new(
+        _shared_context: &SkiaSharedContext,
+        window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
+        size: PhysicalWindowSize,
+        requested_graphics_api: Option<RequestedGraphicsAPI>,
+    ) -> Result<Self, PlatformError> {
+        let (instance, adapter, device, queue, surface) =
+            i_slint_core::graphics::wgpu_26::init_instance_adapter_device_queue_surface(
+                Box::new(WindowAndDisplayHandle(window_handle, display_handle)),
+                requested_graphics_api,
+            )?;
+
+        let mut surface_config =
+            surface.get_default_config(&adapter, size.width, size.height).unwrap();
+
+        let swapchain_capabilities = surface.get_capabilities(&adapter);
+        let swapchain_format = swapchain_capabilities
+            .formats
+            .iter()
+            .find(|f| !f.is_srgb())
+            .copied()
+            .unwrap_or_else(|| swapchain_capabilities.formats[0]);
+        surface_config.format = swapchain_format;
+        surface.configure(&device, &surface_config);
+
+        let backend: Backend = adapter.get_info().backend.try_into()?;
+
+        let gr_context = backend.make_context(&adapter, &device, &queue);
+
+        Ok(Self {
+            gr_context: RefCell::new(
+                gr_context.ok_or_else(|| {
+                    PlatformError::from("Failed to create Skia context from WGPU")
+                })?,
+            ),
+            instance,
+            device,
+            queue,
+            surface_config: surface_config.into(),
+            surface,
+            textures_to_transition_for_sampling: RefCell::new(Vec::new()),
+            backend,
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        "wgpu"
+    }
+
+    fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
+        let mut surface_config = self.surface_config.borrow_mut();
+
+        surface_config.width = size.width;
+        surface_config.height = size.height;
+
+        self.surface.configure(&self.device, &surface_config);
+        Ok(())
+    }
+
+    fn render(
+        &self,
+        _window: &Window,
+        size: PhysicalWindowSize,
+        callback: &dyn Fn(
+            &skia_safe::Canvas,
+            Option<&mut skia_safe::gpu::DirectContext>,
+            u8,
+        ) -> Option<DirtyRegion>,
+        pre_present_callback: &RefCell<Option<Box<dyn FnMut()>>>,
+    ) -> Result<(), PlatformError> {
+        let gr_context = &mut self.gr_context.borrow_mut();
+
+        let frame =
+            self.surface.get_current_texture().expect("unable to get next texture from swapchain");
+
+        let skia_surface = self.backend.make_surface(size, gr_context, &frame);
+
+        let mut skia_surface = skia_surface
+            .ok_or_else(|| PlatformError::from("Failed to create Skia surface from WGPU"))?;
+
+        callback(skia_surface.canvas(), Some(gr_context), 0);
+
+        let textures_to_transition = self.textures_to_transition_for_sampling.take();
+        if !textures_to_transition.is_empty() {
+            let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Skia texture transition encoder"),
+            });
+            encoder.transition_resources(
+                std::iter::empty(),
+                textures_to_transition.iter().map(|texture| wgpu::TextureTransition {
+                    texture,
+                    selector: None,
+                    state: wgpu::TextureUses::RESOURCE,
+                }),
+            );
+
+            self.queue.submit(Some(encoder.finish()));
+        }
+
+        gr_context.submit(None);
+
+        if let Some(pre_present_callback) = pre_present_callback.borrow_mut().as_mut() {
+            pre_present_callback();
+        }
+
+        frame.present();
+
+        Ok(())
+    }
+
+    fn bits_per_pixel(&self) -> Result<u8, PlatformError> {
+        Ok(match self.surface_config.borrow().format {
+            wgpu_26::TextureFormat::Rgba8Unorm
+            | wgpu_26::TextureFormat::Rgba8UnormSrgb
+            | wgpu_26::TextureFormat::Bgra8Unorm
+            | wgpu_26::TextureFormat::Bgra8UnormSrgb => 32,
+            fmt @ _ => return Err(format!("Unsupported surface format {:#?}", fmt).into()),
+        })
+    }
+
+    fn with_graphics_api(&self, callback: &mut dyn FnMut(GraphicsAPI<'_>)) {
+        let api = i_slint_core::graphics::create_graphics_api_wgpu_26(
+            self.instance.clone(),
+            self.device.clone(),
+            self.queue.clone(),
+        );
+        callback(api)
+    }
+
+    fn import_wgpu_texture(
+        &self,
+        canvas: &skia_safe::Canvas,
+        any_wgpu_texture: &i_slint_core::graphics::WGPUTexture,
+    ) -> Option<skia_safe::Image> {
+        let texture = match any_wgpu_texture {
+            i_slint_core::graphics::WGPUTexture::WGPU26Texture(texture) => texture.clone(),
+        };
+
+        // Skia won't submit commands right away, so remember the texture and transition before
+        // submitting.
+        self.textures_to_transition_for_sampling.borrow_mut().push(texture.clone());
+
+        self.backend.import_texture(canvas, texture)
+    }
+}
+
+struct WindowAndDisplayHandle(
+    Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+    Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
+);
+
+impl raw_window_handle::HasWindowHandle for WindowAndDisplayHandle {
+    fn window_handle(
+        &self,
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
+        self.0.window_handle()
+    }
+}
+
+impl raw_window_handle::HasDisplayHandle for WindowAndDisplayHandle {
+    fn display_handle(
+        &self,
+    ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
+        self.1.display_handle()
+    }
+}
+
+enum Backend {
+    #[cfg(target_vendor = "apple")]
+    Metal,
+    #[cfg(target_family = "windows")]
+    Dx12,
+    #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+    Vulkan,
+}
+
+impl TryFrom<wgpu::Backend> for Backend {
+    type Error = PlatformError;
+
+    fn try_from(wgpu_backend: wgpu::Backend) -> Result<Self, Self::Error> {
+        match wgpu_backend {
+            wgpu_26::Backend::Noop => {
+                Err(PlatformError::from("Cannot use WGPU Noop backend with Skia"))
+            }
+            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            wgpu_26::Backend::Vulkan => Ok(Self::Vulkan),
+            #[cfg(target_vendor = "apple")]
+            wgpu_26::Backend::Metal => Ok(Self::Metal),
+            #[cfg(target_family = "windows")]
+            wgpu_26::Backend::Dx12 => Ok(Self::Dx12),
+            other @ _ => Err(PlatformError::from(format!(
+                "Unsupported WGPU backend for use with Skia: {}",
+                other.to_string()
+            ))),
+        }
+    }
+}
+
+impl Backend {
+    fn make_context(
+        &self,
+        _adapter: &wgpu::Adapter,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+    ) -> Option<skia_safe::gpu::DirectContext> {
+        match self {
+            #[cfg(target_vendor = "apple")]
+            Self::Metal => metal::make_metal_context(device, queue),
+            #[cfg(target_family = "windows")]
+            Self::Dx12 => unsafe { dx12::make_dx12_context(&_adapter, &device, &queue) },
+            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            Self::Vulkan => unsafe { vulkan::make_vulkan_context(&device, &queue) },
+        }
+    }
+
+    fn make_surface(
+        &self,
+        size: PhysicalWindowSize,
+        gr_context: &mut skia_safe::gpu::DirectContext,
+        frame: &wgpu::SurfaceTexture,
+    ) -> Option<skia_safe::Surface> {
+        match self {
+            #[cfg(target_vendor = "apple")]
+            Self::Metal => unsafe { metal::make_metal_surface(size, gr_context, frame) },
+            #[cfg(target_family = "windows")]
+            Self::Dx12 => unsafe { dx12::make_dx12_surface(size, gr_context, frame) },
+            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            Self::Vulkan => unsafe { vulkan::make_vulkan_surface(size, gr_context, frame) },
+        }
+    }
+
+    fn import_texture(
+        &self,
+        canvas: &skia_safe::Canvas,
+        texture: wgpu::Texture,
+    ) -> Option<skia_safe::Image> {
+        match self {
+            #[cfg(target_vendor = "apple")]
+            Self::Metal => unsafe { metal::import_metal_texture(canvas, texture) },
+            #[cfg(target_family = "windows")]
+            Self::Dx12 => unsafe { dx12::import_dx12_texture(canvas, texture) },
+            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            Self::Vulkan => unsafe { vulkan::import_vulkan_texture(canvas, texture) },
+        }
+    }
+}

--- a/internal/renderers/skia/wgpu_26_surface/dx12.rs
+++ b/internal/renderers/skia/wgpu_26_surface/dx12.rs
@@ -1,0 +1,135 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
+
+use windows::Win32::Graphics::Direct3D12::{ID3D12Resource, D3D12_RESOURCE_STATE_PRESENT};
+use windows::Win32::Graphics::Dxgi::Common::DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN;
+use windows::Win32::Graphics::Dxgi::Common::{
+    DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
+};
+
+use wgpu_26 as wgpu;
+
+pub unsafe fn make_dx12_surface(
+    size: PhysicalWindowSize,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    frame: &wgpu::SurfaceTexture,
+) -> Option<skia_safe::Surface> {
+    let dx12_texture = frame.texture.as_hal::<wgpu::wgc::api::Dx12>();
+
+    let texture_info = skia_safe::gpu::d3d::TextureResourceInfo {
+        resource: windows_core::Interface::from_raw(windows_core_58::Interface::into_raw(
+            dx12_texture.unwrap().raw_resource().clone(),
+        )),
+        alloc: None,
+        resource_state: D3D12_RESOURCE_STATE_PRESENT,
+        format: DXGI_FORMAT_R8G8B8A8_UNORM,
+        sample_count: 1,
+        level_count: 1,
+        sample_quality_pattern: DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
+        protected: skia_safe::gpu::Protected::No,
+    };
+
+    let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_d3d(
+        (size.width as i32, size.height as i32),
+        &texture_info,
+    );
+
+    skia_safe::gpu::surfaces::wrap_backend_render_target(
+        gr_context,
+        &backend_render_target,
+        skia_safe::gpu::SurfaceOrigin::TopLeft,
+        skia_safe::ColorType::RGBA8888,
+        None,
+        None,
+    )
+}
+
+#[allow(non_snake_case)]
+pub unsafe fn import_dx12_texture(
+    canvas: &skia_safe::Canvas,
+    texture: wgpu::Texture,
+) -> Option<skia_safe::Image> {
+    let dx12_texture = texture.as_hal::<wgpu::wgc::api::Dx12>();
+
+    let resource: ID3D12Resource = windows_core::Interface::from_raw(
+        windows_core_58::Interface::into_raw(dx12_texture.unwrap().raw_resource().clone()),
+    );
+
+    let dxgi_texture_format = resource.GetDesc().Format;
+
+    let color_type = match dxgi_texture_format {
+        DXGI_FORMAT_R8G8B8A8_UNORM => skia_safe::ColorType::RGBA8888,
+        DXGI_FORMAT_R8G8B8A8_UNORM_SRGB => skia_safe::ColorType::SRGBA8888,
+        _ => return None,
+    };
+
+    let texture_info = skia_safe::gpu::d3d::TextureResourceInfo {
+        resource,
+        alloc: None,
+        resource_state: D3D12_RESOURCE_STATE_PRESENT,
+        format: dxgi_texture_format,
+        sample_count: 1,
+        level_count: 1,
+        sample_quality_pattern: DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
+        protected: skia_safe::gpu::Protected::No,
+    };
+    let size = texture.size();
+
+    let backend_texture = skia_safe::gpu::BackendTexture::new_d3d(
+        (size.width as i32, size.height as i32),
+        &texture_info,
+    );
+
+    Some(
+        skia_safe::image::Image::from_texture(
+            canvas.recording_context().as_mut().unwrap(),
+            &backend_texture,
+            skia_safe::gpu::SurfaceOrigin::TopLeft,
+            color_type,
+            skia_safe::AlphaType::Unpremul,
+            None,
+        )
+        .unwrap(),
+    )
+}
+
+pub unsafe fn make_dx12_context(
+    adapter: &wgpu::Adapter,
+    _device: &wgpu::Device,
+    queue: &wgpu::Queue,
+) -> Option<skia_safe::gpu::DirectContext> {
+    let backend = unsafe {
+        let maybe_dx12_queue = queue.as_hal::<wgpu::wgc::api::Dx12>();
+        let dx12_adapter = adapter.as_hal::<wgpu::wgc::api::Dx12>().unwrap();
+
+        maybe_dx12_queue.map(|dx12_queue| {
+            let dx12_queue_raw = dx12_queue.as_raw();
+            let mut dx12_device_old: Option<windows_58::Win32::Graphics::Direct3D12::ID3D12Device> =
+                None;
+            dx12_queue_raw.GetDevice(&mut dx12_device_old as _).unwrap();
+            let dx12_device_old = dx12_device_old.unwrap();
+            let dx12_device = windows_core::Interface::from_raw(
+                windows_core_58::Interface::into_raw(dx12_device_old),
+            );
+
+            let idxgiadapter_1: windows_58::Win32::Graphics::Dxgi::IDXGIAdapter1 =
+                dx12_adapter.as_raw().clone().into();
+
+            skia_safe::gpu::d3d::BackendContext {
+                adapter: windows_core::Interface::from_raw(windows_core_58::Interface::into_raw(
+                    idxgiadapter_1,
+                )),
+                device: dx12_device,
+                queue: windows_core::Interface::from_raw(windows_core_58::Interface::into_raw(
+                    dx12_queue_raw.clone(),
+                )),
+                memory_allocator: None,
+                protected_context: skia_safe::gpu::Protected::No,
+            }
+        })
+    };
+
+    skia_safe::gpu::DirectContext::new_d3d(&backend.unwrap(), None)
+}

--- a/internal/renderers/skia/wgpu_26_surface/metal.rs
+++ b/internal/renderers/skia/wgpu_26_surface/metal.rs
@@ -1,0 +1,91 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use foreign_types::ForeignType;
+use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
+
+use skia_safe::gpu::mtl;
+
+use wgpu_26 as wgpu;
+
+pub unsafe fn make_metal_surface(
+    size: PhysicalWindowSize,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    frame: &wgpu::SurfaceTexture,
+) -> Option<skia_safe::Surface> {
+    let metal_texture = frame.texture.as_hal::<wgpu::wgc::api::Metal>();
+
+    let texture_info =
+        mtl::TextureInfo::new(metal_texture.unwrap().raw_handle().as_ptr() as mtl::Handle);
+
+    let backend_render_target = skia_safe::gpu::backend_render_targets::make_mtl(
+        (size.width as i32, size.height as i32),
+        &texture_info,
+    );
+
+    skia_safe::gpu::surfaces::wrap_backend_render_target(
+        gr_context,
+        &backend_render_target,
+        skia_safe::gpu::SurfaceOrigin::TopLeft,
+        skia_safe::ColorType::BGRA8888,
+        None,
+        None,
+    )
+}
+
+pub unsafe fn import_metal_texture(
+    canvas: &skia_safe::Canvas,
+    texture: wgpu::Texture,
+) -> Option<skia_safe::Image> {
+    let metal_texture = texture.as_hal::<wgpu::wgc::api::Metal>();
+
+    let texture_info =
+        mtl::TextureInfo::new(metal_texture.unwrap().raw_handle().as_ptr() as mtl::Handle);
+    let size = texture.size();
+
+    let backend_texture = skia_safe::gpu::backend_textures::make_mtl(
+        (size.width as _, size.height as _),
+        skia_safe::gpu::Mipmapped::No,
+        &texture_info,
+        "Borrowed Metal texture",
+    );
+    Some(
+        skia_safe::image::Image::from_texture(
+            canvas.recording_context().as_mut().unwrap(),
+            &backend_texture,
+            skia_safe::gpu::SurfaceOrigin::TopLeft,
+            match texture.format() {
+                wgpu::TextureFormat::Rgba8Unorm => skia_safe::ColorType::RGBA8888,
+                wgpu::TextureFormat::Rgba8UnormSrgb => skia_safe::ColorType::SRGBA8888,
+                _ => return None,
+            },
+            skia_safe::AlphaType::Unpremul,
+            None,
+        )
+        .unwrap(),
+    )
+}
+
+pub fn make_metal_context(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+) -> Option<skia_safe::gpu::DirectContext> {
+    let backend = unsafe {
+        let maybe_metal_device = device.as_hal::<wgpu::wgc::api::Metal>();
+        let maybe_metal_queue = queue.as_hal::<wgpu::wgc::api::Metal>();
+
+        maybe_metal_device.and_then(|metal_device| {
+            let metal_device_raw = &*metal_device.raw_device().lock();
+
+            maybe_metal_queue.map(|metal_queue| {
+                let metal_queue_raw = &*metal_queue.as_raw().lock();
+                mtl::BackendContext::new(
+                    metal_device_raw.as_ptr() as mtl::Handle,
+                    metal_queue_raw.as_ptr() as mtl::Handle,
+                )
+            })
+        })?
+    };
+
+    skia_safe::gpu::direct_contexts::make_metal(&backend, None)
+}

--- a/internal/renderers/skia/wgpu_26_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_26_surface/vulkan.rs
@@ -1,0 +1,161 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use i_slint_core::api::PhysicalSize as PhysicalWindowSize;
+
+use ash::vk::Handle;
+use skia_safe::gpu::vk;
+
+use wgpu_26 as wgpu;
+
+pub unsafe fn make_vulkan_surface(
+    size: PhysicalWindowSize,
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    frame: &wgpu::SurfaceTexture,
+) -> Option<skia_safe::Surface> {
+    let vulkan_texture = frame.texture.as_hal::<wgpu::wgc::api::Vulkan>();
+
+    let alloc = skia_safe::gpu::vk::Alloc::default();
+
+    let (vk_format, color_type) = match frame.texture.format() {
+        wgpu::TextureFormat::Rgba8Unorm => {
+            (skia_safe::gpu::vk::Format::R8G8B8A8_UNORM, skia_safe::ColorType::RGBA8888)
+        }
+        wgpu::TextureFormat::Rgba8UnormSrgb => {
+            (skia_safe::gpu::vk::Format::R8G8B8A8_SRGB, skia_safe::ColorType::SRGBA8888)
+        }
+        wgpu::TextureFormat::Bgra8Unorm => {
+            (skia_safe::gpu::vk::Format::B8G8R8A8_UNORM, skia_safe::ColorType::BGRA8888)
+        }
+        _ => return None,
+    };
+
+    let texture_info = &unsafe {
+        skia_safe::gpu::vk::ImageInfo::new(
+            vulkan_texture.unwrap().raw_handle().as_raw() as _,
+            alloc,
+            skia_safe::gpu::vk::ImageTiling::OPTIMAL,
+            skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            vk_format,
+            1,
+            None,
+            None,
+            None,
+            None,
+        )
+    };
+
+    let backend_render_target = skia_safe::gpu::backend_render_targets::make_vk(
+        (size.width as i32, size.height as i32),
+        &texture_info,
+    );
+
+    skia_safe::gpu::surfaces::wrap_backend_render_target(
+        gr_context,
+        &backend_render_target,
+        skia_safe::gpu::SurfaceOrigin::TopLeft,
+        color_type,
+        None,
+        None,
+    )
+}
+
+pub unsafe fn import_vulkan_texture(
+    canvas: &skia_safe::Canvas,
+    texture: wgpu::Texture,
+) -> Option<skia_safe::Image> {
+    let vulkan_texture = texture.as_hal::<wgpu::wgc::api::Vulkan>();
+
+    let alloc = skia_safe::gpu::vk::Alloc::default();
+
+    let (vk_format, color_type) = match texture.format() {
+        wgpu::TextureFormat::Rgba8Unorm => {
+            (skia_safe::gpu::vk::Format::R8G8B8A8_UNORM, skia_safe::ColorType::RGBA8888)
+        }
+        wgpu::TextureFormat::Rgba8UnormSrgb => {
+            (skia_safe::gpu::vk::Format::R8G8B8A8_SRGB, skia_safe::ColorType::SRGBA8888)
+        }
+        wgpu::TextureFormat::Bgra8Unorm => {
+            (skia_safe::gpu::vk::Format::B8G8R8A8_UNORM, skia_safe::ColorType::BGRA8888)
+        }
+        _ => return None,
+    };
+
+    let texture_info = &unsafe {
+        skia_safe::gpu::vk::ImageInfo::new(
+            vulkan_texture.unwrap().raw_handle().as_raw() as _,
+            alloc,
+            skia_safe::gpu::vk::ImageTiling::OPTIMAL,
+            skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            vk_format,
+            1,
+            None,
+            None,
+            None,
+            None,
+        )
+    };
+
+    let size = texture.size();
+
+    let backend_texture = skia_safe::gpu::backend_textures::make_vk(
+        (size.width as _, size.height as _),
+        &texture_info,
+        "Borrowed Vulkan texture",
+    );
+    Some(
+        skia_safe::image::Image::from_texture(
+            canvas.recording_context().as_mut().unwrap(),
+            &backend_texture,
+            skia_safe::gpu::SurfaceOrigin::TopLeft,
+            color_type,
+            skia_safe::AlphaType::Unpremul,
+            None,
+        )
+        .unwrap(),
+    )
+}
+
+pub unsafe fn make_vulkan_context(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+) -> Option<skia_safe::gpu::DirectContext> {
+    let maybe_vulkan_device = device.as_hal::<wgpu::wgc::api::Vulkan>();
+    let maybe_vulkan_queue = queue.as_hal::<wgpu::wgc::api::Vulkan>();
+
+    maybe_vulkan_device.and_then(|vulkan_device| {
+        maybe_vulkan_queue.map(|vulkan_queue| {
+            let vulkan_queue_raw = vulkan_queue.as_raw();
+
+            let get_proc = |of| {
+                let result = match of {
+                    skia_safe::gpu::vk::GetProcOf::Instance(instance, name) => vulkan_device
+                        .shared_instance()
+                        .entry()
+                        .get_instance_proc_addr(ash::vk::Instance::from_raw(instance as _), name),
+                    skia_safe::gpu::vk::GetProcOf::Device(device, name) => vulkan_device
+                        .shared_instance()
+                        .raw_instance()
+                        .get_device_proc_addr(ash::vk::Device::from_raw(device as _), name),
+                };
+
+                match result {
+                    Some(f) => f as _,
+                    None => {
+                        //println!("resolve of {} failed", of.name().to_str().unwrap());
+                        core::ptr::null()
+                    }
+                }
+            };
+
+            let backend = vk::BackendContext::new(
+                vulkan_device.shared_instance().raw_instance().handle().as_raw() as _,
+                vulkan_device.raw_physical_device().as_raw() as _,
+                vulkan_device.raw_device().handle().as_raw() as _,
+                (vulkan_queue_raw.as_raw() as _, vulkan_device.queue_family_index() as _),
+                &get_proc,
+            );
+            skia_safe::gpu::direct_contexts::make_vulkan(&backend, None)
+        })
+    })?
+}


### PR DESCRIPTION
This enables using Skia for GUI rendering but combining it with application-provided WGPU textures, by transparently making `require_wgpu_25` work also with the skia renderer.
