### PR TITLE
Skia/WGPU: Enable vsync by default

### DIFF
--- a/internal/renderers/skia/wgpu_26_surface.rs
+++ b/internal/renderers/skia/wgpu_26_surface.rs
@@ -100,6 +100,8 @@ impl super::Surface for WGPUSurface {
 
         let mut surface_config = self.surface_config.borrow_mut();
 
+        // Prefer FIFO modes over possible Mailbox setting for frame pacing and better energy efficiency.
+        surface_config.present_mode = wgpu::PresentMode::AutoVsync;
         surface_config.width = size.width;
         surface_config.height = size.height;
 


### PR DESCRIPTION
Apply commit ae204bda251489191b2d6bfd0014e791f8a831ce also to the wgpu surface of the skia renderer.

cc #8693

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
