### PR TITLE
Stop the Material CI running when not needed

### DIFF
--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: MIT
 
-name: Build, test and deploy docs
+name: Material - Build, test and publish
 
 on:
   workflow_dispatch:
@@ -11,7 +11,6 @@ on:
         description: "Publish master to Cloudflare Pages"
         default: false
         required: false
-  pull_request:
   push:
     branches-ignore:
       - master


### PR DESCRIPTION
The Material CI would run for all PR's. This change allows the earlier 
limits based on which files have changed to apply. It also stops a 
duplicate run happening for any material PR's.

Name of action tweaked to make it easier to spot in the list of actions.