### PR TITLE
Fix warnings about dead code

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -480,7 +480,7 @@ impl BackendBuilder {
 }
 
 pub(crate) struct SharedBackendData {
-    requested_graphics_api: Option<RequestedGraphicsAPI>,
+    _requested_graphics_api: Option<RequestedGraphicsAPI>,
     #[cfg(enable_skia_renderer)]
     skia_context: i_slint_renderer_skia::SkiaSharedContext,
     active_windows: RefCell<HashMap<winit::window::WindowId, Weak<WinitWindowAdapter>>>,
@@ -551,7 +551,7 @@ impl SharedBackendData {
                 .map_err(|display_err| PlatformError::OtherError(display_err.into()))?,
         );
         Ok(Self {
-            requested_graphics_api,
+            _requested_graphics_api: requested_graphics_api,
             #[cfg(enable_skia_renderer)]
             skia_context: i_slint_renderer_skia::SkiaSharedContext::default(),
             active_windows: Default::default(),

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -22,7 +22,7 @@ mod glcontext;
 #[cfg(supports_opengl)]
 pub struct GlutinFemtoVGRenderer {
     renderer: FemtoVGRenderer<opengl::OpenGLBackend>,
-    requested_graphics_api: Option<RequestedGraphicsAPI>,
+    _requested_graphics_api: Option<RequestedGraphicsAPI>,
 }
 
 #[cfg(supports_opengl)]
@@ -32,7 +32,7 @@ impl GlutinFemtoVGRenderer {
     ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
         Ok(Box::new(Self {
             renderer: FemtoVGRenderer::new_suspended(),
-            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+            _requested_graphics_api: shared_backend_data._requested_graphics_api.clone(),
         }))
     }
 }
@@ -56,7 +56,7 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
         let (winit_window, opengl_context) = glcontext::OpenGLContext::new_context(
             window_attributes,
             active_event_loop,
-            self.requested_graphics_api.as_ref().map(TryInto::try_into).transpose()?,
+            self._requested_graphics_api.as_ref().map(TryInto::try_into).transpose()?,
         )?;
 
         #[cfg(target_arch = "wasm32")]
@@ -98,14 +98,14 @@ impl WGPUFemtoVGRenderer {
         shared_backend_data: &Rc<crate::SharedBackendData>,
     ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
         if !i_slint_core::graphics::wgpu_26::any_wgpu26_adapters_with_gpu(
-            shared_backend_data.requested_graphics_api.clone(),
+            shared_backend_data._requested_graphics_api.clone(),
         ) {
             return Err(PlatformError::from("WGPU: No GPU adapters found"));
         }
         Ok(Box::new(Self {
             renderer: FemtoVGRenderer::<i_slint_renderer_femtovg::wgpu::WGPUBackend>::new_suspended(
             ),
-            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+            requested_graphics_api: shared_backend_data._requested_graphics_api.clone(),
         }))
     }
 }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -20,7 +20,7 @@ impl WinitSkiaRenderer {
     ) -> Result<Box<dyn super::WinitCompatibleRenderer>, PlatformError> {
         Ok(Box::new(Self {
             renderer: SkiaRenderer::default(&shared_backend_data.skia_context),
-            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+            requested_graphics_api: shared_backend_data._requested_graphics_api.clone(),
         }))
     }
 
@@ -30,7 +30,7 @@ impl WinitSkiaRenderer {
     ) -> Result<Box<dyn super::WinitCompatibleRenderer>, PlatformError> {
         Ok(Box::new(Self {
             renderer: SkiaRenderer::default_software(&shared_backend_data.skia_context),
-            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+            requested_graphics_api: shared_backend_data._requested_graphics_api.clone(),
         }))
     }
 
@@ -40,7 +40,7 @@ impl WinitSkiaRenderer {
     ) -> Result<Box<dyn super::WinitCompatibleRenderer>, PlatformError> {
         Ok(Box::new(Self {
             renderer: SkiaRenderer::default_opengl(&shared_backend_data.skia_context),
-            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+            requested_graphics_api: shared_backend_data._requested_graphics_api.clone(),
         }))
     }
 
@@ -50,7 +50,7 @@ impl WinitSkiaRenderer {
     ) -> Result<Box<dyn super::WinitCompatibleRenderer>, PlatformError> {
         Ok(Box::new(Self {
             renderer: SkiaRenderer::default_metal(&shared_backend_data.skia_context),
-            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+            requested_graphics_api: shared_backend_data._requested_graphics_api.clone(),
         }))
     }
 
@@ -60,7 +60,7 @@ impl WinitSkiaRenderer {
     ) -> Result<Box<dyn super::WinitCompatibleRenderer>, PlatformError> {
         Ok(Box::new(Self {
             renderer: SkiaRenderer::default_vulkan(&shared_backend_data.skia_context),
-            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+            requested_graphics_api: shared_backend_data._requested_graphics_api.clone(),
         }))
     }
 
@@ -70,7 +70,7 @@ impl WinitSkiaRenderer {
     ) -> Result<Box<dyn super::WinitCompatibleRenderer>, PlatformError> {
         Ok(Box::new(Self {
             renderer: SkiaRenderer::default_direct3d(&shared_backend_data.skia_context),
-            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+            requested_graphics_api: shared_backend_data._requested_graphics_api.clone(),
         }))
     }
 
@@ -80,7 +80,7 @@ impl WinitSkiaRenderer {
     ) -> Result<Box<dyn super::WinitCompatibleRenderer>, PlatformError> {
         Ok(Box::new(Self {
             renderer: SkiaRenderer::default_wgpu_26(&shared_backend_data.skia_context),
-            requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),
+            requested_graphics_api: shared_backend_data._requested_graphics_api.clone(),
         }))
     }
 


### PR DESCRIPTION
The requested_graphics_api fields are not used in all cfgs. Added ` _`_ instead as that's less error prone than a cfg forest.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
