### PR TITLE
Temporary fix for crashes on Windows

### DIFF
--- a/examples/bevy/main.rs
+++ b/examples/bevy/main.rs
@@ -92,11 +92,6 @@ export component AppWindow inherits Window {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Temporary : Force WGPU_BACKEND to dx12 until vulkan works with the flag renderer-skia on Windows
-    unsafe {
-        std::env::set_var("WGPU_BACKEND", "dx12");
-    }
-
     let (model_selector_sender, model_selector_receiver) = smol::channel::bounded::<GLTFModel>(1);
 
     let (download_progress_sender, download_progress_receiver) =

--- a/examples/bevy/slint_bevy_adapter.rs
+++ b/examples/bevy/slint_bevy_adapter.rs
@@ -47,7 +47,12 @@ pub async fn run_bevy_app_with_slint(
     (smol::channel::Receiver<wgpu::Texture>, smol::channel::Sender<ControlMessage>),
     slint::PlatformError,
 > {
-    let backends = wgpu::Backends::from_env().unwrap_or_default();
+    let mut backends = wgpu::Backends::from_env().unwrap_or_default();
+
+    // Skia’s Vulkan backend is currently broken on Windows.
+    // See: https://github.com/slint-ui/slint/issues/9320
+    #[cfg(target_family = "windows")]
+    backends.remove(wgpu::Backends::VULKAN);
 
     let bevy::render::settings::RenderResources(
         render_device,


### PR DESCRIPTION
Temporary fix to make bevy work on Windows.
Without this the application defaults to Vulkan which clashes with the slint flag `renderer-skia` and crashes.