### PR TITLE
compiler: don't allow the row property in a GridLayout's Row element

### DIFF
--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -194,6 +194,12 @@ fn lower_grid_layout(
             }
             let row_children = std::mem::take(&mut layout_child.borrow_mut().children);
             for x in row_children {
+                x.borrow_mut().bindings.get("row").map(|binding| {
+                    diag.push_error(
+                        "The 'row' property cannot be used for elements inside a Row".to_string(),
+                        &*binding.borrow(),
+                    );
+                });
                 grid.add_element(
                     &x,
                     (&mut row, &mut col),

--- a/internal/compiler/tests/syntax/basic/layout2.slint
+++ b/internal/compiler/tests/syntax/basic/layout2.slint
@@ -16,6 +16,7 @@ export X := Rectangle {
             }
             Text {
                 row: 3;
+//                   ^error{The 'row' property cannot be used for elements inside a Row}
                 col: -2;
 //                   ^error{'col' must be an integer literal}
                 rowspan: 2.2;


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
