### PR TITLE
Group dependabot updates by semver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,32 +42,9 @@ updates:
       - dependency-name: "monaco-languageclient"
 
     groups:
-      vscode:
-        patterns:
-          - "vscode*"
-      starlight_astro:
-        patterns:
-          - "*astro*"
-          - "@*astro*"
-          - "starlight*"
-          - "sharp"
-          - "@expressive-code/plugin-line-numbers"
-      playwright:
-        patterns:
-          - "playwright*"
-          - "@playwright*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-      lumino:
-        patterns:
-          - "@lumino/*"
-      vite:
-        patterns:
-          - "vite*"
-          - "@vitejs*"
-          - "vitest*"
-          - "@vitest*"
+      npm-major-updates:
+        update-types: ["major"]
+      npm-minor-updates:
+        update-types: ["minor"]
+      npm-patch-updates:
+        update-types: ["patch"]


### PR DESCRIPTION
Instead of many seperate PR's they will be grouped by major, minor and patch release.
Plus the group that updates github actions