### PR TITLE
Set `accessible-placeholder-text` even when text input is not empty

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -623,9 +623,8 @@ impl NodeCollection {
             }
         }
 
-        if let Some(placeholder) = item
-            .accessible_string_property(AccessibleStringProperty::PlaceholderText)
-            .filter(|x| !x.is_empty())
+        if let Some(placeholder) =
+            item.accessible_string_property(AccessibleStringProperty::PlaceholderText)
         {
             node.set_placeholder(placeholder.to_string());
         }

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -21,7 +21,7 @@ export component LineEdit {
     accessible-role: text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
 

--- a/internal/compiler/widgets/cosmic/textedit.slint
+++ b/internal/compiler/widgets/cosmic/textedit.slint
@@ -28,7 +28,7 @@ export component TextEdit {
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
 
     public function set-selection-offsets(start: int, end: int) {

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -22,7 +22,7 @@ export component LineEdit {
     accessible-role: text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => {
         text = v;

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -82,7 +82,7 @@ export component TextEdit {
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
 
     public function set-selection-offsets(start: int, end: int) {

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -21,7 +21,7 @@ export component LineEdit {
     accessible-role: text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
 

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -28,7 +28,7 @@ export component TextEdit {
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
 
     public function set-selection-offsets(start: int, end: int) {

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -22,7 +22,7 @@ export component LineEdit {
     accessible-role: text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
 

--- a/internal/compiler/widgets/material/textedit.slint
+++ b/internal/compiler/widgets/material/textedit.slint
@@ -28,7 +28,7 @@ export component TextEdit {
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
 
     public function set-selection-offsets(start: int, end: int) {

--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -20,7 +20,7 @@ export component LineEdit {
     accessible-role: text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
 

--- a/internal/compiler/widgets/qt/textedit.slint
+++ b/internal/compiler/widgets/qt/textedit.slint
@@ -27,7 +27,7 @@ export component TextEdit {
     accessible-role: AccessibleRole.text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: text == "" ? placeholder-text : "";
+    accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
 
     public function set-selection-offsets(start: int, end: int) {

--- a/ui-libraries/material/src/ui/components/text_field.slint
+++ b/ui-libraries/material/src/ui/components/text_field.slint
@@ -37,7 +37,7 @@ export component TextField {
     accessible-role: text-input;
     accessible-enabled: root.enabled;
     accessible-value <=> text;
-    accessible-placeholder-text: root.text == "" ? placeholder_text : "";
+    accessible-placeholder-text: placeholder_text;
     accessible-action-set-value(v) => { text = v; edited(v); }
 
     layout := VerticalLayout {


### PR DESCRIPTION
AccessKit now make sure to only expose the placeholder text when necessary, ensuring it is not presented if the text input is not empty. Workarounds in .slint files can therefore be removed.