### PR TITLE
layout tests: add missing compiler-based tests

### DIFF
--- a/tests/cases/layout/grid_span.slint
+++ b/tests/cases/layout/grid_span.slint
@@ -55,7 +55,22 @@ export component TestCase inherits Window {
         rb.width == 40phx && rg.width == 20phx && rg.height == (400phx - 200phx - 100phx - 20phx) / 2 && rg.colspan == 1 &&
         zero.height == 0 && zero.width == rb.width && zero.x == rb.x && zero.y == rg.y &&
         zero2.height == rg.height && zero2.width == 0 && zero2.x > rb.x && zero2.y == rg.y && zero2.rowspan == 1 && zero2.colspan == 0
-
     }
 
 }
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+*/

--- a/tests/cases/layout/issue6285_auto_explicit_restrictions.slint
+++ b/tests/cases/layout/issue6285_auto_explicit_restrictions.slint
@@ -50,7 +50,7 @@ export component Bug6315  {
 }
 
 
-export component W inherits Window {
+export component TestCase inherits Window {
 
     Rectangle {
         VerticalLayout {
@@ -70,3 +70,19 @@ export component W inherits Window {
         && c2.min-height == 300px && c2.min-width == 200px
         && bug-6315.ok;
 }
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+*/

--- a/tests/cases/layout/opacity_in_layout.slint
+++ b/tests/cases/layout/opacity_in_layout.slint
@@ -38,3 +38,18 @@ export TestCase := Window {
     property <length> layout4_width : layout4.preferred-width;
     property<bool> test: layout1_height == 55px && layout2_width == 88px && layout3_width == 30px && layout4_width == 30px;
 }
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/layout/override_from_parent.slint
+++ b/tests/cases/layout/override_from_parent.slint
@@ -38,3 +38,19 @@ TestCase := Rectangle {
     sc4 := SubComp4 {}
     property<bool> test: sc1.min-width == 200px && sc2.min-width == 200px && sc3.max-width == 200px && sc4.min-width == 200px;
 }
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+*/
+

--- a/tests/cases/layout/text_no_wrap.slint
+++ b/tests/cases/layout/text_no_wrap.slint
@@ -21,3 +21,19 @@ TestCase := Rectangle {
 
     property <bool> test: square.width == square.height;
 }
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+*/


### PR DESCRIPTION
Those were interpreter-only tests, better check the compiled case too.

For completeness.