### PR TITLE
Make dependabot group more 'astro' packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,9 +47,10 @@ updates:
           - "vscode*"
       starlight_astro:
         patterns:
-          - "astro"
-          - "@astro*"
+          - "*astro*"
+          - "@*astro*"
           - "starlight*"
+          - "sharp"
           - "@expressive-code/plugin-line-numbers"
       playwright:
         patterns:


### PR DESCRIPTION
This change should reduce the number of seperate Dependabot PR's by 
grouping more of the astro related packages.