### PR TITLE
Fix typos in comments while reading the code

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1550,8 +1550,8 @@ pub struct BindingExpression {
     pub expression: Expression,
     /// The location of this expression in the source code
     pub span: Option<SourceLocation>,
-    /// How deep is this binding declared in the hierarchy. When two binding are conflicting
-    /// for the same priority (because of two way binding), the lower priority wins.
+    /// How deep is this binding declared in the hierarchy. When two bindings are conflicting
+    /// for the same priority (because of a two way binding), the lower priority wins.
     /// The priority starts at 1, and each level of inlining adds one to the priority.
     /// 0 means the expression was added by some passes and it is not explicit in the source code
     pub priority: i32,

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -453,7 +453,7 @@ fn init_fake_property(
 /// Internal representation of a grid layout
 #[derive(Debug, Clone)]
 pub struct GridLayout {
-    /// All the elements will be layout within that element.
+    /// All the elements which will be laid out within that element.
     pub elems: Vec<GridLayoutElement>,
 
     pub geometry: LayoutGeometry,
@@ -475,7 +475,7 @@ impl GridLayout {
 /// Internal representation of a BoxLayout
 #[derive(Debug, Clone)]
 pub struct BoxLayout {
-    /// Whether, this is a HorizontalLayout, otherwise a VerticalLayout
+    /// Whether this is a HorizontalLayout or a VerticalLayout
     pub orientation: Orientation,
     pub elems: Vec<LayoutItem>,
     pub geometry: LayoutGeometry,

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -389,7 +389,7 @@ pub fn is_currently_tracking() -> bool {
 /// This structure erase the `B` type with a vtable.
 #[repr(C)]
 struct BindingHolder<B = ()> {
-    /// Access to the list of binding which depends on this binding
+    /// Access to the list of bindings which depend on this binding
     dependencies: Cell<usize>,
     /// The binding own the nodes used in the dependencies lists of the properties
     /// From which we depend.
@@ -490,10 +490,10 @@ fn alloc_binding_holder<T, B: BindingCallable<T> + 'static>(binding: B) -> *mut 
 struct PropertyHandle {
     /// The handle can either be a pointer to a binding, or a pointer to the list of dependent properties.
     /// The two least significant bit of the pointer are flags, as the pointer will be aligned.
-    /// The least significant bit (`0b01`) tells that the binding is borrowed. So no two reference to the
+    /// The least significant bit (`0b01`) tells that the binding is borrowed. So no two references to the
     /// binding exist at the same time.
     /// The second to last bit (`0b10`) tells that the pointer points to a binding. Otherwise, it is the head
-    /// node of the linked list of dependent binding
+    /// node of the linked list of dependent bindings.
     handle: Cell<usize>,
 }
 
@@ -511,12 +511,12 @@ impl core::fmt::Debug for PropertyHandle {
 }
 
 impl PropertyHandle {
-    /// The lock flag specify that we can get reference to the Cell or unsafe cell
+    /// The lock flag specifies that we can get a reference to the Cell or unsafe cell
     fn lock_flag(&self) -> bool {
         self.handle.get() & 0b1 == 1
     }
     /// Sets the lock_flag.
-    /// Safety: the lock flag must not be unset if there exist reference to what's inside the cell
+    /// Safety: the lock flag must not be unset if there exist references to what's inside the cell
     unsafe fn set_lock_flag(&self, set: bool) {
         self.handle.set(if set { self.handle.get() | 0b1 } else { self.handle.get() & !0b1 })
     }
@@ -779,9 +779,9 @@ impl<T, F: Fn() -> T> Binding<T> for F {
     }
 }
 
-/// A Property that allow binding that track changes
+/// A Property that allows a binding that tracks changes
 ///
-/// Property can have an assigned value, or binding.
+/// Property can have an assigned value, or a binding.
 /// When a binding is assigned, it is lazily evaluated on demand
 /// when calling `get()`.
 /// When accessing another property from a binding evaluation,

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -208,7 +208,7 @@ impl std::fmt::Debug for Value {
 /// means that `Value::Number` can be converted to / from each of the said rust types
 ///
 /// For `Value::Object` mapping to a rust `struct`, one can use [`declare_value_struct_conversion!`]
-/// And for `Value::EnumerationValue` which maps to a rust `enum`, one can use [`declare_value_struct_conversion!`]
+/// And for `Value::EnumerationValue` which maps to a rust `enum`, one can use [`declare_value_enum_conversion!`]
 macro_rules! declare_value_conversion {
     ( $value:ident => [$($ty:ty),*] ) => {
         $(


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
