### PR TITLE
Use transforms in item_children_bounding_rect

### DIFF
--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -224,17 +224,18 @@ fn item_children_bounding_rect_inner(
     let mut actual_visitor =
         |component: &ItemTreeRc, index: u32, item: Pin<ItemRef>| -> VisitChildrenResult {
             let item_geometry = transform.outer_transformed_rect(
-                &ItemTreeRc::borrow_pin(component).as_ref().item_geometry(index),
+                &ItemTreeRc::borrow_pin(component).as_ref().item_geometry(index).cast(),
             );
             let children_transform = ItemRc::new(component.clone(), index)
                 .children_transform()
                 .unwrap_or_default()
                 .then_translate(item_geometry.origin.to_vector());
 
-            let local_clip_rect = clip_rect.translate(-item_geometry.origin.to_vector());
+            let offset: LogicalPoint = item_geometry.origin.cast();
+            let local_clip_rect = clip_rect.translate(-offset.to_vector());
 
-            if let Some(clipped_item_geometry) = item_geometry.intersection(clip_rect) {
-                bounding_rect = bounding_rect.union(&clipped_item_geometry);
+            if let Some(clipped_item_geometry) = item_geometry.intersection(&clip_rect.cast()) {
+                bounding_rect = bounding_rect.union(&clipped_item_geometry.cast());
             }
 
             if !item.as_ref().clips_children() {


### PR DESCRIPTION
~~I started this in order to solve https://github.com/slint-ui/slint/issues/9758#issue-3522238898. I haven't worked out quite how to get things working for rotations yet. Think I need to adjust `local_clip_rect` by the inverse of the transform maybe?~~

This resolves the clipping issue mentioned here: https://github.com/slint-ui/slint/issues/9758#issuecomment-3415623660.

Note that this _might_ not handle rotations properly