### PR TITLE
Creating `item_clicked` callback for material components `SearchBar` widget

### DIFF
--- a/ui-libraries/material/docs/src/content/docs/components/AppBars/search_bar.mdx
+++ b/ui-libraries/material/docs/src/content/docs/components/AppBars/search_bar.mdx
@@ -95,6 +95,9 @@ Invoked when a key is pressed in the search bar.
 ### key-released(event: KeyEvent) -> EventResult
 Invoked when a key is released in the search bar.
 
+### item-activated(index: int) -> bool
+Invoked when a search item is clicked.  If a callback returns 'true', then do not perform the default behavior of changing the search text.
+
 ## Functions
 
 ### clear-focus()

--- a/ui-libraries/material/src/ui/components/search_bar.slint
+++ b/ui-libraries/material/src/ui/components/search_bar.slint
@@ -132,7 +132,7 @@ export component SearchBar {
     callback action_button_clicked(index: int);
     callback key_pressed(event: KeyEvent) -> EventResult;
     callback key_released(event: KeyEvent) -> EventResult;
-    callback item_clicked(index: int) -> bool;
+    callback item-activated(index: int) -> bool;
 
     property <color> color: MaterialPalette.on_surface_variant;
     property <length> item_height: MaterialStyleMetrics.size_72;
@@ -289,7 +289,7 @@ export component SearchBar {
                         action_button_icon: item.action_button_icon;
 
                         clicked => {
-                            if (!root.item_clicked(index)) {
+                            if (!root.item-activated(index)) {
                                 root.text = self.text;
                             }
                             popup.close();


### PR DESCRIPTION
Currently, `SearchBar` presents a list of items but is hard coded to treat each of these items as "precanned" search text.  This PR introduces an `item_clicked` callback to allow hosts to override this default behavior.
