### PR TITLE
Add the `accessible-id` property

### DIFF
--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -250,6 +250,12 @@ public:
                 cbindgen_private::AccessibleStringProperty::Description);
     }
 
+    /// Returns the accessible-id of that element, if any.
+    std::optional<SharedString> accessible_id() const
+    {
+        return get_accessible_string_property(cbindgen_private::AccessibleStringProperty::Id);
+    }
+
     /// Returns the accessible-value-maximum of that element, if any.
     std::optional<float> accessible_value_maximum() const
     {

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -412,6 +412,23 @@ Whether the element is expanded or not. Applies to combo boxes, menu items,
 tree view items and other widgets.
 </SlintProperty>
 
+### accessible-id
+<SlintProperty typeName="string" propName="accessible-id" default='""'>
+A unique identifier for the element, used to identify widgets for automation and testing purposes.
+This property can be set to any string value and is particularly useful when writing automated tests or
+when using accessibility tools to uniquely identify specific widgets in your application.
+
+If you need to identify repeated elements, make sure to assign different values to each instance as illustrated below.
+
+```slint
+for i in 5: Rectangle {
+    accessible-role: button;
+    accessible-id: "btn-" + i;
+    accessible-label: "Button " + i;
+}
+```
+</SlintProperty>
+
 ### accessible-label
 <SlintProperty typeName="string" propName="accessible-label" default='""'>
 The label for an interactive element. (default value: empty for most elements, or the value of the `text` property for Text elements)

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -624,6 +624,16 @@ impl ElementHandle {
             .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Description))
     }
 
+    /// Returns the value of the `accessible-id` property, if present
+    pub fn accessible_id(&self) -> Option<SharedString> {
+        if self.element_index != 0 {
+            return None;
+        }
+        self.item
+            .upgrade()
+            .and_then(|item| item.accessible_string_property(AccessibleStringProperty::Id))
+    }
+
     /// Returns the value of the `accessible-checked` property, if present
     pub fn accessible_checked(&self) -> Option<bool> {
         if self.element_index != 0 {

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -577,6 +577,10 @@ impl NodeCollection {
             node.set_description(description.to_string());
         }
 
+        if let Some(id) = item.accessible_string_property(AccessibleStringProperty::Id) {
+            node.set_author_id(id.to_string());
+        }
+
         if item
             .accessible_string_property(AccessibleStringProperty::Expandable)
             .is_some_and(|x| x == "true")

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -207,6 +207,7 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-enabled", Type::Bool),
         ("accessible-expandable", Type::Bool),
         ("accessible-expanded", Type::Bool),
+        ("accessible-id", Type::String),
         ("accessible-label", Type::String),
         ("accessible-value", Type::String),
         ("accessible-value-maximum", Type::Float32),

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -24,6 +24,7 @@ pub enum AccessibleStringProperty {
     Enabled,
     Expandable,
     Expanded,
+    Id,
     ItemCount,
     ItemIndex,
     ItemSelectable,

--- a/tests/cases/accessibility/accessible_id.slint
+++ b/tests/cases/accessibility/accessible_id.slint
@@ -1,0 +1,56 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test the accessible-id property for uniquely identifying widgets for automation
+
+export component TestCase inherits Rectangle {
+    width: 300phx;
+    height: 300phx;
+
+    VerticalLayout {
+        button1 := Rectangle {
+            accessible-role: button;
+            accessible-label: "Click Me";
+            accessible-id: "my-unique-button";
+        }
+
+        button2 := Rectangle {
+            accessible-role: button;
+            accessible-label: "Another Button";
+        }
+    }
+}
+
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+
+let buttons = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Click Me").collect::<Vec<_>>();
+assert_eq!(buttons.len(), 1);
+assert_eq!(buttons[0].accessible_id(), Some("my-unique-button".into()));
+
+let buttons = slint_testing::ElementHandle::find_by_accessible_label(&instance, "Another Button").collect::<Vec<_>>();
+assert_eq!(buttons.len(), 1);
+assert!(buttons[0].accessible_id().is_none());
+```
+
+```cpp
+auto handle = TestCase::create();
+
+auto button_search = slint::testing::ElementHandle::find_by_accessible_label(handle, "Click Me");
+assert(button_search.size() == 1);
+auto button_with_id = button_search[0];
+auto accessible_id = button_with_id.accessible_id();
+assert(accessible_id.has_value());
+assert(*accessible_id == "my-unique-button");
+
+button_search = slint::testing::ElementHandle::find_by_accessible_label(handle, "Another Button");
+assert(button_search.size() == 1);
+auto button_without_id = button_search[0];
+accessible_id = button_without_id.accessible_id();
+assert(!accessible_id.has_value());
+```
+
+*/


### PR DESCRIPTION
Closes #3972 

Introduces a new `accessible-id` property to be used for automation and UI testing.

Although I initially suggested using element names for this purpose (essentially the ID used in the testing backends) and Qt seem to roughly do the same, it's probably not a good idea to use such "auto-generated" value for this. I'm not even sure how the ID used by the testing backend handles repetitions.

Let UI designers pick a value that is readable and that make sense for them.

I don't have any strong feeling about the name for this property.

<!--
- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
