### PR TITLE
Interpreter: Fix setting a struct with less fields than expected

### DIFF
--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1418,7 +1418,7 @@ impl ComponentInstance {
             .get_global(comp.borrow(), &&normalize_identifier(global))
             .map_err(|()| SetPropertyError::NoSuchProperty)? // FIXME: should there be a NoSuchGlobal error?
             .as_ref()
-            .set_property(&&normalize_identifier(property), value)
+            .set_property(&normalize_identifier(property), value)
     }
 
     /// Set a handler for the callback in the exported global singleton. A callback with that

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -44,3 +44,56 @@ fn reuse_window() {
         instance
     };
 }
+
+#[test]
+fn set_wrong_struct() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, Struct, Value};
+    let code = r#"
+struct TimeStruct {
+    Clock:              string,
+    Enabled:            bool,
+}
+
+export global Device {
+    in-out property <TimeStruct> Time: { Clock: "11:37", Enabled: true };
+}
+
+export component Clock {
+    ta := TouchArea {
+        enabled: Device.Time.Enabled;
+    }
+    out property <bool> ta_enabled: ta.enabled;
+    out property <string> time: Device.Time.Clock;
+}
+    "#;
+    let compiler = Compiler::default();
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("Clock").unwrap();
+    let instance = definition.create().unwrap();
+    assert_eq!(instance.get_property("ta_enabled").unwrap(), Value::from(true));
+    assert_eq!(instance.get_property("time").unwrap(), Value::String("11:37".into()));
+    // This only has "Clock" but no "Enabled"
+    instance
+        .set_global_property(
+            "Device",
+            "Time",
+            Struct::from_iter([("Clock".into(), Value::String("10:37".into()))]).into(),
+        )
+        .unwrap();
+    assert_eq!(instance.get_property("ta_enabled").unwrap(), Value::from(false));
+    assert_eq!(instance.get_property("time").unwrap(), Value::String("10:37".into()));
+
+    // Setting a struct with wrong fields leads to an error
+    assert_eq!(
+        instance.set_global_property(
+            "Device",
+            "Time",
+            Struct::from_iter([("Broken".into(), Value::Number(12.1))]).into(),
+        ),
+        Err(crate::SetPropertyError::WrongType)
+    );
+    assert_eq!(instance.get_property("ta_enabled").unwrap(), Value::from(false));
+    assert_eq!(instance.get_property("time").unwrap(), Value::String("10:37".into()));
+}


### PR DESCRIPTION
It shouldn't leave bad values in the interpreter which later can cause panic anywhere
