### PR TITLE
parley: Various cleanups and fixes

### DIFF
--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -598,6 +598,17 @@ pub trait GlyphRenderer: ItemRenderer {
         y_offset: f32,
         glyphs_it: &mut dyn Iterator<Item = parley::layout::Glyph>,
     );
+
+    /// Fills the given rectangle with the specified brush. This is used for drawing selection
+    /// rectangles as well as the text cursor.
+    fn fill_rectangle(
+        &mut self,
+        physical_x: f32,
+        physical_y: f32,
+        physical_width: f32,
+        physical_height: f32,
+        brush: Self::PlatformBrush,
+    );
 }
 
 /// Helper trait to express the features of an item renderer.

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -579,6 +579,9 @@ pub trait GlyphRenderer: ItemRenderer {
         size: LogicalSize,
     ) -> Option<Self::PlatformBrush>;
 
+    /// Returns a brush that's a solid fill of the specified color.
+    fn platform_brush_for_color(&mut self, color: &crate::Color) -> Self::PlatformBrush;
+
     /// Returns the brush to be used for stroking text.
     fn platform_text_stroke_brush(
         &mut self,

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -350,6 +350,46 @@ pub trait RenderText {
     }
 }
 
+impl RenderText for (SharedString, Brush) {
+    fn target_size(self: Pin<&Self>) -> LogicalSize {
+        LogicalSize::default()
+    }
+
+    fn text(self: Pin<&Self>) -> SharedString {
+        self.0.clone()
+    }
+
+    fn font_request(self: Pin<&Self>, _self_rc: &ItemRc) -> crate::graphics::FontRequest {
+        Default::default()
+    }
+
+    fn color(self: Pin<&Self>) -> Brush {
+        self.1.clone()
+    }
+
+    fn alignment(
+        self: Pin<&Self>,
+    ) -> (crate::items::TextHorizontalAlignment, crate::items::TextVerticalAlignment) {
+        Default::default()
+    }
+
+    fn wrap(self: Pin<&Self>) -> crate::items::TextWrap {
+        Default::default()
+    }
+
+    fn overflow(self: Pin<&Self>) -> crate::items::TextOverflow {
+        Default::default()
+    }
+
+    fn letter_spacing(self: Pin<&Self>) -> LogicalLength {
+        LogicalLength::default()
+    }
+
+    fn stroke(self: Pin<&Self>) -> (Brush, LogicalLength, TextStrokeStyle) {
+        Default::default()
+    }
+}
+
 /// Trait used to render each items.
 ///
 /// The item needs to be rendered relative to its (x,y) position. For example,
@@ -524,6 +564,40 @@ pub trait ItemRenderer {
     fn metrics(&self) -> crate::graphics::rendering_metrics_collector::RenderingMetrics {
         Default::default()
     }
+}
+
+/// Trait used for drawing text and text input elements with parley, where parley does the
+/// shaping and positioning, and the renderer is responsible for drawing just the glyphs.
+pub trait GlyphRenderer: ItemRenderer {
+    /// A renderer-specific type for a brush used for fill and stroke of glyphs.
+    type PlatformBrush;
+
+    /// Returns the brush to be used for filling text.
+    fn platform_text_fill_brush(
+        &mut self,
+        brush: Brush,
+        size: LogicalSize,
+    ) -> Option<Self::PlatformBrush>;
+
+    /// Returns the brush to be used for stroking text.
+    fn platform_text_stroke_brush(
+        &mut self,
+        brush: Brush,
+        physical_stroke_width: f32,
+        size: LogicalSize,
+    ) -> Option<Self::PlatformBrush>;
+
+    /// Draws the glyphs provided by glyphs_it with the specified font, font_size, and brush at the
+    /// given y offset.
+    fn draw_glyph_run(
+        &mut self,
+        font: &parley::Font,
+        font_size: f32,
+        brush: &Self::PlatformBrush,
+        stroke_style: &Option<TextStrokeStyle>,
+        y_offset: f32,
+        glyphs_it: &mut dyn Iterator<Item = parley::layout::Glyph>,
+    );
 }
 
 /// Helper trait to express the features of an item renderer.

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -566,54 +566,6 @@ pub trait ItemRenderer {
     }
 }
 
-/// Trait used for drawing text and text input elements with parley, where parley does the
-/// shaping and positioning, and the renderer is responsible for drawing just the glyphs.
-pub trait GlyphRenderer: ItemRenderer {
-    /// A renderer-specific type for a brush used for fill and stroke of glyphs.
-    type PlatformBrush;
-
-    /// Returns the brush to be used for filling text.
-    fn platform_text_fill_brush(
-        &mut self,
-        brush: Brush,
-        size: LogicalSize,
-    ) -> Option<Self::PlatformBrush>;
-
-    /// Returns a brush that's a solid fill of the specified color.
-    fn platform_brush_for_color(&mut self, color: &crate::Color) -> Self::PlatformBrush;
-
-    /// Returns the brush to be used for stroking text.
-    fn platform_text_stroke_brush(
-        &mut self,
-        brush: Brush,
-        physical_stroke_width: f32,
-        size: LogicalSize,
-    ) -> Option<Self::PlatformBrush>;
-
-    /// Draws the glyphs provided by glyphs_it with the specified font, font_size, and brush at the
-    /// given y offset.
-    fn draw_glyph_run(
-        &mut self,
-        font: &parley::Font,
-        font_size: f32,
-        brush: &Self::PlatformBrush,
-        stroke_style: &Option<TextStrokeStyle>,
-        y_offset: f32,
-        glyphs_it: &mut dyn Iterator<Item = parley::layout::Glyph>,
-    );
-
-    /// Fills the given rectangle with the specified brush. This is used for drawing selection
-    /// rectangles as well as the text cursor.
-    fn fill_rectangle(
-        &mut self,
-        physical_x: f32,
-        physical_y: f32,
-        physical_width: f32,
-        physical_height: f32,
-        brush: Self::PlatformBrush,
-    );
-}
-
 /// Helper trait to express the features of an item renderer.
 pub trait ItemRendererFeatures {
     /// The renderer supports applying 2D transformations to items.

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -525,3 +525,23 @@ pub fn draw_text_input(
         }
     }
 }
+
+pub fn text_size(
+    font_request: FontRequest,
+    text: &str,
+    max_width: Option<LogicalLength>,
+    scale_factor: ScaleFactor,
+    text_wrap: TextWrap,
+) -> LogicalSize {
+    let layout = layout(
+        text,
+        scale_factor,
+        LayoutOptions {
+            max_width,
+            text_wrap,
+            font_request: Some(font_request),
+            ..Default::default()
+        },
+    );
+    euclid::size2(layout.width(), layout.height()) / scale_factor
+}

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -545,3 +545,19 @@ pub fn text_size(
     );
     euclid::size2(layout.width(), layout.height()) / scale_factor
 }
+
+pub fn font_metrics(font_request: FontRequest) -> crate::items::FontMetrics {
+    let logical_pixel_size = font_request.pixel_size.unwrap_or(DEFAULT_FONT_SIZE).get();
+
+    let font = font_request.query_fontique().unwrap();
+    let face = sharedfontique::ttf_parser::Face::parse(font.blob.data(), font.index).unwrap();
+
+    let metrics = sharedfontique::DesignFontMetrics::new_from_face(&face);
+
+    crate::items::FontMetrics {
+        ascent: metrics.ascent * logical_pixel_size / metrics.units_per_em,
+        descent: metrics.descent * logical_pixel_size / metrics.units_per_em,
+        x_height: metrics.x_height * logical_pixel_size / metrics.units_per_em,
+        cap_height: metrics.cap_height * logical_pixel_size / metrics.units_per_em,
+    }
+}

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -9,13 +9,60 @@ use std::cell::RefCell;
 
 use crate::{
     graphics::FontRequest,
-    item_rendering::GlyphRenderer,
     items::TextStrokeStyle,
     lengths::{LogicalLength, LogicalSize, PhysicalPx, ScaleFactor, SizeLengths},
     textlayout::{TextHorizontalAlignment, TextOverflow, TextVerticalAlignment, TextWrap},
     Coord, SharedString,
 };
 use i_slint_common::sharedfontique;
+
+/// Trait used for drawing text and text input elements with parley, where parley does the
+/// shaping and positioning, and the renderer is responsible for drawing just the glyphs.
+pub trait GlyphRenderer: crate::item_rendering::ItemRenderer {
+    /// A renderer-specific type for a brush used for fill and stroke of glyphs.
+    type PlatformBrush;
+
+    /// Returns the brush to be used for filling text.
+    fn platform_text_fill_brush(
+        &mut self,
+        brush: crate::Brush,
+        size: LogicalSize,
+    ) -> Option<Self::PlatformBrush>;
+
+    /// Returns a brush that's a solid fill of the specified color.
+    fn platform_brush_for_color(&mut self, color: &crate::Color) -> Self::PlatformBrush;
+
+    /// Returns the brush to be used for stroking text.
+    fn platform_text_stroke_brush(
+        &mut self,
+        brush: crate::Brush,
+        physical_stroke_width: f32,
+        size: LogicalSize,
+    ) -> Option<Self::PlatformBrush>;
+
+    /// Draws the glyphs provided by glyphs_it with the specified font, font_size, and brush at the
+    /// given y offset.
+    fn draw_glyph_run(
+        &mut self,
+        font: &parley::Font,
+        font_size: f32,
+        brush: &Self::PlatformBrush,
+        stroke_style: &Option<TextStrokeStyle>,
+        y_offset: f32,
+        glyphs_it: &mut dyn Iterator<Item = parley::layout::Glyph>,
+    );
+
+    /// Fills the given rectangle with the specified brush. This is used for drawing selection
+    /// rectangles as well as the text cursor.
+    fn fill_rectangle(
+        &mut self,
+        physical_x: f32,
+        physical_y: f32,
+        physical_width: f32,
+        physical_height: f32,
+        brush: Self::PlatformBrush,
+    );
+}
 
 pub const DEFAULT_FONT_SIZE: LogicalLength = LogicalLength::new(12.);
 

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -412,7 +412,7 @@ pub fn draw_text_input(
             cursor_pos,
             Default::default(),
         );
-        let rect = cursor.geometry(&layout, (text_input.text_cursor_width()).get());
+        let rect = cursor.geometry(&layout, (text_input.text_cursor_width() * scale_factor).get());
 
         if let Some(cursor_brush) = item_renderer.platform_text_fill_brush(
             visual_representation.cursor_color.into(),

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -921,6 +921,10 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GlyphRenderer for GLItemRendere
         self.brush_to_paint(brush, &text_path)
     }
 
+    fn platform_brush_for_color(&mut self, color: &i_slint_core::Color) -> Self::PlatformBrush {
+        femtovg::Paint::color(to_femtovg_color(&color))
+    }
+
     fn platform_text_stroke_brush(
         &mut self,
         stroke_brush: Brush,

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -12,8 +12,8 @@ use i_slint_core::graphics::euclid::{self};
 use i_slint_core::graphics::rendering_metrics_collector::RenderingMetrics;
 use i_slint_core::graphics::{IntRect, Point, Size};
 use i_slint_core::item_rendering::{
-    CachedRenderingData, GlyphRenderer, ItemCache, ItemRenderer, RenderBorderRectangle,
-    RenderImage, RenderRectangle, RenderText,
+    CachedRenderingData, ItemCache, ItemRenderer, RenderBorderRectangle, RenderImage,
+    RenderRectangle, RenderText,
 };
 use i_slint_core::items::{
     self, Clip, FillRule, ImageRendering, ImageTiling, ItemRc, Layer, Opacity, RenderingResult,
@@ -23,7 +23,7 @@ use i_slint_core::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector,
     RectLengths, ScaleFactor,
 };
-use i_slint_core::textlayout::sharedparley::{self, parley};
+use i_slint_core::textlayout::sharedparley::{self, parley, GlyphRenderer};
 use i_slint_core::{Brush, Color, ImageInner, SharedString};
 
 use crate::images::TextureImporter;

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -296,14 +296,19 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         font_request: i_slint_core::graphics::FontRequest,
         _scale_factor: ScaleFactor,
     ) -> i_slint_core::items::FontMetrics {
+        let logical_pixel_size =
+            font_request.pixel_size.unwrap_or(sharedparley::DEFAULT_FONT_SIZE).get();
+
         let font = font_request.query_fontique().unwrap();
         let face = sharedfontique::ttf_parser::Face::parse(font.blob.data(), font.index).unwrap();
 
+        let metrics = sharedfontique::DesignFontMetrics::new_from_face(&face);
+
         i_slint_core::items::FontMetrics {
-            ascent: face.ascender() as _,
-            descent: face.descender() as _,
-            x_height: face.x_height().unwrap_or_default() as _,
-            cap_height: face.capital_height().unwrap_or_default() as _,
+            ascent: metrics.ascent * logical_pixel_size / metrics.units_per_em,
+            descent: metrics.descent * logical_pixel_size / metrics.units_per_em,
+            x_height: metrics.x_height * logical_pixel_size / metrics.units_per_em,
+            cap_height: metrics.cap_height * logical_pixel_size / metrics.units_per_em,
         }
     }
 

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -296,20 +296,7 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         font_request: i_slint_core::graphics::FontRequest,
         _scale_factor: ScaleFactor,
     ) -> i_slint_core::items::FontMetrics {
-        let logical_pixel_size =
-            font_request.pixel_size.unwrap_or(sharedparley::DEFAULT_FONT_SIZE).get();
-
-        let font = font_request.query_fontique().unwrap();
-        let face = sharedfontique::ttf_parser::Face::parse(font.blob.data(), font.index).unwrap();
-
-        let metrics = sharedfontique::DesignFontMetrics::new_from_face(&face);
-
-        i_slint_core::items::FontMetrics {
-            ascent: metrics.ascent * logical_pixel_size / metrics.units_per_em,
-            descent: metrics.descent * logical_pixel_size / metrics.units_per_em,
-            x_height: metrics.x_height * logical_pixel_size / metrics.units_per_em,
-            cap_height: metrics.cap_height * logical_pixel_size / metrics.units_per_em,
-        }
+        sharedparley::font_metrics(font_request)
     }
 
     fn text_input_byte_offset_for_position(

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -21,7 +21,7 @@ use i_slint_core::lengths::{
 };
 use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::RendererSealed;
-use i_slint_core::textlayout::sharedparley::{self, parley};
+use i_slint_core::textlayout::sharedparley;
 use i_slint_core::window::{WindowAdapter, WindowInner};
 use i_slint_core::Brush;
 use images::TextureImporter;
@@ -321,37 +321,11 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         font_request: FontRequest,
         scale_factor: ScaleFactor,
     ) -> LogicalRect {
-        let text = text_input.text();
-
-        let font_size = font_request.pixel_size.unwrap_or(sharedparley::DEFAULT_FONT_SIZE);
-
-        let width = text_input.width();
-        let height = text_input.height();
-        if width.get() <= 0. || height.get() <= 0. {
-            return LogicalRect::new(
-                LogicalPoint::default(),
-                LogicalSize::from_lengths(LogicalLength::new(1.0), font_size),
-            );
-        }
-
-        let layout = sharedparley::layout(
-            &text,
-            scale_factor,
-            sharedparley::LayoutOptions {
-                max_width: Some(width),
-                max_height: Some(height),
-                ..Default::default()
-            },
-        );
-        let cursor = parley::layout::cursor::Cursor::from_byte_index(
-            &layout,
+        sharedparley::text_input_cursor_rect_for_byte_offset(
+            text_input,
             byte_offset,
-            Default::default(),
-        );
-        let rect = cursor.geometry(&layout, (text_input.text_cursor_width()).get());
-        LogicalRect::new(
-            LogicalPoint::new(rect.min_x() as _, rect.min_y() as f32 + layout.y_offset),
-            LogicalSize::new(rect.width() as _, rect.height() as _),
+            font_request,
+            scale_factor,
         )
     }
 

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -288,17 +288,7 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         scale_factor: ScaleFactor,
         text_wrap: TextWrap,
     ) -> LogicalSize {
-        let layout = sharedparley::layout(
-            text,
-            scale_factor,
-            sharedparley::LayoutOptions {
-                max_width,
-                text_wrap,
-                font_request: Some(font_request),
-                ..Default::default()
-            },
-        );
-        PhysicalSize::new(layout.width(), layout.height()) / scale_factor
+        sharedparley::text_size(font_request, text, max_width, scale_factor, text_wrap)
     }
 
     fn font_metrics(

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -306,31 +306,12 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         font_request: FontRequest,
         scale_factor: ScaleFactor,
     ) -> usize {
-        let pos = pos * scale_factor;
-        let text = text_input.text();
-
-        let width = text_input.width();
-        let height = text_input.height();
-        if width.get() <= 0. || height.get() <= 0. || pos.y < 0. {
-            return 0;
-        }
-
-        let layout = sharedparley::layout(
-            &text,
+        sharedparley::text_input_byte_offset_for_position(
+            text_input,
+            pos,
+            font_request,
             scale_factor,
-            sharedparley::LayoutOptions {
-                font_request: Some(font_request),
-                max_width: Some(width),
-                max_height: Some(height),
-                vertical_align: text_input.vertical_alignment(),
-                ..Default::default()
-            },
-        );
-        let cursor =
-            parley::layout::cursor::Cursor::from_point(&layout, pos.x, pos.y - layout.y_offset);
-
-        let visual_representation = text_input.visual_representation(None);
-        visual_representation.map_byte_offset_from_byte_offset_in_visual_text(cursor.index())
+        )
     }
 
     fn text_input_cursor_rect_for_byte_offset(


### PR DESCRIPTION
This PR minimises the code in the FemtoVG renderer for text rendering and fixes two bugs with the text cursor and selection rendering.

cc #9559