### PR TITLE
LinuxKMS: Restore support for rendering to AR24 framebuffers

### DIFF
--- a/internal/backends/linuxkms/renderer/skia.rs
+++ b/internal/backends/linuxkms/renderer/skia.rs
@@ -20,7 +20,7 @@ pub struct SkiaRendererAdapter {
 const SKIA_SUPPORTED_DRM_FOURCC_FORMATS: &[drm::buffer::DrmFourcc] = &[
     // Preferred formats
     drm::buffer::DrmFourcc::Xrgb8888,
-    // drm::buffer::DrmFourcc::Argb8888,
+    drm::buffer::DrmFourcc::Argb8888,
     // drm::buffer::DrmFourcc::Bgra8888,
     // drm::buffer::DrmFourcc::Rgba8888,
 
@@ -236,6 +236,8 @@ impl i_slint_renderer_skia::software_surface::RenderBuffer for DrmDumbBufferAcce
                 match format {
                     drm::buffer::DrmFourcc::Xrgb8888 => skia_safe::ColorType::BGRA8888,
 
+                    // Note: We use AlphaType::Opaque in software_surface. Might need fixing if
+                    // we want to support Argb8888 proper.
                     drm::buffer::DrmFourcc::Argb8888 => skia_safe::ColorType::BGRA8888,
 
                     drm::buffer::DrmFourcc::Rgba8888 => skia_safe::ColorType::RGBA8888,

--- a/internal/backends/linuxkms/renderer/sw.rs
+++ b/internal/backends/linuxkms/renderer/sw.rs
@@ -21,7 +21,7 @@ pub struct SoftwareRendererAdapter {
 const SOFTWARE_RENDER_SUPPORTED_DRM_FOURCC_FORMATS: &[drm::buffer::DrmFourcc] = &[
     // Preferred formats
     drm::buffer::DrmFourcc::Xrgb8888,
-    // drm::buffer::DrmFourcc::Argb8888,
+    drm::buffer::DrmFourcc::Argb8888,
     // drm::buffer::DrmFourcc::Bgra8888,
     // drm::buffer::DrmFourcc::Rgba8888,
 
@@ -160,7 +160,7 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SoftwareRendererAdap
             });
 
             match format {
-                drm::buffer::DrmFourcc::Xrgb8888 => {
+                drm::buffer::DrmFourcc::Xrgb8888 | drm::buffer::DrmFourcc::Argb8888 => {
                     let buffer: &mut [DumbBufferPixelXrgb888] =
                         bytemuck::cast_slice_mut(pixels.as_mut());
                     self.renderer.render(buffer, self.size.width as usize);


### PR DESCRIPTION
We used to just map 32-bpp to XRGB before commit 6f3cd8763bbbd13833c607007af4dd3a0f22489d and that was also fine. We don't really support transparency right now, but we should keep rendering.

Fixes #9126

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
