### PR TITLE
software renderer: Remove rustybuzz dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,8 @@ wgpu-27 = { package = "wgpu", version = "27", default-features = false }
 input = { version = "0.9.0", default-features = false }
 tr = { version = "0.1", default-features = false }
 fontique = { version = "0.6.0" }
+read-fonts = { version = "0.35" }
+skrifa = { version = "0.37" }
 windows = { version = "0.62" }
 windows-core = { version = "0.62.0" }
 

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -48,7 +48,7 @@ unsafe-single-threaded = []
 
 unicode = ["unicode-script", "unicode-linebreak"]
 
-software-renderer-systemfonts = ["shared-fontique", "rustybuzz", "fontdue", "software-renderer", "shared-parley"]
+software-renderer-systemfonts = ["shared-fontique", "skrifa", "fontdue", "software-renderer", "shared-parley"]
 software-renderer = ["bytemuck"]
 
 image-decoders = ["dep:image", "dep:clru"]
@@ -117,8 +117,7 @@ raw-window-handle-06 = { workspace = true, optional = true }
 bitflags = { version = "2.4.2" }
 
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
-
-rustybuzz = { workspace = true, optional = true }
+skrifa = { workspace = true, optional = true }
 fontdue = { workspace = true, optional = true }
 
 wgpu-26 = { workspace = true, optional = true }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -108,7 +108,7 @@ foreign-types = { version = "0.5.0", optional = true }
 wgpu-26 = { workspace = true, optional = true, features = ["metal"] }
 wgpu-27 = { workspace = true, optional = true, features = ["metal"] }
 
-read-fonts = { version = "0.35" }
+read-fonts = { workspace = true }
 write-fonts = { version = "0.43" }
 
 [target.'cfg(not(any(target_vendor = "apple", target_family = "windows")))'.dependencies]


### PR DESCRIPTION
We're not going to go down the route and do full text layout with our own text layouting, so for the system-fonts case without parley, eliminate the rustybuzz dependency.

It'll remain a dependency with resvg, but that might go away in the future. The skrifa/read-fonts dependencies aren't new, they're part of the parley dependencies.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
