### PR TITLE
live-preview: Don't show reload icon on MacOS

### DIFF
--- a/tools/lsp/ui/main.slint
+++ b/tools/lsp/ui/main.slint
@@ -80,7 +80,7 @@ export component PreviewUi inherits Window {
 
             MenuItem {
                 title: @tr("Reload");
-                icon: Icons.sync;
+                icon: Platform.os != OperatingSystemType.macos ? Icons.sync : @image-url("");
                 activated => {
                     Api.reload-preview();
                 }


### PR DESCRIPTION
This stop the menu icon showing on on MacOS as they are not rendering as
expected.