### PR TITLE
docs: Update Torizon section in embedded.mdx to match latest changes

### DIFF
--- a/docs/astro/src/content/docs/guide/platforms/embedded.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/embedded.mdx
@@ -29,50 +29,68 @@ For C++ applications see [meta-slint](https://github.com/slint-ui/meta-slint) fo
 Rust applications work out of the box with Yocto's Rust support.
 </TabItem>
 <TabItem label="Torizon">
-Toradex provides [TorizonCore](https://developer.toradex.com/torizon/), a Linux based platform for its embedded devices that packages applications in docker containers.
+Toradex provides [Torizon OS](https://developer.toradex.com/torizon/), a Linux based platform for its embedded devices that packages applications in docker containers.
 
-We provide our demos compiled for Toradex as docker containers.
+We provide our demos compiled for Toradex as docker containers with and without GPU acceleration support.
 
 #### Prerequisites
 
- - A device running Torizon
- - A running [weston container](https://developer.toradex.com/torizon/5.0/provided-containers/working-with-weston-on-torizoncore)
+ - A device running Torizon OS 6.0 or later
  - SSH access to the Torizon device
+ - Docker installed on the device
+
+**Note**: The Slint demos run directly on the linux/kms and do not require a Weston container.
 
 #### Running
 
-Our pre-compiled demos are available in four different variants:
+Our pre-compiled demos are available in multiple variants optimized for different hardware platforms:
 
-1. Compiled for ARM 32-bit as `armhf` and compiled for ARM 64-bit as `arm64`
-2. Compiled with Linux DRI or with support for Vivante GPUs (`-vivante` suffix)
+1. **Standard ARM64 without GPU build** (`torizon-demos-arm64`) - Uses software rendering
+2. **i.MX8 GPU build** (`torizon-demos-arm64-imx8`) - Optimized for i.MX8 series with GPU acceleration
+3. **AM62 GPU build** (`torizon-demos-arm64-am62`) - Optimized for AM62 series with GPU acceleration
+4. **i.MX95 GPU build** (`torizon-demos-arm64-imx95`) - Optimized for i.MX95 series with GPU acceleration
 
 A complete list of all containers can be found at
 
 https://github.com/orgs/slint-ui/packages?q=torizon&tab=packages&q=torizon
 
-For example, to run the container on an i.MX8 board with Vivante GPU, use the following command line:
+For example, to run the container on an i.MX8 board with GPU, use the following command line:
 
 ```
-docker run --user=torizon -v /dev:/dev -v /tmp:/tmp --device-cgroup-rule='c 199:* rmw' --device-cgroup-rule='c 226:* rmw' ghcr.io/slint-ui/slint/torizon-demos-arm64-vivante
+sudo docker run --rm --privileged \
+  --user=torizon \
+  -v /dev:/dev \
+  -v /tmp:/tmp \
+  -v /run/udev:/run/udev \
+  --device-cgroup-rule='c 199:* rmw' \
+  --device-cgroup-rule='c 226:* rmw' \
+  --device-cgroup-rule='c 13:* rmw' \
+  --device-cgroup-rule='c 4:* rmw' \
+  ghcr.io/slint-ui/slint/torizon-demos-arm64-imx8
 ```
 
 #### Selecting Demos
 
-By default, the printer demo from /usr/bin is run. The containers however package multiple demos:
+By default, the **energy-monitor** demo is run. The containers package multiple demo applications:
 
- * printerdemo
- * slide_puzzle
- * gallery
- * opengl_underlay
- * carousel
- * todo
- * energy-monitor
- * home-automation
+ * **energy-monitor** (default) - Energy monitoring dashboard
+ * **printerdemo** - 3D printer control interface
+ * **gallery** - Image gallery with touch navigation
+ * **slide_puzzle** - Interactive sliding puzzle game
+ * **opengl_underlay** - OpenGL rendering demonstration
+ * **carousel** - 3D carousel interface
+ * **todo** - Task management application
+ * **weather-demo** - Weather information display (requires API key)
+ * **home-automation** - Smart home control panel
 
-Run then by specifying them as parameter to `docker run`, for example:
+Run a specific demo by specifying it as a parameter to `docker run`, for example:
 
 ```
-docker run --user=torizon -v /dev:/dev -v /tmp:/tmp --device-cgroup-rule='c 199:* rmw' --device-cgroup-rule='c 226:* rmw' ghcr.io/slint-ui/slint/torizon-demos-arm64-vivante opengl_underlay
+sudo docker run --rm --privileged --user=torizon \
+  -v /dev:/dev -v /tmp:/tmp -v /run/udev:/run/udev \
+  --device-cgroup-rule='c 199:* rmw' --device-cgroup-rule='c 226:* rmw' \
+  --device-cgroup-rule='c 13:* rmw' --device-cgroup-rule='c 4:* rmw' \
+  ghcr.io/slint-ui/slint/torizon-demos-arm64-imx8 printerdemo
 ```
 </TabItem>
 </Tabs>


### PR DESCRIPTION
- Update prerequisites to Torizon OS 6.0 or later
- Remove requirement for Weston container (runs directly on linux/kms)
- Update demo variants to show imx8/am62/imx95 GPU-accelerated builds
- Remove deprecated Vivante and ARM32 support
- Change default demo from printerdemo to energy-monitor
- Update docker run commands with new flags and structure
- Add descriptions for all available demos

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
