### PR TITLE
Fix font familly of component that inherit from PopupWindow with the material style

### DIFF
--- a/internal/compiler/passes/apply_default_properties_from_style.rs
+++ b/internal/compiler/passes/apply_default_properties_from_style.rs
@@ -7,7 +7,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Expression, NamedReference};
-use crate::langtype::Type;
+use crate::langtype::{ElementType, Type};
 use crate::object_tree::Component;
 use smol_str::SmolStr;
 use std::rc::Rc;
@@ -24,7 +24,9 @@ pub fn apply_default_properties_from_style(
         &(),
         &mut |elem, _| {
             let mut elem = elem.borrow_mut();
-            match elem.builtin_type().as_ref().map_or("", |b| b.name.as_str()) {
+            let ElementType::Builtin(builtin) = &elem.base_type else { return };
+            let builtin_name = builtin.name.as_str();
+            match builtin_name {
                 "TextInput" => {
                     elem.set_binding_if_not_set("text-cursor-width".into(), || {
                         Expression::PropertyReference(NamedReference::new(


### PR DESCRIPTION
Fixes #9866

The material style defines a `StyleMetrics.default-font-family` which is meant to be applied to `Window` element if not set by the user. But it was mistakely sometimes applied to PopupWindow

Consider this code:
```slint
component MyPopup inherits PopupWindow {
    Text { text: "Hello"; }
}

export component MainWindow inherits Window {
    my_popup := MyPopup { }
}
```

First, we would process MyPopup: `apply_default_property_from_style` wouldn't do anything, but the `lower_popups` pass would replace its root with a Window builtin.
Second, we would process MainWindow: `apply_default_property_from_style` would see that my_popup is using the Window as a builtin and would apply default window properties from style, which it shouldn't.

In fact, `apply_default_property_from_style` should only apply default for elements that are directly using the builtin, not a component that inherits from that builtin, as these property should have been already set.
