### PR TITLE
editors/kate: Change the license to MIT

### DIFF
--- a/editors/kate/slint.ksyntaxhighlighter.xml
+++ b/editors/kate/slint.ksyntaxhighlighter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright © SixtyFPS GmbH <info@slint.dev> -->
 <!-- SPDX-License-Identifier: MIT -->
-<language name="Slint" version="1" kateversion="5.0" section="Sources" extensions="*.slint" mimetype="text/slint" indenter="cstyle" license="GPL" author="SixtyFPS GmbH (info@slint.dev)">
+<language name="Slint" version="1" kateversion="5.0" section="Sources" extensions="*.slint" mimetype="text/slint" indenter="cstyle" license="MIT" author="SixtyFPS GmbH (info@slint.dev)">
   <highlighting>
     <list name="types">
       <item>int</item>


### PR DESCRIPTION
So that we can upstream it in KDE repository

See https://github.com/slint-ui/slint/discussions/10154
