### PR TITLE
CI: Speed up test-driver-rust build

### DIFF
--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -49,6 +49,8 @@ jobs:
             QT_QPA_PLATFORM: offscreen
             RUSTFLAGS: -D warnings
             CARGO_PROFILE_DEV_DEBUG: 0
+            # Build slint-compiler in release to make test-driver-rust's build-time feature build faster.
+            CARGO_PROFILE_DEV_BUILD_OVERRIDE_OPT_LEVEL: 3
             CARGO_INCREMENTAL: false
             RUST_BACKTRACE: 1
             SLINT_EMIT_DEBUG_INFO: 1


### PR DESCRIPTION
On my machine more than a minute is spent on running build.rs for test-driver-rust generating slint code for all the .slint files, as the build-time feature is enabled.

This patch builds the build script with optimizations, to reduce the time spent on generating code. On my machine that cuts it down to ~30 seconds.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
