### PR TITLE
Layout: fix warning about "only has effect on layout elements" when it is actually a layout

### DIFF
--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -878,11 +878,22 @@ fn check_no_layout_properties(
                 prop.as_ref(),
                 "padding" | "padding-left" | "padding-right" | "padding-top" | "padding-bottom"
             )
+            && !check_inherits_layout(item)
         {
             diag.push_warning(
                 format!("{prop} only has effect on layout elements"),
                 &*expr.borrow(),
             );
+        }
+    }
+
+    /// Check if the element inherits from a layout that was lowered
+    fn check_inherits_layout(item: &ElementRc) -> bool {
+        if let ElementType::Component(c) = &item.borrow().base_type {
+            c.root_element.borrow().debug.iter().any(|d| d.layout.is_some())
+                || check_inherits_layout(&c.root_element)
+        } else {
+            false
         }
     }
 }

--- a/internal/compiler/tests/syntax/layout/padding.slint
+++ b/internal/compiler/tests/syntax/layout/padding.slint
@@ -7,6 +7,12 @@ component MyLayout inherits VerticalLayout {
 //                       ^warning{padding only has effect on layout elements}
 }
 
+component MyLayout2 inherits VerticalLayout {
+    padding-top: 5px;
+}
+
+component MyLayoutDerived inherits MyLayout2 {}
+
 export component MyDialog inherits Dialog {
     padding: 5px;
     Rectangle { padding: 5px; }
@@ -50,8 +56,10 @@ export component Test {
     }
 
     if false: MyDialog{ padding-left: 10px; }
-//                                    ^warning{padding-left only has effect on layout elements}
 
-
+    MyLayout2 { padding-right: 10px; }
+    MyLayout2 { padding-top: 10px; }
+    MyLayoutDerived { padding-right: 10px; }
+    MyLayoutDerived { padding-top: 10px; }
 }
 


### PR DESCRIPTION

When deriving from layout, if there is no extra item, we wouldn't inline the layout anymore and we would emit warning despite we shouldn't
