### PR TITLE
Parse: accept changed callback without brace

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -355,7 +355,7 @@ declare_syntax! {
         /// QualifiedName are the properties name
         PropertyAnimation-> [ *QualifiedName, *Binding ],
         /// `changed xxx => {...}`  where `xxx` is the DeclaredIdentifier
-        PropertyChangedCallback-> [ DeclaredIdentifier, CodeBlock ],
+        PropertyChangedCallback-> [ DeclaredIdentifier, ?CodeBlock, ?Expression ],
         /// wraps Identifiers, like `Rectangle` or `SomeModule.SomeType`
         QualifiedName-> [],
         /// Wraps single identifier (to disambiguate when there are other identifier in the production)

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -65,10 +65,17 @@ fn resolve_expression(
             SyntaxKind::BindingExpression => {
                 Expression::from_binding_expression_node(node.clone(), &mut lookup_ctx)
             }
-            SyntaxKind::PropertyChangedCallback => Expression::from_codeblock_node(
-                syntax_nodes::PropertyChangedCallback::from(node.clone()).CodeBlock(),
-                &mut lookup_ctx,
-            ),
+            SyntaxKind::PropertyChangedCallback => {
+                let node = syntax_nodes::PropertyChangedCallback::from(node.clone());
+                if let Some(code_block_node) = node.CodeBlock() {
+                    Expression::from_codeblock_node(code_block_node, &mut lookup_ctx)
+                } else if let Some(expr_node) = node.Expression() {
+                    Expression::from_expression_node(expr_node, &mut lookup_ctx)
+                } else {
+                    assert!(diag.has_errors());
+                    Expression::Invalid
+                }
+            }
             SyntaxKind::TwoWayBinding => {
                 assert!(diag.has_errors(), "Two way binding should have been resolved already  (property: {property_name:?})");
                 Expression::Invalid

--- a/tests/cases/bindings/change_sub_property.slint
+++ b/tests/cases/bindings/change_sub_property.slint
@@ -12,7 +12,7 @@ SubElem := Rectangle {
 
 TestCase := Rectangle {
     callback change();
-    change => { sub.change() }
+    change => sub.change();
     property <int> toplevel: sub.value + 1;
     sub := SubElem { }
 }

--- a/tests/cases/properties/changes_loop.slint
+++ b/tests/cases/properties/changes_loop.slint
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
 
     changed value-plus-1 => {
         result = value-plus-1 * 10;
-    }
+    };
 
     out property <int> result: value - 1;
 

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -265,7 +265,9 @@ pub fn with_property_lookup_ctx<R>(
         .PropertyChangedCallback()
         .find(|p| i_slint_compiler::parser::identifier_text(p).is_some_and(|x| x == prop_name))
     {
-        add_codeblock_local_variables(&cb.CodeBlock(), to_offset, &mut lookup_context);
+        if let Some(block) = cb.CodeBlock() {
+            add_codeblock_local_variables(&block, to_offset, &mut lookup_context);
+        }
     } else if let Some(b) = element
         .Binding()
         .find(|p| i_slint_compiler::parser::identifier_text(p).is_some_and(|x| x == prop_name))


### PR DESCRIPTION
For consistency with the normal callbacks
