### PR TITLE
C++: Fix binary incompatibility with freestanding build

### DIFF
--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -289,7 +289,7 @@ pub struct StaticTextures {
 /// time of the file it points to.
 #[derive(PartialEq, Eq, Debug, Hash, Clone)]
 #[repr(C)]
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "ffi"))]
 pub struct CachedPath {
     path: SharedString,
     /// SystemTime since UNIX_EPOC as secs
@@ -318,7 +318,7 @@ pub enum ImageCacheKey {
     /// This variant indicates that no image cache key can be created for the image.
     /// For example this is the case for programmatically created images.
     Invalid = 0,
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "ffi"))]
     /// The image is identified by its path on the file system and the last modification time stamp.
     Path(CachedPath) = 1,
     /// The image is identified by a URL.


### PR DESCRIPTION
`ImageCacheKey` has a different size depending on the feature `std` which is not reflected by cbindgen. Ensure that it is always the same for C++ build

Fixes #10077

(Another option would have been to add "frature=std" in cbindgen::Config::defines, but the problem is that there is no SLINT_FEATURE_STD (it is SLINT_FEATURE_FREESTANDING and has the opposite meaning), and because of the order of includes it wouldn't be defined when then ImageCacheKey struct is declared)
