### PR TITLE
winit: Fix panic when accessing `Palette.color-scheme` during mu…

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -136,3 +136,7 @@ slint = { path = "../../../api/rs/slint", default-features = false, features = [
 [package.metadata.docs.rs]
 features = ["wayland", "renderer-software", "raw-window-handle-06"]
 rustdoc-args = ["--generate-link-to-definition"]
+
+[[test]]
+name = "menubar_borrow"
+harness = false

--- a/internal/backends/winit/tests/menubar_borrow.rs
+++ b/internal/backends/winit/tests/menubar_borrow.rs
@@ -1,0 +1,38 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+fn main() {
+    slint::slint! {
+        import { Palette } from "std-widgets.slint";
+        export component App inherits Window {
+            property <bool> dark-mode: Palette.color-scheme == ColorScheme.dark;
+            MenuBar {
+                Menu {
+                title: @tr("Settings");
+                MenuItem {
+                    title: @tr("Toggle dark mode");
+                    checkable: true;
+                    checked: { Palette.color-scheme == ColorScheme.dark }  // Result in panic "RefCell already mutably borrowed"
+                    activated => {
+                      Palette.color-scheme = root.dark-mode ? ColorScheme.light : ColorScheme.dark;
+                    }
+               }
+            }
+        }
+        }
+    }
+    use slint::winit_030::WinitWindowAccessor;
+    slint::BackendSelector::new().backend_name("winit".into()).select().unwrap();
+    slint::spawn_local(async move {
+        let app = App::new().unwrap();
+        let slint_window = app.window();
+
+        app.show().unwrap();
+        let result = slint_window.winit_window().await;
+        assert!(result.is_ok(), "Failed to get winit window: {:?}", result.err());
+        slint::quit_event_loop().unwrap();
+    })
+    .unwrap();
+
+    slint::run_event_loop().unwrap();
+}


### PR DESCRIPTION
…da menubar build

When building the muda menubar, we end up evaluating bindings, which in case of access `Palette.color-scheme` invokes
BuiltinFunction::ColorScheme, which tries to borrow the winit_window_or_none for winit::Window::theme() access. Fix this by narrowing the borrow_mut() access window to winit_window_or_none and construct the muda menubar afterwards.

Fixes #9792

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
