### PR TITLE
Fix grammar and typos in comments (in the compiler passes)

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -869,7 +869,7 @@ pub struct LengthConversionPowers {
     pub px_to_phx_power: i8,
 }
 
-/// If the `Type::UnitProduct(a)` can be converted to `Type::UnitProduct(a)` by multiplying
+/// If the `Type::UnitProduct(a)` can be converted to `Type::UnitProduct(b)` by multiplying
 /// by the scale factor, return that scale factor, otherwise, return None
 pub fn unit_product_length_conversion(
     a: &[(Unit, i8)],

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passes that fills the Property::use_count
+//! This pass fills the Property::use_count
 //!
-//! This pass assume that use_count of all properties is zero
+//! It assumes that use_count of all properties is zero initially
 
 use crate::llr::{
     Animation, BindingExpression, CompilationUnit, EvaluationContext, Expression, ParentCtx,

--- a/internal/compiler/passes/apply_default_properties_from_style.rs
+++ b/internal/compiler/passes/apply_default_properties_from_style.rs
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passe that apply the default property from the style.
+//! This pass applies the default properties from the style.
 //!
-//! Note that the layout default property are handled in the lower_layout pass
+//! Note that the layout default properties are handled in the lower_layout pass
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Expression, NamedReference};

--- a/internal/compiler/passes/collect_custom_fonts.rs
+++ b/internal/compiler/passes/collect_custom_fonts.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passes that fills the root component used_global
+//! This pass extends the init code with font registration
 
 use crate::{
     expression_tree::{BuiltinFunction, Expression, Unit},
@@ -10,7 +10,6 @@ use crate::{
 use smol_str::SmolStr;
 use std::collections::BTreeSet;
 
-/// Fill the root_component's used_globals
 pub fn collect_custom_fonts<'a>(
     doc: &Document,
     all_docs: impl Iterator<Item = &'a Document> + 'a,

--- a/internal/compiler/passes/collect_globals.rs
+++ b/internal/compiler/passes/collect_globals.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passes that fills the root component used_types.globals
+//! This pass fills the root component used_types.globals
 
 use by_address::ByAddress;
 

--- a/internal/compiler/passes/collect_init_code.rs
+++ b/internal/compiler/passes/collect_init_code.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passe that collects the code from init callbacks from elements and moves it into the component's init_code.
+//! This pass collects the code from init callbacks from elements and moves it into the component's init_code.
 
 use std::rc::Rc;
 

--- a/internal/compiler/passes/collect_structs_and_enums.rs
+++ b/internal/compiler/passes/collect_structs_and_enums.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passes that fills the root component used_types.structs
+//! This pass fills the root component's used_types.structs_and_enums
 
 use crate::expression_tree::Expression;
 use crate::langtype::Type;

--- a/internal/compiler/passes/collect_subcomponents.rs
+++ b/internal/compiler/passes/collect_subcomponents.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passes that fills the root component used_types.sub_components
+//! This pass fills the root component used_types.sub_components
 
 use by_address::ByAddress;
 

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -1,11 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passes that resolve the type of two way bindings.
+//! This pass resolves the type of two way bindings.
 //!
-//! Before this pass, two way binding that did not specified the type have Type::Void
-//! type and their bindings are still a Expression::Uncompiled,
-//! this pass will attempt to assign a type to these based on the type of property they alias.
+//! Before this pass, two way bindings that did not specify the type have Type::Void
+//! type and their bindings are still a Expression::Uncompiled.
+//! This pass will attempt to assign a type to these based on the type of property they alias.
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::Expression;

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passe that compute the layout constraint
+//! This pass computes the layout constraint
 
 use lyon_path::geom::euclid::approxeq::ApproxEq;
 

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passe lower the `MenuBar` and `ContextMenuArea` as well as all their contents
+//! This pass lowers the `MenuBar` and `ContextMenuArea` as well as all their contents
 //!
 //! We can't have properties of type Model because that is not binary compatible with C++,
 //! so all the code that handle model of MenuEntry need to be handle by code in the generated code

--- a/internal/compiler/passes/lower_platform.rs
+++ b/internal/compiler/passes/lower_platform.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Pass lower the access to the global Platform to constants and builtin function calls.
+//! This pass lowers the access to the global Platform to constants and builtin function calls.
 
 use crate::expression_tree::{BuiltinFunction, Expression};
 use crate::object_tree::{visit_all_expressions, Component};

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passe that transform the PopupWindow element into a component
+//! This pass transforms the PopupWindow element into a component
 
 use crate::diagnostics::{BuildDiagnostics, SourceLocation};
 use crate::expression_tree::{BindingExpression, Expression, NamedReference};

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -3,10 +3,10 @@
 
 // cSpell: ignore tabwidget
 
-//! Passe lower the TabWidget to create the tabbar.
+//! This pass lowers the TabWidget to create the tabbar.
 //!
 //! Must be done before inlining and many other passes because the lowered code must
-//! be further inlined as it may expends to native widget that needs inlining
+//! be further inlined as it may expand to a native widget that needs inlining
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BindingExpression, Expression, MinMaxOp, NamedReference, Unit};

--- a/internal/compiler/passes/lower_text_input_interface.rs
+++ b/internal/compiler/passes/lower_text_input_interface.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passe lower the access to the global TextInputInterface.text-input-focused to getter or setter.
+//! This pass lowers the access to the global TextInputInterface.text-input-focused to getter or setter.
 
 use crate::expression_tree::{BuiltinFunction, Expression};
 use crate::namedreference::NamedReference;

--- a/internal/compiler/passes/lower_timers.rs
+++ b/internal/compiler/passes/lower_timers.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passe that transform the Timer element into a timer in the Component
+//! This pass transforms the Timer element into a timer in the Component
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference};

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Passes that resolve the property binding expression.
+//! This pass resolves the property binding expressions.
 //!
 //! Before this pass, all the expression are of type Expression::Uncompiled,
 //! and there should no longer be Uncompiled expression after this pass.


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
