### PR TITLE
LineEdit clear icons: use if syntax, show passwd icon on focus in fluent

### DIFF
--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -83,10 +83,9 @@ export component LineEdit {
                 horizontal-stretch: 1;
             }
 
-            LineEditClearIcon {
+            if !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only: LineEditClearIcon {
                 width: self.source.width * 1px;
                 text: base.text;
-                visible: !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only;
                 source: @image-url("_edit_clear_symbolic.svg");
                 colorize: base.text-color;
                 clear => {

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -100,10 +100,9 @@ export component LineEdit {
                 horizontal-stretch: 1;
             }
 
-            LineEditClearIcon {
+            if !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only: LineEditClearIcon {
                 width: self.source.width * 1px;
                 text: base.text;
-                visible: !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only;
                 source: @image-url("_clear.svg");
                 colorize: base.text-color;
                 clear => {

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -93,10 +93,9 @@ export component LineEdit {
                 horizontal-stretch: 1;
             }
 
-            LineEditClearIcon {
+            if !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only && root.has-focus: LineEditClearIcon {
                 width: 16px;
                 text: base.text;
-                visible: !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only && root.has-focus;
                 source: @image-url("_dismiss.svg");
                 colorize: base.text-color;
                 clear => {
@@ -105,7 +104,7 @@ export component LineEdit {
                 }
             }
 
-            if root.input-type == InputType.password: LineEditPasswordIcon {
+            if root.input-type == InputType.password && !root.text.is-empty && root.has-focus: LineEditPasswordIcon {
                 width: self.source.width * 1px;
                 show-password-image: @image-url("_eye_show.svg");
                 hide-password-image: @image-url("_eye_hide.svg");

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -85,10 +85,9 @@ export component LineEdit {
                 horizontal-stretch: 1;
             }
 
-            LineEditClearIcon {
+            if !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only: LineEditClearIcon {
                 width: self.source.width * 1px;
                 text: base.text;
-                visible: !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only;
                 source: @image-url("_clear.svg");
                 colorize: base.text-color;
                 clear => {

--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -74,9 +74,8 @@ export component LineEdit {
             margin: layout.padding-left + layout.padding-right;
         }
 
-        LineEditClearIcon {
+        if !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only: LineEditClearIcon {
             text: inner.text;
-            visible: !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only;
             source: native.clear-icon;
             colorize: inner.text-color;
             image-fit: preserve;


### PR DESCRIPTION
Given that 'visible: false' still takes the icon into account in the layout (to my great surprise), use the if syntax instead. This fixes long placeholder texts being truncated too early in the Qt style at least.

Also, in fluent style, show the "eye" icon in password lineedits only when they have focus, just like the clear icon.

