### PR TITLE
wgpu: Fall back to software rendering if there are no GPU-backed WGPU adapters

### DIFF
--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -28,8 +28,8 @@ pub struct GlutinFemtoVGRenderer {
 impl GlutinFemtoVGRenderer {
     pub fn new_suspended(
         _shared_backend_data: &Rc<crate::SharedBackendData>,
-    ) -> Box<dyn WinitCompatibleRenderer> {
-        Box::new(Self { renderer: FemtoVGRenderer::new_suspended() })
+    ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
+        Ok(Box::new(Self { renderer: FemtoVGRenderer::new_suspended() }))
     }
 }
 
@@ -94,11 +94,11 @@ pub struct WGPUFemtoVGRenderer {
 impl WGPUFemtoVGRenderer {
     pub fn new_suspended(
         _shared_backend_data: &Rc<crate::SharedBackendData>,
-    ) -> Box<dyn WinitCompatibleRenderer> {
-        Box::new(Self {
+    ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
+        Ok(Box::new(Self {
             renderer: FemtoVGRenderer::<i_slint_renderer_femtovg::wgpu::WGPUBackend>::new_suspended(
             ),
-        })
+        }))
     }
 }
 

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -22,14 +22,18 @@ mod glcontext;
 #[cfg(supports_opengl)]
 pub struct GlutinFemtoVGRenderer {
     renderer: FemtoVGRenderer<opengl::OpenGLBackend>,
+    requested_graphics_api: Option<RequestedGraphicsAPI>,
 }
 
 #[cfg(supports_opengl)]
 impl GlutinFemtoVGRenderer {
     pub fn new_suspended(
-        _shared_backend_data: &Rc<crate::SharedBackendData>,
+        shared_backend_data: &Rc<crate::SharedBackendData>,
     ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
-        Ok(Box::new(Self { renderer: FemtoVGRenderer::new_suspended() }))
+        Ok(Box::new(Self {
+            renderer: FemtoVGRenderer::new_suspended(),
+            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+        }))
     }
 }
 
@@ -47,15 +51,12 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
         &self,
         active_event_loop: &ActiveEventLoop,
         window_attributes: winit::window::WindowAttributes,
-        #[cfg_attr(target_arch = "wasm32", allow(unused_variables))] requested_graphics_api: Option<
-            RequestedGraphicsAPI,
-        >,
     ) -> Result<Arc<winit::window::Window>, PlatformError> {
         #[cfg(not(target_arch = "wasm32"))]
         let (winit_window, opengl_context) = glcontext::OpenGLContext::new_context(
             window_attributes,
             active_event_loop,
-            requested_graphics_api.map(TryInto::try_into).transpose()?,
+            self.requested_graphics_api.as_ref().map(TryInto::try_into).transpose()?,
         )?;
 
         #[cfg(target_arch = "wasm32")]
@@ -88,16 +89,23 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
 #[cfg(all(feature = "renderer-femtovg-wgpu", not(target_family = "wasm")))]
 pub struct WGPUFemtoVGRenderer {
     renderer: FemtoVGRenderer<i_slint_renderer_femtovg::wgpu::WGPUBackend>,
+    requested_graphics_api: Option<RequestedGraphicsAPI>,
 }
 
 #[cfg(all(feature = "renderer-femtovg-wgpu", not(target_family = "wasm")))]
 impl WGPUFemtoVGRenderer {
     pub fn new_suspended(
-        _shared_backend_data: &Rc<crate::SharedBackendData>,
+        shared_backend_data: &Rc<crate::SharedBackendData>,
     ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
+        if !i_slint_core::graphics::wgpu_26::any_wgpu26_adapters_with_gpu(
+            shared_backend_data.requested_graphics_api.clone(),
+        ) {
+            return Err(PlatformError::from("WGPU: No GPU adapters found"));
+        }
         Ok(Box::new(Self {
             renderer: FemtoVGRenderer::<i_slint_renderer_femtovg::wgpu::WGPUBackend>::new_suspended(
             ),
+            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
         }))
     }
 }
@@ -120,7 +128,6 @@ impl WinitCompatibleRenderer for WGPUFemtoVGRenderer {
         &self,
         active_event_loop: &ActiveEventLoop,
         window_attributes: winit::window::WindowAttributes,
-        requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Arc<winit::window::Window>, PlatformError> {
         let winit_window = Arc::new(active_event_loop.create_window(window_attributes).map_err(
             |winit_os_error| {
@@ -136,7 +143,7 @@ impl WinitCompatibleRenderer for WGPUFemtoVGRenderer {
         self.renderer.set_window_handle(
             Box::new(winit_window.clone()),
             crate::winitwindowadapter::physical_size_to_slint(&size),
-            requested_graphics_api,
+            self.requested_graphics_api.clone(),
         )?;
 
         Ok(winit_window)

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -16,8 +16,8 @@ pub struct WinitSkiaRenderer {
 impl WinitSkiaRenderer {
     pub fn new_suspended(
         shared_backend_data: &Rc<crate::SharedBackendData>,
-    ) -> Box<dyn super::WinitCompatibleRenderer> {
-        Box::new(Self { renderer: SkiaRenderer::default(&shared_backend_data.skia_context) })
+    ) -> Result<Box<dyn super::WinitCompatibleRenderer>, PlatformError> {
+        Ok(Box::new(Self { renderer: SkiaRenderer::default(&shared_backend_data.skia_context) }))
     }
 
     #[cfg(not(target_os = "android"))]

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -5,10 +5,10 @@
 
 use core::num::NonZeroU32;
 use core::ops::DerefMut;
+use i_slint_core::graphics::Rgb8Pixel;
 use i_slint_core::platform::PlatformError;
 pub use i_slint_core::software_renderer::SoftwareRenderer;
 use i_slint_core::software_renderer::{PremultipliedRgbaColor, RepaintBufferType, TargetPixel};
-use i_slint_core::{graphics::RequestedGraphicsAPI, graphics::Rgb8Pixel};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -180,7 +180,6 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
         &self,
         active_event_loop: &ActiveEventLoop,
         window_attributes: winit::window::WindowAttributes,
-        _requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<Arc<winit::window::Window>, PlatformError> {
         let winit_window =
             active_event_loop.create_window(window_attributes).map_err(|winit_os_error| {

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -72,12 +72,12 @@ impl TargetPixel for SoftBufferPixel {
 impl WinitSoftwareRenderer {
     pub fn new_suspended(
         _shared_backend_data: &Rc<crate::SharedBackendData>,
-    ) -> Box<dyn WinitCompatibleRenderer> {
-        Box::new(Self {
+    ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
+        Ok(Box::new(Self {
             renderer: SoftwareRenderer::new(),
             _context: RefCell::new(None),
             surface: RefCell::new(None),
-        })
+        }))
     }
 }
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -385,7 +385,7 @@ impl WinitWindowAdapter {
         requested_graphics_api: Option<RequestedGraphicsAPI>,
         #[cfg(any(enable_accesskit, muda))] proxy: EventLoopProxy<SlintEvent>,
         #[cfg(all(muda, target_os = "macos"))] muda_enable_default_menu_bar: bool,
-    ) -> Result<Rc<Self>, PlatformError> {
+    ) -> Rc<Self> {
         let self_rc = Rc::new_cyclic(|self_weak| Self {
             shared_backend_data: shared_backend_data.clone(),
             window: OnceCell::from(corelib::api::Window::new(self_weak.clone() as _)),
@@ -428,7 +428,7 @@ impl WinitWindowAdapter {
 
         self_rc.shared_backend_data.register_inactive_window((self_rc.clone()) as _);
 
-        Ok(self_rc)
+        self_rc
     }
 
     fn renderer(&self) -> &dyn WinitCompatibleRenderer {

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -195,12 +195,14 @@ pub enum RequestedGraphicsAPI {
     WGPU26(wgpu_26::api::WGPUConfiguration),
 }
 
-impl TryFrom<RequestedGraphicsAPI> for RequestedOpenGLVersion {
+impl TryFrom<&RequestedGraphicsAPI> for RequestedOpenGLVersion {
     type Error = PlatformError;
 
-    fn try_from(requested_graphics_api: RequestedGraphicsAPI) -> Result<Self, Self::Error> {
+    fn try_from(requested_graphics_api: &RequestedGraphicsAPI) -> Result<Self, Self::Error> {
         match requested_graphics_api {
-            RequestedGraphicsAPI::OpenGL(requested_open_glversion) => Ok(requested_open_glversion),
+            RequestedGraphicsAPI::OpenGL(requested_open_glversion) => {
+                Ok(requested_open_glversion.clone())
+            }
             RequestedGraphicsAPI::Metal => {
                 Err("Metal rendering is not supported with an OpenGL renderer".into())
             }

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -39,7 +39,7 @@ impl super::Surface for OpenGLSurface {
             window_handle,
             display_handle,
             size,
-            requested_graphics_api.map(TryInto::try_into).transpose()?,
+            requested_graphics_api.as_ref().map(TryInto::try_into).transpose()?,
             glutin::config::ConfigTemplateBuilder::new(),
             None,
         )


### PR DESCRIPTION
Fixes #9164
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
