### PR TITLE
Remove support for x86-64 macOS binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -232,7 +232,7 @@ jobs:
             CARGO_PROFILE_DEV_DEBUG: 0
         strategy:
             matrix:
-                os: [ubuntu-22.04, macos-13, windows-2022]
+                os: [ubuntu-22.04, macos-14, windows-2022]
         runs-on: ${{ matrix.os }}
 
         steps:
@@ -241,7 +241,7 @@ jobs:
               with:
                   force-gcc-10: true
             - name: Install Qt
-              if: runner.os != 'Windows'
+              if: runner.os == 'Linux'
               uses: jurplel/install-qt-action@v4
               with:
                   version: "5.15.2"

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -28,12 +28,10 @@ jobs:
             CARGO_INCREMENTAL: false
         strategy:
             matrix:
-                os: [ubuntu-22.04, macOS-13, macos-14, windows-2022]
+                os: [ubuntu-22.04, macos-14, windows-2022]
                 include:
                     - os: ubuntu-22.04
                       package_suffix: linux
-                    - os: macOS-13
-                      package_suffix: macos-x86_64
                     - os: macos-14
                       package_suffix: macos-aarch64
                     - os: windows-2022
@@ -237,7 +235,7 @@ jobs:
             CARGO_INCREMENTAL: false
         strategy:
             matrix:
-                os: [ubuntu-22.04, macOS-13, macos-14, windows-2022]
+                os: [ubuntu-22.04, macos-14, windows-2022]
                 include:
                     - os: ubuntu-22.04
                       package_suffix: Linux-x86_64
@@ -245,9 +243,6 @@ jobs:
                     - os: ubuntu-22.04-arm
                       package_suffix: Linux-aarch64
                       cargo_target: aarch64-unknown-linux-gnu
-                    - os: macOS-13
-                      package_suffix: Darwin-x86_64
-                      cargo_target: x86_64-apple-darwin
                     - os: macos-14
                       package_suffix: Darwin-arm64
                       cargo_target: aarch64-apple-darwin

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -117,15 +117,15 @@ jobs:
                   path: |
                       bin
 
-    build_vscode_lsp_macos_x86_64:
+    build_vscode_lsp_macos_aarch64_bundle:
         env:
             SLINT_NO_QT: 1
-        runs-on: macos-13
+        runs-on: macos-14
         steps:
             - uses: actions/checkout@v5
             - uses: ./.github/actions/setup-rust
               with:
-                  target: x86_64-apple-darwin
+                  target: aarch64-apple-darwin
             - name: Install cargo-bundle
               run: cargo install --version=0.6.0 cargo-bundle
             - name: Build Main LSP Bundle
@@ -135,68 +135,18 @@ jobs:
               run: |
                   mkdir bin
                   cp -a target/release/bundle/osx/Slint\ Live\ Preview.app bin
-            - name: "Upload LSP Artifact"
-              uses: actions/upload-artifact@v4
+            - uses: ./.github/actions/codesign
               with:
-                  name: vscode-lsp-binary-x86_64-apple-darwin
-                  path: |
-                      bin
-
-    build_vscode_lsp_macos_aarch64:
-        env:
-            SLINT_NO_QT: 1
-        runs-on: macos-14
-        steps:
-            - uses: actions/checkout@v5
-            - uses: ./.github/actions/setup-rust
-              with:
-                  target: aarch64-apple-darwin
-            - name: Build AArch64 LSP
-              run: cargo build --target aarch64-apple-darwin --features ${{ env.SLINT_BINARY_FEATURES }} --release -p slint-lsp
-            - name: Create artifact directory
-              run: |
-                  mkdir bin
-                  cp -a target/aarch64-apple-darwin/release/slint-lsp bin/slint-lsp-aarch64-apple-darwin
-            - name: "Upload LSP Artifact"
-              uses: actions/upload-artifact@v4
-              with:
-                  name: vscode-lsp-binary-aarch64-apple-darwin
-                  path: |
-                      bin
-
-    build_vscode_lsp_macos_bundle:
-        needs: [build_vscode_lsp_macos_x86_64, build_vscode_lsp_macos_aarch64]
-        runs-on: macos-13
-        steps:
-            - uses: actions/checkout@v5
-              with:
-                  path: "src"
-            - uses: actions/download-artifact@v5
-              with:
-                  name: vscode-lsp-binary-x86_64-apple-darwin
-            - uses: actions/download-artifact@v5
-              with:
-                  name: vscode-lsp-binary-aarch64-apple-darwin
-                  path: bin
-            - name: Add macOS AArch64 binary to bundle
-              run: |
-                  lipo -create -output tmp Slint\ Live\ Preview.app/Contents/MacOS/slint-lsp bin/slint-lsp-aarch64-apple-darwin
-                  mv tmp Slint\ Live\ Preview.app/Contents/MacOS/slint-lsp
-                  rm -rf bin
-            - uses: ./src/.github/actions/codesign
-              with:
-                  binary: "Slint Live Preview.app"
+                  binary: "bin/Slint Live Preview.app"
                   certificate: ${{ secrets.APPLE_CERTIFICATE_P12 }}
                   certificate_password: ${{ secrets.APPLE_CERTIFICATE_P12_PASSWORD }}
                   keychain_password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
                   developer_id: ${{ secrets.APPLE_DEV_ID }}
-            - name: "Remove temporary source checkout"
-              run: rm -rf src
             - name: "Upload LSP macOS bundle Artifact"
               uses: actions/upload-artifact@v4
               with:
                   name: vscode-lsp-binary-darwin
-                  path: .
+                  path: bin
 
     build_vscode_cross_linux_lsp:
         env:
@@ -232,11 +182,11 @@ jobs:
         needs:
             [
                 build_vscode_lsp_linux_windows,
-                build_vscode_lsp_macos_bundle,
+                build_vscode_lsp_macos_aarch64_bundle,
                 build_vscode_cross_linux_lsp,
                 check-for-secrets,
             ]
-        runs-on: macos-13
+        runs-on: macos-14
         if: ${{ needs.check-for-secrets.outputs.has-openvsx-pat == 'yes' && needs.check-for-secrets.outputs.has-vscode-marketplace-pat == 'yes' }}
         steps:
             - uses: actions/checkout@v5

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -201,7 +201,7 @@ jobs:
     uvx_slint_compiler:
         strategy:
             matrix:
-                os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-14, windows-2022, windows-11-arm]
+                os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-2022, windows-11-arm]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v5

--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -61,9 +61,6 @@ jobs:
                     - os: ubuntu-22.04-arm
                       rust-target: aarch64-unknown-linux-gnu
                       napi-rs-target: linux-arm64-gnu
-                    - os: macos-13
-                      rust-target: x86_64-apple-darwin
-                      napi-rs-target: darwin-x64
                     - os: macos-14
                       rust-target: aarch64-apple-darwin
                       napi-rs-target: darwin-arm64
@@ -198,11 +195,6 @@ jobs:
             - name: Download artifacts
               uses: actions/download-artifact@v5
               with:
-                  name: binaries-x86_64-apple-darwin
-                  path: api/node/
-            - name: Download artifacts
-              uses: actions/download-artifact@v5
-              with:
                   name: binaries-aarch64-apple-darwin
                   path: api/node/
             - name: Download artifacts
@@ -218,7 +210,7 @@ jobs:
             - name: Add binary dependencies
               working-directory: api/node
               run: |
-                  for package in @slint-ui/slint-ui-binary-linux-x64-gnu @slint-ui/slint-ui-binary-linux-arm64-gnu @slint-ui/slint-ui-binary-darwin-x64 @slint-ui/slint-ui-binary-darwin-arm64 @slint-ui/slint-ui-binary-win32-x64-msvc @slint-ui/slint-ui-binary-win32-arm64-msvc; do
+                  for package in @slint-ui/slint-ui-binary-linux-x64-gnu @slint-ui/slint-ui-binary-linux-arm64-gnu @slint-ui/slint-ui-binary-darwin-arm64 @slint-ui/slint-ui-binary-win32-x64-msvc @slint-ui/slint-ui-binary-win32-arm64-msvc; do
                       jq --arg pkg "$package" --arg version "$PKG_VERSION" '.optionalDependencies[$pkg]=$version' package.json > new.json
                       mv new.json package.json
                   done
@@ -243,7 +235,6 @@ jobs:
               run: |
                   pnpm publish --no-git-checks --access public $PUBLISH_TAG api/node/slint-ui-slint-ui-binary-linux-x64-gnu-$PKG_VERSION.tgz
                   pnpm publish --no-git-checks --access public $PUBLISH_TAG api/node/slint-ui-slint-ui-binary-linux-arm64-gnu-$PKG_VERSION.tgz
-                  pnpm publish --no-git-checks --access public $PUBLISH_TAG api/node/slint-ui-slint-ui-binary-darwin-x64-$PKG_VERSION.tgz
                   pnpm publish --no-git-checks --access public $PUBLISH_TAG api/node/slint-ui-slint-ui-binary-darwin-arm64-$PKG_VERSION.tgz
                   pnpm publish --no-git-checks --access public $PUBLISH_TAG api/node/slint-ui-slint-ui-binary-win32-x64-msvc-$PKG_VERSION.tgz
                   pnpm publish --no-git-checks --access public $PUBLISH_TAG api/node/slint-ui-slint-ui-binary-win32-arm64-msvc-$PKG_VERSION.tgz

--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -167,12 +167,9 @@ jobs:
                 path: slint-${{ github.event.inputs.program || inputs.program }}-${{ matrix.target }}.tar.gz
 
     build_macos:
-        runs-on: macos-13
+        runs-on: macos-14
         steps:
             - uses: actions/checkout@v5
-            - uses: ./.github/actions/setup-rust
-              with:
-                  target: x86_64-apple-darwin
             - uses: ./.github/actions/setup-rust
               with:
                   target: aarch64-apple-darwin
@@ -180,15 +177,13 @@ jobs:
               with:
                   crate: cargo-about
                   version: "=0.6.6"
-            - name: Build x86_64
-              run: cargo build --verbose --target x86_64-apple-darwin --no-default-features --features ${{ github.event.inputs.features || inputs.features }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
             - name: Build aarch64
               run: cargo build --verbose --target aarch64-apple-darwin --no-default-features --features ${{ github.event.inputs.features || inputs.features }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
             - name: Create artifact directory
               run: |
                   mkdir -p slint-${{ github.event.inputs.program || inputs.program }}
                   cd slint-${{ github.event.inputs.program || inputs.program }}
-                  lipo -create -output ./slint-${{ github.event.inputs.program || inputs.program }} ../target/x86_64-apple-darwin/release/slint-${{ github.event.inputs.program || inputs.program }} ../target/aarch64-apple-darwin/release/slint-${{ github.event.inputs.program || inputs.program }}
+                  lipo -create -output ./slint-${{ github.event.inputs.program || inputs.program }} ../target/aarch64-apple-darwin/release/slint-${{ github.event.inputs.program || inputs.program }}
                   install_name_tool -add_rpath @executable_path/. ./slint-${{ github.event.inputs.program || inputs.program }}
                   cd ..
                   cd tools/${{ github.event.inputs.program || inputs.program }}

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -26,9 +26,6 @@ jobs:
 #                    - runner: windows-11-arm
 #                      target: aarch64
 #                      container: auto
-                    - runner: macos-13
-                      target: x86_64
-                      container: auto
                     - runner: macos-14
                       target: aarch64
                       container: auto

--- a/api/node/binaries.json
+++ b/api/node/binaries.json
@@ -9,7 +9,6 @@
       "additional": [
         "x86_64-unknown-linux-gnu",
         "aarch64-unknown-linux-gnu",
-        "x86_64-apple-darwin",
         "aarch64-apple-darwin",
         "x86_64-pc-windows-msvc",
         "aarch64-pc-windows-msvc"

--- a/docs/astro/src/content/docs/guide/platforms/desktop.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/desktop.mdx
@@ -89,9 +89,9 @@ rustflags = ["-C", "link-arg=/STACK:8000000"]
 
 | Operating System  | Architecture    |
 | ----------------- | --------------- |
-| macOS 13 Ventura  | x86-64, aarch64 |
-| macOS 14 Sonoma   | x86-64, aarch64 |
-| macOS 15 Sequoia  | x86-64, aarch64 |
+| macOS 14 Sonoma   | aarch64 |
+| macOS 15 Sequoia  | aarch64 |
+| macOS 26          | aarch64 |
 
 </TabItem>
 <TabItem label="Linux" icon="linux">


### PR DESCRIPTION
GitHub is going to remove the free x86-64 macos runners, as per https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
