### PR TITLE
chore: Improve dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      time: "04:00"
+      time: "01:00"
     groups:
       github-actions:
         patterns:
@@ -25,7 +25,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-      time: "04:00"
+      time: "01:00"
     ignore:
       - dependency-name: "@types/node"
       - dependency-name: "@types/vscode"
@@ -35,11 +35,10 @@ updates:
       - dependency-name: "@codingame/monaco-vscode-languages-service-override"
       - dependency-name: "@codingame/monaco-vscode-model-service-override"
       - dependency-name: "@codingame/monaco-vscode-storage-service-override"
+      - dependency-name: "@codingame/monaco-vscode-api"
+      - dependency-name: "@codingame/monaco-vscode-editor-api"
 
     groups:
-      codingame:
-        patterns:
-          - "@codingame*"
       vscode:
         patterns:
           - "vscode*"
@@ -62,3 +61,9 @@ updates:
       lumino:
         patterns:
           - "@lumino/*"
+      vite:
+        patterns:
+          - "vite*"
+          - "@vitejs*"
+          - "vitest*"
+          - "@vitest*"


### PR DESCRIPTION
Make it run 3 hours early so CI has finished by the time people login on
monday.

Ignore more vscode extensions (coding game).

Better group vite and vitest updates.