### PR TITLE
Help CI use skia binaries

### DIFF
--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -58,7 +58,7 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Force Skia binaries download on macOS
-              if: runner.os == 'macos-14' # Remember to update this if the macos runner name changes
+              if: runner.os == 'macOS' # Remember to update this if the macos runner name changes
               run: echo "FORCE_SKIA_BINARIES_DOWNLOAD=1" >> $GITHUB_ENV
               shell: bash
             - uses: ./.github/actions/install-linux-dependencies


### PR DESCRIPTION
sets: FORCE_SKIA_BINARIES_DOWNLOAD: 1

Because...
build_support/binary_cache/env.rs (lines 7-9)
pub fn force_skia_binaries_download() -> bool {
        cargo::env_var("FORCE_SKIA_BINARIES_DOWNLOAD").is_some()
}