### PR TITLE
FocusScope: Remove FocusPolicy and adds two bool state instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project are documented in this file.
  - Flickable forward wheel event in a orthogonal direction to their parent
  - Added a compiler warning when using `padding` outside of layout (#6288)
  - Added stop(), start(), and restart() methods to Timer (#8821)
- - Added `focus-policy` property to `FocusScope` (#8940)
+ - Added `focus-on-click` and `focus-on-tab-navigation` property to `FocusScope`
  - `Dialog` and `Window` that aren't top-level now draw their background
  - `FocusScope`: Added `capture_key_pressed` and `capture_key_released` callbacks
  - Added support for `@conic-gradient` (#9021)

--- a/docs/astro/src/content/docs/reference/global-structs-enums.mdx
+++ b/docs/astro/src/content/docs/reference/global-structs-enums.mdx
@@ -20,7 +20,6 @@ import ColorScheme from "../../collections/enums/ColorScheme.md"
 import DialogButtonRole from "../../collections/enums/DialogButtonRole.md"
 import EventResult from "../../collections/enums/EventResult.md"
 import FillRule from "../../collections/enums/FillRule.md"
-import FocusPolicy from "../../collections/enums/FocusPolicy.md"
 import FocusReason from "../../collections/enums/FocusReason.md"
 import ImageFit from "../../collections/enums/ImageFit.md"
 import ImageHorizontalAlignment from "../../collections/enums/ImageHorizontalAlignment.md"
@@ -90,9 +89,6 @@ import TextWrap from "../../collections/enums/TextWrap.md"
 
 ### FillRule
 <FillRule />
-
-### FocusPolicy
-<FocusPolicy />
 
 ### FocusReason
 <FocusReason />

--- a/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
+++ b/docs/astro/src/content/docs/reference/keyboard-input/focusscope.mdx
@@ -55,14 +55,23 @@ Is `true` when the element has keyboard focus.
 
 ### enabled
 <SlintProperty propName="enabled" typeName="bool" defaultValue="true">
- When true, the `FocusScope` will make itself the focused element when clicked. Set this to false if you don't want the click-to-focus
-    behavior. Similarly, a disabled `FocusScope` does not accept the focus via tab focus traversal. A parent `FocusScope` will still receive key events from
-    child `FocusScope`s that were rejected, even if `enabled` is set to false.
+When false, the FocusScope will not accept focus, neither via click nor via tab focus traversal, not even programmatically.
+
+A parent `FocusScope` will still receive key events from child `FocusScope`s that were rejected, even if `enabled` is set to false.
 </SlintProperty>
 
-### focus-policy
-<SlintProperty propName="focus-policy" typeName="enum" enumName="FocusPolicy">
-The focus policy of the scope.
+### focus-on-click
+<SlintProperty propName="focus-on-click" typeName="bool" defaultValue="true">
+When true, the `FocusScope` will make itself the focused element when clicked.
+
+This property has no effect if the `enabled` property is set to false.
+</SlintProperty>
+
+### focus-on-tab-navigation
+<SlintProperty propName="focus-on-tab-navigation" typeName="bool" defaultValue="true">
+When true, the `FocusScope` will accept focus as part of the tab focus traversal.
+
+This property has no effect if the `enabled` property is set to false.
 </SlintProperty>
 
 ## Functions

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -146,17 +146,6 @@ macro_rules! for_each_enums {
                 WindowActivation,
             }
 
-            /// This enum describes the different focus policies for a FocusScope
-            #[non_exhaustive]
-            enum FocusPolicy {
-                /// The FocusScope accepts focus from both tab navigation and pointer clicks
-                TabAndClick,
-                /// The FocusScope only accepts focus from tab navigation
-                TabOnly,
-                /// The FocusScope only accepts focus from pointer clicks
-                ClickOnly,
-            }
-
             /// The enum reports what happened to the `PointerEventButton` in the event
             enum PointerEventKind {
                 /// The action was cancelled.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -134,7 +134,8 @@ export component TouchArea {
 
 export component FocusScope {
     in property <bool> enabled: true;
-    in property <FocusPolicy> focus-policy;
+    in property <bool> focus-on-click: true;
+    in property <bool> focus-on-tab-navigation: true;
     out property <bool> has-focus;
     callback capture_key_pressed(event: KeyEvent) -> EventResult;
     callback capture_key_released(event: KeyEvent) -> EventResult;

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -56,9 +56,6 @@
     "float": {
         "href": "reference/primitive-types/#float"
     },
-    "FocusPolicy": {
-        "href": "reference/global-structs-enums/#focuspolicy"
-    },
     "FocusReason": {
         "href": "reference/global-structs-enums/#focusreason"
     },

--- a/tests/cases/focus/focus_policy.slint
+++ b/tests/cases/focus/focus_policy.slint
@@ -299,7 +299,7 @@ slintlib.private_api.send_mouse_click(instance, 5., 200.);
 assert(instance.fs1_has_focus);
 assert(!instance.fs2_has_focus);
 assert(!instance.fs3_has_focus);
-assert.equal(instance.events, "1 Out Click\n3 In Click\n");
+assert.equal(instance.events, "");
 instance.events = "";
 
 // opening a popup should still remove focus

--- a/tests/cases/focus/focus_policy.slint
+++ b/tests/cases/focus/focus_policy.slint
@@ -6,31 +6,65 @@ export component TestCase inherits Rectangle {
     width: 400phx;
     height: 400phx;
 
+    function reason-str(reason: FocusReason) -> string {
+        if reason == FocusReason.tab-navigation {
+            return "Tab";
+        } else if reason == FocusReason.pointer-click {
+            return "Click";
+        } else if reason == FocusReason.popup-activation {
+            return "Popup";
+        } else if reason == FocusReason.window-activation {
+            return "Window";
+        } else if reason == FocusReason.programmatic {
+            return "Programmatic";
+        } else {
+            return "Unknown";
+        }
+    }
+
+
     VerticalLayout {
         fs1 := FocusScope {
-            focus-policy: FocusPolicy.tab-and-click;
+            focus-on-click: true;
+            focus-on-tab-navigation: true;
             Rectangle {
                 width: 100%;
                 height: 100%;
                 background: red;
             }
+
+            focus-gained(reason) => { events += "1 In " + reason-str(reason) + "\n"; }
+            focus-lost(reason) => { events += "1 Out " + reason-str(reason) + "\n"; }
         }
 
+        // tab only
         fs2 := FocusScope {
-            focus-policy: FocusPolicy.tab-only;
+            focus-on-click: false;
             Rectangle {
                 width: 100%;
                 height: 100%;
                 background: green;
             }
+
+            focus-gained(reason) => { events += "2 In " + reason-str(reason) + "\n"; }
+            focus-lost(reason) => { events += "2 Out " + reason-str(reason) + "\n"; }
         }
 
+        // click only
         fs3 := FocusScope {
-            focus-policy: FocusPolicy.click-only;
+            focus-on-tab-navigation: false;
             Rectangle {
                 width: 100%;
                 height: 100%;
                 background: blue;
+            }
+
+            focus-changed-event(reason) => {
+                if self.has-focus {
+                    events += "3 In " + reason-str(reason) + "\n";
+                } else {
+                    events += "3 Out " + reason-str(reason) + "\n";
+                }
             }
         }
     }
@@ -56,6 +90,7 @@ export component TestCase inherits Rectangle {
     out property <bool> fs1-has-focus: fs1.has-focus;
     out property <bool> fs2-has-focus: fs2.has-focus;
     out property <bool> fs3-has-focus: fs3.has-focus;
+    in-out property <string> events;
 }
 
 /*
@@ -67,56 +102,74 @@ slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert!(instance.get_fs1_has_focus());
 assert!(!instance.get_fs2_has_focus());
 assert!(!instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "1 In Tab\n");
+instance.set_events(Default::default());
 
 // tab to fs2
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert!(!instance.get_fs1_has_focus());
 assert!(instance.get_fs2_has_focus());
 assert!(!instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "1 Out Tab\n2 In Tab\n");
+instance.set_events(Default::default());
 
 // skip fs3 and tab back to fs1
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert!(instance.get_fs1_has_focus());
 assert!(!instance.get_fs2_has_focus());
 assert!(!instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "2 Out Tab\n1 In Tab\n");
+instance.set_events(Default::default());
 
 // click to focus fs3
 slint_testing::send_mouse_click(&instance, 5., 300.);
 assert!(!instance.get_fs1_has_focus());
 assert!(!instance.get_fs2_has_focus());
 assert!(instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "1 Out Click\n3 In Click\n");
+instance.set_events(Default::default());
 
 // click to focus fs1
 slint_testing::send_mouse_click(&instance, 5., 5.);
 assert!(instance.get_fs1_has_focus());
 assert!(!instance.get_fs2_has_focus());
 assert!(!instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "3 Out Click\n1 In Click\n");
+instance.set_events(Default::default());
 
 // click shouldn't focus fs2
 slint_testing::send_mouse_click(&instance, 5., 200.);
 assert!(instance.get_fs1_has_focus());
 assert!(!instance.get_fs2_has_focus());
 assert!(!instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "");
 
 // opening a popup should still remove focus
 instance.invoke_show_popup();
 assert!(!instance.get_fs1_has_focus());
 assert!(!instance.get_fs2_has_focus());
 assert!(!instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "1 Out Popup\n");
+instance.set_events(Default::default());
 
 // programmatic focus should still work too
 instance.invoke_focus_fs1();
 assert!(instance.get_fs1_has_focus());
 assert!(!instance.get_fs2_has_focus());
 assert!(!instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "1 In Programmatic\n");
+instance.set_events(Default::default());
 instance.invoke_focus_fs2();
 assert!(!instance.get_fs1_has_focus());
 assert!(instance.get_fs2_has_focus());
 assert!(!instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "1 Out Programmatic\n2 In Programmatic\n");
+instance.set_events(Default::default());
 instance.invoke_focus_fs3();
 assert!(!instance.get_fs1_has_focus());
 assert!(!instance.get_fs2_has_focus());
 assert!(instance.get_fs3_has_focus());
+assert_eq!(instance.get_events(), "2 Out Programmatic\n3 In Programmatic\n");
 ```
 
 ```cpp
@@ -128,56 +181,74 @@ slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert(instance.get_fs1_has_focus());
 assert(!instance.get_fs2_has_focus());
 assert(!instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "1 In Tab\n");
+instance.set_events("");
 
 // tab to fs2
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert(!instance.get_fs1_has_focus());
 assert(instance.get_fs2_has_focus());
 assert(!instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "1 Out Tab\n2 In Tab\n");
+instance.set_events("");
 
 // skip fs3 and tab back to fs1
 slint_testing::send_keyboard_string_sequence(&instance, "\t");
 assert(instance.get_fs1_has_focus());
 assert(!instance.get_fs2_has_focus());
 assert(!instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "2 Out Tab\n1 In Tab\n");
+instance.set_events("");
 
 // click to focus fs3
 slint_testing::send_mouse_click(&instance, 5., 300.);
 assert(!instance.get_fs1_has_focus());
 assert(!instance.get_fs2_has_focus());
 assert(instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "1 Out Click\n3 In Click\n");
+instance.set_events("");
 
 // click to focus fs1
 slint_testing::send_mouse_click(&instance, 5., 5.);
 assert(instance.get_fs1_has_focus());
 assert(!instance.get_fs2_has_focus());
 assert(!instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "3 Out Click\n1 In Click\n");
+instance.set_events("");
 
 // click shouldn't focus fs2
 slint_testing::send_mouse_click(&instance, 5., 200.);
 assert(instance.get_fs1_has_focus());
 assert(!instance.get_fs2_has_focus());
 assert(!instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "");
 
 // opening a popup should still remove focus
 instance.invoke_show_popup();
 assert(!instance.get_fs1_has_focus());
 assert(!instance.get_fs2_has_focus());
 assert(!instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "1 Out Popup\n");
+instance.set_events("");
 
 // programmatic focus should still work too
 instance.invoke_focus_fs1();
 assert(instance.get_fs1_has_focus());
 assert(!instance.get_fs2_has_focus());
 assert(!instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "1 In Programmatic\n");
+instance.set_events("");
 instance.invoke_focus_fs2();
 assert(!instance.get_fs1_has_focus());
 assert(instance.get_fs2_has_focus());
 assert(!instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "1 Out Programmatic\n2 In Programmatic\n");
+instance.set_events("");
 instance.invoke_focus_fs3();
 assert(!instance.get_fs1_has_focus());
 assert(!instance.get_fs2_has_focus());
 assert(instance.get_fs3_has_focus());
+assert_eq(instance.get_events(), "2 Out Programmatic\n3 In Programmatic\n");
 ```
 
 ```js
@@ -188,55 +259,74 @@ slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
 assert(instance.fs1_has_focus);
 assert(!instance.fs2_has_focus);
 assert(!instance.fs3_has_focus);
+assert.equal(instance.events, "1 In Tab\n");
+instance.events = "";
 
 // tab to fs2
 slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
 assert(!instance.fs1_has_focus);
 assert(instance.fs2_has_focus);
 assert(!instance.fs3_has_focus);
+assert.equal(instance.events, "1 Out Tab\n2 In Tab\n");
+instance.events = "";
 
 // skip fs3 and tab back to fs1
 slintlib.private_api.send_keyboard_string_sequence(instance, "\t");
 assert(instance.fs1_has_focus);
 assert(!instance.fs2_has_focus);
 assert(!instance.fs3_has_focus);
+assert.equal(instance.events, "2 Out Tab\n1 In Tab\n");
+instance.events = "";
 
 // click to focus fs3
 slintlib.private_api.send_mouse_click(instance, 5., 300.);
 assert(!instance.fs1_has_focus);
 assert(!instance.fs2_has_focus);
 assert(instance.fs3_has_focus);
+assert.equal(instance.events, "1 Out Click\n3 In Click\n");
+instance.events = "";
 
 // click to focus fs1
 slintlib.private_api.send_mouse_click(instance, 5., 5.);
 assert(instance.fs1_has_focus);
 assert(!instance.fs2_has_focus);
 assert(!instance.fs3_has_focus);
+assert.equal(instance.events, "3 Out Click\n1 In Click\n");
+instance.events = "";
 
 // click shouldn't focus fs2
 slintlib.private_api.send_mouse_click(instance, 5., 200.);
 assert(instance.fs1_has_focus);
 assert(!instance.fs2_has_focus);
 assert(!instance.fs3_has_focus);
+assert.equal(instance.events, "1 Out Click\n3 In Click\n");
+instance.events = "";
 
 // opening a popup should still remove focus
 instance.show_popup();
 assert(!instance.fs1_has_focus);
 assert(!instance.fs2_has_focus);
 assert(!instance.fs3_has_focus);
+assert.equal(instance.events, "1 Out Popup\n");
+instance.events = "";
 
 // programmatic focus should still work too
 instance.focus_fs1();
 assert(instance.fs1_has_focus);
 assert(!instance.fs2_has_focus);
 assert(!instance.fs3_has_focus);
+assert.equal(instance.events, "1 In Programmatic\n");
+instance.events = "";
 instance.focus_fs2();
 assert(!instance.fs1_has_focus);
 assert(instance.fs2_has_focus);
 assert(!instance.fs3_has_focus);
+assert.equal(instance.events, "1 Out Programmatic\n2 In Programmatic\n");
+instance.events = "";
 instance.focus_fs3();
 assert(!instance.fs1_has_focus);
 assert(!instance.fs2_has_focus);
 assert(instance.fs3_has_focus);
+assert.equal(instance.events, "2 Out Programmatic\n3 In Programmatic\n");
 ```
 */

--- a/tests/cases/focus/keyboard_focus_capture.slint
+++ b/tests/cases/focus/keyboard_focus_capture.slint
@@ -13,7 +13,7 @@ export component TestCase inherits Window {
   in-out property <string> result;
 
   FocusScope {
-    focus-policy: click-only;
+    focus-on-tab-navigation: false;
     capture-key-pressed(event) => {
       if (event.text == "x") {
         result += "Or:";


### PR DESCRIPTION
As discussed in API review, we thought that as we don't have bitflag, it makes more sense to have two boolean properties.

Also change the behavior as the focus out event should always be forwarded regardless of the policy.
