### PR TITLE
[lineedit]: add autotest for testing enable/read_only support

### DIFF
--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -31,11 +31,15 @@ export component LineEditBase inherits Rectangle {
     }
 
     public function clear-selection() {
-        text-input.clear-selection();
+        if (!root.read-only && root.enabled) {
+           text-input.clear-selection();
+        }
     }
 
     public function cut() {
-        text-input.cut();
+        if (!root.read-only && root.enabled) {
+           text-input.cut();
+        }
     }
 
     public function copy() {
@@ -43,7 +47,9 @@ export component LineEditBase inherits Rectangle {
     }
 
     public function paste() {
-        text-input.paste();
+        if (!root.read-only && root.enabled) {
+            text-input.paste();
+        }
     }
 
     // on width < 1px or if the `TextInput` is clipped it cannot be focused therefore min-width 1px

--- a/tests/cases/widgets/lineedit.slint
+++ b/tests/cases/widgets/lineedit.slint
@@ -10,5 +10,46 @@ export component TestCase inherits Window {
         y: 0px;
         width: 10 * self.height; // Test that there is no height for width dependency (loop)
     }
+    in-out property <string> text <=> edit1.text;
+    in-out property <bool> read-only <=> edit1.read-only;
+    public function select-all() {
+        edit1.select-all();
+    }
+    public function cut() {
+        edit1.cut();
+    }
 }
 
+
+/*
+
+```rust
+use slint::{SharedString};
+
+let instance = TestCase::new().unwrap();
+
+let mut result = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::edit1").collect::<Vec<_>>();
+assert_eq!(result.len(), 1);
+let edit1 = result.pop().unwrap();
+assert_eq!(edit1.accessible_value(), Some(SharedString::from("")));
+
+instance.set_text("Hello👋".into());
+assert_eq!(instance.get_text(), "Hello👋");
+
+instance.invoke_select_all();
+
+instance.invoke_cut();
+assert_eq!(instance.get_text(), "");
+
+// Read Only
+instance.set_text("Hello👋".into());
+assert_eq!(instance.get_text(), "Hello👋");
+instance.set_read_only(true);
+instance.invoke_select_all();
+
+instance.invoke_cut();
+assert_eq!(instance.get_text(), "Hello👋");
+
+```
+
+*/


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
