### PR TITLE
Docs: restore documentation for `resize-border-width`

### DIFF
--- a/docs/astro/src/content/docs/reference/window/window.mdx
+++ b/docs/astro/src/content/docs/reference/window/window.mdx
@@ -56,6 +56,14 @@ The window icon shown in the title bar or the task bar on window managers suppor
 Whether the window should be borderless/frameless or not.
 </SlintProperty>
 
+### resize-border-width
+<SlintProperty propName="resize-border-width" typeName="length" defaultValue="0">
+    :::caution[Caution]
+    This property is `winit` only for now.
+    :::
+    Size of the resize border in borderless/frameless windows.
+</SlintProperty>
+
 ### title
 <SlintProperty propName="title" typeName="string">
 The window title that is shown in the title bar.


### PR DESCRIPTION
Was removed by mistake in 0d1412afc5d93c127ff0300127f2173323582b36