### PR TITLE
properties: fix setting properties via two way binding to struct fields

### DIFF
--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -1249,6 +1249,12 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
                 (self.map_from)(value, &sub_value);
                 BindingResult::KeepBinding
             }
+
+            unsafe fn intercept_set(self: Pin<&Self>, value: *const ()) -> bool {
+                let value = &mut *(value as *mut T);
+                let sub_value = (self.map_to)(value);
+                ((*self.b).vtable.intercept_set)(self.b, &sub_value as *const T2 as *const ())
+            }
         }
         impl<T, T2, M1, M2> Drop for BindingMapper<T, T2, M1, M2> {
             fn drop(&mut self) {

--- a/tests/cases/bindings/two_way_binding_structs.slint
+++ b/tests/cases/bindings/two_way_binding_structs.slint
@@ -12,6 +12,9 @@ component MyLineEdit {
     tx := TextInput {
         text: "to be overridden";
     }
+    public function edit() {
+        tx.text += " edited";
+    }
 }
 
 component MyStructViewer {
@@ -35,6 +38,23 @@ component WithinComp {
     in property <int> val <=> my_struct.value;
 }
 
+component Assignments {
+    in-out property <MyStruct> v;
+
+    le := MyLineEdit {
+        text <=> v.name;
+    }
+
+    out property <int> value <=> v.value;
+
+    init => {
+        v = { name: "Hello", value: -8, xyz: "x" };
+        value += 4;
+        le.edit();
+    }
+
+}
+
 
 export component TestCase {
 
@@ -54,6 +74,8 @@ export component TestCase {
         w := WithinComp {
             val: root.value.value + 100;
         }
+
+        a := Assignments {}
     }
 
     in-out property xyz <=> v.value.xyz;
@@ -63,7 +85,8 @@ export component TestCase {
 
     out property <bool> test: v.value.name == "Olivier" && v.value.value == 13 && spinbox.val == 13 && xyz == "xyz" && value.value == 13
         && inner.inner == v.value && inner.z == 13
-        && w.my_struct.value == 113;
+        && w.my_struct.value == 113
+        && a.v == { name: "Hello edited", value: -4, xyz: "x" };
 
 }
 


### PR DESCRIPTION
... when there are two level of indirection, as it is the case with the interpreter as it tries to create mapping to Value as one first level of indirection
