### PR TITLE
Rust&C++: Fix conversion from named struct to anonumous struct

### DIFF
--- a/tests/cases/issues/issue_9209_array_in_struct_conversion.slint
+++ b/tests/cases/issues/issue_9209_array_in_struct_conversion.slint
@@ -22,6 +22,9 @@ export component TestCase inherits Window {
     in property <{xxx: [string], pattern: PatternInstrumentData}> complex2: true ?
         complex : { xxx: [4, 5, 6], pattern: { notes: [] } };
 
+    in-out property <PatternInstrumentData> convert: true ? list_of_lists2[0] : { notes: [-3.0, -4.0] };
+    in-out property <PatternInstrumentData> convert2: list_of_lists2.length == 0 ? { notes: [-3.0, -4.0] } : list_of_lists2[0];
+
 
     out property <bool> test: instruments_left.notes[1] == 4 && instruments_right.notes[1] == 6
        //&& list_of_lists[2].notes[1] == 8


### PR DESCRIPTION
As noticed in https://github.com/slint-ui/slint/actions/runs/17239981969/job/48914213040 (building chiptrack)
