### PR TITLE
Turn note in PopupWindow documentation into an actual note

### DIFF
--- a/docs/astro/src/content/docs/reference/window/popupwindow.mdx
+++ b/docs/astro/src/content/docs/reference/window/popupwindow.mdx
@@ -25,7 +25,9 @@ export component Example inherits Window {
 
 Use this element to show a popup window like a tooltip or a popup menu.
 
-Note: It isn't allowed to access properties of elements within the popup from outside of the `PopupWindow`.
+:::note{Note}
+It isn't allowed to access properties of elements within the popup from outside of the `PopupWindow`. See [#4438](https://github.com/slint-ui/slint/issues/4438).
+:::
 
 ## Properties
 


### PR DESCRIPTION
And also link to the relevant issue, in case someone wants to see if it's fixed in the future.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
