### PR TITLE
Add fontique as a font database alongside fontdb

### DIFF
--- a/internal/common/Cargo.toml
+++ b/internal/common/Cargo.toml
@@ -19,12 +19,14 @@ path = "lib.rs"
 [features]
 default = []
 shared-fontdb = ["dep:fontdb", "dep:libloading", "derive_more", "cfg-if", "dep:ttf-parser"]
+shared-fontique = ["dep:fontique"]
 
 [dependencies]
 fontdb = { workspace = true, optional = true }
 ttf-parser = { workspace = true, optional = true }
 derive_more = { workspace = true, optional = true }
 cfg-if = { version = "1", optional = true }
+fontique = { version = "0.5.0", optional = true }
 
 [target.'cfg(not(any(target_family = "windows", target_vendor = "apple", target_arch = "wasm32", target_os = "android")))'.dependencies]
 libloading = { version = "0.8.0", optional = true }

--- a/internal/common/lib.rs
+++ b/internal/common/lib.rs
@@ -3,11 +3,14 @@
 
 #![doc = include_str!("README.md")]
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
-#![cfg_attr(not(feature = "shared-fontdb"), no_std)]
+#![cfg_attr(not(any(feature = "shared-fontdb", feature = "shared-fontique")), no_std)]
 
 pub mod builtin_structs;
 pub mod enums;
 pub mod key_codes;
+
+#[cfg(feature = "shared-fontique")]
+pub mod sharedfontique;
 
 #[cfg(feature = "shared-fontdb")]
 pub mod sharedfontdb;

--- a/internal/common/sharedfontique.rs
+++ b/internal/common/sharedfontique.rs
@@ -1,0 +1,5 @@
+pub use fontique;
+
+thread_local! {
+    pub static COLLECTION: std::cell::RefCell<fontique::Collection> = Default::default()
+}

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -48,7 +48,7 @@ unsafe-single-threaded = []
 
 unicode = ["unicode-script", "unicode-linebreak"]
 
-software-renderer-systemfonts = ["shared-fontdb", "rustybuzz", "fontdue", "software-renderer"]
+software-renderer-systemfonts = ["shared-fontdb", "shared-fontique", "rustybuzz", "fontdue", "software-renderer"]
 software-renderer = ["bytemuck"]
 
 image-decoders = ["dep:image", "dep:clru"]
@@ -58,6 +58,7 @@ svg = ["dep:resvg", "shared-fontdb"]
 box-shadow-cache = []
 
 shared-fontdb = ["i-slint-common/shared-fontdb"]
+shared-fontique = ["i-slint-common/shared-fontique"]
 
 raw-window-handle-06 = ["dep:raw-window-handle-06"]
 

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -25,7 +25,7 @@ unstable-wgpu-26 = ["wgpu-26"]
 [dependencies]
 i-slint-core = { workspace = true, features = ["default", "box-shadow-cache", "shared-fontdb"] }
 i-slint-core-macros = { workspace = true, features = ["default"] }
-i-slint-common = { workspace = true, features = ["default"] }
+i-slint-common = { workspace = true, features = ["default", "shared-fontique"] }
 
 const-field-offset = { version = "0.1", path = "../../../helper_crates/const-field-offset" }
 


### PR DESCRIPTION
_Very_ barebones initial work to switch from `fontdb` to `fontique` in piecemeal. Can be used like so:

```rust
let id = i_slint_common::sharedfontique::COLLECTION.with_borrow_mut(|col| {
    col.family_id(family_str)
});
```

I'm very happy to convert something that's currently using `sharedfontdb` over. This would help a lot with working out what helpers we need in `sharedfontique.rs`. Finding a good target is a little tricky though.