### PR TITLE
Zed extension: Readd the check for slint-lsp to use the binary in PATH

### DIFF
--- a/editors/zed/src/slint.rs
+++ b/editors/zed/src/slint.rs
@@ -30,6 +30,10 @@ impl SlintExtension {
             return Ok(SlintBinary { path, args: binary_args });
         }
 
+        if let Some(path) = worktree.which("slint-lsp") {
+            return Ok(SlintBinary { path, args: binary_args });
+        }
+
         if let Some(path) = &self.cached_binary_path {
             if fs::metadata(path).is_ok_and(|stat| stat.is_file()) {
                 zed::set_language_server_installation_status(


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Fixes #9826.

On NixOS, the binary provided by the Zed extension cannot currently be used due to how NixOS handles libraries. The `slint` binary present in the `PATH` is currently ignored. This PR prioritizes the binary in the `PATH`.