### PR TITLE
pico2_st7789: Turn on backlight after first frame is drawn (#7482)

### DIFF
--- a/examples/mcu-board-support/pico2_st7789.rs
+++ b/examples/mcu-board-support/pico2_st7789.rs
@@ -128,7 +128,7 @@ pub fn init() {
     });
 
     let rst = pins.gpio15.into_push_pull_output();
-    let mut backlight = pins.gpio13.into_push_pull_output();
+    let backlight = pins.gpio13.into_push_pull_output();
 
     let dc = pins.gpio8.into_push_pull_output();
     let cs = pins.gpio9.into_push_pull_output();
@@ -162,7 +162,6 @@ pub fn init() {
         .invert_colors(mipidsi::options::ColorInversion::Inverted)
         .init(&mut timer)
         .unwrap();
-    backlight.set_high().unwrap();
 
     let touch = xpt2046::XPT2046::new(
         &IRQ_PIN,
@@ -200,14 +199,16 @@ pub fn init() {
         window: Default::default(),
         buffer_provider: buffer_provider.into(),
         touch: touch.into(),
+        backlight: Some(backlight).into(),
     }))
     .expect("backend already initialized");
 }
 
-struct PicoBackend<DrawBuffer, Touch> {
+struct PicoBackend<DrawBuffer, Touch, Backlight> {
     window: RefCell<Option<Rc<renderer::MinimalSoftwareWindow>>>,
     buffer_provider: RefCell<DrawBuffer>,
     touch: RefCell<Touch>,
+    backlight: RefCell<Option<Backlight>>,
 }
 
 impl<
@@ -219,10 +220,12 @@ impl<
         CS_: OutputPin<Error = Infallible>,
         IRQ: InputPin<Error = Infallible>,
         SPI: SpiDevice,
+        BL: OutputPin<Error = Infallible>,
     > slint::platform::Platform
     for PicoBackend<
         DrawBuffer<Display<DI, RST>, PioTransfer<TO, CH>, (DC_, CS_)>,
         xpt2046::XPT2046<IRQ, SPI>,
+        BL,
     >
 {
     fn create_window_adapter(
@@ -254,6 +257,9 @@ impl<
                     let mut buffer_provider = self.buffer_provider.borrow_mut();
                     renderer.render_by_line(&mut *buffer_provider);
                     buffer_provider.flush_frame();
+                    if let Some(mut backlight) = self.backlight.take() {
+                        backlight.set_high().unwrap();
+                    }
                 });
 
                 // handle touch event


### PR DESCRIPTION
43ede0b1c3570f20bc9f4d3f4392c379c4c565f7 was for pico

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
