### PR TITLE
Prospective fix for the docs.rs build

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -311,7 +311,6 @@ features = [
   "renderer-software",
   "renderer-femtovg",
   "raw-window-handle-06",
-  "unstable-wgpu-26",
   "unstable-wgpu-27",
   "unstable-winit-030",
   "unstable-libinput-09",


### PR DESCRIPTION
unstable-wgpu-26 brings skia unconditionally which doesn't compile on docs.rs

Fixes #9815
