### PR TITLE
feat(lsp): add format imports

### DIFF
--- a/tools/lsp/fmt/writer.rs
+++ b/tools/lsp/fmt/writer.rs
@@ -15,6 +15,12 @@ pub trait TokenWriter {
 
     /// Write contents and then the token to the writer.
     fn insert_before(&mut self, token: SyntaxToken, contents: &str) -> std::io::Result<()>;
+
+    /// Just write the given string to the writer.
+    ///
+    /// Useful for inserting tokens which are not required,
+    /// but do a pretty formatting.
+    fn insert_content(&mut self, contents: &str) -> std::io::Result<()>;
 }
 
 /// Just write the token stream to a file
@@ -34,5 +40,9 @@ impl<W: Write> TokenWriter for FileWriter<'_, W> {
     fn insert_before(&mut self, token: SyntaxToken, contents: &str) -> std::io::Result<()> {
         self.file.write_all(contents.as_bytes())?;
         self.file.write_all(token.text().as_bytes())
+    }
+
+    fn insert_content(&mut self, contents: &str) -> std::io::Result<()> {
+        self.file.write_all(contents.as_bytes())
     }
 }

--- a/tools/lsp/language/formatting.rs
+++ b/tools/lsp/language/formatting.rs
@@ -28,6 +28,11 @@ impl writer::TokenWriter for StringWriter {
         self.text += token.text();
         Ok(())
     }
+
+    fn insert_content(&mut self, contents: &str) -> std::io::Result<()> {
+        self.text += contents;
+        Ok(())
+    }
 }
 
 pub fn format_document(


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

This PR adds formatting for imports. I'm closing the other PR #9353. Apologies for the delay.

In this new style, these are some of the options:

### Single import stays in single line

In:

```slint
import {Foo} from "file.slint";
```

Out:
```slint
import { Foo } from "file.slint";
```

### Multiple imports stays in single line if below line length threshold

In:

```slint
import {Foo, Bar, Zar} from "file.slint";
```

Out:
```slint
import { Foo, Bar, Zar } from "file.slint";
```

### Many imports are multiline if above line length threshold

```slint
import { Foo, Bar as BarBer, Quz, Baz, Snaf, Tatta, Tar, Jar } from "./here.slint";
```

Out:
```slint
import {
    Foo,
    Bar as BarBer,
    Quz,
    Baz,
    Snaf,
    Tatta,
    Tar,
    Jar,
} from "./here.slint";
```

### Trailing comma forces new line (whether it's one or more)

In:

```slint
import {Foo,} from "file.slint";
```

Out:
```slint
import {
  Foo,
} from "file.slint";
```