### PR TITLE
fix: incorrect rgba8 premultiply calculations

### DIFF
--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -795,7 +795,7 @@ impl Image {
     }
 
     /// Returns the pixel converted from premultiplied RGBA to RGBA.
-    pub fn premultiplied_rgba_to_rgba(pixel: Rgba8Pixel) -> Rgba8Pixel {
+    fn premultiplied_rgba_to_rgba(pixel: Rgba8Pixel) -> Rgba8Pixel {
         if pixel.a == 0 {
             Rgba8Pixel::new(0, 0, 0, 0)
         } else {
@@ -811,7 +811,7 @@ impl Image {
     }
 
     /// Returns the pixel converted from RGBA to premultiplied RGBA.
-    pub fn rgba_to_premultiplied_rgba(pixel: Rgba8Pixel) -> Rgba8Pixel {
+    fn rgba_to_premultiplied_rgba(pixel: Rgba8Pixel) -> Rgba8Pixel {
         if pixel.a == 255 {
             pixel
         } else {


### PR DESCRIPTION
Hello! 👋

Thank you for a really cool package! I haven't contributed much to Rust packages before, so I hope I have followed best practices and that there are no issues with my contribution. If there are, please let me know so I can fix them!

Anyway, the calculations for premultiplied RGBA8 values were incorrect which was causing issues shown in #9810. My contribution should resolve this.

You can test that the issues have now resolved from running the example provided in the issue (https://github.com/zeroeightysix/slint-white-svg-mre).

All existing tests still pass.

Fixes #9810.

Please let me know if there are any problems! ☺️

For reference, the calculations I used are from here:
[Premultiplied Alpha - Microsoft Learn](https://learn.microsoft.com/en-us/windows/apps/develop/win2d/premultiplied-alpha#converting-between-alpha-formats)

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
