### PR TITLE
`Math.sign`: Change behavior to return 1 when 0

### DIFF
--- a/docs/astro/src/content/docs/reference/global-functions/math.mdx
+++ b/docs/astro/src/content/docs/reference/global-functions/math.mdx
@@ -63,12 +63,12 @@ Math.round(-1.2); // returns -1
 ```
 
 ### sign(float) -> float
-Returns 1 or -1, indicating the sign of the number passed as argument. Returns 0 if the input is 0 or -0.
+Returns 1 or -1, indicating the sign of the number passed as argument.
+Returns 1 if the input is 0.
 ```slint no-test
 Math.sign(10); // returns 1
 Math.sign(-30); // returns -1
-Math.sign(0); // returns 0
-Math.sign(-0); // returns 0
+Math.sign(0); // returns 1
 ```
 
 ### clamp(T, T, T) -> T

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -28,6 +28,25 @@ pub fn lower_macro(
         BuiltinMacroFunction::Clamp => clamp_macro(n, sub_expr.collect(), diag),
         BuiltinMacroFunction::Mod => mod_macro(n, sub_expr.collect(), diag),
         BuiltinMacroFunction::Abs => abs_macro(n, sub_expr.collect(), diag),
+        BuiltinMacroFunction::Sign => {
+            let Some((x, arg_node)) = sub_expr.next() else {
+                diag.push_error("Expected one argument".into(), n);
+                return Expression::Invalid;
+            };
+            if sub_expr.next().is_some() {
+                diag.push_error("Expected only one argument".into(), n);
+            }
+            Expression::Condition {
+                condition: Expression::BinaryExpression {
+                    lhs: x.maybe_convert_to(Type::Float32, &arg_node, diag).into(),
+                    rhs: Expression::NumberLiteral(0., Unit::None).into(),
+                    op: '<',
+                }
+                .into(),
+                true_expr: Expression::NumberLiteral(-1., Unit::None).into(),
+                false_expr: Expression::NumberLiteral(1., Unit::None).into(),
+            }
+        }
         BuiltinMacroFunction::Debug => debug_macro(n, sub_expr.collect(), diag),
         BuiltinMacroFunction::CubicBezier => {
             let mut has_error = None;

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -42,7 +42,6 @@ pub enum BuiltinFunction {
     Ln,
     Pow,
     Exp,
-    Sign,
     ToFixed,
     ToPrecision,
     SetFocusItem,
@@ -131,6 +130,8 @@ pub enum BuiltinMacroFunction {
     Mod,
     /// Add the right conversion operations so that the return type is the same as the argument type
     Abs,
+    /// Equivalent to `x < 0 ? -1 : 1`
+    Sign,
     CubicBezier,
     /// The argument can be r,g,b,a or r,g,b and they can be percentages or integer.
     /// transform the argument so it is always rgb(r, g, b, a) with r, g, b between 0 and 255.
@@ -188,7 +189,6 @@ declare_builtin_function_types!(
     Ln: (Type::Float32) -> Type::Float32,
     Pow: (Type::Float32, Type::Float32) -> Type::Float32,
     Exp: (Type::Float32) -> Type::Float32,
-    Sign: (Type::Float32) -> Type::Float32,
     ToFixed: (Type::Float32, Type::Int32) -> Type::String,
     ToPrecision: (Type::Float32, Type::Int32) -> Type::String,
     SetFocusItem: (Type::ElementReference) -> Type::Void,
@@ -320,7 +320,6 @@ impl BuiltinFunction {
             | BuiltinFunction::Exp
             | BuiltinFunction::ATan
             | BuiltinFunction::ATan2
-            | BuiltinFunction::Sign
             | BuiltinFunction::ToFixed
             | BuiltinFunction::ToPrecision => true,
             BuiltinFunction::SetFocusItem | BuiltinFunction::ClearFocusItem => false,
@@ -406,7 +405,6 @@ impl BuiltinFunction {
             | BuiltinFunction::ATan
             | BuiltinFunction::ATan2
             | BuiltinFunction::ToFixed
-            | BuiltinFunction::Sign
             | BuiltinFunction::ToPrecision => true,
             BuiltinFunction::SetFocusItem | BuiltinFunction::ClearFocusItem => false,
             BuiltinFunction::ShowPopupWindow

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3622,9 +3622,6 @@ fn compile_builtin_function_call(
             ctx.generator_state.conditional_includes.cmath.set(true);
             format!("std::exp({})", a.next().unwrap())
         }
-        BuiltinFunction::Sign => {
-            format!("[](auto a){{ return a == 0 ? 0 : a < 0 ? -1 : 1; }}({})", a.next().unwrap())
-        }
         BuiltinFunction::Sin => {
             ctx.generator_state.conditional_includes.cmath.set(true);
             format!("std::sin(({}) * {})", a.next().unwrap(), pi_180)

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3197,10 +3197,6 @@ fn compile_builtin_function_call(
             quote!((#a1 as f64).powf(#a2 as f64))
         }
         BuiltinFunction::Exp => quote!((#(#a)* as f64).exp()),
-        BuiltinFunction::Sign => quote!({
-            let x: f64 = (#(#a)*) as f64;
-            if x == 0.0 { 0.0 } else { x.signum() }
-        }),
         BuiltinFunction::ToFixed => {
             let (a1, a2) = (a.next().unwrap(), a.next().unwrap());
             quote!(sp::shared_string_from_number_fixed(#a1 as f64, (#a2 as i32).max(0) as usize))

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -106,7 +106,6 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::Ln => 10,
         BuiltinFunction::Pow => 10,
         BuiltinFunction::Exp => 10,
-        BuiltinFunction::Sign => 10,
         BuiltinFunction::ToFixed => ALLOC_COST,
         BuiltinFunction::ToPrecision => ALLOC_COST,
         BuiltinFunction::SetFocusItem | BuiltinFunction::ClearFocusItem => isize::MAX,

--- a/internal/compiler/tests/syntax/expressions/math-macro.slint
+++ b/internal/compiler/tests/syntax/expressions/math-macro.slint
@@ -58,4 +58,19 @@ export component Foo {
 
     property <float> sq2: 1.0.sqrt;
 //                            ^error{Member function must be called. Did you forgot the '()'?}
+
+    property <float> sign1: m1.sign;
+//                          ^error{Member function must be called. Did you forgot the '()'?}
+    property <float> sign2: Math.sign();
+//                               ^error{Expected one argument}
+    property <float> sign3: sign(1,2,3);
+//                          ^error{Expected only one argument}
+    property <float> sign4: sign(85px);
+//                               ^error{Cannot convert length to float. Divide by 1px to convert to a plain number}
+    property <float> sign5: sign("4");
+//                               ^error{Cannot convert string to float}
+    property <float> sign6: sign;
+//                          ^error{Builtin function must be called. Did you forgot the '()'?}
+    property <float> sign7: sign(4,6);
+//                          ^error{Expected only one argument}
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -524,10 +524,6 @@ fn call_builtin_function(
             let digits: usize = digits.max(0) as usize;
             Value::String(i_slint_core::string::shared_string_from_number_fixed(n, digits))
         }
-        BuiltinFunction::Sign => {
-            let x: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
-            Value::Number(if x == 0.0 { 0.0 } else { x.signum() })
-        }
         BuiltinFunction::ToPrecision => {
             let n: f64 = eval_expression(&arguments[0], local_context).try_into().unwrap();
             let precision: i32 = eval_expression(&arguments[1], local_context).try_into().unwrap();

--- a/tests/cases/expr/sign.slint
+++ b/tests/cases/expr/sign.slint
@@ -1,51 +1,56 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
-    property <float> t1: sign(0);
-    property <float> t2: sign(-0);
-    property <float> t3: sign(1);
-    property <float> t4: sign(-1);
-    property <float> t5: sign(-0.5);
-    property <float> t6: sign(-999);
-    property <float> t7: sign(123456);
-    property <float> t8: sign(0.123);
+export component TestCase  {
+    out property <float> t1: sign(0);
+    out property <float> t2: sign(-0);
+    out property <float> t3: sign(1);
+    out property <float> t4: sign(-1);
+    out property <float> t5: sign(-0.5);
+    out property <float> t6: sign(-999);
+    out property <float> t7: sign(123456);
+    out property <float> t8: sign(0.123);
+
+    out property <bool> test: (4).sign() == 1 && -5.8.sign() == -1;
 }
 /*
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
-assert_eq(instance.get_t1(), 0.0);
-assert_eq(instance.get_t2(), 0.0);
+assert_eq(instance.get_t1(), 1.0);
+assert_eq(instance.get_t2(), 1.0);
 assert_eq(instance.get_t3(), 1.0);
 assert_eq(instance.get_t4(), -1.0);
 assert_eq(instance.get_t5(), -1.0);
 assert_eq(instance.get_t6(), -1.0);
 assert_eq(instance.get_t7(), 1.0);
 assert_eq(instance.get_t8(), 1.0);
+assert_eq(instance.get_test(), true);
 ```
 
 ```rust
 let instance = TestCase::new().unwrap();
-assert_eq!(instance.get_t1(), 0.0);
-assert_eq!(instance.get_t2(), 0.0);
+assert_eq!(instance.get_t1(), 1.0);
+assert_eq!(instance.get_t2(), 1.0);
 assert_eq!(instance.get_t3(), 1.0);
 assert_eq!(instance.get_t4(), -1.0);
 assert_eq!(instance.get_t5(), -1.0);
 assert_eq!(instance.get_t6(), -1.0);
 assert_eq!(instance.get_t7(), 1.0);
 assert_eq!(instance.get_t8(), 1.0);
+assert_eq!(instance.get_test(), true);
 ```
 
 ```js
 var instance = new slint.TestCase({});
-assert.equal(instance.t1, 0.0);
-assert.equal(instance.t2, 0.0);
+assert.equal(instance.t1, 1.0);
+assert.equal(instance.t2, 1.0);
 assert.equal(instance.t3, 1.0);
 assert.equal(instance.t4, -1.0);
 assert.equal(instance.t5, -1);
 assert.equal(instance.t6, -1);
 assert.equal(instance.t7, 1);
 assert.equal(instance.t8, 1);
+assert_eq(instance.test, true);
 ```
 */


### PR DESCRIPTION
This is consistent to the Rust/C++ behavior
Even if this depart from the JS behavior

Also replace the funciton with a Macro

As discussed in https://github.com/slint-ui/slint/issues/9651#issuecomment-3376318439
