### PR TITLE
Cupertino ComboBox: remove height-for-height dependency

### DIFF
--- a/internal/compiler/widgets/cupertino/combobox.slint
+++ b/internal/compiler/widgets/cupertino/combobox.slint
@@ -105,13 +105,16 @@ export component ComboBox {
             accessible-role: none;
         }
 
-        VerticalLayout {
-            alignment: center;
+        Rectangle {
+            min-width: 16px;
+            preferred-width: button-layout.preferred-width;
+            min-height: 16px;
+            horizontal-stretch: 0;
 
             Rectangle {
-                horizontal-stretch: 0;
-                min-width: 16px;
-                min-height: max(self.min-width, button-layout.min-height);
+                x: 0px;
+                width: 100%;
+                y: (parent.height - self.height) / 2;
 
                 if root.enabled : Rectangle {
                     width: 100%;

--- a/tests/cases/widgets/combobox.slint
+++ b/tests/cases/widgets/combobox.slint
@@ -21,6 +21,12 @@ export component TestCase inherits Window {
         }
     }
 
+    if false : Rectangle {
+        test-no-loop := ComboBox {
+            width: 10 * self.height; // Test that there is no height for width dependency (loop)
+        }
+    }
+
     public function unfocus() {
         box.clear-focus();
     }


### PR DESCRIPTION
Fixes https://github.com/slint-ui/slint/issues/9219
