### PR TITLE
For the module-buils example, change Copyright line to KDAB

### DIFF
--- a/tests/manual/module-builds/app/Cargo.toml
+++ b/tests/manual/module-builds/app/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright © SixtyFPS GmbH <info@slint.dev>
+# Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 # SPDX-License-Identifier: MIT
 
 [package]

--- a/tests/manual/module-builds/app/build.rs
+++ b/tests/manual/module-builds/app/build.rs
@@ -1,4 +1,4 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 // SPDX-License-Identifier: MIT
 
 fn main() {

--- a/tests/manual/module-builds/app/ui/app-window.slint
+++ b/tests/manual/module-builds/app/ui/app-window.slint
@@ -1,4 +1,4 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 // SPDX-License-Identifier: MIT
 
 import { Button, VerticalBox } from "std-widgets.slint";

--- a/tests/manual/module-builds/blogica/Cargo.toml
+++ b/tests/manual/module-builds/blogica/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright © SixtyFPS GmbH <info@slint.dev>
+# Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 # SPDX-License-Identifier: MIT
 
 [package]

--- a/tests/manual/module-builds/blogica/build.rs
+++ b/tests/manual/module-builds/blogica/build.rs
@@ -1,4 +1,4 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 // SPDX-License-Identifier: MIT
 
 fn main() -> Result<(), slint_build::CompileError> {

--- a/tests/manual/module-builds/blogica/src/lib.rs
+++ b/tests/manual/module-builds/blogica/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 // SPDX-License-Identifier: MIT
 
 pub mod backend {

--- a/tests/manual/module-builds/blogica/ui/blogica.slint
+++ b/tests/manual/module-builds/blogica/ui/blogica.slint
@@ -1,4 +1,4 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 // SPDX-License-Identifier: MIT
 
 export struct BData {

--- a/tests/manual/module-builds/blogicb/Cargo.toml
+++ b/tests/manual/module-builds/blogicb/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright © SixtyFPS GmbH <info@slint.dev>
+# Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 # SPDX-License-Identifier: MIT
 
 [package]

--- a/tests/manual/module-builds/blogicb/src/lib.rs
+++ b/tests/manual/module-builds/blogicb/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 // SPDX-License-Identifier: MIT
 
 use slint::SharedString;

--- a/tests/manual/module-builds/blogicb/ui/blogicb.slint
+++ b/tests/manual/module-builds/blogicb/ui/blogicb.slint
@@ -1,4 +1,4 @@
-// Copyright © SixtyFPS GmbH <info@slint.dev>
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 // SPDX-License-Identifier: MIT
 
 export struct CrankData {


### PR DESCRIPTION
For the module-builds example contributed by KDAB, change the Copyright line to:
```
// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
```
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
