### PR TITLE
Clean up more of the docs cache

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -53,6 +53,7 @@ jobs:
                   toolchain: nightly
                   components: rustfmt
                   target: aarch64-linux-android
+                  cache: false
             - name: Install apt dependencies
               run: sudo apt-get install doxygen
             - uses: baptiste0928/cargo-install@v3


### PR DESCRIPTION
The cache from the docs run is 2GB which is twice the size of any other 
jobs cache. This is causing other useful caches to be evicted to make 
space for it. This deletes the most likely suspects for the extra space
which is most likely the android artefacts.