### PR TITLE
Fix Frontboard issue in nightly tests

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -641,7 +641,6 @@ jobs:
 
     nightly-tests:
         if: github.event.inputs.release != 'true'
-        needs: [prepare_release]
         uses: ./.github/workflows/nightly_tests.yaml
 
     android:

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -182,13 +182,32 @@ jobs:
               timeout-minutes: 5
               run: |
                 echo "Attempting to launch ${{ matrix.bundle_id }}..."
-                xcrun simctl launch booted "${{ matrix.bundle_id }}" || {
-                  echo "Launch failed! Checking simulator logs..."
-                  xcrun simctl spawn booted log show --last 30s --predicate 'processImagePath contains "${{ matrix.scheme }}"'
-                  exit 1
-                }
-                echo "App launched successfully"
-                sleep 5
+                # Retry loop to wait for FrontBoard to register the app
+                MAX_ATTEMPTS=10
+                ATTEMPT=1
+                while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+                  echo "Launch attempt $ATTEMPT of $MAX_ATTEMPTS..."
+                  if xcrun simctl launch booted "${{ matrix.bundle_id }}" 2>&1 | tee launch_output.txt; then
+                    echo "App launched successfully on attempt $ATTEMPT"
+                    sleep 5
+                    exit 0
+                  fi
+
+                  if grep -q "unknown to FrontBoard" launch_output.txt; then
+                    echo "FrontBoard hasn't registered app yet, waiting 2 seconds..."
+                    sleep 2
+                    ATTEMPT=$((ATTEMPT + 1))
+                  else
+                    echo "Launch failed with a different error:"
+                    cat launch_output.txt
+                    echo "Checking simulator logs..."
+                    xcrun simctl spawn booted log show --last 30s --predicate 'processImagePath contains "${{ matrix.scheme }}"' || true
+                    exit 1
+                  fi
+                done
+
+                echo "Failed to launch after $MAX_ATTEMPTS attempts"
+                exit 1
             - name: "Screenshot"
               run: xcrun simctl io booted screenshot "${{ matrix.scheme }}.png"
             - name: Upload Screenshot Artifact


### PR DESCRIPTION
FrontBoard is a system that detects what app are on an iOS device or 
simulator so they can then be launched. It can be slow to detect a newly
installed app leading to a race condition in CI where the action tries 
to launch a successfully installed app before it's been registered. It 
fails to launch and the CI fails with it. Now loop for a few seconds 
retrying to launch before failing after 30 seconds.