### PR TITLE
Python: Be conservative about attaching to the Python interpreter

### DIFF
--- a/api/python/slint/lib.rs
+++ b/api/python/slint/lib.rs
@@ -105,7 +105,7 @@ impl Translator for PyGettextTranslator {
         string: &'a str,
         context: Option<&'a str>,
     ) -> std::borrow::Cow<'a, str> {
-        Python::attach(|py| {
+        Python::try_attach(|py| {
             match if let Some(context) = context {
                 self.0.call_method(py, pyo3::intern!(py, "pgettext"), (context, string), None)
             } else {
@@ -120,6 +120,7 @@ impl Translator for PyGettextTranslator {
             .and_then(|maybe_str| maybe_str.extract::<String>(py).ok())
             .map(std::borrow::Cow::Owned)
         })
+        .flatten()
         .unwrap_or(std::borrow::Cow::Borrowed(string))
         .into()
     }
@@ -131,7 +132,7 @@ impl Translator for PyGettextTranslator {
         plural: &'a str,
         context: Option<&'a str>,
     ) -> std::borrow::Cow<'a, str> {
-        Python::attach(|py| {
+        Python::try_attach(|py| {
             match if let Some(context) = context {
                 self.0.call_method(
                     py,
@@ -151,6 +152,7 @@ impl Translator for PyGettextTranslator {
             .and_then(|maybe_str| maybe_str.extract::<String>(py).ok())
             .map(std::borrow::Cow::Owned)
         })
+        .flatten()
         .unwrap_or(std::borrow::Cow::Borrowed(singular))
         .into()
     }

--- a/api/python/slint/models.rs
+++ b/api/python/slint/models.rs
@@ -96,7 +96,7 @@ impl i_slint_core::model::Model for PyModelShared {
     type Data = slint_interpreter::Value;
 
     fn row_count(&self) -> usize {
-        Python::attach(|py| {
+        Python::try_attach(|py| {
             let obj = self.self_ref.borrow();
             let Some(obj) = obj.as_ref() else {
                 eprintln!("Python: Model implementation is lacking self object (in row_count)");
@@ -125,11 +125,11 @@ impl i_slint_core::model::Model for PyModelShared {
                     0
                 }
             }
-        })
+        }).unwrap_or_default()
     }
 
     fn row_data(&self, row: usize) -> Option<Self::Data> {
-        Python::attach(|py| {
+        Python::try_attach(|py| {
             let obj = self.self_ref.borrow();
             let Some(obj) = obj.as_ref() else {
                 eprintln!("Python: Model implementation is lacking self object (in row_data)");
@@ -164,11 +164,11 @@ impl i_slint_core::model::Model for PyModelShared {
                     None
                 }
             }
-        })
+        }).flatten()
     }
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
-        Python::attach(|py| {
+        Python::try_attach(|py| {
             let obj = self.self_ref.borrow();
             let Some(obj) = obj.as_ref() else {
                 eprintln!("Python: Model implementation is lacking self object (in set_row_data)");


### PR DESCRIPTION
We call Python::attach in a few places. When invoked from the Slint event loop, those should be fine. But there are some that may fail, for example during gc. Fall back to using try_attach and return default values instead of causing a panic.

Fixes #9984

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
