### PR TITLE
live-preview: console scale control

### DIFF
--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -11,7 +11,10 @@ import { WindowManager, WindowGlobal } from "../windowglobal.slint";
 
 export component ConsolePanel inherits SimpleColumn {
     property <bool> panel-expanded: false;
+    property <bool> dragging-up: false;  // Track if currently dragging upward
     property <length> panel-height: ConsoleStyles.log-height;
+    property <length> drag-start-height; // Track height at start of drag
+    property <length> previous-height: 300px; // Track previous panel height for restoration
 
     Rectangle {
         height: ConsoleStyles.header-height;
@@ -20,21 +23,51 @@ export component ConsolePanel inherits SimpleColumn {
             y: 0;
             height: 4px;
             mouse-cursor: ns-resize;
+            property <bool> drag-started: false;
             moved => {
                 if !panel-expanded && self.mouse-y < self.pressed-y {
                     panel-expanded = true;
+                    dragging-up = true;
+                    drag-started = true;
                     panel-height = Math.max(30px, -(self.mouse-y - self.pressed-y));
                 } else if panel-expanded {
+                    // Only update direction if we're actively moving
+                    if !drag-started {
+                        drag-started = true;
+                        dragging-up = self.mouse-y < self.pressed-y;
+                    }
+                    
                     // Resizing panel during drag
                     let max-height = WindowGlobal.window-height * 0.75;
-                    panel-height = Math.max(-28px, Math.min(max-height, panel-height - (self.mouse-y - self.pressed-y)));
+                    let new-height = panel-height - (self.mouse-y - self.pressed-y);
+                    panel-height = Math.max(-28px, Math.min(max-height, new-height));
                 }
             }
             pointer-event(event) => {
+                if event.kind == PointerEventKind.down {
+                    drag-started = false;
+                }
+                
                 // Make close decision on release
-                if event.kind == PointerEventKind.up && panel-expanded && panel-height <= 1px {
-                    panel-expanded = false;
-                    panel-height = ConsoleStyles.log-height; // Reset for next open
+                if event.kind == PointerEventKind.up && panel-expanded {
+                    if !dragging-up && panel-height <= 5px {
+                        // Store current height before closing (if it's a reasonable size)
+                        if panel-height > 50px {
+                            previous-height = panel-height;
+                        }
+                        panel-expanded = false;
+                        panel-height = ConsoleStyles.log-height; // Reset for next open
+                    }
+                    if dragging-up && panel-height <= 30px {
+                        panel-height = previous-height; // Restore previous height
+                    }
+                    // Also update previous-height when panel is at a good size
+                    else if panel-height > 50px {
+                        previous-height = panel-height;
+                    }
+                    // Reset drag tracking
+                    dragging-up = false;
+                    drag-started = false;
                 }
             }
         }

--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -131,7 +131,14 @@ export component ConsolePanel inherits SimpleColumn {
             lm-ta := TouchArea {
                 mouse-cursor: MouseCursor.pointer;
                 clicked => {
-                    panel-expanded = true;
+                    if panel-expanded {
+                        animate-panel = true;
+                        panel-height = -28px;
+                    } else {
+                        panel-height = previous-height;
+                        panel-expanded = true;
+                        animate-panel = true;
+                    }
                 }
             }
         }

--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -11,17 +11,49 @@ import { WindowManager } from "../windowglobal.slint";
 
 export component ConsolePanel inherits SimpleColumn {
     property <bool> panel-expanded: false;
+    property <length> panel-height: ConsoleStyles.log-height;
 
     Rectangle {
         height: ConsoleStyles.header-height;
         background: ConsoleStyles.header-background;
+        main-resize-handle := TouchArea {
+            y: 0;
+            height: 4px;
+            mouse-cursor: ns-resize;
+            moved => {
+                if !panel-expanded && self.mouse-y < self.pressed-y {
+                    panel-expanded = true;
+                    panel-height = Math.max(30px, -(self.mouse-y - self.pressed-y));
+                } else if panel-expanded {
+                    // Resizing panel during drag
+                    panel-height = Math.max(-30px, panel-height - (self.mouse-y - self.pressed-y));
+                }
+            }
+            pointer-event(event) => {
+                // Make close decision on release
+                if event.kind == PointerEventKind.up && panel-expanded && panel-height <= 30px {
+                    panel-expanded = false;
+                    panel-height = ConsoleStyles.log-height; // Reset for next open
+                }
+            }
+        }
+
         Rectangle {
             y: 0;
+            width: 100%;
+            height: 2px;
+            background: ConsoleStyles.divider-line;
+            opacity: main-resize-handle.has-hover ? 1.0 : 0.3;
+        }
+
+        Rectangle {
+            y: parent.height - self.height;
             width: 100%;
             height: 1px;
             background: ConsoleStyles.divider-line;
             opacity: 50%;
         }
+
         Rectangle {
             y: parent.height - self.height;
             width: 100%;
@@ -55,24 +87,6 @@ export component ConsolePanel inherits SimpleColumn {
                     panel-expanded = true;
                 }
             }
-            Rectangle {
-                x: 0;
-                y: parent.height - self.height;
-                width: min(last-message.preferred-width, last-message.width) - 4px;
-                height: 1px;
-                background: ConsoleStyles.slint-blue;
-                opacity: lm-ta.has-hover ? 0.8 : 0;
-
-            }
-        }
-
-        Rectangle {
-            x: 0;
-            y: parent.height - self.height;
-            width: label.width + label.x * 2;
-            height: 2px;
-            background: ConsoleStyles.slint-blue;
-            visible: panel-expanded;
         }
 
         HorizontalLayout {
@@ -144,10 +158,12 @@ export component ConsolePanel inherits SimpleColumn {
             }
         }
     }
+
     if panel-expanded: Rectangle {
         width: 100%;
         height: ConsoleStyles.header-height;
         background: ConsoleStyles.toolbar-background;
+
         Rectangle {
             x: 0;
             width: 36px;
@@ -163,6 +179,7 @@ export component ConsolePanel inherits SimpleColumn {
                     }
                 }
             }
+
             Rectangle {
                 x: parent.width - self.width;
                 width: 1px;
@@ -181,12 +198,15 @@ export component ConsolePanel inherits SimpleColumn {
                 color: ConsoleStyles.text-color;
                 vertical-alignment: center;
             }
+
             Rectangle {
                 width: 6px;
             }
+
             Switch {
                 checked <=> Api.auto-clear-console;
             }
+
             Rectangle {
                 width: 10px;
             }
@@ -201,12 +221,12 @@ export component ConsolePanel inherits SimpleColumn {
     }
 
     if panel-expanded: Rectangle {
-        height: ConsoleStyles.log-height;
+        height: panel-height;
         background: ConsoleStyles.log-background;
 
         // Scroll to end workaround while this feature is missing from ScrollView
         property <int> timer-clicked: 0;
-        function scroll-to-bottom(){
+        function scroll-to-bottom() {
             lv.viewport-y = -100000px;
             timer-clicked = 0;
             scroll-timer.running = true;
@@ -246,6 +266,7 @@ export component ConsolePanel inherits SimpleColumn {
                     wrap: message.wrap;
                     visible: false;
                 }
+
                 message := TextInput {
                     x: 10px;
                     width: parent.width - 80px;

--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -6,7 +6,7 @@ import { Api, LogMessage, LogMessageLevel } from "../api.slint";
 import { RecentColorPicker } from "widgets/floating-brush-sections/palettes.slint";
 import { SimpleColumn } from "layout-helpers.slint";
 import { ConsoleStyles, EditorSizeSettings, Icons,  } from "styling.slint";
-import { WindowManager, WindowGlobal } from "../windowglobal.slint";
+import {WindowGlobal } from "../windowglobal.slint";
 
 
 export component ConsolePanel inherits SimpleColumn {
@@ -23,7 +23,7 @@ export component ConsolePanel inherits SimpleColumn {
         easing: ease-out-quad;
     }
     changed panel-height => {
-        if !dragging-up && panel-height <= -28px {
+        if !dragging-up && panel-height <= (-ConsoleStyles.header-height) {
             panel-expanded = false;
         }
     }
@@ -48,9 +48,9 @@ export component ConsolePanel inherits SimpleColumn {
                     }
 
                     // Resizing panel during drag
-                    let max-height = WindowGlobal.window-height * 0.75;
+                    let max-height = WindowGlobal.window-height - 200px;
                     let new-height = panel-height - (self.mouse-y - self.pressed-y);
-                    panel-height = Math.max(-28px, Math.min(max-height, new-height));
+                    panel-height = Math.max((-ConsoleStyles.header-height), Math.min(max-height, new-height));
                 }
             }
             pointer-event(event) => {
@@ -69,7 +69,7 @@ export component ConsolePanel inherits SimpleColumn {
                         if panel-height > 50px {
                             previous-height = panel-height;
                         }
-                        panel-height = -28px;
+                        panel-height = (-ConsoleStyles.header-height);
                     }
                     if dragging-up && panel-height <= 30px {
                         panel-height = previous-height; // Restore previous height
@@ -133,7 +133,7 @@ export component ConsolePanel inherits SimpleColumn {
                 clicked => {
                     if panel-expanded {
                         animate-panel = true;
-                        panel-height = -28px;
+                        panel-height = (-ConsoleStyles.header-height);
                     } else {
                         panel-height = previous-height;
                         panel-expanded = true;
@@ -198,7 +198,7 @@ export component ConsolePanel inherits SimpleColumn {
                     clicked => {
                         if panel-expanded {
                             animate-panel = true;
-                            panel-height = -28px;
+                            panel-height = (-ConsoleStyles.header-height);
                         } else {
                             panel-height = previous-height;
                             panel-expanded = true;
@@ -282,7 +282,9 @@ export component ConsolePanel inherits SimpleColumn {
     }
 
     if panel-expanded: Rectangle {
-        height: panel-height;
+        preferred-height: Math.min(panel-height, (WindowGlobal.window-height - 200px));
+        min-height: (-ConsoleStyles.header-height);
+
         background: ConsoleStyles.log-background;
 
         // Scroll to end workaround while this feature is missing from ScrollView

--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -15,7 +15,18 @@ export component ConsolePanel inherits SimpleColumn {
     property <length> panel-height: ConsoleStyles.log-height;
     property <length> drag-start-height; // Track height at start of drag
     property <length> previous-height: 300px; // Track previous panel height for restoration
+    property <bool> animate-panel: false; // Control animation state
+    property <bool> drag-started: false;
 
+    animate panel-height {
+        duration: animate-panel ? 200ms : 0ms;
+        easing: ease-out-quad;
+    }
+    changed panel-height => {
+        if !dragging-up && panel-height <= -28px {
+            panel-expanded = false;
+        }
+    }
     Rectangle {
         height: ConsoleStyles.header-height;
         background: ConsoleStyles.header-background;
@@ -23,7 +34,6 @@ export component ConsolePanel inherits SimpleColumn {
             y: 0;
             height: 4px;
             mouse-cursor: ns-resize;
-            property <bool> drag-started: false;
             moved => {
                 if !panel-expanded && self.mouse-y < self.pressed-y {
                     panel-expanded = true;
@@ -46,23 +56,26 @@ export component ConsolePanel inherits SimpleColumn {
             pointer-event(event) => {
                 if event.kind == PointerEventKind.down {
                     drag-started = false;
+                    animate-panel = false; // Disable animation during drag
                 }
-                
+                if event.kind == PointerEventKind.up {
+                    animate-panel = true;
+                }
                 // Make close decision on release
                 if event.kind == PointerEventKind.up && panel-expanded {
+
                     if !dragging-up && panel-height <= 5px {
                         // Store current height before closing (if it's a reasonable size)
                         if panel-height > 50px {
                             previous-height = panel-height;
                         }
-                        panel-expanded = false;
-                        panel-height = ConsoleStyles.log-height; // Reset for next open
+                        panel-height = -28px;
                     }
                     if dragging-up && panel-height <= 30px {
                         panel-height = previous-height; // Restore previous height
-                    }
+                    } 
                     // Also update previous-height when panel is at a good size
-                    else if panel-height > 50px {
+                    if panel-height > 50px {
                         previous-height = panel-height;
                     }
                     // Reset drag tracking
@@ -176,7 +189,14 @@ export component ConsolePanel inherits SimpleColumn {
                 chevron-ta := TouchArea {
                     mouse-cursor: MouseCursor.pointer;
                     clicked => {
-                        panel-expanded = !panel-expanded;
+                        if panel-expanded {
+                            animate-panel = true;
+                            panel-height = -28px;
+                        } else {
+                            panel-height = previous-height;
+                            panel-expanded = true;
+                            animate-panel = true;
+                        }
                     }
                 }
 

--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -6,7 +6,7 @@ import { Api, LogMessage, LogMessageLevel } from "../api.slint";
 import { RecentColorPicker } from "widgets/floating-brush-sections/palettes.slint";
 import { SimpleColumn } from "layout-helpers.slint";
 import { ConsoleStyles, EditorSizeSettings, Icons,  } from "styling.slint";
-import { WindowManager } from "../windowglobal.slint";
+import { WindowManager, WindowGlobal } from "../windowglobal.slint";
 
 
 export component ConsolePanel inherits SimpleColumn {
@@ -26,12 +26,13 @@ export component ConsolePanel inherits SimpleColumn {
                     panel-height = Math.max(30px, -(self.mouse-y - self.pressed-y));
                 } else if panel-expanded {
                     // Resizing panel during drag
-                    panel-height = Math.max(-28px, panel-height - (self.mouse-y - self.pressed-y));
+                    let max-height = WindowGlobal.window-height * 0.75;
+                    panel-height = Math.max(-28px, Math.min(max-height, panel-height - (self.mouse-y - self.pressed-y)));
                 }
             }
             pointer-event(event) => {
                 // Make close decision on release
-                if event.kind == PointerEventKind.up && panel-expanded && panel-height <= 30px {
+                if event.kind == PointerEventKind.up && panel-expanded && panel-height <= 1px {
                     panel-expanded = false;
                     panel-height = ConsoleStyles.log-height; // Reset for next open
                 }

--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -46,7 +46,7 @@ export component ConsolePanel inherits SimpleColumn {
                         drag-started = true;
                         dragging-up = self.mouse-y < self.pressed-y;
                     }
-                    
+
                     // Resizing panel during drag
                     let max-height = WindowGlobal.window-height * 0.75;
                     let new-height = panel-height - (self.mouse-y - self.pressed-y);
@@ -73,7 +73,7 @@ export component ConsolePanel inherits SimpleColumn {
                     }
                     if dragging-up && panel-height <= 30px {
                         panel-height = previous-height; // Restore previous height
-                    } 
+                    }
                     // Also update previous-height when panel is at a good size
                     if panel-height > 50px {
                         previous-height = panel-height;

--- a/tools/lsp/ui/components/console-panel.slint
+++ b/tools/lsp/ui/components/console-panel.slint
@@ -26,7 +26,7 @@ export component ConsolePanel inherits SimpleColumn {
                     panel-height = Math.max(30px, -(self.mouse-y - self.pressed-y));
                 } else if panel-expanded {
                     // Resizing panel during drag
-                    panel-height = Math.max(-30px, panel-height - (self.mouse-y - self.pressed-y));
+                    panel-height = Math.max(-28px, panel-height - (self.mouse-y - self.pressed-y));
                 }
             }
             pointer-event(event) => {

--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -140,7 +140,7 @@ export component PreviewUi inherits Window {
         WindowGlobal.window-height = self.height;
     }
 
-    VerticalLayout {
+    ap := VerticalLayout {
         if !Api.show-preview-ui: no-ui-drawing-rect := Rectangle {
             VerticalLayout {
                 ComponentContainer {
@@ -150,6 +150,7 @@ export component PreviewUi inherits Window {
         }
         if Api.show-preview-ui: Rectangle {
             VerticalLayout {
+                padding-bottom: 0px;
                 header-view := HeaderView {
                     show-left-sidebar <=> root.show-left-sidebar;
                     show-right-sidebar <=> root.show-right-sidebar;
@@ -241,9 +242,16 @@ export component PreviewUi inherits Window {
                     }
                 }
 
-                ConsolePanel { }
+                Rectangle {
+                    height: cp.height;
+                }
 
-                StatusLine { }
+                // StatusLine { }
+            }
+
+            cp := ConsolePanel {
+                y: parent.height - self.height - 1px;
+                width: parent.width;
             }
         }
     }


### PR DESCRIPTION
as per request added a control to scale console
left the right expand button persistent to make scaling to preferred size (and shut) easy
in future would prefer that last console message that shows up in the header to be in the instruction message area
and have an affordance there to expand console - otherwise no other useful messages show up other than console ones - and instructions on what keys to press when on a particular tool do not belong in the console log...

removed highlight for console as nothing else highlights the header and there are not multiple tabs next to console yet. we can cross that bridge when we get to it

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
