### PR TITLE
Qt: fix drawing of blur

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1130,18 +1130,10 @@ impl ItemRenderer for QtItemRenderer<'_> {
                 if blur_radius > 0. {
                     cpp! {
                     unsafe[img as "QImage*", blur_radius as "float"] -> qttypes::QPixmap as "QPixmap" {
-                        class PublicGraphicsBlurEffect : public QGraphicsBlurEffect {
-                        public:
-                            // Make public what's protected
-                            using QGraphicsBlurEffect::draw;
-                        };
-
-                        // Need a scene for the effect source private to draw()
                         QGraphicsScene scene;
-
                         auto pixmap_item = scene.addPixmap(QPixmap::fromImage(*img));
 
-                        auto blur_effect = new PublicGraphicsBlurEffect;
+                        auto blur_effect = new QGraphicsBlurEffect;
                         blur_effect->setBlurRadius(blur_radius);
                         blur_effect->setBlurHints(QGraphicsBlurEffect::QualityHint);
 
@@ -1153,8 +1145,9 @@ impl ItemRenderer for QtItemRenderer<'_> {
                         blurred_scene.fill(Qt::transparent);
 
                         QPainter p(&blurred_scene);
-                        p.translate(blur_radius, blur_radius);
-                        blur_effect->draw(&p);
+                        scene.render(&p,
+                            QRectF(0, 0, blurred_scene.width(), blurred_scene.height()),
+                            QRectF(-blur_radius, -blur_radius, blurred_scene.width(), blurred_scene.height()));
                         p.end();
 
                         return QPixmap::fromImage(blurred_scene);


### PR DESCRIPTION
Avoid the warning
```
QGraphicsEffectSource::draw: Can only begin as a result of QGraphicsEffect::draw
```

Should fix #4008

