### PR TITLE
skia: Fix build after read-fonts release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,8 @@ wgpu-27 = { package = "wgpu", version = "27", default-features = false }
 input = { version = "0.9.0", default-features = false }
 tr = { version = "0.1", default-features = false }
 fontique = { version = "0.6.0" }
-read-fonts = { version = "0.35" }
+# Pin until https://github.com/googlefonts/fontations/issues/1693 is resolved
+read-fonts = { version = "=0.35.0" }
 skrifa = { version = "0.37" }
 windows = { version = "0.62" }
 windows-core = { version = "0.62.0" }


### PR DESCRIPTION
Pin read-fonts to 0.35.0 until https://github.com/googlefonts/fontations/issues/1693 is resolved.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
