### PR TITLE
Introduce `TextInput.caps-mode`

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -327,6 +327,7 @@ fn gen_corelib(
         "FillRule",
         "MouseCursor",
         "InputType",
+        "CapsMode",
         "StandardButtonKind",
         "DialogButtonRole",
         "FocusReason",

--- a/internal/backends/qt/qt_widgets/lineedit.rs
+++ b/internal/backends/qt/qt_widgets/lineedit.rs
@@ -3,7 +3,7 @@
 
 use i_slint_core::graphics::{Image, Rgba8Pixel, SharedPixelBuffer};
 use i_slint_core::input::FocusEventResult;
-use i_slint_core::items::InputType;
+use i_slint_core::items::{CapsMode, InputType};
 
 use super::*;
 
@@ -20,6 +20,7 @@ pub struct NativeLineEdit {
     pub enabled: Property<bool>,
     pub input_type: Property<InputType>,
     pub clear_icon: Property<Image>,
+    pub caps_mode: Property<CapsMode>,
     widget_ptr: std::cell::Cell<SlintTypeErasedWidgetPtr>,
     animation_tracker: Property<i32>,
 }

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -66,6 +66,19 @@ macro_rules! for_each_enums {
                 Center,
             }
 
+            /// This enum describes the how the soft-keyboard auto-capitalization should work for `TextInput`s.
+            /// Currently only supported on Android.
+            enum CapsMode {
+                /// No auto-capitalization
+                None,
+                /// Capitalize the first character of each sentence
+                Sentences,
+                /// capitalize the first character of each word
+                Words,
+                /// Capitalize all characters
+                All,
+            }
+
             /// This enum describes whether an event was rejected or accepted by an event handler.
             enum EventResult {
                 /// The event is rejected by this event handler and may then be handled by the parent item

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -316,6 +316,7 @@ export component TextInput {
     in property <length> page-height;
     in property <length> text-cursor-width; // StyleMetrics.text-cursor-width  set in apply_default_properties_from_style
     in property <InputType> input-type;
+    in property <CapsMode> caps-mode;
     // Internal, undocumented property, only exposed for tests.
     out property <int> cursor-position_byte-offset;
     // Internal, undocumented property, only exposed for tests.

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -9,6 +9,7 @@ export component LineEditBase inherits Rectangle {
     in property <bool> enabled <=> text-input.enabled;
     out property <bool> has-focus: text-input.has-focus;
     in property <InputType> input-type <=> text-input.input-type;
+    in property <CapsMode> caps-mode <=> text-input.caps-mode;
     in property <TextHorizontalAlignment> horizontal-alignment <=> text-input.horizontal-alignment;
     in property <bool> read-only <=> text-input.read-only;
     in property <int> font-weight <=> text-input.font-weight;

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -7,6 +7,7 @@ import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common
 export component LineEdit {
     in property <bool> enabled <=> base.enabled;
     in property <InputType> input-type;
+    in property <CapsMode> caps-mode <=> base.caps-mode;
     in property <TextHorizontalAlignment> horizontal-alignment <=> base.horizontal-alignment;
     in property <bool> read-only <=> base.read-only;
     in property <length> font-size <=> base.font-size;

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -8,6 +8,7 @@ import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common
 export component LineEdit {
     in property <bool> enabled <=> base.enabled;
     in property <InputType> input-type;
+    in property <CapsMode> caps-mode <=> base.caps-mode;
     in property <TextHorizontalAlignment> horizontal-alignment <=> base.horizontal-alignment;
     in property <bool> read-only <=> base.read-only;
     in property <length> font-size <=> base.font-size;

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -7,6 +7,7 @@ import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common
 export component LineEdit {
     in property <bool> enabled <=> base.enabled;
     in property <InputType> input-type;
+    in property <CapsMode> caps-mode <=> base.caps-mode;
     in property <TextHorizontalAlignment> horizontal-alignment <=> base.horizontal-alignment;
     in property <bool> read-only <=> base.read-only;
     in property <length> font-size <=> base.font-size;

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -10,6 +10,7 @@ export component LineEdit {
     in property <string> placeholder-text <=> base.placeholder-text;
     in property <bool> enabled <=> base.enabled;
     in property <InputType> input-type;
+    in property <CapsMode> caps-mode <=> base.caps-mode;
     in property horizontal-alignment <=> base.horizontal-alignment;
     in property read-only <=> base.read-only;
     out property <bool> has-focus: base.has-focus;

--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -7,6 +7,7 @@ export component LineEdit {
     in property <length> font-size <=> inner.font-size;
     in property <string> placeholder-text <=> inner.placeholder-text;
     in property input-type <=> inner.input-type;
+    in property <CapsMode> caps-mode <=> inner.caps-mode;
     in property horizontal-alignment <=> inner.horizontal-alignment;
     in property read-only <=> inner.read-only;
     in property <bool> enabled: true;

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -8,7 +8,7 @@ When adding an item or a property, it needs to be kept in sync with different pl
 Lookup the [`crate::items`] module documentation.
 */
 use super::{
-    EventResult, FontMetrics, InputType, Item, ItemConsts, ItemRc, ItemRef, KeyEventArg,
+    CapsMode, EventResult, FontMetrics, InputType, Item, ItemConsts, ItemRc, ItemRef, KeyEventArg,
     KeyEventResult, KeyEventType, PointArg, PointerEventButton, RenderingResult,
     TextHorizontalAlignment, TextOverflow, TextStrokeStyle, TextVerticalAlignment, TextWrap,
     VoidArg, WindowItem,
@@ -484,6 +484,7 @@ pub struct TextInput {
     pub vertical_alignment: Property<TextVerticalAlignment>,
     pub wrap: Property<TextWrap>,
     pub input_type: Property<InputType>,
+    pub caps_mode: Property<CapsMode>,
     pub letter_spacing: Property<LogicalLength>,
     pub width: Property<LogicalLength>,
     pub height: Property<LogicalLength>,
@@ -1498,6 +1499,7 @@ impl TextInput {
             cursor_rect_size,
             anchor_point,
             input_type: self.input_type(),
+            caps_mode: self.caps_mode(),
         }
     }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -18,7 +18,7 @@ use crate::item_tree::{
     ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeVTable, ItemTreeWeak, ItemWeak,
     ParentItemTraversalMode,
 };
-use crate::items::{ColorScheme, InputType, ItemRef, MouseCursor, PopupClosePolicy};
+use crate::items::{CapsMode, ColorScheme, InputType, ItemRef, MouseCursor, PopupClosePolicy};
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, SizeLengths};
 use crate::menus::MenuVTable;
 use crate::properties::{Property, PropertyTracker};
@@ -293,6 +293,8 @@ pub struct InputMethodProperties {
     pub anchor_point: LogicalPosition,
     /// The type of input for the text edit.
     pub input_type: InputType,
+    /// The caps mode for the text edit
+    pub caps_mode: CapsMode,
 }
 
 /// This struct describes layout constraints of a resizable element, such as a window.
@@ -913,6 +915,11 @@ impl WindowInner {
         } else {
             None
         }
+    }
+
+    /// Unfocus the currently focused item, if any.
+    pub fn unfocus_current(&self) {
+        self.take_focus_item(&FocusEvent::FocusOut(FocusReason::Programmatic));
     }
 
     /// Publish the new focus_item to this Window and return the FocusEventResult


### PR DESCRIPTION
This introduces a `caps-mode` field that sets up the Android soft-keyboard's auto-capitalization (and also allows similar features in other soft keyboards)

This PR is more of a "request for comments", because:
- We needed this property for our own soft keyboard, and I never actually tested the Android implementation, only our custom `input_method_request` window callback. It does work well there.
- I'm not sure about naming and the documentation.
- I couldn't run the doc update because `pnpm i` crashed with a heap overflow. (I also forgot to put the Changelog entry in the commit message, but I can amend it later.)

It would be awesome if someone could help with the above points.

(BTW, it would also be nice if `InputMethodRequest` and the callback was public API, because we really need it for our custom platform implementation, and using `i_slint_core::InternalToken` is super dirty.)