### PR TITLE
property_tracker: don't register dependencies for tracker that don't …

### DIFF
--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -163,15 +163,15 @@ impl PropertyDirtyHandler for FocusDelegationPropertyTracker {
 #[pin_project]
 pub struct SlintAccessibleItemData {
     #[pin]
-    state_tracker: PropertyTracker<AccessibleItemPropertiesTracker>,
+    state_tracker: PropertyTracker<false, AccessibleItemPropertiesTracker>,
     #[pin]
-    value_tracker: PropertyTracker<ValuePropertyTracker>,
+    value_tracker: PropertyTracker<false, ValuePropertyTracker>,
     #[pin]
-    label_tracker: PropertyTracker<LabelPropertyTracker>,
+    label_tracker: PropertyTracker<false, LabelPropertyTracker>,
     #[pin]
-    description_tracker: PropertyTracker<DescriptionPropertyTracker>,
+    description_tracker: PropertyTracker<false, DescriptionPropertyTracker>,
     #[pin]
-    focus_delegation_tracker: PropertyTracker<FocusDelegationPropertyTracker>,
+    focus_delegation_tracker: PropertyTracker<false, FocusDelegationPropertyTracker>,
     item: ItemWeak,
 }
 

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -44,7 +44,7 @@ pub struct AccessKitAdapter {
     inner: accesskit_winit::Adapter,
     window_adapter_weak: Weak<WinitWindowAdapter>,
     nodes: NodeCollection,
-    global_property_tracker: Pin<Box<PropertyTracker<AccessibilitiesPropertyTracker>>>,
+    global_property_tracker: Pin<Box<AccessibilityPropertyTracker>>,
     pending_update: bool,
     initial_tree_sent: bool,
 }
@@ -77,7 +77,9 @@ impl AccessKitAdapter {
                 )),
             },
             global_property_tracker: Box::pin(PropertyTracker::new_with_dirty_handler(
-                AccessibilitiesPropertyTracker { window_adapter_weak: window_adapter_weak.clone() },
+                AccessibilityPropertyDirtyHandler {
+                    window_adapter_weak: window_adapter_weak.clone(),
+                },
             )),
             pending_update: false,
             initial_tree_sent: false,
@@ -280,7 +282,7 @@ struct NodeCollection {
     component_ids: HashMap<NonNull<u8>, u32>,
     all_nodes: Vec<CachedNode>,
     root_node_id: NodeId,
-    focused_node_tracker: Pin<Box<PropertyTracker<DelegateFocusPropertyTracker>>>,
+    focused_node_tracker: Pin<Box<PropertyTracker<false, DelegateFocusPropertyTracker>>>,
 }
 
 impl NodeCollection {
@@ -421,7 +423,7 @@ impl NodeCollection {
     fn build_new_tree(
         &mut self,
         window_adapter_weak: &Weak<WinitWindowAdapter>,
-        property_tracker: Pin<&PropertyTracker<AccessibilitiesPropertyTracker>>,
+        property_tracker: Pin<&AccessibilityPropertyTracker>,
     ) -> TreeUpdate {
         let Some(window_adapter) = window_adapter_weak.upgrade() else {
             return TreeUpdate {
@@ -705,11 +707,13 @@ impl NodeCollection {
     }
 }
 
-struct AccessibilitiesPropertyTracker {
+type AccessibilityPropertyTracker = PropertyTracker<true, AccessibilityPropertyDirtyHandler>;
+
+struct AccessibilityPropertyDirtyHandler {
     window_adapter_weak: Weak<WinitWindowAdapter>,
 }
 
-impl i_slint_core::properties::PropertyDirtyHandler for AccessibilitiesPropertyTracker {
+impl i_slint_core::properties::PropertyDirtyHandler for AccessibilityPropertyDirtyHandler {
     fn notify(self: Pin<&Self>) {
         let win = self.window_adapter_weak.clone();
         i_slint_core::timers::Timer::single_shot(Default::default(), move || {

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -19,7 +19,7 @@ use winit::window::Window;
 
 pub struct MudaAdapter {
     entries: Vec<MenuEntry>,
-    tracker: Option<Pin<Box<PropertyTracker<MudaPropertyTracker>>>>,
+    tracker: Option<Pin<Box<PropertyTracker<false, MudaPropertyTracker>>>>,
     menu: muda::Menu,
 }
 

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1474,7 +1474,7 @@ mod tests {
     fn test_tracking_model_handle() {
         let model: Rc<VecModel<u8>> = Rc::new(Default::default());
         let handle = ModelRc::from(model.clone() as Rc<dyn Model<Data = u8>>);
-        let tracker = Box::pin(crate::properties::PropertyTracker::default());
+        let tracker = Box::pin(<crate::properties::PropertyTracker>::default());
         assert_eq!(
             tracker.as_ref().evaluate(|| {
                 handle.model_tracker().track_row_count_changes();
@@ -1514,7 +1514,7 @@ mod tests {
     fn test_data_tracking() {
         let model: Rc<VecModel<u8>> = Rc::new(VecModel::from(vec![0, 1, 2, 3, 4]));
         let handle = ModelRc::from(model.clone());
-        let tracker = Box::pin(crate::properties::PropertyTracker::default());
+        let tracker = Box::pin(<crate::properties::PropertyTracker>::default());
         assert_eq!(
             tracker.as_ref().evaluate(|| {
                 handle.model_tracker().track_row_data_changes(1);

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -1680,13 +1680,19 @@ impl<F: Fn()> PropertyDirtyHandler for F {
     }
 }
 
-/// This structure allow to run a closure that queries properties, and can report
-/// if any property we accessed have become dirty
-pub struct PropertyTracker<DirtyHandler = ()> {
+/// A PropertyTracker tracks which properties are accessed during evaluation,
+/// and can notify when those properties change.
+///
+/// The `NEEDS_SET_DIRTY` const parameter controls whether this tracker
+/// supports being dirtied externally via [`PropertyTracker::set_dirty`].
+/// When `false` (the default), the tracker can be more efficient: it will
+/// skip registering itself as a dependency of outer bindings if it has no
+/// tracked dependencies of its own, since there is no external way to dirty it.
+pub struct PropertyTracker<const NEEDS_SET_DIRTY: bool = false, DirtyHandler = ()> {
     holder: BindingHolder<DirtyHandler>,
 }
 
-impl Default for PropertyTracker<()> {
+impl<const NEEDS_SET_DIRTY: bool> Default for PropertyTracker<NEEDS_SET_DIRTY, ()> {
     fn default() -> Self {
         static VT: &BindingVTable = &BindingVTable {
             drop: |_| (),
@@ -1711,7 +1717,9 @@ impl Default for PropertyTracker<()> {
     }
 }
 
-impl<DirtyHandler> Drop for PropertyTracker<DirtyHandler> {
+impl<const NEEDS_SET_DIRTY: bool, DirtyHandler> Drop
+    for PropertyTracker<NEEDS_SET_DIRTY, DirtyHandler>
+{
     fn drop(&mut self) {
         unsafe {
             DependencyListHead::drop(self.holder.dependencies.as_ptr() as *mut DependencyListHead);
@@ -1719,7 +1727,9 @@ impl<DirtyHandler> Drop for PropertyTracker<DirtyHandler> {
     }
 }
 
-impl<DirtyHandler: PropertyDirtyHandler> PropertyTracker<DirtyHandler> {
+impl<const NEEDS_SET_DIRTY: bool, DirtyHandler: PropertyDirtyHandler>
+    PropertyTracker<NEEDS_SET_DIRTY, DirtyHandler>
+{
     #[cfg(slint_debug_property)]
     /// set the debug name when `cfg(slint_debug_property`
     pub fn set_debug_name(&mut self, debug_name: alloc::string::String) {
@@ -1729,8 +1739,8 @@ impl<DirtyHandler: PropertyDirtyHandler> PropertyTracker<DirtyHandler> {
     /// Register this property tracker as a dependency to the current binding/property tracker being evaluated
     pub fn register_as_dependency_to_current_binding(self: Pin<&Self>) {
         let dep_nodes = self.holder.dep_nodes.take();
-        if dep_nodes.is_empty() {
-            // No need to register dependency if we have no dependency ourselves
+        if !NEEDS_SET_DIRTY && dep_nodes.is_empty() {
+            // No need to register dependency if we have no dependency ourselves (we can never become dirty)
             return;
         }
         self.holder.dep_nodes.set(dep_nodes);
@@ -1792,12 +1802,6 @@ impl<DirtyHandler: PropertyDirtyHandler> PropertyTracker<DirtyHandler> {
         r
     }
 
-    /// Mark this PropertyTracker as dirty
-    pub fn set_dirty(&self) {
-        self.holder.dirty.set(true);
-        unsafe { mark_dependencies_dirty(self.holder.dependencies.as_ptr() as *mut _) };
-    }
-
     /// Sets the specified callback handler function, which will be called if any
     /// properties that this tracker depends on becomes dirty.
     ///
@@ -1849,6 +1853,14 @@ impl<DirtyHandler: PropertyDirtyHandler> PropertyTracker<DirtyHandler> {
     }
 }
 
+impl<DirtyHandler> PropertyTracker<true, DirtyHandler> {
+    /// Mark this PropertyTracker as dirty
+    pub fn set_dirty(&self) {
+        self.holder.dirty.set(true);
+        unsafe { mark_dependencies_dirty(self.holder.dependencies.as_ptr() as *mut _) };
+    }
+}
+
 #[test]
 fn test_property_handler_binding() {
     assert_eq!(PropertyHandle::has_no_binding_or_lock(BINDING_BORROWED), false);
@@ -1888,8 +1900,8 @@ fn test_property_listener_scope() {
 
 #[test]
 fn test_nested_property_trackers() {
-    let tracker1 = Box::pin(PropertyTracker::default());
-    let tracker2 = Box::pin(PropertyTracker::default());
+    let tracker1 = Box::pin(<PropertyTracker>::default());
+    let tracker2 = Box::pin(<PropertyTracker>::default());
     let prop = Box::pin(Property::new(42));
 
     let r = tracker1.as_ref().evaluate(|| tracker2.as_ref().evaluate(|| prop.as_ref().get()));
@@ -1911,7 +1923,7 @@ fn test_nested_property_trackers() {
 #[test]
 fn test_property_dirty_handler() {
     let call_flag = Rc::new(Cell::new(false));
-    let tracker = Box::pin(PropertyTracker::new_with_dirty_handler({
+    let tracker = Box::pin(PropertyTracker::<false, _>::new_with_dirty_handler({
         let call_flag = call_flag.clone();
         move || {
             (*call_flag).set(true);
@@ -1939,8 +1951,8 @@ fn test_property_dirty_handler() {
 
 #[test]
 fn test_property_tracker_drop() {
-    let outer_tracker = Box::pin(PropertyTracker::default());
-    let inner_tracker = Box::pin(PropertyTracker::default());
+    let outer_tracker = Box::pin(<PropertyTracker>::default());
+    let inner_tracker = Box::pin(<PropertyTracker>::default());
     let prop = Box::pin(Property::new(42));
 
     let r =
@@ -1953,8 +1965,8 @@ fn test_property_tracker_drop() {
 
 #[test]
 fn test_nested_property_tracker_dirty() {
-    let outer_tracker = Box::pin(PropertyTracker::default());
-    let inner_tracker = Box::pin(PropertyTracker::default());
+    let outer_tracker = Box::pin(PropertyTracker::<true, ()>::default());
+    let inner_tracker = Box::pin(PropertyTracker::<true, ()>::default());
     let prop = Box::pin(Property::new(42));
 
     let r =
@@ -1973,8 +1985,8 @@ fn test_nested_property_tracker_dirty() {
 #[test]
 #[allow(clippy::redundant_closure)]
 fn test_nested_property_tracker_evaluate_if_dirty() {
-    let outer_tracker = Box::pin(PropertyTracker::default());
-    let inner_tracker = Box::pin(PropertyTracker::default());
+    let outer_tracker = Box::pin(<PropertyTracker>::default());
+    let inner_tracker = Box::pin(<PropertyTracker>::default());
     let prop = Box::pin(Property::new(42));
 
     let mut cache = 0;

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -426,10 +426,10 @@ pub struct PopupWindow {
 #[pin_project::pin_project]
 struct WindowPinnedFields {
     #[pin]
-    redraw_tracker: PropertyTracker<WindowRedrawTracker>,
+    redraw_tracker: PropertyTracker<false, WindowRedrawTracker>,
     /// Gets dirty when the layout restrictions, or some other property of the windows change
     #[pin]
-    window_properties_tracker: PropertyTracker<WindowPropertiesTracker>,
+    window_properties_tracker: PropertyTracker<true, WindowPropertiesTracker>,
     #[pin]
     scale_factor: Property<f32>,
     #[pin]


### PR DESCRIPTION
…have dependencies themselves

This saves 3% of dependencies in my benchmark
