### PR TITLE
Fix mingw-llvm builds

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT Corrosion_FOUND)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.5.2
+        GIT_TAG master
     )
 
     FetchContent_MakeAvailable(Corrosion)


### PR DESCRIPTION
gnullvm rust target isn't supported at 0.52 of corrosion
