### PR TITLE
mcu-board-support: Fix memory.x linker precedence for STM32H735G

### DIFF
--- a/examples/mcu-board-support/build.rs
+++ b/examples/mcu-board-support/build.rs
@@ -4,6 +4,8 @@
 fn main() -> std::io::Result<()> {
     #[allow(unused)]
     let mut board_config_path: Option<std::path::PathBuf> = None;
+    #[allow(unused)]
+    let mut memory_x_source: Option<std::path::PathBuf> = None;
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "pico-st7789")] {
@@ -12,6 +14,7 @@ fn main() -> std::io::Result<()> {
             board_config_path = Some([env!("CARGO_MANIFEST_DIR"), "pico2_st7789", "board_config.toml"].iter().collect());
         } else if #[cfg(feature = "stm32h735g")] {
             board_config_path = Some([env!("CARGO_MANIFEST_DIR"), "stm32h735g", "board_config.toml"].iter().collect());
+            memory_x_source = Some([env!("CARGO_MANIFEST_DIR"), "stm32h735g", "memory.x"].iter().collect());
         } else if #[cfg(feature = "stm32u5g9j-dk2")] {
             board_config_path = Some([env!("CARGO_MANIFEST_DIR"), "stm32u5g9j_dk2", "board_config.toml"].iter().collect());
         }
@@ -19,6 +22,17 @@ fn main() -> std::io::Result<()> {
 
     if let Some(path) = board_config_path {
         println!("cargo:BOARD_CONFIG_PATH={}", path.display())
+    }
+
+    // Copy memory.x to OUT_DIR and add it to the linker search path.
+    // This ensures the board-specific memory.x takes precedence over
+    // any generic memory.x from dependencies (e.g., ft5336).
+    if let Some(source) = memory_x_source {
+        let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+        let dest = out_dir.join("memory.x");
+        std::fs::copy(&source, &dest)?;
+        println!("cargo:rustc-link-search={}", out_dir.display());
+        println!("cargo:rerun-if-changed={}", source.display());
     }
 
     println!("cargo:EMBED_TEXTURES=1");


### PR DESCRIPTION
Copy board-specific memory.x to OUT_DIR and add it to the linker search path. This ensures the STM32H735G board-specific memory.x takes precedence over any generic memory.x from dependencies like ft5336.

Fixes: #10035

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
