### PR TITLE
Docs: document that the globals are not shared accreoss windows

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/globals.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/globals.mdx
@@ -108,6 +108,11 @@ app.Logic.the_value = 42
 </TabItem>
 </Tabs>
 
+:::note[Note]
+Globals are not shared between windows.
+This means you may need to initialize the global callback and properties for each window instance you create in your application.
+:::
+
 It's possible to re-expose a callback or properties from a global using the two way binding syntax.
 
 ```slint

--- a/docs/astro/src/content/docs/guide/language/coding/globals.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/globals.mdx
@@ -109,7 +109,7 @@ app.Logic.the_value = 42
 </Tabs>
 
 :::note[Note]
-Globals are not shared between windows.
+Global singletons are not shared between windows.
 This means you may need to initialize the global callback and properties for each window instance you create in your application.
 :::
 


### PR DESCRIPTION
As reported in #6877 and #9501
