### PR TITLE
feat: Add smooth scroll to Flickable

### DIFF
--- a/internal/compiler/widgets/cosmic/scrollview.slint
+++ b/internal/compiler/widgets/cosmic/scrollview.slint
@@ -13,8 +13,6 @@ export component ScrollBar {
     in-out property <length> value;
     in property <ScrollBarPolicy> policy: ScrollBarPolicy.as-needed;
 
-    callback scrolled();
-
     private property <length> track-size: root.horizontal ? root.width - 2 * root.offset : root.height - 2 * offset;
     private property <length> step-size: 10px;
     private property <length> offset: 2px;
@@ -65,7 +63,6 @@ export component ScrollBar {
                     root.horizontal ? (touch-area.mouse-x - touch-area.pressed-x) * (root.maximum / (root.track-size - thumb.width))
                                : (touch-area.mouse-y - touch-area.pressed-y) * (root.maximum / (root.track-size - thumb.height))
                 )));
-                root.scrolled();
             }
         }
 
@@ -125,8 +122,6 @@ export component ScrollView {
         horizontal: false;
         maximum:  flickable.viewport-height - flickable.height;
         page-size:  flickable.height;
-
-        scrolled => {root.scrolled()}
     }
 
     horizontal-bar := ScrollBar {
@@ -138,7 +133,5 @@ export component ScrollView {
         horizontal: true;
         maximum:  flickable.viewport-width - flickable.width;
         page-size:  flickable.width;
-
-        scrolled => {root.scrolled()}
     }
 }

--- a/internal/compiler/widgets/cupertino/scrollview.slint
+++ b/internal/compiler/widgets/cupertino/scrollview.slint
@@ -12,8 +12,6 @@ export component ScrollBar inherits Rectangle {
     in-out property <length> value;
     in property <ScrollBarPolicy> policy: ScrollBarPolicy.as-needed;
 
-    callback scrolled();
-
     property <length> track-size: root.horizontal ? root.width - 2 * root.offset : root.height - 2 * offset;
     property <length> step-size: 10px;
     property <length> offset: 2px;
@@ -73,7 +71,6 @@ export component ScrollBar inherits Rectangle {
                     root.horizontal ? (touch-area.mouse-x - touch-area.pressed-x) * (root.maximum / (root.track-size - thumb.width))
                                : (touch-area.mouse-y - touch-area.pressed-y) * (root.maximum / (root.track-size - thumb.height))
                 )));
-                root.scrolled();
             }
         }
 
@@ -135,8 +132,6 @@ export component ScrollView {
         horizontal: false;
         maximum:  flickable.viewport-height - flickable.height;
         page-size:  flickable.height;
-
-        scrolled => {root.scrolled()}
     }
 
     horizontal-bar := ScrollBar {
@@ -148,7 +143,5 @@ export component ScrollView {
         horizontal: true;
         maximum:  flickable.viewport-width - flickable.width;
         page-size:  flickable.width;
-
-        scrolled => {root.scrolled()}
     }
 }

--- a/internal/compiler/widgets/fluent/scrollview.slint
+++ b/internal/compiler/widgets/fluent/scrollview.slint
@@ -42,8 +42,6 @@ component ScrollBar inherits Rectangle {
     in property <ScrollBarPolicy> policy: ScrollBarPolicy.as-needed;
     in property <bool> enabled;
 
-    callback scrolled();
-
     property <length> offset: 16px;
     property <length> size: 2px;
     property <length> track-size: root.horizontal ? root.width - 2 * root.offset : root.height - 2 * offset;
@@ -94,7 +92,6 @@ component ScrollBar inherits Rectangle {
                     root.horizontal ? (touch-area.mouse-x - touch-area.pressed-x) * (root.maximum / (root.track-size - thumb.width))
                                : (touch-area.mouse-y - touch-area.pressed-y) * (root.maximum / (root.track-size - thumb.height))
                 )));
-                root.scrolled();
             }
         }
 
@@ -178,8 +175,6 @@ export component ScrollView {
         horizontal: false;
         maximum:  flickable.viewport-height - flickable.height;
         page-size:  flickable.height;
-
-        scrolled => {root.scrolled()}
     }
 
     horizontal-bar := ScrollBar {
@@ -191,7 +186,5 @@ export component ScrollView {
         horizontal: true;
         maximum:  flickable.viewport-width - flickable.width;
         page-size:  flickable.width;
-
-        scrolled => {root.scrolled()}
     }
 }

--- a/internal/compiler/widgets/material/scrollview.slint
+++ b/internal/compiler/widgets/material/scrollview.slint
@@ -13,8 +13,6 @@ component ScrollBar inherits Rectangle {
     in-out property <bool> enabled <=> touch-area.enabled;
     in property <ScrollBarPolicy> policy: ScrollBarPolicy.as-needed;
 
-    callback scrolled();
-
     states [
         disabled when !touch-area.enabled : {
             background.border-color: MaterialPalette.control-foreground;
@@ -75,7 +73,6 @@ component ScrollBar inherits Rectangle {
                     root.horizontal ? (touch-area.mouse-x - touch-area.pressed-x) * (root.maximum / (root.width - handle.width))
                                : (touch-area.mouse-y - touch-area.pressed-y) * (root.maximum / (root.height - handle.height))
                 )));
-                root.scrolled();
             }
         }
 
@@ -135,8 +132,6 @@ export component ScrollView {
         maximum: flickable.viewport-height - flickable.height;
         page-size: flickable.height;
         enabled: root.enabled;
-
-        scrolled => {root.scrolled()}
     }
 
     horizontal-bar := ScrollBar {
@@ -148,7 +143,5 @@ export component ScrollView {
         maximum: flickable.viewport-width - flickable.width;
         page-size: flickable.width;
         enabled: root.enabled;
-
-        scrolled => {root.scrolled()}
     }
 }

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1281,7 +1281,9 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
             viewport_height.set(inner.cached_item_height * row_count as Coord);
             viewport_width.set(vp_width);
             let new_viewport_y = -inner.anchor_y + new_offset_y;
-            viewport_y.set(new_viewport_y);
+            if viewport_y.get() != new_viewport_y {
+                viewport_y.set(new_viewport_y);
+            }
             inner.previous_viewport_y = new_viewport_y;
             break;
         }

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -44,7 +44,7 @@ TestCase := Window {
     property<bool> inner_ta_has_hover: inner_ta.has_hover;
     property<int> clicked;
     property<int> double-clicked;
-    property <int> flicked;
+    property<int> flicked;
 }
 
 /*
@@ -233,6 +233,7 @@ assert!((instance.get_offset_y() - 55.).abs() < 5.);
 use slint::{LogicalPosition, platform::{WindowEvent, Key} };
 let instance = TestCase::new().unwrap();
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: -30.0, delta_y: -50.0 });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_offset_x(), 30.);
 assert_eq!(instance.get_offset_y(), 50.);
 
@@ -242,6 +243,7 @@ if !cfg!(target_os = "macos") {
     slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
     instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 15.0, delta_y: -60.0 });
     slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
+    slint_testing::mock_elapsed_time(250);
     assert_eq!(instance.get_offset_x(), 30. + 60.);
     assert_eq!(instance.get_offset_y(), 50. - 15.);
 }
@@ -255,6 +257,7 @@ assert_eq!(instance.get_flicked(), 0);
 
 // test scrolling behaviour
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: -30.0, delta_y: -50.0 });
+slint_testing::mock_elapsed_time(250);
 dbg!(instance.get_flicked());
 assert_eq!(instance.get_flicked(), -3000050); //flicked got called after scrolling
 instance.set_flicked(0);
@@ -268,7 +271,8 @@ slint_testing::mock_elapsed_time(10000);
 assert_eq!(instance.get_flicked(), -10500105); //flicked got called during drag
 instance.set_flicked(0);
 instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(100.0, 120.0), button: PointerEventButton::Left });
-assert_eq!(instance.get_flicked(), -10500105); //flicked got called after drag
+slint_testing::mock_elapsed_time(250);
+assert_eq!(instance.get_flicked(), -10682145); //flicked got called after drag
 instance.set_flicked(0);
 
 ```

--- a/tests/cases/elements/flickable2.slint
+++ b/tests/cases/elements/flickable2.slint
@@ -47,7 +47,9 @@ TestCase := Window {
         }
     }
 
-    Flickable { for i in 5: Rectangle {} }
+    Flickable {
+        for i in 5: Rectangle {}
+    }
 
     property<bool> all_ok: r1.ok && r2.ok && r3.ok && r4.ok;
     property<bool> test: all_ok;

--- a/tests/cases/elements/flickable3.slint
+++ b/tests/cases/elements/flickable3.slint
@@ -69,12 +69,14 @@ assert_eq!(instance.get_t1_has_hover(), true);
 assert_eq!(instance.get_t1sec_has_hover(), false);
 assert_eq!(instance.get_t2_has_hover(), false);
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(25.0, 25.0), delta_x: 0.0, delta_y: -30.0 });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_t1_has_hover(), false);
 assert_eq!(instance.get_t1sec_has_hover(), true);
 assert_eq!(instance.get_t2_has_hover(), false);
 assert_eq!(instance.get_f1_pos(), -30.0);
 
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(25.0, 25.0), delta_x: 0.0, delta_y: -30.0 });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_t1_has_hover(), false);
 assert_eq!(instance.get_t1sec_has_hover(), false);
 assert_eq!(instance.get_t2_has_hover(), false);
@@ -88,6 +90,7 @@ instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPo
 assert_eq!(instance.get_t2_has_hover(), true);
 assert_eq!(instance.get_t1_has_hover(), false);
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(275.0, 25.0), delta_x: -30.0, delta_y: 0.0 });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_t2_has_hover(), false);
 assert_eq!(instance.get_t1_has_hover(), false);
 

--- a/tests/cases/elements/flickable_in_flickable.slint
+++ b/tests/cases/elements/flickable_in_flickable.slint
@@ -16,6 +16,7 @@ TestCase := Window {
 
         inner := Flickable {
             viewport_width: 1500px;
+
             Rectangle {
                 background: @radial-gradient(circle, yellow, blue, red, green);
             }
@@ -126,14 +127,17 @@ assert_eq!(instance.get_outer_y(), old_outer_y);
 use slint::{LogicalPosition, platform::WindowEvent };
 let instance = TestCase::new().unwrap();
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 0.0, delta_y: -50.0 });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_inner_x(), 0.);
 assert_eq!(instance.get_outer_y(), 50.);
 
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: -30.0, delta_y: 0.0 });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_inner_x(), 30.);
 assert_eq!(instance.get_outer_y(), 50.);
 
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(175.0, 175.0), delta_x: 0.0, delta_y: 10.0 });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_inner_x(), 30.);
 assert_eq!(instance.get_outer_y(), 40.);
 ```

--- a/tests/cases/elements/listview.slint
+++ b/tests/cases/elements/listview.slint
@@ -55,6 +55,7 @@ assert_eq(instance.get_listview_viewport_width(), 1500.);
 // scroll all the way down with the mouse wheel and click on the last item
 for (int i = 0; i < 10; ++i) {
     instance.window().dispatch_pointer_scroll_event(slint::LogicalPosition({25.0, 105.0}), 0, -50);
+    slint_testing::mock_elapsed_time(250);
 }
 slint_testing::send_mouse_click(&instance, 5., 441.);
 assert_eq(instance.get_value(), "Cyan");
@@ -72,6 +73,7 @@ assert_eq!(instance.get_listview_viewport_width(), 1500.);
 use slint::{LogicalPosition, platform::WindowEvent };
 for _ in 0..10 {
     instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(25.0, 105.0), delta_x: 0.0, delta_y: -50.0 });
+    slint_testing::mock_elapsed_time(250);
 }
 slint_testing::send_mouse_click(&instance, 5., 441.);
 assert_eq!(instance.get_value(), "Cyan");

--- a/tests/cases/focus/listview-hidden.slint
+++ b/tests/cases/focus/listview-hidden.slint
@@ -58,6 +58,7 @@ let delta_y = -600.0;
 
 assert_eq!(instance.get_viewport_y(), 0.0);
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(150.0, 150.0), delta_x: -0.0, delta_y });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_viewport_y(), delta_y);
 assert_eq!(instance.get_current_item(), 1);
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Backtab));

--- a/tests/cases/input/scroll-event.slint
+++ b/tests/cases/input/scroll-event.slint
@@ -48,6 +48,7 @@ use slint::{LogicalPosition, platform::WindowEvent };
 let instance = TestCase::new().unwrap();
 
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(25.0, 30.0), delta_x: -3.0, delta_y: -50.0 });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_result(), "ta1{-3,-50 at 5,10}");
 assert_eq!(instance.get_offset_y(), 0.0);
 assert_eq!(instance.get_offset_x(), 0.0);
@@ -55,6 +56,7 @@ assert_eq!(instance.get_offset_x(), 0.0);
 instance.set_result("".into());
 
 instance.window().dispatch_event(WindowEvent::PointerScrolled { position: LogicalPosition::new(155.0, 50.0), delta_x: -30.0, delta_y: -50.0 });
+slint_testing::mock_elapsed_time(250);
 assert_eq!(instance.get_result(), "ta2{-30,-50 at 35,30}");
 assert_eq!(instance.get_offset_x(), 30.0);
 assert_eq!(instance.get_offset_y(), 50.0);


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
Closes #4115

Also written as fluent scrolling, smooth scroll is one of the details that Slint needs to have a better user experience.

In this PR, I add the opt-out `smooth-scroll` property to `Flickable` and platform-specific `ScrollView` that enables the smooth scrolling.

There's just one thing to resolve, in `ensure_updated_listview` I have to remove one line because it discards the running animated value, but I want some feedback to handle it better.

If everything is right, then I will change the doc.
