### PR TITLE
C++: Fix build generation failing when compiling multiple .slint files

### DIFF
--- a/api/cpp/cmake/SlintMacro.cmake
+++ b/api/cpp/cmake/SlintMacro.cmake
@@ -64,6 +64,8 @@ function(SLINT_TARGET_SOURCES target)
         set(translation_domain_arg "$<IF:$<STREQUAL:${translation_domain_prop},>,${target},${translation_domain_prop}>")
 
         if (compilation_units GREATER 0)
+            # We need to set this to empty, as this variable is reused in every foreach iteration.
+            set(cpp_files "")
             foreach(cpp_num RANGE 1 ${compilation_units})
                 list(APPEND cpp_files "${CMAKE_CURRENT_BINARY_DIR}/slint_generated_${_SLINT_BASE_NAME}_${cpp_num}.cpp")
             endforeach()


### PR DESCRIPTION
If you try to pass multiple files into slint_target_sources, some generators may complain with a strange error like this:

```
ninja: error: build.ninja:226: multiple rules generate slint_generated_dialog_1.cpp
```

The reason for this was how the macro worked (and CMake scoping rules.) While putting together the list of .cpp files to generate - which is 1 by default but is user-configurable - we append a list called cpp_num. However we don't *reset* this list variable, so in each foreach iteration we kept appending a new .cpp file and thus telling CMake we were generating "slint_generated_dialog_1.cpp" twice, in addition to whatever other file you had. We don't hit this issue with the other variables like translation_domain_prop because they're set on every iteration.

The fix for this is simple though, we can just set the variable to empty.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
