### PR TITLE
Skip wgpu surface configuration when size is zero

### DIFF
--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -930,6 +930,10 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
     }
 
     fn resize(&self, size: i_slint_core::api::PhysicalSize) -> Result<(), PlatformError> {
+        if size.width == 0 || size.height == 0 {
+            return Ok(());
+        }
+
         if let Some(surface) = self.surface.borrow().as_ref() {
             surface.resize_event(size)
         } else {


### PR DESCRIPTION
During window initialization, Slint window properties (width/height) are set incrementally, which can result in Surface::configure being called with zero dimensions. This causes wgpu to panic with the error: "Both Surface width and height must be non-zero."

This fix skips surface configuration when either dimension is zero, following wgpu's recommendation to "wait to recreate the Surface until the window has non-zero area."

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
