### PR TITLE
live-preview: Auto highlight property on focus

### DIFF
--- a/tools/lsp/ui/components/widgets/basics.slint
+++ b/tools/lsp/ui/components/widgets/basics.slint
@@ -71,6 +71,9 @@ export component ResettingLineEdit {
                     // self.text = root.default-text;
                     root.can-compile = true;
                 }
+                if self.has_focus {
+                    self.select-all();
+                }
             }
         }
     }


### PR DESCRIPTION
When clicking a property the value was not being highlighted. So as you 
would type the value or '0' would be left and you would end up seeing 
`x: 030`. This now adds the expected behaviour where the value is 
highlighted on focus and typing replaces the whole value.