### PR TITLE
lsp/ui: Remove redundant callback handlers from HeaderView

### DIFF
--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -210,18 +210,6 @@ export component PreviewUi inherits Window {
                     style-selected => {
                         Api.style-changed();
                     }
-                    library-toggled(val) => {
-                        root.library-widget = val;
-                    }
-                    outline-toggled(val) => {
-                        root.outline-widget = val;
-                    }
-                    properties-toggled(val) => {
-                        root.properties-widget = val;
-                    }
-                    simulator-toggled(val) => {
-                        root.data-widget = val;
-                    }
                     edit := Button {
                         icon: Icons.inspect;
                         colorize-icon: preview.select-mode ? false : true;

--- a/tools/lsp/ui/views/header-view.slint
+++ b/tools/lsp/ui/views/header-view.slint
@@ -18,11 +18,6 @@ export component HeaderView {
     in-out property <bool> data-widget <=> shortcut-simulator-data.checked;
 
     callback style-selected();
-    callback edit-mode-toggled();
-    callback library-toggled(bool);
-    callback properties-toggled(bool);
-    callback outline-toggled(bool);
-    callback simulator-toggled(bool);
 
     background-layer := Rectangle {
         background: Palette.alternate-background;
@@ -68,9 +63,6 @@ export component HeaderView {
 
                     interaction-switch := Switch {
                         checked: true;
-                        toggled => {
-                            root.edit-mode-toggled();
-                        }
                     }
 
                     BodyText {
@@ -87,10 +79,6 @@ export component HeaderView {
                         icon: Icons.library;
                         colorize-icon: !self.checked;
                         primary: self.checked;
-                        clicked => {
-                            root.library-toggled(self.checked);
-                            library-widget = self.checked;
-                        }
                     }
 
                     shortcut-properties := Button {
@@ -99,10 +87,6 @@ export component HeaderView {
                         icon: Icons.properties;
                         colorize-icon: !self.checked;
                         primary: self.checked;
-                        clicked => {
-                            root.properties-toggled(self.checked);
-                            properties-widget = self.checked;
-                        }
                     }
 
                     shortcut-outline := Button {
@@ -111,10 +95,6 @@ export component HeaderView {
                         icon: Icons.outline;
                         colorize-icon: !self.checked;
                         primary: self.checked;
-                        clicked => {
-                            root.outline-toggled(self.checked);
-                            outline-widget = self.checked;
-                        }
                     }
 
                     shortcut-simulator-data := Button {
@@ -123,10 +103,6 @@ export component HeaderView {
                         icon: Icons.simulator;
                         colorize-icon: !self.checked;
                         primary: self.checked;
-                        clicked => {
-                            root.simulator-toggled(self.checked);
-                            data-widget = self.checked;
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Remove unused callback definitions and handlers that became redundant after switching to direct property bindings for widget state management.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
