### PR TITLE
Fix compile errors in generated code or interpreter panic when using …

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3220,16 +3220,20 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                             unreachable!()
                         }
                     }.collect::<Vec<_>>();
-                    format!(
-                        r#"[&](){{
-                            slint::private_api::PathElement elements[{}] = {{
-                                {}
-                            }};
-                            return slint::private_api::PathData(&elements[0], std::size(elements));
-                        }}()"#,
-                        path_elements.len(),
-                        path_elements.join(",")
-                    )
+                    if !path_elements.is_empty() {
+                        format!(
+                            r#"[&](){{
+                                slint::private_api::PathElement elements[{}] = {{
+                                    {}
+                                }};
+                                return slint::private_api::PathData(&elements[0], std::size(elements));
+                            }}()"#,
+                            path_elements.len(),
+                            path_elements.join(",")
+                        )
+                    } else {
+                        "slint::private_api::PathData()".into()
+                    }
                 }
                 (Type::Struct { .. }, Type::PathData)
                     if matches!(

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -101,14 +101,6 @@ pub async fn run_passes(
         keep_raw.then(|| crate::typeloader::snapshot_with_extra_doc(type_loader, doc).unwrap());
 
     collect_subcomponents::collect_subcomponents(doc);
-    doc.visit_all_used_components(|component| {
-        compile_paths::compile_paths(
-            component,
-            &doc.local_registry,
-            type_loader.compiler_config.embed_resources,
-            diag,
-        );
-    });
     lower_tabwidget::lower_tabwidget(doc, type_loader, diag).await;
     lower_menus::lower_menus(doc, type_loader, diag).await;
     lower_component_container::lower_component_container(doc, type_loader, diag);
@@ -123,6 +115,12 @@ pub async fn run_passes(
         );
         lower_states::lower_states(component, &doc.local_registry, diag);
         lower_text_input_interface::lower_text_input_interface(component);
+        compile_paths::compile_paths(
+            component,
+            &doc.local_registry,
+            type_loader.compiler_config.embed_resources,
+            diag,
+        );
         repeater_component::process_repeater_components(component);
         lower_popups::lower_popups(component, &doc.local_registry, diag);
         collect_init_code::collect_init_code(component);

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -11,7 +11,6 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::*;
-use crate::langtype::ElementType;
 use crate::langtype::{Struct, Type};
 use crate::object_tree::*;
 use crate::EmbedResourcesKind;
@@ -28,15 +27,10 @@ pub fn compile_paths(
     let path_type = tr.lookup_element("Path").unwrap();
     let path_type = path_type.as_builtin();
 
-    recurse_elem(&component.root_element, &(), &mut |elem_, _| {
-        let accepted_type = match &elem_.borrow().base_type {
-            ElementType::Builtin(be)
-                if be.native_class.class_name == path_type.native_class.class_name =>
-            {
-                path_type
-            }
-            _ => return,
-        };
+    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem_, _| {
+        if !elem_.borrow().builtin_type().is_some_and(|bt| bt.name == "Path") {
+            return;
+        }
 
         #[cfg(feature = "software-renderer")]
         if _embed_resources == EmbedResourcesKind::EmbedTextures {
@@ -46,7 +40,7 @@ pub fn compile_paths(
             )
         }
 
-        let element_types = &accepted_type.additional_accepted_child_types;
+        let element_types = &path_type.additional_accepted_child_types;
 
         let commands_binding =
             elem_.borrow_mut().bindings.remove("commands").map(RefCell::into_inner);

--- a/tests/cases/crashes/issue9141_path_commands.slint
+++ b/tests/cases/crashes/issue9141_path_commands.slint
@@ -1,0 +1,16 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component TestPath inherits Path { }
+
+export component TestCase inherits Window {
+    TestPath {
+        x: 0phx;
+        y: 0phx;
+        width: 100%;
+        height: 100%;
+        commands: "M 100 300 Q 150 50 1100 400 Q 1450 500 750 500 Q 1000 600 950 600 C 325 575 350 450 150 550 Q 0 600 100 800 C 250 850 300 600 550 850 C 800 850 850 650 2000 700 ";
+        stroke: red;
+        stroke_width: 2px;
+    }
+}

--- a/tests/cases/crashes/issue9141_path_commands.slint
+++ b/tests/cases/crashes/issue9141_path_commands.slint
@@ -3,6 +3,29 @@
 
 component TestPath inherits Path { }
 
+export component Triangle inherits Rectangle {
+    width: 200px;
+    height: 200px;
+    background: #333333;
+
+    property <bool> Expanded;
+
+    states [
+        DownArrow when Expanded: {
+            Arrow.commands: "M0,0.75L141.73,0L71.32,85.04L0,0.75z";
+        }
+        LeftArrow when !Expanded: {
+            Arrow.commands: "M84.29,0l0.75,141.73L0,71.32L84.29,0z";
+        }
+    ]
+
+    Arrow := Path {
+        width: 100px;
+        fill: #ffffff;
+        commands: "M0,0.75L141.73,0L71.32,85.04L0,0.75z";
+    }
+}
+
 export component TestCase inherits Window {
     TestPath {
         x: 0phx;
@@ -13,4 +36,6 @@ export component TestCase inherits Window {
         stroke: red;
         stroke_width: 2px;
     }
+
+    Triangle { }
 }


### PR DESCRIPTION
…Path's commands in sub-components or states.

This code is old :-). Use the modern functions for visiting all elements (to not miss any) and modernize the inheritance check.

Fixes #9141
Fixes #4080

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
