### PR TITLE
winit: Mark zero-size Windows windows as occluded

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -186,9 +186,17 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                 // trigger a resize event. We need to update the internal window
                 // state to match the actual window state. We simulate a "window
                 // state event" since there is not an official event for it yet.
-                // Because we don't always get a Resized event (eg, minimized), also handle Occluded
                 // See: https://github.com/rust-windowing/winit/issues/2334
                 window.window_state_event();
+
+                // Some platforms (e.g., Windows) may not emit an Occluded event when minimized,
+                // so manually mark the window as occluded if its size is zero.
+                #[cfg(target_os = "windows")]
+                {
+                    if size.width == 0 || size.height == 0 {
+                        window.renderer.occluded(true);
+                    }
+                }
             }
             WindowEvent::CloseRequested => {
                 self.loop_error = window

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -171,7 +171,7 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
     }
 
     fn occluded(&self, _: bool) {
-        // On X11, the buffer is completely cleared when the window is hidden
+        // On X11 and Windows, the buffer is completely cleared when the window is hidden
         // and the buffer age doesn't respect that, so clean the partial rendering cache
         self.renderer.set_repaint_buffer_type(RepaintBufferType::NewBuffer);
     }


### PR DESCRIPTION
Fixes #9977
