### PR TITLE
Material Site/Docs/Demos have to be manually deployed to material.slint.dev

### DIFF
--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -21,6 +21,7 @@ on:
         type: boolean
         required: false
         default: false
+        description: "Tick the box to publish master to material.slint.dev"
     secrets:
       CLOUDFLARE_API_TOKEN:
         required: true


### PR DESCRIPTION
This changes the behaviour so PR's still deploy, but will end up at 
preview URL's. However the merge to master no longer deploys a 
production site. Instead the production site can only be deployed 
manually via the github site.