### PR TITLE
LinuxKMS / winit: Add support for custom event processing

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -35,7 +35,7 @@ jobs:
             - name: Set up crate rustdoc link
               run: |
                   rgb_version=`grep 'rgb = '  internal/core/Cargo.toml | sed 's/^.*"\(.*\)"/\1/'`
-                  echo "RUSTDOCFLAGS=$RUSTDOCFLAGS --extern-html-root-url rgb=https://docs.rs/rgb/$rgb_version/ --extern-html-root-url android_activity=https://docs.rs/android-activity/0.5/ --extern-html-root-url raw_window_handle=https://docs.rs/raw_window_handle/0.6 --extern-html-root-url winit=https://docs.rs/winit/0.30 --extern-html-root-url wgpu=https://docs.rs/wgpu/26" >> $GITHUB_ENV
+                  echo "RUSTDOCFLAGS=$RUSTDOCFLAGS --extern-html-root-url rgb=https://docs.rs/rgb/$rgb_version/ --extern-html-root-url android_activity=https://docs.rs/android-activity/0.5/ --extern-html-root-url raw_window_handle=https://docs.rs/raw_window_handle/0.6 --extern-html-root-url winit=https://docs.rs/winit/0.30 --extern-html-root-url wgpu=https://docs.rs/wgpu/26 --extern-html-root-url input=https://docs.rs/input/0.9" >> $GITHUB_ENV
             - uses: actions/setup-node@v4
               with:
                 node-version: 20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ unicode-segmentation = { version = "1.12.0" }
 glow = { version = "0.16" }
 tikv-jemallocator = { version = "0.6" }
 wgpu-26 = { package = "wgpu", version = "26", default-features = false }
+input = { version = "0.9.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -215,6 +215,20 @@ unstable-wgpu-26 = ["i-slint-core/unstable-wgpu-26", "i-slint-backend-selector/u
 ## ```
 unstable-winit-030 = ["backend-winit", "dep:i-slint-backend-winit", "i-slint-backend-selector/unstable-winit-030"]
 
+
+## Enable support for exposing [libinput](https://docs.rs/input/latest/input/index.html) related APIs in the LinuxKMS backend.
+##
+## APIs guarded with this feature are *NOT* subject to the usual Slint API stability guarantees. This feature as well as the APIs changed or removed
+## in future minor releases of Slint, likely to be replaced by a feature with a similar name but the input version suffix being bumped.
+##
+## To avoid unintended compilation failures, we recommend to use the [tilde requirement](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements)
+## in your `Cargo.toml` when enabling this feature:
+##
+## ```toml
+## slint = { version = "~1.13", features = ["unstable-input-09"] }
+## ```
+unstable-input-09 = ["i-slint-backend-selector/unstable-input-09"]
+
 [dependencies]
 i-slint-core = { workspace = true }
 slint-macros = { workspace = true }
@@ -273,5 +287,6 @@ features = [
   "raw-window-handle-06",
   "unstable-wgpu-26",
   "unstable-winit-030",
+  "unstable-input-09",
 ]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -604,6 +604,7 @@ pub mod winit_030 {
     //! and [`BackendSelector::with_winit_window_attributes_hook()`](crate::BackendSelector::with_winit_window_attributes_hook()).
 
     pub use i_slint_backend_winit::{
-        winit, EventLoopBuilder, SlintEvent, WinitWindowAccessor, WinitWindowEventResult,
+        winit, CustomApplicationHandler, EventLoopBuilder, SlintEvent, WinitWindowAccessor,
+        WinitWindowEventResult,
     };
 }

--- a/internal/backends/linuxkms/Cargo.toml
+++ b/internal/backends/linuxkms/Cargo.toml
@@ -33,7 +33,7 @@ i-slint-renderer-skia = { workspace = true, features = ["default", "kms"], optio
 i-slint-renderer-femtovg = { workspace = true, features = ["default"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-input = { version = "0.9.0" }
+input = { workspace = true, default-features = true }
 xkbcommon = { version = "0.8.0" }
 calloop = { version = "0.14.1" }
 libseat = { version = "0.2.1", optional = true, default-features = false }

--- a/internal/backends/linuxkms/calloop_backend/input.rs
+++ b/internal/backends/linuxkms/calloop_backend/input.rs
@@ -119,6 +119,7 @@ pub struct LibInputHandler<'a> {
     last_touch_pos: LogicalPosition,
     window: &'a RefCell<Option<Rc<FullscreenWindowAdapter>>>,
     keystate: Option<xkb::State>,
+    input_event_hook: &'a Option<Box<dyn Fn(&::input::Event) -> bool>>,
 }
 
 impl<'a> LibInputHandler<'a> {
@@ -126,6 +127,7 @@ impl<'a> LibInputHandler<'a> {
         window: &'a RefCell<Option<Rc<FullscreenWindowAdapter>>>,
         event_loop_handle: &calloop::LoopHandle<'a, T>,
         #[cfg(feature = "libseat")] seat: &'a Rc<RefCell<libseat::Seat>>,
+        input_event_hook: &'a Option<Box<dyn Fn(&::input::Event) -> bool>>,
     ) -> Result<Pin<Rc<Property<Option<LogicalPosition>>>>, PlatformError> {
         #[cfg(feature = "libseat")]
         let libinput = SeatWrap::new(seat);
@@ -141,6 +143,7 @@ impl<'a> LibInputHandler<'a> {
             last_touch_pos: Default::default(),
             window,
             keystate: Default::default(),
+            input_event_hook,
         };
 
         event_loop_handle
@@ -179,6 +182,9 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
         let screen_size = window.size().to_logical(window.scale_factor());
 
         for event in &mut self.libinput {
+            if self.input_event_hook.as_ref().map_or(false, |hook| hook(&event)) {
+                continue;
+            };
             match event {
                 input::Event::Pointer(pointer_event) => {
                     match pointer_event {

--- a/internal/backends/linuxkms/lib.rs
+++ b/internal/backends/linuxkms/lib.rs
@@ -80,12 +80,37 @@ mod renderer {
 mod calloop_backend;
 
 #[cfg(target_os = "linux")]
-pub use calloop_backend::*;
+use calloop_backend::*;
 
 #[cfg(not(target_os = "linux"))]
 mod noop_backend;
+use i_slint_core::api::PlatformError;
 #[cfg(not(target_os = "linux"))]
-pub use noop_backend::*;
+use noop_backend::*;
+
+#[derive(Default)]
+pub struct BackendBuilder {
+    pub(crate) renderer_name: Option<String>,
+    #[cfg(target_os = "linux")]
+    pub(crate) input_event_hook: Option<Box<dyn Fn(&input::Event) -> bool>>,
+}
+
+impl BackendBuilder {
+    pub fn with_renderer_name(mut self, name: String) -> Self {
+        self.renderer_name = Some(name);
+        self
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn with_input_event_hook(mut self, event_hook: Box<dyn Fn(&input::Event) -> bool>) -> Self {
+        self.input_event_hook = Some(event_hook);
+        self
+    }
+
+    pub fn build(self) -> Result<Backend, PlatformError> {
+        Backend::build(self)
+    }
+}
 
 #[doc(hidden)]
 pub type NativeWidgets = ();

--- a/internal/backends/linuxkms/noop_backend.rs
+++ b/internal/backends/linuxkms/noop_backend.rs
@@ -5,10 +5,7 @@ use i_slint_core::platform::PlatformError;
 pub struct Backend {}
 
 impl Backend {
-    pub fn new() -> Result<Self, PlatformError> {
-        Self::new_with_renderer_by_name(None)
-    }
-    pub fn new_with_renderer_by_name(_renderer_name: Option<&str>) -> Result<Self, PlatformError> {
+    pub fn build(_builder: super::BackendBuilder) -> Result<Self, PlatformError> {
         Ok(Backend {})
     }
 }

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -58,6 +58,8 @@ unstable-wgpu-26 = [
 
 unstable-winit-030 = ["i-slint-backend-winit"]
 
+unstable-input-09 = ["dep:input"]
+
 # note that default enable the i-slint-backend-qt, but not its enable feature
 default = ["i-slint-backend-qt", "backend-winit"]
 
@@ -76,6 +78,7 @@ i-slint-backend-qt = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 i-slint-backend-linuxkms = { workspace = true, features = ["default"], optional = true }
+input = { workspace = true, optional = true }
 
 [build-dependencies]
 i-slint-common = { workspace = true }

--- a/internal/backends/selector/lib.rs
+++ b/internal/backends/selector/lib.rs
@@ -32,7 +32,7 @@ fn create_winit_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> 
 
 #[cfg(all(feature = "i-slint-backend-linuxkms", target_os = "linux"))]
 fn create_linuxkms_backend() -> Result<Box<dyn Platform + 'static>, PlatformError> {
-    Ok(Box::new(i_slint_backend_linuxkms::Backend::new()?))
+    Ok(Box::new(i_slint_backend_linuxkms::BackendBuilder::default().build()?))
 }
 
 cfg_if::cfg_if! {
@@ -101,7 +101,13 @@ cfg_if::cfg_if! {
                 #[cfg(feature = "i-slint-backend-winit")]
                 "winit" => return i_slint_backend_winit::Backend::new_with_renderer_by_name((!_renderer.is_empty()).then_some(_renderer)).map(|b| Box::new(b) as Box<dyn Platform + 'static>),
                 #[cfg(all(feature = "i-slint-backend-linuxkms", target_os = "linux"))]
-                "linuxkms" => return i_slint_backend_linuxkms::Backend::new_with_renderer_by_name((!_renderer.is_empty()).then(|| _renderer)).map(|b| Box::new(b) as Box<dyn Platform + 'static>),
+                "linuxkms" => {
+                    let mut builder = i_slint_backend_linuxkms::BackendBuilder::default();
+                    if !_renderer.is_empty() {
+                        builder = builder.with_renderer_name(_renderer.into());
+                    }
+                    return builder.build().map(|b| Box::new(b) as Box<dyn Platform + 'static>)
+                },
                 _ => {},
             }
 

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -329,9 +329,9 @@ impl BackendBuilder {
     #[must_use]
     pub fn with_custom_application_handler(
         mut self,
-        handler: impl CustomApplicationHandler + 'static,
+        handler: Box<dyn CustomApplicationHandler + 'static>,
     ) -> Self {
-        self.custom_application_handler = Some(Box::new(handler));
+        self.custom_application_handler = Some(handler);
         self
     }
 


### PR DESCRIPTION
This PR extends the BackendSelector with APIs to permit hooking into the event processing of the winit and linuxkms backend.

This will be used in an application to implement detection of user-inactivity.
