### PR TITLE
Python: Improve diagnostics around compile errors

### DIFF
--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -113,12 +113,12 @@ impl PyDiagnostic {
 
     #[getter]
     fn column_number(&self) -> usize {
-        self.0.line_column().0
+        self.0.line_column().1
     }
 
     #[getter]
     fn line_number(&self) -> usize {
-        self.0.line_column().1
+        self.0.line_column().0
     }
 
     #[getter]

--- a/api/python/slint/slint/__init__.py
+++ b/api/python/slint/slint/__init__.py
@@ -34,8 +34,11 @@ class CompileError(Exception):
 
     def __init__(self, message: str, diagnostics: list[native.PyDiagnostic]):
         """@private"""
+        super().__init__(message)
         self.message = message
         self.diagnostics = diagnostics
+        for diag in self.diagnostics:
+            self.add_note(str(diag))
 
 
 class Component:

--- a/api/python/slint/tests/test-file-error.slint
+++ b/api/python/slint/tests/test-file-error.slint
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+
+export component App inherits Window {
+    property <garbage> foo;
+    NewType { }
+}

--- a/api/python/slint/tests/test_load_file.py
+++ b/api/python/slint/tests/test_load_file.py
@@ -51,6 +51,25 @@ def test_load_file_fail() -> None:
         load_file("non-existent.slint")
 
 
+def test_compile_error() -> None:
+    with pytest.raises(CompileError) as excinfo:
+        load_file(base_dir() / "test-file-error.slint")
+    err = excinfo.value
+    diagnostics = err.diagnostics
+    assert len(diagnostics) == 2
+    assert diagnostics[0].message == "Unknown type 'garbage'"
+    assert diagnostics[0].line_number == 6
+    assert diagnostics[0].column_number == 15
+    assert diagnostics[1].message == "Unknown element 'NewType'"
+    assert diagnostics[1].line_number == 7
+    assert diagnostics[1].column_number == 5
+    path = base_dir() / "test-file-error.slint"
+    assert str(err) == f"Could not compile {path}"
+    assert len(err.__notes__) == 2
+    assert err.__notes__[0] == f"{path}:6: Unknown type 'garbage'"
+    assert err.__notes__[1] == f"{path}:7: Unknown element 'NewType'"
+
+
 def test_load_file_wrapper() -> None:
     module = load_file(base_dir() / "test-load-file.slint", quiet=False)
 


### PR DESCRIPTION
- Fix accidental swapping of line and column
- Use exception notes to feed the diagnostics into the exception in a more idiomatic manner

Fixes #5474

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
