### PR TITLE
femtovg: Implement webgl context loss and restore event handling

### DIFF
--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -62,7 +62,7 @@ mod renderer {
     use i_slint_core::platform::PlatformError;
     use winit::event_loop::ActiveEventLoop;
 
-    pub trait WinitCompatibleRenderer {
+    pub trait WinitCompatibleRenderer: std::any::Any {
         fn render(&self, window: &i_slint_core::api::Window) -> Result<(), PlatformError>;
 
         fn as_core_renderer(&self) -> &dyn i_slint_core::renderer::Renderer;
@@ -77,9 +77,6 @@ mod renderer {
             active_event_loop: &ActiveEventLoop,
             window_attributes: winit::window::WindowAttributes,
         ) -> Result<Arc<winit::window::Window>, PlatformError>;
-
-        #[cfg_attr(not(target_family = "wasm"), allow(unused))]
-        fn as_any(&self) -> &dyn std::any::Any;
     }
 
     #[cfg(any(

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -94,10 +94,6 @@ impl super::WinitCompatibleRenderer for GlutinFemtoVGRenderer {
     fn suspend(&self) -> Result<(), PlatformError> {
         self.renderer.clear_graphics_context()
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 #[cfg(all(supports_opengl, target_family = "wasm"))]
@@ -131,7 +127,9 @@ impl GlutinFemtoVGRenderer {
                     i_slint_core::debug_log!(
                         "Slint: Suspending renderer due to WebGL context loss"
                     );
-                    let this = window_adapter.renderer().as_any().downcast_ref::<Self>().unwrap();
+                    let this = (window_adapter.renderer() as &dyn std::any::Any)
+                        .downcast_ref::<Self>()
+                        .unwrap();
                     let _ = this.renderer.clear_graphics_context().ok();
                     // Preventing default is the way to make sure the browser sends a webglcontextrestored event
                     // when the context is back.
@@ -154,7 +152,9 @@ impl GlutinFemtoVGRenderer {
                     i_slint_core::debug_log!(
                         "Slint: Restoring renderer due to WebGL context restoration"
                     );
-                    let this = window_adapter.renderer().as_any().downcast_ref::<Self>().unwrap();
+                    let this = (window_adapter.renderer() as &dyn std::any::Any)
+                        .downcast_ref::<Self>()
+                        .unwrap();
                     if this.renderer.set_opengl_context(html_canvas.clone()).is_ok() {
                         use i_slint_core::platform::WindowAdapter;
                         window_adapter.request_redraw();
@@ -227,9 +227,5 @@ impl WinitCompatibleRenderer for WGPUFemtoVGRenderer {
         )?;
 
         Ok(winit_window)
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }

--- a/internal/backends/winit/renderer/skia.rs
+++ b/internal/backends/winit/renderer/skia.rs
@@ -199,8 +199,4 @@ impl super::WinitCompatibleRenderer for WinitSkiaRenderer {
 
         Ok(winit_window)
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }

--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -207,8 +207,4 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
         drop(self._context.borrow_mut().take());
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }


### PR DESCRIPTION
Handle it gracefully when the browser decides to take away our WebGL context.

Fixes #1088

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
