### PR TITLE
Add support for the Back key on Android

### DIFF
--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -264,6 +264,32 @@ impl AndroidWindowAdapter {
         Ok(ControlFlow::Continue(()))
     }
 
+    fn try_dispatch_key_event(&self, ev: WindowEvent) -> i_slint_core::input::KeyEventResult {
+        match ev {
+            WindowEvent::KeyPressed { text } => WindowInner::from_pub(&self.window)
+                .process_key_input(i_slint_core::input::KeyEvent {
+                    text,
+                    repeat: false,
+                    event_type: i_slint_core::input::KeyEventType::KeyPressed,
+                    ..Default::default()
+                }),
+            WindowEvent::KeyPressRepeated { text } => WindowInner::from_pub(&self.window)
+                .process_key_input(i_slint_core::input::KeyEvent {
+                    text,
+                    repeat: true,
+                    event_type: i_slint_core::input::KeyEventType::KeyPressed,
+                    ..Default::default()
+                }),
+            WindowEvent::KeyReleased { text } => WindowInner::from_pub(&self.window)
+                .process_key_input(i_slint_core::input::KeyEvent {
+                    text,
+                    event_type: i_slint_core::input::KeyEventType::KeyReleased,
+                    ..Default::default()
+                }),
+            _ => i_slint_core::input::KeyEventResult::EventIgnored,
+        }
+    }
+
     fn process_inputs(&self) -> Result<(), PlatformError> {
         let mut iter =
             self.app.input_events_iter().map_err(|e| PlatformError::Other(e.to_string()))?;
@@ -272,8 +298,13 @@ impl AndroidWindowAdapter {
             let read_input = iter.next(|event| match event {
                 InputEvent::KeyEvent(key_event) => match map_key_event(key_event) {
                     Some(ev) => {
-                        result = self.window.try_dispatch_event(ev);
-                        InputStatus::Handled
+                        if self.try_dispatch_key_event(ev)
+                            == i_slint_core::input::KeyEventResult::EventAccepted
+                        {
+                            InputStatus::Handled
+                        } else {
+                            InputStatus::Unhandled
+                        }
                     }
                     None => InputStatus::Unhandled,
                 },
@@ -322,7 +353,7 @@ impl AndroidWindowAdapter {
                                     .to_logical(self.window.scale_factor()),
                                 button: PointerEventButton::Left,
                             })
-                            .and_then(|()| {
+                            .and_then(|_| {
                                 // Also send exit to avoid remaining hover state
                                 self.window.try_dispatch_event(WindowEvent::PointerExited)
                             });
@@ -538,7 +569,7 @@ fn map_key_code(code: android_activity::input::Keycode) -> Option<SharedString> 
         Keycode::SoftLeft => None,
         Keycode::SoftRight => None,
         Keycode::Home => None,
-        Keycode::Back => None,
+        Keycode::Back => Some(Key::Back.into()),
         Keycode::Call => None,
         Keycode::Endcall => None,
         Keycode::Keycode0 => Some("0".into()),

--- a/internal/common/key_codes.rs
+++ b/internal/common/key_codes.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! This module is meant to be included by different crate and each crate must define the macro for_each_keys
+//! This module is meant to be included by different crates and each crate must define the macro for_each_special_keys
 //!
 //! The key code comes from <https://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/CORPCHAR.TXT>
 //! the names comes should match with <https://www.w3.org/TR/uievents-key/#named-key-attribute-values>,
@@ -121,6 +121,7 @@ macro_rules! for_each_special_keys {
 //'\u{F745}'	# Find        # Qt_Key_Key_Find         #              ;
 //'\u{F746}'	# Help        # Qt_Key_Key_Help         #              ;
 //'\u{F747}'	# ModeSwitch  # Qt_Key_Key_Mode_switch  #            ;
+'\u{F748}'	# Back  # Qt_Key_Key_Back  #           #    ;
 ];
     };
 }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -632,7 +632,7 @@ impl Window {
                     repeat: false,
                     event_type: KeyEventType::KeyPressed,
                     ..Default::default()
-                })
+                });
             }
             crate::platform::WindowEvent::KeyPressRepeated { text } => {
                 self.0.process_key_input(crate::input::KeyEvent {
@@ -640,14 +640,14 @@ impl Window {
                     repeat: true,
                     event_type: KeyEventType::KeyPressed,
                     ..Default::default()
-                })
+                });
             }
             crate::platform::WindowEvent::KeyReleased { text } => {
                 self.0.process_key_input(crate::input::KeyEvent {
                     text,
                     event_type: KeyEventType::KeyReleased,
                     ..Default::default()
-                })
+                });
             }
             crate::platform::WindowEvent::ScaleFactorChanged { scale_factor } => {
                 self.0.set_scale_factor(scale_factor);

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -767,9 +767,6 @@ impl WindowInner {
     /// Arguments:
     /// * `event`: The key event received by the windowing system.
     pub fn process_key_input(&self, mut event: KeyEvent) -> crate::input::KeyEventResult {
-        scopeguard::defer! {
-            crate::properties::ChangeTracker::run_change_handlers();
-        }
         if let Some(updated_modifier) = self
             .modifiers
             .get()
@@ -806,6 +803,7 @@ impl WindowInner {
             if i.borrow().as_ref().capture_key_event(&event, &self.window_adapter(), &i)
                 == crate::input::KeyEventResult::EventAccepted
             {
+                crate::properties::ChangeTracker::run_change_handlers();
                 return crate::input::KeyEventResult::EventAccepted;
             }
         }
@@ -817,6 +815,7 @@ impl WindowInner {
             if focus_item.borrow().as_ref().key_event(&event, &self.window_adapter(), &focus_item)
                 == crate::input::KeyEventResult::EventAccepted
             {
+                crate::properties::ChangeTracker::run_change_handlers();
                 return crate::input::KeyEventResult::EventAccepted;
             }
             item = focus_item.parent_item(ParentItemTraversalMode::StopAtPopups);
@@ -830,6 +829,7 @@ impl WindowInner {
             && event.event_type == KeyEventType::KeyPressed
         {
             self.focus_next_item();
+            crate::properties::ChangeTracker::run_change_handlers();
             return crate::input::KeyEventResult::EventAccepted;
         } else if (event.text.starts_with(key_codes::Backtab)
             || (event.text.starts_with(key_codes::Tab) && event.modifiers.shift))
@@ -837,6 +837,7 @@ impl WindowInner {
             && !extra_mod
         {
             self.focus_previous_item();
+            crate::properties::ChangeTracker::run_change_handlers();
             return crate::input::KeyEventResult::EventAccepted;
         } else if event.event_type == KeyEventType::KeyPressed
             && event.text.starts_with(key_codes::Escape)
@@ -863,8 +864,10 @@ impl WindowInner {
             if close_on_escape {
                 window.close_top_popup();
             }
+            crate::properties::ChangeTracker::run_change_handlers();
             return crate::input::KeyEventResult::EventAccepted;
         }
+        crate::properties::ChangeTracker::run_change_handlers();
         crate::input::KeyEventResult::EventIgnored
     }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -766,7 +766,10 @@ impl WindowInner {
     ///
     /// Arguments:
     /// * `event`: The key event received by the windowing system.
-    pub fn process_key_input(&self, mut event: KeyEvent) {
+    pub fn process_key_input(&self, mut event: KeyEvent) -> crate::input::KeyEventResult {
+        scopeguard::defer! {
+            crate::properties::ChangeTracker::run_change_handlers();
+        }
         if let Some(updated_modifier) = self
             .modifiers
             .get()
@@ -803,8 +806,7 @@ impl WindowInner {
             if i.borrow().as_ref().capture_key_event(&event, &self.window_adapter(), &i)
                 == crate::input::KeyEventResult::EventAccepted
             {
-                crate::properties::ChangeTracker::run_change_handlers();
-                return;
+                return crate::input::KeyEventResult::EventAccepted;
             }
         }
 
@@ -815,8 +817,7 @@ impl WindowInner {
             if focus_item.borrow().as_ref().key_event(&event, &self.window_adapter(), &focus_item)
                 == crate::input::KeyEventResult::EventAccepted
             {
-                crate::properties::ChangeTracker::run_change_handlers();
-                return;
+                return crate::input::KeyEventResult::EventAccepted;
             }
             item = focus_item.parent_item(ParentItemTraversalMode::StopAtPopups);
         }
@@ -829,12 +830,14 @@ impl WindowInner {
             && event.event_type == KeyEventType::KeyPressed
         {
             self.focus_next_item();
+            return crate::input::KeyEventResult::EventAccepted;
         } else if (event.text.starts_with(key_codes::Backtab)
             || (event.text.starts_with(key_codes::Tab) && event.modifiers.shift))
             && event.event_type == KeyEventType::KeyPressed
             && !extra_mod
         {
             self.focus_previous_item();
+            return crate::input::KeyEventResult::EventAccepted;
         } else if event.event_type == KeyEventType::KeyPressed
             && event.text.starts_with(key_codes::Escape)
         {
@@ -860,8 +863,9 @@ impl WindowInner {
             if close_on_escape {
                 window.close_top_popup();
             }
+            return crate::input::KeyEventResult::EventAccepted;
         }
-        crate::properties::ChangeTracker::run_change_handlers();
+        crate::input::KeyEventResult::EventIgnored
     }
 
     /// Installs a binding on the specified property that's toggled whenever the text cursor is supposed to be visible or not.


### PR DESCRIPTION
Successfully tested with this code

    forward-focus: my-key-handler;
    my-key-handler := FocusScope {
        key-pressed(event) => {
            if (event.text == Key.Back) {
                root.close();
            }
            accept
        }
    }

but also without (that was the hard part: letting Android terminate the activity on Back if it's not accepted by slint, which no longer happened after returning Some(...) in key_codes.rs)

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
