### PR TITLE
Fix text navigation shortcuts on WASM build running on macOS

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -203,22 +203,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
             WindowEvent::KeyboardInput { event, is_synthetic, .. } => {
                 let key_code = event.logical_key;
                 // For now: Match Qt's behavior of mapping command to control and control to meta (LWin/RWin).
-                cfg_if::cfg_if!(
-                    if #[cfg(target_vendor = "apple")] {
-                        let swap_cmd_ctrl = true;
-                    } else if #[cfg(target_family = "wasm")] {
-                        let swap_cmd_ctrl = web_sys::window()
-                            .and_then(|window| window.navigator().platform().ok())
-                            .is_some_and(|platform| {
-                                let platform = platform.to_ascii_lowercase();
-                                platform.contains("mac")
-                                    || platform.contains("iphone")
-                                    || platform.contains("ipad")
-                            });
-                    } else {
-                        let swap_cmd_ctrl = false;
-                    }
-                );
+                let swap_cmd_ctrl = i_slint_core::is_apple_platform();
 
                 let key_code = if swap_cmd_ctrl {
                     match key_code {

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -66,10 +66,7 @@ impl WasmInputHelper {
         let mut h = Self { input, canvas: canvas.clone() };
 
         // macos, or ipad with an attached keyboard, etc.
-        let is_apple = window.navigator().platform().ok().map_or(false, |platform| {
-            let platform = platform.to_ascii_lowercase();
-            platform.contains("mac") || platform.contains("iphone") || platform.contains("ipad")
-        });
+        let is_apple = i_slint_core::is_apple_platform();
 
         let shared_state = Rc::new(RefCell::new(WasmInputState::default()));
         #[cfg(web_sys_unstable_apis)]

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -354,22 +354,7 @@ impl KeyEvent {
     pub fn text_shortcut(&self) -> Option<TextShortcut> {
         let keycode = self.text.chars().next()?;
 
-        cfg_if::cfg_if!(
-            if #[cfg(target_vendor = "apple")] {
-                let is_apple = true;
-            } else if #[cfg(target_family = "wasm")] {
-                let is_apple = web_sys::window()
-                    .and_then(|window| window.navigator().platform().ok())
-                    .is_some_and(|platform| {
-                        let platform = platform.to_ascii_lowercase();
-                        platform.contains("mac")
-                            || platform.contains("iphone")
-                            || platform.contains("ipad")
-                    });
-            } else {
-                let is_apple = false;
-            }
-        );
+        let is_apple = crate::is_apple_platform();
 
         let move_mod = if is_apple {
             self.modifiers.alt && !self.modifiers.control && !self.modifiers.meta
@@ -416,24 +401,22 @@ impl KeyEvent {
             }
         }
 
-        if is_apple {
-            if self.modifiers.control {
-                match keycode {
-                    key_codes::LeftArrow => {
-                        return Some(TextShortcut::Move(TextCursorDirection::StartOfLine))
-                    }
-                    key_codes::RightArrow => {
-                        return Some(TextShortcut::Move(TextCursorDirection::EndOfLine))
-                    }
-                    key_codes::UpArrow => {
-                        return Some(TextShortcut::Move(TextCursorDirection::StartOfText))
-                    }
-                    key_codes::DownArrow => {
-                        return Some(TextShortcut::Move(TextCursorDirection::EndOfText))
-                    }
-                    _ => (),
-                };
-            }
+        if is_apple && self.modifiers.control {
+            match keycode {
+                key_codes::LeftArrow => {
+                    return Some(TextShortcut::Move(TextCursorDirection::StartOfLine))
+                }
+                key_codes::RightArrow => {
+                    return Some(TextShortcut::Move(TextCursorDirection::EndOfLine))
+                }
+                key_codes::UpArrow => {
+                    return Some(TextShortcut::Move(TextCursorDirection::StartOfText))
+                }
+                key_codes::DownArrow => {
+                    return Some(TextShortcut::Move(TextCursorDirection::EndOfText))
+                }
+                _ => (),
+            };
         }
 
         if let Ok(direction) = TextCursorDirection::try_from(keycode) {

--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -140,3 +140,8 @@ pub fn detect_operating_system() -> OperatingSystemType {
         OperatingSystemType::Other
     }
 }
+
+/// Returns true if the current platform is an Apple platform (macOS, iOS, iPadOS)
+pub fn is_apple_platform() -> bool {
+    matches!(detect_operating_system(), OperatingSystemType::Macos | OperatingSystemType::Ios)
+}


### PR DESCRIPTION
This PR fixes macOS text navigation shortcuts (Cmd/Option+Arrow keys) on WASM platforms by refactoring Apple platform detection logic and moving from compile-time to runtime platform detection.

### Problem

Previously, macOS text shortcuts (like Option+Left/Right arrow for line navigation, Cmd+Up/Down for document navigation) were not working correctly on WASM builds when running on Apple platforms. 
The issue was caused by compile-time detection - text shortcuts used `cfg!(target_os = "macos")` which doesn't work for WASM targets running on macOS browsers.

### Solution

- Added a new `is_apple_platform()` function in `internal/core/lib.rs` that provides Apple platform detection.
This function works correctly across all targets including WASM by using the existing `detect_operating_system()` logic.
- Fixed text shortcuts to use runtime platform detection via new `is_apple_platform()`function.

#### Shortcuts fixed

- [x] Option + Left should move the caret to the beginning of the previous word;
- [x] Option + Right should move the caret to the end of the following word;
- [x] Option + Up should move the caret to the beginning of paragraph;
- [x] Option + Down should move the caret to the end of the paragraph;
- [x] Option + Delete should delete the previous word;
- [ ] Fn + Option + Delete should delete the following word;
- [x] Command + Left should move the caret to the beginning of the line;
- [x] Command + Right should move the caret to the end of the line;
- [x] Command + Up should move the caret to the beginning of the whole text (position zero, so to speak);
- [x] Command + Down should move the caret to the end of the whole text;
- [x] Command + Delete should delete the entire line;
- [ ] Fn + Command + Delete should do nothing (plays the system alert sound, to tell the user no action can be performed).

### Notes
- Apple platform detection was scattered across multiple files with similar but not identical implementations, hence moved into one place in `core`.
- I'm not sure where is the best place for `is_apple_platform` function, so I've put it next to the `detect_operating_system()`

<!--
### Video
<details>

<summary>Expand to see videos of behaviour after changes</summary>

#### WASM

https://github.com/user-attachments/assets/ea873ecb-94b5-4b7b-8399-264801af6089

#### Native

https://github.com/user-attachments/assets/cbe2a6db-3c92-47fa-bdcf-27bfd3af4901

</details>


- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
