### PR TITLE
doc: Fix up function calling example

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/functions-and-callbacks.mdx
@@ -45,7 +45,7 @@ A function can be called without an element name (like a function call in other 
 an element name (like a method call in other languages):
 
 ```slint
-import { Button } from "std-widgets.slint";
+import { Button, VerticalBox } from "std-widgets.slint";
 
 export component Example {
     // Call without an element name:
@@ -57,14 +57,18 @@ export component Example {
         return "result";
     }
 
-    Text {
-        // Called with a pre-defined element:
-        text: root.my-function();
-    }
+    VerticalBox {
+        Text {
+            // Called with a pre-defined element:
+            text: root.my-function();
+        }
 
-    my_button := Button {
-        pure function my-other-function() -> int {
-            return 42;
+        my_button := Button {
+            text: "Click me";
+            clicked => { self.text = root.my-other-property; }
+            pure function my-other-function() -> int {
+                return 42;
+            }
         }
     }
 }


### PR DESCRIPTION
- Don't render text and button on top of each other.
- Let something happen when clicking the button.

Fixes #9088

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
