### PR TITLE
Python: Use maturin-action for building slint compiler wheels

### DIFF
--- a/.github/workflows/upload_pypi_slint_compiler.yaml
+++ b/.github/workflows/upload_pypi_slint_compiler.yaml
@@ -31,17 +31,14 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: PyO3/maturin-action@v1
         with:
-          package-dir: tools/compiler
-          output-dir: wheelhouse
-        env:
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
-          CIBW_BUILD_FRONTEND: "build"
+          working-directory: tools/compiler
+          args: --release --out wheelhouse --find-interpreter
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}
-          path: wheelhouse/*.whl
+          path: tools/compiler/wheelhouse/*.whl
 
   build-sdist:
     name: Build source distribution


### PR DESCRIPTION
pypa/cibuildwheel seems to have issues with the linux builds and we use maturin-action also for our main python packages.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
