### PR TITLE
LSP: Fix position column to be in UTF-16 code unit

### DIFF
--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -94,7 +94,7 @@ clru = { workspace = true }
 dissimilar = "1.0.7"
 itertools = { workspace = true }
 # Not updated because of https://github.com/gluon-lang/lsp-types/issues/284
-lsp-types = { version = "0.95.0", features = ["proposed"] }
+lsp-types = { version = "0.95.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smol_str = { workspace = true }

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -13,6 +13,7 @@ use std::{collections::HashMap, path::PathBuf};
 pub mod component_catalog;
 pub mod document_cache;
 pub use document_cache::{DocumentCache, SourceFileVersion};
+pub use i_slint_compiler::diagnostics::ByteFormat;
 pub mod rename_component;
 pub mod rename_element_id;
 #[cfg(test)]
@@ -537,6 +538,7 @@ pub struct PreviewConfig {
     pub style: String,
     pub include_paths: Vec<PathBuf>,
     pub library_paths: HashMap<String, PathBuf>,
+    pub format_utf8: bool,
 }
 
 /// The Component to preview

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -121,8 +121,16 @@ fn fix_specifier(
         y: &SyntaxToken,
         new_type: &str,
     ) -> common::SingleTextEdit {
-        let start_position = util::text_size_to_lsp_position(source_file, x.text_range().start());
-        let end_position = util::text_size_to_lsp_position(source_file, y.text_range().end());
+        let start_position = util::text_size_to_lsp_position(
+            source_file,
+            x.text_range().start(),
+            document_cache.format,
+        );
+        let end_position = util::text_size_to_lsp_position(
+            source_file,
+            y.text_range().end(),
+            document_cache.format,
+        );
         common::SingleTextEdit::from_path(
             document_cache,
             source_file.path(),
@@ -165,7 +173,7 @@ fn fix_specifier(
                         document_cache,
                         source_file.path(),
                         lsp_types::TextEdit {
-                            range: util::token_to_lsp_range(&type_name),
+                            range: util::token_to_lsp_range(&type_name, document_cache.format),
                             new_text: new_type.to_string(),
                         },
                     )
@@ -185,7 +193,7 @@ fn fix_specifier(
                     document_cache,
                     source_file.path(),
                     lsp_types::TextEdit {
-                        range: util::token_to_lsp_range(&type_name),
+                        range: util::token_to_lsp_range(&type_name, document_cache.format),
                         new_text: new_type.to_string(),
                     },
                 )
@@ -223,7 +231,7 @@ fn fix_specifier(
                         document_cache,
                         source_file.path(),
                         lsp_types::TextEdit {
-                            range: util::token_to_lsp_range(&renamed_to),
+                            range: util::token_to_lsp_range(&renamed_to, document_cache.format),
                             new_text: new_type.to_string(),
                         },
                     )
@@ -392,7 +400,7 @@ fn rename_local_symbols(
                     document_cache,
                     current.source_file.path(),
                     lsp_types::TextEdit {
-                        range: util::token_to_lsp_range(&current),
+                        range: util::token_to_lsp_range(&current, document_cache.format),
                         new_text: new_type.to_string(),
                     },
                 )

--- a/tools/lsp/common/rename_element_id.rs
+++ b/tools/lsp/common/rename_element_id.rs
@@ -1,6 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use crate::common::ByteFormat;
 use i_slint_compiler::parser::{
     syntax_nodes, NodeOrToken, SyntaxKind, SyntaxNode, SyntaxToken, TextRange,
 };
@@ -83,13 +84,14 @@ pub fn find_element_ids(token: &SyntaxToken, parent: &SyntaxNode) -> Option<Vec<
 pub fn rename_element_id(
     element: syntax_nodes::SubElement,
     new_name: &str,
+    format: ByteFormat,
 ) -> Option<Vec<TextEdit>> {
     let edits = if let Some(current_id) = element.child_token(SyntaxKind::Identifier) {
         let all_ids = find_element_ids(&current_id, &element)?;
         all_ids
             .into_iter()
             .map(|r| TextEdit {
-                range: crate::util::text_range_to_lsp_range(&element.source_file, r),
+                range: crate::util::text_range_to_lsp_range(&element.source_file, r, format),
                 new_text: new_name.into(),
             })
             .collect::<Vec<_>>()
@@ -97,6 +99,7 @@ pub fn rename_element_id(
         let position = crate::util::text_size_to_lsp_position(
             &element.source_file,
             element.text_range().start(),
+            format,
         );
         element.text_range().start();
         vec![TextEdit {
@@ -143,7 +146,7 @@ component Foo inherits Rectangle {
         let edit = crate::common::create_workspace_edit(
             uri.clone(),
             None,
-            rename_element_id(rect_x, "name-for-x").unwrap(),
+            rename_element_id(rect_x, "name-for-x", dc.format).unwrap(),
         );
         let renamed = crate::common::text_edit::apply_workspace_edit(&dc, &edit)
             .unwrap()
@@ -182,7 +185,7 @@ component Foo inherits Rectangle {
         let edit = crate::common::create_workspace_edit(
             uri.clone(),
             None,
-            rename_element_id(rect_y, "name-for-y").unwrap(),
+            rename_element_id(rect_y, "name-for-y", dc.format).unwrap(),
         );
         let renamed = crate::common::text_edit::apply_workspace_edit(&dc, &edit)
             .unwrap()
@@ -221,7 +224,7 @@ component Foo inherits Rectangle {
         let edit = crate::common::create_workspace_edit(
             uri.clone(),
             None,
-            rename_element_id(t_a, "toucharea").unwrap(),
+            rename_element_id(t_a, "toucharea", dc.format).unwrap(),
         );
         let renamed = crate::common::text_edit::apply_workspace_edit(&dc, &edit)
             .unwrap()
@@ -260,7 +263,7 @@ component Foo inherits Rectangle {
         let edit = crate::common::create_workspace_edit(
             uri.clone(),
             None,
-            rename_element_id(rect_z, "zzz").unwrap(),
+            rename_element_id(rect_z, "zzz", dc.format).unwrap(),
         );
         let renamed = crate::common::text_edit::apply_workspace_edit(&dc, &edit)
             .unwrap()

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -227,7 +227,6 @@ impl RequestHandler {
 pub fn server_initialize_result(client_cap: &ClientCapabilities) -> InitializeResult {
     InitializeResult {
         capabilities: ServerCapabilities {
-            // Note: we only support UTF8 at the moment (which is a bug, as the spec says that support for utf-16 is mandatory)
             position_encoding: client_cap
                 .general
                 .as_ref()
@@ -294,7 +293,6 @@ pub fn server_initialize_result(client_cap: &ClientCapabilities) -> InitializeRe
             name: env!("CARGO_PKG_NAME").to_string(),
             version: Some(env!("CARGO_PKG_VERSION").to_string()),
         }),
-        offset_encoding: Some("utf-8".to_string()),
     }
 }
 
@@ -433,14 +431,14 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
                     offset: element.text_range().start().into(),
                 });
 
-                let range = util::node_to_lsp_range(&p);
+                let range = util::node_to_lsp_range(&p, document_cache.format);
                 return Ok(Some(vec![lsp_types::DocumentHighlight { range, kind: None }]));
             }
 
             if p.kind() == SyntaxKind::QualifiedName
                 && gp.as_ref().is_some_and(|n| n.kind() == SyntaxKind::Element)
             {
-                let range = util::node_to_lsp_range(&p);
+                let range = util::node_to_lsp_range(&p, document_cache.format);
 
                 if gp
                     .as_ref()
@@ -466,7 +464,11 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
                     value
                         .into_iter()
                         .map(|r| lsp_types::DocumentHighlight {
-                            range: util::text_range_to_lsp_range(&p.source_file, r),
+                            range: util::text_range_to_lsp_range(
+                                &p.source_file,
+                                r,
+                                document_cache.format,
+                            ),
                             kind: None,
                         })
                         .collect(),
@@ -489,7 +491,11 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
                 let edits: Vec<_> = value
                     .into_iter()
                     .map(|r| TextEdit {
-                        range: util::text_range_to_lsp_range(&p.source_file, r),
+                        range: util::text_range_to_lsp_range(
+                            &p.source_file,
+                            r,
+                            document_cache.format,
+                        ),
                         new_text: params.new_name.clone(),
                     })
                     .collect();
@@ -518,10 +524,16 @@ pub fn register_request_handlers(rh: &mut RequestHandler) {
         let uri = params.text_document.uri;
         if let Some((tk, _)) = token_descr(&mut document_cache, &uri, &params.position) {
             if common::rename_element_id::find_element_ids(&tk, &tk.parent()).is_some() {
-                return Ok(Some(PrepareRenameResponse::Range(util::token_to_lsp_range(&tk))));
+                return Ok(Some(PrepareRenameResponse::Range(util::token_to_lsp_range(
+                    &tk,
+                    document_cache.format,
+                ))));
             }
             if common::rename_component::find_declaration_node(&document_cache, &tk).is_some() {
-                return Ok(Some(PrepareRenameResponse::Range(util::token_to_lsp_range(&tk))));
+                return Ok(Some(PrepareRenameResponse::Range(util::token_to_lsp_range(
+                    &tk,
+                    document_cache.format,
+                ))));
             }
         }
         Ok(None)
@@ -575,7 +587,10 @@ pub fn show_preview_command(
     Ok(())
 }
 
-fn populate_command_range(node: &SyntaxNode) -> Option<lsp_types::Range> {
+fn populate_command_range(
+    node: &SyntaxNode,
+    format: common::ByteFormat,
+) -> Option<lsp_types::Range> {
     let range = node.text_range();
 
     let start_offset = node
@@ -588,6 +603,7 @@ fn populate_command_range(node: &SyntaxNode) -> Option<lsp_types::Range> {
     (start_offset <= end_offset).then_some(util::text_range_to_lsp_range(
         &node.source_file,
         TextRange::new(start_offset, end_offset),
+        format,
     ))
 }
 
@@ -657,7 +673,7 @@ pub async fn populate_command(
             });
         };
 
-        let Some(range) = populate_command_range(node) else {
+        let Some(range) = populate_command_range(node, document_cache.format) else {
             return Err(LspError {
                 code: LspErrorCode::InvalidParameter,
                 message: "No slint code range in document".into(),
@@ -797,6 +813,7 @@ pub async fn reload_document(
 pub fn convert_diagnostics(
     extra_files: &HashSet<PathBuf>,
     diag: BuildDiagnostics,
+    format: common::ByteFormat,
 ) -> HashMap<Url, Vec<lsp_types::Diagnostic>> {
     // Always provide diagnostics for all files. Empty diagnostics clear any previous ones.
     let mut lsp_diags: HashMap<Url, Vec<lsp_types::Diagnostic>> = extra_files
@@ -812,7 +829,7 @@ pub fn convert_diagnostics(
             continue;
         }
         let uri = Url::from_file_path(d.source_file().unwrap()).unwrap();
-        lsp_diags.entry(uri).or_default().push(util::to_lsp_diag(&d));
+        lsp_diags.entry(uri).or_default().push(util::to_lsp_diag(&d, format));
     }
 
     lsp_diags
@@ -824,7 +841,7 @@ fn send_diagnostics(
     extra_files: &HashSet<PathBuf>,
     diag: BuildDiagnostics,
 ) {
-    let lsp_diags = convert_diagnostics(extra_files, diag);
+    let lsp_diags = convert_diagnostics(extra_files, diag, document_cache.format);
     for (uri, _diagnostics) in lsp_diags {
         let _version = document_cache.document_version(&uri);
 
@@ -953,7 +970,11 @@ fn get_code_actions(
     }
 
     if token.kind() == SyntaxKind::StringLiteral && node.kind() == SyntaxKind::Expression {
-        let r = util::text_range_to_lsp_range(&token.source_file, node.text_range());
+        let r = util::text_range_to_lsp_range(
+            &token.source_file,
+            node.text_range(),
+            document_cache.format,
+        );
         let edits = vec![
             TextEdit::new(lsp_types::Range::new(r.start, r.start), "@tr(".into()),
             TextEdit::new(lsp_types::Range::new(r.end, r.end), ")".into()),
@@ -1005,6 +1026,7 @@ fn get_code_actions(
             let r = util::text_range_to_lsp_range(
                 &token.source_file,
                 node.parent().unwrap().text_range(),
+                document_cache.format,
             );
             let element = document_cache.element_at_position(&uri, &r.start);
             let element_indent = element.as_ref().and_then(util::find_element_indent);
@@ -1162,7 +1184,7 @@ fn get_document_color(
     loop {
         if token.kind() == SyntaxKind::ColorLiteral {
             (|| -> Option<()> {
-                let range = util::token_to_lsp_range(&token);
+                let range = util::token_to_lsp_range(&token, document_cache.format);
                 let col = i_slint_common::color_parsing::parse_color_literal(token.text())?;
                 let shift = |s: u32| -> f32 { ((col >> s) & 0xff) as f32 / 255. };
                 result.push(ColorInformation {
@@ -1206,14 +1228,17 @@ fn get_document_symbols(
             let root_element = c.root_element.borrow();
             let element_node = &root_element.debug.first()?.node;
             let component_node = syntax_nodes::Component::new(element_node.parent()?)?;
-            let selection_range = util::node_to_lsp_range(&component_node.DeclaredIdentifier());
+            let selection_range = util::node_to_lsp_range(
+                &component_node.DeclaredIdentifier(),
+                document_cache.format,
+            );
             if c.id.is_empty() {
                 // Symbols with empty names are invalid
                 return None;
             }
 
             Some(DocumentSymbol {
-                range: util::node_to_lsp_range(&component_node),
+                range: util::node_to_lsp_range(&component_node, document_cache.format),
                 selection_range,
                 name: c.id.to_string(),
                 kind: if c.is_global() {
@@ -1221,7 +1246,7 @@ fn get_document_symbols(
                 } else {
                     lsp_types::SymbolKind::CLASS
                 },
-                children: gen_children(&c.root_element, &ds),
+                children: gen_children(&c.root_element, &ds, document_cache.format),
                 ..ds.clone()
             })
         })
@@ -1229,17 +1254,24 @@ fn get_document_symbols(
 
     r.extend(inner_types.iter().filter_map(|c| match c {
         Type::Struct(s) if s.name.is_some() && s.node.is_some() => Some(DocumentSymbol {
-            range: util::node_to_lsp_range(s.node.as_ref().unwrap().parent().as_ref()?),
+            range: util::node_to_lsp_range(
+                s.node.as_ref().unwrap().parent().as_ref()?,
+                document_cache.format,
+            ),
             selection_range: util::node_to_lsp_range(
                 &s.node.as_ref().unwrap().parent()?.child_node(SyntaxKind::DeclaredIdentifier)?,
+                document_cache.format,
             ),
             name: s.name.as_ref().unwrap().to_string(),
             kind: lsp_types::SymbolKind::STRUCT,
             ..ds.clone()
         }),
         Type::Enumeration(enumeration) => enumeration.node.as_ref().map(|node| DocumentSymbol {
-            range: util::node_to_lsp_range(node),
-            selection_range: util::node_to_lsp_range(&node.DeclaredIdentifier()),
+            range: util::node_to_lsp_range(node, document_cache.format),
+            selection_range: util::node_to_lsp_range(
+                &node.DeclaredIdentifier(),
+                document_cache.format,
+            ),
             name: enumeration.name.to_string(),
             kind: lsp_types::SymbolKind::ENUM,
             ..ds.clone()
@@ -1247,7 +1279,11 @@ fn get_document_symbols(
         _ => None,
     }));
 
-    fn gen_children(elem: &ElementRc, ds: &DocumentSymbol) -> Option<Vec<DocumentSymbol>> {
+    fn gen_children(
+        elem: &ElementRc,
+        ds: &DocumentSymbol,
+        format: common::ByteFormat,
+    ) -> Option<Vec<DocumentSymbol>> {
         let r = elem
             .borrow()
             .children
@@ -1258,14 +1294,15 @@ fn get_document_symbols(
                 let sub_element_node = element_node.parent()?;
                 debug_assert_eq!(sub_element_node.kind(), SyntaxKind::SubElement);
                 Some(DocumentSymbol {
-                    range: util::node_to_lsp_range(&sub_element_node),
+                    range: util::node_to_lsp_range(&sub_element_node, format),
                     selection_range: util::node_to_lsp_range(
                         element_node.QualifiedName().as_ref()?,
+                        format,
                     ),
                     name: e.base_type.to_string(),
                     detail: (!e.id.is_empty()).then(|| e.id.to_string()),
                     kind: lsp_types::SymbolKind::VARIABLE,
-                    children: gen_children(child, ds),
+                    children: gen_children(child, ds, format),
                     ..ds.clone()
                 })
             })
@@ -1311,9 +1348,9 @@ fn get_code_lenses(
             let component_node = c.root_element.borrow().debug.first()?.node.parent()?;
             let range = match component_node.parent() {
                 Some(parent) if parent.kind() == SyntaxKind::ExportsList => {
-                    util::node_to_lsp_range(&parent)
+                    util::node_to_lsp_range(&parent, document_cache.format)
                 }
-                _ => util::node_to_lsp_range(&component_node),
+                _ => util::node_to_lsp_range(&component_node, document_cache.format),
             };
             let command =
                 Some(create_show_preview_command(true, &text_document.uri, c.id.as_str()));
@@ -1326,7 +1363,7 @@ fn get_code_lenses(
             .children_with_tokens()
             .any(|nt| nt.kind() != SyntaxKind::Whitespace && nt.kind() != SyntaxKind::Eof);
         if !has_non_ws_token {
-            if let Some(range) = populate_command_range(node) {
+            if let Some(range) = populate_command_range(node, document_cache.format) {
                 result.push(CodeLens {
                     range,
                     command: Some(create_populate_command(
@@ -1432,6 +1469,7 @@ pub async fn load_configuration(ctx: &Context) -> common::Result<()> {
         style: cc.style.clone().unwrap_or_default(),
         include_paths: cc.include_paths.clone(),
         library_paths: cc.library_paths.clone(),
+        format_utf8: cc.format == common::ByteFormat::Utf8,
     };
     *ctx.preview_config.borrow_mut() = config.clone();
     let mut diag = BuildDiagnostics::default();

--- a/tools/lsp/language/formatting.rs
+++ b/tools/lsp/language/formatting.rs
@@ -60,8 +60,11 @@ pub fn format_document(
             }
             Chunk::Delete(text) => {
                 let len = TextSize::of(text);
-                let deleted_range =
-                    text_range_to_lsp_range(&doc.source_file, TextRange::at(pos, len));
+                let deleted_range = text_range_to_lsp_range(
+                    &doc.source_file,
+                    TextRange::at(pos, len),
+                    document_cache.format,
+                );
                 edits.push(TextEdit { range: deleted_range, new_text: String::new() });
                 last_was_deleted = true;
                 pos += len;
@@ -75,7 +78,7 @@ pub fn format_document(
                 }
 
                 let range = TextRange::empty(pos);
-                let range = text_range_to_lsp_range(&doc.source_file, range);
+                let range = text_range_to_lsp_range(&doc.source_file, range, document_cache.format);
                 edits.push(TextEdit { range, new_text: text.into() });
             }
         }

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -77,7 +77,7 @@ pub fn get_tooltip(
 
     Some(Hover {
         contents: HoverContents::Markup(contents),
-        range: Some(util::token_to_lsp_range(&token)),
+        range: Some(util::token_to_lsp_range(&token, document_cache.format)),
     })
 }
 

--- a/tools/lsp/language/semantic_tokens.rs
+++ b/tools/lsp/language/semantic_tokens.rs
@@ -162,11 +162,17 @@ pub fn get_semantic_tokens(
             SyntaxKind::At => Some((self::MACRO, 0)),
             _ => None,
         };
+        let len = |txt: &str| -> u32 {
+            match document_cache.format {
+                crate::common::ByteFormat::Utf8 => txt.len() as u32,
+                crate::common::ByteFormat::Utf16 => txt.encode_utf16().count() as u32,
+            }
+        };
         if let Some((token_type, token_modifiers_bitset)) = t_m {
             data.push(SemanticToken {
                 delta_line,
                 delta_start,
-                length: token.text().encode_utf16().count() as u32,
+                length: len(token.text()),
                 token_type,
                 token_modifiers_bitset,
             });
@@ -176,10 +182,10 @@ pub fn get_semantic_tokens(
         let text = token.text();
         let l = text.bytes().filter(|x| *x == b'\n').count();
         if l == 0 {
-            delta_start += text.encode_utf16().count() as u32;
+            delta_start += len(text);
         } else {
             delta_line += l as u32;
-            delta_start = text[(text.rfind('\n').unwrap() + 1)..].encode_utf16().count() as u32;
+            delta_start = len(&text[(text.rfind('\n').unwrap() + 1)..]);
         }
         token = match token.next_token() {
             None => break,

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -48,7 +48,7 @@ pub fn loaded_document_cache_with_file_name(
     let (extra_files, diag) =
         spin_on::spin_on(reload_document_impl(None, content, url.clone(), Some(42), &mut dc));
 
-    let diag = convert_diagnostics(&extra_files, diag);
+    let diag = convert_diagnostics(&extra_files, diag, dc.format);
     (dc, url, diag)
 }
 
@@ -127,7 +127,7 @@ pub fn load(
         document_cache,
     ));
 
-    (url, convert_diagnostics(&main_file, diag))
+    (url, convert_diagnostics(&main_file, diag, document_cache.format))
 }
 
 #[test]

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -353,7 +353,18 @@ fn main_loop(connection: Connection, init_param: InitializeParams, cli_args: Cli
                 Some(contents.map(|c| (None, c)))
             })
         })),
-        ..Default::default()
+        format: if init_param
+            .capabilities
+            .general
+            .as_ref()
+            .and_then(|x| x.position_encodings.as_ref())
+            .is_some_and(|x| x.iter().any(|x| x == &lsp_types::PositionEncodingKind::UTF8))
+        {
+            common::ByteFormat::Utf8
+        } else {
+            common::ByteFormat::Utf16
+        },
+        resource_url_mapper: None,
     };
 
     let ctx = Rc::new(Context {

--- a/tools/lsp/preview/element_selection.rs
+++ b/tools/lsp/preview/element_selection.rs
@@ -57,22 +57,21 @@ fn self_or_embedded_component_root(element: &ElementRc) -> ElementRc {
 
 fn lsp_element_node_position(
     element: &common::ElementRcNode,
+    format: common::ByteFormat,
 ) -> Option<(String, lsp_types::Range)> {
-    let location = element.with_element_node(|n| {
+    let (f, sl, sc, el, ec) = element.with_element_node(|n| {
         n.parent()
             .filter(|p| p.kind() == i_slint_compiler::parser::SyntaxKind::SubElement)
             .map_or_else(
-                || Some(n.source_file.text_size_to_file_line_column(n.text_range().start())),
-                |p| Some(p.source_file.text_size_to_file_line_column(p.text_range().start())),
+                || n.source_file.text_size_to_file_line_column(n.text_range().start(), format),
+                |p| p.source_file.text_size_to_file_line_column(p.text_range().start(), format),
             )
     });
-    location.map(|(f, sl, sc, el, ec)| {
-        use lsp_types::{Position, Range};
-        let start = Position::new((sl as u32).saturating_sub(1), (sc as u32).saturating_sub(1));
-        let end = Position::new((el as u32).saturating_sub(1), (ec as u32).saturating_sub(1));
 
-        (f, Range::new(start, end))
-    })
+    use lsp_types::{Position, Range};
+    let start = Position::new((sl as u32).saturating_sub(1), (sc as u32).saturating_sub(1));
+    let end = Position::new((el as u32).saturating_sub(1), (ec as u32).saturating_sub(1));
+    Some((f, Range::new(start, end)))
 }
 
 fn element_covers_point(
@@ -171,7 +170,9 @@ fn select_element_node(
         SelectionNotification::Never, // We update directly;-)
     );
 
-    if let Some(document_position) = lsp_element_node_position(selected_element) {
+    let format = preview::PREVIEW_STATE.with_borrow(|ps| ps.format());
+
+    if let Some(document_position) = lsp_element_node_position(selected_element, format) {
         let to_lsp = preview::PREVIEW_STATE.with_borrow(|ps| ps.to_lsp.borrow().clone().unwrap());
         to_lsp
             .ask_editor_to_show_document(&document_position.0, document_position.1, false)

--- a/tools/lsp/preview/outline.rs
+++ b/tools/lsp/preview/outline.rs
@@ -341,6 +341,7 @@ fn drop_edit(
             &drop_info,
             &moving_element,
             Default::default(),
+            document_cache.format,
         )?
     } else if let Ok(library_index) = data.parse::<usize>() {
         let component = super::PREVIEW_STATE.with(|preview_state| {

--- a/tools/tr-extractor/main.rs
+++ b/tools/tr-extractor/main.rs
@@ -116,7 +116,10 @@ fn visit_node(node: SyntaxNode, results: &mut Messages, current_context: Option<
                 let update = |msg: &mut dyn polib::message::MessageMutView| {
                     let span = node.span();
                     if span.is_valid() {
-                        let (line, _) = node.source_file.line_column(span.offset);
+                        let (line, _) = node.source_file.line_column(
+                            span.offset,
+                            i_slint_compiler::diagnostics::ByteFormat::Utf8,
+                        );
                         if line > 0 {
                             let source = msg.source_mut();
                             let path = node.source_file.path().to_string_lossy();


### PR DESCRIPTION
The language server protocol specify that the default for client is to interpret the column position to be in UTF-16 unless negotiated otherwise.
Editors such as vscode only support UTF-16 and we were still trying to send position in UTF-8, which caused error when the text contained comments or string in non-ascii languages.

Fixes #5669
