### PR TITLE
Run Autofix and then the CI one after the other.

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -55,3 +55,8 @@ jobs:
             deployments: write
             pull-requests: read
         uses: ./.github/workflows/ci.yaml
+        secrets:
+            ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+            ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+            CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+            CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,15 @@ name: CI
 on:
     workflow_dispatch:
     workflow_call:
+      secrets:
+        CLOUDFLARE_API_TOKEN:
+          required: true
+        CLOUDFLARE_ACCOUNT_ID:
+          required: true
+        ANDROID_KEYSTORE_PASSWORD:
+          required: true
+        ANDROID_KEYSTORE_BASE64:
+          required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}


### PR DESCRIPTION
Previously they ran in parallel which meant any commit by autofix would 
cancel the CI jobs. This ensures the CI only runs afterwards and is 
helped by autofix now only taking ~2 mins to run.

It should make a small difference to the amount of free runners.