### PR TITLE
preview: Fix highlighted elements not following items

### DIFF
--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1547,47 +1547,6 @@ fn convert_diagnostics(
     result
 }
 
-fn reset_selections(ui: &ui::PreviewUi) {
-    let model = Rc::new(slint::VecModel::from(Vec::new()));
-    let api = ui.global::<ui::Api>();
-    api.set_selections(slint::ModelRc::from(model));
-}
-
-fn set_selections(
-    ui: Option<&ui::PreviewUi>,
-    main_index: usize,
-    layout_kind: ui::LayoutKind,
-    is_interactive: bool,
-    is_moveable: bool,
-    is_resizable: bool,
-    positions: &[i_slint_core::lengths::LogicalRect],
-) {
-    let Some(ui) = ui else {
-        return;
-    };
-
-    let values = positions
-        .iter()
-        .enumerate()
-        .map(|(i, g)| ui::Selection {
-            geometry: ui::SelectionRectangle {
-                width: g.size.width,
-                height: g.size.height,
-                x: g.origin.x,
-                y: g.origin.y,
-            },
-            layout_data: layout_kind,
-            is_primary: i == main_index,
-            is_interactive,
-            is_moveable,
-            is_resizable,
-        })
-        .collect::<Vec<_>>();
-    let model = Rc::new(slint::VecModel::from(values));
-    let api = ui.global::<ui::Api>();
-    api.set_selections(slint::ModelRc::from(model));
-}
-
 fn set_drop_mark(mark: &Option<drop_location::DropMark>) {
     PREVIEW_STATE.with_borrow(move |preview_state| {
         let Some(ui) = &preview_state.ui else {
@@ -1617,7 +1576,6 @@ pub enum SelectionNotification {
 
 fn set_selected_element(
     selection: Option<element_selection::ElementSelection>,
-    positions: &[i_slint_core::lengths::LogicalRect],
     editor_notification: SelectionNotification,
 ) {
     let (layout_kind, parent_layout_kind, type_name) = {
@@ -1659,17 +1617,16 @@ fn set_selected_element(
                 .unwrap_or_default()
         };
 
-        set_selections(
-            preview_state.ui.as_ref(),
-            selection.as_ref().map(|s| s.instance_index).unwrap_or_default(),
-            layout_kind,
-            is_interactive,
-            true,
-            !is_in_layout && !is_layout,
-            positions,
-        );
-
         if let Some(ui) = &preview_state.ui {
+            let api = ui.global::<ui::Api>();
+            api.set_selection(ui::Selection {
+                highlight_index: selection.as_ref().map(|s| s.instance_index as i32).unwrap_or(-1),
+                layout_data: layout_kind,
+                is_interactive,
+                is_moveable: true,
+                is_resizable: !is_in_layout && !is_layout,
+            });
+
             if let Some(document_cache) = document_cache_from(preview_state) {
                 if let Some((uri, version, selection)) = selection
                     .clone()
@@ -1827,6 +1784,7 @@ fn update_preview_area(
         if let Some(compiled) = compiled {
             let api = ui.global::<ui::Api>();
             api.set_focus_previewed_element(behavior == LoadBehavior::BringWindowToFront);
+            api.set_current_element(Default::default());
 
             set_preview_factory(
                 ui,
@@ -1846,7 +1804,6 @@ fn update_preview_area(
                 }),
                 behavior,
             );
-            reset_selections(ui);
         }
 
         ui.show().and_then(|_| {

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -101,6 +101,7 @@ pub fn create_ui(
         );
     });
     api.on_select_behind(super::element_selection::select_element_behind);
+    api.on_highlight_positions(super::element_selection::highlight_positions);
     let lsp = to_lsp.clone();
     api.on_can_drop(super::can_drop_component);
     api.on_drop(move |component_index: i32, x: f32, y: f32| {

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -37,7 +37,7 @@ export enum LayoutKind {
 }
 
 /// A rectangular region that is selected
-struct SelectionRectangle {
+export struct SelectionRectangle {
     x: length,
     y: length,
     width: length,
@@ -46,10 +46,9 @@ struct SelectionRectangle {
 
 /// A `Selection`
 export struct Selection {
-    geometry: SelectionRectangle,
+    highlight-index: int,
     layout-data: LayoutKind,
     is-interactive: bool,
-    is-primary: bool,
     is-moveable: bool,
     is-resizable: bool,
 }
@@ -292,7 +291,8 @@ export global Api {
 
     // ## Drawing Area
     // Borders around things
-    in property <[Selection]> selections;
+    pure callback highlight-positions(source-uri: string, offset: int) -> [SelectionRectangle];
+    in-out property <Selection> selection;
     in-out property <DropMark> drop-mark;
     // The actual preview
     in-out property <component-factory> preview-area;

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -4,7 +4,7 @@
 // cSpell: ignore resizer
 
 import { Button, ComboBox, HorizontalBox, LineEdit, ListView, Palette, ScrollView, VerticalBox } from "std-widgets.slint";
-import { Api, ComponentItem, DiagnosticSummary, DropMark, LayoutKind, Selection } from "../api.slint";
+import { Api, ComponentItem, DiagnosticSummary, DropMark, LayoutKind, Selection, SelectionRectangle } from "../api.slint";
 import { Resizer } from "../components/resizer.slint";
 import { Group, GroupHeader } from "../components/group.slint";
 import { SelectionPopup } from "../components/selection-popup.slint";
@@ -30,23 +30,24 @@ export enum DrawAreaMode {
 
 component SelectionFrame {
     in property <Selection> selection;
+    in property <bool> is-primary;
     in property <bool> interactive: true;
 
     function pick-selection-color(selection: Selection) -> color {
         if selection.layout-data != LayoutKind.None {
-            if selection.is-primary {
+            if is-primary {
                 return EditorPalette.layout-element-selection-primary;
             } else {
                 return EditorPalette.layout-element-selection-secondary;
             }
         } else if selection.is-interactive {
-            if selection.is-primary {
+            if is-primary {
                 return EditorPalette.interactive-element-selection-primary;
             } else {
                 return EditorPalette.interactive-element-selection-secondary;
             }
         } else {
-            if selection.is-primary {
+            if is-primary {
                 return EditorPalette.general-element-selection-primary;
             } else {
                 return EditorPalette.general-element-selection-secondary;
@@ -56,10 +57,6 @@ component SelectionFrame {
 
     private property <color> selection-color: pick-selection-color(root.selection);
 
-    x: root.selection.geometry.x;
-    y: root.selection.geometry.y;
-    width: root.selection.geometry.width;
-    height: root.selection.geometry.height;
 
     property <bool> had-drag-distance: false;
 
@@ -70,20 +67,20 @@ component SelectionFrame {
     callback selection-stack-at(x: length, y: length);
     callback selected-element-delete();
 
-    if !root.interactive || !selection.is-primary: Rectangle {
+    if !root.interactive || !is-primary: Rectangle {
         x: 0;
         y: 0;
         border-color: root.selection-color;
         border-width: 1px;
     }
 
-    if root.interactive && selection.is-primary: Resizer {
+    if root.interactive && is-primary: Resizer {
         clicked(x, y, modifiers) => {
             key-handler.focus();
         }
 
         double-clicked(x, y, modifiers) => {
-            root.select-through(root.selection.geometry.x + x, root.selection.geometry.y + y, modifiers.control, modifiers.shift);
+            root.select-through(root.x + x, root.y + y, modifiers.control, modifiers.shift);
         }
 
         changed has-hover => {
@@ -96,7 +93,7 @@ component SelectionFrame {
 
         pointer-event(x, y, event) => {
             if event.button == PointerEventButton.right && event.kind == PointerEventKind.down {
-                root.selection-stack-at(root.selection.geometry.x + x, root.selection.geometry.y + y);
+                root.selection-stack-at(root.x + x, root.y + y);
             }
         }
 
@@ -169,7 +166,7 @@ component SelectionFrame {
     }
 
     // Size label:
-    if selection.is-resizable && root.selection.is-primary && interactive: Rectangle {
+    if selection.is-resizable && is-primary && interactive: Rectangle {
         x: (root.width - label.width) * 0.5;
         y: root.height + 3px;
         width: label.width;
@@ -188,7 +185,7 @@ component SelectionFrame {
 }
 
 export component PreviewView {
-    property <[Selection]> selections <=> Api.selections;
+    property <[SelectionRectangle]> selections: Api.highlight-positions(Api.current-element.source-uri, Api.current-element.offset);
     in property <ComponentItem> visible-component;
     property <DiagnosticSummary> diagnostic-summary <=> Api.diagnostic-summary;
     out property <bool> preview-is-current: self.diagnostic-summary != DiagnosticSummary.Errors;
@@ -424,9 +421,14 @@ export component PreviewView {
                 }
 
                 selection-display-area := Rectangle {
-                    for s in root.selections: SelectionFrame {
+                    for s[idx] in root.selections: SelectionFrame {
+                        x: s.x;
+                        y: s.y;
+                        width: s.width;
+                        height: s.height;
                         interactive: root.mode == DrawAreaMode.selecting;
-                        selection: s;
+                        selection: Api.selection;
+                        is-primary: self.selection.highlight-index == idx;
                         resize(x, y, w, h) => {
                             Api.selected-element-resize(x, y, w, h);
                         }


### PR DESCRIPTION
Rely on the fact that `component_instance.component_positions` read properties and do the property tracking for us. By accessing it from a callback we get free dirty notification.
