### PR TITLE
CI: Fix nightly tests on iOS

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -149,7 +149,7 @@ jobs:
                 - demo: demos/energy-monitor
                   scheme: "Energy Monitor"
                   bundle_id: dev.slint.demos.EnergyMonitor
-                  device: iPhone 16
+                  device: iPhone 17
         runs-on: macos-26
         steps:
             - uses: actions/checkout@v5


### PR DESCRIPTION
Upgrade to the latest Simulator installed on the macOS 26 image, in hope to fix hangs. That image has the latest iOS Simulator installed for iPhone 17 instead of 16.
