### PR TITLE
Fix m5stack_cores3 build

### DIFF
--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -160,6 +160,7 @@ m5stack-cores3 = [
   "dep:static_cell",
   "dep:embedded-graphics-framebuf",
   "dep:ft3x68-rs",                  # FT6336U touch controller (compatible with FT3x68)
+  "esp-bootloader-esp-idf/esp32s3",
 ]
 stm32u5g9j-dk2 = [
   "embassy-stm32/stm32u5g9zj",
@@ -232,7 +233,7 @@ esp-alloc = { version = "0.8.0", optional = true }
 esp-println = { version = "0.15.0", default-features = false, features = ["auto", "log-04"], optional = true }
 esp-backtrace = { version = "0.17.0", optional = true, features = ["esp32s3", "exception-handler", "println"] }
 static_cell = { version = "2.1.0", optional = true }
-esp-bootloader-esp-idf = { version = "0.2.0", features = ["esp32s3"] }
+esp-bootloader-esp-idf = { version = "0.2.0", optional = true }
 
 mipidsi = { version = "0.9.0", optional = true }
 embedded-graphics-core = { version = "0.4", optional = true }

--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -232,7 +232,7 @@ esp-alloc = { version = "0.8.0", optional = true }
 esp-println = { version = "0.15.0", default-features = false, features = ["auto", "log-04"], optional = true }
 esp-backtrace = { version = "0.17.0", optional = true, features = ["esp32s3", "exception-handler", "println"] }
 static_cell = { version = "2.1.0", optional = true }
-esp-bootloader-esp-idf = { version = "0.2.0", optional = true }
+esp-bootloader-esp-idf = { version = "0.2.0", features = ["esp32s3"] }
 
 mipidsi = { version = "0.9.0", optional = true }
 embedded-graphics-core = { version = "0.4", optional = true }

--- a/examples/mcu-board-support/m5stack_cores3.rs
+++ b/examples/mcu-board-support/m5stack_cores3.rs
@@ -6,6 +6,24 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     esp_println::println!("Panic: {:?}", info);
     loop {}
 }
+esp_bootloader_esp_idf::esp_app_desc!(
+    // Version
+    "1.0.0",
+    // Project name
+    "slint-m5stack_cores3",
+    // Build time
+    "12:00:00",
+    // Build date
+    "2025-01-01",
+    // ESP-IDF version
+    "4.4",
+    // MMU page size
+    8 * 1024,
+    // Minimal eFuse block revision supported by image. Format: major * 100 + minor
+    0,
+    // Maximum eFuse block revision supported by image. Format: major * 100 + minor
+    u16::MAX
+);
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;

--- a/examples/mcu-board-support/m5stack_cores3.rs
+++ b/examples/mcu-board-support/m5stack_cores3.rs
@@ -6,24 +6,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     esp_println::println!("Panic: {:?}", info);
     loop {}
 }
-esp_bootloader_esp_idf::esp_app_desc!(
-    // Version
-    "1.0.0",
-    // Project name
-    "slint-m5stack_cores3",
-    // Build time
-    "12:00:00",
-    // Build date
-    "2025-01-01",
-    // ESP-IDF version
-    "4.4",
-    // MMU page size
-    8 * 1024,
-    // Minimal eFuse block revision supported by image. Format: major * 100 + minor
-    0,
-    // Maximum eFuse block revision supported by image. Format: major * 100 + minor
-    u16::MAX
-);
+esp_bootloader_esp_idf::esp_app_desc!();
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;


### PR DESCRIPTION
* The `esp-bootloader-esp-idf` dependency requires `esp32s3` as feature. Not sure if this works with all ESP devices.
* The `esp_bootloader_esp_idf::esp_app_desc!` macro is broken when there are no arguments. I added a few dummy arguments.
