### PR TITLE
Fix default font size not being propagated to popup windows

### DIFF
--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1325,7 +1325,7 @@ impl WindowItem {
         }
     }
 
-    pub fn resolve_font_property<T>(
+    fn resolve_font_property<T>(
         self_rc: &ItemRc,
         property_fn: impl Fn(Pin<&Self>) -> Option<T>,
     ) -> Option<T> {
@@ -1366,7 +1366,7 @@ impl WindowItem {
                 if !local_font_family.is_empty() {
                     Some(local_font_family)
                 } else {
-                    crate::items::WindowItem::resolve_font_property(
+                    Self::resolve_font_property(
                         &window_item_rc,
                         crate::items::WindowItem::font_family,
                     )
@@ -1374,7 +1374,7 @@ impl WindowItem {
             },
             weight: {
                 if local_font_weight == 0 {
-                    crate::items::WindowItem::resolve_font_property(
+                    Self::resolve_font_property(
                         &window_item_rc,
                         crate::items::WindowItem::font_weight,
                     )
@@ -1384,7 +1384,7 @@ impl WindowItem {
             },
             pixel_size: {
                 if local_font_size.get() == 0 as Coord {
-                    crate::items::WindowItem::resolve_font_property(
+                    Self::resolve_font_property(
                         &window_item_rc,
                         crate::items::WindowItem::font_size,
                     )

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -447,7 +447,7 @@ pub struct WindowInner {
     mouse_input_state: Cell<MouseInputState>,
     pub(crate) modifiers: Cell<InternalKeyboardModifierState>,
 
-    /// ItemRC that currently have the focus. (possibly a, instance of TextInput)
+    /// ItemRC that currently have the focus (possibly an instance of TextInput)
     pub focus_item: RefCell<crate::item_tree::ItemWeak>,
     /// The last text that was sent to the input method
     pub(crate) last_ime_text: RefCell<SharedString>,
@@ -569,7 +569,7 @@ impl WindowInner {
         self.component.borrow().upgrade()
     }
 
-    /// Returns a slice of the active poppups.
+    /// Returns a slice of the active popups.
     pub fn active_popups(&self) -> core::cell::Ref<'_, [PopupWindow]> {
         core::cell::Ref::map(self.active_popups.borrow(), |v| v.as_slice())
     }

--- a/tests/cases/text/componentcontainer_font_size_propagation.slint
+++ b/tests/cases/text/componentcontainer_font_size_propagation.slint
@@ -1,0 +1,72 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//ignore: cpp,js
+
+export component TestCase inherits Window {
+    default-font-size: 24px;
+    HorizontalLayout {
+        cont := ComponentContainer { }
+    }
+
+    in property <component-factory> component-factory <=> cont.component-factory;
+    out property <length> pref-height: root.preferred-height;
+}
+
+/*
+
+
+
+```rust
+
+use slint::ComponentHandle;
+let inner_instance = std::rc::Rc::<core::cell::RefCell<Option<slint_interpreter::ComponentInstance>>>::default();
+let inner_instance_clone = inner_instance.clone();
+let factory = slint::ComponentFactory::new(move |ctx| {
+    let compiler = slint_interpreter::Compiler::new();
+    let e = spin_on::spin_on(compiler.build_from_source(
+        // This is the same test as font_size_propagation.slint
+        r#"export component Inner inherits Window {
+                default-font-size: 34px;
+                preferred-height: t.font-metrics.ascent - t.font-metrics.descent;
+                t := Text {
+                    text: "Hello 🌍";
+                }
+
+                out property <length> popup-text-size: 0px;
+
+                popup := PopupWindow {
+                    popup-text := Text {
+                        text: "Ok 🌍";
+                    }
+                    init => {
+                        popup-text-size = popup-text.font-metrics.ascent - popup-text.font-metrics.descent;
+                    }
+                }
+
+                TouchArea {
+                    clicked => {
+                        popup.show();
+                    }
+                }
+            }"#.into(),
+        std::path::PathBuf::from("embedded.slint"),
+     )).component("Inner").unwrap();
+
+    let inner = e.create_embedded(ctx).unwrap();
+    inner_instance_clone.replace(Some(inner.clone_strong()));
+    Some(inner)
+});
+
+let instance = TestCase::new().unwrap();
+instance.set_component_factory(factory.clone());
+assert_eq!(instance.get_pref_height(), 34.);
+let popup_text_size = inner_instance.borrow().as_ref().expect("should have been created").get_property("popup-text-size").unwrap();
+assert_eq!(popup_text_size, slint_interpreter::Value::from(0.));
+slint_testing::send_mouse_click(&instance, 5., 5.);
+let popup_text_size = inner_instance.borrow().as_ref().expect("should have been created").get_property("popup-text-size").unwrap();
+assert_eq!(popup_text_size, slint_interpreter::Value::from(34.));
+```
+
+
+*/

--- a/tests/cases/text/font_size_propagation.slint
+++ b/tests/cases/text/font_size_propagation.slint
@@ -1,71 +1,48 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//ignore: cpp,js
-
 export component TestCase inherits Window {
-    default-font-size: 24px;
-    HorizontalLayout {
-        cont := ComponentContainer { }
+    default-font-size: 34px;
+    preferred-height: t.font-metrics.ascent - t.font-metrics.descent;
+    t := Text {
+        text: "Hello 🌍";
     }
 
-    in property <component-factory> component-factory <=> cont.component-factory;
-    out property <length> pref-height: root.preferred-height;
+    out property <length> popup-text-size: 0px;
+
+    popup := PopupWindow {
+        popup-text := Text {
+            text: "Ok 🌍";
+        }
+        init => {
+            popup-text-size = popup-text.font-metrics.ascent - popup-text.font-metrics.descent;
+        }
+    }
+
+    TouchArea {
+        clicked => {
+            popup.show();
+        }
+    }
 }
 
 /*
-
-
-
 ```rust
-
-use slint::ComponentHandle;
-let inner_instance = std::rc::Rc::<core::cell::RefCell<Option<slint_interpreter::ComponentInstance>>>::default();
-let inner_instance_clone = inner_instance.clone();
-let factory = slint::ComponentFactory::new(move |ctx| {
-    let compiler = slint_interpreter::Compiler::new();
-    let e = spin_on::spin_on(compiler.build_from_source(
-        r#"export component Inner inherits Window {
-                default-font-size: 34px;
-                preferred-height: t.font-metrics.ascent - t.font-metrics.descent;
-                t := Text {
-                    text: "Hello 🌍";
-                }
-
-                out property <length> popup-text-size: 0px;
-
-                popup := PopupWindow {
-                    popup-text := Text {
-                        text: "Ok 🌍";
-                    }
-                    init => {
-                        popup-text-size = popup-text.font-metrics.ascent - popup-text.font-metrics.descent;
-                    }
-                }
-
-                TouchArea {
-                    clicked => {
-                        popup.show();
-                    }
-                }
-            }"#.into(),
-        std::path::PathBuf::from("embedded.slint"),
-     )).component("Inner").unwrap();
-
-    let inner = e.create_embedded(ctx).unwrap();
-    inner_instance_clone.replace(Some(inner.clone_strong()));
-    Some(inner)
-});
-
 let instance = TestCase::new().unwrap();
-instance.set_component_factory(factory.clone());
-assert_eq!(instance.get_pref_height(), 34.);
-let popup_text_size = inner_instance.borrow().as_ref().expect("should have been created").get_property("popup-text-size").unwrap();
-assert_eq!(popup_text_size, slint_interpreter::Value::from(0.));
+let popup_text_size = instance.get_popup_text_size();
+assert_eq!(popup_text_size, 0.);
 slint_testing::send_mouse_click(&instance, 5., 5.);
-let popup_text_size = inner_instance.borrow().as_ref().expect("should have been created").get_property("popup-text-size").unwrap();
-assert_eq!(popup_text_size, slint_interpreter::Value::from(34.));
+let popup_text_size = instance.get_popup_text_size();
+assert_eq!(popup_text_size, 34.);
 ```
 
-
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+auto popup_text_size = instance.get_popup_text_size();
+assert_eq(popup_text_size, 0.);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+popup_text_size = instance.get_popup_text_size();
+assert_eq(popup_text_size, 34.);
+```
 */


### PR DESCRIPTION
With thanks to Simon for the guidance on how to fix this.

Fixes #8855

Please review carefully, I'm not sure about the assumption that if there's a context but no repeater index then it must be a PopupWindow (which is based on how ˋgenerate_item_treeˋ is currently called, but could be surprising if that changes in the future). Should I pass an extra argument to ˋgenerate_item_treeˋ instead, like it already has for ˋis_popup_menuˋ? (if so, maybe an enum then, to avoid 2 bools?)

Also, this showed that autotests could pass with the interpreter and fail with the compiler - should the test framework be extended to also run these test cases with the compiler?