### PR TITLE
Warm the github cache in the morning

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -9,6 +9,9 @@ on:
   push:
     branches: [master, "feature/*"]
   workflow_dispatch:
+  schedule:
+    # Run daily before the work day to warm caches
+    - cron: '0 5 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Overnight github evicts nearly all the useful cache as it's over 10GB in
size. This job re-runs the last 'successful' run in master and 
repopulates the cache ready for the start of the work day.

<img width="1314" height="550" alt="Screenshot 2025-11-02 at 22 15 46" src="https://github.com/user-attachments/assets/75088543-1190-4f22-ada9-dcfb3e16eed2" />