### PR TITLE
[switch] fix accessible_default_action when switch is disabled

### DIFF
--- a/internal/compiler/widgets/cosmic/switch.slint
+++ b/internal/compiler/widgets/cosmic/switch.slint
@@ -33,8 +33,10 @@ export component Switch {
     accessible-checked <=> root.checked;
     accessible-role: switch;
     accessible-action-default => {
-        root.checked = !root.checked;
-        root.toggled();
+        if(root.enabled) {
+           root.checked = !root.checked;
+           root.toggled();
+        }
     }
     forward-focus: state-layer;
 

--- a/internal/compiler/widgets/cupertino/switch.slint
+++ b/internal/compiler/widgets/cupertino/switch.slint
@@ -34,8 +34,10 @@ export component Switch {
     accessible-checked <=> root.checked;
     accessible-role: switch;
     accessible-action-default => {
-        root.checked = !root.checked;
-        root.toggled();
+        if (root.enabled) {
+           root.checked = !root.checked;
+           root.toggled();
+        }
     }
     forward-focus: i-focus-scope;
 

--- a/internal/compiler/widgets/fluent/switch.slint
+++ b/internal/compiler/widgets/fluent/switch.slint
@@ -33,8 +33,10 @@ export component Switch {
     accessible-checked <=> root.checked;
     accessible-role: switch;
     accessible-action-default => {
-        root.checked = !root.checked;
-        root.toggled();
+        if(root.enabled) {
+            root.checked = !root.checked;
+            root.toggled();
+        }
     }
     forward-focus: focus-scope;
 

--- a/internal/compiler/widgets/material/switch.slint
+++ b/internal/compiler/widgets/material/switch.slint
@@ -30,8 +30,10 @@ export component Switch {
     accessible-checked <=> root.checked;
     accessible-role: switch;
     accessible-action-default => {
-        root.checked = !root.checked;
-        root.toggled();
+        if(root.enabled) {
+            root.checked = !root.checked;
+            root.toggled();
+        }
     }
 
     states [

--- a/internal/compiler/widgets/qt/switch.slint
+++ b/internal/compiler/widgets/qt/switch.slint
@@ -8,7 +8,9 @@ export component Switch inherits NativeCheckBox {
     accessible-label <=> root.text;
     accessible-role: switch;
     accessible-action-default => {
-        root.checked = !root.checked;
-        root.toggled();
+        if(root.enabled) {
+           root.checked = !root.checked;
+           root.toggled();
+        }
     }
 }

--- a/tests/cases/widgets/switch.slint
+++ b/tests/cases/widgets/switch.slint
@@ -6,6 +6,7 @@ export component TestCase inherits Window {
 
     in-out property <string> toggled;
     in-out property <bool> checked <=> a.checked;
+    in-out property <bool> enabled <=> a.enabled;
 
     HorizontalLayout {
         alignment: start;
@@ -40,6 +41,15 @@ aaa.invoke_accessible_default_action();
 assert_eq!(instance.get_checked(), true, "Switch a was not checked");
 assert_eq!(aaa.accessible_checked(), Some(true));
 assert_eq!(instance.get_toggled(), SharedString::from("a"));
+
+assert_eq!(aaa.accessible_enabled(), Some(true));
+instance.set_enabled(false);
+assert_eq!(aaa.accessible_enabled(), Some(false));
+assert_eq!(instance.get_toggled(), SharedString::from("a"));
+
+aaa.invoke_accessible_default_action();
+assert_eq!(instance.get_toggled(), SharedString::from("a"));
+
 ```
 
 ```cpp
@@ -61,6 +71,13 @@ assert_eq(instance.get_checked(), true);
 assert_eq(aaa.accessible_checked().value(), true);
 assert_eq(instance.get_toggled(), "a");
 
+assert_eq(aaa.accessible_enabled().value(), true);
+
+instance.set_enabled(false);
+assert_eq(aaa.accessible_enabled().value(), false);
+assert_eq(instance.get_toggled(), "a");
+aaa.invoke_accessible_default_action();
+assert_eq(instance.get_toggled(), "a");
 ```
 
 */

--- a/ui-libraries/material/src/ui/components/switch.slint
+++ b/ui-libraries/material/src/ui/components/switch.slint
@@ -26,7 +26,7 @@ export component Switch {
     accessible-checkable: true;
     accessible-checked <=> root.checked;
     accessible-role: switch;
-    accessible-action-default => { touch_area.clicked(); }
+    accessible-action-default => { if(root.enabled) {touch_area.clicked();} }
     forward_focus: touch_area;
 
     touch_area := FocusTouchArea {


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
