### PR TITLE
fix: button receives pressed event in Flickable(#9521)

### DIFF
--- a/internal/core/items/flickable.rs
+++ b/internal/core/items/flickable.rs
@@ -278,7 +278,7 @@ impl FlickableData {
                 if inner.capture_events {
                     InputEventFilterResult::Intercept
                 } else {
-                    InputEventFilterResult::DelayForwarding(FORWARD_DELAY.as_millis() as _)
+                    InputEventFilterResult::ForwardAndInterceptGrab
                 }
             }
             MouseEvent::Exit | MouseEvent::Released { button: PointerEventButton::Left, .. } => {


### PR DESCRIPTION
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`


Fixes: #9521