### PR TITLE
FocusReason: change the default value

### DIFF
--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -134,14 +134,14 @@ macro_rules! for_each_enums {
             /// This enum describes the different reasons for a FocusEvent
             #[non_exhaustive]
             enum FocusReason {
+                /// A built-in function invocation caused the event (`.focus()`, `.clear-focus()`)
+                Programmatic,
                 /// Keyboard navigation caused the event (tabbing)
                 TabNavigation,
                 /// A mouse click caused the event
                 PointerClick,
                 /// A popup caused the event
                 PopupActivation,
-                /// A built-in function invocation caused the event (`.focus()`, `.clear-focus()`)
-                Programmatic,
                 /// The window manager changed the active window and caused the event
                 WindowActivation,
             }


### PR DESCRIPTION
`Programmatic` makes more sense as a default value for that enum

Technically a breaking change, but since that enum was introduced recently and it is unlikely that people have used it in property so far, it makes sense to get a decent default now.