### PR TITLE
slint macro: Do not rely on the debug of Span to know if token are adjacent

### DIFF
--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -25,7 +25,7 @@ fn are_token_touching(token1: proc_macro::Span, token2: proc_macro::Span) -> Opt
     let t2 = token2.start();
     let t1_column = t1.column();
     if t1_column == 1 && t1.line() == 1 && t2.end().line() == 1 && t2.end().column() == 1 {
-        // If everything is 1, this means that Span::line and Span::column are not not working properly
+        // If everything is 1, this means that Span::line and Span::column are not working properly
         // (eg, rust-analyzer)
         return None;
     }


### PR DESCRIPTION

We need to know if two Span are adjacent to distinguish between `foo-bar` and `foo - bar`  (one identifier, or a minus expression)

From Rust 1.88 it is possible to use the line and column information from Span.

The eventual goal is also to address https://github.com/slint-ui/slint/issues/685 unfortunately, rust-analyzer still do not implement these in their macro server

