### PR TITLE
Docs: Fix missing enums and structs

### DIFF
--- a/docs/common/src/utils/utils.ts
+++ b/docs/common/src/utils/utils.ts
@@ -17,7 +17,7 @@ export async function getEnumContent(enumName: string | undefined) {
     if (enumName) {
         try {
             const module = await import(
-                `../content/collections/enums/${enumName}.md`
+                `../../../astro/src/content/collections/enums/${enumName}.md`
             );
             return module.compiledContent();
         } catch (error) {
@@ -39,7 +39,7 @@ export async function getStructContent(
     if (baseStruct === "Time" || baseStruct === "Date") {
         try {
             const module = await import(
-                `../content/collections/std-widgets/${baseStruct}.md`
+                `../../../astro/src/content/collections/std-widgets/${baseStruct}.md`
             );
             return module.compiledContent();
         } catch (error) {
@@ -51,7 +51,7 @@ export async function getStructContent(
     if (baseStruct) {
         try {
             const module = await import(
-                `../content/collections/structs/${baseStruct}.md`
+                `../../../astro/src/content/collections/structs/${baseStruct}.md`
             );
             return module.compiledContent();
         } catch (error) {


### PR DESCRIPTION
This is a quick fix for now. However these files should be reusable by the Material docs as well and so a better way to make them generic AND NOT break the hot reload system is needed later.