### PR TITLE
Interpreter: Forward debug handler to popups

### DIFF
--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2412,6 +2412,8 @@ pub fn show_popup(
     parent_item: &ItemRc,
 ) {
     generativity::make_guard!(guard);
+    let debug_handler = instance.description.debug_handler.borrow().clone();
+
     // FIXME: we should compile once and keep the cached compiled component
     let compiled = generate_item_tree(
         &popup.component,
@@ -2420,6 +2422,8 @@ pub fn show_popup(
         false,
         guard,
     );
+    compiled.recursively_set_debug_handler(debug_handler);
+
     let inst = instantiate(
         compiled,
         Some(parent_comp),


### PR DESCRIPTION
This is the one thing that really annoyed me using the live preview in a customer project all week :-)
