### PR TITLE
live-preview: account for transformation when highlighting items

### DIFF
--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1503,7 +1503,7 @@ impl ComponentInstance {
         &self,
         path: &Path,
         offset: u32,
-    ) -> Vec<i_slint_core::lengths::LogicalRect> {
+    ) -> Vec<crate::highlight::HighlightedRect> {
         crate::highlight::component_positions(&self.inner, path, offset)
     }
 
@@ -1514,7 +1514,7 @@ impl ComponentInstance {
     pub fn element_positions(
         &self,
         element: &i_slint_compiler::object_tree::ElementRc,
-    ) -> Vec<i_slint_core::lengths::LogicalRect> {
+    ) -> Vec<crate::highlight::HighlightedRect> {
         crate::highlight::element_positions(
             &self.inner,
             element,

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -819,7 +819,7 @@ fn resize_selected_element_impl(
 
     // They all have the same size anyway:
     let (path, offset) = element_node.path_and_offset();
-    let geometry = element_node.geometries(&component_instance).get(instance_index).cloned()?;
+    let geometry = element_node.geometries(&component_instance).get(instance_index).cloned()?.rect;
 
     let position = rect.origin;
     let root_element = element_selection::root_element(&component_instance);
@@ -830,7 +830,7 @@ fn resize_selected_element_impl(
                 .element_positions(&parent_element)
                 .iter()
                 .find(|g| g.contains(position))
-                .map(|g| g.origin)
+                .map(|g| g.rect.origin)
         })
         .unwrap_or_default();
 

--- a/tools/lsp/preview/ext.rs
+++ b/tools/lsp/preview/ext.rs
@@ -7,30 +7,28 @@ use i_slint_core::lengths::{LogicalPoint, LogicalRect};
 use crate::common;
 use crate::preview::ui;
 
+use slint_interpreter::highlight::HighlightedRect;
 use slint_interpreter::ComponentInstance;
 
 pub trait ElementRcNodeExt {
     fn layout_kind(&self) -> crate::preview::ui::LayoutKind;
 
     /// Find all geometries for the given `ElementRcNode`
-    fn geometries(
-        &self,
-        component_instance: &ComponentInstance,
-    ) -> Vec<i_slint_core::lengths::LogicalRect>;
+    fn geometries(&self, component_instance: &ComponentInstance) -> Vec<HighlightedRect>;
 
     /// Find the first geometry of `ElementRcNode` that includes the point `x`, `y`
     fn geometry_at(
         &self,
         component_instance: &ComponentInstance,
         position: LogicalPoint,
-    ) -> Option<i_slint_core::lengths::LogicalRect>;
+    ) -> Option<HighlightedRect>;
 
     /// Find the first geometry of ElementRcNode in `rect`
     fn geometry_in(
         &self,
         component_instance: &ComponentInstance,
         rect: &LogicalRect,
-    ) -> Option<i_slint_core::lengths::LogicalRect>;
+    ) -> Option<HighlightedRect>;
 }
 
 impl ElementRcNodeExt for common::ElementRcNode {
@@ -49,10 +47,7 @@ impl ElementRcNodeExt for common::ElementRcNode {
         })
     }
 
-    fn geometries(
-        &self,
-        component_instance: &ComponentInstance,
-    ) -> Vec<i_slint_core::lengths::LogicalRect> {
+    fn geometries(&self, component_instance: &ComponentInstance) -> Vec<HighlightedRect> {
         component_instance.element_positions(self.as_element())
     }
 
@@ -60,15 +55,15 @@ impl ElementRcNodeExt for common::ElementRcNode {
         &self,
         component_instance: &ComponentInstance,
         position: LogicalPoint,
-    ) -> Option<i_slint_core::lengths::LogicalRect> {
-        self.geometries(component_instance).iter().find(|g| g.contains(position)).cloned()
+    ) -> Option<HighlightedRect> {
+        self.geometries(component_instance).iter().find(|g| g.rect.contains(position)).cloned()
     }
 
     fn geometry_in(
         &self,
         component_instance: &ComponentInstance,
         rect: &LogicalRect,
-    ) -> Option<i_slint_core::lengths::LogicalRect> {
-        self.geometries(component_instance).iter().find(|g| rect.contains_rect(g)).cloned()
+    ) -> Option<HighlightedRect> {
+        self.geometries(component_instance).iter().find(|g| rect.contains_rect(&g.rect)).cloned()
     }
 }

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -42,6 +42,7 @@ export struct SelectionRectangle {
     y: length,
     width: length,
     height: length,
+    angle: angle,
 }
 
 /// A `Selection`

--- a/tools/lsp/ui/views/preview-view.slint
+++ b/tools/lsp/ui/views/preview-view.slint
@@ -421,7 +421,8 @@ export component PreviewView inherits Rectangle {
                             y: s.y;
                             width: s.width;
                             height: s.height;
-                            interactive: root.mode == DrawAreaMode.selecting;
+                            transform-rotation: s.angle;
+                            interactive: root.mode == DrawAreaMode.selecting && s.angle == 0.0;
                             selection: Api.selection;
                             is-primary: self.selection.highlight-index == idx;
                             resize(x, y, w, h) => {


### PR DESCRIPTION
Fixes #9760

Drag&drop over transformed item is still not working properly so this is disabled
