### PR TITLE
cmake: Add the live-preview feature to the CMake reference

### DIFF
--- a/api/cpp/docs/index.rst
+++ b/api/cpp/docs/index.rst
@@ -15,6 +15,8 @@ Slint C++ documentation
 
    First Steps <getting_started.md>
 
+   live_preview.md
+
 .. toctree::
    :maxdepth: 2
    :hidden:

--- a/api/cpp/docs/live_preview.md
+++ b/api/cpp/docs/live_preview.md
@@ -1,0 +1,14 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+<!-- cSpell: ignore ccmake dslint femtovg -->
+
+# Live-Preview
+
+`.slint` files are compiled to C++ code when using the [`slint_target_sources()`](cmake_reference.md#slint_target_sources) function.
+This is the default and recommended for release builds.
+
+During debugging and development, changes to `.slint` files requires re-compiling and re-starting the application. To speed up
+modifications to the UI while connected to the applications' business logic, you can opt into enabling Live-Preview for C++:
+
+1. Compile Slint [from sources](cmake.md#build-from-sources). At the configure step, enable the `SLINT_FEATURE_LIVE_PREVIEW` cmake option.
+2. When compiling your application, set the `SLINT_LIVE_PREVIEW=1` environment variable.
+3. Start you application. The Slint run-time library will load and reload `.slint` files after you've modified them on disk.


### PR DESCRIPTION
So that it can be linked to from the blog post :)

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
