### PR TITLE
zed extension: Fix "documented" syntax for configuring slint-lsp path

### DIFF
--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -13,8 +13,11 @@ Normally you won't need to configure anything. Unless you are using a developmen
 {
   "lsp": {
     "slint": {
-      "binary": "slint-lsp",
-      "args": []
+      "binary": {
+        "path": "/path/to/slint-lsp",
+        "arguments": [],
+        "env": {}
+      },
     }
   }
 }


### PR DESCRIPTION
The binary field is not a string but a struct:

```rust
/// The settings for a command.
#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
pub struct CommandSettings {
    /// The path to the command.
    pub path: Option<String>,
    /// The arguments to pass to the command.
    pub arguments: Option<Vec<String>>,
    /// The environment variables.
    pub env: Option<HashMap<String, String>>,
}
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
