### PR TITLE
Prospective CI fix

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -105,7 +105,7 @@ accesskit = { version = "0.20", optional = true }
 accesskit_winit = { version = "0.28", optional = true }
 copypasta = { version = "0.10", default-features = false }
 
-[target.'cfg(not(any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32")))'.dependencies]
+[target.'cfg(not(any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32", target_os = "android")))'.dependencies]
 # Use same version and executor as accesskit
 zbus = { version = "5.7.0", default-features = false, features = ["async-io"] }
 futures = { version = "0.3.31" }

--- a/internal/backends/winit/build.rs
+++ b/internal/backends/winit/build.rs
@@ -11,7 +11,7 @@ fn main() {
        enable_femtovg_renderer: { any(feature = "renderer-femtovg", feature = "renderer-femtovg-wgpu") },
        enable_accesskit: { all(feature = "accessibility", not(target_arch = "wasm32")) },
        supports_opengl: { all(any(enable_skia_renderer, feature = "renderer-femtovg"), not(ios_and_friends)) },
-       use_winit_theme: { any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32") },
+       use_winit_theme: { any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32", target_os = "android") },
        muda: { all(feature = "muda", any(target_os = "windows", target_os = "macos")) },
     }
     // This uses `web_sys_unstable_api`, which is typically set via `RUST_FLAGS`


### PR DESCRIPTION
The new release rustix 1.1.1 fails to compile on android when it's feature "process" is activated. This is enabled by the zbus crate

We do not need zbus from i-slint-backend-winit on android (actually we do not usually use that backend on android, but we just compile it there on the CI for the internal docs)
