### PR TITLE
winit: Fix occasional hang on Windows when quitting python app that u…

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -8,6 +8,7 @@
     aspects of windows on the screen.
 */
 use crate::drag_resize_window::{handle_cursor_move_for_resize, handle_resize};
+use crate::winitwindowadapter::WindowVisibility;
 use crate::WinitWindowEventResult;
 use crate::{SharedBackendData, SlintEvent};
 use corelib::graphics::euclid;
@@ -87,6 +88,22 @@ impl EventLoopState {
             current_resize_direction: Default::default(),
             pumping_events_instantly: Default::default(),
             custom_application_handler,
+        }
+    }
+
+    /// Free graphics resources for any hidden windows. Called when quitting the event loop, to work
+    /// around #8795.
+    fn suspend_all_hidden_windows(&self) {
+        let windows_to_suspend = self
+            .shared_backend_data
+            .active_windows
+            .borrow()
+            .values()
+            .filter_map(|w| w.upgrade())
+            .filter(|w| matches!(w.visibility(), WindowVisibility::Hidden))
+            .collect::<Vec<_>>();
+        for window in windows_to_suspend.into_iter() {
+            let _ = window.suspend();
         }
     }
 }
@@ -407,7 +424,10 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
     fn user_event(&mut self, event_loop: &ActiveEventLoop, event: SlintEvent) {
         match event.0 {
             CustomEvent::UserEvent(user_callback) => user_callback(),
-            CustomEvent::Exit => event_loop.exit(),
+            CustomEvent::Exit => {
+                self.suspend_all_hidden_windows();
+                event_loop.exit()
+            }
             #[cfg(enable_accesskit)]
             CustomEvent::Accesskit(accesskit_winit::Event { window_id, window_event }) => {
                 if let Some(window) = self.shared_backend_data.window_by_id(window_id) {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -276,7 +276,7 @@ impl WinitWindowOrNone {
 }
 
 #[derive(Default, PartialEq, Clone, Copy)]
-enum WindowVisibility {
+pub(crate) enum WindowVisibility {
     #[default]
     Hidden,
     /// This implies that we might resize the window the first time it's shown.
@@ -513,7 +513,7 @@ impl WinitWindowAdapter {
         Ok(winit_window)
     }
 
-    fn suspend(&self) -> Result<(), PlatformError> {
+    pub(crate) fn suspend(&self) -> Result<(), PlatformError> {
         let mut winit_window_or_none = self.winit_window_or_none.borrow_mut();
         match *winit_window_or_none {
             WinitWindowOrNone::HasWindow { ref window, .. } => {
@@ -936,6 +936,10 @@ impl WinitWindowAdapter {
             }*/
             Ok(())
         }
+    }
+
+    pub(crate) fn visibility(&self) -> WindowVisibility {
+        self.shown.get()
     }
 
     pub(crate) fn pending_redraw(&self) -> bool {


### PR DESCRIPTION
…ses skia opengl renderer and certain renderer features

The backtrace indicates a very late shutdown causing an infinite loop deep inside skia.

To work around this, gracefully release any rendering resources for any hidden windows when quitting the event loop, thus earlier and ordered.

Fixes #8795

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
