### PR TITLE
servo: Fix clean build

### DIFF
--- a/examples/servo/Cargo.toml
+++ b/examples/servo/Cargo.toml
@@ -72,3 +72,6 @@ gl_generator = "0.14.0"
 
 [[package.metadata.android.uses_permission]]
 name = "android.permission.INTERNET"
+
+[patch.'https://github.com/servo/mozjs.git']
+mozjs = { git = "https://github.com/slint-ui/mozjs.git", rev = "b9555e20d4abcb206888e8c921373d095db3b1a6" }


### PR DESCRIPTION
Servo's script crate uses

    js = { package = "mozjs", git = "https://github.com/servo/mozjs" }

which means it would pick mozjs from master. Inside servo this works because of the present `Cargo.lock` file that pins it. But the version of servo we're using doesn't compile with the master branch of mozjs.

Unfortunately the `[patch]` section in `Cargo.toml` can't just change the revision, only if also the URL changes. So point mozjs to a fork of ours and then we can pin the correct version that servo also uses.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
