### PR TITLE
Don't allow to undo/redo when textedit is readonly

### DIFF
--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -830,11 +830,11 @@ impl Item for TextInput {
                         StandardShortcut::Paste | StandardShortcut::Cut => {
                             return KeyEventResult::EventIgnored;
                         }
-                        StandardShortcut::Undo => {
+                        StandardShortcut::Undo if !self.read_only() => {
                             self.undo(window_adapter, self_rc);
                             return KeyEventResult::EventAccepted;
                         }
-                        StandardShortcut::Redo => {
+                        StandardShortcut::Redo if !self.read_only() => {
                             self.redo(window_adapter, self_rc);
                             return KeyEventResult::EventAccepted;
                         }


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
