### PR TITLE
LineEdit: Fix show password icon being out of sync with fluent

### DIFF
--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -157,14 +157,12 @@ export component LineEditPasswordIcon inherits Image {
     in property <bool> show-password;
     in property <image> show-password-image;
     in property <image> hide-password-image;
-    private property <bool> internal-show-password : show-password;
 
-    source: internal-show-password ? hide-password-image : show-password-image;
+    source: show-password ? hide-password-image : show-password-image;
     vertical-alignment: center;
     TouchArea {
         clicked => {
-            internal-show-password = !internal-show-password;
-            root.show-password-changed(internal-show-password);
+            root.show-password-changed(!show-password);
         }
     }
 }

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -99,6 +99,7 @@ export component LineEdit {
                 show-password-image: @image-url("_view_reveal.svg");
                 hide-password-image: @image-url("_view_conceal.svg");
                 colorize: base.text-color;
+                show-password: base.input-type != InputType.password;
                 show-password-changed(show) => {
                     base.input-type = show ? InputType.text : root.input-type;
                     base.focus();

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -104,6 +104,7 @@ export component LineEdit {
                 show-password-image: @image-url("_visibility.svg");
                 hide-password-image: @image-url("_visibility_off.svg");
                 colorize: base.text-color;
+                show-password: base.input-type != InputType.password;
                 show-password-changed(show) => {
                     base.input-type = show ? InputType.text : root.input-type;
                     base.focus();

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -109,6 +109,7 @@ export component LineEdit {
                 show-password-image: @image-url("_eye_show.svg");
                 hide-password-image: @image-url("_eye_hide.svg");
                 colorize: base.text-color;
+                show-password: base.input-type != InputType.password;
                 show-password-changed(show) => {
                     base.input-type = show ? InputType.text : root.input-type;
                     base.focus();

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -101,6 +101,7 @@ export component LineEdit {
                 show-password-image: @image-url("_visibility.svg");
                 hide-password-image: @image-url("_visibility_off.svg");
                 colorize: base.text-color;
+                show-password: base.input-type != InputType.password;
                 show-password-changed(show) => {
                     base.input-type = show ? InputType.text : root.input-type;
                     base.focus();


### PR DESCRIPTION
The problem was that the `LineEditPasswordIcon` had an internal property that would get out of sync when the component is re-created. The component does get re-created in fluent depeding on the focus, and this is the case especially with wasm because of the hidden input that takes the focus.

Fixes #9225
