### PR TITLE
android: provide correct java path to check_javac_version

### DIFF
--- a/internal/backends/android-activity/build.rs
+++ b/internal/backends/android-activity/build.rs
@@ -68,8 +68,8 @@ fn main() {
 
     if !o.status.success() {
         eprintln!("Dex conversion failed: {}", String::from_utf8_lossy(&o.stderr));
-        let javac = android_build::javac().unwrap();
-        let java_ver = android_build::check_javac_version(&javac).unwrap();
+        let java_home = android_build::java_home().unwrap();
+        let java_ver = android_build::check_javac_version(&java_home).unwrap();
         if java_ver >= 21 {
             eprintln!("WARNING: JDK version 21 is known to cause an error with older android SDK");
             eprintln!("See https://github.com/slint-ui/slint/issues/4973");


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
[`check_javac_version`](https://docs.rs/android-build/0.1.2/src/android_build/env_paths/mod.rs.html#217-218) expects `JAVA_HOME` and not `JAVA_HOME/bin/javac` leading to `Failed to execute javac -version: Os { code: 20, kind: NotADirectory, message: \"Not a directory\" }`.