### PR TITLE
Mark `Window::default-font-size` as `in`

### DIFF
--- a/docs/astro/src/content/docs/reference/window/window.mdx
+++ b/docs/astro/src/content/docs/reference/window/window.mdx
@@ -37,7 +37,7 @@ The font family to use as default in text elements inside this window, that don'
 </SlintProperty>
 
 ### default-font-size
-<SlintProperty propName="default-font-size" typeName="length" defaultValue="0" propertyVisibility="in-out">
+<SlintProperty propName="default-font-size" typeName="length" defaultValue="0" propertyVisibility="in">
 The font size to use as default in text elements inside this window, that don't have their `font-size` property set. The value of this property also forms the basis for relative font sizes.
 </SlintProperty>
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -292,7 +292,7 @@ component WindowItem {
     in property <bool> always-on-top;
     in-out property <bool> full-screen;
     in property <string> default-font-family;
-    in-out property <length> default-font-size; // <=> StyleMetrics.default-font-size  set in apply_default_properties_from_style
+    in property <length> default-font-size;
     in property <int> default-font-weight;
     in property <image> icon;
 }


### PR DESCRIPTION
Without that, the compiler won't ever mark it as const, which is necessary to avoid dependency from the runtime which query this property quite often
