### PR TITLE
If lineedit is disabled don't allow to show password or switching state.

### DIFF
--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -94,7 +94,7 @@ export component LineEdit {
                 }
             }
 
-            if root.input-type == InputType.password: LineEditPasswordIcon {
+            if root.input-type == InputType.password && root.enabled: LineEditPasswordIcon {
                 width: self.source.width * 1px;
                 show-password-image: @image-url("_view_reveal.svg");
                 hide-password-image: @image-url("_view_conceal.svg");

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -99,7 +99,7 @@ export component LineEdit {
                 horizontal-stretch: 1;
             }
 
-            if root.input-type == InputType.password: LineEditPasswordIcon {
+            if root.input-type == InputType.password && root.enabled: LineEditPasswordIcon {
                 width: self.source.width * 1px;
                 show-password-image: @image-url("_visibility.svg");
                 hide-password-image: @image-url("_visibility_off.svg");

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -104,7 +104,7 @@ export component LineEdit {
                 }
             }
 
-            if root.input-type == InputType.password && !root.text.is-empty && root.has-focus: LineEditPasswordIcon {
+            if root.input-type == InputType.password && !root.text.is-empty && root.has-focus && root.enabled: LineEditPasswordIcon {
                 width: self.source.width * 1px;
                 show-password-image: @image-url("_eye_show.svg");
                 hide-password-image: @image-url("_eye_hide.svg");

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -96,7 +96,7 @@ export component LineEdit {
                 }
             }
 
-            if root.input-type == InputType.password: LineEditPasswordIcon {
+            if root.input-type == InputType.password && root.enabled: LineEditPasswordIcon {
                 width: self.source.width * 1px;
                 show-password-image: @image-url("_visibility.svg");
                 hide-password-image: @image-url("_visibility_off.svg");

--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -91,7 +91,7 @@ export component LineEdit {
             }
         }
 
-        if root.input-type == InputType.password && !root.text.is-empty && root.has-focus: LineEditPasswordIcon {
+        if root.input-type == InputType.password && !root.text.is-empty && root.has-focus && root.enabled: LineEditPasswordIcon {
             width: self.source.width * 1px;
             show-password-image: @image-url("_visibility.svg");
             hide-password-image: @image-url("_visibility_off.svg");


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
