### PR TITLE
Align DatePickerPopup and TimePickerPopup placement logic

### DIFF
--- a/internal/compiler/widgets/cosmic/datepicker.slint
+++ b/internal/compiler/widgets/cosmic/datepicker.slint
@@ -16,9 +16,10 @@ export component DatePickerPopup inherits PopupWindow {
 
     callback canceled();
     callback accepted(date: Date);
+    
+    width: dialog.width;
+    height: dialog.height;
 
-    width: 360px;
-    height: 524px;
     close-policy: PopupClosePolicy.no-auto-close;
 
     background-layer := MenuBorder {

--- a/internal/compiler/widgets/cosmic/time-picker.slint
+++ b/internal/compiler/widgets/cosmic/time-picker.slint
@@ -19,6 +19,9 @@ export component TimePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(/* current-time */ Time);
 
+    width: dialog.width;
+    height: dialog.height;
+    
     close-policy: PopupClosePolicy.no-auto-close;
 
     background-layer := MenuBorder {

--- a/internal/compiler/widgets/cupertino/datepicker.slint
+++ b/internal/compiler/widgets/cupertino/datepicker.slint
@@ -17,8 +17,9 @@ export component DatePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(date: Date);
 
-    width: 360px;
-    height: 524px;
+    width: dialog.width;
+    height: dialog.height;
+
     close-policy: PopupClosePolicy.no-auto-close;
 
     background-layer := MenuBorder {

--- a/internal/compiler/widgets/cupertino/time-picker.slint
+++ b/internal/compiler/widgets/cupertino/time-picker.slint
@@ -20,6 +20,9 @@ export component TimePickerPopup inherits PopupWindow {
 
     close-policy: PopupClosePolicy.no-auto-close;
 
+    width: dialog.width;
+    height: dialog.height;
+
     background-layer := MenuBorder {
         width: dialog.width;
         height: dialog.height;

--- a/internal/compiler/widgets/fluent/datepicker.slint
+++ b/internal/compiler/widgets/fluent/datepicker.slint
@@ -17,8 +17,9 @@ export component DatePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(date: Date);
 
-    width: 368px;
-    height: 524px;
+    width: dialog.width;
+    height: dialog.height;
+
     close-policy: PopupClosePolicy.no-auto-close;
 
     background-layer := MenuBorder {

--- a/internal/compiler/widgets/fluent/time-picker.slint
+++ b/internal/compiler/widgets/fluent/time-picker.slint
@@ -18,6 +18,9 @@ export component TimePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(/* current-time */ Time);
 
+    width: dialog.width;
+    height: dialog.height;
+    
     close-policy: PopupClosePolicy.no-auto-close;
 
     background-layer := MenuBorder {

--- a/internal/compiler/widgets/material/datepicker.slint
+++ b/internal/compiler/widgets/material/datepicker.slint
@@ -15,8 +15,9 @@ export component DatePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(date: Date);
 
-    width: 360px;
-    height: 524px;
+    width: dialog.width;
+    height: dialog.height;
+
     close-policy: PopupClosePolicy.no-auto-close;
 
     background-layer := Rectangle {

--- a/internal/compiler/widgets/material/time-picker.slint
+++ b/internal/compiler/widgets/material/time-picker.slint
@@ -17,6 +17,9 @@ export component TimePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(/* current-time */ Time);
 
+    width: dialog.width;
+    height: dialog.height;
+
     close-policy: PopupClosePolicy.no-auto-close;
 
     background-layer := Rectangle {

--- a/internal/compiler/widgets/qt/datepicker.slint
+++ b/internal/compiler/widgets/qt/datepicker.slint
@@ -19,8 +19,9 @@ export component DatePickerPopup inherits PopupWindow  {
     callback canceled();
     callback accepted(date: Date);
 
-    width: 360px;
-    height: 524px;
+    width: dialog.width;
+    height: dialog.height;
+
     close-policy: PopupClosePolicy.no-auto-close;
 
     background-layer := Rectangle {

--- a/internal/compiler/widgets/qt/time-picker.slint
+++ b/internal/compiler/widgets/qt/time-picker.slint
@@ -18,6 +18,9 @@ export component TimePickerPopup inherits PopupWindow {
     callback canceled();
     callback accepted(/* current-time */ Time);
 
+    width: dialog.width;
+    height: dialog.height;
+
     close-policy: PopupClosePolicy.no-auto-close;
 
     background-layer := Rectangle {


### PR DESCRIPTION
Updated the `width` and `height` properties of `DatePickerPopup` and `TimePickerPopup` components to use dynamic sizing based on `dialog` dimensions instead of fixed pixel values.

Previously, the lack of `width` and `height` in `TimePickerPopup` caused inconsistent placement when displayed at a specific location:
- `DatePickerPopup` was centered on the given (x, y)
- `TimePickerPopup` used its top-left corner as the anchor point

Now both components consistently render centered at the specified (x, y).

Fixes #9262 

<details>

<summary>Screenshots (before & after)</summary>

## Before

### `TimePickerPopup`

<img width="1265" height="1394" alt="image" src="https://github.com/user-attachments/assets/7df427e7-2a7e-41c8-96df-c6820f19c4dc" />

### `DatePickerPopup`:
<img width="1265" height="1394" alt="image" src="https://github.com/user-attachments/assets/74e03cc0-591a-4339-bce8-513e6ba985bf" />

## After

### `TimerPickerPopup`

<img width="1265" height="1394" alt="image" src="https://github.com/user-attachments/assets/c5f0e167-466f-4395-b2e3-adb67b997e6c" />


### `DatePickerPopup`

<img width="1265" height="1394" alt="image" src="https://github.com/user-attachments/assets/391892f1-3ac5-49a2-b7b9-c51d805eab46" />

</details>
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
