### PR TITLE
autofix: Stop type-checking the vscode project

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -50,8 +50,8 @@ depends = ["prepare:pnpm-install"]
 
 ["lint:ts:typecheck"]
 description = "Run pnpm format:fix"
-run = "pnpm type-check"
-depends = ["prepare:pnpm-install", "build:lsp:wasm", "build:interpreter:wasm"]
+run = "pnpm type-check:ci"
+depends = ["prepare:pnpm-install"]
 
 ### Build
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "format:fix": "biome format biome.json --write && pnpm --stream -r format:fix",
     "lint": "pnpm --stream -r lint",
     "lint:fix": "pnpm --stream -r lint:fix",
-    "type-check": "pnpm --stream -r type-check"
+    "type-check": "pnpm --stream -r type-check",
+    "type-check:ci": "pnpm --stream --filter '!./editors/vscode' -r type-check"
   },
   "packageManager": "pnpm@10.18.2",
   "pnpm": {


### PR DESCRIPTION
Typechecking the vscode project needs a wasm build of slint so the types
are generated. This stop that so autofix should now run in ~1 minute.

If this works the next stage will be to run autofix before all other 
jobs and only kick them off once its successful. The reason for this is 
we only have 20 runners. Autofix and the normal ci.yaml jobs start. This
takes up 10 to 15 runners. After 5-6 mins autofix often finds a problem.
Makes a new commit and now the other ~15 jobs need to be cancelled. So 
in theory we can reduce pointless jobs running.