### PR TITLE
editors/kate: Update syntax highlighting definition

### DIFF
--- a/editors/kate/slint.ksyntaxhighlighter.xml
+++ b/editors/kate/slint.ksyntaxhighlighter.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- Copyright © SixtyFPS GmbH <info@slint.dev> -->
 <!-- # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0 -->
-
-<language name="Slint" version="1" kateversion="5.0" section="Sources" extensions="*.slint" mimetype="text/slint" indenter="cstyle" license="GPL" author="info@slint.dev" priority="6">
-<highlighting>
+<language name="Slint" version="1" kateversion="5.0" section="Sources" extensions="*.slint" mimetype="text/slint" indenter="cstyle" license="GPL" author="SixtyFPS GmbH (info@slint.dev)">
+  <highlighting>
     <list name="types">
       <item>int</item>
       <item>bool</item>
@@ -50,49 +48,43 @@
       <item>@linear-gradient</item>
       <item>@radial-gradient</item>
     </list>
-  <contexts>
-    <context attribute="Normal Text" lineEndContext="#stay" name="Normal Text">
-      <RegExpr attribute="Property" context="#stay" String="[a-zA-Z_][a-zA-Z_\-0-9]*:" />
-      <RegExpr attribute="Property" context="#stay" String="[a-zA-Z_][a-zA-Z_\-0-9]* *&lt;?=>" />
-      <RegExpr attribute="Color" context="#stay" String="#[0-9a-fA-F]+" />
-      <keyword attribute="Types" context="#stay" String="types" />
-      <keyword attribute="Keyword" context="#stay" String="keywords" />
-      <DetectSpaces/>
-      <IncludeRules context="Comments"/>
-      <DetectChar attribute="String" context="string" char="&quot;" />
-      <RegExpr attribute="Number" context="#stay" String="[0-9]+\.?[0-9]*[a-z%]*" />
-      <AnyChar attribute="Symbol" context="#stay" String="!%&amp;()+,-/*&lt;=&gt;?[]&amp;|;"/>
-
-
-    </context>
-
-    <context attribute="String" lineEndContext="#stay" name="string" >
-      <IncludeRules context="EscapeString" />
-      <DetectChar attribute="String" context="#pop" char="&quot;" />
-    </context>
-    <context attribute="Normal Text" lineEndContext="#stay" name="EscapeString">
+    <contexts>
+      <context attribute="Normal Text" lineEndContext="#stay" name="Normal Text">
+        <RegExpr attribute="Property" context="#stay" String="[a-zA-Z_][a-zA-Z_\-0-9]*(?: *&lt;?=>|:)" />
+        <RegExpr attribute="Color" context="#stay" String="#[0-9a-fA-F]+" />
+        <keyword attribute="Types" context="#stay" String="types" />
+        <keyword attribute="Keyword" context="#stay" String="keywords" />
+        <DetectSpaces/>
+        <IncludeRules context="Comments"/>
+        <DetectChar attribute="String" context="string" char="&quot;" />
+        <RegExpr attribute="Number" context="#stay" String="[0-9]+\.?[0-9]*[a-z%]*" />
+        <AnyChar attribute="Symbol" context="#stay" String="!%&amp;()+,-/*&lt;=&gt;?[]&amp;|;"/>
+      </context>
+      <context attribute="String" lineEndContext="#stay" name="string" >
+        <IncludeRules context="EscapeString" />
+        <DetectChar attribute="String" context="#pop" char="&quot;" />
+      </context>
+      <context attribute="Normal Text" lineEndContext="#stay" name="EscapeString">
         <LineContinue attribute="String" context="#stay" />
         <DetectChar attribute="String" context="Character Escape" char="\" />
       </context>
       <context attribute="String" lineEndContext="#pop" name="Character Escape">
         <RegExpr attribute="String" context="#pop" String="." />
       </context>
-
-
-    <context attribute="Normal Text" lineEndContext="#stay" name="Comments">
-      <Detect2Chars char="/" char1="/" attribute="Comment" context="CommentsLine"/>
-      <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentsBlock" beginRegion="Comment"/>
-    </context>
-    <context attribute="Comment" lineEndContext="#pop" name="CommentsLine">
-      <DetectSpaces/>
-    </context>
-    <context attribute="Comment" lineEndContext="#stay" name="CommentsBlock">
-      <DetectSpaces/>
-      <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentsBlock" beginRegion="Comment"/>
-      <Detect2Chars char="*" char1="/" attribute="Comment" context="#pop" endRegion="Comment"/>
-    </context>
-  </contexts>
-   <itemDatas>
+      <context attribute="Normal Text" lineEndContext="#stay" name="Comments">
+        <Detect2Chars char="/" char1="/" attribute="Comment" context="CommentsLine"/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentsBlock" beginRegion="Comment"/>
+      </context>
+      <context attribute="Comment" lineEndContext="#pop" name="CommentsLine">
+        <DetectSpaces/>
+      </context>
+      <context attribute="Comment" lineEndContext="#stay" name="CommentsBlock">
+        <DetectSpaces/>
+        <Detect2Chars char="/" char1="*" attribute="Comment" context="CommentsBlock" beginRegion="Comment"/>
+        <Detect2Chars char="*" char1="/" attribute="Comment" context="#pop" endRegion="Comment"/>
+      </context>
+    </contexts>
+    <itemDatas>
       <itemData name="Normal Text" defStyleNum="dsNormal" />
       <itemData name="Keyword" defStyleNum="dsKeyword" />
       <itemData name="String" defStyleNum="dsString" />
@@ -102,14 +94,13 @@
       <itemData name="Symbol" defStyleNum="dsOperator" />
       <itemData name="Property" defStyleNum="dsVariable" />
       <itemData name="Color" defStyleNum="dsConstant" />
-
     </itemDatas>
-</highlighting>
-<general>
-  <comments>
-    <comment name="singleLine" start="//" />
-    <comment name="multiLine" start="/*" end="*/" region="Comment"/>
-  </comments>
-  <keywords casesensitive="1" />
-</general>
+  </highlighting>
+  <general>
+    <comments>
+      <comment name="singleLine" start="//" />
+      <comment name="multiLine" start="/*" end="*/" region="Comment"/>
+    </comments>
+    <keywords casesensitive="1" />
+  </general>
 </language>


### PR DESCRIPTION
When upstreaming this to KSyntaxHighlighting, I fixed a few minor problems:
* Redone the formatting and removed the extra newlines.
* Our validation caught that there were too similar-looking RegExpr expressions, so I combined them into one.
* Updated the author attribute to include the company name, alongside the email.
* Removed the priority attribute since it seems useless here, I don't think there are non-Slint .slint files.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
