### PR TITLE
Improve Rust caching and setup in autofix.ci

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -31,8 +31,10 @@ jobs:
               with:
                 version: 2025.9.18
                 log_level: debug
-            - name: Install rust dependencies
-              run: rustup toolchain install stable-x86_64-unknown-linux-gnu --profile default
+                cache_key_prefix: mise-autofix-v1
+            - uses: Swatinem/rust-cache@v2
+              with:
+                key: autofix-format-v1
             - name: Run fixes
               run: mise run --force --jobs=1 'ci:autofix:fix'
             - name: Suggest format changes
@@ -47,7 +49,9 @@ jobs:
               with:
                 version: 2025.9.18
                 log_level: debug
-            - name: Install rust dependencies
-              run: rustup toolchain install stable-x86_64-unknown-linux-gnu --profile default
+                cache_key_prefix: mise-autofix-v1
+            - uses: Swatinem/rust-cache@v2
+              with:
+                key: autofix-lint-v1
             - name: Run lints
               run: mise run --force --jobs=1 'ci:autofix:lint'


### PR DESCRIPTION
The rust tooling was being installed twice in autofix.ci. First by MISE
and then again in a dedicated step. This now leaves the Rust install to 
MISE.

There was no cache being used at in in the autofix step. This fixes 
that. If at any point the cache needs to be reset increment the -v1 part
of the cache key name.