### PR TITLE
Zed-extension: Synchronize the version with Slint version

### DIFF
--- a/.github/workflows/upgrade_version.yaml
+++ b/.github/workflows/upgrade_version.yaml
@@ -26,7 +26,7 @@ jobs:
                   sed -i 's/ VERSION [0-9]*\.[0-9]*\.[0-9]*)$/ VERSION ${{ github.event.inputs.new_version }})/' api/cpp/CMakeLists.txt
 
                   # The version is also in these files
-                  sed -i "s/^version = \"[0-9]*\.[0-9]*\.[0-9]*\(.*\)\"/version = \"${{ github.event.inputs.new_version }}\1\"/" api/cpp/docs/conf.py api/python/slint/pyproject.toml api/python/briefcase/pyproject.toml api/python/compiler/pyproject.toml
+                  sed -i "s/^version = \"[0-9]*\.[0-9]*\.[0-9]*\(.*\)\"/version = \"${{ github.event.inputs.new_version }}\1\"/" api/cpp/docs/conf.py api/python/slint/pyproject.toml api/python/briefcase/pyproject.toml api/python/compiler/pyproject.toml editors/zed/extension.toml
 
                   # Version in package.json files
                   git ls-files | grep package.json | xargs sed -i 's/"version": ".*"/"version": "${{ github.event.inputs.new_version }}"/'

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -3,13 +3,13 @@
 
 [package]
 name = "zed_slint"
-version = "0.1.1"
+version = "1.13.0"
 edition = "2021"
 publish = false
 license = "GPL-3.0-or-later"
 
 [dependencies]
-zed_extension_api = "0.3.0"
+zed_extension_api = "0.6.0"
 
 [lib]
 path = "src/slint.rs"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -4,9 +4,9 @@
 id = "slint"
 name = "Slint"
 description = "Slint support for Zed"
-version = "0.1.1"
+version = "1.13.0"
 schema_version = 1
-authors = ["Luke. D Jones <luke@ljones.dev>"]
+authors = ["Slint Developers <info@slint.dev>", "Luke. D Jones <luke@ljones.dev>"]
 repository = "https://github.com/slint-ui/slint"
 
 [language_servers.slint]
@@ -15,4 +15,4 @@ language = "Slint"
 
 [grammars.slint]
 repository = "https://github.com/slint-ui/tree-sitter-slint.git"
-commit = "4e2765d4cac1f03ada6f635eeb6008d1d0aff5a3"
+commit = "96bc969d20ff347030519184ea2467f4046a524d"


### PR DESCRIPTION
 - Use always the same github release as the github version (If that doesn't exist, assume this is a build from source and use the nightly)
 - Remove the way it checks for `slint-lsp` in the `$PATH`
 - Update dependencies

