### PR TITLE
live-preview: fixed x for cupertino input fields

### DIFF
--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { CupertinoFontSettings, CupertinoPalette } from "styling.slint";
+import { CupertinoFontSettings, CupertinoPalette, CupertinoSizeSettings } from "styling.slint";
 import { FocusBorder } from "components.slint";
 import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common/lineedit-base.slint";
 
@@ -28,7 +28,6 @@ export component LineEdit {
         text = v;
         edited(v);
     }
-
     public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);
     }
@@ -83,42 +82,50 @@ export component LineEdit {
         border-color: CupertinoPalette.border;
         border-width: 1px;
         opacity: root.enabled ? 1 : 0.5;
+        ta := TouchArea {
+            layout := HorizontalLayout {
+                padding-left: 7px;
+                padding-right: 7px;
+                spacing: 3px;
 
-        layout := HorizontalLayout {
-            padding-left: 7px;
-            padding-right: 7px;
-
-            base := LineEditBase {
-                input-type: root.input-type;
-                font-size: CupertinoFontSettings.body.font-size;
-                font-weight: CupertinoFontSettings.body.font-weight;
-                selection-background-color: CupertinoPalette.selection-background;
-                selection-foreground-color: CupertinoPalette.selection-foreground;
-                text-color: CupertinoPalette.foreground;
-                margin: layout.padding-left + layout.padding-right;
-                placeholder-color: CupertinoPalette.foreground-secondary;
-                horizontal-stretch: 1;
-            }
-
-            if !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only: LineEditClearIcon {
-                width: self.source.width * 1px;
-                text: base.text;
-                source: @image-url("_clear.svg");
-                colorize: base.text-color;
-                clear => {
-                    base.text = "";
-                    base.focus();
+                base := LineEditBase {
+                    input-type: root.input-type;
+                    font-size: CupertinoFontSettings.body.font-size;
+                    font-weight: CupertinoFontSettings.body.font-weight;
+                    selection-background-color: CupertinoPalette.selection-background;
+                    selection-foreground-color: CupertinoPalette.selection-foreground;
+                    text-color: CupertinoPalette.foreground;
+                    margin: layout.padding-left + layout.padding-right;
+                    placeholder-color: CupertinoPalette.foreground-secondary;
+                    horizontal-stretch: 1;
                 }
-            }
 
-            if root.input-type == InputType.password: LineEditPasswordIcon {
-                width: self.source.width * 1px;
-                show-password-image: @image-url("_visibility.svg");
-                hide-password-image: @image-url("_visibility_off.svg");
-                colorize: base.text-color;
-                show-password-changed(show) => {
-                    base.input-type = show ? InputType.text : root.input-type;
-                    base.focus();
+                ci := LineEditClearIcon {
+                    visible: !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only && ta.has-hover;
+
+                    width: ta.has-hover ? self.source.width * 0.5 * 1px : 0px;
+                    text: base.text;
+                    source: @image-url("_clear.svg");
+                    colorize: base.text-color.transparentize(0.5);
+                    clear => {
+                        base.text = "";
+                        base.focus();
+                    }
+                    animate width {
+                        duration: 100ms;
+                        easing: ease-in-out-bounce;
+                    }
+                }
+
+                if root.input-type == InputType.password: LineEditPasswordIcon {
+                    width: self.source.width * 1px;
+                    show-password-image: @image-url("_visibility.svg");
+                    hide-password-image: @image-url("_visibility_off.svg");
+                    colorize: base.text-color;
+                    show-password-changed(show) => {
+                        base.input-type = show ? InputType.text : root.input-type;
+                        base.focus();
+                    }
                 }
             }
         }

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { CupertinoFontSettings, CupertinoPalette, CupertinoSizeSettings } from "styling.slint";
+import { CupertinoFontSettings, CupertinoPalette } from "styling.slint";
 import { FocusBorder } from "components.slint";
 import { LineEditBase, LineEditClearIcon, LineEditPasswordIcon } from "../common/lineedit-base.slint";
 

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -82,50 +82,31 @@ export component LineEdit {
         border-color: CupertinoPalette.border;
         border-width: 1px;
         opacity: root.enabled ? 1 : 0.5;
-        ta := TouchArea {
-            layout := HorizontalLayout {
-                padding-left: 7px;
-                padding-right: 7px;
-                spacing: 3px;
+        layout := HorizontalLayout {
+            padding-left: 7px;
+            padding-right: 7px;
+            spacing: 3px;
 
-                base := LineEditBase {
-                    input-type: root.input-type;
-                    font-size: CupertinoFontSettings.body.font-size;
-                    font-weight: CupertinoFontSettings.body.font-weight;
-                    selection-background-color: CupertinoPalette.selection-background;
-                    selection-foreground-color: CupertinoPalette.selection-foreground;
-                    text-color: CupertinoPalette.foreground;
-                    margin: layout.padding-left + layout.padding-right;
-                    placeholder-color: CupertinoPalette.foreground-secondary;
-                    horizontal-stretch: 1;
-                }
+            base := LineEditBase {
+                input-type: root.input-type;
+                font-size: CupertinoFontSettings.body.font-size;
+                font-weight: CupertinoFontSettings.body.font-weight;
+                selection-background-color: CupertinoPalette.selection-background;
+                selection-foreground-color: CupertinoPalette.selection-foreground;
+                text-color: CupertinoPalette.foreground;
+                margin: layout.padding-left + layout.padding-right;
+                placeholder-color: CupertinoPalette.foreground-secondary;
+                horizontal-stretch: 1;
+            }
 
-                ci := LineEditClearIcon {
-                    visible: !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only && ta.has-hover;
-
-                    width: ta.has-hover ? self.source.width * 0.5 * 1px : 0px;
-                    text: base.text;
-                    source: @image-url("_clear.svg");
-                    colorize: base.text-color.transparentize(0.5);
-                    clear => {
-                        base.text = "";
-                        base.focus();
-                    }
-                    animate width {
-                        duration: 100ms;
-                        easing: ease-in-out-bounce;
-                    }
-                }
-
-                if root.input-type == InputType.password: LineEditPasswordIcon {
-                    width: self.source.width * 1px;
-                    show-password-image: @image-url("_visibility.svg");
-                    hide-password-image: @image-url("_visibility_off.svg");
-                    colorize: base.text-color;
-                    show-password-changed(show) => {
-                        base.input-type = show ? InputType.text : root.input-type;
-                        base.focus();
-                    }
+            if root.input-type == InputType.password: LineEditPasswordIcon {
+                width: self.source.width * 1px;
+                show-password-image: @image-url("_visibility.svg");
+                hide-password-image: @image-url("_visibility_off.svg");
+                colorize: base.text-color;
+                show-password-changed(show) => {
+                    base.input-type = show ? InputType.text : root.input-type;
+                    base.focus();
                 }
             }
         }


### PR DESCRIPTION
The latest iteration of mac OS doesn't seem to have an x anywhere other than search fields.   I don't know if I'm allowed to just not have it for cupertino (like if something breaks in code if I don't include it in there) so I've altered it so it doesn't look so intensely ungood
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
