### PR TITLE
Node.js: Don't run npm to install for dev dependencies that use a cat…

### DIFF
--- a/tests/driver/nodejs/nodejs.rs
+++ b/tests/driver/nodejs/nodejs.rs
@@ -13,40 +13,39 @@ fn check_output(o: std::process::Output) {
             String::from_utf8_lossy(&o.stderr),
             String::from_utf8_lossy(&o.stdout),
         );
-        //panic!("Build Failed {:?}", o.status);
+        panic!("Build Failed {:?}", o.status);
     }
 }
 
 static NODE_API_JS_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let node_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../api/node");
 
-    // On Windows npm is 'npm.cmd', which Rust's process::Command doesn't look for as extension, because
+    // On Windows pnpm is 'pnpm.cmd', which Rust's process::Command doesn't look for as extension, because
     // it tries to emulate CreateProcess.
-    let npm = which::which("npm").unwrap();
+    let pnpm = which::which("pnpm").unwrap();
 
     // installs the slint node package dependencies
-    let o = std::process::Command::new(npm.clone())
+    let o = std::process::Command::new(pnpm.clone())
         .arg("install")
-        .arg("--no-audit")
         .arg("--ignore-scripts")
         .current_dir(node_dir.clone())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
-        .map_err(|err| format!("Could not launch npm install: {err}"))
+        .map_err(|err| format!("Could not launch pnpm install: {err}"))
         .unwrap();
 
     check_output(o);
 
     // builds the slint node package in debug
-    let o = std::process::Command::new(npm.clone())
+    let o = std::process::Command::new(pnpm.clone())
         .arg("run")
         .arg("build:testing")
         .current_dir(node_dir.clone())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
-        .map_err(|err| format!("Could not launch npm install: {err}"))
+        .map_err(|err| format!("Could not launch pnpm install: {err}"))
         .unwrap();
 
     check_output(o);
@@ -95,7 +94,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
-        .map_err(|err| format!("Could not launch npm start: {err}"))?;
+        .map_err(|err| format!("Could not launch node main.js: {err}"))?;
 
     if !output.status.success() {
         print!("{}", String::from_utf8_lossy(output.stdout.as_ref()));


### PR DESCRIPTION
…alog url

That only works with pnpm or yarn, AFAICS.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
