### PR TITLE
MCU: fix timer not starting if started before first call to update_timers_and_animations

### DIFF
--- a/internal/core/unsafe_single_threaded.rs
+++ b/internal/core/unsafe_single_threaded.rs
@@ -55,7 +55,7 @@ impl<T> FakeThreadStorage<T> {
         f(self.0.get_or_init(self.1))
     }
     pub fn try_with<R>(&self, f: impl FnOnce(&T) -> R) -> Result<R, ()> {
-        Ok(f(self.0.get().ok_or(())?))
+        Ok(self.with(f))
     }
 }
 // Safety: the unsafe_single_threaded feature means we will only be called from a single thread


### PR DESCRIPTION
The FakeThreadStorage's `try_with` should always initialize the data. This is what the real one does.
The timer regressed in 4d2ae39f87d5e2f3ac9cb56e2ca3b6755d4b5cd0 as try_with was used instead of with.
