### PR TITLE
Waveshare S3 Touch AMOLED - add touch

### DIFF
--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -140,6 +140,7 @@ waveshare-esp32-s3-touch-amoled-1-8 = [
   "dep:static_cell",
   "dep:embedded-graphics-framebuf",
   "dep:sh8601-rs",
+  "dep:ft3x68-rs",
 ]
 stm32u5g9j-dk2 = [
   "embassy-stm32/stm32u5g9zj",
@@ -209,7 +210,7 @@ ft5336 = { version = "0.2", optional = true }
 # Updated ESP dependencies to match working Embassy project versions
 esp-hal = { version = "=1.0.0-rc.0", optional = true }
 esp-alloc = { version = "0.8.0", optional = true }
-esp-println = { version = "0.15.0", default-features = false, features = ["jtag-serial", "log-04"], optional = true }
+esp-println = { version = "0.15.0", default-features = false, features = ["auto", "log-04"], optional = true }
 esp-backtrace = { version = "0.17.0", optional = true, features = ["esp32s3", "exception-handler", "println"] }
 static_cell = { version = "2.1.0", optional = true, features = ["nightly"] }
 
@@ -230,7 +231,10 @@ embassy-sync = { version = "0.7.0", optional = true }
 esp-hal-embassy = { version = "0.9.0", optional = true, features = ["esp32s3"] }
 gt911 = { version = "0.3.0", optional = true }
 sitronix-touch = { version = "0.0.1", optional = true }
-sh8601-rs = { version = "0.1.4", features = ["waveshare_18_amoled"], optional = true }
+#sh8601-rs = { version = "0.1.6", features = ["waveshare_18_amoled"], optional = true }
+sh8601-rs = { git = "https://github.com/georgik/sh8601-rs.git", branch = "feature/i2c-bus-compatibility", features = ["waveshare_18_amoled"], optional = true }
+#ft3x68-rs = { version = "0.1.2", optional = true }
+ft3x68-rs = { git = "https://github.com/georgik/ft3x68-rs.git", branch = "feature/touchstate", optional = true }
 
 rand_core = { version = "0.6.3", optional = true }
 

--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -231,10 +231,8 @@ embassy-sync = { version = "0.7.0", optional = true }
 esp-hal-embassy = { version = "0.9.0", optional = true, features = ["esp32s3"] }
 gt911 = { version = "0.3.0", optional = true }
 sitronix-touch = { version = "0.0.1", optional = true }
-#sh8601-rs = { version = "0.1.6", features = ["waveshare_18_amoled"], optional = true }
-sh8601-rs = { git = "https://github.com/georgik/sh8601-rs.git", branch = "feature/i2c-bus-compatibility", features = ["waveshare_18_amoled"], optional = true }
-#ft3x68-rs = { version = "0.1.2", optional = true }
-ft3x68-rs = { git = "https://github.com/georgik/ft3x68-rs.git", branch = "feature/touchstate", optional = true }
+sh8601-rs = { version = "0.1.6", features = ["waveshare_18_amoled"], optional = true }
+ft3x68-rs = { version = "0.1.2", optional = true }
 
 rand_core = { version = "0.6.3", optional = true }
 

--- a/examples/mcu-board-support/waveshare_esp32_s3_touch_amoled_1_8.rs
+++ b/examples/mcu-board-support/waveshare_esp32_s3_touch_amoled_1_8.rs
@@ -5,6 +5,7 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::cell::RefCell;
 use embedded_hal::delay::DelayNs;
+use embedded_hal_bus::i2c::RefCellDevice;
 use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::clock::CpuClock;
@@ -17,12 +18,45 @@ use esp_hal::spi::master::{Config as SpiConfig, Spi};
 use esp_hal::spi::Mode;
 use esp_hal::time::{Instant, Rate};
 use esp_println::logger::init_logger_from_env;
+use ft3x68_rs::{Ft3x68Driver, ResetInterface, FT3168_DEVICE_ADDRESS};
 use log::{error, info};
 use sh8601_rs::{
     framebuffer_size, ColorMode, DisplaySize, ResetDriver, Sh8601Driver, Ws18AmoledDriver,
     DMA_CHUNK_SIZE,
 };
-use slint::Rgb8Pixel;
+use slint::platform::{PointerEventButton, WindowEvent};
+use slint::{LogicalPosition, PhysicalPosition, Rgb8Pixel};
+use static_cell::StaticCell;
+
+// Provide a reset implementation for the FT3x68 touch driver
+// In the Waveshare 1.8" AMOLED display, the reset pin is controlled via an I2C GPIO expander (TCA9554PWR).
+// The touch reset pin is connected to Pin 2
+pub struct TouchResetDriver<I2C> {
+    i2c: I2C,
+}
+
+impl<I2C> TouchResetDriver<I2C> {
+    pub fn new(i2c: I2C) -> Self {
+        TouchResetDriver { i2c }
+    }
+}
+
+impl<I2C> ResetInterface for TouchResetDriver<I2C>
+where
+    I2C: embedded_hal::i2c::I2c,
+{
+    type Error = I2C::Error;
+
+    fn reset(&mut self) -> Result<(), Self::Error> {
+        let delay = Delay::new();
+        self.i2c.write(0x20, &[0x03, 0x00])?; // Configure all pins as output
+        self.i2c.write(0x20, &[0x01, 0b0000_0000])?; // Drive low
+        delay.delay_millis(20);
+        self.i2c.write(0x20, &[0x01, 0b0000_0100])?; // Drive high
+        delay.delay_millis(300);
+        Ok(())
+    }
+}
 
 struct EspBackend {
     window: RefCell<Option<Rc<slint::platform::software_renderer::MinimalSoftwareWindow>>>,
@@ -104,21 +138,39 @@ impl EspBackend {
         .with_dma(peripherals.DMA_CH0)
         .with_buffers(dma_rx_buf, dma_tx_buf);
 
-        // I2C Configuration for Waveshare ESP32-S3 1.8inch AMOLED Touch Display
-        let i2c =
+        // Shared I2C bus for Waveshare ESP32-S3 1.8inch AMOLED Touch Display
+        // Using embedded-hal-bus RefCellDevice for shared access
+        let i2c_instance =
             I2c::new(peripherals.I2C0, I2cConfig::default().with_frequency(Rate::from_khz(400)))
                 .unwrap()
                 .with_sda(peripherals.GPIO15)
                 .with_scl(peripherals.GPIO14);
 
-        // Initialize I2C GPIO Reset Pin for the WaveShare 1.8" AMOLED display
-        let reset = ResetDriver::new(i2c);
+        // Use StaticCell to create a shared I2C bus
+        static I2C_BUS: StaticCell<RefCell<I2c<'static, esp_hal::Blocking>>> = StaticCell::new();
+        let i2c_bus = I2C_BUS.init(RefCell::new(i2c_instance));
+
+        // Initialize the FT3x68 touch driver FIRST using shared I2C bus
+        info!("Initializing FT3x68 Touch Driver first...");
+
+        let touch_reset = TouchResetDriver::new(RefCellDevice::new(i2c_bus));
+        let mut touch_driver = Ft3x68Driver::new(
+            RefCellDevice::new(i2c_bus),
+            FT3168_DEVICE_ADDRESS,
+            touch_reset,
+            delay,
+        );
+        touch_driver.initialize().expect("Failed to initialize touch driver");
+        info!("Touch driver initialized successfully");
+
+        // NOW initialize I2C GPIO Reset Pin for the WaveShare 1.8" AMOLED display
+        let reset = ResetDriver::new(RefCellDevice::new(i2c_bus));
 
         // Initialize display driver for the Waveshare 1.8" AMOLED display
         let ws_driver = Ws18AmoledDriver::new(lcd_spi);
 
-        // Instantiate and Initialize Display
-        info!("Initializing SH8601 Display...");
+        // Instantiate and Initialize Display AFTER touch
+        info!("Initializing SH8601 Display after touch...");
         let mut display = Sh8601Driver::new_heap::<_, FB_SIZE>(
             ws_driver,
             reset,
@@ -131,22 +183,22 @@ impl EspBackend {
             slint::PlatformError::Other("Display initialization failed".into())
         })?;
 
-        info!("Display initialized successfully");
+        info!("Display initialized successfully after touch");
 
         // Update the Slint window size from the display
         let size = slint::PhysicalSize::new(DISPLAY_SIZE.width as u32, DISPLAY_SIZE.height as u32);
         self.window.borrow().as_ref().unwrap().set_size(size);
 
-        // --- End Display Initialization ---
+        // --- End Initialization ---
 
-        // Allocate a full-screen buffer for rendering
+        // Create a pixel buffer for Slint to render into (allocate once outside the loop)
         const FRAME_PIXELS: usize = (368 * 448) as usize;
         let mut pixel_buffer: Box<[Rgb8Pixel; FRAME_PIXELS]> =
             Box::new([Rgb8Pixel { r: 0, g: 0, b: 0 }; FRAME_PIXELS]);
         let pixel_buf: &mut [Rgb8Pixel] = &mut *pixel_buffer;
 
         // Variable to track the last touch position
-        let _last_touch: Option<()> = None;
+        let mut last_touch: Option<LogicalPosition> = None;
 
         info!("Entering main event loop...");
 
@@ -155,15 +207,80 @@ impl EspBackend {
             slint::platform::update_timers_and_animations();
 
             if let Some(window) = self.window.borrow().clone() {
-                // TODO: Add touch support for FT3168 when available
-                // For now, the display will work without touch input
+                // Poll touch input
+                match touch_driver.touch1() {
+                    Ok(touch_state) => {
+                        match touch_state {
+                            ft3x68_rs::TouchState::Pressed(touch_point) => {
+                                info!("Touch detected: x={}, y={}", touch_point.x, touch_point.y);
+
+                                // Convert touch coordinates to logical position
+                                let pos = PhysicalPosition::new(
+                                    touch_point.x as i32,
+                                    touch_point.y as i32,
+                                )
+                                .to_logical(window.scale_factor());
+
+                                info!(
+                                    "Converted to logical position: {:?}, scale_factor: {}",
+                                    pos,
+                                    window.scale_factor()
+                                );
+
+                                if let Some(prev_pos) = last_touch.replace(pos) {
+                                    // If position changed, send a PointerMoved event
+                                    if prev_pos != pos {
+                                        info!("Sending PointerMoved event");
+                                        let _ =
+                                            window.try_dispatch_event(WindowEvent::PointerMoved {
+                                                position: pos,
+                                            });
+                                    }
+                                } else {
+                                    // No previous touch, send a PointerPressed event
+                                    info!("Sending PointerPressed event");
+                                    let _ =
+                                        window.try_dispatch_event(WindowEvent::PointerPressed {
+                                            position: pos,
+                                            button: PointerEventButton::Left,
+                                        });
+                                }
+                            }
+                            ft3x68_rs::TouchState::Released => {
+                                // Touch was released, send PointerReleased if we had a previous touch
+                                if let Some(pos) = last_touch.take() {
+                                    info!("Touch released, sending PointerReleased event");
+                                    let _ =
+                                        window.try_dispatch_event(WindowEvent::PointerReleased {
+                                            position: pos,
+                                            button: PointerEventButton::Left,
+                                        });
+                                    let _ = window.try_dispatch_event(WindowEvent::PointerExited);
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // I2C error or other driver error - send release if we had a previous touch
+                        if let Some(pos) = last_touch.take() {
+                            info!("Touch driver error, sending PointerReleased event: {:?}", e);
+                            let _ = window.try_dispatch_event(WindowEvent::PointerReleased {
+                                position: pos,
+                                button: PointerEventButton::Left,
+                            });
+                            let _ = window.try_dispatch_event(WindowEvent::PointerExited);
+                        }
+                        // Don't log every "no touch" - only log actual errors
+                        // info!("Touch error: {:?}", e);
+                    }
+                }
 
                 // Render the window if needed
                 window.draw_if_needed(|renderer| {
                     renderer.render(pixel_buf, DISPLAY_SIZE.width as usize);
                 });
 
-                // Draw the rendered pixels to the display using draw_iter for better performance
+                // Draw the rendered pixels to the display using draw_iter
                 use embedded_graphics::prelude::*;
                 use embedded_graphics::Pixel;
 


### PR DESCRIPTION
Add touch support to examples/mcu-board-support.

The current version is using custom forks of display and touch drivers:
- https://github.com/georgik/sh8601-rs
- https://github.com/georgik/ft3x68-rs

Once those changes get merged, those crate version could be switched to official release at crates.io.

PRs:
- https://github.com/theembeddedrustacean/ft3x68-rs/pull/1
- https://github.com/theembeddedrustacean/sh8601-rs/pull/1