### PR TITLE
Slintpad: allow to load libraries with `?lib=foo=https://...`

### DIFF
--- a/internal/compiler/tests/syntax/imports/library.slint
+++ b/internal/compiler/tests/syntax/imports/library.slint
@@ -8,8 +8,6 @@ import { NotFound } from "@not-found/foo.slint";
 
 import { NotFound2 } from "@test-lib/lib.slint";
 //                        ^error{No exported type called 'NotFound2' found in "@test-lib/lib.slint"}
-import { NotFound3 } from "@test-lib/not-existing.slint";
-//                        ^error{Cannot find requested import "@test-lib/not-existing.slint" in the library search path}
 
 import { NotFound4 } from "@notexist";
 //                        ^error{Cannot find requested import "@notexist" in the library search path}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -2140,7 +2140,7 @@ import { E } from "@unknown/lib.slint";
         &diags[2],
         &format!(
             "HELLO:5: Error reading requested import \"{}\": ",
-            test_source_path.join("lib.slint/unknown.slint").to_string_lossy()
+            test_source_path.join("lib.slint").join("unknown.slint").to_string_lossy()
         ),
     );
     assert_eq!(

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -2132,7 +2132,7 @@ import { E } from "@unknown/lib.slint";
     assert_starts_with(
         &diags[1],
         &format!(
-            "HELLO:4: Error reading requested import \"{}\": No such file or directory",
+            "HELLO:4: Error reading requested import \"{}\": ",
             test_source_path.join("unknown.slint").to_string_lossy(),
         ),
     );

--- a/tools/slintpad/README.md
+++ b/tools/slintpad/README.md
@@ -56,3 +56,9 @@ The `preview.html` page contains only the preview and the code must be given via
     -   https://slint.dev/editor/preview.html?snippet=_+%3A%3D+Text+%7B+text%3A+%22Hello+Slint%22%3B+%7D?style=material
 
 -   `?gz=` Like `?snippet=` but compressed with gzip and base64 encoded.
+
+-   `?lib=lib_name=<url>` query argument, followed by the name of the library and the URL to load it from.
+
+    Example: The to use the `@material` library:
+
+     -   https://slint.dev/editor/?lib=material=https://raw.githubusercontent.com/slint-ui/material-components/refs/heads/master/material.slint


### PR DESCRIPTION
Also allow `https://` URL to be mapped directly for libraries (without loading them in a editor tab)
