### PR TITLE
LinuxKMS: Support framebuffers with padded lines

### DIFF
--- a/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
+++ b/internal/backends/linuxkms/display/swdisplay/linuxfb.rs
@@ -143,7 +143,7 @@ impl LinuxFBDisplay {
         let min_line_length = width * bpp;
         if line_length < min_line_length {
             return Err(format!(
-                "Error using linux framebuffer: line length ({}) is less than minimum required ({})", 
+                "Error using linux framebuffer: line length ({}) is less than minimum required ({})",
                 line_length, min_line_length
             ).into());
         }


### PR DESCRIPTION
Implement support for Linux framebuffers that have line padding by properly handling the line_length field from fb_fix_screeninfo. This allows the backend to work with displays that use non-linear memory organization where each row has padding bytes at the end.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
