### PR TITLE
Reduce the height used by MenuSeparator for all styles

### DIFF
--- a/internal/compiler/widgets/cosmic/menu.slint
+++ b/internal/compiler/widgets/cosmic/menu.slint
@@ -52,7 +52,8 @@ export component MenuItem {
     callback clear-current <=> base.clear-current;
     callback activate <=> base.activate;
 
-    min-height: max(40px, base.min-height);
+    min-height: entry.is-separator ? 1px : max(40px, base.min-height);
+    max-height: entry.is-separator ? 1px : base.max-height;
 
     HorizontalLayout {
         base := MenuItemBase {

--- a/internal/compiler/widgets/cupertino/menu.slint
+++ b/internal/compiler/widgets/cupertino/menu.slint
@@ -51,7 +51,8 @@ export component MenuItem {
     callback clear-current <=> base.clear-current;
     callback activate <=> base.activate;
 
-    min-height: max(22px, base.min-height);
+    min-height: entry.is-separator ? 5px : max(22px, base.min-height);
+    max-height: entry.is-separator ? 5px : base.max-height;
 
     HorizontalLayout {
         base := MenuItemBase {

--- a/internal/compiler/widgets/fluent/menu.slint
+++ b/internal/compiler/widgets/fluent/menu.slint
@@ -53,7 +53,8 @@ export component MenuItem {
     callback clear-current <=> base.clear-current;
     callback activate <=> base.activate;
 
-    min-height: max(40px, base.min-height);
+    min-height: entry.is-separator ? 1px : max(40px, base.min-height);
+    max-height: entry.is-separator ? 1px : base.max-height;
 
     HorizontalLayout {
         padding: 5px;

--- a/internal/compiler/widgets/material/menu.slint
+++ b/internal/compiler/widgets/material/menu.slint
@@ -52,7 +52,8 @@ export component MenuItem {
     callback clear-current <=> base.clear-current;
     callback activate <=> base.activate;
 
-    min-height: max(40px, base.min-height);
+    min-height: entry.is-separator ? 1px : max(40px, base.min-height);
+    max-height: entry.is-separator ? 1px : base.max-height;
 
     HorizontalLayout {
         base := MenuItemBase {

--- a/internal/compiler/widgets/qt/menu.slint
+++ b/internal/compiler/widgets/qt/menu.slint
@@ -49,7 +49,8 @@ export component MenuItem {
     callback clear-current <=> base.clear-current;
     callback activate <=> base.activate;
 
-    min-height: max(40px, base.min-height);
+    min-height: entry.is-separator ? 1px : max(40px, base.min-height);
+    max-height: entry.is-separator ? 1px : base.max-height;
 
     HorizontalLayout {
         padding: 5px;


### PR DESCRIPTION
Fixes #8339. This reduces the height for the MenuSeparator element in all styles to become more compact.

| Fluent | Material | Cupertino | Cosmic | Qt |
|--------|--------|--------|--------|--------|
| <img width="758" height="879" alt="Screenshot_20251003_111952" src="https://github.com/user-attachments/assets/0000fe2d-2b28-434a-80ab-17e27135b496" /> | <img width="842" height="939" alt="Screenshot_20251003_112047" src="https://github.com/user-attachments/assets/801726e9-2e88-499d-98fd-78ee80d0e41d" /> | <img width="717" height="933" alt="Screenshot_20251003_112218" src="https://github.com/user-attachments/assets/f2aac2ad-8d70-48a4-bafd-c4d82d425052" /> | <img width="782" height="954" alt="Screenshot_20251003_112334" src="https://github.com/user-attachments/assets/dbf5f4f2-803e-41b5-a8e3-65b0bdf4517b" /> | <img width="707" height="818" alt="Screenshot_20251003_112422" src="https://github.com/user-attachments/assets/d7c5285e-4f9c-43d4-bca8-e76eb5e8cf90" /> | 

(I only really care about the Qt style, so if the height doesn't look right on the other styles that's out of ignorance and I can fix it :smile: )