### PR TITLE
slint-compiler: Write output file atomically

### DIFF
--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -32,6 +32,7 @@ clap = { workspace = true }
 proc-macro2 = "1.0.11"
 spin_on = { workspace = true }
 itertools = { workspace = true }
+atomic-write-file = "0.2.3"
 
 [target.'cfg(not(any(target_os = "windows", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -198,12 +198,10 @@ fn main() -> std::io::Result<()> {
     if args.output == std::path::Path::new("-") {
         generator::generate(format, &mut std::io::stdout(), &doc, &loader.compiler_config)?;
     } else {
-        generator::generate(
-            format,
-            &mut BufWriter::new(std::fs::File::create(&args.output)?),
-            &doc,
-            &loader.compiler_config,
-        )?;
+        let mut file =
+            BufWriter::new(atomic_write_file::AtomicWriteFile::options().open(&args.output)?);
+        generator::generate(format, &mut file, &doc, &loader.compiler_config)?;
+        file.into_inner()?.commit()?;
     }
 
     if let Some(depfile) = args.depfile {


### PR DESCRIPTION
Avoid a partially flushed/written file on disk. Instead, create the file under a different name and rename it when all content is written.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
