### PR TITLE
Simplify dial example by using inline property bindings

### DIFF
--- a/examples/dial/dial.slint
+++ b/examples/dial/dial.slint
@@ -67,20 +67,17 @@ export component AppWindow inherits Window {
     ta := TouchArea {
         property <length> centerX: self.width / 2;
         property <length> centerY: self.height / 2;
-        property <length> relativeX;
-        property <length> relativeY;
+        property <length> relativeX: ta.mouse-x - centerX;
+        property <length> relativeY: ta.mouse-y - centerY;
         property <angle> lastAngle;
-        property <angle> nextAngle;
         property <bool> hovering: Math.pow(relativeX / 1px, 2) + Math.pow(relativeY / 1px, 2) < metalKnob.width / 2px * metalKnob.height / 2px;
         property <bool> touching: false;
         width: base.width;
         height: base.height;
 
-        mouse-cursor: touching ? move : hovering ? grab : default;
+        mouse-cursor: touching ? grabbing : hovering ? grab : default;
 
         pointer-event(event) => {
-            relativeX = ta.mouse-x - centerX;
-            relativeY = ta.mouse-y - centerY;
             let newAngle = AppState.normalizeAngle(atan2(relativeY / 1px, relativeX / 1px));
             if event.kind == PointerEventKind.down {
                 if hovering {
@@ -91,7 +88,7 @@ export component AppWindow inherits Window {
                 touching = false;
             } else if event.kind == PointerEventKind.move {
                 if touching {
-                    nextAngle = AppState.normalizeAngle(AppState.angle - lastAngle + newAngle);
+                    let nextAngle = AppState.normalizeAngle(AppState.angle - lastAngle + newAngle);
                     // Check if the new angle is within the start and end angles
                     if nextAngle >= AppState.startAngle || nextAngle <= AppState.endAngle {
                         AppState.angle = nextAngle;


### PR DESCRIPTION
Compute relativeX/relativeY as inline bindings instead of updating them in the event handler. Also use grabbing cursor for better UX.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
