### PR TITLE
Tweak iOS simulator builds for success

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -179,7 +179,7 @@ jobs:
                 echo "Verifying installation..."
                 xcrun simctl listapps booted | grep -q "${{ matrix.bundle_id }}" && echo "App installed successfully" || echo "WARNING: App may not be installed"
             - name: "Launch"
-              timeout-minutes: 3
+              timeout-minutes: 5
               run: |
                 echo "Attempting to launch ${{ matrix.bundle_id }}..."
                 xcrun simctl launch booted "${{ matrix.bundle_id }}" || {


### PR DESCRIPTION
Instead of using 'sleep' the system now waits for the simulators to boot 
using 'xcrun simctl bootstatus booted -b'

Also added a timeout so if the system fails it won't hang forever.