### PR TITLE
Fix regression in the Path element when used with inheritance

### DIFF
--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -118,10 +118,29 @@ pub fn compile_paths(
                     elem.children.push(child);
                 }
             }
+
+            if elem.is_binding_set("elements", false) {
+                if path_data.is_empty() {
+                    // Just Path subclass that had elements declared earlier, since path_data is empty we should retain the
+                    // existing elements
+                    return;
+                } else {
+                    diag.push_error(
+                        "The Path was already populated in the base type and it can't be re-populated again"
+                            .into(),
+                        &*elem,
+                    );
+                    return;
+                }
+            }
+
             Expression::PathData(crate::expression_tree::Path::Elements(path_data)).into()
         };
 
-        elem_.borrow_mut().bindings.insert("elements".into(), RefCell::new(path_data_binding));
+        elem_
+            .borrow_mut()
+            .bindings
+            .insert(SmolStr::new_static("elements"), RefCell::new(path_data_binding));
     });
 }
 

--- a/internal/compiler/tests/syntax/elements/path.slint
+++ b/internal/compiler/tests/syntax/elements/path.slint
@@ -1,0 +1,20 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Arc inherits Path {
+    MoveTo {
+        x: 0;
+        y: 0;
+    }
+}
+
+export component Foo inherits Rectangle {
+    Arc { } // OK!
+    Arc {
+//   ^error{The Path was already populated in the base type and it can't be re-populated again}
+        LineTo {
+            x: 1;
+            y: 1;
+        }
+    }
+}

--- a/internal/compiler/tests/syntax/elements/path.slint
+++ b/internal/compiler/tests/syntax/elements/path.slint
@@ -11,7 +11,7 @@ component Arc inherits Path {
 export component Foo inherits Rectangle {
     Arc { } // OK!
     Arc {
-//   ^error{The Path was already populated in the base type and it can't be re-populated again}
+//  ^error{The Path was already populated in the base type and it can't be re-populated again}
         LineTo {
             x: 1;
             y: 1;


### PR DESCRIPTION
After commit ef2e6491cddd619fa00af321d379b77071635b0a we end up processing Paths multiple times, and thus we might end up attempting to replace an elements binding. Don't do that if no new elements are declared, but yield an error if attempting to do so. We could support this in the future (appending), but for now it's better to produce an error.

Fixes #9170

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
