### PR TITLE
compiler: fix compilation error when using Rust 1.88

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -827,7 +827,7 @@ impl SyntaxNode {
             .find(|n| n.kind() == kind)
             .and_then(|x| x.as_token().map(|x| x.text().into()))
     }
-    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> + use<'_> {
         let source_file = self.source_file.clone();
         self.node
             .descendants()


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Rust 1.88 produced a compilation error on a piece of code that previous Rust versions accepted. This is a trivial fix that does exactly what `rustc` suggests in the error message.

Update: I tried to roll back both Rust and Slint, but I couldn't find a working combination for Slint >=1.10, when the relevant piece of code was added. This is very curious, because these combinations worked just fine the day before, so it was neither a Rust update nor a Slint change that broke it, but then what?

```
error[E0700]: hidden type for `impl Iterator<Item = parser::SyntaxNode>` captures lifetime that does not appear in bounds
   --> internal\compiler\parser.rs:832:9
    |
830 |       pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> {
    |                          -----     -------------------------------- opaque type defined here
    |                          |
    |                          hidden type `std::iter::Map<impl Iterator<Item = rowan::SyntaxNode<parser::Language>>, {closure@internal\compiler\parser.rs:834:18: 834:29}>` captures the anonymous lifetime defined here
831 |           let source_file = self.source_file.clone();
832 | /         self.node
833 | |             .descendants()
834 | |             .map(move |node| SyntaxNode { node, source_file: source_file.clone() })
    | |___________________________________________________________________________________^
    |
help: add a `use<...>` bound to explicitly capture `'_`
    |
830 |     pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> + use<'_> {
    |                                                                   +++++++++
```