### PR TITLE
core: make autoenums an optional dependency

### DIFF
--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -27,11 +27,12 @@ rtti = []
 std = [
   "euclid/std",
   "once_cell/std",
-  "scoped-tls-hkt",
-  "lyon_path",
-  "lyon_algorithms",
-  "lyon_geom",
-  "lyon_extra",
+  "dep:scoped-tls-hkt",
+  "dep:lyon_path",
+  "dep:lyon_algorithms",
+  "dep:lyon_geom",
+  "dep:lyon_extra",
+  "dep:auto_enums",
   "dep:web-time",
   "image-decoders",
   "svg",
@@ -82,7 +83,7 @@ const-field-offset = { version = "0.1.5", path = "../../helper_crates/const-fiel
 vtable = { workspace = true }
 
 portable-atomic = { version = "1", features = ["critical-section"] }
-auto_enums = "0.8.0"
+auto_enums = { version = "0.8.0", optional = true }
 cfg-if = "1"
 derive_more = { workspace = true, features = ["error"] }
 euclid = { workspace = true }


### PR DESCRIPTION
It is only used for our Path algorithms
