### PR TITLE
home-automation: Enable tap toggle for overhead controls

### DIFF
--- a/demos/home-automation/ui/components/overhead.slint
+++ b/demos/home-automation/ui/components/overhead.slint
@@ -4,6 +4,7 @@ import { Palette, Measurements } from "../common.slint";
 import { FancySlider } from "general/fancySlider.slint";
 import { HaText } from "general/haText.slint";
 import { Control } from "control.slint";
+import { AppState } from "../appState.slint";
 
 export component Overhead inherits Control {
     show-label: false;
@@ -11,16 +12,15 @@ export component Overhead inherits Control {
     tile-shadow-blur: 0px;
     control-background: @image-url("../images/overhead-frame.png", nine-slice(50));
 
+    property <bool> is-dragging: false;
+    property <length> drag-threshold: 5px;
+    property <float> saved-value: 22;
+    property <float> drag-min-value: 5;
+
     in property <length> tilePadding: (root.height > Measurements.small-height-tile) ? 18px : 9px;
     tile := Rectangle {
         width: 100%;
         height: 100%;
-
-        TouchArea {
-            clicked => {
-                slider.toggle();
-            }
-        }
 
         VerticalLayout {
             alignment: space-between;
@@ -35,17 +35,25 @@ export component Overhead inherits Control {
             }
 
             slider := FancySlider {
+                minValue: 0;
+                maxValue: 24;
+                value: 22;
                 width: (root.height < Measurements.medium-height-tile) ? root.width - 0 - 18px : root.width * 0.8;
-                value: 0.0;
                 icon: @image-url("../images/brightness.svg");
             }
         }
     }
     TouchArea {
         clicked => {
-            if self.mouse-x == slider.initial-position {
+            AppState.end-kiosk-mode();
+            if !root.is-dragging {
                 slider.anim-duration = 300ms;
-                slider.animated-value = (self.mouse-x / self.width) * (slider.maxValue - slider.minValue) + slider.minValue;
+                if slider.value > 0 {
+                    root.saved-value = slider.value;
+                    slider.animated-value = 0;
+                } else {
+                    slider.animated-value = root.saved-value;
+                }
             }
         }
         moved => {
@@ -56,15 +64,23 @@ export component Overhead inherits Control {
                 slider.previous-value = slider.value;
                 slider.anim-duration = 0ms;
             } else {
-                slider.change-value = ((self.mouse-x / self.width) * (slider.maxValue - slider.minValue) + slider.minValue) - slider.initial-value;
-                slider.value = Math.clamp(slider.previous-value + slider.change-value, slider.minValue, slider.maxValue);
-                slider.animated-value = slider.value;
+                if Math.abs(self.mouse-x - slider.initial-position) > root.drag-threshold {
+                    root.is-dragging = true;
+                }
+
+                if root.is-dragging {
+                    slider.change-value = ((self.mouse-x / self.width) * (slider.maxValue - slider.minValue) + slider.minValue) - slider.initial-value;
+                    slider.value = Math.clamp(slider.previous-value + slider.change-value, root.drag-min-value, slider.maxValue);
+                    slider.animated-value = slider.value;
+                    root.saved-value = slider.value;
+                }
             }
         }
 
         changed pressed => {
             if !self.pressed {
                 slider.first-touch = false;
+                root.is-dragging = false;
             }
         }
     }


### PR DESCRIPTION
The overhead control had a button-like appearance but only responded to drag gestures. Add tap-to-toggle for on/off switching while preserving swipe for brightness adjustment. This provides more intuitive interaction matching the visual affordance of the UI element.

This applies the same changes from commit bf4ab9a01466c5523a988aa622899d99726794c7 (lamp controls) to the overhead component.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
