### PR TITLE
Android: Fix build with unstable-wgpu-26 feature enabled

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -201,7 +201,12 @@ backend-android-activity-05 = [
 ## ```toml
 ## slint = { version = "~1.13", features = ["unstable-wgpu-26"] }
 ## ```
-unstable-wgpu-26 = ["i-slint-core/unstable-wgpu-26", "i-slint-backend-selector/unstable-wgpu-26", "dep:wgpu-26"]
+unstable-wgpu-26 = [
+  "i-slint-core/unstable-wgpu-26",
+  "i-slint-backend-selector/unstable-wgpu-26",
+  "i-slint-backend-android-activity?/unstable-wgpu-26",
+  "dep:wgpu-26",
+]
 
 ## APIs guarded with this feature are *NOT* subject to the usual Slint API stability guarantees, because winit releases new major
 ## versions more frequently than Slint. This feature as well as the APIs changed or removed in future minor releases of Slint, likely to be replaced

--- a/internal/backends/android-activity/Cargo.toml
+++ b/internal/backends/android-activity/Cargo.toml
@@ -20,6 +20,7 @@ game-activity = ["android-activity-06?/game-activity", "android-activity-05?/gam
 native-activity = ["android-activity-06?/native-activity", "android-activity-05?/native-activity"]
 aa-06 = ["android-activity-06", "ndk-09"]
 aa-05 = ["android-activity-05", "ndk-08"]
+unstable-wgpu-26 = ["i-slint-renderer-skia/unstable-wgpu-26"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 i-slint-renderer-skia = { workspace = true }


### PR DESCRIPTION
Fixes #9452

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
