### PR TITLE
Interpreter: Register the popup id in the right instance

### DIFF
--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -663,7 +663,7 @@ fn call_builtin_function(
 
                 crate::dynamic_item_tree::show_popup(
                     popup_window,
-                    component,
+                    enclosing_component,
                     popup,
                     |instance_ref| {
                         let comp = ComponentInstance::InstanceRef(instance_ref);

--- a/tests/cases/elements/popupwindow_close_policy.slint
+++ b/tests/cases/elements/popupwindow_close_policy.slint
@@ -114,6 +114,17 @@ export component TestCase {
             }
         }
     }
+
+    // ISSUE #10089
+    if true : TouchArea {
+        x: 250px;
+        y: 140px;
+        width: 3px;
+        height: 3px;
+        clicked => {
+            self-closing-popup.show();
+        }
+    }
 }
 /*
 
@@ -280,6 +291,22 @@ slint_testing::send_keyboard_string_sequence(&instance, "\u{001b}");
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq!(instance.get_click_count(), 2);
 
+// -- ISSUE #10089
+instance.set_popup_created(false);
+instance.set_click_count(0);
+instance.set_popup_clicked(0);
+slint_testing::send_mouse_click(&instance, 251., 141.);
+assert_eq!(instance.get_click_count(), 0);
+assert_eq!(instance.get_popup_created(), true);
+assert_eq!(instance.get_popup_clicked(), 0);
+
+// Click on the popup, should close it()
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq!(instance.get_click_count(), 0);
+
+// Subsequent click to verify that it was closed
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq!(instance.get_click_count(), 1);
 ```
 
 ```cpp
@@ -440,6 +467,24 @@ assert_eq(instance.get_popup_clicked(), 2005);
 slint_testing::send_keyboard_string_sequence(&instance, "\u001b");
 slint_testing::send_mouse_click(&instance, 15., 15.);
 assert_eq(instance.get_click_count(), 2);
+
+// -- ISSUE #10089
+instance.set_popup_created(false);
+instance.set_click_count(0);
+instance.set_popup_clicked(0);
+slint_testing::send_mouse_click(&instance, 251., 141.);
+assert_eq(instance.get_click_count(), 0);
+assert_eq(instance.get_popup_created(), true);
+assert_eq(instance.get_popup_clicked(), 0);
+
+// Click on the popup, should close it()
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_click_count(), 0);
+
+// Subsequent click to verify that it was closed
+slint_testing::send_mouse_click(&instance, 15., 15.);
+assert_eq(instance.get_click_count(), 1);
+
 ```
 
 ```js
@@ -527,6 +572,23 @@ assert.equal(instance.popup_clicked, 2005);
 slintlib.private_api.send_keyboard_string_sequence(instance, "\u{001b}");
 slintlib.private_api.send_mouse_click(instance, 15., 15.);
 assert.equal(instance.click_count, 2);
+
+// -- ISSUE #10089
+instance.popup_created = false;
+instance.click_count = 0;
+instance.popup_clicked = 0;
+slintlib.private_api.send_mouse_click(instance, 251., 141.);
+assert.equal(instance.click_count, 0);
+assert.equal(instance.popup_created, true);
+assert.equal(instance.popup_clicked, 0);
+
+// Click on the popup, should close it()
+slintlib.private_api.send_mouse_click(instance, 15., 15.);
+assert.equal(instance.click_count, 0);
+
+// Subsequent click to verify that it was closed
+slintlib.private_api.send_mouse_click(instance, 15., 15.);
+assert.equal(instance.click_count, 1);
 ```
 
 */


### PR DESCRIPTION
The instance containing the popup instead of the current instance

Fixes #10089
