### PR TITLE
Python: Fix support for underscores in async callback decorators

### DIFF
--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -307,7 +307,7 @@ impl ComponentDefinition {
         self.definition
             .properties_and_callbacks()
             .find_map(|(name, (ty, _))| {
-                if name == callback_name {
+                if normalize_identifier(&name) == callback_name {
                     if let Type::Callback(signature) = ty {
                         return Some(signature.return_type == Type::Void);
                     }
@@ -324,7 +324,7 @@ impl ComponentDefinition {
             .global_properties_and_callbacks(&global_name)
             .and_then(|mut props| {
                 props.find_map(|(name, (ty, _))| {
-                    if name == callback_name {
+                    if normalize_identifier(&name) == callback_name {
                         if let Type::Callback(signature) = ty {
                             return Some(signature.return_type == Type::Void);
                         }

--- a/api/python/slint/tests/test-load-file.slint
+++ b/api/python/slint/tests/test-load-file.slint
@@ -55,6 +55,11 @@ export component App inherits Window {
         call-void();
     }
     callback call-void();
+    callback invoke-call-void2();
+    invoke-call-void2 => {
+        call_void2();
+    }
+    callback call_void2();
 
     in-out property <TestEnum> enum-property: TestEnum.Variant2;
     in-out property <[TestEnum]> model-with-enums: [TestEnum.Variant2, TestEnum.Variant1];

--- a/api/python/slint/tests/test_callback_decorators.py
+++ b/api/python/slint/tests/test_callback_decorators.py
@@ -54,12 +54,20 @@ def test_callback_decorators_async() -> None:
             value = await self.in_queue.get()
             await self.out_queue.put(value + 1)
 
+        @slint.callback()
+        async def call_void2(self) -> None:
+            value = await self.in_queue.get()
+            await self.out_queue.put(value + 2)
+
     async def main(
         instance: SubClass, in_queue: asyncio.Queue[int], out_queue: asyncio.Queue[int]
     ) -> None:
         await in_queue.put(42)
         instance.invoke_call_void()
         assert await out_queue.get() == 43
+        await in_queue.put(43)
+        instance.invoke_call_void2()
+        assert await out_queue.get() == 45
         slint.quit_event_loop()
 
     in_queue: asyncio.Queue[int] = asyncio.Queue()


### PR DESCRIPTION
Fixes #10024

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
