### PR TITLE
FemtoVG: Support compiling without OpenGL

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -40,8 +40,8 @@ x11 = [
   "softbuffer?/x11",
   "softbuffer?/x11-dlopen",
 ]
-renderer-femtovg = ["dep:i-slint-renderer-femtovg", "dep:glutin", "dep:glutin-winit"]
-renderer-femtovg-wgpu = ["i-slint-renderer-femtovg/wgpu", "renderer-femtovg"]
+renderer-femtovg = ["i-slint-renderer-femtovg/opengl", "dep:glutin", "dep:glutin-winit"]
+renderer-femtovg-wgpu = ["i-slint-renderer-femtovg/wgpu", "dep:i-slint-renderer-femtovg"]
 renderer-skia = ["i-slint-renderer-skia"]
 renderer-skia-opengl = ["renderer-skia", "i-slint-renderer-skia/opengl"]
 renderer-skia-vulkan = ["renderer-skia", "i-slint-renderer-skia/vulkan"]

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -8,6 +8,7 @@ fn main() {
     cfg_aliases! {
        ios_and_friends: { all(target_vendor = "apple", not(target_os = "macos"))},
        enable_skia_renderer: { any(feature = "renderer-skia", feature = "renderer-skia-opengl", feature = "renderer-skia-vulkan", ios_and_friends) },
+       enable_femtovg_renderer: { any(feature = "renderer-femtovg", feature = "renderer-femtovg-wgpu") },
        enable_accesskit: { all(feature = "accessibility", not(target_arch = "wasm32")) },
        supports_opengl: { all(any(enable_skia_renderer, feature = "renderer-femtovg"), not(ios_and_friends)) },
        use_winit_theme: { any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32") },

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -101,7 +101,7 @@ mod xdg_color_scheme;
 pub(crate) mod wasm_input_helper;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "renderer-femtovg")] {
+    if #[cfg(enable_femtovg_renderer)] {
         const DEFAULT_RENDERER_NAME: &str = "FemtoVG";
     } else if #[cfg(enable_skia_renderer)] {
         const DEFAULT_RENDERER_NAME: &'static str = "Skia";
@@ -143,6 +143,8 @@ fn try_create_window_with_fallback_renderer(
             feature = "renderer-skia-vulkan"
         ))]
         renderer::skia::WinitSkiaRenderer::new_suspended,
+        #[cfg(feature = "renderer-femtovg-wgpu")]
+        renderer::femtovg::WGPUFemtoVGRenderer::new_suspended,
         #[cfg(all(feature = "renderer-femtovg", supports_opengl))]
         renderer::femtovg::GlutinFemtoVGRenderer::new_suspended,
         #[cfg(feature = "renderer-software")]
@@ -368,10 +370,7 @@ impl BackendBuilder {
             self.renderer_name.as_deref(),
             self.requested_graphics_api.as_ref(),
         ) {
-            #[cfg(any(
-                all(feature = "renderer-femtovg", supports_opengl),
-                feature = "renderer-femtovg-wgpu"
-            ))]
+            #[cfg(all(feature = "renderer-femtovg", supports_opengl))]
             (Some("gl"), maybe_graphics_api) | (Some("femtovg"), maybe_graphics_api) => {
                 // If a graphics API was requested, double check that it's GL. FemtoVG doesn't support Metal, etc.
                 if let Some(api) = maybe_graphics_api {

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 
 use i_slint_core::renderer::Renderer;
 use i_slint_core::{graphics::RequestedGraphicsAPI, platform::PlatformError};
-use i_slint_renderer_femtovg::{
-    opengl, FemtoVGOpenGLRendererExt, FemtoVGRenderer, FemtoVGRendererExt,
-};
+#[cfg(supports_opengl)]
+use i_slint_renderer_femtovg::{opengl, FemtoVGOpenGLRendererExt};
+use i_slint_renderer_femtovg::{FemtoVGRenderer, FemtoVGRendererExt};
 
 use winit::event_loop::ActiveEventLoop;
 #[cfg(target_arch = "wasm32")]
@@ -16,13 +16,15 @@ use winit::platform::web::WindowExtWebSys;
 
 use super::WinitCompatibleRenderer;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(supports_opengl, not(target_arch = "wasm32")))]
 mod glcontext;
 
+#[cfg(supports_opengl)]
 pub struct GlutinFemtoVGRenderer {
     renderer: FemtoVGRenderer<opengl::OpenGLBackend>,
 }
 
+#[cfg(supports_opengl)]
 impl GlutinFemtoVGRenderer {
     pub fn new_suspended(
         _shared_backend_data: &Rc<crate::SharedBackendData>,
@@ -31,6 +33,7 @@ impl GlutinFemtoVGRenderer {
     }
 }
 
+#[cfg(supports_opengl)]
 impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn render(&self, _window: &i_slint_core::api::Window) -> Result<(), PlatformError> {
         self.renderer.render()
@@ -105,7 +108,7 @@ impl WinitCompatibleRenderer for WGPUFemtoVGRenderer {
         self.renderer.render()
     }
 
-    fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer {
+    fn as_core_renderer(&self) -> &dyn Renderer {
         &self.renderer
     }
 

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -17,6 +17,7 @@ path = "lib.rs"
 
 [features]
 default = []
+opengl = []
 wgpu = ["wgpu-26"]
 wgpu-26 = ["dep:wgpu-26", "femtovg/wgpu", "i-slint-core/unstable-wgpu-26"]
 unstable-wgpu-26 = ["wgpu-26"]

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -36,6 +36,7 @@ use self::itemrenderer::CanvasRc;
 mod fonts;
 mod images;
 mod itemrenderer;
+#[cfg(feature = "opengl")]
 pub mod opengl;
 #[cfg(feature = "wgpu-26")]
 pub mod wgpu;
@@ -514,6 +515,7 @@ pub trait FemtoVGRendererExt {
 /// The purpose of this trait is to add internal API specific to the OpenGL renderer that's accessed from the winit
 /// backend. In this case, the ability to resume a suspended OpenGL renderer by providing a new context.
 #[doc(hidden)]
+#[cfg(feature = "opengl")]
 pub trait FemtoVGOpenGLRendererExt {
     fn set_opengl_context(
         &self,
@@ -585,6 +587,7 @@ impl<B: GraphicsBackend> FemtoVGRendererExt for FemtoVGRenderer<B> {
     }
 }
 
+#[cfg(feature = "opengl")]
 impl FemtoVGOpenGLRendererExt for FemtoVGRenderer<opengl::OpenGLBackend> {
     fn set_opengl_context(
         &self,
@@ -601,4 +604,5 @@ impl FemtoVGOpenGLRendererExt for FemtoVGRenderer<opengl::OpenGLBackend> {
     }
 }
 
+#[cfg(feature = "opengl")]
 pub type FemtoVGOpenGLRenderer = FemtoVGRenderer<opengl::OpenGLBackend>;


### PR DESCRIPTION
Building with --no-default-features --features compat-1-2,backend-winit,renderer-femtovg-wgpu should not require glutin.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
