### PR TITLE
Get tid of a "unused_import" Rust warning when builind Slint code

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -180,7 +180,10 @@ pub fn generate(
             .iter()
             .map(|(symbol, library_info)| {
                 let ident = qualified_name_ident(symbol, library_info);
-                quote!(pub use #ident;)
+                quote!(
+                    #[allow(unused_imports)]
+                    pub use #ident;
+                )
             })
             .chain(doc_used_types.library_global_imports.iter().map(|(symbol, library_info)| {
                 let ident = qualified_name_ident(symbol, library_info);


### PR DESCRIPTION
This may only happen when slint-build/experimental-module-builds feature is enabled, and in a very specific circumstanances the type is collected as 'used', but not directly used by the generated Rust code.

CC #7060

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
