### PR TITLE
Draft: Improve femtovg rendering on high-DPI displays

### DIFF
--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -154,7 +154,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
                     // We pass an integer that is greater than or equal to the scale factor as
                     // dpi / device pixel ratio as the anti-alias of femtovg needs that to draw text clearly.
                     // We need to care about that `ceil()` when calculating metrics.
-                    femtovg_canvas.set_size(surface_size.width, surface_size.height, scale);
+                    femtovg_canvas.set_size(surface_size.width, surface_size.height, 1.0);
 
                     // Clear with window background if it is a solid color otherwise it will drawn as gradient
                     if let Some(Brush::SolidColor(clear_color)) = window_background_brush {
@@ -184,7 +184,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
                     let commands = femtovg_canvas.flush_to_surface(surface.render_surface());
                     self.graphics_backend.submit_commands(commands);
 
-                    femtovg_canvas.set_size(width.get(), height.get(), scale);
+                    femtovg_canvas.set_size(width.get(), height.get(), 1.0);
                     drop(femtovg_canvas);
 
                     self.with_graphics_api(|api| {


### PR DESCRIPTION
DO NOT MERGE

This is a complete draft and I do not know what I'm doing.

Related to https://github.com/slint-ui/slint/issues/6298 https://github.com/slint-ui/slint/issues/6215 https://github.com/slint-ui/slint/issues/5748 afaik.

What _seems_ to be happening is that slint is doing its own handling of [monitor scale factors](https://docs.rs/winit/latest/winit/window/struct.Window.html#method.scale_factor)/DPI scales greater than 1. At the same time, there's code in femtovg to handle this, but the logic is either somewhat botched or unaware of what slint is already doing. Such that if slint is already handling a scale factor of e.g. 1.5, then that is mistakenly being multiplied by another 1.5 in femtovg to produce a value of 2.25 that's doing something bad somewhere. Or something.

Regardless, compare how the bevy example looks on my 1.566667 scale factor laptop monitor before and after this change. You might need to download the file and view it 1:1 to properly see the difference:

<img width="1115" height="847" alt="20250902_12h32m51s_grim" src="https://github.com/user-attachments/assets/eb4afaa7-9bc3-4d91-a726-a5b2c73959c0" />


<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
