### PR TITLE
Qt: Fix gradient colorize by using pixmap size instead of dest rect

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1398,8 +1398,11 @@ impl QtItemRenderer<'_> {
                     let colorize = image.colorize();
                     if !colorize.is_transparent() {
                         let pixmap_size = pixmap.size();
-                        let brush: qttypes::QBrush =
-                            into_qbrush(colorize, pixmap_size.width.into(), pixmap_size.height.into());
+                        let brush: qttypes::QBrush = into_qbrush(
+                            colorize,
+                            pixmap_size.width.into(),
+                            pixmap_size.height.into(),
+                        );
                         cpp!(unsafe [mut pixmap as "QPixmap", brush as "QBrush"] {
                             QPainter p(&pixmap);
                             p.setCompositionMode(QPainter::CompositionMode_SourceIn);

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1353,8 +1353,6 @@ impl QtItemRenderer<'_> {
         size: LogicalSize,
         image: Pin<&dyn i_slint_core::item_rendering::RenderImage>,
     ) {
-        let dest_rect: qttypes::QRectF = check_geometry!(size);
-
         let source_rect = image.source_clip();
 
         let pixmap: qttypes::QPixmap = self.cache.get_or_update_cache_entry(item_rc, || {
@@ -1399,8 +1397,9 @@ impl QtItemRenderer<'_> {
                 |mut pixmap: qttypes::QPixmap| {
                     let colorize = image.colorize();
                     if !colorize.is_transparent() {
+                        let pixmap_size = pixmap.size();
                         let brush: qttypes::QBrush =
-                            into_qbrush(colorize, dest_rect.width, dest_rect.height);
+                            into_qbrush(colorize, pixmap_size.width.into(), pixmap_size.height.into());
                         cpp!(unsafe [mut pixmap as "QPixmap", brush as "QBrush"] {
                             QPainter p(&pixmap);
                             p.setCompositionMode(QPainter::CompositionMode_SourceIn);

--- a/tests/cases/examples/colored_image.slint
+++ b/tests/cases/examples/colored_image.slint
@@ -19,5 +19,14 @@ Win := Window {
             source: @image-url("../../../examples/memory/icons/tile_logo.png");
             colorize: @linear-gradient(0, red, yellow, green, transparent);
         }
+        Image {
+            row: 2;
+            source: @image-url("../../../examples/memory/icons/tile_logo.png");
+            colorize: @radial-gradient(circle, blue, red);
+        }
+        Image {
+            source: @image-url("../../../examples/memory/icons/tile_logo.png");
+            colorize: @radial-gradient(circle, red, yellow, green, transparent);
+        }
     }
 }


### PR DESCRIPTION
When applying colorize with gradients to images, use the actual pixmap dimensions for the gradient brush instead of the destination rectangle dimensions. This ensures gradients are properly applied to the source image before any transformations.

https://github.com/slint-ui/slint/blob/master/tests/cases/examples/colored_image.slint

skia:
<img width="388" height="787" alt="image" src="https://github.com/user-attachments/assets/68d89759-8f00-4982-93ef-b479dc1e2cbf" />

Qt:
<img width="260" height="678" alt="image" src="https://github.com/user-attachments/assets/d326c43e-4b9f-40d0-8a03-6201f7552550" />

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
