### PR TITLE
Skia/WGPU/DX12: Fix crash when resizing window

### DIFF
--- a/internal/renderers/skia/wgpu_26_surface.rs
+++ b/internal/renderers/skia/wgpu_26_surface.rs
@@ -91,6 +91,13 @@ impl super::Surface for WGPUSurface {
     }
 
     fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), PlatformError> {
+        {
+            let gr_context = &mut self.gr_context.borrow_mut();
+            // This is brute force, but for the lack of access to the fences this seems to work: Avoid any pending work so that
+            // IDXGISwapChain::ResizeBuffers doesn't complain that the surface is still in use.
+            gr_context.flush_submit_and_sync_cpu();
+        }
+
         let mut surface_config = self.surface_config.borrow_mut();
 
         surface_config.width = size.width;


### PR DESCRIPTION
Resizing the window may cause a panic in wgpu. DebugView with d3d debug layers enabled yields a more elaborate message:

    IDXGISwapChain::ResizeBuffers: Swapchain cannot be resized unless all outstanding buffer references have been released.

So before resizing, force Skia to submit and flush everything to the CPU level. This isn't optimal - especially since it's cross window - but it seems to work.

Fixes #9320

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
