### PR TITLE
Python: Add support for sys.exit() from callbacks/timers/etc.

### DIFF
--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -479,8 +479,12 @@ impl GcVisibleCallbacks {
                 let result = match callable.call(py, py_args, None) {
                     Ok(result) => result,
                     Err(err) => {
-                        eprintln!(
-                            "Python: Invoking python callback for {name} threw an exception: {err}"
+                        crate::handle_unraisable(
+                            py,
+                            format!(
+                                "Python: Invoking python callback for {name} threw an exception"
+                            ),
+                            err,
                         );
                         return Value::Void;
                     }
@@ -493,7 +497,13 @@ impl GcVisibleCallbacks {
                 ) {
                     Ok(value) => value,
                     Err(err) => {
-                        eprintln!("Python: Unable to convert return value of Python callback for {name} to Slint value: {err}");
+                        crate::handle_unraisable(
+                            py,
+                            format!(
+                                "Python: Unable to convert return value of Python callback for {name} to Slint value"
+                            ),
+                            err,
+                        );
                         return Value::Void;
                     }
                 };

--- a/api/python/slint/models.rs
+++ b/api/python/slint/models.rs
@@ -97,8 +97,10 @@ impl i_slint_core::model::Model for PyModelShared {
             let result = match obj.call_method0(py, "row_count") {
                 Ok(result) => result,
                 Err(err) => {
-                    eprintln!(
-                        "Python: Model implementation of row_count() threw an exception: {err}"
+                    crate::handle_unraisable(
+                        py,
+                        "Python: Model implementation of row_count() threw an exception".into(),
+                        err,
                     );
                     return 0;
                 }
@@ -107,7 +109,11 @@ impl i_slint_core::model::Model for PyModelShared {
             match result.extract::<usize>(py) {
                 Ok(count) => count,
                 Err(err) => {
-                    eprintln!("Python: Model implementation of row_count() returned value that cannot be cast to usize: {err}");
+                    crate::handle_unraisable(
+                        py,
+                        "Python: Model implementation of row_count() returned value that cannot be cast to usize".into(),
+                        err,
+                    );
                     0
                 }
             }
@@ -126,8 +132,10 @@ impl i_slint_core::model::Model for PyModelShared {
                 Ok(result) => result,
                 Err(err) if err.is_instance_of::<PyIndexError>(py) => return None,
                 Err(err) => {
-                    eprintln!(
-                        "Python: Model implementation of row_data() threw an exception: {err}"
+                    crate::handle_unraisable(
+                        py,
+                        "Python: Model implementation of row_data() threw an exception".into(),
+                        err,
                     );
                     return None;
                 }
@@ -140,7 +148,11 @@ impl i_slint_core::model::Model for PyModelShared {
             ) {
                 Ok(pv) => Some(pv),
                 Err(err) => {
-                    eprintln!("Python: Model implementation of row_data() returned value that cannot be converted to Rust: {err}");
+                    crate::handle_unraisable(
+                        py,
+                        "Python: Model implementation of row_data() returned value that cannot be cast to usize".into(),
+                        err,
+                    );
                     None
                 }
             }
@@ -165,8 +177,10 @@ impl i_slint_core::model::Model for PyModelShared {
             if let Err(err) =
                 obj.call_method1(py, "set_row_data", (row, type_collection.to_py_value(data)))
             {
-                eprintln!(
-                    "Python: Model implementation of set_row_data() threw an exception: {err}"
+                crate::handle_unraisable(
+                    py,
+                    "Python: Model implementation of set_row_data() threw an exception".into(),
+                    err,
                 );
             };
         });

--- a/api/python/slint/tests/test_loop.py
+++ b/api/python/slint/tests/test_loop.py
@@ -1,0 +1,21 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import slint
+from slint import slint as native
+from datetime import timedelta
+import pytest
+import sys
+
+
+def test_sysexit_exception() -> None:
+    def call_sys_exit() -> None:
+        sys.exit(42)
+
+    slint.Timer.single_shot(timedelta(milliseconds=100), call_sys_exit)
+    with pytest.raises(SystemExit) as exc_info:
+        native.run_event_loop()
+    assert (
+        "unexpected failure running python singleshot timer callback"
+        in exc_info.value.__notes__
+    )

--- a/api/python/slint/timer.rs
+++ b/api/python/slint/timer.rs
@@ -72,7 +72,13 @@ impl PyTimer {
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         self.timer.start(mode.into(), interval, move || {
             Python::attach(|py| {
-                callback.call0(py).expect("unexpected failure running python timer callback");
+                if let Err(err) = callback.call0(py) {
+                    crate::handle_unraisable(
+                        py,
+                        "unexpected failure running python timer callback".into(),
+                        err,
+                    );
+                }
             });
         });
         Ok(())
@@ -91,7 +97,13 @@ impl PyTimer {
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         i_slint_core::timers::Timer::single_shot(duration, move || {
             Python::attach(|py| {
-                callback.call0(py).expect("unexpected failure running python timer callback");
+                if let Err(err) = callback.call0(py) {
+                    crate::handle_unraisable(
+                        py,
+                        "unexpected failure running python singleshot timer callback".into(),
+                        err,
+                    );
+                }
             });
         });
         Ok(())


### PR DESCRIPTION
Instead of printing exceptions in callbacks to stderr, let's raise them as unraisable exceptions, but catch SystemExit and forward it through the event loop.

Fixes #9416

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
