### PR TITLE
Fix opengl underlay example shader crash after 65s

### DIFF
--- a/examples/opengl_underlay/main.rs
+++ b/examples/opengl_underlay/main.rs
@@ -32,7 +32,11 @@ impl EGLUnderlay {
                 gl_Position = vec4(position, 0.0, 1.0);
             }"#,
                 r#"#version 100
-            precision highp float;
+            #ifdef GL_FRAGMENT_PRECISION_HIGH
+                precision highp float;
+            #else
+                precision mediump float;
+            #endif
             varying vec2 frag_position;
             uniform float effect_time;
             uniform float rotation_time;

--- a/examples/opengl_underlay/main.rs
+++ b/examples/opengl_underlay/main.rs
@@ -32,7 +32,7 @@ impl EGLUnderlay {
                 gl_Position = vec4(position, 0.0, 1.0);
             }"#,
                 r#"#version 100
-            precision mediump float;
+            precision highp float;
             varying vec2 frag_position;
             uniform float effect_time;
             uniform float rotation_time;


### PR DESCRIPTION
<!--
- [ x ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ x ] If possible, the change is auto-tested
- [ x ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ x ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

`mediump` limits uniforms to an `f16` which limits `effect_time` to `65504` milliseconds and so once we reach 66 seconds the shader crashes.