### PR TITLE
fix: use render by line when buffer1 and buffer2 are used

### DIFF
--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -230,8 +230,10 @@ void EspPlatform<PixelType>::run_event_loop()
 #endif
                     auto region = m_window->m_renderer.render_by_line<PixelType>(
                             [this, &stride](std::size_t line_y, std::size_t line_start,
-                                              std::size_t line_end, auto &&render_fn) {
-                                std::span<PixelType> view { buffer1->data() + line_y*stride + line_start, line_end - line_start };
+                                            std::size_t line_end, auto &&render_fn) {
+                                std::span<PixelType> view { buffer1->data() + line_y * stride
+                                                                    + line_start,
+                                                            line_end - line_start };
                                 render_fn(view);
                                 if (byte_swap) {
                                     // Swap endianness to big endian
@@ -240,10 +242,9 @@ void EspPlatform<PixelType>::run_event_loop()
                                 }
                                 esp_lcd_panel_draw_bitmap(panel_handle, line_start, line_y,
                                                           line_end, line_y + 1, buffer1->data());
-
                             });
 
-                    if(buffer2) {
+                    if (buffer2) {
                         auto s = region.bounding_box_size();
                         if (s.width > 0 && s.height > 0) {
                             std::swap(buffer1, buffer2);


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

This solution address the difference in performance in passing or not the `buffer1` config parameter to the `slint_esp_init` function.
Specifically, this change allows to use the `render_by_line` render mode when `buffer1` and `buffer2` are used.

This is possible since in the [esp_lcd_panel_draw_bitmap](https://github.com/espressif/esp-idf/blob/53ff7d43dbff642d831a937b066ea0735a6aca24/components/esp_lcd/src/esp_lcd_panel_rgb.c#L681), the `color_data` parameter is only used to check wheter data needs to be copied to the actual frame buffer or not. Since data has already been written to the frame buffer by the `render_by_line` callback, it is safe to pass the actual frame buffer to signal the function no copy is needed.
