### PR TITLE
Qt: Fix slow text rendering

### DIFF
--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -997,8 +997,11 @@ pub fn draw_text(
         TextStrokeStyle::Outside => stroke_width * 2.0,
         TextStrokeStyle::Center => stroke_width,
     };
-    let platform_stroke_brush =
-        item_renderer.platform_text_stroke_brush(stroke_brush, stroke_width, size);
+    let platform_stroke_brush = if !stroke_brush.is_transparent() {
+        item_renderer.platform_text_stroke_brush(stroke_brush, stroke_width, size)
+    } else {
+        None
+    };
 
     let (horizontal_align, vertical_align) = text.alignment();
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -947,12 +947,8 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GlyphRenderer for GLItemRendere
         let text_path = rect_to_path((size * self.scale_factor).into());
         match self.brush_to_paint(stroke_brush.clone(), &text_path) {
             Some(mut paint) => {
-                if stroke_brush.is_transparent() {
-                    None
-                } else {
-                    paint.set_line_width(physical_stroke_width);
-                    Some(GlyphBrush::Stroke(paint))
-                }
+                paint.set_line_width(physical_stroke_width);
+                Some(GlyphBrush::Stroke(paint))
             }
             None => None,
         }

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -941,17 +941,13 @@ impl GlyphRenderer for SkiaItemRenderer<'_> {
             size.height_length() * self.scale_factor,
         ) {
             Some(mut stroke_paint) => {
-                if brush.is_transparent() {
-                    None
-                } else {
-                    stroke_paint.set_style(skia_safe::PaintStyle::Stroke);
-                    stroke_paint.set_stroke_width(physical_stroke_width);
-                    // Set stroke cap/join/miter to match FemtoVG
-                    stroke_paint.set_stroke_cap(skia_safe::PaintCap::Butt);
-                    stroke_paint.set_stroke_join(skia_safe::PaintJoin::Miter);
-                    stroke_paint.set_stroke_miter(10.0);
-                    Some(stroke_paint)
-                }
+                stroke_paint.set_style(skia_safe::PaintStyle::Stroke);
+                stroke_paint.set_stroke_width(physical_stroke_width);
+                // Set stroke cap/join/miter to match FemtoVG
+                stroke_paint.set_stroke_cap(skia_safe::PaintCap::Butt);
+                stroke_paint.set_stroke_join(skia_safe::PaintJoin::Miter);
+                stroke_paint.set_stroke_miter(10.0);
+                Some(stroke_paint)
             }
             None => None,
         }


### PR DESCRIPTION
Most text is rendered without a stroke but just a fill. This is currently detected by checking if the stroke brush is transparent, inside platform_text_stroke_brush(). For Qt, that check was missing, so in essence every Text element went through QPainterPath for stroking.

Centralize this decision in the shared parley code, to avoid repeating this mistake in future renderers.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
