### PR TITLE
SlintPad: Replace web menubar with Slint menubar

### DIFF
--- a/editors/vscode/src/wasm_preview.ts
+++ b/editors/vscode/src/wasm_preview.ts
@@ -146,7 +146,8 @@ function getPreviewHtml(
             vscode.postMessage({ command: "map_url", url: url });
         })},
         "${default_style}",
-        ${experimental ? "true" : "false"}
+        ${experimental ? "true" : "false"},
+        undefined
     );
 
     window.addEventListener('message', async message => {

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -116,7 +116,7 @@ lsp-server = "0.7"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.5"
 js-sys = { version = "0.3.57" }
-web-sys = { workspace = true, features = ["Navigator"] }
+web-sys = { workspace = true, features = ["Navigator", "Clipboard", "UrlSearchParams", "Location"] }
 send_wrapper = { workspace = true }
 serde-wasm-bindgen = "0.6.0"
 wasm-bindgen = "0.2.80"

--- a/tools/lsp/preview/connector/wasm.rs
+++ b/tools/lsp/preview/connector/wasm.rs
@@ -101,14 +101,7 @@ impl PreviewConnector {
                             Ok(ui) => {
                                 let api = ui.global::<crate::preview::ui::Api>();
 
-                                api.set_runs_in_slintpad(true);
-                                api.on_share_permalink_to_clipboard(|| {
-                                    share_url_to_clipboard();
-                                });
-                                api.on_load_demo(move |url| {
-                                    open_demo_url(&url);
-                                });
-
+                                init_slintpad_specific_ui(&api);
                                 preview_state.borrow_mut().ui = Some(ui);
                                 *preview_state.borrow().to_lsp.borrow_mut() = Some(to_lsp);
 
@@ -265,6 +258,22 @@ impl common::PreviewToLsp for WasmPreviewToLsp {
             Ok(())
         })
     }
+}
+
+fn init_slintpad_specific_ui(api: &crate::preview::ui::Api) {
+    if !WASM_CALLBACKS.with_borrow(|callbacks| {
+        callbacks.as_ref().map_or(false, |cb| cb.demo_opener.is_function())
+    }) {
+        return;
+    }
+
+    api.set_runs_in_slintpad(true);
+    api.on_share_permalink_to_clipboard(|| {
+        share_url_to_clipboard();
+    });
+    api.on_load_demo(move |url| {
+        open_demo_url(&url);
+    });
 }
 
 fn share_url_to_clipboard() {

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -607,4 +607,24 @@ export global Api {
     callback redo();
     in-out property <bool> undo-enabled: false;
     in-out property <bool> redo-enabled: false;
+
+    // ## SlintPad related APIs
+    in-out property <bool> runs-in-slintpad;
+    in-out property <[{title: string, url: string}]> demos: [
+            { url: "", title: "Hello World!"},
+            { url: "examples/gallery/gallery.slint", title: "Gallery" },
+            { url: "demos/home-automation/ui/demo-debug.slint", title: "Home Automation" },
+            { url: "demos/usecases/ui/app.slint", title: "Use Cases Demo" },
+            { url: "demos/printerdemo/ui/printerdemo.slint", title: "Printer Demo" },
+            { url: "demos/energy-monitor/ui/desktop_window.slint", title: "Energy Monitor" },
+            { url: "examples/todo/ui/todo.slint", title: "Todo Demo" },
+            { url: "examples/iot-dashboard/main.slint", title: "IOT Dashboard" },
+            { url: "examples/fancy-switches/demo.slint", title: "Fancy Switches" },
+            { url: "examples/dial/dial.slint", title: "Fanncy Dial" },
+            { url: "examples/orbit-animation/demo.slint", title: "Fancy Animations" },
+            { url: "examples/repeater/demo.slint", title: "Fancy Repeater" },
+            { url: "examples/sprite-sheet/demo.slint", title: "Spritesheet Demo" },
+    ];
+    callback share-permalink-to-clipboard();
+    callback load-demo(url: string);
 }

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -627,4 +627,5 @@ export global Api {
     ];
     callback share-permalink-to-clipboard();
     callback load-demo(url: string);
+    callback show-about-slint();
 }

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -47,10 +47,34 @@ export component PreviewUi inherits Window {
     MenuBar {
         Menu {
             title: @tr("File");
+
+            if Api.runs-in-slintpad: Menu {
+                title: @tr("Open Demo");
+                for demo in Api.demos: MenuItem {
+                    title: demo.title;
+                    activated => {
+                        Api.load-demo(demo.url);
+                    }
+                }
+            }
+
+            MenuSeparator { }
+
             MenuItem {
                 title: @tr("Reload");
                 activated => {
                     Api.reload-preview();
+                }
+            }
+
+            if Api.runs-in-slintpad: Menu {
+                title: @tr("Share");
+
+                MenuItem {
+                    title: @tr("Copy Permalink to Clipboard");
+                    activated => {
+                        Api.share-permalink-to-clipboard();
+                    }
                 }
             }
         }

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -96,7 +96,7 @@ export component PreviewUi inherits Window {
             }
         }
 
-        Menu {
+        if !Api.runs-in-slintpad: Menu {
             title: @tr("Window");
             kot := MenuItem {
                 title: @tr("Keep on Top");

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -110,6 +110,16 @@ export component PreviewUi inherits Window {
                 }
             }
         }
+
+        if Api.runs-in-slintpad: Menu {
+            title: @tr("Help");
+            MenuItem {
+                title: @tr("About");
+                activated => {
+                    Api.show-about-slint();
+                }
+            }
+        }
     }
 
     Button {

--- a/tools/slintpad/src/editor_widget.ts
+++ b/tools/slintpad/src/editor_widget.ts
@@ -555,24 +555,6 @@ export class EditorWidget extends Widget {
         );
     }
 
-    public known_demos(): [string, string][] {
-        return [
-            ["", "Hello World!"],
-            ["examples/gallery/gallery.slint", "Gallery"],
-            ["demos/home-automation/ui/demo-debug.slint", "Home Automation"],
-            ["demos/usecases/ui/app.slint", "Use Cases Demo"],
-            ["demos/printerdemo/ui/printerdemo.slint", "Printer Demo"],
-            ["demos/energy-monitor/ui/desktop_window.slint", "Energy Monitor"],
-            ["examples/todo/ui/todo.slint", "Todo Demo"],
-            ["examples/iot-dashboard/main.slint", "IOT Dashboard"],
-            ["examples/fancy-switches/demo.slint", "Fancy Switches"],
-            ["examples/dial/dial.slint", "Fanncy Dial"],
-            ["examples/orbit-animation/demo.slint", "Fancy Animations"],
-            ["examples/repeater/demo.slint", "Fancy Repeater"],
-            ["examples/sprite-sheet/demo.slint", "Spritesheet Demo"],
-        ];
-    }
-
     public add_empty_file_to_project(name: string) {
         let abs_name = name;
         if (!abs_name.startsWith("/")) {

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -27,171 +27,6 @@ const lsp_waiter = new LspWaiter();
 
 const commands = new CommandRegistry();
 
-function create_demo_menu(editor: EditorWidget): Menu {
-    const menu = new Menu({ commands });
-    menu.title.label = "Open Demo";
-
-    for (const demo of editor.known_demos()) {
-        const command_name = "slint:set_demo_" + demo[1];
-        commands.addCommand(command_name, {
-            label: demo[1],
-            execute: () => {
-                return editor.set_demo(demo[0]);
-            },
-        });
-        menu.addItem({ command: command_name });
-    }
-    return menu;
-}
-
-function create_settings_menu(): Menu {
-    const menu = new Menu({ commands });
-    menu.title.label = "Settings";
-
-    commands.addCommand("slint:store_github_token", {
-        label: "Manage Github login",
-        iconClass: "fa-brands fa-github",
-        execute: () => {
-            void manage_github_access();
-        },
-    });
-
-    menu.addItem({ command: "slint:store_github_token" });
-
-    return menu;
-}
-
-function create_project_menu(
-    editor: EditorWidget,
-    preview: PreviewWidget,
-): Menu {
-    const menu = new Menu({ commands });
-    menu.title.label = "Project";
-
-    commands.addCommand("slint:open_url", {
-        label: "Open URL",
-        iconClass: "fa fa-link",
-        mnemonic: 1,
-        execute: () => {
-            const url = prompt("Please enter the URL to open");
-            void editor.project_from_url(url);
-        },
-    });
-
-    commands.addKeyBinding({
-        keys: ["Accel O"],
-        selector: "body",
-        command: "slint:open_url",
-    });
-
-    commands.addCommand("slint:add_file", {
-        label: "Add File",
-        iconClass: "fa-regular fa-file",
-        mnemonic: 1,
-        execute: () => {
-            let name = prompt("Please enter the file name");
-            if (name == null) {
-                return;
-            }
-            if (!name.endsWith(".slint")) {
-                name = name + ".slint";
-            }
-            editor.add_empty_file_to_project(name);
-        },
-    });
-
-    commands.addKeyBinding({
-        keys: ["Accel N"],
-        selector: "body",
-        command: "slint:add_file",
-    });
-
-    menu.addItem({ command: "slint:open_url" });
-    menu.addItem({ type: "submenu", submenu: create_demo_menu(editor) });
-    menu.addItem({ type: "separator" });
-    menu.addItem({ command: "slint:add_file" });
-    menu.addItem({
-        type: "submenu",
-        submenu: create_share_menu(editor, preview),
-    });
-    menu.addItem({ type: "separator" });
-    menu.addItem({ type: "submenu", submenu: create_settings_menu() });
-    menu.addItem({ type: "separator" });
-
-    commands.addCommand("slint:about", {
-        label: "About",
-        iconClass: "fa-info-circle",
-        execute: () => about_dialog(),
-    });
-    menu.addItem({ command: "slint:about" });
-
-    return menu;
-}
-
-function create_share_menu(editor: EditorWidget, preview: PreviewWidget): Menu {
-    const menu = new Menu({ commands });
-    menu.title.label = "Share";
-
-    commands.addCommand("slint:copy_permalink", {
-        label: "Copy Permalink to Clipboard",
-        iconClass: "fa fa-share",
-        mnemonic: 1,
-        isEnabled: () => {
-            return editor.open_document_urls.length === 1;
-        },
-        execute: () => {
-            const params = new URLSearchParams();
-            params.set("snippet", editor.current_editor_content);
-            params.set("style", preview.current_style());
-            const this_url = new URL(window.location.toString());
-            this_url.search = params.toString();
-
-            report_export_url_dialog(this_url.toString());
-        },
-    });
-    commands.addCommand("slint:create_gist", {
-        label: "Export to github Gist",
-        iconClass: "fa-brands fa-github",
-        mnemonic: 1,
-        isEnabled: () => {
-            return editor.open_document_urls.length > 0;
-        },
-        execute: async () => {
-            let has_token = has_github_access_token();
-            if (!has_token) {
-                await manage_github_access();
-            }
-            has_token = has_github_access_token();
-
-            if (has_token) {
-                await export_gist_dialog((desc, is_public) => {
-                    export_to_gist(editor, desc, is_public)
-                        .then((url) => {
-                            const params = new URLSearchParams();
-                            params.set("load_url", url);
-                            const extra_url = new URL(
-                                window.location.toString(),
-                            );
-                            extra_url.search = params.toString();
-
-                            report_export_url_dialog(url, extra_url.toString());
-                        })
-                        .catch((e) => report_export_error_dialog(e));
-                });
-            } else {
-                alert(
-                    "You need a github access token set up to export as a gist.",
-                );
-            }
-        },
-    });
-
-    menu.addItem({ command: "slint:create_gist" });
-    menu.addItem({ command: "slint:copy_permalink" });
-
-    return menu;
-}
-
 const url_params = new URLSearchParams(window.location.search);
 const url_style = url_params.get("style");
 
@@ -201,16 +36,15 @@ function setup(lsp: Lsp) {
         lsp,
         (url: string) => editor.map_url(url),
         url_style ?? "",
+        (demo_url) => {
+            void editor.set_demo(demo_url);
+        },
     );
-
-    const menu_bar = new MenuBar();
-    menu_bar.id = "menuBar";
-    menu_bar.addMenu(create_project_menu(editor, preview));
 
     const main = new SplitPanel({ orientation: "horizontal" });
     main.id = "main";
-    main.addWidget(editor);
     main.addWidget(preview);
+    main.addWidget(editor);
 
     window.onresize = () => {
         main.update();
@@ -220,7 +54,6 @@ function setup(lsp: Lsp) {
         commands.processKeydownEvent(event);
     });
 
-    Widget.attach(menu_bar, document.body);
     Widget.attach(main, document.body);
 }
 

--- a/tools/slintpad/src/index.ts
+++ b/tools/slintpad/src/index.ts
@@ -23,6 +23,8 @@ import {
 import { CommandRegistry } from "@lumino/commands";
 import { Menu, MenuBar, SplitPanel, Widget } from "@lumino/widgets";
 
+import { type InvokeSlintpadCallback, SlintPadCallbackFunction } from "./lsp";
+
 const lsp_waiter = new LspWaiter();
 
 const commands = new CommandRegistry();
@@ -36,8 +38,12 @@ function setup(lsp: Lsp) {
         lsp,
         (url: string) => editor.map_url(url),
         url_style ?? "",
-        (demo_url) => {
-            void editor.set_demo(demo_url);
+        (func_type, args) => {
+            if (func_type === SlintPadCallbackFunction.OpenDemoUrl) {
+                void editor.set_demo(args as string);
+            } else if (func_type === SlintPadCallbackFunction.ShowAbout) {
+                about_dialog();
+            }
         },
     );
 

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -24,11 +24,16 @@ import type { Position as LspPosition } from "vscode-languageserver-types";
 
 import slint_init, * as slint_preview from "@lsp/slint_lsp_wasm.js";
 
-import type {
-    ResourceUrlMapperFunction,
-    OpenDemoUrlFunction,
+import {
+    type ResourceUrlMapperFunction,
+    type InvokeSlintpadCallback,
+    SlintPadCallbackFunction,
 } from "@lsp/slint_lsp_wasm.js";
-export { ResourceUrlMapperFunction, OpenDemoUrlFunction };
+export {
+    ResourceUrlMapperFunction,
+    InvokeSlintpadCallback,
+    SlintPadCallbackFunction,
+};
 
 export type ShowDocumentCallback = (
     _uri: string,
@@ -223,7 +228,7 @@ export class Lsp {
     async previewer(
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
-        demo_opener: OpenDemoUrlFunction,
+        slintpad_callback: InvokeSlintpadCallback,
     ): Promise<Previewer> {
         if (this.#preview_connector === null) {
             slint_preview.run_event_loop();
@@ -243,7 +248,7 @@ export class Lsp {
                     resource_url_mapper,
                     style,
                     experimental === "1",
-                    demo_opener,
+                    slintpad_callback,
                 );
         }
         return new Previewer(this.#preview_connector);

--- a/tools/slintpad/src/lsp.ts
+++ b/tools/slintpad/src/lsp.ts
@@ -24,8 +24,11 @@ import type { Position as LspPosition } from "vscode-languageserver-types";
 
 import slint_init, * as slint_preview from "@lsp/slint_lsp_wasm.js";
 
-import type { ResourceUrlMapperFunction } from "@lsp/slint_lsp_wasm.js";
-export { ResourceUrlMapperFunction };
+import type {
+    ResourceUrlMapperFunction,
+    OpenDemoUrlFunction,
+} from "@lsp/slint_lsp_wasm.js";
+export { ResourceUrlMapperFunction, OpenDemoUrlFunction };
 
 export type ShowDocumentCallback = (
     _uri: string,
@@ -220,6 +223,7 @@ export class Lsp {
     async previewer(
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
+        demo_opener: OpenDemoUrlFunction,
     ): Promise<Previewer> {
         if (this.#preview_connector === null) {
             slint_preview.run_event_loop();
@@ -239,6 +243,7 @@ export class Lsp {
                     resource_url_mapper,
                     style,
                     experimental === "1",
+                    demo_opener,
                 );
         }
         return new Previewer(this.#preview_connector);

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -6,7 +6,12 @@
 import type { Message } from "@lumino/messaging";
 import { Widget } from "@lumino/widgets";
 
-import type { Previewer, Lsp, ResourceUrlMapperFunction } from "./lsp";
+import type {
+    Previewer,
+    Lsp,
+    ResourceUrlMapperFunction,
+    OpenDemoUrlFunction,
+} from "./lsp";
 
 const canvas_id = "canvas";
 
@@ -34,6 +39,7 @@ export class PreviewWidget extends Widget {
         lsp: Lsp,
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
+        demo_url_opener: OpenDemoUrlFunction,
     ) {
         super({ node: PreviewWidget.createNode() });
 
@@ -44,20 +50,22 @@ export class PreviewWidget extends Widget {
         this.title.caption = "Slint Viewer";
         this.title.closable = true;
 
-        void lsp.previewer(resource_url_mapper, style).then((p) => {
-            this.#previewer = p;
+        void lsp
+            .previewer(resource_url_mapper, style, demo_url_opener)
+            .then((p) => {
+                this.#previewer = p;
 
-            // Give the UI some time to wire up the canvas so it can be found
-            // when searching the document.
-            this.#previewer.show_ui().then(() => {
-                console.info("SlintPad: started");
-                const canvas = document.getElementById(
-                    canvas_id,
-                ) as HTMLElement;
-                canvas.style.width = "100%";
-                canvas.style.height = "100%";
+                // Give the UI some time to wire up the canvas so it can be found
+                // when searching the document.
+                this.#previewer.show_ui().then(() => {
+                    console.info("SlintPad: started");
+                    const canvas = document.getElementById(
+                        canvas_id,
+                    ) as HTMLElement;
+                    canvas.style.width = "100%";
+                    canvas.style.height = "100%";
+                });
             });
-        });
     }
 
     public current_style(): string {

--- a/tools/slintpad/src/preview_widget.ts
+++ b/tools/slintpad/src/preview_widget.ts
@@ -10,7 +10,7 @@ import type {
     Previewer,
     Lsp,
     ResourceUrlMapperFunction,
-    OpenDemoUrlFunction,
+    InvokeSlintpadCallback,
 } from "./lsp";
 
 const canvas_id = "canvas";
@@ -39,7 +39,7 @@ export class PreviewWidget extends Widget {
         lsp: Lsp,
         resource_url_mapper: ResourceUrlMapperFunction,
         style: string,
-        demo_url_opener: OpenDemoUrlFunction,
+        slintpad_callback: InvokeSlintpadCallback,
     ) {
         super({ node: PreviewWidget.createNode() });
 
@@ -51,7 +51,7 @@ export class PreviewWidget extends Widget {
         this.title.closable = true;
 
         void lsp
-            .previewer(resource_url_mapper, style, demo_url_opener)
+            .previewer(resource_url_mapper, style, slintpad_callback)
             .then((p) => {
                 this.#previewer = p;
 

--- a/tools/slintpad/tests/smoke-test.spec.ts
+++ b/tools/slintpad/tests/smoke-test.spec.ts
@@ -4,6 +4,5 @@ import { test, expect } from "@playwright/test";
 
 test("smoke test", async ({ page }) => {
     await page.goto("http://localhost:3000/");
-    await expect(page.getByRole("menubar")).toContainText("Project");
     await expect(page.locator("#tab-key-1-0")).toContainText("main.slint");
 });


### PR DESCRIPTION
This swaps the text editor to the right and thus makes room for the Slint built-in menu bar. In Slintpad, the menu bar shows two additional entries in the File menu:

- The "Open Demo" sub-menu originates from the earlier web menubar and forwards to the editor.
- The share menu item is also quite useful from the web menu, but is now implemented by means of directly copying to the clipboard.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
