### PR TITLE
Add interpreter test for dialog button order

### DIFF
--- a/tests/cases/elements/dialog.slint
+++ b/tests/cases/elements/dialog.slint
@@ -3,24 +3,37 @@
 
 import { StandardButton, Button, GridBox } from "std-widgets.slint";
 
-TestCase := Dialog {
-    Rectangle {
+export component TestCase inherits Dialog {
+    mainwidget := Rectangle {
         background: red;
         preferred-width: 600px;
         preferred-height: 600px;
     }
     forward-focus: ok-button;
 
-    StandardButton { kind: help; }
+    help-button := StandardButton { kind: help; }
     ok-button := StandardButton { kind: ok; }
-    StandardButton { kind: cancel; }
-    StandardButton { kind: apply; }
-    StandardButton { kind: reset; }
-    StandardButton { kind: yes; }
-    Button {
-        text: "Action";
+    cancel-button := StandardButton { kind: cancel; }
+    apply-button := StandardButton { kind: apply; }
+    reset-button := StandardButton { kind: reset; }
+    yes-button := StandardButton { kind: yes; }
+    action-button := Button {
+        text: mainwidget.colspan;
         dialog-button-role: action;
     }
+
+    property <length> buttons_y: mainwidget.y + mainwidget.height + 8px;
+
+    // The interpreter in test mode assumes Windows layout: Reset, Accept, Action, Reject, Apply, Help
+    property <bool> mainwidget_ok: mainwidget.x == 8px && mainwidget.y == 8px;
+    property <bool> reset_ok: reset-button.x == 8px && reset-button.y == buttons_y;
+    property <bool> ok_ok: ok-button.x > reset-button.x && ok-button.y == buttons_y;
+    property <bool> yes_ok: yes-button.x > ok-button.x && yes-button.y == buttons_y;
+    property <bool> action_ok: action-button.x > ok-button.x && action-button.y == buttons_y;
+    property <bool> cancel_ok: cancel-button.x > action-button.x && cancel-button.y == buttons_y;
+    property <bool> apply_ok: apply-button.x > cancel-button.x && apply-button.y == buttons_y;
+    property <bool> help_ok: help-button.x > apply-button.x && help-button.y == buttons_y;
+    out property <bool> test: mainwidget_ok && reset_ok && ok_ok && yes_ok && action_ok && cancel_ok && apply_ok && help_ok;
 }
 
 /*

--- a/tests/driver/interpreter/Cargo.toml
+++ b/tests/driver/interpreter/Cargo.toml
@@ -20,6 +20,7 @@ name = "test-driver-interpreter"
 [dev-dependencies]
 slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2"] }
 i-slint-backend-testing = { workspace = true }
+i-slint-core = { workspace = true }
 
 itertools = { workspace = true }
 spin_on = { version = "0.1" }

--- a/tests/driver/interpreter/interpreter.rs
+++ b/tests/driver/interpreter/interpreter.rs
@@ -20,6 +20,11 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
     compiler.set_library_paths(library_paths);
     compiler.set_style(testcase.requested_style.unwrap_or("fluent").into());
 
+    // Ensure we get consistent results on all platforms even for OS-dependent
+    // behavior like dialog button order.
+    i_slint_core::OPERATING_SYSTEM_OVERRIDE
+        .set(Some(i_slint_core::items::OperatingSystemType::Windows));
+
     let result =
         spin_on::spin_on(compiler.build_from_source(source, testcase.absolute_path.clone()));
 


### PR DESCRIPTION
There was no such test yet, and my upcoming changes refactor how and when this reordering happens.

To ensure the test doesn't depend on the OS/WM, the interpreter sets a global bool to force the Windows layout on all platforms (I picked Windows because it was the first branch in the code).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
