### PR TITLE
winit: Fix showing a previously hidden window

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -552,7 +552,11 @@ impl SharedBackendData {
     }
 
     pub fn register_inactive_window(&self, window: Rc<WinitWindowAdapter>) {
-        self.inactive_windows.borrow_mut().push(Rc::downgrade(&window));
+        let window = Rc::downgrade(&window);
+        let mut inactive_windows = self.inactive_windows.borrow_mut();
+        if inactive_windows.iter().position(|w| Weak::ptr_eq(w, &window)).is_none() {
+            inactive_windows.push(window);
+        }
     }
 
     pub fn unregister_window(&self, id: Option<winit::window::WindowId>) {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -881,8 +881,11 @@ impl WinitWindowAdapter {
             let recreating_window = matches!(visibility, WindowVisibility::Shown);
 
             let Some(winit_window) = self.winit_window() else {
-                // Can't really show it on the screen, safe it in the attributes and try again later.
+                // Can't really show it on the screen, safe it in the attributes and try again later
+                // by registering it for activation when we can.
                 self.winit_window_or_none.borrow().set_visible(true);
+                self.shared_backend_data
+                    .register_inactive_window((self.self_weak.upgrade().unwrap()) as _);
                 return Ok(());
             };
 


### PR DESCRIPTION
When the API set_visible() call comes in, but we don't have a winit window yet, make sure the WinitWindowAdapter is registered for window creation.

Test: tests/manual/windowattributes -> toggle visibility under wayland

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
