### PR TITLE
Change render_layer to take a function that generates LogicalRects instead of just sizes

### DIFF
--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1090,7 +1090,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
                 }
 
                 *self.state.last_mut().unwrap() = State {
-                                        scissor: LogicalRect::new(LogicalPoint::default(), bounding_rect.size),
+                    scissor: LogicalRect::new(LogicalPoint::default(), bounding_rect.size),
                     global_alpha: 1.,
                     current_render_target: layer_image.as_render_target(),
                 };


### PR DESCRIPTION
Thanks @ogoffart. This fixes https://github.com/slint-ui/slint/issues/9758. It changes the femtovg API for this from the other backends, but they don't seem to have the same issue in testing. Changing their function signatures might be a good idea for a future PR.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
