### PR TITLE
Gridlayout: make implicit properties row, col, rowspan, colspan accessible for bindings

### DIFF
--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -184,6 +184,8 @@ pub fn initialize(elem: &ElementRc, name: &str) -> Option<Expression> {
         "preferred-width" => layout_constraint_prop(elem, "preferred", Orientation::Horizontal),
         "opacity" => Expression::NumberLiteral(1., Unit::None),
         "visible" => Expression::BoolLiteral(true),
+        "rowspan" => Expression::NumberLiteral(1., Unit::None),
+        "colspan" => Expression::NumberLiteral(1., Unit::None),
         _ => return None,
     };
     Some(expr)

--- a/internal/compiler/tests/syntax/basic/layout2.slint
+++ b/internal/compiler/tests/syntax/basic/layout2.slint
@@ -50,4 +50,8 @@ export X := Rectangle {
     col: 3;
 //       ^error{col used outside of a GridLayout}
 
+    HorizontalLayout {
+        col: 3;
+//           ^error{col used outside of a GridLayout}
+    }
 }

--- a/tests/cases/layout/grid.slint
+++ b/tests/cases/layout/grid.slint
@@ -28,7 +28,10 @@ TestCase := Rectangle {
     property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == 150phx && rect1.height == 150phx;
     property <bool> rect2_pos_ok: rect2.x == 150phx && rect2.y == 0phx && rect2.width == 150phx && rect2.height == 150phx;
     property <bool> rect3_pos_ok: rect3.x == 0phx && rect3.y == 150phx && rect3.width == 150phx && rect3.height == 150phx;
+    property <bool> row_col_ok: rect1.row == 0 && rect1.col == 0 && rect2.row == 0 && rect2.col == 1 && rect3.row == 1 && rect3.col == 0;
     property <length> layout_width: layout.width;
+
+    out property <bool> test: rect1_pos_ok && rect2_pos_ok && rect3_pos_ok && row_col_ok && layout_width == 300phx;
 }
 
 /*
@@ -39,6 +42,7 @@ const TestCase &instance = *handle;
 assert(instance.get_rect1_pos_ok());
 assert(instance.get_rect2_pos_ok());
 assert(instance.get_rect3_pos_ok());
+assert(instance.get_row_col_ok());
 assert_eq(instance.get_layout_width(), 300);
 ```
 
@@ -48,9 +52,7 @@ let instance = TestCase::new().unwrap();
 assert!(instance.get_rect1_pos_ok());
 assert!(instance.get_rect2_pos_ok());
 assert!(instance.get_rect3_pos_ok());
+assert!(instance.get_row_col_ok());
 assert_eq!(instance.get_layout_width(), 300.);
 ```
-
-// FIXME! interpreter test
-
 */

--- a/tests/cases/layout/grid_span.slint
+++ b/tests/cases/layout/grid_span.slint
@@ -51,10 +51,10 @@ export component TestCase inherits Window {
     }
 
     out property <bool> test: {
-        rr.x == 50phx && rr.y == 50phx && rr.width == 30phx && rr.height == (200phx - 10phx) / 2 &&
-        rb.width == 40phx && rg.width == 20phx && rg.height == (400phx - 200phx - 100phx - 20phx) / 2 &&
+        rr.x == 50phx && rr.y == 50phx && rr.width == 30phx && rr.height == (200phx - 10phx) / 2 && rr.colspan == 2 &&
+        rb.width == 40phx && rg.width == 20phx && rg.height == (400phx - 200phx - 100phx - 20phx) / 2 && rg.colspan == 1 &&
         zero.height == 0 && zero.width == rb.width && zero.x == rb.x && zero.y == rg.y &&
-        zero2.height == rg.height && zero2.width == 0 && zero2.x > rb.x && zero2.y == rg.y
+        zero2.height == rg.height && zero2.width == 0 && zero2.x > rb.x && zero2.y == rg.y && zero2.rowspan == 1 && zero2.colspan == 0
 
     }
 


### PR DESCRIPTION
ChangeLog: implicit properties row, col, rowspan, colspan for items in a GridLayout are now accessible to bindings expressions