### PR TITLE
TextEdit: change the `has-focus` property to be an output property

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
@@ -47,7 +47,7 @@ TextEdit {
 </SlintProperty>
 
 ### has-focus
-<SlintProperty propName="has-focus" typeName="bool" propertyVisibility="in-out" >
+<SlintProperty propName="has-focus" typeName="bool" propertyVisibility="out" >
 Set to true when the widget currently has the focus.
 </SlintProperty>
 

--- a/internal/compiler/widgets/common/textedit-base.slint
+++ b/internal/compiler/widgets/common/textedit-base.slint
@@ -11,7 +11,7 @@ export component TextEditBase inherits Rectangle {
     in property <bool> read-only <=> text-input.read-only;
     in property <length> font-size <=> text-input.font-size;
     in property <bool> enabled <=> text-input.enabled;
-    in-out property <bool> has-focus: text-input.has-focus;
+    out property <bool> has-focus: text-input.has-focus;
     out property <length> visible-width <=> scroll-view.visible-width;
     out property <length> visible-height <=> scroll-view.visible-height;
     in-out property <string> text <=> text-input.text;

--- a/internal/compiler/widgets/cosmic/textedit.slint
+++ b/internal/compiler/widgets/cosmic/textedit.slint
@@ -12,7 +12,7 @@ export component TextEdit {
     in property <length> font-size <=> base.font-size;
     in property <bool> enabled <=> base.enabled;
     in property <string> placeholder-text <=> base.placeholder-text;
-    in-out property <bool> has-focus: base.has-focus;
+    out property <bool> has-focus: base.has-focus;
     out property <length> visible-width <=> base.visible-width;
     out property <length> visible-height <=> base.visible-height;
     in-out property <string> text <=> base.text;

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -14,8 +14,6 @@ component ScrollView {
     in-out property <length> viewport-height <=> flickable.viewport-height;
     in-out property <length> viewport-x <=> flickable.viewport-x;
     in-out property <length> viewport-y <=> flickable.viewport-y;
-    // FIXME: remove. This property is currently set by the ListView and is used by the native style to draw the scrollbar differently when it has focus
-    in-out property <bool> has-focus;
 
     min-height: 50px;
     min-width: 50px;
@@ -69,7 +67,7 @@ export component TextEdit {
     in property <bool> enabled <=> text-input.enabled;
     out property <length> visible-width <=> scroll-view.visible-width;
     out property <length> visible-height <=> scroll-view.visible-height;
-    in-out property <bool> has-focus: text-input.has-focus;
+    out property <bool> has-focus: text-input.has-focus;
     in-out property <string> text <=> text-input.text;
     in-out property <length> viewport-x <=> scroll-view.viewport-x;
     in-out property <length> viewport-y <=> scroll-view.viewport-y;

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -12,7 +12,7 @@ export component TextEdit {
     in property <length> font-size <=> base.font-size;
     in property <bool> enabled <=> base.enabled;
     in property <string> placeholder-text <=> base.placeholder-text;
-    in-out property <bool> has-focus: base.has-focus;
+    out property <bool> has-focus: base.has-focus;
     out property <length> visible-width <=> base.visible-width;
     out property <length> visible-height <=> base.visible-height;
     in-out property <string> text <=> base.text;

--- a/internal/compiler/widgets/material/textedit.slint
+++ b/internal/compiler/widgets/material/textedit.slint
@@ -12,7 +12,7 @@ export component TextEdit {
     in property <length> font-size <=> base.font-size;
     in property <bool> enabled <=> base.enabled;
     in property <string> placeholder-text <=> base.placeholder-text;
-    in-out property <bool> has-focus: base.has-focus;
+    out property <bool> has-focus: base.has-focus;
     out property <length> visible-width <=> base.visible-width;
     out property <length> visible-height <=> base.visible-height;
     in-out property <string> text <=> base.text;

--- a/internal/compiler/widgets/qt/textedit.slint
+++ b/internal/compiler/widgets/qt/textedit.slint
@@ -11,7 +11,7 @@ export component TextEdit {
     in property <length> font-size <=> base.font-size;
     in property <bool> enabled <=> base.enabled;
     in property <string> placeholder-text <=> base.placeholder-text;
-    in-out property <bool> has-focus: base.has-focus;
+    out property <bool> has-focus: base.has-focus;
     out property <length> visible-width <=> base.visible-width;
     out property <length> visible-height <=> base.visible-height;
     in-out property <string> text <=> base.text;


### PR DESCRIPTION
It was an oversight to be `in-out`

As discussed in #9661
