### PR TITLE
Fix slint_debug_property build

### DIFF
--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -1174,12 +1174,15 @@ impl<T: PartialEq + Clone + 'static> Property<T> {
                 PropertyHandle::default()
             };
 
+            #[cfg(slint_debug_property)]
+            let debug_name = alloc::format!("{}*", prop1.debug_name.borrow());
+
             let common_property = Rc::pin(Property {
                 handle,
                 value: UnsafeCell::new(prop1.get_internal()),
                 pinned: PhantomPinned,
                 #[cfg(slint_debug_property)]
-                debug_name: alloc::format("{}*", prop1.debug_name.borrow()).into(),
+                debug_name: debug_name.clone().into(),
             });
             // Safety: TwoWayBinding's T is the same as the type for both properties
             unsafe {


### PR DESCRIPTION
* must be format!() instead of format()

* line 1192 uses a debug_name local variable, which got removed

Amends commit e11015e7b3020f0c6b9c531876479259b1587a0a ("Two way binding with struct for the interpreter")

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
