### PR TITLE
core: fix edition 2024 warnings with slint_debug_property enabled

### DIFF
--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -592,7 +592,7 @@ impl PropertyHandle {
     ) {
         let binding = alloc_binding_holder::<T, B>(binding);
         #[cfg(slint_debug_property)]
-        {
+        unsafe {
             (*binding).debug_name = debug_name.into();
         }
         self.set_binding_impl(binding);


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
