### PR TITLE
torizon: Remove Vivante support as Torizon 4 is no longer supported

### DIFF
--- a/.github/workflows/torizon_demos.yaml
+++ b/.github/workflows/torizon_demos.yaml
@@ -44,12 +44,6 @@ jobs:
                       rust_toolchain_arch: aarch64-unknown-linux-gnu
                       base_image_suffix: "-imx95"
                       build_home_automation_sw_renderer: false
-                    # Legacy vivante support (for backward compatibility)
-                    - target: arm64
-                      image_arch: linux/arm64
-                      rust_toolchain_arch: aarch64-unknown-linux-gnu
-                      base_image_suffix: "-vivante"
-                      build_home_automation_sw_renderer: false
 
         steps:
             - uses: actions/checkout@v5

--- a/docs/torizon.md
+++ b/docs/torizon.md
@@ -1,5 +1,5 @@
 <!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
-<!-- cSpell: ignore Torizon Toradex Vivante imx8 am62 imx95 PowerVR -->
+<!-- cSpell: ignore Torizon Toradex imx8 am62 imx95 -->
 # Running Slint Demos on Torizon OS
 
 Toradex provides [Torizon OS](https://developer.toradex.com/torizon/) a Linux based platform for its embedded devices that packages applications in docker containers.
@@ -22,7 +22,6 @@ Our pre-compiled demos are available in multiple variants optimized for differen
 2. **i.MX8 GPU build** (`torizon-demos-arm64-imx8`) - Optimized for i.MX8 series with GPU acceleration
 3. **AM62 GPU build** (`torizon-demos-arm64-am62`) - Optimized for AM62 series with GPU acceleration
 4. **i.MX95 GPU build** (`torizon-demos-arm64-imx95`) - Optimized for i.MX95 series with GPU acceleration
-5. **Vivante GPU build** (`torizon-demos-arm64-vivante`) - Legacy variant for i.MX8 with Vivante GPU acceleration
 
 A complete list of all containers can be found at
 


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
