### PR TITLE
winit: Fix explicit renderer-femtovg-wgpu selection

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -384,17 +384,14 @@ impl BackendBuilder {
             }
             #[cfg(feature = "renderer-femtovg-wgpu")]
             (Some("femtovg-wgpu"), maybe_graphics_api) => {
-                if !maybe_graphics_api.is_some_and(|_api| {
+                if let Some(_api) = maybe_graphics_api {
                     #[cfg(feature = "unstable-wgpu-27")]
-                    if matches!(_api, RequestedGraphicsAPI::WGPU27(..)) {
-                        return true;
+                    if !matches!(_api, RequestedGraphicsAPI::WGPU27(..)) {
+                        return Err(
+                           "The FemtoVG WGPU renderer only supports the WGPU27 graphics API selection"
+                                .into(),
+                        );
                     }
-                    false
-                }) {
-                    return Err(
-                        "The FemtoVG WGPU renderer only supports the WGPU27 graphics API selection"
-                            .into(),
-                    );
                 }
                 renderer::femtovg::WGPUFemtoVGRenderer::new_suspended
             }


### PR DESCRIPTION
When no graphics API is requested by the app, permit the selection to continue.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
