### PR TITLE
Add `enabled` property to animations to toggle them on/off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project are documented in this file.
  - Re-evaluate property bindings when a callback handler is changed from native code (#9551)
  - TextInput: allow setting the accessibility value
  - Add landmark accessible roles to `AccessibleRole` (#11831)
+ - `animate`: Added `enabled` boolean to toggle animations on/off (defaults to `true`). (#9604)
 
 ### Widgets
 

--- a/docs/astro/src/content/docs/guide/language/coding/animation.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/animation.mdx
@@ -70,3 +70,7 @@ Can be any of the following. See [`easings.net`](https://easings.net/) for a vis
 Use this to set or change the direction of the animation.
 </SlintProperty>
 
+### enabled
+<SlintProperty propName="enabled" typeName="bool" defaultValue="true">
+Controls whether the animation runs. When set to `false`, the property value changes immediately to its target without delay, easing, or iterations.
+</SlintProperty>

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2757,6 +2757,7 @@ component PropertyAnimation {
     in property <AnimationDirection> direction;
     in property <easing> easing;
     in property <float> iteration-count: 1.0;
+    in property <bool> enabled: true;
     //-is_non_item_type
 }
 

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -555,7 +555,13 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
             values: animation_fields()
                 .map(|(k, ty)| {
                     let e = a.borrow().bindings.get(&k).map_or_else(
-                        || llr_Expression::default_value_for_type(&ty).unwrap(),
+                        || {
+                            if k == "enabled" {
+                                llr_Expression::BoolLiteral(true)
+                            } else {
+                                llr_Expression::default_value_for_type(&ty).unwrap()
+                            }
+                        },
                         |v| lower_expression(&v.borrow().expression, ctx),
                     );
                     (k, e)
@@ -575,6 +581,7 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
             ),
             (SmolStr::new_static("easing"), Type::Easing),
             (SmolStr::new_static("delay"), Type::Int32),
+            (SmolStr::new_static("enabled"), Type::Bool),
         ])
     }
 
@@ -592,8 +599,21 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
                 name: "state".into(),
                 value: Box::new(lower_expression(state_ref, ctx)),
             };
-            let animation_ty = Type::Struct(animation_ty());
-            let mut get_anim = llr_Expression::default_value_for_type(&animation_ty).unwrap();
+            let anim_struct_ty = animation_ty();
+            let animation_ty = Type::Struct(anim_struct_ty.clone());
+            let mut get_anim = llr_Expression::Struct {
+                ty: anim_struct_ty,
+                values: animation_fields()
+                    .map(|(k, ty)| {
+                        let e = if k == "enabled" {
+                            llr_Expression::BoolLiteral(true)
+                        } else {
+                            llr_Expression::default_value_for_type(&ty).unwrap()
+                        };
+                        (k, e)
+                    })
+                    .collect(),
+            };
             for tr in animations.iter().rev() {
                 let condition = lower_expression(
                     &tr.condition(tree_Expression::ReadLocalVariable {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1228,6 +1228,8 @@ pub struct PropertyAnimation {
     pub direction: AnimationDirection,
     #[rtti_field]
     pub easing: crate::animations::EasingCurve,
+    #[rtti_field]
+    pub enabled: bool,
 }
 
 impl Default for PropertyAnimation {
@@ -1240,6 +1242,7 @@ impl Default for PropertyAnimation {
             iteration_count: 1.,
             direction: Default::default(),
             easing: Default::default(),
+            enabled: true,
         }
     }
 }

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -78,6 +78,11 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
 
     /// Single iteration of the animation
     pub fn compute_interpolated_value(&mut self) -> (T, bool) {
+        // If animation is disabled, immediately return the target value
+        if !self.details.enabled {
+            return (self.to_value.clone(), true);
+        }
+
         let new_tick = crate::animations::current_tick();
         let mut time_progress = new_tick.duration_since(self.start_time).as_millis() as u64;
         let reversed = |iteration: u64| -> bool {

--- a/tests/cases/properties/animation_enabled.slint
+++ b/tests/cases/properties/animation_enabled.slint
@@ -1,0 +1,306 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Rectangle {
+    // Static enabled values
+    in-out property <int> value-with-default: 100;
+    animate value-with-default {
+        duration: 1000ms;
+        // enabled defaults to true
+    }
+
+    in-out property <int> value-disabled: 100;
+    animate value-disabled {
+        duration: 1000ms;
+        enabled: false;
+    }
+
+    in-out property <int> value-enabled: 100;
+    animate value-enabled {
+        duration: 1000ms;
+        enabled: true;
+    }
+
+    // Dynamic enabled value, with the animated property set via setter
+    in-out property <bool> animation-enabled: true;
+    in-out property <int> value-dynamic: 100;
+    animate value-dynamic {
+        duration: 1000ms;
+        enabled: animation-enabled;
+    }
+
+    // Binding-driven case: the animated property is a binding whose
+    // value changes because of another property (issue #348 territory).
+    in-out property <bool> binding-source: false;
+    in-out property <bool> binding-anim-enabled: true;
+    out property <int> value-binding: binding-source ? 200 : 100;
+    animate value-binding {
+        duration: 1000ms;
+        enabled: binding-anim-enabled;
+    }
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+
+// --- Static enabled values via setter ---
+assert_eq!(instance.get_value_with_default(), 100);
+assert_eq!(instance.get_value_disabled(), 100);
+assert_eq!(instance.get_value_enabled(), 100);
+
+instance.set_value_with_default(200);
+instance.set_value_disabled(200);
+instance.set_value_enabled(200);
+
+// no time has elapsed yet
+assert_eq!(instance.get_value_with_default(), 100);
+assert_eq!(instance.get_value_disabled(), 200); // disabled: no animation
+assert_eq!(instance.get_value_enabled(), 100);
+
+// Half the animation
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_with_default(), 150);
+assert_eq!(instance.get_value_disabled(), 200);
+assert_eq!(instance.get_value_enabled(), 150);
+
+// Full animation
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_with_default(), 200);
+assert_eq!(instance.get_value_disabled(), 200);
+assert_eq!(instance.get_value_enabled(), 200);
+
+// --- Dynamic enabled toggled via setter on the animated property ---
+assert_eq!(instance.get_value_dynamic(), 100);
+
+// enabled=true (initial), value changes via setter -> animates
+instance.set_value_dynamic(300);
+assert_eq!(instance.get_value_dynamic(), 100);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_dynamic(), 200);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_dynamic(), 300);
+
+// disable, then set: should jump immediately
+instance.set_animation_enabled(false);
+instance.set_value_dynamic(100);
+assert_eq!(instance.get_value_dynamic(), 100);
+
+// re-enable, then set: should animate again
+instance.set_animation_enabled(true);
+instance.set_value_dynamic(500);
+assert_eq!(instance.get_value_dynamic(), 100);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_dynamic(), 300);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_dynamic(), 500);
+
+// --- Binding-driven case ---
+assert_eq!(instance.get_value_binding(), 100);
+
+// enabled=true, flip source -> animates
+instance.set_binding_source(true);
+assert_eq!(instance.get_value_binding(), 100);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_binding(), 150);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_binding(), 200);
+
+// disable, flip source -> jumps
+instance.set_binding_anim_enabled(false);
+instance.set_binding_source(false);
+assert_eq!(instance.get_value_binding(), 100);
+
+// re-enable, flip source -> animates
+instance.set_binding_anim_enabled(true);
+instance.set_binding_source(true);
+assert_eq!(instance.get_value_binding(), 100);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_binding(), 150);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_binding(), 200);
+
+// --- Mid-flight: setting `enabled` to false during an active animation
+// does not abort the animation, as animation parameters are snapshotted
+// when the animation starts (consistent with `duration`, `easing`, etc.). ---
+instance.set_binding_source(false); // flip back, start a new animation
+assert_eq!(instance.get_value_binding(), 200);
+slint_testing::mock_elapsed_time(250);
+assert_eq!(instance.get_value_binding(), 175); // 1/4 of the way
+
+instance.set_binding_anim_enabled(false); // toggle mid-flight; running animation keeps going
+slint_testing::mock_elapsed_time(250);
+assert_eq!(instance.get_value_binding(), 150);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_value_binding(), 100); // animation completed normally
+```
+
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+// --- Static enabled values via setter ---
+assert_eq(instance.get_value_with_default(), 100);
+assert_eq(instance.get_value_disabled(), 100);
+assert_eq(instance.get_value_enabled(), 100);
+
+instance.set_value_with_default(200);
+instance.set_value_disabled(200);
+instance.set_value_enabled(200);
+
+assert_eq(instance.get_value_with_default(), 100);
+assert_eq(instance.get_value_disabled(), 200);
+assert_eq(instance.get_value_enabled(), 100);
+
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_with_default(), 150);
+assert_eq(instance.get_value_disabled(), 200);
+assert_eq(instance.get_value_enabled(), 150);
+
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_with_default(), 200);
+assert_eq(instance.get_value_disabled(), 200);
+assert_eq(instance.get_value_enabled(), 200);
+
+// --- Dynamic enabled toggled via setter on the animated property ---
+assert_eq(instance.get_value_dynamic(), 100);
+
+instance.set_value_dynamic(300);
+assert_eq(instance.get_value_dynamic(), 100);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_dynamic(), 200);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_dynamic(), 300);
+
+instance.set_animation_enabled(false);
+instance.set_value_dynamic(100);
+assert_eq(instance.get_value_dynamic(), 100);
+
+instance.set_animation_enabled(true);
+instance.set_value_dynamic(500);
+assert_eq(instance.get_value_dynamic(), 100);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_dynamic(), 300);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_dynamic(), 500);
+
+// --- Binding-driven case ---
+assert_eq(instance.get_value_binding(), 100);
+
+instance.set_binding_source(true);
+assert_eq(instance.get_value_binding(), 100);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_binding(), 150);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_binding(), 200);
+
+instance.set_binding_anim_enabled(false);
+instance.set_binding_source(false);
+assert_eq(instance.get_value_binding(), 100);
+
+instance.set_binding_anim_enabled(true);
+instance.set_binding_source(true);
+assert_eq(instance.get_value_binding(), 100);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_binding(), 150);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_binding(), 200);
+
+// Mid-flight: toggling enabled during a running animation does not abort it.
+instance.set_binding_source(false);
+assert_eq(instance.get_value_binding(), 200);
+slint_testing::mock_elapsed_time(250);
+assert_eq(instance.get_value_binding(), 175);
+
+instance.set_binding_anim_enabled(false);
+slint_testing::mock_elapsed_time(250);
+assert_eq(instance.get_value_binding(), 150);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_value_binding(), 100);
+```
+
+```js
+var instance = new slint.TestCase({});
+
+// --- Static enabled values via setter ---
+assert.equal(instance.value_with_default, 100);
+assert.equal(instance.value_disabled, 100);
+assert.equal(instance.value_enabled, 100);
+
+instance.value_with_default = 200;
+instance.value_disabled = 200;
+instance.value_enabled = 200;
+
+assert.equal(instance.value_with_default, 100);
+assert.equal(instance.value_disabled, 200);
+assert.equal(instance.value_enabled, 100);
+
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_with_default, 150);
+assert.equal(instance.value_disabled, 200);
+assert.equal(instance.value_enabled, 150);
+
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_with_default, 200);
+assert.equal(instance.value_disabled, 200);
+assert.equal(instance.value_enabled, 200);
+
+// --- Dynamic enabled toggled via setter on the animated property ---
+assert.equal(instance.value_dynamic, 100);
+
+instance.value_dynamic = 300;
+assert.equal(instance.value_dynamic, 100);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_dynamic, 200);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_dynamic, 300);
+
+instance.animation_enabled = false;
+instance.value_dynamic = 100;
+assert.equal(instance.value_dynamic, 100);
+
+instance.animation_enabled = true;
+instance.value_dynamic = 500;
+assert.equal(instance.value_dynamic, 100);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_dynamic, 300);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_dynamic, 500);
+
+// --- Binding-driven case ---
+assert.equal(instance.value_binding, 100);
+
+instance.binding_source = true;
+assert.equal(instance.value_binding, 100);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_binding, 150);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_binding, 200);
+
+instance.binding_anim_enabled = false;
+instance.binding_source = false;
+assert.equal(instance.value_binding, 100);
+
+instance.binding_anim_enabled = true;
+instance.binding_source = true;
+assert.equal(instance.value_binding, 100);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_binding, 150);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_binding, 200);
+
+// Mid-flight: toggling enabled during a running animation does not abort it.
+instance.binding_source = false;
+assert.equal(instance.value_binding, 200);
+slintlib.private_api.mock_elapsed_time(250);
+assert.equal(instance.value_binding, 175);
+
+instance.binding_anim_enabled = false;
+slintlib.private_api.mock_elapsed_time(250);
+assert.equal(instance.value_binding, 150);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.value_binding, 100);
+```
+*/


### PR DESCRIPTION
This adds an `enabled` boolean property to the `animate` block, which defaults to `true`. When set to `false`, property changes apply immediately without animation, bypassing duration, easing, and iterations.

- Added `enabled` field to PropertyAnimation struct
- Updated compiler to handle enabled property with proper defaults
- Added runtime check to skip animation when disabled
- Included comprehensive tests for static and dynamic enabled values
- Updated documentation and CHANGELOG

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
