### PR TITLE
Link to global structs & enum page for enum properties

### DIFF
--- a/docs/common/src/utils/utils.ts
+++ b/docs/common/src/utils/utils.ts
@@ -126,7 +126,7 @@ export function getTypeInfo(typeName: KnownType): TypeInfo {
             };
         case "enum":
             return {
-                href: "", // No need to link here!
+                href: linkMap.EnumType.href,
                 defaultValue: "the first enum value",
             };
         case "float":

--- a/ui-libraries/material/docs/src/utils/utils.ts
+++ b/ui-libraries/material/docs/src/utils/utils.ts
@@ -120,7 +120,7 @@ export function getTypeInfo(typeName: KnownType): TypeInfo {
             };
         case "enum":
             return {
-                href: "", // No need to link here!
+                href: linkMap.EnumType.href,
                 defaultValue: "the first enum value",
             };
         case "float":


### PR DESCRIPTION
This had an entry in the linkMap, but was never hooked up and forgotten. It has the obvious limitation of not going to the specific enum you're looking for, but this is the same for struct properties anyway.
