### PR TITLE
Qt: Fix rendering of LineEdit clear button

### DIFF
--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -74,16 +74,19 @@ export component LineEdit {
             margin: layout.padding-left + layout.padding-right;
         }
 
-        if !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only: LineEditClearIcon {
-            text: inner.text;
-            source: native.clear-icon;
-            colorize: inner.text-color;
-            image-fit: preserve;
-            height: inner.min-height;
-            width: self.height;
-            clear => {
-                inner.text = "";
-                inner.focus();
+        if !root.text.is-empty && root.input-type != InputType.password && root.enabled && !root.read-only: Rectangle {
+            width: inner.min-height;
+            LineEditClearIcon {
+                width: 100%;
+                height: self.width;
+                image-fit: ImageFit.contain;
+                text: inner.text;
+                source: native.clear-icon;
+                colorize: inner.text-color;
+                clear => {
+                    inner.text = "";
+                    inner.focus();
+                }
             }
         }
 


### PR DESCRIPTION
 - Take in account the scale factor (unfortunately we don't have access to the actual window scale factor so just use the Qt one)
 - Draw directly in the final SharedPixelBuffer
 - Use an intermediate Rectangle to center the image because otherwise we get height for width dependency that breaks layout.

<img width="860" height="207" alt="image" src="https://github.com/user-attachments/assets/cc3e4c87-4b53-49df-94c7-5046ced70b85" />

(After the patch, and before the patch)


CC @dfaure

