### PR TITLE
femtovg: Upgrade to wgpu 27

### DIFF
--- a/examples/bevy/Cargo.toml
+++ b/examples/bevy/Cargo.toml
@@ -19,7 +19,7 @@ name = "bevy_example"
 path = "main.rs"
 
 [dependencies]
-slint = { path = "../../api/rs/slint", features = ["unstable-wgpu-26", "renderer-skia"] }
+slint = { path = "../../api/rs/slint", features = ["unstable-wgpu-26"] }
 spin_on = { version = "0.1" }
 bevy = { version = "0.17.0", default-features = false, features = ["bevy_core_pipeline", "bevy_pbr", "bevy_window", "bevy_scene", "bevy_gltf", "bevy_log", "jpeg", "png", "tonemapping_luts", "multi_threaded", "reflect_auto_register", "debug"] }
 bevy_image = { version = "0.17.0", features = ["zstd_rust"] }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -41,7 +41,7 @@ x11 = [
   "softbuffer?/x11-dlopen",
 ]
 renderer-femtovg = ["i-slint-renderer-femtovg/opengl", "dep:glutin", "dep:glutin-winit"]
-renderer-femtovg-wgpu = ["i-slint-renderer-femtovg/wgpu", "dep:i-slint-renderer-femtovg", "unstable-wgpu-26"]
+renderer-femtovg-wgpu = ["i-slint-renderer-femtovg/wgpu", "dep:i-slint-renderer-femtovg", "unstable-wgpu-27"]
 renderer-skia = ["i-slint-renderer-skia"]
 renderer-skia-opengl = ["renderer-skia", "i-slint-renderer-skia/opengl"]
 renderer-skia-vulkan = ["renderer-skia", "i-slint-renderer-skia/vulkan"]
@@ -56,15 +56,15 @@ accessibility = ["dep:accesskit", "dep:accesskit_winit"]
 raw-window-handle-06 = ["i-slint-core/raw-window-handle-06"]
 unstable-wgpu-26 = [
   "i-slint-core/unstable-wgpu-26",
-  "renderer-femtovg-wgpu",
-  "i-slint-renderer-femtovg/unstable-wgpu-26",
-  "i-slint-renderer-skia?/unstable-wgpu-26",
+  "i-slint-renderer-femtovg?/unstable-wgpu-26",
+  "renderer-skia",
+  "i-slint-renderer-skia/unstable-wgpu-26",
 ]
 unstable-wgpu-27 = [
   "i-slint-core/unstable-wgpu-27",
-  "renderer-skia",
-  "i-slint-renderer-femtovg?/unstable-wgpu-27",
-  "i-slint-renderer-skia/unstable-wgpu-27",
+  "renderer-femtovg-wgpu",
+  "i-slint-renderer-femtovg/unstable-wgpu-27",
+  "i-slint-renderer-skia?/unstable-wgpu-27",
 ]
 default = []
 

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -385,14 +385,14 @@ impl BackendBuilder {
             #[cfg(feature = "renderer-femtovg-wgpu")]
             (Some("femtovg-wgpu"), maybe_graphics_api) => {
                 if !maybe_graphics_api.is_some_and(|_api| {
-                    #[cfg(feature = "unstable-wgpu-26")]
-                    if matches!(_api, RequestedGraphicsAPI::WGPU26(..)) {
+                    #[cfg(feature = "unstable-wgpu-27")]
+                    if matches!(_api, RequestedGraphicsAPI::WGPU27(..)) {
                         return true;
                     }
                     false
                 }) {
                     return Err(
-                        "The FemtoVG WGPU renderer only supports the WGPU26 graphics API selection"
+                        "The FemtoVG WGPU renderer only supports the WGPU27 graphics API selection"
                             .into(),
                     );
                 }
@@ -480,17 +480,17 @@ impl BackendBuilder {
             }
             #[cfg(feature = "unstable-wgpu-26")]
             (None, Some(RequestedGraphicsAPI::WGPU26(..))) => {
+                renderer::skia::WinitSkiaRenderer::new_wgpu_26_suspended
+            }
+            #[cfg(feature = "unstable-wgpu-27")]
+            (None, Some(RequestedGraphicsAPI::WGPU27(..))) => {
                 cfg_if::cfg_if! {
                     if #[cfg(enable_skia_renderer)] {
-                        renderer::skia::WinitSkiaRenderer::new_wgpu_26_suspended
+                        renderer::skia::WinitSkiaRenderer::new_wgpu_27_suspended
                     } else {
                         renderer::femtovg::WGPUFemtoVGRenderer::new_suspended
                     }
                 }
-            }
-            #[cfg(feature = "unstable-wgpu-27")]
-            (None, Some(RequestedGraphicsAPI::WGPU27(..))) => {
-                renderer::skia::WinitSkiaRenderer::new_wgpu_27_suspended
             }
             (None, Some(_requested_graphics_api)) => {
                 cfg_if::cfg_if! {

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -97,7 +97,7 @@ impl WGPUFemtoVGRenderer {
     pub fn new_suspended(
         shared_backend_data: &Rc<crate::SharedBackendData>,
     ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
-        if !i_slint_core::graphics::wgpu_26::any_wgpu26_adapters_with_gpu(
+        if !i_slint_core::graphics::wgpu_27::any_wgpu27_adapters_with_gpu(
             shared_backend_data._requested_graphics_api.clone(),
         ) {
             return Err(PlatformError::from("WGPU: No GPU adapters found"));

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -18,10 +18,10 @@ path = "lib.rs"
 [features]
 default = []
 opengl = []
-wgpu = ["wgpu-26"]
-wgpu-26 = ["dep:wgpu-26", "femtovg/wgpu", "i-slint-core/unstable-wgpu-26"]
-unstable-wgpu-26 = ["wgpu-26"]
-unstable-wgpu-27 = []
+wgpu = ["wgpu-27"]
+wgpu-27 = ["dep:wgpu-27", "femtovg/wgpu", "i-slint-core/unstable-wgpu-27"]
+unstable-wgpu-26 = []
+unstable-wgpu-27 = ["wgpu-27"]
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["default", "box-shadow-cache", "shared-fontique", "shared-parley"] }
@@ -34,14 +34,14 @@ cfg-if = "1"
 derive_more = { workspace = true }
 lyon_path = "1.0"
 pin-weak = "1"
-femtovg = { version = "0.18.1" }
+femtovg = { version = "0.19.0", default-features = false, features = ["image-loading"] }
 ttf-parser = { workspace = true }
 imgref = { version = "1.6.1" }
 rgb = { version = "0.8.27" }
 
 glow = { workspace = true }
 
-wgpu-26 = { workspace = true, optional = true, default-features = true }
+wgpu-27 = { workspace = true, optional = true, default-features = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { workspace = true, features = ["console", "WebGlContextAttributes", "CanvasRenderingContext2d", "HtmlInputElement", "HtmlCanvasElement", "Window", "Document"] }

--- a/internal/renderers/femtovg/font_cache.rs
+++ b/internal/renderers/femtovg/font_cache.rs
@@ -3,7 +3,6 @@
 
 // cspell:ignore Noto fontconfig
 
-use core::num::NonZeroUsize;
 use femtovg::TextContext;
 use i_slint_core::textlayout::sharedparley::parley;
 use std::cell::RefCell;
@@ -17,9 +16,6 @@ pub struct FontCache {
 impl Default for FontCache {
     fn default() -> Self {
         let text_context = TextContext::default();
-        text_context.resize_shaped_words_cache(NonZeroUsize::new(10_000_000).unwrap());
-        text_context.resize_shaping_run_cache(NonZeroUsize::new(1_000_000).unwrap());
-
         Self { text_context, fonts: Default::default() }
     }
 }

--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -21,8 +21,8 @@ where
     #[cfg(not(target_family = "wasm"))]
     fn convert_opengl_texture(opengl_texture: std::num::NonZero<u32>) -> Self::NativeTexture;
 
-    #[cfg(feature = "unstable-wgpu-26")]
-    fn convert_wgpu_26_texture(wgpu_texture: wgpu_26::Texture) -> Self::NativeTexture;
+    #[cfg(feature = "unstable-wgpu-27")]
+    fn convert_wgpu_27_texture(wgpu_texture: wgpu_27::Texture) -> Self::NativeTexture;
 }
 
 impl TextureImporter for femtovg::renderer::OpenGl {
@@ -31,8 +31,8 @@ impl TextureImporter for femtovg::renderer::OpenGl {
         glow::NativeTexture(opengl_texture)
     }
 
-    #[cfg(feature = "unstable-wgpu-26")]
-    fn convert_wgpu_26_texture(_wgpu_texture: wgpu_26::Texture) -> Self::NativeTexture {
+    #[cfg(feature = "unstable-wgpu-27")]
+    fn convert_wgpu_27_texture(_wgpu_texture: wgpu_27::Texture) -> Self::NativeTexture {
         unimplemented!()
     }
 }
@@ -43,8 +43,8 @@ impl TextureImporter for femtovg::renderer::WGPURenderer {
         todo!()
     }
 
-    #[cfg(feature = "unstable-wgpu-26")]
-    fn convert_wgpu_26_texture(wgpu_texture: wgpu_26::Texture) -> Self::NativeTexture {
+    #[cfg(feature = "unstable-wgpu-27")]
+    fn convert_wgpu_27_texture(wgpu_texture: wgpu_27::Texture) -> Self::NativeTexture {
         wgpu_texture
     }
 }
@@ -183,8 +183,8 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
                     )
                     .unwrap()
             }
-            #[cfg(all(not(target_arch = "wasm32"), feature = "unstable-wgpu-26"))]
-            ImageInner::WGPUTexture(i_slint_core::graphics::WGPUTexture::WGPU26Texture(
+            #[cfg(all(not(target_arch = "wasm32"), feature = "unstable-wgpu-27"))]
+            ImageInner::WGPUTexture(i_slint_core::graphics::WGPUTexture::WGPU27Texture(
                 texture,
             )) => {
                 let texture = texture.clone();
@@ -193,7 +193,7 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
                 canvas
                     .borrow_mut()
                     .create_image_from_native_texture(
-                        <R as TextureImporter>::convert_wgpu_26_texture(texture),
+                        <R as TextureImporter>::convert_wgpu_27_texture(texture),
                         femtovg::ImageInfo::new(
                             image_flags,
                             size.width as _,
@@ -203,8 +203,8 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
                     )
                     .unwrap()
             }
-            #[cfg(all(not(target_arch = "wasm32"), feature = "unstable-wgpu-27"))]
-            ImageInner::WGPUTexture(i_slint_core::graphics::WGPUTexture::WGPU27Texture(..)) => {
+            #[cfg(all(not(target_arch = "wasm32"), feature = "unstable-wgpu-26"))]
+            ImageInner::WGPUTexture(i_slint_core::graphics::WGPUTexture::WGPU26Texture(..)) => {
                 return None;
             }
             _ => {

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -39,7 +39,7 @@ mod images;
 mod itemrenderer;
 #[cfg(feature = "opengl")]
 pub mod opengl;
-#[cfg(feature = "wgpu-26")]
+#[cfg(feature = "wgpu-27")]
 pub mod wgpu;
 
 pub trait WindowSurface<R: femtovg::Renderer> {

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -7,7 +7,7 @@ use i_slint_core::{api::PhysicalSize as PhysicalWindowSize, graphics::RequestedG
 
 use crate::{FemtoVGRenderer, GraphicsBackend, WindowSurface};
 
-use wgpu_26 as wgpu;
+use wgpu_27 as wgpu;
 
 pub struct WGPUBackend {
     instance: RefCell<Option<wgpu::Instance>>,
@@ -73,7 +73,7 @@ impl GraphicsBackend for WGPUBackend {
         Ok(())
     }
 
-    #[cfg(feature = "unstable-wgpu-26")]
+    #[cfg(feature = "unstable-wgpu-27")]
     fn with_graphics_api<R>(
         &self,
         callback: impl FnOnce(Option<i_slint_core::api::GraphicsAPI<'_>>) -> R,
@@ -82,7 +82,7 @@ impl GraphicsBackend for WGPUBackend {
         let device = self.device.borrow().clone();
         let queue = self.queue.borrow().clone();
         if let (Some(instance), Some(device), Some(queue)) = (instance, device, queue) {
-            Ok(callback(Some(i_slint_core::graphics::create_graphics_api_wgpu_26(
+            Ok(callback(Some(i_slint_core::graphics::create_graphics_api_wgpu_27(
                 instance, device, queue,
             ))))
         } else {
@@ -90,7 +90,7 @@ impl GraphicsBackend for WGPUBackend {
         }
     }
 
-    #[cfg(not(feature = "unstable-wgpu-26"))]
+    #[cfg(not(feature = "unstable-wgpu-27"))]
     fn with_graphics_api<R>(
         &self,
         callback: impl FnOnce(Option<i_slint_core::api::GraphicsAPI<'_>>) -> R,
@@ -130,7 +130,7 @@ impl FemtoVGRenderer<WGPUBackend> {
         requested_graphics_api: Option<RequestedGraphicsAPI>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let (instance, adapter, device, queue, surface) =
-            i_slint_core::graphics::wgpu_26::init_instance_adapter_device_queue_surface(
+            i_slint_core::graphics::wgpu_27::init_instance_adapter_device_queue_surface(
                 window_handle,
                 requested_graphics_api,
                 /* rendering artifacts :( */


### PR DESCRIPTION
Also:
 - The newer version of femtovg permits disabling text layouting, so this means less dependencies
 - Skia is the only renderer left to support wgpu 26, so unstable-wgpu-26 now implies a dependency to renderer-skia

Closes #9605

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
