### PR TITLE
CI: Streamline and fix windows tool binary artifact creation

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -591,18 +591,14 @@ jobs:
                   mv slint-viewer-armv7-unknown-linux-gnueabihf.tar.gz artifacts/
                   mv slint-viewer-aarch64-unknown-linux-gnu.tar.gz artifacts/
                   mv slint-viewer-macos.tar.gz artifacts/
+                  mv slint-viewer-windows*.zip artifacts/
                   mv slint-lsp-linux.tar.gz artifacts/
                   mv slint-lsp-armv7-unknown-linux-gnueabihf.tar.gz artifacts/
                   mv slint-lsp-aarch64-unknown-linux-gnu.tar.gz artifacts/
                   mv slint-lsp-macos.tar.gz artifacts/
+                  mv slint-lsp-windows*.zip artifacts/
                   mv slint-compiler-*.tar.gz artifacts/
                   mv figma-plugin.zip artifacts/
-            - uses: montudor/action-zip@v1
-              with:
-                  args: zip -r artifacts/slint-viewer-windows-x86_64-pc-windows-msvc.zip slint-viewer
-            - uses: montudor/action-zip@v1
-              with:
-                  args: zip -r artifacts/slint-lsp-windowsx86_64-pc-windows-msvc.zip slint-lsp
             - uses: actions/checkout@v4
               with:
                 path: "slint-src"

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -89,13 +89,17 @@ jobs:
                   cd ..
                   cd tools\${{ github.event.inputs.program || inputs.program }}
                   bash -x ../../scripts/prepare_binary_package.sh ..\..\pkg\slint-${{ github.event.inputs.program || inputs.program }}
-
+            - name: Create archive
+              shell: powershell
+              run: |
+                  cd pkg
+                  Compress-Archive -Path * -Destination ..\slint-${{ github.event.inputs.program || inputs.program }}-windows-${{ matrix.package_suffix }}.zip
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
                   name: slint-${{ github.event.inputs.program || inputs.program }}-windows-${{ matrix.package_suffix }}
                   path: |
-                      pkg
+                      slint-${{ github.event.inputs.program || inputs.program }}-windows-${{ matrix.package_suffix }}.zip
 
     build_linux:
         runs-on: ubuntu-22.04


### PR DESCRIPTION
Instead of wrongly fixing up the .zip archive name in the prepare_release phase (and missing a space as per #9050), let the slint_tool_binary workflow create the correct .zip archive, then let upload-artifact archive the zip (instead of the directory), so that unpacking on the release job side will retain the zip file.

This way it's handled the same as for .tar.gz (where download-artifact doesn't unarchive) and the file name is decided in one place (slint_tool_binary).

Fixes #9050

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
