### PR TITLE
Link directly to individual global enums/structs in documentation

### DIFF
--- a/docs/common/src/components/SlintProperty.astro
+++ b/docs/common/src/components/SlintProperty.astro
@@ -57,6 +57,14 @@ const typeInfo = getTypeInfo(typeName);
 if (typeInfo.href !== "") {
     const base = import.meta.env.BASE_URL;
     typeInfo.href = `${base}${typeInfo.href}`;
+
+    // For enums and structs, we can assume they have a permalink to their header on the target page.
+    // (These permalinks are also always lower-case.)
+    if (typeName === "enum") {
+        typeInfo.href += "#" + enumName.toLowerCase();
+    } else if (typeName === "struct") {
+        typeInfo.href += "#" + structName.toLowerCase();
+    }
 }
 const enumContent = await getEnumContent(enumName);
 const structContent = await getStructContent(structName);


### PR DESCRIPTION
Previously, we sent users to the top of the page whenever they click on a property that refers to a global enum/struct in our documentation. However the page is already filled with permalinks we can use, so I made it so we assume there's a permalink.

If the permalink doesn't exist, it would just send them back to the top of the page anyway which was the previous status quo.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
