### PR TITLE
renderer: Remove the scale factor argument from the text functions

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2101,16 +2101,14 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
         font_request: FontRequest,
         text: &str,
         max_width: Option<LogicalLength>,
-        scale_factor: ScaleFactor,
         text_wrap: TextWrap,
     ) -> LogicalSize {
-        sharedparley::text_size(font_request, text, max_width, scale_factor, text_wrap)
+        sharedparley::text_size(self, font_request, text, max_width, text_wrap)
     }
 
     fn font_metrics(
         &self,
         font_request: i_slint_core::graphics::FontRequest,
-        _scale_factor: ScaleFactor,
     ) -> i_slint_core::items::FontMetrics {
         sharedparley::font_metrics(font_request)
     }
@@ -2120,14 +2118,8 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
         text_input: Pin<&i_slint_core::items::TextInput>,
         pos: LogicalPoint,
         font_request: FontRequest,
-        scale_factor: ScaleFactor,
     ) -> usize {
-        sharedparley::text_input_byte_offset_for_position(
-            text_input,
-            pos,
-            font_request,
-            scale_factor,
-        )
+        sharedparley::text_input_byte_offset_for_position(self, text_input, pos, font_request)
     }
 
     fn text_input_cursor_rect_for_byte_offset(
@@ -2135,13 +2127,12 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
         text_input: Pin<&i_slint_core::items::TextInput>,
         byte_offset: usize,
         font_request: FontRequest,
-        scale_factor: ScaleFactor,
     ) -> LogicalRect {
         sharedparley::text_input_cursor_rect_for_byte_offset(
+            self,
             text_input,
             byte_offset,
             font_request,
-            scale_factor,
         )
     }
 
@@ -2185,6 +2176,10 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
 
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>) {
         // No-op because QtWindow is also the WindowAdapter
+    }
+
+    fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
+        Some(WindowInner::from_pub(&self.window).window_adapter())
     }
 
     fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -4,10 +4,10 @@
 use i_slint_core::api::PhysicalSize;
 use i_slint_core::graphics::euclid::{Point2D, Size2D};
 use i_slint_core::graphics::FontRequest;
-use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
+use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize};
 use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::{Renderer, RendererSealed};
-use i_slint_core::window::{InputMethodRequest, WindowAdapter, WindowAdapterInternal};
+use i_slint_core::window::{InputMethodRequest, WindowAdapter, WindowAdapterInternal, WindowInner};
 
 use i_slint_core::items::TextWrap;
 use std::cell::{Cell, RefCell};
@@ -167,7 +167,6 @@ impl RendererSealed for TestingWindow {
         _font_request: i_slint_core::graphics::FontRequest,
         text: &str,
         _max_width: Option<LogicalLength>,
-        _scale_factor: ScaleFactor,
         _text_wrap: TextWrap,
     ) -> LogicalSize {
         LogicalSize::new(text.len() as f32 * 10., 10.)
@@ -176,7 +175,6 @@ impl RendererSealed for TestingWindow {
     fn font_metrics(
         &self,
         font_request: i_slint_core::graphics::FontRequest,
-        _scale_factor: ScaleFactor,
     ) -> i_slint_core::items::FontMetrics {
         let pixel_size = font_request.pixel_size.unwrap_or(LogicalLength::new(10.));
         i_slint_core::items::FontMetrics {
@@ -192,7 +190,6 @@ impl RendererSealed for TestingWindow {
         text_input: Pin<&i_slint_core::items::TextInput>,
         pos: LogicalPoint,
         _font_request: FontRequest,
-        _scale_factor: ScaleFactor,
     ) -> usize {
         let text = text_input.text();
         if pos.y < 0. {
@@ -213,7 +210,6 @@ impl RendererSealed for TestingWindow {
         text_input: Pin<&i_slint_core::items::TextInput>,
         byte_offset: usize,
         _font_request: FontRequest,
-        _scale_factor: ScaleFactor,
     ) -> LogicalRect {
         let text = text_input.text();
         let line = text[..byte_offset].chars().filter(|c| *c == '\n').count();
@@ -241,6 +237,10 @@ impl RendererSealed for TestingWindow {
 
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>) {
         // No-op since TestingWindow is also the WindowAdapter
+    }
+
+    fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
+        Some(WindowInner::from_pub(&self.window).window_adapter())
     }
 
     fn supports_transformations(&self) -> bool {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -20,7 +20,7 @@ use crate::input::{
 };
 use crate::item_rendering::{CachedRenderingData, ItemRenderer, RenderText};
 use crate::layout::{LayoutInfo, Orientation};
-use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, ScaleFactor};
+use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize};
 use crate::platform::Clipboard;
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
@@ -216,10 +216,8 @@ impl ComplexText {
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> FontMetrics {
-        let window_inner = WindowInner::from_pub(window_adapter.window());
-        let scale_factor = ScaleFactor::new(window_inner.scale_factor());
         let font_request = self.font_request(self_rc);
-        window_adapter.renderer().font_metrics(font_request, scale_factor)
+        window_adapter.renderer().font_metrics(font_request)
     }
 }
 
@@ -292,7 +290,7 @@ impl Item for MarkdownText {
                 is_touch: _,
             } => {
                 let window_inner = WindowInner::from_pub(window_adapter.window());
-                let scale_factor = ScaleFactor::new(window_inner.scale_factor());
+                let scale_factor = crate::lengths::ScaleFactor::new(window_inner.scale_factor());
                 if let Some(link) = crate::textlayout::sharedparley::link_under_cursor(
                     scale_factor,
                     self,
@@ -438,10 +436,8 @@ impl MarkdownText {
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> FontMetrics {
-        let window_inner = WindowInner::from_pub(window_adapter.window());
-        let scale_factor = ScaleFactor::new(window_inner.scale_factor());
         let font_request = self.font_request(self_rc);
-        window_adapter.renderer().font_metrics(font_request, scale_factor)
+        window_adapter.renderer().font_metrics(font_request)
     }
 }
 
@@ -617,10 +613,8 @@ impl SimpleText {
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> FontMetrics {
-        let window_inner = WindowInner::from_pub(window_adapter.window());
-        let scale_factor = ScaleFactor::new(window_inner.scale_factor());
         let font_request = self.font_request(self_rc);
-        window_adapter.renderer().font_metrics(font_request, scale_factor)
+        window_adapter.renderer().font_metrics(font_request)
     }
 }
 
@@ -631,16 +625,13 @@ fn text_layout_info(
     orientation: Orientation,
     width: Pin<&Property<LogicalLength>>,
 ) -> LayoutInfo {
-    let window_inner = WindowInner::from_pub(window_adapter.window());
     let text_string = text.text();
     let font_request = text.font_request(self_rc);
-    let scale_factor = ScaleFactor::new(window_inner.scale_factor());
     let implicit_size = |max_width, text_wrap| {
         window_adapter.renderer().text_size(
             font_request.clone(),
             text_string.as_str(),
             max_width,
-            scale_factor,
             text_wrap,
         )
     };
@@ -655,7 +646,7 @@ fn text_layout_info(
                 TextOverflow::Elide => implicit_size.width.min(
                     window_adapter
                         .renderer()
-                        .text_size(font_request, "…", None, scale_factor, TextWrap::NoWrap)
+                        .text_size(font_request, "…", None, TextWrap::NoWrap)
                         .width,
                 ),
                 TextOverflow::Clip => match text.wrap() {
@@ -789,7 +780,6 @@ impl Item for TextInput {
                     }
                 },
                 max_width,
-                ScaleFactor::new(window_adapter.window().scale_factor()),
                 text_wrap,
             )
         };
@@ -1477,13 +1467,7 @@ impl TextInput {
 
         let font_height = window_adapter
             .renderer()
-            .text_size(
-                self.font_request(self_rc),
-                " ",
-                None,
-                ScaleFactor::new(window_adapter.window().scale_factor()),
-                TextWrap::NoWrap,
-            )
+            .text_size(self.font_request(self_rc), " ", None, TextWrap::NoWrap)
             .height;
 
         let mut reset_preferred_x_pos = true;
@@ -2050,7 +2034,6 @@ impl TextInput {
             self,
             byte_offset,
             self.font_request(self_rc),
-            ScaleFactor::new(window_adapter.window().scale_factor()),
         )
     }
 
@@ -2064,7 +2047,6 @@ impl TextInput {
             self,
             pos,
             self.font_request(self_rc),
-            ScaleFactor::new(window_adapter.window().scale_factor()),
         )
     }
 
@@ -2224,10 +2206,8 @@ impl TextInput {
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
     ) -> FontMetrics {
-        let window_inner = WindowInner::from_pub(window_adapter.window());
-        let scale_factor = ScaleFactor::new(window_inner.scale_factor());
         let font_request = self.font_request(self_rc);
-        window_adapter.renderer().font_metrics(font_request, scale_factor)
+        window_adapter.renderer().font_metrics(font_request)
     }
 
     fn accept_text_input(self: Pin<&Self>, text_to_insert: &str) -> bool {

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -33,16 +33,12 @@ pub trait RendererSealed {
         font_request: crate::graphics::FontRequest,
         text: &str,
         max_width: Option<LogicalLength>,
-        scale_factor: ScaleFactor,
         text_wrap: TextWrap,
     ) -> LogicalSize;
 
     /// Returns the metrics of the given font.
-    fn font_metrics(
-        &self,
-        font_request: crate::graphics::FontRequest,
-        scale_factor: ScaleFactor,
-    ) -> crate::items::FontMetrics;
+    fn font_metrics(&self, font_request: crate::graphics::FontRequest)
+        -> crate::items::FontMetrics;
 
     /// Returns the (UTF-8) byte offset in the text property that refers to the character that contributed to
     /// the glyph cluster that's visually nearest to the given coordinate. This is used for hit-testing,
@@ -53,7 +49,6 @@ pub trait RendererSealed {
         text_input: Pin<&crate::items::TextInput>,
         pos: LogicalPoint,
         font_request: crate::graphics::FontRequest,
-        scale_factor: ScaleFactor,
     ) -> usize;
 
     /// That's the opposite of [`Self::text_input_byte_offset_for_position`]
@@ -64,7 +59,6 @@ pub trait RendererSealed {
         text_input: Pin<&crate::items::TextInput>,
         byte_offset: usize,
         font_request: crate::graphics::FontRequest,
-        scale_factor: ScaleFactor,
     ) -> LogicalRect;
 
     /// Clear the caches for the items that are being removed
@@ -117,6 +111,13 @@ pub trait RendererSealed {
     }
 
     fn set_window_adapter(&self, _window_adapter: &Rc<dyn WindowAdapter>);
+
+    fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>>;
+
+    fn scale_factor(&self) -> Option<ScaleFactor> {
+        self.window_adapter()
+            .map(|window_adapter| ScaleFactor::new(window_adapter.window().scale_factor()))
+    }
 
     fn default_font_size(&self) -> LogicalLength;
 

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -724,15 +724,17 @@ impl RendererSealed for SoftwareRenderer {
         font_request: crate::graphics::FontRequest,
         text: &str,
         max_width: Option<LogicalLength>,
-        scale_factor: ScaleFactor,
         text_wrap: TextWrap,
     ) -> LogicalSize {
+        let Some(scale_factor) = self.scale_factor() else {
+            return LogicalSize::default();
+        };
         let font = fonts::match_font(&font_request, scale_factor);
 
         match (font, parley_disabled()) {
             #[cfg(feature = "software-renderer-systemfonts")]
             (fonts::Font::VectorFont(_), false) => {
-                sharedparley::text_size(font_request, text, max_width, scale_factor, text_wrap)
+                sharedparley::text_size(self, font_request, text, max_width, text_wrap)
             }
             #[cfg(feature = "software-renderer-systemfonts")]
             (fonts::Font::VectorFont(vf), true) => {
@@ -761,8 +763,10 @@ impl RendererSealed for SoftwareRenderer {
     fn font_metrics(
         &self,
         font_request: crate::graphics::FontRequest,
-        scale_factor: ScaleFactor,
     ) -> crate::items::FontMetrics {
+        let Some(scale_factor) = self.scale_factor() else {
+            return crate::items::FontMetrics::default();
+        };
         let font = fonts::match_font(&font_request, scale_factor);
 
         match (font, parley_disabled()) {
@@ -803,18 +807,20 @@ impl RendererSealed for SoftwareRenderer {
         text_input: Pin<&crate::items::TextInput>,
         pos: LogicalPoint,
         font_request: crate::graphics::FontRequest,
-        scale_factor: ScaleFactor,
     ) -> usize {
+        let Some(scale_factor) = self.scale_factor() else {
+            return 0;
+        };
         let font = fonts::match_font(&font_request, scale_factor);
 
         match (font, parley_disabled()) {
             #[cfg(feature = "software-renderer-systemfonts")]
             (fonts::Font::VectorFont(_), false) => {
                 sharedparley::text_input_byte_offset_for_position(
+                    self,
                     text_input,
                     pos,
                     font_request,
-                    scale_factor,
                 )
             }
             #[cfg(feature = "software-renderer-systemfonts")]
@@ -882,18 +888,20 @@ impl RendererSealed for SoftwareRenderer {
         text_input: Pin<&crate::items::TextInput>,
         byte_offset: usize,
         font_request: crate::graphics::FontRequest,
-        scale_factor: ScaleFactor,
     ) -> LogicalRect {
+        let Some(scale_factor) = self.scale_factor() else {
+            return LogicalRect::default();
+        };
         let font = fonts::match_font(&font_request, scale_factor);
 
         match (font, parley_disabled()) {
             #[cfg(feature = "software-renderer-systemfonts")]
             (fonts::Font::VectorFont(_), false) => {
                 sharedparley::text_input_cursor_rect_for_byte_offset(
+                    self,
                     text_input,
                     byte_offset,
                     font_request,
-                    scale_factor,
                 )
             }
             #[cfg(feature = "software-renderer-systemfonts")]
@@ -1008,6 +1016,13 @@ impl RendererSealed for SoftwareRenderer {
     fn set_window_adapter(&self, window_adapter: &Rc<dyn WindowAdapter>) {
         *self.maybe_window_adapter.borrow_mut() = Some(Rc::downgrade(window_adapter));
         self.partial_rendering_state.clear_cache();
+    }
+
+    fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
+        self.maybe_window_adapter
+            .borrow()
+            .as_ref()
+            .and_then(|window_adapter| window_adapter.upgrade())
     }
 
     fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -17,6 +17,7 @@ use crate::{
         LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PhysicalPx,
         PointLengths, ScaleFactor, SizeLengths,
     },
+    renderer::RendererSealed,
     textlayout::{TextHorizontalAlignment, TextOverflow, TextVerticalAlignment, TextWrap},
     SharedString,
 };
@@ -1352,12 +1353,15 @@ pub fn draw_text_input(
 }
 
 pub fn text_size(
+    renderer: &dyn RendererSealed,
     font_request: FontRequest,
     text: &str,
     max_width: Option<LogicalLength>,
-    scale_factor: ScaleFactor,
     text_wrap: TextWrap,
 ) -> LogicalSize {
+    let Some(scale_factor) = renderer.scale_factor() else {
+        return LogicalSize::default();
+    };
     let layout = layout(
         Text::PlainText(text),
         scale_factor,
@@ -1397,11 +1401,14 @@ pub fn font_metrics(font_request: FontRequest) -> crate::items::FontMetrics {
 }
 
 pub fn text_input_byte_offset_for_position(
+    renderer: &dyn RendererSealed,
     text_input: Pin<&crate::items::TextInput>,
     pos: LogicalPoint,
     font_request: FontRequest,
-    scale_factor: ScaleFactor,
 ) -> usize {
+    let Some(scale_factor) = renderer.scale_factor() else {
+        return 0;
+    };
     let pos: PhysicalPoint = pos * scale_factor;
     let text = text_input.text();
 
@@ -1428,11 +1435,14 @@ pub fn text_input_byte_offset_for_position(
 }
 
 pub fn text_input_cursor_rect_for_byte_offset(
+    renderer: &dyn RendererSealed,
     text_input: Pin<&crate::items::TextInput>,
     byte_offset: usize,
     font_request: FontRequest,
-    scale_factor: ScaleFactor,
 ) -> LogicalRect {
+    let Some(scale_factor) = renderer.scale_factor() else {
+        return LogicalRect::default();
+    };
     let text = text_input.text();
 
     let font_size = font_request.pixel_size.unwrap_or(DEFAULT_FONT_SIZE);

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -17,9 +17,7 @@ use i_slint_core::graphics::{FontRequest, SharedPixelBuffer};
 use i_slint_core::item_rendering::ItemRenderer;
 use i_slint_core::item_tree::ItemTreeWeak;
 use i_slint_core::items::TextWrap;
-use i_slint_core::lengths::{
-    LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PhysicalPx, ScaleFactor,
-};
+use i_slint_core::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalSize, PhysicalPx};
 use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::RendererSealed;
 use i_slint_core::textlayout::sharedparley;
@@ -289,16 +287,14 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         font_request: i_slint_core::graphics::FontRequest,
         text: &str,
         max_width: Option<LogicalLength>,
-        scale_factor: ScaleFactor,
         text_wrap: TextWrap,
     ) -> LogicalSize {
-        sharedparley::text_size(font_request, text, max_width, scale_factor, text_wrap)
+        sharedparley::text_size(self, font_request, text, max_width, text_wrap)
     }
 
     fn font_metrics(
         &self,
         font_request: i_slint_core::graphics::FontRequest,
-        _scale_factor: ScaleFactor,
     ) -> i_slint_core::items::FontMetrics {
         sharedparley::font_metrics(font_request)
     }
@@ -308,14 +304,8 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         text_input: Pin<&i_slint_core::items::TextInput>,
         pos: LogicalPoint,
         font_request: FontRequest,
-        scale_factor: ScaleFactor,
     ) -> usize {
-        sharedparley::text_input_byte_offset_for_position(
-            text_input,
-            pos,
-            font_request,
-            scale_factor,
-        )
+        sharedparley::text_input_byte_offset_for_position(self, text_input, pos, font_request)
     }
 
     fn text_input_cursor_rect_for_byte_offset(
@@ -323,13 +313,12 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         text_input: Pin<&i_slint_core::items::TextInput>,
         byte_offset: usize,
         font_request: FontRequest,
-        scale_factor: ScaleFactor,
     ) -> LogicalRect {
         sharedparley::text_input_cursor_rect_for_byte_offset(
+            self,
             text_input,
             byte_offset,
             font_request,
-            scale_factor,
         )
     }
 
@@ -388,6 +377,13 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
                 self.texture_cache.borrow_mut().clear();
             })
             .ok();
+    }
+
+    fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
+        self.maybe_window_adapter
+            .borrow()
+            .as_ref()
+            .and_then(|window_adapter| window_adapter.upgrade())
     }
 
     fn resize(&self, size: i_slint_core::api::PhysicalSize) -> Result<(), PlatformError> {

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -826,16 +826,14 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         font_request: i_slint_core::graphics::FontRequest,
         text: &str,
         max_width: Option<LogicalLength>,
-        scale_factor: ScaleFactor,
         text_wrap: TextWrap,
     ) -> LogicalSize {
-        sharedparley::text_size(font_request, text, max_width, scale_factor, text_wrap)
+        sharedparley::text_size(self, font_request, text, max_width, text_wrap)
     }
 
     fn font_metrics(
         &self,
         font_request: i_slint_core::graphics::FontRequest,
-        _scale_factor: ScaleFactor,
     ) -> i_slint_core::items::FontMetrics {
         sharedparley::font_metrics(font_request)
     }
@@ -845,14 +843,8 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
         pos: LogicalPoint,
         font_request: FontRequest,
-        scale_factor: ScaleFactor,
     ) -> usize {
-        sharedparley::text_input_byte_offset_for_position(
-            text_input,
-            pos,
-            font_request,
-            scale_factor,
-        )
+        sharedparley::text_input_byte_offset_for_position(self, text_input, pos, font_request)
     }
 
     fn text_input_cursor_rect_for_byte_offset(
@@ -860,13 +852,12 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
         byte_offset: usize,
         font_request: FontRequest,
-        scale_factor: ScaleFactor,
     ) -> LogicalRect {
         sharedparley::text_input_cursor_rect_for_byte_offset(
+            self,
             text_input,
             byte_offset,
             font_request,
-            scale_factor,
         )
     }
 
@@ -927,6 +918,13 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         if let Some(partial_rendering_state) = self.partial_rendering_state() {
             partial_rendering_state.clear_cache();
         }
+    }
+
+    fn window_adapter(&self) -> Option<Rc<dyn WindowAdapter>> {
+        self.maybe_window_adapter
+            .borrow()
+            .as_ref()
+            .and_then(|window_adapter| window_adapter.upgrade())
     }
 
     fn resize(&self, size: i_slint_core::api::PhysicalSize) -> Result<(), PlatformError> {


### PR DESCRIPTION
Instead of each caller obtaining the scale factor, the renderer can do that, too. This also eliminates the dependency to the scale factor where it's not needed, such as for the font metrics.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
