### PR TITLE
Qt: don't include the full of QtWidgets

### DIFF
--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -263,7 +263,8 @@ impl SlintAccessibleItemData {
 }
 
 cpp! {{
-    #include <QtWidgets/QtWidgets>
+    #include <QtGui/QAccessible>
+    #include <QtWidgets/QWidget>
 
     #include <memory>
 

--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -151,6 +151,7 @@ cpp! {{
     #include <QtWidgets/QStyleFactory>
     #include <QtGui/QPainter>
     #include <QtGui/QClipboard>
+    #include <QtGui/QPaintEngine>
     #include <QtCore/QMimeData>
     #include <QtCore/QDebug>
     #include <QtCore/QScopeGuard>


### PR DESCRIPTION
So it doesn't need to include GL/gl.h which cannot be found on some systems
Fixes #9309
