### PR TITLE
Add assertions for clocks monotonicity

### DIFF
--- a/internal/core/animations.rs
+++ b/internal/core/animations.rs
@@ -249,7 +249,9 @@ impl AnimationDriver {
     /// Iterates through all animations based on the new time tick and updates their state. This should be called by
     /// the windowing system driver for every frame.
     pub fn update_animations(&self, new_tick: Instant) {
-        if self.global_instant.as_ref().get_untracked() != new_tick {
+        let current_tick = self.global_instant.as_ref().get_untracked();
+        assert!(current_tick <= new_tick, "The platform's clock is not monotonic!");
+        if current_tick != new_tick {
             self.active_animations.set(false);
             self.global_instant.as_ref().set(new_tick);
         }

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -94,7 +94,9 @@ pub trait Platform {
         #[cfg(feature = "std")]
         {
             let the_beginning = *INITIAL_INSTANT.get_or_init(time::Instant::now);
-            time::Instant::now() - the_beginning
+            let now = time::Instant::now();
+            assert!(now >= the_beginning, "The platform's clock is not monotonic!");
+            now - the_beginning
         }
         #[cfg(not(feature = "std"))]
         unimplemented!("The platform abstraction must implement `duration_since_start`")


### PR DESCRIPTION
It may not exactly be the solution requested in #3491, but after looking around the code I found the clock monotonicity is an invariant and `Duration` (base type `u64`) arithmetic may panic if new tick is lower than old one. It makes sense to assert the new value is higher than the current one. I'm not sure about risks on embedded targets, however.

I'm open to suggestions.

On the topic of warnings, I found only `debug_log!()` macro in `internal/core/tests.rs` - is this only logging available for Slint's internals?

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
