### PR TITLE
Core: Remove some usage of the `as_any()` pattern

### DIFF
--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -337,7 +337,7 @@ impl QtWidgetAccessor for i_slint_core::api::Window {
         i_slint_core::window::WindowInner::from_pub(self)
             .window_adapter()
             .internal(i_slint_core::InternalToken)
-            .and_then(|wa| wa.as_any().downcast_ref::<qt_window::QtWindow>())
+            .and_then(|wa| (wa as &dyn core::any::Any).downcast_ref::<qt_window::QtWindow>())
             .map(qt_window::QtWindow::widget_ptr)
     }
 }

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2045,10 +2045,6 @@ impl WindowAdapterInternal for QtWindow {
         }};
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn handle_focus_change(&self, _old: Option<ItemRc>, new: Option<ItemRc>) {
         let widget_ptr = self.widget_ptr();
         if let Some(ai) = accessible_item(new) {
@@ -2368,7 +2364,7 @@ pub(crate) mod ffi {
     ) -> *mut c_void {
         window_adapter
             .internal(i_slint_core::InternalToken)
-            .and_then(|wa| <dyn std::any::Any>::downcast_ref(wa.as_any()))
+            .and_then(|wa| <dyn std::any::Any>::downcast_ref(wa))
             .map_or(std::ptr::null_mut(), |win: &QtWindow| {
                 win.widget_ptr().cast::<c_void>().as_ptr()
             })

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -76,7 +76,7 @@ pub fn access_testing_window<R>(
     i_slint_core::window::WindowInner::from_pub(window)
         .window_adapter()
         .internal(i_slint_core::InternalToken)
-        .and_then(|wa| wa.as_any().downcast_ref::<TestingWindow>())
+        .and_then(|wa| (wa as &dyn core::any::Any).downcast_ref::<TestingWindow>())
         .map(callback)
         .expect("access_testing_window called without testing backend/adapter")
 }

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -111,10 +111,6 @@ pub struct TestingWindow {
 }
 
 impl WindowAdapterInternal for TestingWindow {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
         self.ime_requests.borrow_mut().push(request)
     }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -968,7 +968,7 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
         i_slint_core::window::WindowInner::from_pub(self)
             .window_adapter()
             .internal(i_slint_core::InternalToken)
-            .and_then(|wa| wa.as_any().downcast_ref::<WinitWindowAdapter>())
+            .and_then(|wa| (wa as &dyn core::any::Any).downcast_ref::<WinitWindowAdapter>())
             .is_some_and(|adapter| adapter.winit_window().is_some())
     }
 
@@ -979,7 +979,7 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
         i_slint_core::window::WindowInner::from_pub(self)
             .window_adapter()
             .internal(i_slint_core::InternalToken)
-            .and_then(|wa| wa.as_any().downcast_ref::<WinitWindowAdapter>())
+            .and_then(|wa| (wa as &dyn core::any::Any).downcast_ref::<WinitWindowAdapter>())
             .and_then(|adapter| adapter.winit_window().map(|w| callback(&w)))
     }
 
@@ -990,7 +990,7 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
             let adapter_weak = i_slint_core::window::WindowInner::from_pub(self)
                 .window_adapter()
                 .internal(i_slint_core::InternalToken)
-                .and_then(|wa| wa.as_any().downcast_ref::<WinitWindowAdapter>())
+                .and_then(|wa| (wa as &dyn core::any::Any).downcast_ref::<WinitWindowAdapter>())
                 .map(|wa| wa.self_weak.clone())
                 .ok_or_else(|| {
                     PlatformError::OtherError(
@@ -1009,7 +1009,7 @@ impl WinitWindowAccessor for i_slint_core::api::Window {
         if let Some(adapter) = i_slint_core::window::WindowInner::from_pub(self)
             .window_adapter()
             .internal(i_slint_core::InternalToken)
-            .and_then(|wa| wa.as_any().downcast_ref::<WinitWindowAdapter>())
+            .and_then(|wa| (wa as &dyn core::any::Any).downcast_ref::<WinitWindowAdapter>())
         {
             adapter
                 .window_event_filter

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1409,10 +1409,6 @@ impl WindowAdapterInternal for WinitWindowAdapter {
         };
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn color_scheme(&self) -> ColorScheme {
         self.color_scheme
             .get_or_init(|| {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -165,7 +165,7 @@ pub trait WindowAdapter {
 /// users to call or re-implement these functions.
 // TODO: add events for window receiving and loosing focus
 #[doc(hidden)]
-pub trait WindowAdapterInternal {
+pub trait WindowAdapterInternal: core::any::Any {
     /// This function is called by the generated code when a component and therefore its tree of items are created.
     fn register_item_tree(&self) {}
 
@@ -194,12 +194,6 @@ pub trait WindowAdapterInternal {
 
     /// This method allow editable input field to communicate with the platform about input methods
     fn input_method_request(&self, _: InputMethodRequest) {}
-
-    /// Return self as any so the backend can upcast
-    // TODO: consider using the as_any crate, or deriving the trait from Any to provide a better default
-    fn as_any(&self) -> &dyn core::any::Any {
-        &()
-    }
 
     /// Handle focus change
     // used for accessibility

--- a/tools/docsnapper/headless.rs
+++ b/tools/docsnapper/headless.rs
@@ -102,10 +102,6 @@ pub struct HeadlessWindow {
 }
 
 impl WindowAdapterInternal for HeadlessWindow {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn input_method_request(&self, request: i_slint_core::window::InputMethodRequest) {
         self.ime_requests.borrow_mut().push(request)
     }


### PR DESCRIPTION
Since Rust 1.86 we can replace that by trait upcasting