### PR TITLE
CI: Don't build the material gallery for every CI build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
             os: ${{ matrix.os }}
             name: ${{ matrix.name }}
             rust_version: ${{ matrix.rust_version }}
-            extra_args: ${{ matrix.extra_args }}
+            extra_args: ${{ matrix.extra_args }} --exclude material-gallery
             save_if: ${{ matrix.save_if }}
             timeout_minutes: 120
 


### PR DESCRIPTION
It's just built in the nightly. On macOS in the CI it's built twice, once as bin and once as lib, with a total of 600seconds according to cargo-timings.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
