### PR TITLE
Python: Speed up testing

### DIFF
--- a/api/python/slint/pyproject.toml
+++ b/api/python/slint/pyproject.toml
@@ -47,3 +47,6 @@ dev = ["pdoc>=15.0.1", "pytest>=8.3.4", "ruff>=0.9.6", "pillow>=11.3.0", "numpy>
 cache-keys = [{ file = "pyproject.toml" }, { file = "Cargo.toml" }, { file = "**/*.rs" }]
 # Uncomment to build rust code in development mode
 # config-settings = { build-args = '--profile=dev' }
+
+[tool.maturin]
+editable-profile = "dev"


### PR DESCRIPTION
Build editable builds as cargo debug builds, not release. This is faster (because we don't need LTO) and in theory gives additional coverage to debug asserts.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
