### PR TITLE
Compiler: Fix menu separator not always being visible

### DIFF
--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -753,7 +753,7 @@ fn generate_menu_entries(
                 }
             }
         } else {
-            values.insert(SmolStr::new_static("is_separator"), Expression::BoolLiteral(true));
+            values.insert(SmolStr::new_static("is-separator"), Expression::BoolLiteral(true));
         }
 
         entries.push(mk_struct(state.menu_entry.clone(), values));

--- a/tests/cases/widgets/menubar.slint
+++ b/tests/cases/widgets/menubar.slint
@@ -45,7 +45,10 @@ export component TestCase inherits Window {
             MenuSeparator {}
             MenuItem {
                 title: "Save";
-                activated => { debug("Save"); }
+                activated => {
+                    result += "Save";
+                    debug("Save");
+                }
             }
         }
         Menu {
@@ -94,6 +97,18 @@ assert_eq!(instance.get_result(), "");
 // click on the first entry (new)  (this value seems to work with all styles)
 slint_testing::send_mouse_click(&instance, 30., 49.);
 assert_eq!(instance.get_result(), "New");
+
+instance.set_result("".into());
+// click on the file menu
+slint_testing::send_mouse_click(&instance, 10., 16.);
+// arrow should skip the separators before "save"
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow)); // New
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow)); // Open
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow)); // Open Recent
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::DownArrow)); // Save (skipped the separator)
+assert_eq!(instance.get_result(), "");
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("\n"));
+assert_eq!(instance.get_result(), "Save");
 ```
 
 ```cpp
@@ -119,5 +134,17 @@ assert_eq(instance.get_result(), "");
 // click on the first entry (new)  (this value seems to work with all styles)
 slint_testing::send_mouse_click(&instance, 30., 49.);
 assert_eq(instance.get_result(), "New");
+
+instance.set_result("");
+// click on the file menu
+slint_testing::send_mouse_click(&instance, 10., 16.);
+// arrow should skip the separators before "save"
+slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::DownArrow); // New
+slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::DownArrow); // Open
+slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::DownArrow); // Open Recent
+slint_testing::send_keyboard_string_sequence(&instance, slint::platform::key_codes::DownArrow); // Save (skipped the separator)
+assert_eq(instance.get_result(), "");
+slint_testing::send_keyboard_string_sequence(&instance, "\n");
+assert_eq(instance.get_result(), "Save");
 ```
 */


### PR DESCRIPTION
Fixes #9005

Both `is-separator` and `is_separator` were on the HashMap of the value struct for the MenuEntry. When lowered to actual struct, the `_` is normalized, but then it depends on the order of t