### PR TITLE
live-preview: implement MenuBar so we have undo/redo and move the rest over

### DIFF
--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -44,12 +44,63 @@ export component PreviewUi inherits Window {
     icon: @image-url("assets/slint-logo-small-light.png");
     always-on-top <=> Api.always-on-top;
 
+    MenuBar {
+        Menu {
+            title: @tr("File");
+            MenuItem {
+                title: @tr("Reload");
+                activated => {
+                    Api.reload-preview();
+                }
+            }
+        }
+
+        Menu {
+            title: @tr("Edit");
+            MenuItem {
+                title: @tr("Undo");
+                activated => {
+                    Api.undo();
+                }
+            }
+
+            MenuItem {
+                title: @tr("Redo");
+                activated => {
+                    Api.redo();
+                }
+            }
+        }
+
+        Menu {
+            title: @tr("Window");
+            kot := MenuItem {
+                title: @tr("Keep on Top");
+                activated => {
+                    Api.always-on-top = !Api.always-on-top;
+                    if Api.always-on-top {
+                        kot.title = @tr("Remove from Top");
+                    } else {
+                        kot.title = @tr("Keep on Top");
+                    }
+                }
+            }
+        }
+    }
+
+    Button {
+        icon: Icons.sync;
+        colorize-icon: true;
+        clicked => {
+            Api.reload-preview();
+        }
+    }
+
     init => {
         WindowGlobal.window-width = self.width;
         WindowGlobal.window-height = self.height;
         initial-floating-x = (self.width - PickerStyles.picker-width - 350px).max(0);
     }
-
     changed width => {
         WindowGlobal.window-width = self.width;
         initial-floating-x = (self.width - PickerStyles.picker-width - 350px).max(0);
@@ -78,7 +129,6 @@ export component PreviewUi inherits Window {
                     style-selected => {
                         Api.style-changed();
                     }
-
                     edit := Button {
                         icon: Icons.inspect;
                         colorize-icon: preview.select-mode ? false : true;
@@ -110,9 +160,10 @@ export component PreviewUi inherits Window {
                             width: 4px;
                             background: @linear-gradient(90deg, #0000, #0002);
                         }
+
                         VerticalLayout {
                             tw := TabWidget {
-                                width: EditorSizeSettings.property-bar-width - (EditorSpaceSettings.default-padding*2);
+                                width: EditorSizeSettings.property-bar-width - (EditorSpaceSettings.default-padding * 2);
                                 current-index: 0;
                                 Tab {
                                     title: @tr("Properties");
@@ -154,13 +205,11 @@ export component PreviewUi inherits Window {
                                         enabled: preview.preview-is-current;
                                     }
                                 }
-
-
                             }
                         }
                     }
-
                 }
+
                 ConsolePanel { }
 
                 StatusLine { }
@@ -186,7 +235,6 @@ export component PreviewUi inherits Window {
         }
     }
 
-
     if show-floating-widget: ColorPickerView {
         init => {
             self.initial-x = root.initial-floating-x;
@@ -209,5 +257,4 @@ export component PreviewUi inherits Window {
             WindowManager.hide-color-stop-picker();
         }
     }
-
 }

--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -30,22 +30,6 @@ export component HeaderView {
                 spacing: EditorSpaceSettings.default-spacing / 2;
 
                 Button {
-                    text: "↩️";
-                    enabled: Api.undo-enabled;
-                    clicked => {
-                        Api.undo();
-                    }
-                }
-                Button {
-                    text: "↪️";
-                    enabled: Api.redo-enabled;
-                    clicked => {
-                        Api.redo();
-                    }
-                }
-
-
-                Button {
                     icon: Icons.sync;
                     colorize-icon: true;
                     clicked => {
@@ -82,6 +66,7 @@ export component HeaderView {
                         text: @tr("Edit");
                     }
                 }
+
                 @children
 
                 left-panel-button := Button {
@@ -104,7 +89,7 @@ export component HeaderView {
 
             HorizontalLayout {
                 alignment: end;
-                spacing:4px;
+                spacing: 4px;
 
                 BodyText {
                     horizontal-stretch: 0;


### PR DESCRIPTION
as per a conversation with Simon, I've left the reload button in the UI 
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
