### PR TITLE
Switch: ensure that the min-width contains the text

### DIFF
--- a/internal/compiler/widgets/cosmic/switch.slint
+++ b/internal/compiler/widgets/cosmic/switch.slint
@@ -23,7 +23,7 @@ export component Switch {
         root.toggled();
     }
 
-    min-width: 48px;
+    min-width: max(48px, layout.min-width);
     min-height: max(24px, layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 0;

--- a/internal/compiler/widgets/cupertino/switch.slint
+++ b/internal/compiler/widgets/cupertino/switch.slint
@@ -24,7 +24,7 @@ export component Switch {
         root.toggled();
     }
 
-    min-width: 26px;
+    min-width: max(26px, i-layout.min-width);
     min-height: max(15px, i-layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 0;

--- a/internal/compiler/widgets/fluent/switch.slint
+++ b/internal/compiler/widgets/fluent/switch.slint
@@ -23,7 +23,7 @@ export component Switch {
         root.toggled();
     }
 
-    min-width: 40px;
+    min-width: max(40px, layout.min-width);
     min-height: max(20px, layout.min-height);
     vertical-stretch: 0;
     horizontal-stretch: 0;


### PR DESCRIPTION
Currently, the min-with don't account for the text. That means that, for example, the switch on the top bar of the gallery, get the text to overflow which doesn't look good by default
