### PR TITLE
Qt: Emit scrolled callback when dragging scrollbar

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -658,6 +658,7 @@ export component NativeScrollView {
     in property <ScrollBarPolicy> vertical-scrollbar-policy;
     in property <ScrollBarPolicy> horizontal-scrollbar-policy;
     in property <bool> enabled: true;
+    callback scrolled;
     //-default_size_binding:expands_to_parent_geometry
     //-is_internal
 }

--- a/internal/compiler/widgets/qt/internal-scrollview.slint
+++ b/internal/compiler/widgets/qt/internal-scrollview.slint
@@ -39,6 +39,8 @@ export component InternalScrollView {
 
         horizontal-max: fli.viewport-width > fli.width ? fli.viewport-width - fli.width : 0phx;
         horizontal-page-size: fli.width;
+
+        scrolled => root.scrolled();
     }
 
     fli := Flickable {


### PR DESCRIPTION
This is supposed to be emitted whenever the user performs an intentional interaction, which works whenever you scroll the Slint Flickable with the scrollwheel. Dragging the scrollbar on the Qt style didn't do anything, since that was never hooked up to this callback.

I only implemented this in the Qt style, because that's the only one that uses the NativeScrollView element.

See #9574.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
