### PR TITLE
Qt: Use selection colors from NativePalette for MenuItem/MenuBar

### DIFF
--- a/internal/compiler/widgets/qt/menu.slint
+++ b/internal/compiler/widgets/qt/menu.slint
@@ -17,10 +17,10 @@ export component MenuBarItem {
         top-padding: 4px;
         bottom-padding: 6px;
         default-foreground: NativePalette.foreground;
-        hover-foreground: NativePalette.accent-foreground;
-        pressed-foreground: NativePalette.accent-foreground;
-        hover-background: NativePalette.accent-background;
-        pressed-background: NativePalette.accent-background;
+        hover-foreground: NativePalette.selection-foreground;
+        pressed-foreground: NativePalette.selection-foreground;
+        hover-background: NativePalette.selection-background;
+        pressed-background: NativePalette.selection-background;
         font-weight: 300;
         border-radius: 3px;
     }
@@ -56,8 +56,8 @@ export component MenuItem {
 
         base := MenuItemBase {
             default-foreground: NativePalette.foreground;
-            current-foreground: NativePalette.accent-foreground;
-            current-background: NativePalette.accent-background;
+            current-foreground: NativePalette.selection-foreground;
+            current-background: NativePalette.selection-background;
             separator-color: NativePalette.border;
             font-weight: 300;
             border-radius: 4px;


### PR DESCRIPTION
This makes it much more readable for more on my KDE Plasma system. These colors are also meant for highlights/selection too, especially compared to the QPalette::Highlight/Accent which doesn't have enough contrast for text.

I also changed it for MenuBarItem.

| Before | After |
|--------|--------|
| <img width="325" height="321" alt="Screenshot_20251003_131943" src="https://github.com/user-attachments/assets/59729550-5bf1-4f1e-8fe3-91cd3a7082f0" /> | <img width="325" height="321" alt="Screenshot_20251003_131906" src="https://github.com/user-attachments/assets/4fe2fc5b-2689-442e-9210-53764e15898a" /> | 

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
