### PR TITLE
Material: Stop the APK building for external PR's

### DIFF
--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -35,6 +35,7 @@ jobs:
   wasm_demo:
       uses: ./.github/workflows/wasm_gallery.yaml
   apk_demo:
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       uses: ./.github/workflows/apk_gallery.yaml
       secrets:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -99,6 +100,7 @@ jobs:
           name: wasm_gallery
           path: ui-libraries/material/docs/dist/wasm
       - uses: actions/download-artifact@v5
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           name: apk_gallery
           path: ui-libraries/material/docs/dist/apk


### PR DESCRIPTION
Currently PR's that trigger the Material CI to run will fail for 
external PR's due to how the APK signing key needs to be secured. This 
PR skips the APK build for external PR's as we build it in a manual run 
only when we publish a new Material update.