### PR TITLE
Remove incorrect cross-demo import from home-automation

### DIFF
--- a/demos/home-automation/ui/components/mainView/mainScreen.slint
+++ b/demos/home-automation/ui/components/mainView/mainScreen.slint
@@ -7,7 +7,6 @@ import { Palette as StdPalette } from "std-widgets.slint";
 import { Palette, Animation, Style } from "../../common.slint";
 import { AppState, Orientation } from "../../appState.slint";
 import { FullScreenView } from "fullScreenView.slint";
-import { Page } from "../../../../printerdemo/ui/common.slint";
 import { HaText } from "../general/haText.slint";
 import { Api } from "../../api.slint";
 


### PR DESCRIPTION
Removes import of Page component from printerdemo in home-automation demo, as this creates an inappropriate dependency between separate demo projects.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
