### PR TITLE
parley: Fix horizontal alignment for text input elements

### DIFF
--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -550,6 +550,7 @@ pub fn draw_text_input(
         LayoutOptions {
             max_width: Some(width),
             max_height: Some(height),
+            horizontal_align: text_input.horizontal_alignment(),
             vertical_align: text_input.vertical_alignment(),
             font_request,
             selection: Some(min_select..max_select),


### PR DESCRIPTION
Fixes #9675

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
