### PR TITLE
Modernize layout testcases

### DIFF
--- a/tests/cases/layout/box_alignment.slint
+++ b/tests/cases/layout/box_alignment.slint
@@ -9,7 +9,7 @@ MyWid := Rectangle {
 }
 
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -52,17 +52,17 @@ TestCase := Rectangle {
     }
 
     // check the vertical layout
-    property <bool> v1: ls.y == height - (4*20phx + 15phx) && rs1.y == 0 && rs1.y == rs2.y && rs1.y == rs3.y;
-    property <bool> v2: lb.y == height - (3*20phx + 10phx) && rb1.y == 0 && rb1.y == rb2.y && rb1.y == rb3.y;
-    property <bool> v3: la.y == height - (2*20phx + 5phx) && ra1.y == 0 && ra1.y == ra2.y && ra1.y == ra3.y;
-    property <bool> v4: lc.y == height - (1*20phx + 0phx) && rc1.y == 0 && rc1.y == rc2.y && rc1.y == rc3.y;
+    out property <bool> v1: ls.y == self.height - (4*20phx + 15phx) && rs1.y == 0 && rs1.y == rs2.y && rs1.y == rs3.y;
+    out property <bool> v2: lb.y == self.height - (3*20phx + 10phx) && rb1.y == 0 && rb1.y == rb2.y && rb1.y == rb3.y;
+    out property <bool> v3: la.y == self.height - (2*20phx + 5phx) && ra1.y == 0 && ra1.y == ra2.y && ra1.y == ra3.y;
+    out property <bool> v4: lc.y == self.height - (1*20phx + 0phx) && rc1.y == 0 && rc1.y == rc2.y && rc1.y == rc3.y;
 
     // check the horizontal layout
-    property <bool> s1: rs1.x == 0phx && rs2.x == 22phx && rs3.x == 44phx;
-    property <bool> c1: rc1.x == (width - 64phx)/2 && rc2.x == (width - rc2.width)/2 && rc3.x == (width + 64phx)/2 - ra3.width;
-    property <bool> b1: rb1.x == 0phx && rb2.x == (width - rb2.width)/2 && rb3.x == width - rb3.width;
+    out property <bool> s1: rs1.x == 0phx && rs2.x == 22phx && rs3.x == 44phx;
+    out property <bool> c1: rc1.x == (self.width - 64phx)/2 && rc2.x == (self.width - rc2.width)/2 && rc3.x == (self.width + 64phx)/2 - ra3.width;
+    out property <bool> b1: rb1.x == 0phx && rb2.x == (self.width - rb2.width)/2 && rb3.x == self.width - rb3.width;
 
-    property <bool> test: v1 && v2 && v3 && v4 && s1 && c1 && b1;
+    out property <bool> test: v1 && v2 && v3 && v4 && s1 && c1 && b1;
 }
 
 /*

--- a/tests/cases/layout/box_percentages.slint
+++ b/tests/cases/layout/box_percentages.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -46,13 +46,13 @@ TestCase := Rectangle {
     property <length> expected_y2: 90phx + 300phx * 0.15;
     property <length> expected_x1: 30phx;
 
-    property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == expected_x1 && rect1.height == expected_y1;
-    property <bool> rect2_pos_ok: rect2.x == expected_x1 && rect2.y == 0phx && rect2.width == 270phx && rect2.height == expected_y1;
-    property <bool> rect3_pos_ok: rect3.x == 0phx && rect3.y == expected_y1 && rect3.width == 300phx && rect3.height == 300phx * 0.15;
-    property <bool> rect4_pos_ok: rect4.x == 0phx && hl2.y == expected_y2 && rect4.width == expected_x1 && rect4.height == 300phx - expected_y2;
-    property <bool> rect5_pos_ok: rect5.x == expected_x1 && hl2.y == expected_y2 && rect5.width == 270phx && rect5.height == 300phx - expected_y2;
+    out property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == expected_x1 && rect1.height == expected_y1;
+    out property <bool> rect2_pos_ok: rect2.x == expected_x1 && rect2.y == 0phx && rect2.width == 270phx && rect2.height == expected_y1;
+    out property <bool> rect3_pos_ok: rect3.x == 0phx && rect3.y == expected_y1 && rect3.width == 300phx && rect3.height == 300phx * 0.15;
+    out property <bool> rect4_pos_ok: rect4.x == 0phx && hl2.y == expected_y2 && rect4.width == expected_x1 && rect4.height == 300phx - expected_y2;
+    out property <bool> rect5_pos_ok: rect5.x == expected_x1 && hl2.y == expected_y2 && rect5.width == 270phx && rect5.height == 300phx - expected_y2;
 
-    property <bool> test: rect1_pos_ok && rect2_pos_ok && rect3_pos_ok && rect4_pos_ok && rect5_pos_ok;
+    out property <bool> test: rect1_pos_ok && rect2_pos_ok && rect3_pos_ok && rect4_pos_ok && rect5_pos_ok;
 }
 
 /*

--- a/tests/cases/layout/box_preferred_size.slint
+++ b/tests/cases/layout/box_preferred_size.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     background: green;
     width: 300phx;
     height: 50phx;
@@ -22,8 +22,8 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> fake-image-width-ok: fake-image.width == 25phx;
-    property <bool> fake-image-height-ok: fake-image.height == 50phx;
+    out property <bool> fake-image-width-ok: fake-image.width == 25phx;
+    out property <bool> fake-image-height-ok: fake-image.height == 50phx;
     out property <bool> test: fake-image-width-ok && fake-image-height-ok;
 }
 

--- a/tests/cases/layout/flickable_in_layout.slint
+++ b/tests/cases/layout/flickable_in_layout.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export TestCase := Window {
+export component TestCase inherits Window {
     VerticalLayout {
         padding: 7px;
         Flickable {
@@ -17,7 +17,7 @@ export TestCase := Window {
         }
     }
 
-    property <bool> test: root.min_width == 7px*2 && root.min_height == 7px*2 && root.preferred_width == 114px && root.preferred_height == 14px + 600px;
+    out property <bool> test: root.min_width == 7px*2 && root.min_height == 7px*2 && root.preferred_width == 114px && root.preferred_height == 14px + 600px;
 }
 
 /*

--- a/tests/cases/layout/geometry_center_by_default.slint
+++ b/tests/cases/layout/geometry_center_by_default.slint
@@ -30,11 +30,11 @@ Old := Rectangle {
         && t1.x == 0 && t1.y == 0;
 }
 
-TestCase := Window {
+export component TestCase inherits Window {
     f := Foo {}
     o := Old {}
 
-    property <bool> test : f.test && o.test;
+    out property <bool> test : f.test && o.test;
 }
 
 /*

--- a/tests/cases/layout/grid2.slint
+++ b/tests/cases/layout/grid2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+export component TestCase inherits Window {
     width: 200phx;
     height: 500phx;
 
@@ -28,7 +28,7 @@ TestCase := Window {
     }
 
     // there should be 5 rows
-    property <bool> size_ok:
+    out property <bool> size_ok:
         rect1.width == 100phx && rect1.height == 100phx &&
         rect2.width == 100phx && rect2.height == 100phx &&
         rect3.width == 100phx && rect3.height == 100phx &&
@@ -39,14 +39,14 @@ TestCase := Window {
         rect8.width == 100phx && rect8.height == 100phx &&
         rect9.width == 100phx && rect9.height == 100phx &&
         rect10.width == 100phx && rect10.height == 100phx;
-    property <bool> x_ok:
+    out property <bool> x_ok:
         rect1.x == 0phx && rect2.x == 100phx &&
         rect3.x == 0phx && rect4.x == 100phx &&
         rect5.x == 0phx && rect6.x == 100phx &&
         rect7.x == 0phx && rect8.x == 100phx &&
         rect9.x == 0phx && rect10.x == 100phx;
 
-    property <bool> y_ok:
+    out property <bool> y_ok:
         rect1.y == 0phx && rect2.y == 0phx &&
         rect3.y == 100phx && rect4.y == 100phx &&
         rect5.y == 200phx && rect6.y == 200phx &&

--- a/tests/cases/layout/grid_fixed_size.slint
+++ b/tests/cases/layout/grid_fixed_size.slint
@@ -6,7 +6,7 @@ SubWithConstraints := Rectangle {
     min-height: 20px;
 }
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -47,11 +47,11 @@ TestCase := Rectangle {
     property <length> expected_y2: 300phx*0.3 + 20phx;
     property <length> expected_x1: 30phx;
 
-    property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == expected_x1 && rect1.height == expected_y1;
-    property <bool> rect2_pos_ok: rect2.x == expected_x1 && rect2.y == 0phx && rect2.width == 270phx && rect2.height == expected_y1;
-    property <bool> rect3_pos_ok: rect3.x == 0phx && rect3.y == expected_y1 && rect3.width == expected_x1 && rect3.height == 20phx;
-    property <bool> rect4_pos_ok: rect4.x == 0phx && rect4.y == expected_y2 && rect4.width == expected_x1 && rect4.height == 300phx - expected_y2;
-    property <bool> rect5_pos_ok: rect5.x == expected_x1 && rect5.y == expected_y2 && rect5.width == 270phx && rect5.height == 300phx - expected_y2;
+    out property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == expected_x1 && rect1.height == expected_y1;
+    out property <bool> rect2_pos_ok: rect2.x == expected_x1 && rect2.y == 0phx && rect2.width == 270phx && rect2.height == expected_y1;
+    out property <bool> rect3_pos_ok: rect3.x == 0phx && rect3.y == expected_y1 && rect3.width == expected_x1 && rect3.height == 20phx;
+    out property <bool> rect4_pos_ok: rect4.x == 0phx && rect4.y == expected_y2 && rect4.width == expected_x1 && rect4.height == 300phx - expected_y2;
+    out property <bool> rect5_pos_ok: rect5.x == expected_x1 && rect5.y == expected_y2 && rect5.width == 270phx && rect5.height == 300phx - expected_y2;
 
     out property <bool> test: rect1_pos_ok && rect2_pos_ok && rect3_pos_ok && rect4_pos_ok && rect5_pos_ok;
 }

--- a/tests/cases/layout/grid_min_max.slint
+++ b/tests/cases/layout/grid_min_max.slint
@@ -3,7 +3,7 @@
 
 // Test the maximum and minimum size within a grid layout
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -38,9 +38,9 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == 60phx && rect1.height == 20phx;
-    property <bool> rect2_pos_ok: rect2.x == 61phx && rect2.y == 0phx && rect2.width == 138phx && rect2.height == 20phx;
-    property <bool> rect3_pos_ok: rect3.x == 0phx && rect3.y == 21phx && rect3.width == 60phx && rect3.height == 279phx;
+    out property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == 60phx && rect1.height == 20phx;
+    out property <bool> rect2_pos_ok: rect2.x == 61phx && rect2.y == 0phx && rect2.width == 138phx && rect2.height == 20phx;
+    out property <bool> rect3_pos_ok: rect3.x == 0phx && rect3.y == 21phx && rect3.width == 60phx && rect3.height == 279phx;
     out property <bool> test: rect1_pos_ok && rect2_pos_ok && rect3_pos_ok;
 }
 

--- a/tests/cases/layout/grid_padding.slint
+++ b/tests/cases/layout/grid_padding.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 600phx;
     height: 300phx;
 
@@ -43,8 +43,8 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> rect1_pos_ok: rect1.x == 20phx && rect1.y == 10phx && rect1.width == 250phx && rect1.height == 250phx;
-    property <bool> rect2_pos_ok: rect2.x == 20phx && rect2.y == 25phx && rect2.width == 250phx && rect2.height == 250phx;
+    out property <bool> rect1_pos_ok: rect1.x == 20phx && rect1.y == 10phx && rect1.width == 250phx && rect1.height == 250phx;
+    out property <bool> rect2_pos_ok: rect2.x == 20phx && rect2.y == 25phx && rect2.width == 250phx && rect2.height == 250phx;
     out property <bool> test: rect1_pos_ok && rect2_pos_ok;
 }
 

--- a/tests/cases/layout/grid_preferred_size.slint
+++ b/tests/cases/layout/grid_preferred_size.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     background: green;
     width: 300phx;
     height: 50phx;
@@ -28,8 +28,8 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> fake-image-width-ok: fake-image.width == 25phx;
-    property <bool> fake-image-height-ok: fake-image.height == 50phx;
+    out property <bool> fake-image-width-ok: fake-image.width == 25phx;
+    out property <bool> fake-image-height-ok: fake-image.height == 50phx;
 
     out property <bool> test: fake-image-width-ok && fake-image-height-ok;
 }

--- a/tests/cases/layout/grid_simple.slint
+++ b/tests/cases/layout/grid_simple.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -25,11 +25,11 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == 150phx && rect1.height == 150phx;
-    property <bool> rect2_pos_ok: rect2.x == 150phx && rect2.y == 0phx && rect2.width == 150phx && rect2.height == 150phx;
-    property <bool> rect3_pos_ok: rect3.x == 0phx && rect3.y == 150phx && rect3.width == 150phx && rect3.height == 150phx;
-    property <bool> row_col_ok: rect1.row == 0 && rect1.col == 0 && rect2.row == 0 && rect2.col == 1 && rect3.row == 1 && rect3.col == 0;
-    property <length> layout_width: layout.width;
+    out property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == 150phx && rect1.height == 150phx;
+    out property <bool> rect2_pos_ok: rect2.x == 150phx && rect2.y == 0phx && rect2.width == 150phx && rect2.height == 150phx;
+    out property <bool> rect3_pos_ok: rect3.x == 0phx && rect3.y == 150phx && rect3.width == 150phx && rect3.height == 150phx;
+    out property <bool> row_col_ok: rect1.row == 0 && rect1.col == 0 && rect2.row == 0 && rect2.col == 1 && rect3.row == 1 && rect3.col == 0;
+    out property <length> layout_width: layout.width;
 
     out property <bool> test: rect1_pos_ok && rect2_pos_ok && rect3_pos_ok && row_col_ok && layout_width == 300phx;
 }

--- a/tests/cases/layout/grid_spacing.slint
+++ b/tests/cases/layout/grid_spacing.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 600phx;
     height: 300phx;
 
@@ -40,8 +40,8 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> rect1_pos_ok: rect1.x == 15phx && rect1.y == 0phx;
-    property <bool> rect2_pos_ok: rect2.x == 15phx && rect2.y == 15phx;
+    out property <bool> rect1_pos_ok: rect1.x == 15phx && rect1.y == 0phx;
+    out property <bool> rect2_pos_ok: rect2.x == 15phx && rect2.y == 15phx;
 
     Rectangle {
         width: 300phx;
@@ -80,8 +80,8 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> rect3_pos_ok: rect3.x == 25phx && rect3.y == 0phx;
-    property <bool> rect4_pos_ok: rect4.x == 25phx && rect4.y == 35phx;
+    out property <bool> rect3_pos_ok: rect3.x == 25phx && rect3.y == 0phx;
+    out property <bool> rect4_pos_ok: rect4.x == 25phx && rect4.y == 35phx;
 
     out property <bool> test: rect1_pos_ok && rect2_pos_ok &&rect3_pos_ok && rect4_pos_ok;
 }

--- a/tests/cases/layout/height_for_width.slint
+++ b/tests/cases/layout/height_for_width.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 //include_path: ../../../demos/printerdemo/ui/images/
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 500phx;
     height: 2000phx;
 
@@ -34,7 +34,7 @@ TestCase := Rectangle {
                 Row {
                     hfw_rect := Rectangle {
                         background: orange;
-                        height: width / 2;
+                        height: self.width / 2;
                     }
                     Rectangle { }
                 }
@@ -43,11 +43,11 @@ TestCase := Rectangle {
         Image { }
     }
 
-    property <length> top_image_height: top_image.height;
-    property <length> second_image_height: second_image.height;
-    property <length> second_image_width: second_image.width;
-    property <bool> hfw_rect_ok: hfw_rect.width == 250phx && hfw_rect.height == 125phx;
-    property <bool> test: top_image_height == 750phx && second_image_width == 200phx && second_image_height == 300phx && hfw_rect_ok;
+    out property <length> top_image_height: top_image.height;
+    out property <length> second_image_height: second_image.height;
+    out property <length> second_image_width: second_image.width;
+    out property <bool> hfw_rect_ok: hfw_rect.width == 250phx && hfw_rect.height == 125phx;
+    out property <bool> test: top_image_height == 750phx && second_image_width == 200phx && second_image_height == 300phx && hfw_rect_ok;
 }
 
 /*

--- a/tests/cases/layout/horizontal_for.slint
+++ b/tests/cases/layout/horizontal_for.slint
@@ -1,10 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 100phx;
     height: 100phx;
-    property<int> value: -10;
+    out property<int> value: -10;
 
     HorizontalLayout {
 

--- a/tests/cases/layout/horizontal_sizes.slint
+++ b/tests/cases/layout/horizontal_sizes.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -50,12 +50,12 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> blue_rect_ok: blue-rect.x == 0phx && blue-rect.y == 0phx && blue-rect.width == 100phx && blue-rect.height == 100phx;
-    property <bool> red_rect_ok: red-rect.x == 100phx && red-rect.y == 0phx && red-rect.width == 50phx && red-rect.height == 100phx;
-    property <bool> green_rect_ok: green-rect.x == 150phx && green-rect.y == 0phx && green-rect.width == 20phx && green-rect.height == 100phx;
-    property <bool> orange_rect_ok: orange-rect.x == 170phx && orange-rect.y == 0phx && orange-rect.width == 10phx && orange-rect.height == 100phx;
-    property <bool> yellow_rect_ok: yellow-rect.x == 180phx && yellow-rect.y == 0phx && yellow-rect.width == 120phx/3 && yellow-rect.height == 100phx;
-    property <bool> pink_rect_ok: pink-rect.x == 180phx + yellow-rect.width && pink-rect.y == 0phx && pink-rect.width == 120phx*2/3 && pink-rect.height == 100phx;
+    out property <bool> blue_rect_ok: blue-rect.x == 0phx && blue-rect.y == 0phx && blue-rect.width == 100phx && blue-rect.height == 100phx;
+    out property <bool> red_rect_ok: red-rect.x == 100phx && red-rect.y == 0phx && red-rect.width == 50phx && red-rect.height == 100phx;
+    out property <bool> green_rect_ok: green-rect.x == 150phx && green-rect.y == 0phx && green-rect.width == 20phx && green-rect.height == 100phx;
+    out property <bool> orange_rect_ok: orange-rect.x == 170phx && orange-rect.y == 0phx && orange-rect.width == 10phx && orange-rect.height == 100phx;
+    out property <bool> yellow_rect_ok: yellow-rect.x == 180phx && yellow-rect.y == 0phx && yellow-rect.width == 120phx/3 && yellow-rect.height == 100phx;
+    out property <bool> pink_rect_ok: pink-rect.x == 180phx + yellow-rect.width && pink-rect.y == 0phx && pink-rect.width == 120phx*2/3 && pink-rect.height == 100phx;
     out property <bool> test: blue_rect_ok && red_rect_ok && green_rect_ok && orange_rect_ok && yellow_rect_ok && pink_rect_ok;
 }
 

--- a/tests/cases/layout/materialized_minmax.slint
+++ b/tests/cases/layout/materialized_minmax.slint
@@ -3,7 +3,7 @@
 
 // Test the propagation of maximum and minimum size through nested grid layouts
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -32,17 +32,17 @@ TestCase := Rectangle {
         }
     }
 
-    property<float> materialized_max_width: layout.max-width / 1phx;
-    property<float> materialized_max_height: layout.max-height / 1phx;
-    property<float> materialized_min_width: layout.min-width / 1phx;
-    property<float> materialized_min_height: layout.min-height / 1phx;
+    out property<float> materialized_max_width: layout.max-width / 1phx;
+    out property<float> materialized_max_height: layout.max-height / 1phx;
+    out property<float> materialized_min_width: layout.min-width / 1phx;
+    out property<float> materialized_min_height: layout.min-height / 1phx;
 
-    property<float> materialized_rect_max_width: rect.max-width / 1phx;
-    property<float> materialized_rect_max_height: rect.max-height / 1phx;
-    property<float> materialized_rect_min_width: rect.min-width / 1phx;
-    property<float> materialized_rect_min_height: rect.min-height / 1phx;
+    out property<float> materialized_rect_max_width: rect.max-width / 1phx;
+    out property<float> materialized_rect_max_height: rect.max-height / 1phx;
+    out property<float> materialized_rect_min_width: rect.min-width / 1phx;
+    out property<float> materialized_rect_min_height: rect.min-height / 1phx;
 
-    property <bool> test:
+    out property <bool> test:
         materialized_max_height == 300 && materialized_min_width == 50 && materialized_min_height == 25 && materialized_max_width > 100000 &&
         materialized_rect_max_height == 300 && materialized_rect_min_width == 50 && materialized_rect_min_height == 25 && materialized_rect_max_width > 100000;
 }

--- a/tests/cases/layout/nested_boxes.slint
+++ b/tests/cases/layout/nested_boxes.slint
@@ -19,12 +19,12 @@ RectRed := Rectangle {
         }
     }
 
-    property <bool> rect_green_ok:
+    out property <bool> rect_green_ok:
         rect_green.x == 0phx &&
         rect_green.y == 0phx &&
         rect_green.width == 50phx &&
         rect_green.height == 50phx;
-    property <bool> rect_pink_ok:
+    out property <bool> rect_pink_ok:
         rect_pink.x == 60phx &&
         rect_pink.y == 0phx &&
         rect_pink.width == 140phx &&
@@ -41,22 +41,22 @@ RedBlue := HorizontalLayout {
         background: blue;
     }
 
-    property rect_green_ok <=> rect_red.rect_green_ok;
-    property rect_pink_ok <=> rect_red.rect_pink_ok;
+    out property rect_green_ok <=> rect_red.rect_green_ok;
+    out property rect_pink_ok <=> rect_red.rect_pink_ok;
 
-    property <bool> rect_blue_ok:
+    out property <bool> rect_blue_ok:
         rect_blue.x == 200phx &&
         rect_blue.y == 0phx &&
         rect_blue.width == 100phx &&
         rect_blue.height == 50phx;
-    property <bool> rect_red_ok:
+    out property <bool> rect_red_ok:
         rect_red.x == 0phx &&
         rect_red.y == 0phx &&
         rect_red.width == 200phx &&
         rect_red.height == 50phx;
 }
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -112,35 +112,35 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> rect_orange_ok:
+    out property <bool> rect_orange_ok:
         rect_orange.x == 0phx &&
         rect_orange.y == 0phx &&
         rect_orange.width == 300phx &&
         rect_orange.height == 10phx;
-    property <bool> rect_blue_ok:
+    out property <bool> rect_blue_ok:
         hl_redblue.y == 10phx && hl-redblue.rect-blue-ok;
-    property <bool> rect_red_ok:
+    out property <bool> rect_red_ok:
         hl_redblue.y == 10phx && hl-redblue.rect-red-ok;
-    property <bool> rect_yellow_ok:
+    out property <bool> rect_yellow_ok:
         rect_yellow.x == 0phx &&
         rect_yellow.y == 60phx &&
         rect_yellow.width == 300phx &&
         rect_yellow.height == 240phx;
-    property <bool> rect_black1_ok:
+    out property <bool> rect_black1_ok:
         rect_black1.x + vl1.x == 8phx &&
         rect_black1.y + vl1.y == 1phx * (2 + 5) &&
         rect_black1.width == 1phx * (300 - 18 - 2)/2 &&
         rect_black1.height == 1phx * (240 - 6 - 10)/2 ;
-    property <bool> rect_black2_ok:
+    out property <bool> rect_black2_ok:
         rect_black2.x + vl2.x == 300phx - 1phx * (300 - 20) / 2 - 10phx &&
         rect_black2.y + vl2.y == 2phx &&
         rect_black2.width == 1phx * (300 - 18 - 2)/2 &&
         rect_black2.height == 1phx * (240 - 6 - 10)/2 ;
 
-    property rect_green_ok <=> hl_redblue.rect_green_ok;
-    property rect_pink_ok <=> hl_redblue.rect_pink_ok;
+    out property rect_green_ok <=> hl_redblue.rect_green_ok;
+    out property rect_pink_ok <=> hl_redblue.rect_pink_ok;
 
-    property <bool> test: rect_orange_ok && rect_blue_ok && rect_red_ok && rect_green_ok && rect_pink_ok && rect_yellow_ok && rect_black1_ok && rect_black2_ok;
+    out property <bool> test: rect_orange_ok && rect_blue_ok && rect_red_ok && rect_green_ok && rect_pink_ok && rect_yellow_ok && rect_black1_ok && rect_black2_ok;
 }
 
 /*

--- a/tests/cases/layout/nested_grid_1.slint
+++ b/tests/cases/layout/nested_grid_1.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -26,12 +26,12 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == 148phx && rect1.height == 148phx;
-    property <bool> rect2_pos_ok: rect2.x == 0phx && rect2.y == 148phx && rect2.width == 148phx && rect2.height == 152phx;
-    property <bool> rect3_pos_ok: ig.x + rect3.x == 148phx && ig.y + rect3.y == 148phx && rect3.width == 74phx && rect3.height == 74phx;
-    property <bool> rect4_pos_ok: ig.x + rect4.x == 226phx && ig.y + rect4.y == 148phx && rect4.width == 74phx && rect4.height == 74phx;
-    property <bool> rect5_pos_ok: ig.x + rect5.x == 148phx && ig.y + rect5.y == 226phx && rect5.width == 74phx && rect5.height == 74phx;
-    property <bool> rect6_pos_ok: ig.x + rect6.x == 226phx && ig.y + rect6.y == 226phx && rect6.width == 74phx && rect6.height == 74phx;
+    out property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == 148phx && rect1.height == 148phx;
+    out property <bool> rect2_pos_ok: rect2.x == 0phx && rect2.y == 148phx && rect2.width == 148phx && rect2.height == 152phx;
+    out property <bool> rect3_pos_ok: ig.x + rect3.x == 148phx && ig.y + rect3.y == 148phx && rect3.width == 74phx && rect3.height == 74phx;
+    out property <bool> rect4_pos_ok: ig.x + rect4.x == 226phx && ig.y + rect4.y == 148phx && rect4.width == 74phx && rect4.height == 74phx;
+    out property <bool> rect5_pos_ok: ig.x + rect5.x == 148phx && ig.y + rect5.y == 226phx && rect5.width == 74phx && rect5.height == 74phx;
+    out property <bool> rect6_pos_ok: ig.x + rect6.x == 226phx && ig.y + rect6.y == 226phx && rect6.width == 74phx && rect6.height == 74phx;
 
     out property <bool> test: rect1_pos_ok && rect2_pos_ok && rect3_pos_ok && rect4_pos_ok && rect5_pos_ok && rect6_pos_ok;
 }

--- a/tests/cases/layout/nested_grid_2.slint
+++ b/tests/cases/layout/nested_grid_2.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -38,10 +38,10 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 250phx && rect1.width == 155phx && rect1.height == 50phx;
-    property <bool> rect2_pos_ok: rect2.x == 0phx && rect2.y == 0phx && rect2.width == 50phx && rect2.height == 50phx;
-    property <bool> rect3_pos_ok: rect3.x == 60phx && rect3.y == 0phx && rect3.width == 95phx && rect3.height == 50phx;
-    property <bool> rect4_pos_ok: rect4.x == 155phx && rect4.y == 250phx && rect4.width == 145phx && rect4.height == 50phx;
+    out property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 250phx && rect1.width == 155phx && rect1.height == 50phx;
+    out property <bool> rect2_pos_ok: rect2.x == 0phx && rect2.y == 0phx && rect2.width == 50phx && rect2.height == 50phx;
+    out property <bool> rect3_pos_ok: rect3.x == 60phx && rect3.y == 0phx && rect3.width == 95phx && rect3.height == 50phx;
+    out property <bool> rect4_pos_ok: rect4.x == 155phx && rect4.y == 250phx && rect4.width == 145phx && rect4.height == 50phx;
 
     out property <bool> test: rect1_pos_ok && rect2_pos_ok && rect3_pos_ok && rect4_pos_ok;
 }

--- a/tests/cases/layout/nested_grid_minmax.slint
+++ b/tests/cases/layout/nested_grid_minmax.slint
@@ -3,7 +3,7 @@
 
 // Test the propagation of maximum and minimum size through nested grid layouts
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -29,8 +29,8 @@ TestCase := Rectangle {
         }
     }
 
-    property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == 50phx && rect1.height == 20phx;
-    property <bool> rect2_pos_ok: rect2.x == 50phx && rect2.y == 0phx && rect2.width == 250phx && rect2.height == 20phx;
+    out property <bool> rect1_pos_ok: rect1.x == 0phx && rect1.y == 0phx && rect1.width == 50phx && rect1.height == 20phx;
+    out property <bool> rect2_pos_ok: rect2.x == 50phx && rect2.y == 0phx && rect2.width == 250phx && rect2.height == 20phx;
     out property <bool> test: rect1_pos_ok && rect2_pos_ok;
 }
 

--- a/tests/cases/layout/opacity_in_layout.slint
+++ b/tests/cases/layout/opacity_in_layout.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export TestCase := Window {
+export component TestCase inherits Window {
     layout1 := VerticalLayout {
         if (true) : test1 := VerticalLayout {
             Rectangle { height: 55px; }
@@ -32,11 +32,11 @@ export TestCase := Window {
         }
     }
 
-    property <length> layout1_height : layout1.min-height;
-    property <length> layout2_width : layout2.max-width;
-    property <length> layout3_width : layout3.preferred-width;
-    property <length> layout4_width : layout4.preferred-width;
-    property<bool> test: layout1_height == 55px && layout2_width == 88px && layout3_width == 30px && layout4_width == 30px;
+    out property <length> layout1_height : layout1.min-height;
+    out property <length> layout2_width : layout2.max-width;
+    out property <length> layout3_width : layout3.preferred-width;
+    out property <length> layout4_width : layout4.preferred-width;
+    out property<bool> test: layout1_height == 55px && layout2_width == 88px && layout3_width == 30px && layout4_width == 30px;
 }
 
 /*

--- a/tests/cases/layout/override_from_parent.slint
+++ b/tests/cases/layout/override_from_parent.slint
@@ -27,7 +27,7 @@ SubComp3 := HorizontalLayout {
 SubComp4 := SubComp1 {}
 
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
     width: 300phx;
     height: 300phx;
 
@@ -36,7 +36,7 @@ TestCase := Rectangle {
     // FIXME: the HorizontalLayout is required here because the sc3.max-width takes the existing binding instead of being re-materialized
     sc3 := HorizontalLayout { SubComp3 { width: 200px; } }
     sc4 := SubComp4 {}
-    property<bool> test: sc1.min-width == 200px && sc2.min-width == 200px && sc3.max-width == 200px && sc4.min-width == 200px;
+    out property<bool> test: sc1.min-width == 200px && sc2.min-width == 200px && sc3.max-width == 200px && sc4.min-width == 200px;
 }
 
 /*
@@ -53,4 +53,3 @@ let instance = TestCase::new().unwrap();
 assert!(instance.get_test());
 ```
 */
-

--- a/tests/cases/layout/text_no_wrap.slint
+++ b/tests/cases/layout/text_no_wrap.slint
@@ -4,7 +4,7 @@
 
 // A Text that does not use word wrap's height should not depends on the width
 
-TestCase := Rectangle {
+export component TestCase inherits Rectangle {
 
     VerticalLayout {
         HorizontalLayout {
@@ -12,14 +12,14 @@ TestCase := Rectangle {
                 text: "Hello World";
             }
             square := Rectangle {
-                width: height;
+                width: self.height;
                 background: violet;
             }
         }
         Rectangle {}
     }
 
-    property <bool> test: square.width == square.height;
+    out property <bool> test: square.width == square.height;
 }
 
 /*

--- a/tests/cases/layout/vertical_if.slint
+++ b/tests/cases/layout/vertical_if.slint
@@ -1,11 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export TestCase := Window {
+export component TestCase inherits Window {
     width: 100phx;
     height: 100phx;
-    property<int> value: -10;
-    property <bool> cond: true;
+    out property<int> value: -10;
+    in property <bool> cond: true;
 
     VerticalLayout {
         padding: 0px;

--- a/tests/cases/layout/window_preferred.slint
+++ b/tests/cases/layout/window_preferred.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-TestCase := Window {
+export component TestCase inherits Window {
     VerticalLayout {
         padding: 10px;
         spacing: 27px;
@@ -18,9 +18,9 @@ TestCase := Window {
         }
     }
 
-    property w <=> root.preferred-width;
+    out property w <=> root.preferred-width;
 
-    property <bool> test: root.preferred_height == 500phx + 20px + 27px && root.preferred_width == 25phx + 20px;
+    out property <bool> test: root.preferred_height == 500phx + 20px + 27px && root.preferred_width == 25phx + 20px;
 }
 
 /*


### PR DESCRIPTION
* testing: Rename testcases to ease debugging
    
    Rename grid to grid_simple, otherwise
        cargo test -p test-driver-interpreter -- test_interpreter_layout_grid
    runs multiple tests, no way to run only that one.
    
    Same for nested_grid.slint given that there's a nested_grid_2.slint

* testing: Modernize layout testcases
    
    I kept seeing distracting warnings when working with these testcases,
    and it's better to have good examples when writing new testcases.
    
    I didn't touch the `issue_*.slint` regression tests, so those will
    still be testing the old syntax.
