### PR TITLE
Stop duplicate Material CI run

### DIFF
--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -11,9 +11,6 @@ on:
         description: "Publish master to Cloudflare Pages"
         default: false
         required: false
-  push:
-    branches-ignore:
-      - master
   workflow_call:
     inputs:
       publish:


### PR DESCRIPTION
Turns out it wasn't running twice. It was running 3 times. This finally 
fixes the duplicate runs.