### PR TITLE
Parley: cleanups

### DIFF
--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -1396,14 +1396,7 @@ pub fn draw_text_input(
         },
     );
 
-    let (cursor_visible, cursor_pos) =
-        if let Some(cursor_pos) = visual_representation.cursor_position {
-            (true, cursor_pos)
-        } else {
-            (false, 0)
-        };
-
-    if cursor_visible {
+    if let Some(cursor_pos) = visual_representation.cursor_position {
         let cursor_rect = layout
             .cursor_rect_for_byte_offset(cursor_pos, text_input.text_cursor_width() * scale_factor);
         item_renderer.fill_rectange_with_color(cursor_rect, visual_representation.cursor_color);


### PR DESCRIPTION
This series of changes tries to separate concerns within the parley layout a little:

1. Setup parley with LayoutWithoutLineBreaksBuilder.
2. Split text into paragraphs, apply formatting, and shape the text, with create_text_paragraphs()
3. Break text into multiple lines and position glyphs, with layout().

The objective beyond this PR is to cache steps 1 and 2 using "standard" property tracking techniques (ItemCache) and only do 3 as needed. But there's a little more work to do before that's possible. This is a snapshot on the way.