### PR TITLE
Fix bug#9046: Password LineEdit in Cupertino style shows password by default

### DIFF
--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -89,6 +89,7 @@ export component LineEdit {
             padding-right: 7px;
 
             base := LineEditBase {
+                input-type: root.input-type;
                 font-size: CupertinoFontSettings.body.font-size;
                 font-weight: CupertinoFontSettings.body.font-weight;
                 selection-background-color: CupertinoPalette.selection-background;


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
