### PR TITLE
Tweak to reduce total number of rust-caches

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -31,7 +31,7 @@ inputs:
     save_if:
         description: "Condition to save the cache"
         required: false
-        default: "true"
+        default: ${{ github.ref == 'refs/heads/master' }}
 
 runs:
     using: composite

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -84,6 +84,7 @@ jobs:
                   toolchain: ${{ inputs.rust_version }}
                   key: x-v3
                   save_if: ${{ inputs.save_if }}
+                  cache: ${{ inputs.cache }}
             - name: Run tests
               run:  cargo test --verbose --all-features --workspace --timings ${{ inputs.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python -- --skip=_qt::t
               env:


### PR DESCRIPTION
50GB of caches in branches is still being created. This doesn't 
eliminate them all but makes a decent dent. This stops the more useful 
master branch cache being evicted.