### PR TITLE
Docs: document SpinBox::read-only

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinbox.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/spinbox.mdx
@@ -68,6 +68,11 @@ SpinBox {
 ```
 </SlintProperty>
 
+### read-only
+<SlintProperty propName="read-only" typeName="bool" defaultValue="false">
+If true, the user can't modify the value.
+</SlintProperty>
+
 ### step-size
 <SlintProperty propName="step-size" typeName="int" defaultValue="1">
 The size that is used on increment or decrement of `value`.


### PR DESCRIPTION
Was added in https://github.com/slint-ui/slint/pull/10133 but forgot to document.