### PR TITLE
Add support for FB Renderer Format DrmFourcc(BA24) in LinuxKMS

### DIFF
--- a/internal/backends/linuxkms/renderer/sw.rs
+++ b/internal/backends/linuxkms/renderer/sw.rs
@@ -90,7 +90,7 @@ impl From<PremultipliedRgbaColor> for DumbBufferPixelXrgb888 {
     }
 }
 
-impl From<DumbBufferPixelBgra888> for PremultipliedRgbaColor {
+impl From<DumbBufferPixelBgra8888> for PremultipliedRgbaColor {
     #[inline]
     fn from(pixel: DumbBufferPixelBgra8888) -> Self {
         let v = pixel.0;


### PR DESCRIPTION
As suggested in #9862 this PR adds support for FB Renderer Format DrmFourcc(BA24) in LinuxKMS.

Changelog: Added support for FB Renderer Format DrmFourcc(BA24) in LinuxKMS
Closes #9862
