### PR TITLE
compiler: Fix rust generated code adding a `;` in parentheses

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2415,7 +2415,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                     quote!(sp::PathData::Commands(#f))
                 }
                 (_, Type::Void) => {
-                    quote!(#f;)
+                    quote!({#f;})
                 }
                 _ => f,
             }

--- a/tests/cases/issues/issue_4942_no_else_value.slint
+++ b/tests/cases/issues/issue_4942_no_else_value.slint
@@ -8,10 +8,6 @@ export component TestCase {
         if (cond) {
             45
         }
-        // FIXME: Removing the following debug statement will cause a failure in C++ with this warning:
-        // error: unused parameter 'arg_0' [-Werror=unused-parameter]
-        // 115 | inline auto TestCase::fn_issue4942 (bool arg_0) const -> int{
-        debug(cond);
         12
     }
 
@@ -20,6 +16,11 @@ export component TestCase {
 
 
 /*
+
+FIXME:
+error: unused parameter 'arg_0' [-Werror=unused-parameter]
+inline auto TestCase::fn_issue4942 (bool arg_0) const -> int{
+gcc-args: -Wno-unused-parameter
 
 ```cpp
 auto handle = TestCase::create();

--- a/tests/cases/issues/issue_9546.slint
+++ b/tests/cases/issues/issue_9546.slint
@@ -1,0 +1,32 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Demo inherits Window {
+    function b(c:int,d:int) -> bool {
+        c == d
+    }
+
+    function a() {
+        if b(0,1) {
+            return;
+        }
+        b(0,1);
+    }
+
+    TouchArea {
+        clicked => {
+            a();
+            bar();
+        }
+    }
+
+
+    callback foo() -> int;
+    function bar() {
+        if foo() == 0 {
+            return;
+        }
+        foo();
+    }
+}
+

--- a/tests/cases/issues/issue_9546.slint
+++ b/tests/cases/issues/issue_9546.slint
@@ -30,3 +30,5 @@ export component Demo inherits Window {
     }
 }
 
+// gcc-args: -Wno-unused-value
+

--- a/tests/driver/cpp/cppdriver.rs
+++ b/tests/driver/cpp/cppdriver.rs
@@ -135,6 +135,15 @@ namespace slint_testing = slint::private_api::testing;
         compiler_command.arg(concat!("-L", env!("CPP_LIB_PATH")));
         compiler_command.arg("-lslint_cpp");
         compiler_command.arg("-o").arg(&*binary_path);
+
+        if let Some(x) = source.find("gcc-args:") {
+            for arg in source[x..].split_once(':').unwrap().1.split_once('\n').unwrap().0.split(' ')
+            {
+                if !arg.is_empty() {
+                    compiler_command.arg(arg);
+                }
+            }
+        }
     } else if compiler.is_like_msvc() {
         compiler_command.arg("/std:c++20");
         compiler_command.arg("/link").arg(concat!(env!("CPP_LIB_PATH"), "\\slint_cpp.dll.lib"));


### PR DESCRIPTION
A cast to void in an expression sometimes added a `;` at the wrong place.

Fixes #9546
