### PR TITLE
C++: Denote limitation compiling multiple .slint files in one namespace

### DIFF
--- a/api/cpp/docs/cmake_reference.md
+++ b/api/cpp/docs/cmake_reference.md
@@ -36,6 +36,10 @@ than 1 to create multiple `.cpp` files. These can be compiled in parallel, which
 across multiple `.cpp` files decreases the compiler's visibility and thus ability to perform optimizations. You can also pass `COMPILATION_UNITS 0` to generate
 only one single `.h` file.
 
+```{caution}
+Compiling multiple .slint files with the same namespace may create conflicting symbols. Avoid this by putting each .slint file in its own namespace.
+```
+
 ## Resource Embedding
 
 By default, images from {{ '[`@image-url()`]({})'.format(slint_href_ImageType) }} or fonts that your Slint files reference are loaded from disk at run-time. This minimises build times, but requires that the directory structure with the files remains stable. If you want to build a program that runs anywhere, then you can configure the Slint compiler to embed such sources into the binary.


### PR DESCRIPTION
Coming from the QML world  it was normal to just throw a bunch of QML files into a single CMake target without any thinking. But with Slint, I encounter into strange symbol conflict issues and thinking this was a bug in our compiler.

In reality this was actually an acceptable limitation (see #2909) which is fine... but this wasn't isn't mentioned anywhere in the CMake documentation - so I never knew about this or the solution. I added a new cautionary warning to let future developers know that in case of symbol conflicts, they need to separate files into their own namespaces.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
