### PR TITLE
parley: Fix memory leak

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -4,7 +4,7 @@
 // cSpell: ignore frameless qbrush qpointf qreal qwidgetsize svgz
 
 use cpp::*;
-use i_slint_common::sharedfontique;
+use i_slint_common::sharedfontique::{self, HashedBlob};
 use i_slint_core::graphics::rendering_metrics_collector::{
     RenderingMetrics, RenderingMetricsCollector,
 };
@@ -1163,7 +1163,7 @@ impl QRawFont {
 
 pub struct FontCache {
     /// Fonts are indexed by unique blob id (atomically incremented in fontique) and the font collection index.
-    fonts: HashMap<(u64, u32), Option<QRawFont>>,
+    fonts: HashMap<(HashedBlob, u32), Option<QRawFont>>,
 }
 
 impl Default for FontCache {
@@ -1175,7 +1175,7 @@ impl Default for FontCache {
 impl FontCache {
     pub fn font(&mut self, font: &parley::FontData) -> Option<QRawFont> {
         self.fonts
-            .entry((font.data.id(), font.index))
+            .entry((font.data.clone().into(), font.index))
             .or_insert_with(move || {
                 let mut raw_font = QRawFont::default();
                 raw_font.load_from_data(font.data.as_ref(), 12.0);

--- a/internal/common/sharedfontique.rs
+++ b/internal/common/sharedfontique.rs
@@ -241,3 +241,34 @@ pub const FALLBACK_FAMILIES: [fontique::GenericFamily; 2] = [
     fontique::GenericFamily::SansSerif,
     fontique::GenericFamily::SystemUi,
 ];
+
+/// Wraper around fontique::Blob to permit use of the blob as a key in the cache in the different renderers,
+/// to map the blob to the native type face representation (skia_safe::Typeface, femtovg::FontId, QRawFont, etc.).
+/// The use as key also ensures the blob remains strongly referenced, so that it doesn't vanish from the
+/// shared SourceCache (parley prunes it).
+pub struct HashedBlob(fontique::Blob<u8>);
+impl core::hash::Hash for HashedBlob {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.id().hash(state);
+    }
+}
+
+impl PartialEq for HashedBlob {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.id() == other.0.id()
+    }
+}
+
+impl Eq for HashedBlob {}
+
+impl From<fontique::Blob<u8>> for HashedBlob {
+    fn from(value: fontique::Blob<u8>) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<fontique::Blob<u8>> for HashedBlob {
+    fn as_ref(&self) -> &fontique::Blob<u8> {
+        &self.0
+    }
+}

--- a/internal/core/software_renderer/fonts/systemfonts.rs
+++ b/internal/core/software_renderer/fonts/systemfonts.rs
@@ -8,21 +8,18 @@ use alloc::rc::Rc;
 use std::collections::HashMap;
 
 use crate::lengths::ScaleFactor;
-use i_slint_common::sharedfontique::{self, fontique};
+use i_slint_common::sharedfontique::{self, HashedBlob, fontique};
 
 use super::super::PhysicalLength;
 use super::vectorfont::VectorFont;
 
 struct CachedFont {
     fontdue_font: Rc<fontdue::Font>,
-    // Keep a strong reference to the blob, otherwise it disappears. The fontique collection
-    // is temporary, and the shared cache keeps only weak references.
-    _fontique_blob: fontique::Blob<u8>,
 }
 
 crate::thread_local! {
     // fontdue fonts cached and indexed by fontique blob id (unique incremental) and true type collection index
-    static FONTDUE_FONTS: RefCell<HashMap<(u64, u32), CachedFont>> = Default::default();
+    static FONTDUE_FONTS: RefCell<HashMap<(HashedBlob, u32), CachedFont>> = Default::default();
 }
 
 pub fn get_or_create_fontdue_font_from_blob_and_index(
@@ -32,7 +29,7 @@ pub fn get_or_create_fontdue_font_from_blob_and_index(
     FONTDUE_FONTS.with(|font_cache| {
         font_cache
             .borrow_mut()
-            .entry((blob.id(), index))
+            .entry((blob.clone().into(), index))
             .or_insert_with(move || CachedFont {
                 fontdue_font: fontdue::Font::from_bytes(
                     blob.data(),
@@ -44,7 +41,6 @@ pub fn get_or_create_fontdue_font_from_blob_and_index(
                 )
                 .expect("fatal: fontdue is unable to parse truetype font")
                 .into(),
-                _fontique_blob: blob.clone(),
             })
             .fontdue_font
             .clone()

--- a/internal/renderers/femtovg/font_cache.rs
+++ b/internal/renderers/femtovg/font_cache.rs
@@ -4,13 +4,14 @@
 // cspell:ignore Noto fontconfig
 
 use femtovg::TextContext;
+use i_slint_common::sharedfontique::HashedBlob;
 use i_slint_core::textlayout::sharedparley::parley;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
 pub struct FontCache {
     pub(crate) text_context: femtovg::TextContext,
-    fonts: HashMap<(u64, u32), femtovg::FontId>,
+    fonts: HashMap<(HashedBlob, u32), femtovg::FontId>,
 }
 
 impl Default for FontCache {
@@ -24,7 +25,7 @@ impl FontCache {
     pub fn font(&mut self, font: &parley::FontData) -> femtovg::FontId {
         let text_context = self.text_context.clone();
 
-        *self.fonts.entry((font.data.id(), font.index)).or_insert_with(move || {
+        *self.fonts.entry((font.data.clone().into(), font.index)).or_insert_with(move || {
             text_context.add_shared_font_with_index(font.data.clone(), font.index).unwrap()
         })
     }

--- a/internal/renderers/skia/font_cache.rs
+++ b/internal/renderers/skia/font_cache.rs
@@ -1,13 +1,14 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use i_slint_common::sharedfontique::HashedBlob;
 use i_slint_core::textlayout::sharedparley::parley;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
 pub struct FontCache {
     font_mgr: skia_safe::FontMgr,
-    fonts: HashMap<(u64, u32), Option<skia_safe::Typeface>>,
+    fonts: HashMap<(HashedBlob, u32), Option<skia_safe::Typeface>>,
 }
 
 impl Default for FontCache {
@@ -19,7 +20,7 @@ impl Default for FontCache {
 impl FontCache {
     pub fn font(&mut self, font: &parley::FontData) -> Option<skia_safe::Typeface> {
         self.fonts
-            .entry((font.data.id(), font.index))
+            .entry((font.data.clone().into(), font.index))
             .or_insert_with(|| {
                 let typeface = self.font_mgr.new_from_data(
                     font.data.as_ref(),


### PR DESCRIPTION
The issue outlined in eff2ddbbea6e7a40a49e871799e30c87e1d6df3f affects also regular parley use. The shared data in the fontique source cache uses weak references to the blogs, the thread-local one uses strong references. However, the thread-local source cache is pruned by parley when creating a builder, as LRU.

As discussed with Olivier, for now let's keep a strong reference in the renderers by means of using the blog as hash key, where we anyway need to map the Blob to a renderer-specific data structure.

Fixes #10129

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
