### PR TITLE
Disable objc2 encoding assertions (#9583)

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -120,6 +120,10 @@ wgpu-27 = { workspace = true, optional = true, features = ["vulkan"] }
 # Text layout is enabled here just so that we can make use of the pre-built Skia libraries.
 skia-safe = { version = "0.89", features = ["textlayout"] }
 
+[target.aarch64-apple-ios-sim.dependencies]
+# Disabling encoding assertions until https://github.com/madsmtm/objc2/issues/795 is fixed.
+objc2 = { version = "*", features = ["disable-encoding-assertions"] }
+
 [build-dependencies]
 cfg_aliases = { workspace = true }
 


### PR DESCRIPTION
The definition of MTLResourceID differs between iOS simulator and iOS device SDKs, which objc2-metal doesn't handle correctly. See https://github.com/madsmtm/objc2/issues/795

Fixes #9583