### PR TITLE
parley: Apply elision only on the last line

### DIFF
--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -200,7 +200,8 @@ fn draw_glyphs<R: femtovg::Renderer + TextureImporter>(
     canvas: &mut Canvas<R>,
     paint: &mut femtovg::Paint,
 ) {
-    for line in layout.lines() {
+    for (line_index, line) in layout.lines().enumerate() {
+        let last_line = line_index == layout.len() - 1;
         for item in line.items() {
             match item {
                 parley::PositionedLayoutItem::GlyphRun(glyph_run) => {
@@ -211,33 +212,13 @@ fn draw_glyphs<R: femtovg::Renderer + TextureImporter>(
 
                     let brush = glyph_run.style().brush;
 
-                    let filtered_glyphs: Vec<_> = glyph_run
-                        .positioned_glyphs()
-                        .filter(|&glyph| {
-                            if let Some(info) = layout.elision_info_for_run(&glyph_run) {
-                                if info.positioned_glyph_needs_removal(glyph) {
-                                    return false;
-                                }
-                            }
-
-                            true
-                        })
-                        .collect();
-
-                    let glyphs = filtered_glyphs
-                        .iter()
-                        .map(|glyph| femtovg::PositionedGlyph {
+                    let glyphs = layout.glyphs_with_elision(&glyph_run, last_line).map(|glyph| {
+                        femtovg::PositionedGlyph {
                             x: glyph.x,
                             y: glyph.y + layout.y_offset,
                             glyph_id: glyph.id,
-                        })
-                        .chain(layout.elision_info_for_run(&glyph_run).and_then(|info| {
-                            filtered_glyphs.last().map(|last| femtovg::PositionedGlyph {
-                                x: last.x + last.advance + info.elipsis_glyph.x,
-                                y: info.elipsis_glyph.y + layout.y_offset,
-                                glyph_id: info.elipsis_glyph.id,
-                            })
-                        }));
+                        }
+                    });
 
                     paint.set_font_size(run.font_size());
 


### PR DESCRIPTION
When breaking multiples lines of text and the last line can't be broken anymore but exceeds the available width *and* overflow handling is set to elide, *then* apply the elision glyph substitution.

Also, centralize more of this inside just one glyph iterator, so that re-use in the other renderers will be trivial. This also avoids one extra vec allocation when collecting the glyphs.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
