### PR TITLE
Revert "feat: raise compiler error if musl is used (#8450)"

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -201,9 +201,6 @@ each instance will have their own instance of associated globals singletons.
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::needless_doctest_main)] // We document how to write a main function
 
-#[cfg(target_env = "musl")]
-compile_error!("Compiling with MUSL is not supported by this crate.");
-
 extern crate alloc;
 
 #[cfg(not(feature = "compat-1-2"))]


### PR DESCRIPTION
This reverts commit 14483a6e32f782d98eeb71848cd48c6041e1e70c. musl works fine with slint and making it a fatal error instead of warning prevents usage of slint.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
