### PR TITLE
Revert "CI: pin the nightly version"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
                       rust_version: "beta"
                       extra_args: "--exclude ffmpeg --exclude gstreamer-player"
                     - os: ubuntu-22.04
-                      rust_version: "nightly-2025-08-15" # Pinned because of a bug
+                      rust_version: "nightly"
                     # Bevy requires 1.86, won't compile with 1.85
                     - rust_version: "1.85"
                       maybe_exclude_bevy: "--exclude bevy-example"


### PR DESCRIPTION
This reverts commit 3319dcfa338a646cc4382686b16576d5d4871f14.

The build failure should have been fixed
