### PR TITLE
LineEdit: fix height for width dependency

### DIFF
--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -84,6 +84,7 @@ export component LineEdit {
             }
 
             LineEditClearIcon {
+                width: self.source.width * 1px;
                 text: base.text;
                 input-type: root.input-type;
                 source: @image-url("_edit_clear_symbolic.svg");
@@ -95,6 +96,7 @@ export component LineEdit {
             }
 
             if root.input-type == InputType.password: LineEditPasswordIcon {
+                width: self.source.width * 1px;
                 show-password-image: @image-url("_view_reveal.svg");
                 hide-password-image: @image-url("_view_conceal.svg");
                 colorize: base.text-color;

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -100,6 +100,7 @@ export component LineEdit {
             }
 
             LineEditClearIcon {
+                width: self.source.width * 1px;
                 text: base.text;
                 input-type: root.input-type;
                 source: @image-url("_clear.svg");
@@ -111,6 +112,7 @@ export component LineEdit {
             }
 
             if root.input-type == InputType.password: LineEditPasswordIcon {
+                width: self.source.width * 1px;
                 show-password-image: @image-url("_visibility.svg");
                 hide-password-image: @image-url("_visibility_off.svg");
                 colorize: base.text-color;

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -94,6 +94,7 @@ export component LineEdit {
             }
 
             LineEditClearIcon {
+                width: 16px;
                 text: base.text;
                 input-type: root.input-type;
                 source: @image-url("_dismiss.svg");
@@ -105,6 +106,7 @@ export component LineEdit {
             }
 
             if root.input-type == InputType.password: LineEditPasswordIcon {
+                width: self.source.width * 1px;
                 show-password-image: @image-url("_eye_show.svg");
                 hide-password-image: @image-url("_eye_hide.svg");
                 colorize: base.text-color;

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -86,6 +86,7 @@ export component LineEdit {
             }
 
             LineEditClearIcon {
+                width: self.source.width * 1px;
                 text: base.text;
                 input-type: root.input-type;
                 source: @image-url("_clear.svg");
@@ -97,6 +98,7 @@ export component LineEdit {
             }
 
             if root.input-type == InputType.password: LineEditPasswordIcon {
+                width: self.source.width * 1px;
                 show-password-image: @image-url("_visibility.svg");
                 hide-password-image: @image-url("_visibility_off.svg");
                 colorize: base.text-color;

--- a/tests/cases/widgets/lineedit.slint
+++ b/tests/cases/widgets/lineedit.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { LineEdit } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 200px;
+    height: 200px;
+
+    edit1 := LineEdit {
+        y: 0px;
+        width: 10 * self.height; // Test that there is no height for width dependency (loop)
+    }
+}
+


### PR DESCRIPTION
There is a binding loop that cause a failure in the property editor of the live preview.
Previous version of the LineEdit didn't have a dependency between the height and the width.
Apply an explicit width binding on the recently added image to prevent that.

For the fluent style, also change the size of the `x` to something closer to the actual fluent style (picked the value from fluent's figma design)


(cc @dfaure )