### PR TITLE
compiler: fix clippy warnings

### DIFF
--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -62,7 +62,7 @@ pub fn lower_macro(
                 Some((Expression::NumberLiteral(val, Unit::None), _)) => val as f32,
                 // handle negative numbers
                 Some((Expression::UnaryOp { sub, op: '-' }, n)) => match *sub {
-                    Expression::NumberLiteral(val, Unit::None) => (-1.0 * val) as f32,
+                    Expression::NumberLiteral(val, Unit::None) => -val as f32,
                     _ => {
                         has_error
                             .get_or_insert((n.to_source_location(), expected_argument_type_error));

--- a/internal/compiler/fileaccess.rs
+++ b/internal/compiler/fileaccess.rs
@@ -122,10 +122,10 @@ mod builtin_library {
                 components.push(part);
             }
         }
-        if let Some(f) = components.first_mut() {
-            if let Some((_, x)) = ALIASES.iter().find(|x| x.0 == *f) {
-                *f = std::ffi::OsStr::new(x);
-            }
+        if let Some(f) = components.first_mut()
+            && let Some((_, x)) = ALIASES.iter().find(|x| x.0 == *f)
+        {
+            *f = std::ffi::OsStr::new(x);
         }
         if let &[folder, file] = components.as_slice() {
             let library = widget_library().iter().find(|x| x.0 == folder)?.1;

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -392,7 +392,7 @@ impl From<BuiltinFunction> for BuiltinPropertyInfo {
 }
 
 /// The base of an element
-#[derive(Clone, Debug, derive_more::From)]
+#[derive(Clone, Debug, derive_more::From, Default)]
 pub enum ElementType {
     /// The element is based of a component
     Component(Rc<Component>),
@@ -401,6 +401,7 @@ pub enum ElementType {
     /// The native type was resolved by the resolve_native_class pass.
     Native(Rc<NativeClass>),
     /// The base element couldn't be looked up
+    #[default]
     Error,
     /// This should be the base type of the root element of a global component
     Global,
@@ -627,12 +628,6 @@ impl Display for ElementType {
             Self::Error => write!(f, "<error>"),
             Self::Global => Ok(()),
         }
-    }
-}
-
-impl Default for ElementType {
-    fn default() -> Self {
-        Self::Error
     }
 }
 
@@ -917,7 +912,7 @@ impl StructName {
     pub fn or(self, other: Self) -> Self {
         match self {
             Self::None => other,
-            this @ _ => this,
+            this => this,
         }
     }
 }

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -417,10 +417,10 @@ fn find_binding<R>(
     let mut element = element.clone();
     let mut depth = 0;
     loop {
-        if let Some(b) = element.borrow().bindings.get(name) {
-            if b.borrow().has_binding() {
-                return Some(f(&b.borrow(), &element.borrow().enclosing_component, depth));
-            }
+        if let Some(b) = element.borrow().bindings.get(name)
+            && b.borrow().has_binding()
+        {
+            return Some(f(&b.borrow(), &element.borrow().enclosing_component, depth));
         }
         let e = match &element.borrow().base_type {
             ElementType::Component(base) => base.root_element.clone(),
@@ -443,17 +443,16 @@ fn init_fake_property(
 ) {
     if grid_layout_element.borrow().property_declarations.contains_key(name)
         && !grid_layout_element.borrow().bindings.contains_key(name)
+        && let Some(e) = lazy_default()
     {
-        if let Some(e) = lazy_default() {
-            if e.name() == name && Rc::ptr_eq(&e.element(), grid_layout_element) {
-                // Don't reference self
-                return;
-            }
-            grid_layout_element
-                .borrow_mut()
-                .bindings
-                .insert(name.into(), RefCell::new(Expression::PropertyReference(e).into()));
+        if e.name() == name && Rc::ptr_eq(&e.element(), grid_layout_element) {
+            // Don't reference self
+            return;
         }
+        grid_layout_element
+            .borrow_mut()
+            .bindings
+            .insert(name.into(), RefCell::new(Expression::PropertyReference(e).into()));
     }
 }
 

--- a/internal/compiler/lexer.rs
+++ b/internal/compiler/lexer.rs
@@ -102,7 +102,7 @@ pub fn lex_string(text: &str, state: &mut LexState) -> usize {
     } else if !text.starts_with('"') {
         return 0;
     }
-    let text_len = text.as_bytes().len();
+    let text_len = text.len();
     let mut end = 1; // skip the '"'
     loop {
         let stop = match text[end..].find(&['"', '\\'][..]) {
@@ -334,12 +334,12 @@ pub fn locate_slint_macro(rust_source: &str) -> impl Iterator<Item = core::ops::
         let (open, close) = loop {
             if let Some(m) = rust_source[begin..].find("slint") {
                 // heuristics to find if we are not in a comment or a string literal. Not perfect, but should work in most cases
-                if let Some(x) = rust_source[begin..(begin + m)].rfind(['\\', '\n', '/', '\"']) {
-                    if rust_source.as_bytes()[begin + x] != b'\n' {
-                        begin += m + 5;
-                        begin += rust_source[begin..].find(['\n']).unwrap_or(0);
-                        continue;
-                    }
+                if let Some(x) = rust_source[begin..(begin + m)].rfind(['\\', '\n', '/', '\"'])
+                    && rust_source.as_bytes()[begin + x] != b'\n'
+                {
+                    begin += m + 5;
+                    begin += rust_source[begin..].find(['\n']).unwrap_or(0);
+                    continue;
                 }
                 begin += m + 5;
                 while rust_source[begin..].starts_with(' ') {

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -568,17 +568,17 @@ impl<'a, T> EvaluationContext<'a, T> {
 
             let animation = sc.animations.get(prop).map(|a| (a, map.clone()));
             let analysis = sc.prop_analysis.get(&prop.clone().into());
-            if let Some(a) = &analysis {
-                if let Some(init) = a.property_init {
-                    let u = use_count_and_ty();
-                    return PropertyInfoResult {
-                        analysis: Some(&a.analysis),
-                        binding: Some((&sc.property_init[init].1, map)),
-                        animation,
-                        ty: u.map_or(Type::Invalid, |x| x.1.clone()),
-                        use_count: u.map(|x| x.0),
-                    };
-                }
+            if let Some(a) = &analysis
+                && let Some(init) = a.property_init
+            {
+                let u = use_count_and_ty();
+                return PropertyInfoResult {
+                    analysis: Some(&a.analysis),
+                    binding: Some((&sc.property_init[init].1, map)),
+                    animation,
+                    ty: u.map_or(Type::Invalid, |x| x.1.clone()),
+                    use_count: u.map(|x| x.0),
+                };
             }
             let mut r = if let &[idx, ref rest @ ..] = prop.sub_component_path.as_slice() {
                 let prop2 = LocalMemberReference {
@@ -618,25 +618,25 @@ impl<'a, T> EvaluationContext<'a, T> {
             match r {
                 LocalMemberIndex::Property(index) => {
                     let property_decl = &g.properties[*index];
-                    return PropertyInfoResult {
+                    PropertyInfoResult {
                         analysis: Some(&g.prop_analysis[*index]),
                         binding,
                         animation: None,
                         ty: property_decl.ty.clone(),
                         use_count: Some(&property_decl.use_count),
-                    };
+                    }
                 }
                 LocalMemberIndex::Callback(index) => {
                     let callback_decl = &g.callbacks[*index];
-                    return PropertyInfoResult {
+                    PropertyInfoResult {
                         analysis: None,
                         binding,
                         animation: None,
                         ty: callback_decl.ty.clone(),
                         use_count: Some(&callback_decl.use_count),
-                    };
+                    }
                 }
-                _ => return PropertyInfoResult::default(),
+                _ => PropertyInfoResult::default(),
             }
         }
 
@@ -719,7 +719,7 @@ impl<'a, T> EvaluationContext<'a, T> {
                     // The `Path::elements` property is not in the NativeClass
                     return &Type::PathData;
                 }
-                &sc.items[*item_index].ty.lookup_property(prop_name).unwrap()
+                sc.items[*item_index].ty.lookup_property(prop_name).unwrap()
             }
         }
     }
@@ -804,7 +804,7 @@ impl ContextMap {
                         },
                     }
                 }
-                MemberReference::Global { .. } => return p.clone(),
+                MemberReference::Global { .. } => p.clone(),
             },
             ContextMap::InGlobal(global_index) => match p {
                 MemberReference::Relative { parent_level, local_reference } => {

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -78,16 +78,15 @@ pub fn lower_expression(
             let elem = e.upgrade().unwrap();
             let enclosing = elem.borrow().enclosing_component.upgrade().unwrap();
             // When within a ShowPopupMenu builtin function, this is a reference to the root of the menu item tree
-            if Rc::ptr_eq(&elem, &enclosing.root_element) {
-                if let Some(idx) = ctx
+            if Rc::ptr_eq(&elem, &enclosing.root_element)
+                && let Some(idx) = ctx
                     .component
                     .menu_item_tree
                     .borrow()
                     .iter()
                     .position(|c| Rc::ptr_eq(c, &enclosing))
-                {
-                    return llr_Expression::NumberLiteral(idx as _);
-                }
+            {
+                return llr_Expression::NumberLiteral(idx as _);
             }
 
             // We map an element reference to a reference to the property "" inside that native item

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -466,15 +466,14 @@ fn lower_sub_component(
             .borrow()
             .get(p)
             .is_none_or(|a| a.is_set || a.is_set_externally)
+            && let Some(anim) = binding.animation.as_ref()
         {
-            if let Some(anim) = binding.animation.as_ref() {
-                match super::lower_expression::lower_animation(anim, &mut ctx) {
-                    Animation::Static(anim) => {
-                        sub_component.animations.insert(prop.local(), anim);
-                    }
-                    Animation::Transition(_) => {
-                        // Cannot set a property with a transition anyway
-                    }
+            match super::lower_expression::lower_animation(anim, &mut ctx) {
+                Animation::Static(anim) => {
+                    sub_component.animations.insert(prop.local(), anim);
+                }
+                Animation::Transition(_) => {
+                    // Cannot set a property with a transition anyway
                 }
             }
         }

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -80,8 +80,8 @@ pub fn count_property_use(root: &CompilationUnit) {
 
         // 7. aliases (if they were not optimize, they are probably used)
         for (a, b, _) in &sc.two_way_bindings {
-            visit_property(&a.clone().into(), ctx);
-            visit_property(&b.clone().into(), ctx);
+            visit_property(&a.clone(), ctx);
+            visit_property(&b.clone(), ctx);
         }
 
         // 8.functions (TODO: only visit used function)
@@ -91,7 +91,7 @@ pub fn count_property_use(root: &CompilationUnit) {
 
         // 9. change callbacks
         for (p, e) in &sc.change_callbacks {
-            visit_property(&p.clone().into(), ctx);
+            visit_property(&p.clone(), ctx);
             e.borrow().visit_property_references(ctx, &mut visit_property);
         }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -200,11 +200,11 @@ fn inline_simple_expressions_in_expression(expr: &mut Expression, ctx: &Evaluati
                         }
                     }
                 }
-            } else if let Some(use_count) = prop_info.use_count {
-                if let Some(e) = Expression::default_value_for_type(&prop_info.ty) {
-                    use_count.set(use_count.get() - 1);
-                    *expr = e;
-                }
+            } else if let Some(use_count) = prop_info.use_count
+                && let Some(e) = Expression::default_value_for_type(&prop_info.ty)
+            {
+                use_count.set(use_count.get() - 1);
+                *expr = e;
             }
         }
     };

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -247,16 +247,16 @@ mod visitor {
         visitor: &mut (impl Visitor + ?Sized),
     ) {
         for c in public_components {
-            visit_public_component(c, &state, visitor);
+            visit_public_component(c, state, visitor);
         }
         for (idx, sc) in sub_components.iter_mut_enumerated() {
-            visit_sub_component(idx, sc, &state, visitor);
+            visit_sub_component(idx, sc, state, visitor);
         }
         for (idx, g) in globals.iter_mut_enumerated() {
-            visit_global(idx, g, &state, visitor);
+            visit_global(idx, g, state, visitor);
         }
         if let Some(p) = popup_menu {
-            visit_popup_menu(p, &state, visitor);
+            visit_popup_menu(p, state, visitor);
         }
     }
 
@@ -372,10 +372,8 @@ mod visitor {
         for i in init_code {
             visit_expression(i.get_mut(), &scope, state, visitor);
         }
-        for g in geometries {
-            if let Some(g) = g {
-                visit_expression(g.get_mut(), &scope, state, visitor);
-            }
+        for g in geometries.iter_mut().flatten() {
+            visit_expression(g.get_mut(), &scope, state, visitor);
         }
         visit_expression(layout_info_h.get_mut(), &scope, state, visitor);
         visit_expression(layout_info_v.get_mut(), &scope, state, visitor);
@@ -540,7 +538,7 @@ mod visitor {
                     .follow_sub_components(*sub_component_idx, &local_reference.sub_component_path),
                 None,
             ),
-            scope => scope.clone(),
+            scope => *scope,
         };
         visit_member_index(&mut local_reference.reference, &scope, state, visitor);
     }

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -269,20 +269,19 @@ fn compiled(
 /// or `Some(Some(value))` if there is a `//-key:value`  match
 fn parse_annotation(key: &str, node: &SyntaxNode) -> Option<Option<SmolStr>> {
     for x in node.children_with_tokens() {
-        if x.kind() == SyntaxKind::Comment {
-            if let Some(comment) = x
+        if x.kind() == SyntaxKind::Comment
+            && let Some(comment) = x
                 .as_token()
                 .unwrap()
                 .text()
                 .strip_prefix("//-")
                 .and_then(|x| x.trim_end().strip_prefix(key))
-            {
-                if comment.is_empty() {
-                    return Some(None);
-                }
-                if let Some(comment) = comment.strip_prefix(':') {
-                    return Some(Some(comment.into()));
-                }
+        {
+            if comment.is_empty() {
+                return Some(None);
+            }
+            if let Some(comment) = comment.strip_prefix(':') {
+                return Some(Some(comment.into()));
             }
         }
     }

--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -70,11 +70,12 @@ impl NamedReference {
     fn is_constant_impl(&self, mut check_binding: bool) -> bool {
         let mut elem = self.element();
         let e = elem.borrow();
-        if let Some(decl) = e.property_declarations.get(self.name()) {
-            if decl.expose_in_public_api && decl.visibility != PropertyVisibility::Input {
-                // could be set by the public API
-                return false;
-            }
+        if let Some(decl) = e.property_declarations.get(self.name())
+            && decl.expose_in_public_api
+            && decl.visibility != PropertyVisibility::Input
+        {
+            // could be set by the public API
+            return false;
         }
         if e.property_analysis.borrow().get(self.name()).is_some_and(|a| a.is_set_externally) {
             return false;
@@ -111,10 +112,10 @@ impl NamedReference {
                     continue;
                 }
                 ElementType::Builtin(b) => {
-                    return b.properties.get(self.name()).map_or(true, |pi| !pi.is_native_output());
+                    return b.properties.get(self.name()).is_none_or(|pi| !pi.is_native_output());
                 }
                 ElementType::Native(n) => {
-                    return n.properties.get(self.name()).map_or(true, |pi| !pi.is_native_output());
+                    return n.properties.get(self.name()).is_none_or(|pi| !pi.is_native_output());
                 }
                 crate::langtype::ElementType::Error | crate::langtype::ElementType::Global => {
                     return true;

--- a/internal/compiler/passes/apply_default_properties_from_style.rs
+++ b/internal/compiler/passes/apply_default_properties_from_style.rs
@@ -39,7 +39,6 @@ pub fn apply_default_properties_from_style(
                             &palette.root_element,
                             SmolStr::new_static("foreground"),
                         ))
-                        .into()
                     });
                     elem.set_binding_if_not_set("selection-background-color".into(), || {
                         Expression::Cast {

--- a/internal/compiler/passes/collect_globals.rs
+++ b/internal/compiler/passes/collect_globals.rs
@@ -18,11 +18,12 @@ pub fn collect_globals(doc: &Document, _diag: &mut BuildDiagnostics) {
     let mut set = HashSet::new();
     let mut sorted_globals = vec![];
     for (_, ty) in &*doc.exports {
-        if let Some(c) = ty.as_ref().left() {
-            if c.is_global() && set.insert(ByAddress(c.clone())) {
-                collect_in_component(c, &mut set, &mut sorted_globals);
-                sorted_globals.push(c.clone());
-            }
+        if let Some(c) = ty.as_ref().left()
+            && c.is_global()
+            && set.insert(ByAddress(c.clone()))
+        {
+            collect_in_component(c, &mut set, &mut sorted_globals);
+            sorted_globals.push(c.clone());
         }
     }
     doc.visit_all_used_components(|component| {

--- a/internal/compiler/passes/collect_init_code.rs
+++ b/internal/compiler/passes/collect_init_code.rs
@@ -10,12 +10,11 @@ use crate::object_tree::{Component, recurse_elem};
 
 pub fn collect_init_code(component: &Rc<Component>) {
     recurse_elem(&component.root_element, &(), &mut |elem, _| {
-        if elem.borrow().repeated.is_some() {
-            if let ElementType::Component(base) = &elem.borrow().base_type {
-                if base.parent_element.upgrade().is_some() {
-                    collect_init_code(base);
-                }
-            }
+        if elem.borrow().repeated.is_some()
+            && let ElementType::Component(base) = &elem.borrow().base_type
+            && base.parent_element.upgrade().is_some()
+        {
+            collect_init_code(base);
         }
 
         if let Some(init_callback) = elem.borrow_mut().bindings.remove("init") {

--- a/internal/compiler/passes/collect_structs_and_enums.rs
+++ b/internal/compiler/passes/collect_structs_and_enums.rs
@@ -68,11 +68,11 @@ fn collect_types_in_component(root_component: &Rc<Component>, hash: &mut BTreeMa
 /// it are placed before in the vector
 fn sort_types(hash: &mut BTreeMap<SmolStr, Type>, vec: &mut Vec<Type>, key: &str) {
     let ty = if let Some(ty) = hash.remove(key) { ty } else { return };
-    if let Type::Struct(s) = &ty {
-        if let StructName::User { .. } = &s.name {
-            for sub_ty in s.fields.values() {
-                visit_declared_type(sub_ty, &mut |name, _| sort_types(hash, vec, name));
-            }
+    if let Type::Struct(s) = &ty
+        && let StructName::User { .. } = &s.name
+    {
+        for sub_ty in s.fields.values() {
+            visit_declared_type(sub_ty, &mut |name, _| sort_types(hash, vec, name));
         }
     }
     vec.push(ty)
@@ -82,10 +82,10 @@ fn sort_types(hash: &mut BTreeMap<SmolStr, Type>, vec: &mut Vec<Type>, key: &str
 fn visit_declared_type(ty: &Type, visitor: &mut impl FnMut(&SmolStr, &Type)) {
     match ty {
         Type::Struct(s) => {
-            if s.node().is_some() {
-                if let StructName::User { name, .. } = &s.name {
-                    visitor(name, ty);
-                }
+            if s.node().is_some()
+                && let StructName::User { name, .. } = &s.name
+            {
+                visitor(name, ty);
             }
             for sub_ty in s.fields.values() {
                 visit_declared_type(sub_ty, visitor);

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -28,7 +28,7 @@ pub fn compile_paths(
     let path_type = path_type.as_builtin();
 
     recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem_, _| {
-        if !elem_.borrow().builtin_type().is_some_and(|bt| bt.name == "Path") {
+        if elem_.borrow().builtin_type().is_none_or(|bt| bt.name != "Path") {
             return;
         }
 

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -133,11 +133,11 @@ fn simplify_expression(expr: &mut Expression, ga: &GlobalAnalysis) -> bool {
         }
         Expression::StructFieldAccess { base, name } => {
             let r = simplify_expression(base, ga);
-            if let Expression::Struct { values, .. } = &mut **base {
-                if let Some(e) = values.remove(name) {
-                    *expr = e;
-                    return simplify_expression(expr, ga);
-                }
+            if let Expression::Struct { values, .. } = &mut **base
+                && let Some(e) = values.remove(name)
+            {
+                *expr = e;
+                return simplify_expression(expr, ga);
             }
             r
         }
@@ -201,11 +201,9 @@ fn simplify_expression(expr: &mut Expression, ga: &GlobalAnalysis) -> bool {
             for arg in arguments.iter_mut() {
                 args_can_inline &= simplify_expression(arg, ga);
             }
-            if args_can_inline {
-                if let Some(inlined) = try_inline_function(function, arguments, ga) {
-                    *expr = inlined;
-                    return true;
-                }
+            if args_can_inline && let Some(inlined) = try_inline_function(function, arguments, ga) {
+                *expr = inlined;
+                return true;
             }
             false
         }

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -30,10 +30,7 @@ pub fn default_geometry(root_component: &Rc<Component>, diag: &mut BuildDiagnost
             if elem.borrow().repeated.is_some() {
                 return None;
             }
-            if elem.borrow().geometry_props.is_none() {
-                // Not an element with geometry, skip it
-                return None;
-            }
+            elem.borrow().geometry_props.as_ref()?;
 
             // whether the width, or height, is filling the parent
             let (mut w100, mut h100) = (false, false);

--- a/internal/compiler/passes/embed_images.rs
+++ b/internal/compiler/passes/embed_images.rs
@@ -71,10 +71,10 @@ fn collect_image_urls_from_expression(
     e: &Expression,
     urls: &mut HashMap<SmolStr, Option<SmolStr>>,
 ) {
-    if let Expression::ImageReference { resource_ref, .. } = e {
-        if let ImageReference::AbsolutePath(path) = resource_ref {
-            urls.insert(path.clone(), None);
-        }
+    if let Expression::ImageReference { resource_ref, .. } = e
+        && let ImageReference::AbsolutePath(path) = resource_ref
+    {
+        urls.insert(path.clone(), None);
     };
 
     e.visit(|e| collect_image_urls_from_expression(e, urls));
@@ -88,27 +88,27 @@ fn embed_images_from_expression(
     scale_factor: f32,
     diag: &mut BuildDiagnostics,
 ) {
-    if let Expression::ImageReference { resource_ref, source_location, nine_slice: _ } = e {
-        if let ImageReference::AbsolutePath(path) = resource_ref {
-            // used mapped path:
-            let mapped_path =
-                urls.get(path).unwrap_or(&Some(path.clone())).clone().unwrap_or(path.clone());
-            *path = mapped_path;
-            if embed_files != EmbedResourcesKind::Nothing
-                && (embed_files != EmbedResourcesKind::OnlyBuiltinResources
-                    || path.starts_with("builtin:/"))
-            {
-                let image_ref = embed_image(
-                    global_embedded_resources,
-                    embed_files,
-                    path,
-                    scale_factor,
-                    diag,
-                    source_location,
-                );
-                if embed_files != EmbedResourcesKind::ListAllResources {
-                    *resource_ref = image_ref;
-                }
+    if let Expression::ImageReference { resource_ref, source_location, nine_slice: _ } = e
+        && let ImageReference::AbsolutePath(path) = resource_ref
+    {
+        // used mapped path:
+        let mapped_path =
+            urls.get(path).unwrap_or(&Some(path.clone())).clone().unwrap_or(path.clone());
+        *path = mapped_path;
+        if embed_files != EmbedResourcesKind::Nothing
+            && (embed_files != EmbedResourcesKind::OnlyBuiltinResources
+                || path.starts_with("builtin:/"))
+        {
+            let image_ref = embed_image(
+                global_embedded_resources,
+                embed_files,
+                path,
+                scale_factor,
+                diag,
+                source_location,
+            );
+            if embed_files != EmbedResourcesKind::ListAllResources {
+                *resource_ref = image_ref;
             }
         }
     };

--- a/internal/compiler/passes/ensure_window.rs
+++ b/internal/compiler/passes/ensure_window.rs
@@ -141,7 +141,7 @@ pub fn ensure_window(
 }
 
 pub fn inherits_window(component: &Rc<Component>) -> bool {
-    component.root_element.borrow().builtin_type().map_or(true, |b| {
+    component.root_element.borrow().builtin_type().is_none_or(|b| {
         matches!(b.name.as_str(), "Window" | "Dialog" | "WindowItem" | "PopupWindow")
     })
 }

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -124,10 +124,10 @@ fn create_viewport_element(flickable: &ElementRc, native_empty: &Rc<NativeClass>
         .is_set_externally = true;
 
     let enclosing_component = flickable.borrow().enclosing_component.upgrade().unwrap();
-    if let Some(insertion_point) = &mut *enclosing_component.child_insertion_point.borrow_mut() {
-        if std::rc::Rc::ptr_eq(&insertion_point.parent, flickable) {
-            insertion_point.parent = viewport.clone()
-        }
+    if let Some(insertion_point) = &mut *enclosing_component.child_insertion_point.borrow_mut()
+        && std::rc::Rc::ptr_eq(&insertion_point.parent, flickable)
+    {
+        insertion_point.parent = viewport.clone()
     }
 
     flickable.borrow_mut().children.push(viewport);
@@ -216,9 +216,9 @@ fn set_binding_if_not_explicit(
     expression: impl FnOnce() -> Option<Expression>,
 ) {
     // we can't use `set_binding_if_not_set` directly because `expression()` may borrow `elem`
-    if elem.borrow().bindings.get(property).map_or(true, |b| !b.borrow().has_binding()) {
-        if let Some(e) = expression() {
-            elem.borrow_mut().set_binding_if_not_set(property.into(), || e);
-        }
+    if elem.borrow().bindings.get(property).is_none_or(|b| !b.borrow().has_binding())
+        && let Some(e) = expression()
+    {
+        elem.borrow_mut().set_binding_if_not_set(property.into(), || e);
     }
 }

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -221,7 +221,7 @@ impl<'a> LocalFocusForwards<'a> {
                         function.name().into(),
                         PropertyDeclaration {
                             property_type: Type::Function(Rc::new(Function {
-                                return_type: Type::Void.into(),
+                                return_type: Type::Void,
                                 args: vec![],
                                 arg_names: vec![],
                             })),

--- a/internal/compiler/passes/lower_component_container.rs
+++ b/internal/compiler/passes/lower_component_container.rs
@@ -52,13 +52,12 @@ fn diagnose_component_container(element: &ElementRc, diag: &mut BuildDiagnostics
     }
     if let Some(cip) =
         elem.enclosing_component.upgrade().unwrap().child_insertion_point.borrow().clone()
+        && Rc::ptr_eq(&cip.parent, element)
     {
-        if Rc::ptr_eq(&cip.parent, element) {
-            diag.push_error(
-                "The @children placeholder cannot appear in a ComponentContainer".into(),
-                &*element.borrow(),
-            );
-        }
+        diag.push_error(
+            "The @children placeholder cannot appear in a ComponentContainer".into(),
+            &*element.borrow(),
+        );
     }
 }
 

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -384,15 +384,12 @@ fn process_window(
             .into(),
         };
         condition = match condition {
-            Some(condition) => Some(
-                Expression::BinaryExpression {
-                    lhs: condition.into(),
-                    rhs: supportes_native_menu_bar.into(),
-                    op: '&',
-                }
-                .into(),
-            ),
-            None => Some(supportes_native_menu_bar.into()),
+            Some(condition) => Some(Expression::BinaryExpression {
+                lhs: condition.into(),
+                rhs: supportes_native_menu_bar.into(),
+                op: '&',
+            }),
+            None => Some(supportes_native_menu_bar),
         };
     }
 
@@ -495,7 +492,7 @@ fn process_window(
             &menu_bar,
             SmolStr::new_static(ACTIVATED),
         )),
-        item_tree_root.into(),
+        item_tree_root,
         Expression::BoolLiteral(no_native_menu),
     ];
 
@@ -508,7 +505,7 @@ fn process_window(
         arguments,
         source_location,
     };
-    component.init_code.borrow_mut().constructor_code.push(setup_menubar.into());
+    component.init_code.borrow_mut().constructor_code.push(setup_menubar);
 
     true
 }

--- a/internal/compiler/passes/lower_platform.rs
+++ b/internal/compiler/passes/lower_platform.rs
@@ -27,7 +27,7 @@ pub fn lower_platform(component: &Rc<Component>, type_loader: &mut crate::typelo
                                 .strip_suffix("-light")
                                 .unwrap_or(&type_loader.resolved_style)
                         });
-                    *e = Expression::StringLiteral(style.into()).into();
+                    *e = Expression::StringLiteral(style.into());
                 }
             }
 

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -66,13 +66,13 @@ fn lower_popup_window(
                 report_const_error(CLOSE_ON_CLICK, &binding.borrow().span, diag);
             }
         }
-    } else if let Some(binding) = popup_window_element.borrow().bindings.get(CLOSE_POLICY) {
-        if !matches!(
+    } else if let Some(binding) = popup_window_element.borrow().bindings.get(CLOSE_POLICY)
+        && !matches!(
             super::ignore_debug_hooks(&binding.borrow().expression),
             Expression::EnumerationValue(_)
-        ) {
-            report_const_error(CLOSE_POLICY, &binding.borrow().span, diag);
-        }
+        )
+    {
+        report_const_error(CLOSE_POLICY, &binding.borrow().span, diag);
     }
 
     let parent_component = popup_window_element.borrow().enclosing_component.upgrade().unwrap();
@@ -105,10 +105,11 @@ fn lower_popup_window(
     parent_element_borrowed.children.remove(index);
     parent_element_borrowed.has_popup_child = true;
     drop(parent_element_borrowed);
-    if let Some(parent_cip) = &mut *parent_component.child_insertion_point.borrow_mut() {
-        if Rc::ptr_eq(&parent_cip.parent, parent_element) && parent_cip.insertion_index > index {
-            parent_cip.insertion_index -= 1;
-        }
+    if let Some(parent_cip) = &mut *parent_component.child_insertion_point.borrow_mut()
+        && Rc::ptr_eq(&parent_cip.parent, parent_element)
+        && parent_cip.insertion_index > index
+    {
+        parent_cip.insertion_index -= 1;
     }
 
     if matches!(popup_window_element.borrow().base_type, ElementType::Builtin(_)) {

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -105,12 +105,11 @@ fn create_property_element(
             let mut bind = BindingExpression::new_two_way(
                 NamedReference::new(child, property_name.clone()).into(),
             );
-            if let Some(default_value_for_extra_properties) = default_value_for_extra_properties {
-                if !child.borrow().bindings.contains_key(&property_name) {
-                    if let Some(e) = default_value_for_extra_properties(child, &property_name) {
-                        bind.expression = e;
-                    }
-                }
+            if let Some(default_value_for_extra_properties) = default_value_for_extra_properties
+                && !child.borrow().bindings.contains_key(&property_name)
+                && let Some(e) = default_value_for_extra_properties(child, &property_name)
+            {
+                bind.expression = e;
             }
             (property_name, bind.into())
         })

--- a/internal/compiler/passes/lower_text_input_interface.rs
+++ b/internal/compiler/passes/lower_text_input_interface.rs
@@ -35,7 +35,7 @@ pub fn lower_text_input_interface(component: &Rc<Component>) {
 }
 
 fn is_input_text_focused_prop(nr: &NamedReference) -> bool {
-    if !nr.element().borrow().builtin_type().is_some_and(|bt| bt.name == "TextInputInterface") {
+    if nr.element().borrow().builtin_type().is_none_or(|bt| bt.name != "TextInputInterface") {
         return false;
     }
     assert_eq!(nr.name(), "text-input-focused");

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -22,12 +22,11 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
     visit_all_named_references(component, &mut |nr| {
         let elem = nr.element();
         let elem = elem.borrow();
-        if !to_materialize.contains_key(nr) {
-            if let Some(ty) =
+        if !to_materialize.contains_key(nr)
+            && let Some(ty) =
                 should_materialize(&elem.property_declarations, &elem.base_type, nr.name())
-            {
-                to_materialize.insert(nr.clone(), ty);
-            }
+        {
+            to_materialize.insert(nr.clone(), ty);
         }
     });
 
@@ -154,7 +153,7 @@ pub fn initialize(elem: &ElementRc, name: &str) -> Option<Expression> {
     // later optimization steps to eliminate these properties.
     // Note that Rectangles and Empties are similarly optimized in layout_constraint_prop, and
     // we rely on struct field access simplification for those.
-    if elem.borrow().builtin_type().map_or(false, |n| n.name == "Image") {
+    if elem.borrow().builtin_type().is_some_and(|n| n.name == "Image") {
         if elem.borrow().layout_info_prop(Orientation::Horizontal).is_none() {
             match name {
                 "min-width" => return Some(Expression::NumberLiteral(0., Unit::Px)),

--- a/internal/compiler/passes/purity_check.rs
+++ b/internal/compiler/passes/purity_check.rs
@@ -73,7 +73,7 @@ fn ensure_pure(
                         match nr.element().borrow().bindings.get(nr.name()) {
                             None => {
                                 debug_assert!(
-                                    diag.as_ref().map_or(true, |d| d.has_errors()),
+                                    diag.as_ref().is_none_or(|d| d.has_errors()),
                                     "private functions must be local and defined"
                                 );
                             }

--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -25,17 +25,15 @@ impl PropertySets {
         if !std::rc::Weak::ptr_eq(
             &e1.borrow().enclosing_component,
             &e2.borrow().enclosing_component,
-        ) {
-            if !(e1.borrow().enclosing_component.upgrade().unwrap().is_global()
-                && !e2.borrow().change_callbacks.contains_key(p2.name()))
-                && !(e2.borrow().enclosing_component.upgrade().unwrap().is_global()
-                    && !e1.borrow().change_callbacks.contains_key(p1.name()))
-            {
-                // We can only merge aliases if they are in the same Component. (unless one of them is global if the other one don't have change event)
-                // TODO: actually we could still merge two alias in a component pointing to the same
-                // property in a parent component
-                return;
-            }
+        ) && !(e1.borrow().enclosing_component.upgrade().unwrap().is_global()
+            && !e2.borrow().change_callbacks.contains_key(p2.name()))
+            && !(e2.borrow().enclosing_component.upgrade().unwrap().is_global()
+                && !e1.borrow().change_callbacks.contains_key(p1.name()))
+        {
+            // We can only merge aliases if they are in the same Component. (unless one of them is global if the other one don't have change event)
+            // TODO: actually we could still merge two alias in a component pointing to the same
+            // property in a parent component
+            return;
         }
 
         if let Some(s1) = self.map.get(&p1).cloned() {

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -129,23 +129,22 @@ fn adjust_references(comp: &Rc<Component>) {
             return;
         }
         let e = nr.element();
-        if e.borrow().repeated.is_some() {
-            if let ElementType::Component(c) = e.borrow().base_type.clone() {
-                *nr = NamedReference::new(&c.root_element, nr.name().clone())
-            };
-        }
+        if e.borrow().repeated.is_some()
+            && let ElementType::Component(c) = e.borrow().base_type.clone()
+        {
+            *nr = NamedReference::new(&c.root_element, nr.name().clone())
+        };
     });
     // Transform any references to the repeated element to refer to the root of each instance.
     visit_all_expressions(comp, |expr, _| {
         expr.visit_recursive_mut(&mut |expr| {
-            if let Expression::ElementReference(element_ref) = expr {
-                if let Some(repeater_element) =
+            if let Expression::ElementReference(element_ref) = expr
+                && let Some(repeater_element) =
                     element_ref.upgrade().filter(|e| e.borrow().repeated.is_some())
-                {
-                    let inner_element =
-                        repeater_element.borrow().base_type.as_component().root_element.clone();
-                    *element_ref = Rc::downgrade(&inner_element);
-                }
+            {
+                let inner_element =
+                    repeater_element.borrow().base_type.as_component().root_element.clone();
+                *element_ref = Rc::downgrade(&inner_element);
             }
         })
     });

--- a/internal/compiler/passes/resolving/remove_noop.rs
+++ b/internal/compiler/passes/resolving/remove_noop.rs
@@ -61,9 +61,9 @@ fn without_side_effects(expression: &Expression) -> bool {
         Expression::RepeaterModelReference { .. } => true,
         Expression::StoreLocalVariable { .. } => false,
         Expression::ReadLocalVariable { .. } => true,
-        Expression::StructFieldAccess { base, name: _ } => without_side_effects(&*base),
+        Expression::StructFieldAccess { base, name: _ } => without_side_effects(base),
         Expression::ArrayIndex { array, index } => {
-            without_side_effects(&*array) && without_side_effects(&*index)
+            without_side_effects(array) && without_side_effects(index)
         }
         // Note: This assumes that the cast itself does not have any side effects, which may not be
         // the case if custom casting rules are implemented.
@@ -74,16 +74,16 @@ fn without_side_effects(expression: &Expression) -> bool {
         Expression::FunctionCall { .. } => false,
         Expression::SelfAssignment { .. } => false,
         Expression::BinaryExpression { lhs, rhs, .. } => {
-            without_side_effects(&*lhs) && without_side_effects(&*rhs)
+            without_side_effects(lhs) && without_side_effects(rhs)
         }
-        Expression::UnaryOp { sub, op: _ } => without_side_effects(&*sub),
+        Expression::UnaryOp { sub, op: _ } => without_side_effects(sub),
         Expression::ImageReference { .. } => true,
         Expression::Array { element_ty: _, values } => values.iter().all(without_side_effects),
         Expression::Struct { ty: _, values } => values.values().all(without_side_effects),
         Expression::PathData(_) => true,
         Expression::EasingCurve(_) => true,
         Expression::LinearGradient { angle, stops } => {
-            without_side_effects(&angle)
+            without_side_effects(angle)
                 && stops
                     .iter()
                     .all(|(start, end)| without_side_effects(start) && without_side_effects(end))

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1077,7 +1077,7 @@ impl TypeLoader {
                 let core::task::Poll::Ready((mut import, doc_path)) = fut.as_mut().poll(cx) else { return true; };
                 let Some(doc_path) = doc_path else { return false };
                 let mut state = state.borrow_mut();
-                let state: &mut BorrowedTypeLoader<'a> = &mut *state;
+                let state: &mut BorrowedTypeLoader<'a> = &mut state;
                 let Some(doc) = state.tl.get_document(&doc_path) else {
                     panic!("Just loaded document not available")
                 };
@@ -1221,13 +1221,12 @@ impl TypeLoader {
                         && file_name.eq_ignore_ascii_case(
                             file_to_import.get(len - file_name.len()..).unwrap_or(""),
                         )
+                        && import_token.as_ref().and_then(|x| x.source_file()).is_some()
                     {
-                        if import_token.as_ref().and_then(|x| x.source_file()).is_some() {
-                            borrowed_state.diag.push_warning(
+                        borrowed_state.diag.push_warning(
                                 format!("Loading \"{file_to_import}\" resolved to a file named \"{file_name}\" with different casing. This behavior is not cross platform. Rename the file, or edit the import to use the same casing"),
                                 &import_token,
                             );
-                        }
                     }
                 }
                 x
@@ -1589,7 +1588,7 @@ impl TypeLoader {
             };
             crate::fileaccess::load_file(path.as_path())
                 .map(|virtual_file| (virtual_file.canon_path, virtual_file.builtin_contents))
-                .or_else(|| Some((path, None)))
+                .or(Some((path, None)))
         })
     }
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -300,18 +300,18 @@ pub fn reserved_property(name: std::borrow::Cow<'_, str>) -> PropertyLookupResul
     for pre in &["min", "max"] {
         if let Some(a) = name.strip_prefix(pre) {
             for suf in &["width", "height"] {
-                if let Some(b) = a.strip_suffix(suf) {
-                    if b == "imum-" {
-                        return PropertyLookupResult {
-                            property_type: Type::LogicalLength,
-                            resolved_name: format!("{pre}-{suf}").into(),
-                            is_local_to_component: false,
-                            is_in_direct_base: false,
-                            property_visibility: crate::object_tree::PropertyVisibility::InOut,
-                            declared_pure: None,
-                            builtin_function: None,
-                        };
-                    }
+                if let Some(b) = a.strip_suffix(suf)
+                    && b == "imum-"
+                {
+                    return PropertyLookupResult {
+                        property_type: Type::LogicalLength,
+                        resolved_name: format!("{pre}-{suf}").into(),
+                        is_local_to_component: false,
+                        is_in_direct_base: false,
+                        property_visibility: crate::object_tree::PropertyVisibility::InOut,
+                        declared_pure: None,
+                        builtin_function: None,
+                    };
                 }
             }
         }


### PR DESCRIPTION
Switching to the 2024 edition of rust brought in new warnings (e.g. suggesting to use "let chains"), plus some were introduced recently (e.g. my changes).

The fixes were all made by clippy --fix, except for two that broke the build and that I reverted (clippy got confused by the declare_units macro, for instance).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
