### PR TITLE
docsnapper: Print erros in red

### DIFF
--- a/tools/docsnapper/Cargo.toml
+++ b/tools/docsnapper/Cargo.toml
@@ -23,6 +23,7 @@ i-slint-renderer-skia = { workspace = true, features = ["default", "wayland"] }
 clap = { workspace = true }
 itertools = { workspace = true }
 spin_on = { workspace = true }
+termcolor = { version = "1.4.1" }
 walkdir = { version = "2.5" }
 
 # Enable image-rs' default features to make all image formats available for preview


### PR DESCRIPTION
Highlight errors in red when running docsnapper when running in a terminal.

Print "[error]" in all cases as apparently Github will highlight that in red in CI run logs (which are not considered to be in a terminal).