### PR TITLE
live-preview: Fix broken header icons

### DIFF
--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -85,7 +85,8 @@ export component HeaderView {
                         horizontal-stretch: 0;
                         checkable: true;
                         icon: Icons.library;
-                        colorize-icon: true;
+                        colorize-icon: !self.checked;
+                        primary: self.checked;
                         clicked => {
                             root.library-toggled(self.checked);
                             library-widget = self.checked;
@@ -96,7 +97,8 @@ export component HeaderView {
                         horizontal-stretch: 0;
                         checkable: true;
                         icon: Icons.properties;
-                        colorize-icon: true;
+                        colorize-icon: !self.checked;
+                        primary: self.checked;
                         clicked => {
                             root.properties-toggled(self.checked);
                             properties-widget = self.checked;
@@ -107,7 +109,8 @@ export component HeaderView {
                         horizontal-stretch: 0;
                         checkable: true;
                         icon: Icons.outline;
-                        colorize-icon: true;
+                        colorize-icon: !self.checked;
+                        primary: self.checked;
                         clicked => {
                             root.outline-toggled(self.checked);
                             outline-widget = self.checked;
@@ -118,7 +121,8 @@ export component HeaderView {
                         horizontal-stretch: 0;
                         checkable: true;
                         icon: Icons.simulator;
-                        colorize-icon: true;
+                        colorize-icon: !self.checked;
+                        primary: self.checked;
                         clicked => {
                             root.simulator-toggled(self.checked);
                             data-widget = self.checked;


### PR DESCRIPTION
On MacOS the header icons have been broken since 1.13 in Dark mode.
<img width="262" height="53" alt="Screenshot 2025-10-01 at 17 30 41" src="https://github.com/user-attachments/assets/e0fcf2e1-4189-44bb-9f30-dd6366da12e6" />
This fixes them (also tested in light mode)
<img width="231" height="47" alt="Screenshot 2025-10-01 at 17 40 48" src="https://github.com/user-attachments/assets/cbfc72ab-0c08-4b0e-9275-a3382ed0594c" />
