### PR TITLE
esp-idf: Permit usage of slint::invoke_from_event_loop() before runni…

### DIFF
--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -49,6 +49,7 @@ struct EspPlatform : public slint::platform::Platform
           byte_swap(config.byte_swap),
           rotation(config.rotation)
     {
+        task = xTaskGetCurrentTaskHandle();
     }
 
     std::unique_ptr<slint::platform::WindowAdapter> create_window_adapter() override;
@@ -129,8 +130,6 @@ void byte_swap_color(slint::Rgb8Pixel *pixel)
 template<typename PixelType>
 void EspPlatform<PixelType>::run_event_loop()
 {
-    task = xTaskGetCurrentTaskHandle();
-
     esp_lcd_panel_disp_on_off(panel_handle, true);
 
     TickType_t max_ticks_to_wait = portMAX_DELAY;


### PR DESCRIPTION
…ng the event loop

With EspPlatform, we need to initialize the FreeRTOS task used for posting events before calling invoke_from_event_loop(). This is now done basically in `slint_esp_init()` (well, the platform ctor).

The assumption preserved here is that the task that sets the Slint platform is also the same task that ends up spinning the event loop.

This should fix the following (pseudo-code):

```cpp
void main()
{
    slint_esp_init(...);
    ...
    // used to crash because EspPlatform::task is only initialized in run_event_loop()
    slint::invoke_from_event_loop(some_functor);
    ...
    slint::run_event_loop();
}
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
