### PR TITLE
More optimization when the scale factor is constant

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -545,7 +545,7 @@ fn gen_corelib(
             "slint_windowrc_hide",
             "slint_windowrc_is_visible",
             "slint_windowrc_get_scale_factor",
-            "slint_windowrc_set_scale_factor",
+            "slint_windowrc_set_const_scale_factor",
             "slint_windowrc_get_text_input_focused",
             "slint_windowrc_set_text_input_focused",
             "slint_windowrc_set_focus_item",

--- a/api/cpp/include/slint_window.h
+++ b/api/cpp/include/slint_window.h
@@ -82,7 +82,10 @@ public:
     bool is_visible() const { return slint_windowrc_is_visible(&inner); }
 
     float scale_factor() const { return slint_windowrc_get_scale_factor(&inner); }
-    void set_scale_factor(float value) const { slint_windowrc_set_scale_factor(&inner, value); }
+    void set_const_scale_factor(float value) const
+    {
+        slint_windowrc_set_const_scale_factor(&inner, value);
+    }
 
     cbindgen_private::ColorScheme color_scheme() const
     {

--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -170,11 +170,12 @@ impl CompilerConfiguration {
     /// as constant value. This is only intended for MCU environments. Use
     /// in combination with [`Self::embed_resources`] to pre-scale images and glyphs
     /// accordingly.
+    ///
+    /// If this is set, changing the scale factor at runtime will not have any effect.
     #[must_use]
-    pub fn with_scale_factor(self, factor: f32) -> Self {
-        let mut config = self.config;
-        config.const_scale_factor = factor as f64;
-        Self { config }
+    pub fn with_scale_factor(mut self, factor: f32) -> Self {
+        self.config.const_scale_factor = Some(factor);
+        self
     }
 
     /// Configures the compiler to bundle translations when compiling Slint code.

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -289,7 +289,9 @@ impl BuiltinFunction {
     /// It is const if the return value only depends on its argument and has no side effect
     fn is_const(&self, global_analysis: Option<&crate::passes::GlobalAnalysis>) -> bool {
         match self {
-            BuiltinFunction::GetWindowScaleFactor => false,
+            BuiltinFunction::GetWindowScaleFactor => {
+                global_analysis.is_some_and(|x| x.const_scale_factor.is_some())
+            }
             BuiltinFunction::GetWindowDefaultFontSize => {
                 global_analysis.is_some_and(|x| x.default_font_size.is_const())
             }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -6,7 +6,6 @@
 
 // cSpell:ignore cmath constexpr cstdlib decltype intptr itertools nullptr prepended struc subcomponent uintptr vals
 
-use lyon_path::geom::euclid::approxeq::ApproxEq;
 use std::collections::HashSet;
 use std::fmt::Write;
 use std::io::BufWriter;
@@ -769,11 +768,9 @@ pub fn generate(
         "   auto &window = self->m_window.emplace(slint::private_api::WindowAdapterRc());".into(),
     ];
 
-    if !compiler_config.const_scale_factor.approx_eq(&1.0) {
-        window_creation_code.push(format!(
-            "window.dispatch_scale_factor_change_event({});",
-            compiler_config.const_scale_factor
-        ));
+    if let Some(scale_factor) = compiler_config.const_scale_factor {
+        window_creation_code
+            .push(format!("window.window_handle().set_const_scale_factor({scale_factor});"));
     }
 
     window_creation_code.extend([

--- a/internal/compiler/lib.rs
+++ b/internal/compiler/lib.rs
@@ -128,8 +128,8 @@ pub struct CompilerConfiguration {
     pub inline_all_elements: bool,
 
     /// Compile time scale factor to apply to embedded resources such as images and glyphs.
-    /// If != 1.0 then the scale factor will be set on the `slint::Window`.
-    pub const_scale_factor: f64,
+    /// It will also be set as a const scale factor on the `slint::Window`.
+    pub const_scale_factor: Option<f32>,
 
     /// expose the accessible role and properties
     pub accessibility: bool,
@@ -209,9 +209,8 @@ impl CompilerConfiguration {
 
         let const_scale_factor = std::env::var("SLINT_SCALE_FACTOR")
             .ok()
-            .and_then(|x| x.parse::<f64>().ok())
-            .filter(|f| *f > 0.)
-            .unwrap_or(1.);
+            .and_then(|x| x.parse::<f32>().ok())
+            .filter(|f| *f > 0.);
 
         let enable_experimental = std::env::var_os("SLINT_ENABLE_EXPERIMENTAL_FEATURES").is_some();
 

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -236,7 +236,7 @@ pub async fn run_passes(
     embed_images::embed_images(
         doc,
         type_loader.compiler_config.embed_resources,
-        type_loader.compiler_config.const_scale_factor,
+        type_loader.compiler_config.const_scale_factor.unwrap_or(1.),
         &type_loader.compiler_config.resource_url_mapper,
         diag,
     )
@@ -265,15 +265,12 @@ pub async fn run_passes(
         crate::EmbedResourcesKind::EmbedTextures => {
             let mut characters_seen = std::collections::HashSet::new();
 
+            let sf = type_loader.compiler_config.const_scale_factor.unwrap_or(1.) as f64;
+
             // Include at least the default font sizes used in the MCU backend
-            let mut font_pixel_sizes =
-                vec![(12. * type_loader.compiler_config.const_scale_factor) as i16];
+            let mut font_pixel_sizes = vec![(12. * sf) as i16];
             doc.visit_all_used_components(|component| {
-                embed_glyphs::collect_font_sizes_used(
-                    component,
-                    type_loader.compiler_config.const_scale_factor,
-                    &mut font_pixel_sizes,
-                );
+                embed_glyphs::collect_font_sizes_used(component, sf, &mut font_pixel_sizes);
                 embed_glyphs::scan_string_literals(component, &mut characters_seen);
             });
 

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -47,6 +47,7 @@ impl DefaultFontSize {
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct GlobalAnalysis {
     pub default_font_size: DefaultFontSize,
+    pub const_scale_factor: Option<f32>,
 }
 
 /// Maps the alias in the other direction than what the BindingExpression::two_way_binding does.
@@ -60,6 +61,7 @@ pub fn binding_analysis(
     diag: &mut BuildDiagnostics,
 ) -> GlobalAnalysis {
     let mut global_analysis = GlobalAnalysis::default();
+    global_analysis.const_scale_factor = compiler_config.const_scale_factor;
     let mut reverse_aliases = Default::default();
     mark_used_base_properties(doc);
     propagate_is_set_on_aliases(doc, &mut reverse_aliases);

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -48,7 +48,7 @@ pub fn embed_glyphs<'a>(
     use crate::diagnostics::Spanned;
 
     let generic_diag_location = doc.node.as_ref().map(|n| n.to_source_location());
-    let scale_factor = compiler_config.const_scale_factor;
+    let scale_factor = compiler_config.const_scale_factor.unwrap_or(1.);
 
     characters_seen.extend(
         ('a'..='z')
@@ -62,7 +62,7 @@ pub fn embed_glyphs<'a>(
     if let Ok(sizes_str) = std::env::var("SLINT_FONT_SIZES") {
         for custom_size_str in sizes_str.split(',') {
             let custom_size = if let Ok(custom_size) = custom_size_str
-                .parse::<f64>()
+                .parse::<f32>()
                 .map(|size_as_float| (size_as_float * scale_factor) as i16)
             {
                 custom_size

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 pub async fn embed_images(
     doc: &Document,
     embed_files: EmbedResourcesKind,
-    scale_factor: f64,
+    scale_factor: f32,
     resource_url_mapper: &Option<Rc<dyn Fn(&str) -> Pin<Box<dyn Future<Output = Option<String>>>>>>,
     diag: &mut BuildDiagnostics,
 ) {
@@ -85,7 +85,7 @@ fn embed_images_from_expression(
     urls: &HashMap<SmolStr, Option<SmolStr>>,
     global_embedded_resources: &RefCell<BTreeMap<SmolStr, EmbeddedResources>>,
     embed_files: EmbedResourcesKind,
-    scale_factor: f64,
+    scale_factor: f32,
     diag: &mut BuildDiagnostics,
 ) {
     if let Expression::ImageReference { resource_ref, source_location, nine_slice: _ } = e {
@@ -129,7 +129,7 @@ fn embed_image(
     global_embedded_resources: &RefCell<BTreeMap<SmolStr, EmbeddedResources>>,
     embed_files: EmbedResourcesKind,
     path: &str,
-    _scale_factor: f64,
+    _scale_factor: f32,
     diag: &mut BuildDiagnostics,
     source_location: &Option<crate::diagnostics::SourceLocation>,
 ) -> ImageReference {
@@ -365,7 +365,7 @@ enum SourceFormat {
 #[cfg(feature = "software-renderer")]
 fn load_image(
     file: crate::fileaccess::VirtualFile,
-    scale_factor: f64,
+    scale_factor: f32,
 ) -> image::ImageResult<(image::RgbaImage, SourceFormat, Size)> {
     use resvg::{tiny_skia, usvg};
     use std::ffi::OsStr;
@@ -428,8 +428,8 @@ fn load_image(
 
         if scale_factor < 1. {
             image = image.resize_exact(
-                (original_width as f64 * scale_factor) as u32,
-                (original_height as f64 * scale_factor) as u32,
+                (original_width as f32 * scale_factor) as u32,
+                (original_height as f32 * scale_factor) as u32,
                 image::imageops::FilterType::Gaussian,
             );
         }

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -716,6 +716,16 @@ impl PropertyHandle {
             }
         }
     }
+
+    fn is_constant(&self) -> bool {
+        let dependencies = self.dependencies();
+        core::ptr::eq(
+            // Safety: dependencies is a valid pointer to a DependencyListHead which is a Cell<usize> internally
+            // and usize can be casted to a pointer
+            unsafe { *(dependencies as *mut *const u32) },
+            (&CONSTANT_PROPERTY_SENTINEL) as *const u32,
+        )
+    }
 }
 
 impl Drop for PropertyHandle {
@@ -987,6 +997,11 @@ impl<T: Clone> Property<T> {
     /// Mark that this property will never be modified again and that no tracking should be done
     pub fn set_constant(&self) {
         self.handle.set_constant();
+    }
+
+    /// Returns true if set_constant was called on this property
+    pub fn is_constant(&self) -> bool {
+        self.handle.is_constant()
     }
 }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1435,7 +1435,18 @@ impl WindowInner {
 
     /// Sets the scale factor for the window. This is set by the backend or for testing.
     pub(crate) fn set_scale_factor(&self, factor: f32) {
-        self.pinned_fields.scale_factor.set(factor)
+        if !self.pinned_fields.scale_factor.is_constant() {
+            self.pinned_fields.scale_factor.set(factor)
+        }
+    }
+
+    /// Sets the scale factor for the window.
+    /// From that point on, the scale factor is constant and cannot be changed anymore.
+    pub fn set_const_scale_factor(&self, factor: f32) {
+        if !self.pinned_fields.scale_factor.is_constant() {
+            self.pinned_fields.scale_factor.set(factor);
+            self.pinned_fields.scale_factor.set_constant();
+        }
     }
 
     /// Reads the global property `TextInputInterface.text-input-focused`
@@ -1685,12 +1696,12 @@ pub mod ffi {
 
     /// Sets the window scale factor, merely for testing purposes.
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_windowrc_set_scale_factor(
+    pub unsafe extern "C" fn slint_windowrc_set_const_scale_factor(
         handle: *const WindowAdapterRcOpaque,
         value: f32,
     ) {
         let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-        WindowInner::from_pub(window_adapter.window()).set_scale_factor(value)
+        WindowInner::from_pub(window_adapter.window()).set_const_scale_factor(value)
     }
 
     /// Returns the text-input-focused property value.

--- a/tests/cases/types/length.slint
+++ b/tests/cases/types/length.slint
@@ -47,7 +47,7 @@ assert(instance.get_test_zero());
 assert(instance.get_test());
 
 ratio = 2.;
-instance.window().window_handle().set_scale_factor(ratio);
+instance.window().dispatch_scale_factor_change_event(ratio);
 assert_eq(instance.get_l1(), 12.);
 assert_eq(instance.get_l2(), 12. * ratio);
 assert_eq(instance.get_l3(), 100. + 12. * ratio);

--- a/tests/cases/types/rem.slint
+++ b/tests/cases/types/rem.slint
@@ -31,7 +31,7 @@ assert(instance.get_test());
 
 assert_eq(instance.get_phx_to_rem(), 2.);
 assert_eq(instance.get_px_to_rem(), 2.);
-instance.window().window_handle().set_scale_factor(2.0);
+instance.window().dispatch_scale_factor_change_event(2.);
 assert_eq(instance.get_phys_pixel_size(), 20.);
 assert_eq(instance.get_phx_to_rem(), 1.);
 assert_eq(instance.get_px_to_rem(), 2.);

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -69,7 +69,7 @@ struct Cli {
     /// Apply a constant scale factor to embedded assets, typically for high-DPI displays.
     /// This scale factor is also applied to the window by default.
     #[arg(long, name = "scale factor")]
-    scale_factor: Option<f64>,
+    scale_factor: Option<f32>,
 
     /// Generate a dependency file for build systems like CMake or Ninja.
     /// This file is similar to the output of `gcc -M`.
@@ -184,7 +184,7 @@ fn main() -> std::io::Result<()> {
         compiler_config.style = Some(style);
     }
     if let Some(constant_scale_factor) = args.scale_factor {
-        compiler_config.const_scale_factor = constant_scale_factor;
+        compiler_config.const_scale_factor = Some(constant_scale_factor);
     }
     if let Some(path) = args.bundle_translations {
         compiler_config.translation_path_bundle = Some(path);


### PR DESCRIPTION
When compiled with a const scale factor, we don't want to register too many dependencies to the scale factor.
