### PR TITLE
tools/tr-extractor: Make the paths argument required

### DIFF
--- a/tools/tr-extractor/main.rs
+++ b/tools/tr-extractor/main.rs
@@ -12,7 +12,7 @@ type Messages = polib::catalog::Catalog;
 #[derive(clap::Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    #[arg(name = "path to .slint file(s)", action)]
+    #[arg(name = "path to .slint file(s)", action, required = true)]
     paths: Vec<std::path::PathBuf>,
 
     #[arg(long = "default-domain", short = 'd')]


### PR DESCRIPTION
It doesn't make sense to extract messages from "no files", and I was confused I was even able to do this when trying it out. If we tell clap that it's required, then it'll give a better hint to the user when they didn't pass anything.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
