### PR TITLE
compiler: port from codemap-diagnostics to annotate-snippets

### DIFF
--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -26,7 +26,7 @@ python = ["dep:pathdiff", "dep:serde", "smol_str/serde", "dep:serde_json", "dep:
 proc_macro_span = ["quote", "proc-macro2"]
 
 # Feature to print the diagnostics to the console
-display-diagnostics = ["codemap", "codemap-diagnostic"]
+display-diagnostics = ["dep:annotate-snippets"]
 
 # Enable the support to render images and font in the binary
 software-renderer = ["image", "dep:resvg", "fontdue", "i-slint-common/shared-fontique", "dep:rayon"]
@@ -49,8 +49,7 @@ strum = { workspace = true }
 rowan = { version = "0.16.1" }
 smol_str = { workspace = true }
 derive_more = { workspace = true }
-codemap-diagnostic = { version = "0.1.1", optional = true }
-codemap = { version = "0.1", optional = true }
+annotate-snippets = { version = "0.12.9", optional = true }
 quote = { version = "1.0", optional = true }
 proc-macro2 = { version = "1.0.17", optional = true }
 lyon_path = { version = "1.0" }

--- a/tools/updater/Cargo.toml
+++ b/tools/updater/Cargo.toml
@@ -20,8 +20,6 @@ categories = ["gui", "development-tools", "command-line-utilities"]
 i-slint-compiler = { workspace = true, features = ["default", "display-diagnostics"] }
 
 clap = { workspace = true }
-codemap = "0.1"
-codemap-diagnostic = "0.1.1"
 spin_on = { workspace = true }
 by_address = { workspace = true }
 smol_str = { workspace = true }

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -58,8 +58,6 @@ slint-interpreter = { workspace = true, features = ["display-diagnostics", "comp
 i-slint-backend-selector = { workspace = true }
 
 clap = { workspace = true }
-codemap = "0.1"
-codemap-diagnostic = "0.1.1"
 notify = { version = "8.0.0", default-features = false, features = ["macos_kqueue"] }
 shlex = "1"
 spin_on = { workspace = true }


### PR DESCRIPTION
codemap is no longer maintained and deprecated.
annotate-snippets is the crate now used by cargo and rustc
