### PR TITLE
Items: Permit calling focus() on invisible items

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -973,7 +973,7 @@ impl WindowInner {
         let mut visited = Vec::new();
 
         loop {
-            if current_item.is_visible()
+            if (current_item.is_visible() || reason == FocusReason::Programmatic)
                 && self.publish_focus_item(&Some(current_item.clone()), reason)
                     == crate::input::FocusEventResult::FocusAccepted
             {

--- a/tests/cases/focus/hidden_programmatic.slint
+++ b/tests/cases/focus/hidden_programmatic.slint
@@ -1,0 +1,75 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    in-out property <bool> is_search_on: false;
+    width: 495px;
+    height: 40px;
+    Rectangle {
+        width: 20px;
+        height: 20px;
+        x: 2px;
+        background: red;
+        button := TouchArea {
+            clicked => {
+                if is_search_on {
+                    is_search_on = false;
+                    entryarea.clear-focus();
+                } else {
+                    is_search_on = true;
+                    entryarea.focus();
+                }
+            }
+            accessible-role: AccessibleRole.button;
+            accessible-action-default => {
+                self.clicked();
+            }
+        }
+    }
+
+    Rectangle {
+        x: 30px;
+        y: is_search_on ? 0px : -42px;
+        entryarea := TextInput {
+            y: 5px;
+            width: parent.width;
+            height: 25px;
+        }
+
+        animate y { duration: 500ms; }
+    }
+
+    out property <bool> textinput-has-focus <=> entryarea.has-focus;
+}
+
+/*
+
+
+```rust
+let instance = TestCase::new().unwrap();
+
+let mut result = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::button").collect::<Vec<_>>();
+assert_eq!(result.len(), 1);
+let button = result.pop().unwrap();
+
+// Not visible yet
+result = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::entryarea").collect::<Vec<_>>();
+assert_eq!(result.len(), 0);
+
+assert!(!instance.get_textinput_has_focus());
+button.invoke_accessible_default_action();
+assert!(instance.get_textinput_has_focus());
+
+// Not visible yet either
+result = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::entryarea").collect::<Vec<_>>();
+assert_eq!(result.len(), 0);
+
+slint_testing::mock_elapsed_time(600);
+
+// Now it's visible and still has focus
+result = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::entryarea").collect::<Vec<_>>();
+assert_eq!(result.len(), 1);
+assert!(instance.get_textinput_has_focus());
+```
+
+*/


### PR DESCRIPTION
Focus transfer via keyboard or mouse only works between visible items, but let's permit programmatic focus transfer and trust the developer to do the right thing towards the user.

Reported by ramayen at https://chat.slint.dev/public/pl/kaik88s9tbbaxp6mq9ht1ysw5a

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
