### PR TITLE
fontique: Fix text rendering with wasm32-unknown-unknown and QNX

### DIFF
--- a/internal/common/sharedfontique.rs
+++ b/internal/common/sharedfontique.rs
@@ -17,6 +17,18 @@ pub static COLLECTION: std::sync::LazyLock<Collection> = std::sync::LazyLock::ne
 
     let mut default_fonts: HashMap<std::path::PathBuf, fontique::QueryFont> = Default::default();
 
+    #[cfg(any(target_family = "wasm", target_os = "nto"))]
+    {
+        let data = include_bytes!("sharedfontique/DejaVuSans.ttf");
+        let fonts = collection.register_fonts(fontique::Blob::new(Arc::new(data)), None);
+        for script in fontique::Script::all_samples().iter().map(|(script, _)| *script) {
+            collection.append_fallbacks(
+                fontique::FallbackKey::new(script, None),
+                fonts.iter().map(|(family_id, _)| *family_id),
+            );
+        }
+    }
+
     let mut add_font_from_path = |path: std::path::PathBuf| {
         if let Ok(bytes) = std::fs::read(&path) {
             // just use the first font of the first family in the file.


### PR DESCRIPTION
When targeting wasm32-unknown-unknown, there's on system font fallback on fontique, because there isn't a way to discover and fetch fonts from. With QNX there are ways of discovering fonts on the file system, but neither we nor fontique do that yet.

So do what we did with fontdb: Include a trimmed version of DejaVu Sans and install it as fallback for everything.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
