### PR TITLE
Removed non-neded clone

### DIFF
--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1723,7 +1723,7 @@ pub fn instantiate(
             repeater.set_model_binding(move || {
                 let m = model_binding_closure();
                 if let Value::Model(m) = m {
-                    m.clone()
+                    m
                 } else {
                     ModelRc::new(crate::value_model::ValueModel::new(m))
                 }


### PR DESCRIPTION
`ModelRc` is nothing than `Rc` under the hood. `Rc` is `!Copy` and always requires calling of `clone()` or passing the ownership. Therefore, we have a value provided by `model_binding_closure` that is owned and can be passed to `set_model_binding` without any reference counter change forth and back.