### PR TITLE
feat: add space-evenly alignment to layout

### DIFF
--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -331,9 +331,12 @@ macro_rules! for_each_enums {
                 /// Use the preferred size for all elements, distribute remaining space evenly between
                 /// elements.
                 SpaceBetween,
+                /// Use the preferred size for all elements, distribute remaining space evenly
+                /// between the elements, and use half spaces at the start and end.
+                SpaceAround,
                 /// Use the preferred size for all elements, distribute remaining space evenly before the
                 /// first element, after the last element and between elements.
-                SpaceAround,
+                SpaceEvenly,
             }
 
             /// PathEvent is a low-level data structure describing the composition of a path. Typically it is

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -570,6 +570,10 @@ pub fn solve_box_layout(data: &BoxLayoutData, repeater_indexes: Slice<u32>) -> S
             let spacing = (size_without_padding - pref_size) / (num_spacings + 1 as Coord);
             Some((data.padding.begin + spacing / 2 as Coord, spacing))
         }
+        LayoutAlignment::SpaceEvenly => {
+            let spacing = (size_without_padding - pref_size) / (num_spacings + 2 as Coord);
+            Some((data.padding.begin + spacing, spacing))
+        }
     };
     if let Some((mut pos, spacing)) = align {
         for it in &mut layout_data {

--- a/ui-libraries/material/docs/src/content/collections/enums/LayoutAlignment.md
+++ b/ui-libraries/material/docs/src/content/collections/enums/LayoutAlignment.md
@@ -14,4 +14,5 @@ Enum representing the `alignment` property of a layout
 * **`start`**:  Use the preferred size for all elements, put remaining space after the last element.
 * **`end`**:  Use the preferred size for all elements, put remaining space before the first element.
 * **`space-between`**:  Use the preferred size for all elements, distribute remaining space evenly between elements.
-* **`space-around`**:  Use the preferred size for all elements, distribute remaining space evenly before the first element, after the last element and between elements.
+* **`space-around`**:  Use the preferred size for all elements, distribute remaining space evenly between the elements, and use half spaces at the start and end.
+* **`space-evenly`**:  Use the preferred size for all elements, distribute remaining space evenly before the first element, after the last element and between elements.


### PR DESCRIPTION
Add `space-evenly` to the layout options. These already included `space-around`, `space-between`, `start`, `end`, etc.

Also rewords the definition of `SpaceAround`, which now mentions that the spaces at the beginning and end are half spaces.

As for documentation, I included the definition inside [LayoutAlignment.md](https://github.com/slint-ui/slint/tree/master/ui-libraries/material/docs/src/content/collections/enums/LayoutAlignment.md), but I'm aware this would require future additions, such as in the official [docs](https://github.com/slint-ui/slint/tree/master/docs/astro/src/content/docs/guide/language/coding/positioning-and-layouts.mdx), where I found this missing feature in the first place.

These are fairly straightforward changes and should not break anything. I'd be happy to run the tests, but I am currently unsure how to do so.


Closes #9540
