### PR TITLE
Change the `Rotate` item to a `Transform` that supports scaling

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -308,7 +308,7 @@ fn gen_corelib(
         "TextInput",
         "Clip",
         "BoxShadow",
-        "Rotate",
+        "Transform",
         "Opacity",
         "Layer",
         "ContextMenu",

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -204,7 +204,7 @@ pub mod re_exports {
         visit_item_tree, ItemTreeNode, ItemVisitorRefMut, ItemVisitorVTable, ItemWeak,
         TraversalOrder, VisitChildrenResult,
     };
-    pub use i_slint_core::items::*;
+    pub use i_slint_core::items::{Transform, *};
     pub use i_slint_core::layout::*;
     pub use i_slint_core::lengths::{
         logical_position_to_api, LogicalLength, LogicalPoint, LogicalRect,

--- a/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
+++ b/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
@@ -80,7 +80,7 @@ The Qt renderer comes with the <Link type="QtBackend" label="Qt backend" /> and 
 - Suitable for Microcontrollers.
 - Some features haven't been implemented yet:
   * No support for `Path`.
-  * No image rotation or smooth scaling.
+  * No support for rotations or scaling.
   * No support for `drop-shadow-*` properties.
   * No support for `border-radius` in combination with `clip: true`.
   * No text stroking/outlining.

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -41,6 +41,40 @@ The width and height of the element. When set, this overrides the default size.
 </SlintProperty>
 
 
+### Transforms
+
+Transforms allow for rotating and scaling items around a specified origin point. The default origin point is the center of the element.
+
+```slint {5-7}
+Image {
+    x: 0;
+    y: 0;
+    source: @image-url("images/slint-logo.svg");
+    rotation-angle: 45deg;
+    rotation-origin-x: 0;
+    rotation-origin-y: 0;
+}
+```
+
+#### rotation-angle
+<SlintProperty propName="rotation-angle" typeName="angle" defaultValue='0deg'/>
+#### rotation-origin-x
+<SlintProperty propName="rotation-origin-x" typeName="length" defaultValue='self.width / 2'>
+The x component of the origin to rotate and scale around.
+
+In the future this will be deprecated in favour of a transform-origin property.
+</SlintProperty>
+#### rotation-origin-y
+<SlintProperty propName="rotation-origin-y" typeName="length" defaultValue='self.height / 2'>
+The y component of the origin to rotate and scale around.
+
+In the future this will be deprecated in favour of a transform-origin property.
+</SlintProperty>
+#### scale-x
+<SlintProperty propName="scale-x" typeName="percent" defaultValue='100%'/>
+#### scale-y
+<SlintProperty propName="scale-y" typeName="percent" defaultValue='100%'/>
+
 ### opacity
 <CodeSnippetMD imagePath="/src/assets/generated/rectangle-opacity.png" scale="3" imageWidth="100" imageHeight="310"  imageAlt='rectangle opacity'>
 ```slint playground

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -45,6 +45,8 @@ The width and height of the element. When set, this overrides the default size.
 
 Transforms allow for rotating and scaling items around a specified origin point. The default origin point is the center of the element.
 
+Transforms are not available for the software renderer.
+
 ```slint {5-7}
 Image {
     x: 0;

--- a/docs/astro/src/content/docs/reference/elements/image.mdx
+++ b/docs/astro/src/content/docs/reference/elements/image.mdx
@@ -172,29 +172,6 @@ Image {
 
 </SlintProperty>
 
-## Rotation
-
-Rotates the text by the given angle around the specified origin point. The default origin point is the center of the element.
-When these properties are set, the `Image` can't have children.
-
-```slint {5-7}
-Image {
-    x: 0;
-    y: 0;
-    source: @image-url("images/slint-logo.svg");
-    rotation-angle: 45deg;
-    rotation-origin-x: 0;
-    rotation-origin-y: 0;
-}
-```
-
-### rotation-angle
-<SlintProperty propName="rotation-angle" typeName="angle" defaultValue='0deg'/>
-### rotation-origin-x
-<SlintProperty propName="rotation-origin-x" typeName="length" defaultValue='self.width / 2'/>
-### rotation-origin-y
-<SlintProperty propName="rotation-origin-y" typeName="length" defaultValue='self.height / 2'/>
-
 ## Source Properties
 
 ### source

--- a/docs/astro/src/content/docs/reference/elements/text.mdx
+++ b/docs/astro/src/content/docs/reference/elements/text.mdx
@@ -233,35 +233,6 @@ Text {
 </CodeSnippetMD>
 </SlintProperty>
 
-## Rotation
-
-Rotates the text by the given angle around the specified origin point. The default origin point is the center of the element.
-:::caution[Caution]
-When these properties are set, the `Text` can't have children.
-:::
-
-<CodeSnippetMD imagePath="/src/assets/generated/text-rotation.png" imageWidth="200" needsBackground="true" imageHeight="200" imageAlt='rotation properties'>
-
-```slint {3-5}
-Text {
-    text: "I'm dizzy";
-    rotation-angle: 45deg;
-    rotation-origin-x: self.width / 2;
-    rotation-origin-y: self.height / 2;
-    font-size: 30pt;
-}
-```
-</CodeSnippetMD>
-
-### rotation-angle
-<SlintProperty propName="rotation-angle" typeName="angle"/>
-
-### rotation-origin-x
-<SlintProperty propName="rotation-origin-x" typeName="length" defaultValue='self.width / 2'/>
-
-### rotation-origin-y
-<SlintProperty propName="rotation-origin-y" typeName="length" defaultValue='self.height / 2'/>
-
 ## Accessibility
 
 By default, `Text` elements have the following accessibility properties set:

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1323,6 +1323,13 @@ impl ItemRenderer for QtItemRenderer<'_> {
         }}
     }
 
+    fn scale(&mut self, x_factor: f32, y_factor: f32) {
+        let painter: &mut QPainterPtr = &mut self.painter;
+        cpp! { unsafe [painter as "QPainterPtr*", x_factor as "float", y_factor as "float"] {
+            (*painter)->scale(x_factor, y_factor);
+        }}
+    }
+
     fn apply_opacity(&mut self, opacity: f32) {
         let painter: &mut QPainterPtr = &mut self.painter;
         cpp! { unsafe [painter as "QPainterPtr*", opacity as "float"] {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -81,7 +81,7 @@ export component ComponentContainer inherits Empty {
     //-accepts_focus
 }
 
-export component Rotate inherits Empty {
+export component Transform inherits Empty {
     in property <angle> rotation-angle;
     in property <length> rotation-origin-x;
     in property <length> rotation-origin-y;

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -83,6 +83,8 @@ export component ComponentContainer inherits Empty {
 
 export component Transform inherits Empty {
     in property <angle> rotation-angle;
+    in property <percent> scale-x;
+    in property <percent> scale-y;
     in property <length> rotation-origin-x;
     in property <length> rotation-origin-y;
     //-default_size_binding:expands_to_parent_geometry

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -176,7 +176,7 @@ pub async fn run_passes(
                     match prop {
                         "rotation-origin-x" => SmolStr::new_static("width"),
                         "rotation-origin-y" => SmolStr::new_static("height"),
-                        "rotation-angle" => return Expression::Invalid,
+                        "rotation-angle" | "scale-x" | "scale-y" => return Expression::Invalid,
                         _ => unreachable!(),
                     },
                 ))

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -146,7 +146,7 @@ pub async fn run_passes(
         z_order::reorder_by_z_order(component, diag);
         lower_property_to_element::lower_property_to_element(
             component,
-            "opacity",
+            core::iter::once("opacity"),
             core::iter::empty(),
             None,
             &SmolStr::new_static("Opacity"),
@@ -155,7 +155,7 @@ pub async fn run_passes(
         );
         lower_property_to_element::lower_property_to_element(
             component,
-            "cache-rendering-hint",
+            core::iter::once("cache-rendering-hint"),
             core::iter::empty(),
             None,
             &SmolStr::new_static("Layer"),
@@ -166,8 +166,10 @@ pub async fn run_passes(
         lower_shadows::lower_shadow_properties(component, &doc.local_registry, diag);
         lower_property_to_element::lower_property_to_element(
             component,
-            crate::typeregister::RESERVED_ROTATION_PROPERTIES[0].0,
-            crate::typeregister::RESERVED_ROTATION_PROPERTIES[1..]
+            crate::typeregister::RESERVED_TRANSFORM_PROPERTIES[..3]
+                .iter()
+                .map(|(prop_name, _)| *prop_name),
+            crate::typeregister::RESERVED_TRANSFORM_PROPERTIES[3..]
                 .iter()
                 .map(|(prop_name, _)| *prop_name),
             Some(&|e, prop| Expression::BinaryExpression {

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -184,7 +184,7 @@ pub async fn run_passes(
                 op: '/',
                 rhs: Expression::NumberLiteral(2., Default::default()).into(),
             }),
-            &SmolStr::new_static("Rotate"),
+            &SmolStr::new_static("Transform"),
             &global_type_registry.borrow(),
             diag,
         );

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -177,8 +177,8 @@ pub const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
 
 pub const RESERVED_TRANSFORM_PROPERTIES: &[(&str, Type)] = &[
     ("rotation-angle", Type::Angle),
-    ("scale-x", Type::Percent),
-    ("scale-y", Type::Percent),
+    ("scale-x", Type::Float32),
+    ("scale-y", Type::Float32),
     ("rotation-origin-x", Type::LogicalLength),
     ("rotation-origin-y", Type::LogicalLength),
 ];

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -177,6 +177,8 @@ pub const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
 
 pub const RESERVED_ROTATION_PROPERTIES: &[(&str, Type)] = &[
     ("rotation-angle", Type::Angle),
+    ("scale-x", Type::Percent),
+    ("scale-y", Type::Percent),
     ("rotation-origin-x", Type::LogicalLength),
     ("rotation-origin-y", Type::LogicalLength),
 ];

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -175,7 +175,7 @@ pub const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
     ("drop-shadow-color", Type::Color),
 ];
 
-pub const RESERVED_ROTATION_PROPERTIES: &[(&str, Type)] = &[
+pub const RESERVED_TRANSFORM_PROPERTIES: &[(&str, Type)] = &[
     ("rotation-angle", Type::Angle),
     ("scale-x", Type::Percent),
     ("scale-y", Type::Percent),
@@ -228,7 +228,7 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
         .chain(RESERVED_LAYOUT_PROPERTIES.iter())
         .chain(RESERVED_OTHER_PROPERTIES.iter())
         .chain(RESERVED_DROP_SHADOW_PROPERTIES.iter())
-        .chain(RESERVED_ROTATION_PROPERTIES.iter())
+        .chain(RESERVED_TRANSFORM_PROPERTIES.iter())
         .map(|(k, v)| (*k, v.clone(), PropertyVisibility::Input))
         .chain(reserved_accessibility_properties().map(|(k, v)| (k, v, PropertyVisibility::Input)))
         .chain(

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -1087,6 +1087,7 @@ impl<T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRenderer<'_
     fn rotate(&mut self, angle_in_degrees: f32) {
         self.actual_renderer.rotate(angle_in_degrees)
     }
+
     fn scale(&mut self, x_factor: f32, y_factor: f32) {
         self.actual_renderer.scale(x_factor, y_factor)
     }

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -470,6 +470,7 @@ pub trait ItemRenderer {
         unimplemented!()
     }
     fn rotate(&mut self, angle_in_degrees: f32);
+    fn scale(&mut self, scale_x_factor: f32, scale_y_factor: f32);
     /// Apply the opacity (between 0 and 1) for all following items until the next call to restore_state.
     fn apply_opacity(&mut self, opacity: f32);
 
@@ -1085,6 +1086,9 @@ impl<T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRenderer<'_
 
     fn rotate(&mut self, angle_in_degrees: f32) {
         self.actual_renderer.rotate(angle_in_degrees)
+    }
+    fn scale(&mut self, x_factor: f32, y_factor: f32) {
+        self.actual_renderer.scale(x_factor, y_factor)
     }
 
     fn apply_opacity(&mut self, opacity: f32) {

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -817,15 +817,15 @@ impl ItemRc {
     /// Returns the transform to apply to children to map them into the local coordinate space of this item.
     /// Typically this is None, but rotation for example may return Some.
     pub fn children_transform(&self) -> Option<ItemTransform> {
-        self.downcast::<crate::items::Rotate>().map(|rotate_item| {
+        self.downcast::<crate::items::Transform>().map(|transform_item| {
             let origin = euclid::Vector2D::<f32, crate::lengths::LogicalPx>::from_lengths(
-                rotate_item.as_pin_ref().rotation_origin_x().cast(),
-                rotate_item.as_pin_ref().rotation_origin_y().cast(),
+                transform_item.as_pin_ref().rotation_origin_x().cast(),
+                transform_item.as_pin_ref().rotation_origin_y().cast(),
             );
             ItemTransform::translation(-origin.x, -origin.y)
                 .cast()
                 .then_rotate(euclid::Angle {
-                    radians: rotate_item.as_pin_ref().rotation_angle().to_radians(),
+                    radians: transform_item.as_pin_ref().rotation_angle().to_radians(),
                 })
                 .then_translate(origin)
         })

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -825,8 +825,8 @@ impl ItemRc {
             ItemTransform::translation(-origin.x, -origin.y)
                 .cast()
                 .then_scale(
-                    transform_item.as_pin_ref().scale_x() / 100.0,
-                    transform_item.as_pin_ref().scale_y() / 100.0,
+                    transform_item.as_pin_ref().scale_x(),
+                    transform_item.as_pin_ref().scale_y(),
                 )
                 .then_rotate(euclid::Angle {
                     radians: transform_item.as_pin_ref().rotation_angle().to_radians(),

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -824,6 +824,7 @@ impl ItemRc {
             );
             ItemTransform::translation(-origin.x, -origin.y)
                 .cast()
+                .then_scale(transform_item.as_pin_ref().scale_x() / 100.0, transform_item.as_pin_ref().scale_y() / 100.0)
                 .then_rotate(euclid::Angle {
                     radians: transform_item.as_pin_ref().rotation_angle().to_radians(),
                 })

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -824,7 +824,10 @@ impl ItemRc {
             );
             ItemTransform::translation(-origin.x, -origin.y)
                 .cast()
-                .then_scale(transform_item.as_pin_ref().scale_x() / 100.0, transform_item.as_pin_ref().scale_y() / 100.0)
+                .then_scale(
+                    transform_item.as_pin_ref().scale_x() / 100.0,
+                    transform_item.as_pin_ref().scale_y() / 100.0,
+                )
                 .then_rotate(euclid::Angle {
                     radians: transform_item.as_pin_ref().rotation_angle().to_radians(),
                 })

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1025,14 +1025,14 @@ declare_item_vtable! {
 #[derive(FieldOffsets, Default, SlintElement)]
 #[pin]
 /// The implementation of the `Rotate` element
-pub struct Rotate {
+pub struct Transform {
     pub rotation_angle: Property<f32>,
     pub rotation_origin_x: Property<LogicalLength>,
     pub rotation_origin_y: Property<LogicalLength>,
     pub cached_rendering_data: CachedRenderingData,
 }
 
-impl Item for Rotate {
+impl Item for Transform {
     fn init(self: Pin<&Self>, _self_rc: &ItemRc) {}
 
     fn layout_info(
@@ -1117,15 +1117,15 @@ impl Item for Rotate {
     }
 }
 
-impl ItemConsts for Rotate {
+impl ItemConsts for Transform {
     const cached_rendering_data_offset: const_field_offset::FieldOffset<
-        Rotate,
+        Transform,
         CachedRenderingData,
-    > = Rotate::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
+    > = Transform::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {
-    fn slint_get_RotateVTable() -> RotateVTable for Rotate
+    fn slint_get_TransformVTable() -> TransformVTable for Transform
 }
 
 declare_item_vtable! {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1100,7 +1100,7 @@ impl Item for Transform {
         let origin =
             LogicalVector::from_lengths(self.rotation_origin_x(), self.rotation_origin_y());
         (*backend).translate(origin);
-        (*backend).scale(self.scale_x() / 100.0, self.scale_y() / 100.0);
+        (*backend).scale(self.scale_x(), self.scale_y());
         (*backend).rotate(self.rotation_angle());
         (*backend).translate(-origin);
         RenderingResult::ContinueRenderingChildren

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1027,6 +1027,8 @@ declare_item_vtable! {
 /// The implementation of the `Rotate` element
 pub struct Transform {
     pub rotation_angle: Property<f32>,
+    pub scale_x: Property<f32>,
+    pub scale_y: Property<f32>,
     pub rotation_origin_x: Property<LogicalLength>,
     pub rotation_origin_y: Property<LogicalLength>,
     pub cached_rendering_data: CachedRenderingData,
@@ -1098,6 +1100,7 @@ impl Item for Transform {
         let origin =
             LogicalVector::from_lengths(self.rotation_origin_x(), self.rotation_origin_y());
         (*backend).translate(origin);
+        (*backend).scale(self.scale_x() / 100.0, self.scale_y() / 100.0);
         (*backend).rotate(self.rotation_angle());
         (*backend).translate(-origin);
         RenderingResult::ContinueRenderingChildren

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -2498,6 +2498,10 @@ impl<T: ProcessScene> crate::item_rendering::ItemRenderer for SceneBuilder<'_, T
         // TODO (#6068)
     }
 
+    fn scale(&mut self, _x_factor: f32, _y_factor: f32) {
+        // TODO
+    }
+
     fn apply_opacity(&mut self, opacity: f32) {
         self.current_state.alpha *= opacity;
     }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -995,7 +995,7 @@ fn generate_rtti() -> HashMap<&'static str, Rc<ItemRTTI>> {
             rtti_for::<TextInput>(),
             rtti_for::<Clip>(),
             rtti_for::<BoxShadow>(),
-            rtti_for::<Rotate>(),
+            rtti_for::<Transform>(),
             rtti_for::<Opacity>(),
             rtti_for::<Layer>(),
             rtti_for::<DragArea>(),

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1102,10 +1102,9 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
 
     fn scale(&mut self, x_factor: f32, y_factor: f32) {
         self.canvas.borrow_mut().scale(x_factor, y_factor);
-        // TOOD: untested
         let clip = &mut self.state.last_mut().unwrap().scissor;
-        clip.size.width *= x_factor;
-        clip.size.height *= y_factor;
+        clip.size.width /= x_factor;
+        clip.size.height /= y_factor;
     }
 
     fn apply_opacity(&mut self, opacity: f32) {

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1100,6 +1100,11 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         *clip = LogicalRect::new(origin, (end - origin).into());
     }
 
+    fn scale(&mut self, x_factor: f32, y_factor: f32) {
+        // TODO: adjust clip
+        self.canvas.borrow_mut().scale(x_factor, y_factor);
+    }
+
     fn apply_opacity(&mut self, opacity: f32) {
         let state = &mut self.state.last_mut().unwrap().global_alpha;
         *state *= opacity;

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1101,8 +1101,11 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
     }
 
     fn scale(&mut self, x_factor: f32, y_factor: f32) {
-        // TODO: adjust clip
         self.canvas.borrow_mut().scale(x_factor, y_factor);
+        // TOOD: untested
+        let clip = &mut self.state.last_mut().unwrap().scissor;
+        clip.size.width *= x_factor;
+        clip.size.height *= y_factor;
     }
 
     fn apply_opacity(&mut self, opacity: f32) {

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -921,6 +921,10 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
         self.canvas.rotate(angle_in_degrees, None);
     }
 
+    fn scale(&mut self, x_factor: f32, y_factor: f32) {
+        self.canvas.scale((x_factor, y_factor));
+    }
+
     fn apply_opacity(&mut self, opacity: f32) {
         self.current_state.alpha *= opacity;
     }

--- a/tests/cases/elements/event_scaling.slint
+++ b/tests/cases/elements/event_scaling.slint
@@ -1,0 +1,106 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase  {
+    in-out property <int> touch1;
+    in-out property <int> touch_double1;
+
+    in-out property <string> pointer-event-test;
+
+    in property <bool> enabled1 <=> area1.enabled;
+    out property <bool> pressed1 <=> area1.pressed;
+    out property <bool> has-hover1 <=> area1.has-hover;
+
+
+    width: 800px;
+    height: 600px;
+
+    Rectangle {
+        x: 0px;
+        y: 0px;
+        width: 50px;
+        height: 50px;
+        scale-x: 200%;
+        scale-y: 400%;
+        rotation-origin-x: 0px;
+        rotation-origin-y: 0px;
+        area1 := TouchArea {
+            clicked => {
+                pointer-event-test += "click:";
+                touch1+=1;
+            }
+            double-clicked => {
+                pointer-event-test += "double_click:";
+                touch_double1+=1;
+            }
+            pointer-event(e) => {
+                if (e.kind == PointerEventKind.cancel) {
+                        pointer-event-test += "cancel,";
+                    } else if (e.kind == PointerEventKind.up) {
+                        pointer-event-test += "up.";
+                    } else if (e.kind == PointerEventKind.down) {
+                        pointer-event-test += "down.";
+                    } else if (e.kind == PointerEventKind.move) {
+                        pointer-event-test += "move.";
+                    } else {
+                        pointer-event-test += "err.";
+                    }
+                    if (e.button == PointerEventButton.right) {
+                        pointer-event-test += "right";
+                    } else if (e.button == PointerEventButton.left) {
+                        pointer-event-test += "left";
+                    } else if (e.button == PointerEventButton.middle) {
+                        pointer-event-test += "middle";
+                    } else if (e.button == PointerEventButton.back) {
+                        pointer-event-test += "back";
+                    } else if (e.button == PointerEventButton.forward) {
+                        pointer-event-test += "forward";
+                    } else if (e.button == PointerEventButton.other) {
+                        pointer-event-test += "other";
+                    } else {
+                        pointer-event-test += "???";
+                    }
+                    if (e.modifiers.control) {
+                        pointer-event-test += "(ctrl)";
+                    }
+                    if (e.modifiers.shift) {
+                        pointer-event-test += "(shift)";
+                    }
+                    if (e.modifiers.meta) {
+                        pointer-event-test += "(meta)";
+                    }
+                    if (e.modifiers.alt) {
+                        pointer-event-test += "(alt)";
+                    }
+                    pointer-event-test += ":";
+            }
+        }
+    }
+}
+
+/*
+```rust
+use slint::private_unstable_api::re_exports::MouseCursor;
+
+let instance = TestCase::new().unwrap();
+
+/*let double_click = |x, y| {
+    slint_testing::send_mouse_click(&instance, x, y);
+    slint_testing::mock_elapsed_time(50);
+    slint_testing::send_mouse_click(&instance, x, y);
+};*/
+
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor.get()), MouseCursor::Default);
+assert_eq!(instance.get_touch1(), 0);
+slint_testing::send_mouse_click(&instance, 1.0,1.0);
+assert_eq!(instance.get_touch1(), 1);
+slint_testing::send_mouse_click(&instance, 49.9,49.9);
+assert_eq!(instance.get_touch1(), 2);
+slint_testing::send_mouse_click(&instance, 99.9,199.9);
+assert_eq!(instance.get_touch1(), 3);
+slint_testing::send_mouse_click(&instance, 99.9,200.1);
+slint_testing::send_mouse_click(&instance, 100.1,200.1);
+slint_testing::send_mouse_click(&instance, 100.1,199.9);
+assert_eq!(instance.get_touch1(), 3);
+```
+*/

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -467,13 +467,11 @@ pub(super) fn get_properties(
                     group_priority: depth,
                 });
 
-                    result.extend(get_reserved_properties(
-                        &b.name,
-                        depth,
-                        i_slint_compiler::typeregister::RESERVED_TRANSFORM_PROPERTIES
-                            .iter()
-                            .cloned(),
-                    ));
+                result.extend(get_reserved_properties(
+                    &b.name,
+                    depth,
+                    i_slint_compiler::typeregister::RESERVED_TRANSFORM_PROPERTIES.iter().cloned(),
+                ));
 
                 if matches!(b.name.as_str(), "GridLayout" | "HorizontalLayout" | "VerticalLayout") {
                     // Add the padding that is otherwise filtered out

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -467,11 +467,13 @@ pub(super) fn get_properties(
                     group_priority: depth,
                 });
 
-                result.extend(get_reserved_properties(
-                    &b.name,
-                    depth,
-                    i_slint_compiler::typeregister::RESERVED_ROTATION_PROPERTIES.iter().cloned(),
-                ));
+                    result.extend(get_reserved_properties(
+                        &b.name,
+                        depth,
+                        i_slint_compiler::typeregister::RESERVED_TRANSFORM_PROPERTIES
+                            .iter()
+                            .cloned(),
+                    ));
 
                 if matches!(b.name.as_str(), "GridLayout" | "HorizontalLayout" | "VerticalLayout") {
                     // Add the padding that is otherwise filtered out


### PR DESCRIPTION
Takes over from https://github.com/slint-ui/slint/pull/9382. @tronical @NigelBreslaw.

I think we're going to need some equivalent of this compiler pass: https://github.com/slint-ui/slint/blob/d16d531709bde23c447788503be16dbc9cf08220/internal/compiler/passes.rs#L168-L191 that checks for `rotation-angle` or `scale-x` or `scale-y` (or even a uniform `scale` in the future).