### PR TITLE
Linear Gradient in color picker missing 'degrees'

### DIFF
--- a/tools/lsp/ui/components/widgets/floating-brush-sections/gradient-ui.slint
+++ b/tools/lsp/ui/components/widgets/floating-brush-sections/gradient-ui.slint
@@ -346,7 +346,7 @@ export component GradientPicker inherits SimpleColumn {
         degrees := CustomLineEdit {
             x: parent.width - self.width - EditorSizeSettings.standard-margin;
             width: 40px;
-            visible: cb.current-index == 0;
+            visible: cb.current-index == 1;
             Rectangle {
                 x: parent.width - self.width;
                 width: 48px;


### PR DESCRIPTION
Degrees was incorrectly showing for 'conic gradient' and not 'linear 
gradient.