### PR TITLE
Add `AccessibleRole.radio-button`

### DIFF
--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -334,6 +334,7 @@ cpp! {{
                     i_slint_core::items::AccessibleRole::TabPanel => QAccessible_Role_Pane,
                     i_slint_core::items::AccessibleRole::Groupbox => QAccessible_Role_Grouping,
                     i_slint_core::items::AccessibleRole::Image => QAccessible_Role_Graphic,
+                    i_slint_core::items::AccessibleRole::RadioButton => QAccessible_Role_RadioButton,
                     _ => QAccessible_Role_NoRole,
                 }
             });

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -101,6 +101,7 @@ enum AccessibleRole {
     TabPanel = 16;
     Groupbox = 17;
     Image = 18;
+    RadioButton = 19;
 }
 
 message ElementQueryInstruction {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -562,6 +562,7 @@ fn convert_to_proto_accessible_role(
         i_slint_core::items::AccessibleRole::ListItem => proto::AccessibleRole::ListItem,
         i_slint_core::items::AccessibleRole::TabPanel => proto::AccessibleRole::TabPanel,
         i_slint_core::items::AccessibleRole::Image => proto::AccessibleRole::Image,
+        i_slint_core::items::AccessibleRole::RadioButton => proto::AccessibleRole::RadioButton,
         _ => return None,
     })
 }
@@ -591,6 +592,7 @@ fn convert_from_proto_accessible_role(
         proto::AccessibleRole::ListItem => i_slint_core::items::AccessibleRole::ListItem,
         proto::AccessibleRole::TabPanel => i_slint_core::items::AccessibleRole::TabPanel,
         proto::AccessibleRole::Image => i_slint_core::items::AccessibleRole::Image,
+        proto::AccessibleRole::RadioButton => i_slint_core::items::AccessibleRole::RadioButton,
     })
 }
 

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -510,6 +510,7 @@ impl NodeCollection {
                     i_slint_core::items::AccessibleRole::Switch => Role::Switch,
                     i_slint_core::items::AccessibleRole::ListItem => Role::ListBoxOption,
                     i_slint_core::items::AccessibleRole::Image => Role::Image,
+                    i_slint_core::items::AccessibleRole::RadioButton => Role::RadioButton,
                     _ => Role::Unknown,
                 },
                 item.accessible_string_property(

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -399,6 +399,8 @@ macro_rules! for_each_enums {
                 Switch,
                 /// The element is an item in a `ListView`.
                 ListItem,
+                /// The element is a `RadioButton` or behaves like one.
+                RadioButton,
             }
 
             /// This enum represents the different values of the `sort-order` property.

--- a/ui-libraries/material/src/ui/components/radio_button.slint
+++ b/ui-libraries/material/src/ui/components/radio_button.slint
@@ -19,7 +19,7 @@ export component RadioButton {
     accessible-enabled: root.enabled;
     accessible-checkable: true;
     accessible-checked <=> root.checked;
-    accessible-role: checkbox;
+    accessible-role: radio-button;
     accessible-action-default => { state_area.clicked(); }
     forward_focus: state_area;
 


### PR DESCRIPTION
Relates to #2732 

Adding this role since it exists a RadioButton widget in the Material Design widget collection. The role for "radio button group" should eventually be added as well. Note that more properties will be needed to tell assistive technologies which radio buttons are linked.