### PR TITLE
Windows: Use `WM_SETREDRAW` to disable redraw when rebuilding `muda` menus

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -118,6 +118,10 @@ objc2-app-kit = { version = "0.3.0" }
 # Enable Skia by default on Apple platforms with iOS, etc. (but not macOS). See also enable_skia_renderer in build.rs
 i-slint-renderer-skia = { workspace = true, features = ["default"] }
 
+[target.'cfg(target_os = "windows")'.dependencies.windows]
+version = "0.61.1"
+features = ["Win32"]
+
 [build-dependencies]
 cfg_aliases = { workspace = true }
 


### PR DESCRIPTION
When the state of menus are changed, the `muda` representation of menus is completely torn down and rebuilt.  On Windows, this can create a slight flicker unless the act of redrawing the window is disabled.  With this change, we use `WM_SETREDRAW` to disable redrawing while the menus are being reconstructed.

It isn't clear to me if other platforms have a similar problem.