### PR TITLE
Changing `win32_set_window_redraw()` to only be functional when the window is visible

### DIFF
--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -119,7 +119,10 @@ impl MudaAdapter {
         menubar: Option<&vtable::VRc<MenuVTable>>,
         muda_type: MudaType,
     ) {
-        win32_set_window_redraw(winit_window, false);
+        let must_set_window_redraw = cfg!(windows) && winit_window.is_visible() == Some(true);
+        if must_set_window_redraw {
+            win32_set_window_redraw(winit_window, false);
+        }
 
         // clear the menu
         while self.menu.remove_at(0).is_some() {}
@@ -225,7 +228,9 @@ impl MudaAdapter {
             }
         }
 
-        win32_set_window_redraw(winit_window, true);
+        if must_set_window_redraw {
+            win32_set_window_redraw(winit_window, true);
+        }
     }
 
     pub fn invoke(&self, menubar: &vtable::VRc<MenuVTable>, entry_id: usize) {


### PR DESCRIPTION
According to Stack Overflow (https://stackoverflow.com/questions/9248553/wm-setredraw-and-losing-z-order-focus) the default handling of `WM_SETREDRAW` has some weird behaviors for windows that are not visible.  This seems to be the case for Slint windows that are freshly created.

This should fix https://github.com/slint-ui/slint/issues/9921
