### PR TITLE
fix(tree-sitter): support named parameters in callback signatures

### DIFF
--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -583,7 +583,7 @@ module.exports = grammar({
       prec.left(
         seq(
           "(",
-          field("arguments", optional(seq(commaSep1($.type), optional(",")))),
+            field("arguments", optional(seq(commaSep1(choice($.typed_identifier, $.type)), optional(",")))),
           ")",
         ),
       ),


### PR DESCRIPTION
## Problem

The tree-sitter grammar for Slint does not support named parameters in callback signatures.

According to the [official Slint documentation](https://docs.slint.dev/latest/docs/slint/guide/language/coding/functions-and-callbacks/), callback arguments can have names:
```slint
callback hello(foo: int, bar: string);
```

However, the current grammar only accepts types without names, causing parse errors for valid Slint code.

## Solution

Changed `_callback_signature` to accept both `typed_identifier` (name: type) and plain `type`, matching the behavior of `_function_signature`.

## Checklist

- [x] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [x] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
