### PR TITLE
mcu-board-support: Remove extraneous line from README

### DIFF
--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -192,7 +192,6 @@ CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="pro
 
 ### STM32U5G9J-DK2
 
- cargo build -p mcu-board-support --target=thumbv8m.main-none-eabihf --features stm32u5g9j-dk2 --no-default-features
 Using [probe-rs](https://probe.rs).
 
 ```sh


### PR DESCRIPTION
Clean up documentation by removing an extra cargo build command that was incorrectly placed in the STM32U5G9J-DK2 section.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
