### PR TITLE
Port from vec![] to Vec::new()

### DIFF
--- a/api/node/rust/interpreter/component_compiler.rs
+++ b/api/node/rust/interpreter/component_compiler.rs
@@ -37,7 +37,7 @@ impl JsComponentCompiler {
             Some(paths) => {
                 std::env::split_paths(&paths).filter(|path| !path.as_os_str().is_empty()).collect()
             }
-            None => vec![],
+            None => Vec::new(),
         };
         let library_paths = match std::env::var_os("SLINT_LIBRARY_PATH") {
             Some(paths) => std::env::split_paths(&paths)
@@ -55,7 +55,7 @@ impl JsComponentCompiler {
 
         compiler.set_include_paths(include_paths);
         compiler.set_library_paths(library_paths);
-        Self { internal: compiler, diagnostics: vec![], structs_and_enums: vec![] }
+        Self { internal: compiler, diagnostics: Vec::new(), structs_and_enums: vec![] }
     }
 
     #[napi(setter)]

--- a/api/node/rust/interpreter/value.rs
+++ b/api/node/rust/interpreter/value.rs
@@ -248,7 +248,7 @@ pub fn to_value(env: &Env, unknown: JsUnknown, typ: &Type) -> Result<Value> {
         Type::Array(a) => {
             if unknown.is_array()? {
                 let array = Array::from_unknown(unknown)?;
-                let mut vec = vec![];
+                let mut vec = Vec::new();
 
                 for i in 0..array.len() {
                     vec.push(to_value(

--- a/api/node/rust/types/image_data.rs
+++ b/api/node/rust/types/image_data.rs
@@ -90,7 +90,7 @@ impl SlintImageData {
 }
 
 fn rgb_to_rgba(bytes: &[u8], size: usize) -> Vec<u8> {
-    let mut rgba_bytes = vec![];
+    let mut rgba_bytes = Vec::new();
 
     for i in 0..size {
         if (i * 3) + 2 >= bytes.len() {

--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -438,7 +438,7 @@ impl ComponentInstance {
 
     #[pyo3(signature = (callback_name, *args))]
     fn invoke(&self, callback_name: &str, args: Bound<'_, PyTuple>) -> PyResult<SlintToPyValue> {
-        let mut rust_args = vec![];
+        let mut rust_args = Vec::new();
         for arg in args.iter() {
             let pv =
                 TypeCollection::slint_value_from_py_value_bound(&arg, Some(&self.type_collection))?;
@@ -456,7 +456,7 @@ impl ComponentInstance {
         callback_name: &str,
         args: Bound<'_, PyTuple>,
     ) -> PyResult<SlintToPyValue> {
-        let mut rust_args = vec![];
+        let mut rust_args = Vec::new();
         for arg in args.iter() {
             let pv =
                 TypeCollection::slint_value_from_py_value_bound(&arg, Some(&self.type_collection))?;

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -349,7 +349,7 @@ pub fn slint(stream: TokenStream) -> TokenStream {
 
     let token_iter = extract_compiler_config(token_iter, &mut compiler_config);
 
-    let mut tokens = vec![];
+    let mut tokens = Vec::new();
     fill_token_vec(token_iter, &mut tokens);
 
     fn local_file(tokens: &[parser::Token]) -> Option<PathBuf> {

--- a/demos/energy-monitor/src/controllers/weather.rs
+++ b/demos/energy-monitor/src/controllers/weather.rs
@@ -37,7 +37,7 @@ async fn weather_worker_loop(window_weak: Weak<MainWindow>) {
 
     let now = Local::now();
 
-    let mut forecast_days = vec![];
+    let mut forecast_days = Vec::new();
 
     let client = Client::new(&api_key, true);
     let mut forecast_list = future::join_all((0..FORECAST_DAYS).map(|i| {

--- a/demos/weather-demo/src/weather/dummyweathercontroller.rs
+++ b/demos/weather-demo/src/weather/dummyweathercontroller.rs
@@ -14,7 +14,7 @@ pub struct DummyWeatherController {
 
 impl DummyWeatherController {
     pub fn new() -> Self {
-        Self { city_weather_data: vec![] }
+        Self { city_weather_data: Vec::new() }
     }
 
     fn generate_dummy_data() -> Vec<CityWeatherData> {
@@ -43,7 +43,7 @@ impl DummyWeatherController {
             }
         }
 
-        vec![]
+        Vec::new()
     }
 }
 

--- a/demos/weather-demo/src/weather/openweathercontroller.rs
+++ b/demos/weather-demo/src/weather/openweathercontroller.rs
@@ -13,7 +13,6 @@ use std::io::{BufReader, BufWriter, Write};
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::vec;
 use tokio::sync::Mutex;
 
 use crate::weather::utils::*;
@@ -100,7 +99,7 @@ impl OpenWeatherController {
         Self {
             tokio_runtime: tokio::runtime::Runtime::new().unwrap(),
             weather_api,
-            city_clients: Arc::new(Mutex::new(vec![])),
+            city_clients: Arc::new(Mutex::new(Vec::new())),
             storage_path,
         }
     }
@@ -170,7 +169,7 @@ impl OpenWeatherController {
     fn forecast_day_weather_data_from_response(
         weather_response: &Option<OneCallResponse>,
     ) -> Vec<ForecastWeatherData> {
-        let mut forecast_weather_info: Vec<ForecastWeatherData> = vec![];
+        let mut forecast_weather_info: Vec<ForecastWeatherData> = Vec::new();
 
         if let Some(weather_data) = weather_response {
             if let Some(daily_weather_data) = &weather_data.daily {
@@ -296,7 +295,7 @@ impl WeatherController for OpenWeatherController {
         self.tokio_runtime.block_on(async move {
             let mut city_clients = city_clients_clone.lock().await;
 
-            let mut errors = vec![];
+            let mut errors = Vec::new();
             for client in city_clients.iter_mut() {
                 // TODO: Spawn all tasks at once and join them later.
                 if let Err(e) = client.refresh_weather(&weather_api).await {
@@ -369,7 +368,7 @@ impl WeatherController for OpenWeatherController {
         let weather_api = self.weather_api.clone();
 
         if query.is_empty() {
-            return Ok(vec![]);
+            return Ok(Vec::new());
         }
 
         self.tokio_runtime.block_on(async move {

--- a/demos/weather-demo/src/weather/weatherdisplaycontroller.rs
+++ b/demos/weather-demo/src/weather/weatherdisplaycontroller.rs
@@ -114,10 +114,12 @@ impl WeatherDisplayController {
         let geo_location = window.global::<GeoLocation>();
 
         // initialized models
-        city_weather
-            .set_city_weather(ModelRc::from(Rc::new(VecModel::<CityWeatherInfo>::from(vec![]))));
-        geo_location
-            .set_result_list(ModelRc::from(Rc::new(VecModel::<GeoLocationEntry>::from(vec![]))));
+        city_weather.set_city_weather(ModelRc::from(Rc::new(VecModel::<CityWeatherInfo>::from(
+            Vec::new(),
+        ))));
+        geo_location.set_result_list(ModelRc::from(Rc::new(VecModel::<GeoLocationEntry>::from(
+            Vec::new(),
+        ))));
 
         // initialize state
         city_weather.set_can_add_city(support_add_city);

--- a/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
+++ b/examples/servo/src/webview/rendering_context/gpu_rendering_context.rs
@@ -279,7 +279,7 @@ impl GPURenderingContext {
                         mip_level_count: 1,
                         sample_count: 1,
                         usage: wgpu::TextureUses::RESOURCE | wgpu::TextureUses::COLOR_TARGET,
-                        view_formats: vec![],
+                        view_formats: Vec::new(),
                         memory_flags: wgpu_hal::MemoryFlags::empty(),
                     },
                     Some(Box::new(move || {

--- a/examples/slide_puzzle/main.rs
+++ b/examples/slide_puzzle/main.rs
@@ -176,7 +176,7 @@ pub fn main() -> Result<(), slint::PlatformError> {
     let state = Rc::new(RefCell::new(AppState {
         pieces: Rc::new(slint::VecModel::<Piece>::from(vec![Piece::default(); 15])),
         main_window: main_window.as_weak(),
-        positions: vec![],
+        positions: Vec::new(),
         auto_play_timer: Default::default(),
         kick_animation_timer: Default::default(),
         speed_for_kick_animation: Default::default(),

--- a/helper_crates/vtable/macro/macro.rs
+++ b/helper_crates/vtable/macro/macro.rs
@@ -192,7 +192,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let vtable_name = input.ident.clone();
 
-    let mut drop_impls = vec![];
+    let mut drop_impls = Vec::new();
 
     let mut generated_trait = ItemTrait {
         attrs: input
@@ -222,9 +222,9 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut generated_trait_assoc_const = None;
 
-    let mut generated_to_fn_trait = vec![];
-    let mut generated_type_assoc_fn = vec![];
-    let mut vtable_ctor = vec![];
+    let mut generated_to_fn_trait = Vec::new();
+    let mut generated_type_assoc_fn = Vec::new();
+    let mut vtable_ctor = Vec::new();
 
     for field in &mut fields.named {
         // The vtable can only be accessed in unsafe code, so it is ok if all its fields are Public
@@ -570,7 +570,7 @@ pub fn vtable(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         "/** Trait containing the associated constant relative to the trait {trait_name}.\n{additional_doc} */",
                     )).unwrap(),
                     ident: quote::format_ident!("{}Consts", trait_name),
-                    items: vec![],
+                    items: Vec::new(),
                     ..generated_trait.clone()
                 });
 

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -98,7 +98,7 @@ impl ElementQueryInstruction {
 
         match query {
             ElementQueryInstruction::MatchDescendants => {
-                let mut results = vec![];
+                let mut results = Vec::new();
                 match element.visit_descendants_impl(
                     &mut |child| {
                         let (next_control_flow, sub_results) = Self::match_recursively(
@@ -117,7 +117,7 @@ impl ElementQueryInstruction {
                 }
             }
             ElementQueryInstruction::MatchSingleElement(criteria) => {
-                let mut results = vec![];
+                let mut results = Vec::new();
                 let control_flow = if criteria.matches(&element) {
                     let (next_control_flow, sub_results) = Self::match_recursively(
                         tail,

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -130,7 +130,7 @@ impl AccessKitAdapter {
             return;
         }
         self.inner.update_if_active(|| TreeUpdate {
-            nodes: vec![],
+            nodes: Vec::new(),
             tree: None,
             focus: self.nodes.focus_node(&self.window_adapter_weak),
         })

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -264,7 +264,7 @@ impl MudaAdapter {
         let menu_bar = muda::Menu::new();
         create_default_app_menu(&menu_bar)?;
         menu_bar.init_for_nsapp();
-        Ok(Self { entries: vec![], menu: menu_bar, tracker: None })
+        Ok(Self { entries: Vec::new(), menu: menu_bar, tracker: None })
     }
 
     #[cfg(target_os = "macos")]

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -158,7 +158,7 @@ macro_rules! declare_builtin_function_types {
                     $($Name : Rc::new(Function{
                         args: vec![$($Arg),*],
                         return_type: $ReturnType,
-                        arg_names: vec![],
+                        arg_names: Vec::new(),
                     })),*
                 }
             }
@@ -855,7 +855,7 @@ impl Expression {
                         } else if let Some(u) = ty.default_unit() {
                             vec![(u, 1)]
                         } else {
-                            vec![]
+                            Vec::new()
                         }
                     };
                     let mut l_units = unit_vec(lhs.ty());
@@ -1310,7 +1310,7 @@ impl Expression {
                                             lhs: Box::new(result),
                                             rhs: Box::new(Expression::FunctionCall {
                                                 function: Callable::Builtin(builtin_fn.clone()),
-                                                arguments: vec![],
+                                                arguments: Vec::new(),
                                                 source_location: Some(node.to_source_location()),
                                             }),
                                             op,
@@ -1415,7 +1415,7 @@ impl Expression {
             | Type::InferredCallback
             | Type::ElementReference
             | Type::LayoutCache => Expression::Invalid,
-            Type::Void => Expression::CodeBlock(vec![]),
+            Type::Void => Expression::CodeBlock(Vec::new()),
             Type::Float32 => Expression::NumberLiteral(0., Unit::None),
             Type::String => Expression::StringLiteral(SmolStr::default()),
             Type::Int32 | Type::Color | Type::UnitProduct(_) => Expression::Cast {
@@ -1435,9 +1435,9 @@ impl Expression {
             },
             Type::Bool => Expression::BoolLiteral(false),
             Type::Model => Expression::Invalid,
-            Type::PathData => Expression::PathData(Path::Elements(vec![])),
+            Type::PathData => Expression::PathData(Path::Elements(Vec::new())),
             Type::Array(element_ty) => {
-                Expression::Array { element_ty: (**element_ty).clone(), values: vec![] }
+                Expression::Array { element_ty: (**element_ty).clone(), values: Vec::new() }
             }
             Type::Struct(s) => Expression::Struct {
                 ty: s.clone(),
@@ -1572,7 +1572,7 @@ impl TwoWayBinding {
 
 impl From<NamedReference> for TwoWayBinding {
     fn from(nr: NamedReference) -> Self {
-        Self { property: nr, field_access: vec![] }
+        Self { property: nr, field_access: Vec::new() }
     }
 }
 

--- a/internal/compiler/fileaccess.rs
+++ b/internal/compiler/fileaccess.rs
@@ -114,7 +114,7 @@ mod builtin_library {
     }
 
     pub(crate) fn load_builtin_file(builtin_path: &std::path::Path) -> Option<VirtualFile> {
-        let mut components = vec![];
+        let mut components = Vec::new();
         for part in builtin_path.iter() {
             if part == ".." {
                 components.pop();

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -803,7 +803,7 @@ pub fn generate(
         }),
     ));
 
-    let mut init_global = vec![];
+    let mut init_global = Vec::new();
 
     for (idx, glob) in llr.globals.iter_enumerated() {
         if !glob.must_generate() {
@@ -2550,7 +2550,7 @@ fn generate_repeated_component(
 
     let access_prop = |idx: &llr::PropertyIdx| {
         access_member(
-            &llr::LocalMemberReference { sub_component_path: vec![], reference: (*idx).into() }
+            &llr::LocalMemberReference { sub_component_path: Vec::new(), reference: (*idx).into() }
                 .into(),
             &ctx,
         )
@@ -2721,7 +2721,7 @@ fn generate_global(
             name: ident(&global.name),
             signature: "(const class SharedGlobals *globals)".into(),
             is_constructor_or_destructor: true,
-            statements: Some(vec![]),
+            statements: Some(Vec::new()),
             constructor_member_initializers: vec!["globals(globals)".into()],
             ..Default::default()
         }),
@@ -2785,7 +2785,7 @@ fn generate_global_builtin(
                 ident(&global.name)
             ),
             is_constructor_or_destructor: true,
-            statements: Some(vec![]),
+            statements: Some(Vec::new()),
             constructor_member_initializers: vec!["builtin(std::move(builtin))".into()],
             ..Default::default()
         }),

--- a/internal/compiler/generator/cpp_live_preview.rs
+++ b/internal/compiler/generator/cpp_live_preview.rs
@@ -184,7 +184,7 @@ fn generate_public_component(
             signature: "(slint::private_api::live_preview::LiveReloadingComponent live_preview)"
                 .into(),
             constructor_member_initializers: vec!["live_preview(std::move(live_preview))".into()],
-            statements: Some(vec![]),
+            statements: Some(Vec::new()),
             ..Default::default()
         }),
     ));
@@ -258,7 +258,7 @@ fn generate_global(file: &mut File, global: &llr::GlobalComponent) {
                 "(const slint::private_api::live_preview::LiveReloadingComponent &live_preview)"
                     .into(),
             constructor_member_initializers: vec!["live_preview(live_preview)".into()],
-            statements: Some(vec![]),
+            statements: Some(Vec::new()),
             ..Default::default()
         }),
     ));

--- a/internal/compiler/generator/python.rs
+++ b/internal/compiler/generator/python.rs
@@ -263,7 +263,7 @@ impl From<&PyEnum> for python_ast::Declaration {
                     default_value: Some(format_smolstr!("\"{}\"", variant.strvalue)),
                 })
                 .collect(),
-            function_declarations: vec![],
+            function_declarations: Vec::new(),
         })
     }
 }

--- a/internal/compiler/generator/python/diff.rs
+++ b/internal/compiler/generator/python/diff.rs
@@ -464,8 +464,8 @@ fn globals() {
             },
             PyComponent {
                 name: SmolStr::new_static("ToBeRemoved"),
-                properties: vec![],
-                aliases: vec![],
+                properties: Vec::new(),
+                aliases: Vec::new(),
             },
         ],
         ..Default::default()
@@ -505,7 +505,7 @@ fn globals() {
                     name: SmolStr::new_static("str_prop"),
                     ty: SmolStr::new_static("str"),
                 }],
-                aliases: vec![],
+                aliases: Vec::new(),
             },
         ],
         ..Default::default()
@@ -576,13 +576,13 @@ fn structs_and_enums() {
             }),
             PyStructOrEnum::Struct(PyStruct {
                 name: SmolStr::new_static("RemovedStruct"),
-                fields: vec![],
-                aliases: vec![],
+                fields: Vec::new(),
+                aliases: Vec::new(),
             }),
             PyStructOrEnum::Struct(PyStruct {
                 name: SmolStr::new_static("StructBecomesEnum"),
-                fields: vec![],
-                aliases: vec![],
+                fields: Vec::new(),
+                aliases: Vec::new(),
             }),
             PyStructOrEnum::Enum(PyEnum {
                 name: SmolStr::new_static("SameEnum"),
@@ -624,7 +624,7 @@ fn structs_and_enums() {
                         strvalue: SmolStr::new_static("Variant2"),
                     },
                 ],
-                aliases: vec![],
+                aliases: Vec::new(),
             }),
         ],
         ..Default::default()
@@ -660,8 +660,8 @@ fn structs_and_enums() {
             }),
             PyStructOrEnum::Struct(PyStruct {
                 name: SmolStr::new_static("AddedStruct"),
-                fields: vec![],
-                aliases: vec![],
+                fields: Vec::new(),
+                aliases: Vec::new(),
             }),
             PyStructOrEnum::Enum(PyEnum {
                 name: SmolStr::new_static("StructBecomesEnum"),
@@ -675,7 +675,7 @@ fn structs_and_enums() {
                         strvalue: SmolStr::new_static("Variant2"),
                     },
                 ],
-                aliases: vec![],
+                aliases: Vec::new(),
             }),
             PyStructOrEnum::Enum(PyEnum {
                 name: SmolStr::new_static("SameEnum"),
@@ -717,7 +717,7 @@ fn structs_and_enums() {
                         strvalue: SmolStr::new_static("Variant2"),
                     },
                 ],
-                aliases: vec![],
+                aliases: Vec::new(),
             }),
         ],
         ..Default::default()

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -660,7 +660,7 @@ fn public_api(
     self_init: TokenStream,
     ctx: &EvaluationContext,
 ) -> TokenStream {
-    let mut property_and_callback_accessors: Vec<TokenStream> = vec![];
+    let mut property_and_callback_accessors: Vec<TokenStream> = Vec::new();
     for p in public_properties {
         let prop_ident = ident(&p.name);
         let prop = access_member(&p.prop, ctx).unwrap();
@@ -795,11 +795,11 @@ fn generate_sub_component(
         }))
         .collect::<Vec<_>>();
 
-    let mut declared_property_vars = vec![];
-    let mut declared_property_types = vec![];
-    let mut declared_callbacks = vec![];
-    let mut declared_callbacks_types = vec![];
-    let mut declared_callbacks_ret = vec![];
+    let mut declared_property_vars = Vec::new();
+    let mut declared_property_types = Vec::new();
+    let mut declared_callbacks = Vec::new();
+    let mut declared_callbacks_types = Vec::new();
+    let mut declared_callbacks_ret = Vec::new();
 
     for property in component.properties.iter() {
         let prop_ident = ident(&property.name);
@@ -825,9 +825,9 @@ fn generate_sub_component(
 
     let declared_functions = generate_functions(component.functions.as_ref(), &ctx);
 
-    let mut init = vec![];
-    let mut item_names = vec![];
-    let mut item_types = vec![];
+    let mut init = Vec::new();
+    let mut item_names = Vec::new();
+    let mut item_types = Vec::new();
 
     #[cfg(slint_debug_property)]
     init.push(quote!(
@@ -857,10 +857,10 @@ fn generate_sub_component(
         }
     }
 
-    let mut repeated_visit_branch: Vec<TokenStream> = vec![];
-    let mut repeated_element_components: Vec<TokenStream> = vec![];
-    let mut repeated_subtree_ranges: Vec<TokenStream> = vec![];
-    let mut repeated_subtree_components: Vec<TokenStream> = vec![];
+    let mut repeated_visit_branch: Vec<TokenStream> = Vec::new();
+    let mut repeated_element_components: Vec<TokenStream> = Vec::new();
+    let mut repeated_subtree_ranges: Vec<TokenStream> = Vec::new();
+    let mut repeated_subtree_components: Vec<TokenStream> = Vec::new();
 
     for (idx, repeated) in component.repeated.iter_enumerated() {
         extra_components.push(generate_repeated_component(
@@ -967,9 +967,9 @@ fn generate_sub_component(
         }
     }
 
-    let mut accessible_role_branch = vec![];
-    let mut accessible_string_property_branch = vec![];
-    let mut accessibility_action_branch = vec![];
+    let mut accessible_role_branch = Vec::new();
+    let mut accessible_string_property_branch = Vec::new();
+    let mut accessibility_action_branch = Vec::new();
     let mut supported_accessibility_actions = BTreeMap::<u32, BTreeSet<_>>::new();
     for ((index, what), expr) in &component.accessible_prop {
         let e = compile_expression(&expr.borrow(), &ctx);
@@ -1015,8 +1015,8 @@ fn generate_sub_component(
 
     let mut user_init_code: Vec<TokenStream> = Vec::new();
 
-    let mut sub_component_names: Vec<Ident> = vec![];
-    let mut sub_component_types: Vec<Ident> = vec![];
+    let mut sub_component_names: Vec<Ident> = Vec::new();
+    let mut sub_component_types: Vec<Ident> = Vec::new();
 
     for sub in &component.sub_components {
         let field_name = ident(&sub.name);
@@ -1426,11 +1426,11 @@ fn generate_global(
     compiler_config: &CompilerConfiguration,
     global_exports: &mut Vec<TokenStream>,
 ) -> TokenStream {
-    let mut declared_property_vars = vec![];
-    let mut declared_property_types = vec![];
-    let mut declared_callbacks = vec![];
-    let mut declared_callbacks_types = vec![];
-    let mut declared_callbacks_ret = vec![];
+    let mut declared_property_vars = Vec::new();
+    let mut declared_property_types = Vec::new();
+    let mut declared_callbacks = Vec::new();
+    let mut declared_callbacks_types = Vec::new();
+    let mut declared_callbacks_ret = Vec::new();
 
     for property in global.properties.iter() {
         declared_property_vars.push(ident(&property.name));
@@ -1444,7 +1444,7 @@ fn generate_global(
         declared_callbacks_ret.push(rust_primitive_type(&callback.ret_ty));
     }
 
-    let mut init = vec![];
+    let mut init = Vec::new();
     let inner_component_id = global_inner_name(global);
 
     #[cfg(slint_debug_property)]
@@ -1650,8 +1650,8 @@ fn generate_item_tree(
             }
         }
     }));
-    let mut item_tree_array = vec![];
-    let mut item_array = vec![];
+    let mut item_tree_array = Vec::new();
+    let mut item_array = Vec::new();
     sub_tree.tree.visit_in_array(&mut |node, children_offset, parent_index| {
         let parent_index = parent_index as u32;
         let (path, component) =
@@ -3427,7 +3427,7 @@ fn box_layout_function(
     let inner_component_id = self::inner_component_id(ctx.current_sub_component().unwrap());
     let mut fixed_count = 0usize;
     let mut repeated_count = quote!();
-    let mut push_code = vec![];
+    let mut push_code = Vec::new();
     let mut repeater_idx = 0usize;
     for item in elements {
         match item {

--- a/internal/compiler/generator/rust_live_preview.rs
+++ b/internal/compiler/generator/rust_live_preview.rs
@@ -92,7 +92,7 @@ fn generate_public_component(
         quote!(#main_file)
     };
 
-    let mut property_and_callback_accessors: Vec<TokenStream> = vec![];
+    let mut property_and_callback_accessors: Vec<TokenStream> = Vec::new();
     for p in &llr.public_properties {
         let prop_name = p.name.as_str();
         let prop_ident = ident(&p.name);
@@ -251,7 +251,7 @@ fn generate_global(global: &llr::GlobalComponent, root: &llr::CompilationUnit) -
         return quote!();
     }
     let global_name = global.name.as_str();
-    let mut property_and_callback_accessors: Vec<TokenStream> = vec![];
+    let mut property_and_callback_accessors: Vec<TokenStream> = Vec::new();
     for p in &global.public_properties {
         let prop_name = p.name.as_str();
         let prop_ident = ident(&p.name);

--- a/internal/compiler/lexer.rs
+++ b/internal/compiler/lexer.rs
@@ -191,7 +191,7 @@ pub fn lex_identifier(text: &str, _: &mut LexState) -> usize {
 
 #[allow(clippy::needless_update)] // Token may have extra fields depending on selected features
 pub fn lex(mut source: &str) -> Vec<crate::parser::Token> {
-    let mut result = vec![];
+    let mut result = Vec::new();
     let mut offset = 0;
     let mut state = LexState::default();
     if source.starts_with("\u{FEFF}") {

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -238,7 +238,7 @@ impl Expression {
             Type::PathData => return None,
             Type::Array(element_ty) => Expression::Array {
                 element_ty: (**element_ty).clone(),
-                values: vec![],
+                values: Vec::new(),
                 as_model: true,
             },
             Type::Struct(s) => Expression::Struct {
@@ -772,7 +772,7 @@ impl ContextMap {
         if parent_level == 0 {
             ContextMap::Identity
         } else {
-            ContextMap::InSubElement { parent: parent_level, path: vec![] }
+            ContextMap::InSubElement { parent: parent_level, path: Vec::new() }
         }
     }
 

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -177,7 +177,7 @@ pub struct LocalMemberReference {
 
 impl<T: Into<LocalMemberIndex>> From<T> for LocalMemberReference {
     fn from(reference: T) -> Self {
-        Self { sub_component_path: vec![], reference: reference.into() }
+        Self { sub_component_path: Vec::new(), reference: reference.into() }
     }
 }
 

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -399,7 +399,7 @@ pub fn repeater_special_property(
     MemberReference::Relative {
         parent_level: parent_level - 1,
         local_reference: LocalMemberReference {
-            sub_component_path: vec![],
+            sub_component_path: Vec::new(),
             reference: property_index.into(),
         },
     }
@@ -775,7 +775,7 @@ fn solve_layout(
                         data,
                         llr_Expression::Array {
                             element_ty: Type::Int32,
-                            values: vec![],
+                            values: Vec::new(),
                             as_model: false,
                         },
                     ],
@@ -838,7 +838,7 @@ fn box_layout_data(
         };
         BoxLayoutDataResult { alignment, cells, compute_cells: None }
     } else {
-        let mut elements = vec![];
+        let mut elements = Vec::new();
         for item in &layout.elems {
             if item.element.borrow().repeated.is_some() {
                 let repeater_index =
@@ -1079,7 +1079,7 @@ fn compile_path(
         }
         crate::expression_tree::Path::Events(events, points) => {
             if events.is_empty() || points.is_empty() {
-                return llr_path_elements(vec![]);
+                return llr_path_elements(Vec::new());
             }
 
             let events: Vec<_> = events.iter().map(|event| lower_expression(event, ctx)).collect();

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -165,7 +165,7 @@ impl LoweredSubComponentMapping {
             LoweredElement::NativeItem { item_index } => MemberReference::Relative {
                 parent_level: 0,
                 local_reference: LocalMemberReference {
-                    sub_component_path: vec![],
+                    sub_component_path: Vec::new(),
                     reference: LocalMemberIndex::Native {
                         item_index: *item_index,
                         prop_name: from.name().clone(),
@@ -300,7 +300,7 @@ fn lower_sub_component(
                     ret_ty: function.return_type.clone(),
                     args: function.args.clone(),
                     // will be replaced later
-                    code: super::Expression::CodeBlock(vec![]),
+                    code: super::Expression::CodeBlock(Vec::new()),
                 });
                 index.into()
             } else if let Type::Callback(callback) = &x.property_type {
@@ -324,7 +324,10 @@ fn lower_sub_component(
                 NamedReference::new(element, p.clone()),
                 MemberReference::Relative {
                     parent_level: 0,
-                    local_reference: LocalMemberReference { sub_component_path: vec![], reference },
+                    local_reference: LocalMemberReference {
+                        sub_component_path: Vec::new(),
+                        reference,
+                    },
                 },
             );
         }
@@ -722,7 +725,7 @@ fn lower_timer(timer: &object_tree::Timer, ctx: &ExpressionLoweringCtx) -> Timer
         // TODO: this calls a callback instead of inlining the callback code directly
         triggered: super::Expression::CallBackCall {
             callback: ctx.map_property_reference(&timer.triggered),
-            arguments: vec![],
+            arguments: Vec::new(),
         }
         .into(),
     }
@@ -753,7 +756,7 @@ fn lower_global(
                 ret_ty: function.return_type.clone(),
                 args: function.args.clone(),
                 // will be replaced later
-                code: super::Expression::CodeBlock(vec![]),
+                code: super::Expression::CodeBlock(Vec::new()),
             });
             state.global_properties.insert(
                 nr.clone(),
@@ -963,13 +966,13 @@ fn make_tree(
             is_accessible: false,
             sub_component_path: sub_component_path.into(),
             item_index: itertools::Either::Right(usize::from(*repeated_index) as u32),
-            children: vec![],
+            children: Vec::new(),
         },
         LoweredElement::ComponentPlaceholder { repeated_index } => TreeNode {
             is_accessible: false,
             sub_component_path: sub_component_path.into(),
             item_index: itertools::Either::Right(*repeated_index + repeater_count),
-            children: vec![],
+            children: Vec::new(),
         },
     }
 }

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -167,14 +167,14 @@ fn clean_unused_bindings(root: &CompilationUnit) {
     root.for_each_sub_components(&mut |sc, _| {
         for (_, e) in &sc.property_init {
             if e.use_count.get() == 0 {
-                e.expression.replace(Expression::CodeBlock(vec![]));
+                e.expression.replace(Expression::CodeBlock(Vec::new()));
             }
         }
     });
     for g in &root.globals {
         for e in g.init_values.values() {
             if e.use_count.get() == 0 {
-                e.expression.replace(Expression::CodeBlock(vec![]));
+                e.expression.replace(Expression::CodeBlock(Vec::new()));
             }
         }
     }

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -196,7 +196,7 @@ fn inline_simple_expressions_in_expression(expr: &mut Expression, ctx: &Evaluati
                         adjust_use_count(expr, ctx, 1);
                         if use_count == 1 {
                             adjust_use_count(&binding.expression.borrow(), &mapped_ctx, -1);
-                            binding.expression.replace(Expression::CodeBlock(vec![]));
+                            binding.expression.replace(Expression::CodeBlock(Vec::new()));
                         }
                     }
                 }

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -170,7 +170,7 @@ pub(crate) fn load_builtins(register: &mut TypeRegister) {
             (
                 name,
                 BuiltinPropertyInfo::new(Type::Function(
-                    Function { return_type, args: vec![], arg_names: vec![] }.into(),
+                    Function { return_type, args: Vec::new(), arg_names: vec![] }.into(),
                 )),
             )
         }));

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -780,7 +780,7 @@ impl LookupObject for SlintInternal {
                 } else {
                     Expression::FunctionCall {
                         function: BuiltinFunction::ColorScheme.into(),
-                        arguments: vec![],
+                        arguments: Vec::new(),
                         source_location: sl(),
                     }
                 }
@@ -792,7 +792,7 @@ impl LookupObject for SlintInternal {
                 "use-24-hour-format",
                 Expression::FunctionCall {
                     function: BuiltinFunction::Use24HourFormat.into(),
-                    arguments: vec![],
+                    arguments: Vec::new(),
                     source_location: sl(),
                 }
                 .into(),

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -81,8 +81,8 @@ impl Document {
         debug_assert_eq!(node.kind(), SyntaxKind::Document);
 
         let mut local_registry = TypeRegister::new(parent_registry);
-        let mut inner_components = vec![];
-        let mut inner_types = vec![];
+        let mut inner_components = Vec::new();
+        let mut inner_types = Vec::new();
 
         let mut process_component =
             |n: syntax_nodes::Component,
@@ -1309,8 +1309,8 @@ impl Element {
                 continue;
             }
 
-            let mut args = vec![];
-            let mut arg_names = vec![];
+            let mut args = Vec::new();
+            let mut arg_names = Vec::new();
             for a in func.ArgumentDeclaration() {
                 args.push(type_from_node(a.Type(), diag, tr));
                 let name =

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -150,7 +150,7 @@ impl PropertyPath {
 
 impl From<NamedReference> for PropertyPath {
     fn from(prop: NamedReference) -> Self {
-        Self { elements: vec![], prop }
+        Self { elements: Vec::new(), prop }
     }
 }
 

--- a/internal/compiler/passes/collect_globals.rs
+++ b/internal/compiler/passes/collect_globals.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 pub fn collect_globals(doc: &Document, _diag: &mut BuildDiagnostics) {
     doc.used_types.borrow_mut().globals.clear();
     let mut set = HashSet::new();
-    let mut sorted_globals = vec![];
+    let mut sorted_globals = Vec::new();
     for (_, ty) in &*doc.exports {
         if let Some(c) = ty.as_ref().left()
             && c.is_global()

--- a/internal/compiler/passes/collect_subcomponents.rs
+++ b/internal/compiler/passes/collect_subcomponents.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 
 /// Fill the root_component's used_types.sub_components
 pub fn collect_subcomponents(doc: &Document) {
-    let mut result = vec![];
+    let mut result = Vec::new();
     let mut hash = HashSet::new();
     for component in doc.exported_roots().chain(doc.popup_menu_impl.iter().cloned()) {
         collect_subcomponents_recursive(&component, &mut result, &mut hash);

--- a/internal/compiler/passes/embed_glyphs.rs
+++ b/internal/compiler/passes/embed_glyphs.rs
@@ -404,7 +404,7 @@ fn embed_sdf_glyphs(
     const RANGE: f64 = 6.;
 
     let Some(max_size) = pixel_sizes.iter().max() else {
-        return vec![];
+        return Vec::new();
     };
     let min_size = pixel_sizes.iter().min().expect("we have a 'max' so the vector is not empty");
     let target_pixel_size = (max_size * 2 / 3).max(16).min(RANGE as i16 * min_size);

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -222,8 +222,8 @@ impl<'a> LocalFocusForwards<'a> {
                         PropertyDeclaration {
                             property_type: Type::Function(Rc::new(Function {
                                 return_type: Type::Void,
-                                args: vec![],
-                                arg_names: vec![],
+                                args: Vec::new(),
+                                arg_names: Vec::new(),
                             })),
                             visibility: PropertyVisibility::Public,
                             pure: Some(false),
@@ -289,7 +289,7 @@ fn call_set_focus_function(
                 element,
                 SmolStr::new_static(function_name),
             )),
-            arguments: vec![],
+            arguments: Vec::new(),
             source_location: source_location.cloned(),
         })
     } else if builtin_focus_function {

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -21,7 +21,7 @@ struct ComponentScope(Vec<ElementRc>);
 
 pub fn resolve_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
     for component in doc.inner_components.iter() {
-        let scope = ComponentScope(vec![]);
+        let scope = ComponentScope(Vec::new());
         crate::object_tree::recurse_elem_no_borrow(
             &component.root_element,
             &scope,
@@ -29,7 +29,7 @@ pub fn resolve_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
                 let mut new_scope = scope.clone();
                 new_scope.0.push(elem.clone());
 
-                let mut need_resolving = vec![];
+                let mut need_resolving = Vec::new();
                 for (prop, decl) in elem.borrow().property_declarations.iter() {
                     if matches!(decl.property_type, Type::InferredProperty | Type::InferredCallback)
                     {

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -679,7 +679,7 @@ fn lower_dialog_layout(
     );
 
     let mut main_widget = None;
-    let mut button_roles = vec![];
+    let mut button_roles = Vec::new();
     let mut seen_buttons = HashSet::new();
     let layout_children = std::mem::take(&mut dialog_element.borrow_mut().children);
     for layout_child in &layout_children {

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -378,7 +378,7 @@ fn process_window(
             op: '!',
             sub: Expression::FunctionCall {
                 function: BuiltinFunction::SupportsNativeMenuBar.into(),
-                arguments: vec![],
+                arguments: Vec::new(),
                 source_location: None,
             }
             .into(),

--- a/internal/compiler/passes/lower_platform.rs
+++ b/internal/compiler/passes/lower_platform.rs
@@ -16,7 +16,7 @@ pub fn lower_platform(component: &Rc<Component>, type_loader: &mut crate::typelo
                 if nr.name() == "os" {
                     *e = Expression::FunctionCall {
                         function: BuiltinFunction::DetectOperatingSystem.into(),
-                        arguments: vec![],
+                        arguments: Vec::new(),
                         source_location: None,
                     };
                 } else if nr.name() == "style-name" {

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -164,7 +164,7 @@ fn lower_transitions_in_element(
                 direction: transition.direction,
                 animation,
             };
-            props.entry(p).or_insert_with(|| (span.clone(), vec![])).1.push(t);
+            props.entry(p).or_insert_with(|| (span.clone(), Vec::new())).1.push(t);
         }
     }
     for (ne, (span, animations)) in props {

--- a/internal/compiler/passes/lower_text_input_interface.rs
+++ b/internal/compiler/passes/lower_text_input_interface.rs
@@ -14,7 +14,7 @@ pub fn lower_text_input_interface(component: &Rc<Component>) {
             Expression::PropertyReference(nr) if is_input_text_focused_prop(nr) => {
                 *e = Expression::FunctionCall {
                     function: BuiltinFunction::TextInputFocused.into(),
-                    arguments: vec![],
+                    arguments: Vec::new(),
                     source_location: None,
                 };
             }

--- a/internal/compiler/passes/lower_timers.rs
+++ b/internal/compiler/passes/lower_timers.rs
@@ -104,7 +104,7 @@ fn lower_timer(
     });
     let update_timers = Expression::FunctionCall {
         function: BuiltinFunction::UpdateTimers.into(),
-        arguments: vec![],
+        arguments: Vec::new(),
         source_location: None,
     };
     let change_callbacks = &mut timer_element.borrow_mut().change_callbacks;

--- a/internal/compiler/passes/remove_return.rs
+++ b/internal/compiler/passes/remove_return.rs
@@ -56,7 +56,7 @@ fn process_expression(
                 }
                 (ExpressionResult::Just(te), ExpressionResult::Return(fe)) => {
                     ExpressionResult::MaybeReturn {
-                        pre_statements: vec![],
+                        pre_statements: Vec::new(),
                         condition: *condition,
                         returned_value: fe,
                         actual_value: cleanup_empty_block(te),
@@ -64,7 +64,7 @@ fn process_expression(
                 }
                 (ExpressionResult::Return(te), ExpressionResult::Just(fe)) => {
                     ExpressionResult::MaybeReturn {
-                        pre_statements: vec![],
+                        pre_statements: Vec::new(),
                         condition: Expression::UnaryOp { sub: condition, op: '!' },
                         returned_value: te,
                         actual_value: cleanup_empty_block(fe),
@@ -73,8 +73,8 @@ fn process_expression(
                 (ExpressionResult::Return(te), ExpressionResult::Return(fe)) => {
                     ExpressionResult::Return(Some(Expression::Condition {
                         condition,
-                        true_expr: te.unwrap_or(Expression::CodeBlock(vec![])).into(),
-                        false_expr: fe.unwrap_or(Expression::CodeBlock(vec![])).into(),
+                        true_expr: te.unwrap_or(Expression::CodeBlock(Vec::new())).into(),
+                        false_expr: fe.unwrap_or(Expression::CodeBlock(Vec::new())).into(),
                     }))
                 }
                 (te, fe) => {
@@ -121,7 +121,7 @@ fn process_codeblock(
     ty: &Type,
     ctx: &RemoveReturnContext,
 ) -> ExpressionResult {
-    let mut stmts = vec![];
+    let mut stmts = Vec::new();
     while let Some(e) = iter.next() {
         let is_last = iter.peek().is_none();
         match process_expression(e, toplevel, ctx, if is_last { ty } else { &Type::Void }) {
@@ -167,7 +167,7 @@ fn process_codeblock(
                         ty,
                         ctx,
                         ExpressionResult::MaybeReturn {
-                            pre_statements: vec![],
+                            pre_statements: Vec::new(),
                             condition,
                             returned_value,
                             actual_value,
@@ -273,7 +273,7 @@ impl ExpressionResult {
     fn to_expression(self, ty: &Type) -> Expression {
         match self {
             ExpressionResult::Just(e) => e,
-            ExpressionResult::Return(e) => e.unwrap_or(Expression::CodeBlock(vec![])),
+            ExpressionResult::Return(e) => e.unwrap_or(Expression::CodeBlock(Vec::new())),
             ExpressionResult::MaybeReturn {
                 mut pre_statements,
                 condition,
@@ -282,8 +282,8 @@ impl ExpressionResult {
             } => {
                 pre_statements.push(Expression::Condition {
                     condition: condition.into(),
-                    true_expr: actual_value.unwrap_or(Expression::CodeBlock(vec![])).into(),
-                    false_expr: returned_value.unwrap_or(Expression::CodeBlock(vec![])).into(),
+                    true_expr: actual_value.unwrap_or(Expression::CodeBlock(Vec::new())).into(),
+                    false_expr: returned_value.unwrap_or(Expression::CodeBlock(Vec::new())).into(),
                 });
                 Expression::CodeBlock(pre_statements)
             }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -43,11 +43,11 @@ fn resolve_expression(
             property_type,
             component_scope: scope,
             diag,
-            arguments: vec![],
+            arguments: Vec::new(),
             type_register,
             type_loader: Some(type_loader),
             current_token: None,
-            local_variables: vec![],
+            local_variables: Vec::new(),
         };
 
         let new_expr = match node.kind() {
@@ -124,7 +124,7 @@ pub fn resolve_expressions(
     for component in doc.inner_components.iter() {
         recurse_elem_with_scope(
             &component.root_element,
-            ComponentScope(vec![]),
+            ComponentScope(Vec::new()),
             &mut |elem, scope| {
                 let mut is_repeated = elem.borrow().repeated.is_some();
                 visit_element_expressions(elem, |expr, property_name, property_type| {
@@ -612,7 +612,7 @@ impl Expression {
             panic!("Not a gradient {grad_text:?}");
         };
 
-        let mut stops = vec![];
+        let mut stops = Vec::new();
         enum Stop {
             Empty,
             Color(Expression),
@@ -1971,7 +1971,7 @@ fn resolve_two_way_bindings(
     for component in doc.inner_components.iter() {
         recurse_elem_with_scope(
             &component.root_element,
-            ComponentScope(vec![]),
+            ComponentScope(Vec::new()),
             &mut |elem, scope| {
                 for (prop_name, binding) in &elem.borrow().bindings {
                     let mut binding = binding.borrow_mut();
@@ -1990,11 +1990,11 @@ fn resolve_two_way_bindings(
                             property_type: lhs_lookup.property_type.clone(),
                             component_scope: &scope.0,
                             diag,
-                            arguments: vec![],
+                            arguments: Vec::new(),
                             type_register,
                             type_loader: None,
                             current_token: Some(node.clone().into()),
-                            local_variables: vec![],
+                            local_variables: Vec::new(),
                         };
 
                         binding.expression = Expression::Invalid;

--- a/internal/compiler/passes/z_order.rs
+++ b/internal/compiler/passes/z_order.rs
@@ -26,7 +26,7 @@ fn reorder_children_by_zorder(
     diag: &mut BuildDiagnostics,
 ) {
     // maps indexes to their z order
-    let mut children_z_order = vec![];
+    let mut children_z_order = Vec::new();
     for (idx, child_elm) in elem.borrow().children.iter().enumerate() {
         let z = child_elm
             .borrow_mut()

--- a/internal/compiler/tests/consistent_styles.rs
+++ b/internal/compiler/tests/consistent_styles.rs
@@ -106,8 +106,8 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
                         PropertyInfo {
                             ty: Type::Function(Rc::new(Function {
                                 return_type: Type::Void,
-                                args: vec![],
-                                arg_names: vec![],
+                                args: Vec::new(),
+                                arg_names: Vec::new(),
                             })),
                             vis: PropertyVisibility::Public,
                             pure: false,
@@ -118,8 +118,8 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
                         PropertyInfo {
                             ty: Type::Function(Rc::new(Function {
                                 return_type: Type::Void,
-                                args: vec![],
-                                arg_names: vec![],
+                                args: Vec::new(),
+                                arg_names: Vec::new(),
                             })),
                             vis: PropertyVisibility::Public,
                             pure: false,

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -151,7 +151,7 @@ pub(crate) fn snapshot_with_extra_doc(
     if let Some(doc_node) = &new_doc.node {
         let path = doc_node.source_file.path().to_path_buf();
         if let Some(r) = &mut result {
-            r.all_documents.docs.insert(path, (LoadedDocument::Document(new_doc), vec![]));
+            r.all_documents.docs.insert(path, (LoadedDocument::Document(new_doc), Vec::new()));
         }
     }
 
@@ -999,8 +999,8 @@ impl TypeLoader {
         registry_to_populate: &'b Rc<RefCell<TypeRegister>>,
         import_stack: &'b HashSet<PathBuf>,
     ) -> (Vec<ImportedTypes>, Exports) {
-        let mut imports = vec![];
-        let mut dependencies_futures = vec![];
+        let mut imports = Vec::new();
+        let mut dependencies_futures = Vec::new();
         for mut import in Self::collect_dependencies(state, doc) {
             if matches!(import.import_kind, ImportKind::FileImport) {
                 if let Some((path, _)) = state.borrow().tl.resolve_import_path(

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -126,13 +126,13 @@ impl BuiltinTypes {
             })),
             noarg_callback_type: Type::Callback(Rc::new(Function {
                 return_type: Type::Void,
-                args: vec![],
-                arg_names: vec![],
+                args: Vec::new(),
+                arg_names: Vec::new(),
             })),
             strarg_callback_type: Type::Callback(Rc::new(Function {
                 return_type: Type::Void,
                 args: vec![Type::String],
-                arg_names: vec![],
+                arg_names: Vec::new(),
             })),
             layout_info_type: layout_info_type.clone(),
             path_element_type: Type::Struct(Rc::new(Struct {

--- a/internal/core/api/styled_text.rs
+++ b/internal/core/api/styled_text.rs
@@ -368,7 +368,7 @@ fn markdown_parsing() {
         [StyledTextParagraph {
             text: "hello world".into(),
             formatting: alloc::vec![FormattedSpan { range: 6..11, style: Style::Emphasis }],
-            links: alloc::vec![]
+            links: alloc::vec::Vec::new()
         }]
     );
 
@@ -384,13 +384,13 @@ fn markdown_parsing() {
         [
             StyledTextParagraph {
                 text: "• line 1".into(),
-                formatting: alloc::vec![],
-                links: alloc::vec![]
+                formatting: alloc::vec::Vec::new(),
+                links: alloc::vec::Vec::new()
             },
             StyledTextParagraph {
                 text: "• line 2".into(),
-                formatting: alloc::vec![],
-                links: alloc::vec![]
+                formatting: alloc::vec::Vec::new(),
+                links: alloc::vec::Vec::new()
             }
         ]
     );
@@ -408,18 +408,18 @@ fn markdown_parsing() {
         [
             StyledTextParagraph {
                 text: "1. a".into(),
-                formatting: alloc::vec![],
-                links: alloc::vec![]
+                formatting: alloc::vec::Vec::new(),
+                links: alloc::vec::Vec::new()
             },
             StyledTextParagraph {
                 text: "2. b".into(),
-                formatting: alloc::vec![],
-                links: alloc::vec![]
+                formatting: alloc::vec::Vec::new(),
+                links: alloc::vec::Vec::new()
             },
             StyledTextParagraph {
                 text: "3. c".into(),
-                formatting: alloc::vec![],
-                links: alloc::vec![]
+                formatting: alloc::vec::Vec::new(),
+                links: alloc::vec::Vec::new()
             }
         ]
     );
@@ -442,12 +442,12 @@ new *line*
                     FormattedSpan { range: 21..34, style: Style::Strikethrough },
                     FormattedSpan { range: 35..39, style: Style::Code }
                 ],
-                links: alloc::vec![]
+                links: alloc::vec::Vec::new()
             },
             StyledTextParagraph {
                 text: "new line".into(),
                 formatting: alloc::vec![FormattedSpan { range: 4..8, style: Style::Emphasis },],
-                links: alloc::vec![]
+                links: alloc::vec::Vec::new()
             }
         ]
     );
@@ -466,23 +466,23 @@ new *line*
         [
             StyledTextParagraph {
                 text: "• root".into(),
-                formatting: alloc::vec![],
-                links: alloc::vec![]
+                formatting: alloc::vec::Vec::new(),
+                links: alloc::vec::Vec::new()
             },
             StyledTextParagraph {
                 text: "    ◦ child".into(),
-                formatting: alloc::vec![],
-                links: alloc::vec![]
+                formatting: alloc::vec::Vec::new(),
+                links: alloc::vec::Vec::new()
             },
             StyledTextParagraph {
                 text: "        ▪ grandchild".into(),
-                formatting: alloc::vec![],
-                links: alloc::vec![]
+                formatting: alloc::vec::Vec::new(),
+                links: alloc::vec::Vec::new()
             },
             StyledTextParagraph {
                 text: "            • great grandchild".into(),
-                formatting: alloc::vec![],
-                links: alloc::vec![]
+                formatting: alloc::vec::Vec::new(),
+                links: alloc::vec::Vec::new()
             },
         ]
     );
@@ -504,7 +504,7 @@ new *line*
         [StyledTextParagraph {
             text: "hello world".into(),
             formatting: alloc::vec![FormattedSpan { range: 0..11, style: Style::Underline },],
-            links: alloc::vec![]
+            links: alloc::vec::Vec::new()
         }]
     );
 
@@ -516,7 +516,7 @@ new *line*
                 range: 0..11,
                 style: Style::Color(crate::Color::from_rgb_u8(0, 0, 255))
             },],
-            links: alloc::vec![]
+            links: alloc::vec::Vec::new()
         }]
     );
 
@@ -531,7 +531,7 @@ new *line*
                 },
                 FormattedSpan { range: 0..11, style: Style::Underline },
             ],
-            links: alloc::vec![]
+            links: alloc::vec::Vec::new()
         }]
     );
 }

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1489,7 +1489,7 @@ mod tests {
                 parent_index: 0,
                 item_array_index: 0,
             }],
-            subtrees: std::cell::RefCell::new(vec![]),
+            subtrees: std::cell::RefCell::new(Vec::new()),
             subtree_index: usize::MAX,
         });
         VRc::into_dyn(component)
@@ -1560,7 +1560,7 @@ mod tests {
                     item_array_index: 3,
                 },
             ],
-            subtrees: std::cell::RefCell::new(vec![]),
+            subtrees: std::cell::RefCell::new(Vec::new()),
             subtree_index: usize::MAX,
         });
         VRc::into_dyn(component)
@@ -1670,7 +1670,7 @@ mod tests {
                 },
                 ItemTreeNode::DynamicTree { index: 0, parent_index: 0 },
             ],
-            subtrees: std::cell::RefCell::new(vec![vec![]]),
+            subtrees: std::cell::RefCell::new(vec![Vec::new()]),
             subtree_index: usize::MAX,
         });
         vtable::VRc::into_dyn(component)
@@ -1739,7 +1739,7 @@ mod tests {
                     item_array_index: 0,
                 },
             ],
-            subtrees: std::cell::RefCell::new(vec![]),
+            subtrees: std::cell::RefCell::new(Vec::new()),
             subtree_index: usize::MAX,
         });
 
@@ -1752,7 +1752,7 @@ mod tests {
                 parent_index: 2,
                 item_array_index: 0,
             }],
-            subtrees: std::cell::RefCell::new(vec![]),
+            subtrees: std::cell::RefCell::new(Vec::new()),
             subtree_index: 0,
         })]]);
 
@@ -1864,7 +1864,7 @@ mod tests {
                     item_array_index: 0,
                 },
             ],
-            subtrees: std::cell::RefCell::new(vec![]),
+            subtrees: std::cell::RefCell::new(Vec::new()),
             subtree_index: usize::MAX,
         });
 
@@ -1880,7 +1880,7 @@ mod tests {
                 },
                 ItemTreeNode::DynamicTree { index: 0, parent_index: 0 },
             ],
-            subtrees: std::cell::RefCell::new(vec![]),
+            subtrees: std::cell::RefCell::new(Vec::new()),
             subtree_index: usize::MAX,
         });
         let sub_component2 = VRc::new(TestItemTree {
@@ -1901,7 +1901,7 @@ mod tests {
                     item_array_index: 0,
                 },
             ],
-            subtrees: std::cell::RefCell::new(vec![]),
+            subtrees: std::cell::RefCell::new(Vec::new()),
             subtree_index: usize::MAX,
         });
 
@@ -2041,7 +2041,7 @@ mod tests {
                     item_array_index: 0,
                 },
             ],
-            subtrees: std::cell::RefCell::new(vec![]),
+            subtrees: std::cell::RefCell::new(Vec::new()),
             subtree_index: usize::MAX,
         });
 
@@ -2055,7 +2055,7 @@ mod tests {
                     parent_index: 1,
                     item_array_index: 0,
                 }],
-                subtrees: std::cell::RefCell::new(vec![]),
+                subtrees: std::cell::RefCell::new(Vec::new()),
                 subtree_index: 0,
             }),
             VRc::new(TestItemTree {
@@ -2067,7 +2067,7 @@ mod tests {
                     parent_index: 1,
                     item_array_index: 0,
                 }],
-                subtrees: std::cell::RefCell::new(vec![]),
+                subtrees: std::cell::RefCell::new(Vec::new()),
                 subtree_index: 1,
             }),
             VRc::new(TestItemTree {
@@ -2079,7 +2079,7 @@ mod tests {
                     parent_index: 1,
                     item_array_index: 0,
                 }],
-                subtrees: std::cell::RefCell::new(vec![]),
+                subtrees: std::cell::RefCell::new(Vec::new()),
                 subtree_index: 2,
             }),
         ]]);

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -1536,7 +1536,7 @@ mod tests {
         model.insert(0, 255);
         assert!(tracker.is_dirty());
 
-        model.set_vec(vec![]);
+        model.set_vec(Vec::new());
         assert!(tracker.is_dirty());
     }
 

--- a/internal/core/software_renderer.rs
+++ b/internal/core/software_renderer.rs
@@ -37,7 +37,7 @@ use crate::textlayout::{AbstractFont, FontMetrics, TextParagraphLayout};
 use crate::window::{WindowAdapter, WindowInner};
 use crate::{Brush, Color, ImageInner, StaticTextures};
 use alloc::rc::{Rc, Weak};
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
 use core::pin::Pin;
 use euclid::Length;
@@ -571,7 +571,11 @@ impl SoftwareRenderer {
             size,
             factor,
             window_inner,
-            RenderToBuffer { buffer, dirty_range_cache: vec![], dirty_region: Default::default() },
+            RenderToBuffer {
+                buffer,
+                dirty_range_cache: Vec::new(),
+                dirty_region: Default::default(),
+            },
             rotation,
         );
         let mut renderer = self.partial_rendering_state.create_partial_renderer(buffer_renderer);
@@ -1973,7 +1977,7 @@ impl<'a, T: ProcessScene> SceneBuilder<'a, T> {
     ) -> Self {
         Self {
             processor,
-            state_stack: vec![],
+            state_stack: Vec::new(),
             current_state: RenderState {
                 alpha: 1.,
                 offset: LogicalPoint::default(),

--- a/internal/core/string.rs
+++ b/internal/core/string.rs
@@ -382,7 +382,7 @@ fn simple_test() {
 fn threading() {
     let shared_cst = SharedString::from("Hello there!");
     let shared_mtx = std::sync::Arc::new(std::sync::Mutex::new(SharedString::from("Shared:")));
-    let mut handles = std::vec![];
+    let mut handles = std::vec::Vec::new();
     for _ in 0..20 {
         let cst = shared_cst.clone();
         let mtx = shared_mtx.clone();

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -587,7 +587,7 @@ impl Default for ComponentCompiler {
             i_slint_compiler::generator::OutputFormat::Interpreter,
         );
         config.components_to_generate = i_slint_compiler::ComponentSelection::LastExported;
-        Self { config, diagnostics: vec![] }
+        Self { config, diagnostics: Vec::new() }
     }
 }
 
@@ -2120,7 +2120,7 @@ fn lang_type_to_value_type() {
     assert_eq!(ValueType::from(LangType::PhysicalLength), ValueType::Number);
     assert_eq!(ValueType::from(LangType::LogicalLength), ValueType::Number);
     assert_eq!(ValueType::from(LangType::Percent), ValueType::Number);
-    assert_eq!(ValueType::from(LangType::UnitProduct(vec![])), ValueType::Number);
+    assert_eq!(ValueType::from(LangType::UnitProduct(Vec::new())), ValueType::Number);
     assert_eq!(ValueType::from(LangType::String), ValueType::String);
     assert_eq!(ValueType::from(LangType::Color), ValueType::Brush);
     assert_eq!(ValueType::from(LangType::Brush), ValueType::Brush);

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -1160,14 +1160,14 @@ pub(crate) fn generate_item_tree<'id>(
     }
 
     let mut builder = TreeBuilder {
-        tree_array: vec![],
-        item_array: vec![],
-        original_elements: vec![],
+        tree_array: Vec::new(),
+        item_array: Vec::new(),
+        original_elements: Vec::new(),
         items_types: HashMap::new(),
         type_builder: dynamic_type::TypeBuilder::new(guard),
-        repeater: vec![],
+        repeater: Vec::new(),
         repeater_names: HashMap::new(),
-        change_callbacks: vec![],
+        change_callbacks: Vec::new(),
         popup_menu_description,
     };
 

--- a/internal/interpreter/dynamic_type.rs
+++ b/internal/interpreter/dynamic_type.rs
@@ -79,7 +79,7 @@ pub struct TypeBuilder<'id> {
 
 impl<'id> TypeBuilder<'id> {
     pub fn new(id: generativity::Guard<'id>) -> Self {
-        let mut s = Self { align: 1, size: 0, fields: vec![], id: id.into() };
+        let mut s = Self { align: 1, size: 0, fields: Vec::new(), id: id.into() };
         type T<'id> = Rc<TypeInfo<'id>>;
         s.add_field(StaticTypeInfo {
             construct: None,

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -247,6 +247,6 @@ fn repeater_path(elem: &ElementRc) -> Option<Vec<SmolStr>> {
         r.push(parent.borrow().id.clone());
         Some(r)
     } else {
-        Some(vec![])
+        Some(Vec::new())
     }
 }

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -59,7 +59,7 @@ impl<'a> SkiaItemRenderer<'a> {
             scale_factor: ScaleFactor::new(window.scale_factor()),
             window,
             surface,
-            state_stack: vec![],
+            state_stack: Vec::new(),
             current_state: RenderState { alpha: 1.0, translation: Default::default() },
             image_cache,
             layer_cache,

--- a/tests/driver/driverlib/lib.rs
+++ b/tests/driver/driverlib/lib.rs
@@ -36,7 +36,7 @@ impl TestCase {
 
 /// Returns a list of all the `.slint` files in the subfolders e.g. `tests/cases` .
 pub fn collect_test_cases(sub_folders: &str) -> std::io::Result<Vec<TestCase>> {
-    let mut results = vec![];
+    let mut results = Vec::new();
 
     let mut all_styles = vec!["fluent", "material", "cupertino", "cosmic"];
 

--- a/tools/lsp/common/component_catalog.rs
+++ b/tools/lsp/common/component_catalog.rs
@@ -19,7 +19,7 @@ fn builtin_component_info(name: &str) -> ComponentInformation {
     let default_properties = match name {
         "Text" | "TextInput" => vec![PropertyChange::new("text", format!("\"{name}\""))],
         "Image" => vec![PropertyChange::new("source", "@image-url(\"EDIT_ME.png\")".to_string())],
-        _ => vec![],
+        _ => Vec::new(),
     };
 
     let component = {
@@ -66,7 +66,7 @@ fn std_widgets_info(name: &str, is_global: bool) -> ComponentInformation {
             PropertyChange::new("maximum", "100".to_string()),
         ],
         "StandardButton" => vec![PropertyChange::new("kind", "ok".to_string())],
-        _ => vec![],
+        _ => Vec::new(),
     };
 
     ComponentInformation {
@@ -98,7 +98,7 @@ fn exported_project_component_info(
         is_interactive: false,
         is_exported: true,
         defined_at: Some(position),
-        default_properties: vec![],
+        default_properties: Vec::new(),
     }
 }
 
@@ -118,7 +118,7 @@ fn file_local_component_info(
         is_interactive: false,
         is_exported: false,
         defined_at: Some(position),
-        default_properties: vec![],
+        default_properties: Vec::new(),
     }
 }
 

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -432,7 +432,7 @@ fn rename_internal_name(
         return Default::default();
     };
 
-    let mut edits = vec![];
+    let mut edits = Vec::new();
 
     let parent: syntax_nodes::ImportIdentifier = internal_name.parent().unwrap().into();
     let external_name = parent.ExternalName();
@@ -462,7 +462,7 @@ fn rename_export_name(
     export_name: &syntax_nodes::ExportName,
     new_type: &str,
 ) -> lsp_types::WorkspaceEdit {
-    let mut edits = vec![];
+    let mut edits = Vec::new();
 
     let specifier: syntax_nodes::ExportSpecifier = export_name.parent().unwrap().into();
     let Some(internal_name) = main_identifier(&specifier.ExportIdentifier()) else {
@@ -1089,7 +1089,7 @@ fn rename_declared_identifier(
         return Ok(lsp_types::WorkspaceEdit::default());
     }
 
-    let mut edits = vec![];
+    let mut edits = Vec::new();
 
     // Change all local usages:
     rename_local_symbols(document_cache, document_node, query, new_type, &mut edits);

--- a/tools/lsp/common/test.rs
+++ b/tools/lsp/common/test.rs
@@ -87,7 +87,7 @@ pub fn recompile_test_with_sources(
     let url = lsp_types::Url::from_file_path(main_test_file_name()).unwrap();
     let source_code = code.get(&url).unwrap().clone();
     let (diagnostics, type_loader) = spin_on::spin_on(parse_source(
-        vec![],
+        Vec::new(),
         std::collections::HashMap::new(),
         url,
         source_code.to_string(),

--- a/tools/lsp/common/text_edit.rs
+++ b/tools/lsp/common/text_edit.rs
@@ -494,7 +494,7 @@ fn test_edit_iterator_changes_one_empty() {
     let workspace_edit = lsp_types::WorkspaceEdit {
         changes: Some(std::collections::HashMap::from([(
             lsp_types::Url::parse("file://foo/bar.slint").unwrap(),
-            vec![],
+            Vec::new(),
         )])),
         document_changes: None,
         change_annotations: None,
@@ -637,7 +637,7 @@ fn test_edit_iterator_changes_two() {
 fn test_edit_iterator_document_changes_empty() {
     let workspace_edit = lsp_types::WorkspaceEdit {
         changes: None,
-        document_changes: Some(lsp_types::DocumentChanges::Edits(vec![])),
+        document_changes: Some(lsp_types::DocumentChanges::Edits(Vec::new())),
         change_annotations: None,
     };
 
@@ -650,7 +650,7 @@ fn test_edit_iterator_document_changes_empty() {
 fn test_edit_iterator_document_changes_operations() {
     let workspace_edit = lsp_types::WorkspaceEdit {
         changes: None,
-        document_changes: Some(lsp_types::DocumentChanges::Operations(vec![])),
+        document_changes: Some(lsp_types::DocumentChanges::Operations(Vec::new())),
         change_annotations: None,
     };
 
@@ -665,7 +665,7 @@ fn test_edit_iterator_document_changes_one_empty() {
         changes: None,
         document_changes: Some(lsp_types::DocumentChanges::Edits(vec![
             lsp_types::TextDocumentEdit {
-                edits: vec![],
+                edits: Vec::new(),
                 text_document: lsp_types::OptionalVersionedTextDocumentIdentifier {
                     uri: lsp_types::Url::parse("file://foo/bar.slint").unwrap(),
                     version: Some(99),

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -936,7 +936,7 @@ fn get_code_actions(
 ) -> Option<Vec<CodeActionOrCommand>> {
     let node = token.parent();
     let uri = Url::from_file_path(token.source_file.path()).ok()?;
-    let mut result = vec![];
+    let mut result = Vec::new();
 
     let component = syntax_nodes::Component::new(node.clone())
         .or_else(|| {
@@ -1337,7 +1337,7 @@ fn get_code_lenses(
     let doc = document_cache.get_document(&text_document.uri)?;
     let version = document_cache.document_version(&text_document.uri);
 
-    let mut result = vec![];
+    let mut result = Vec::new();
 
     if cfg!(any(feature = "preview-builtin", feature = "preview-external")) {
         let inner_components = doc.inner_components.clone();

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -556,7 +556,7 @@ fn resolve_element_scope(
                         None => {
                             let base_type = component.root_element.borrow().base_type.clone();
                             if base_type == tr.empty_type() {
-                                return (false, true, vec![]);
+                                return (false, true, Vec::new());
                             }
                             base_type
                         }
@@ -575,7 +575,7 @@ fn resolve_element_scope(
                         extra,
                     )
                 }
-                _ => (true, true, vec![]),
+                _ => (true, true, Vec::new()),
             }
         }
         let (accepts_children, is_item, extra) = accepts_children(&element_type, tr);

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -181,7 +181,7 @@ fn test_goto_definition_multi_files() {
     "#;
     let (mut dc, url1, diags) = crate::language::test::loaded_document_cache(source1.into());
     for (u, ds) in diags {
-        assert_eq!(ds, vec![], "errors in {u}");
+        assert_eq!(ds, Vec::new(), "errors in {u}");
     }
     let url2 = url1.join("../file2.slint").unwrap();
     let source2 = format!(
@@ -201,7 +201,7 @@ fn test_goto_definition_multi_files() {
     ));
     let diag = crate::language::convert_diagnostics(&extra_files, diag, common::ByteFormat::Utf8);
     for (u, ds) in diag {
-        assert_eq!(ds, vec![], "errors in {u}");
+        assert_eq!(ds, Vec::new(), "errors in {u}");
     }
 
     let doc2 = dc.get_document(&url2).unwrap().node.clone().unwrap();

--- a/tools/lsp/language/semantic_tokens.rs
+++ b/tools/lsp/language/semantic_tokens.rs
@@ -33,7 +33,7 @@ pub fn get_semantic_tokens(
     let doc = document_cache.get_document(&text_document.uri)?;
     let doc_node = doc.node.as_ref()?;
     let mut token = doc_node.first_token()?;
-    let mut data = vec![];
+    let mut data = Vec::new();
     let mut delta_start = 0;
     let mut delta_line = 0;
     loop {

--- a/tools/lsp/language/signature_help.rs
+++ b/tools/lsp/language/signature_help.rs
@@ -15,7 +15,7 @@ pub(crate) fn get_signature_help(
 ) -> Option<SignatureHelp> {
     let pos = token.text_range().start();
     let mut node = token.parent();
-    let mut result = vec![];
+    let mut result = Vec::new();
 
     loop {
         if let Some(node) = syntax_nodes::FunctionCallExpression::new(node.clone()) {
@@ -203,7 +203,7 @@ export component Abc {
                     SignatureInformation {
                         label: "Sqrt()".into(),
                         documentation: None,
-                        parameters: Some(vec![]),
+                        parameters: Some(Vec::new()),
                         active_parameter: Some(0),
                     },
                     make_signature_info(

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -141,7 +141,7 @@ fn accurate_diagnostics_in_dependencies() {
         &std::env::current_dir().unwrap().join("xxx/bar.slint"),
         r#" export component Bar { property <int> hi; } "#,
     );
-    assert_eq!(diag, HashMap::from_iter([(bar_url.clone(), vec![])]));
+    assert_eq!(diag, HashMap::from_iter([(bar_url.clone(), Vec::new())]));
 
     let (reexport_url, diag) = load(
         None,
@@ -149,7 +149,7 @@ fn accurate_diagnostics_in_dependencies() {
         &std::env::current_dir().unwrap().join("xxx/reexport.slint"),
         r#"import { Bar } from "bar.slint"; export component Foo inherits Bar { in property <string> reexport; }"#,
     );
-    assert_eq!(diag, HashMap::from_iter([(reexport_url.clone(), vec![])]));
+    assert_eq!(diag, HashMap::from_iter([(reexport_url.clone(), Vec::new())]));
 
     let (foo_url, diag) = load(
         None,
@@ -182,9 +182,9 @@ fn accurate_diagnostics_in_dependencies() {
     assert_eq!(
         diag,
         HashMap::from_iter([
-            (reexport_url.clone(), vec![]),
-            (bar_url.clone(), vec![]),
-            (foo_url.clone(), vec![])
+            (reexport_url.clone(), Vec::new()),
+            (bar_url.clone(), Vec::new()),
+            (foo_url.clone(), Vec::new())
         ])
     );
 
@@ -209,7 +209,7 @@ fn accurate_diagnostics_in_dependencies() {
         &std::env::current_dir().unwrap().join("xxx/foo.slint"),
         r#"import { Foo } from "reexport.slint"; export component MainWindow inherits Window { Foo { hello: 12; } }"#,
     );
-    assert_eq!(diag[&foo_url], vec![]);
+    assert_eq!(diag[&foo_url], Vec::new());
 }
 
 #[test]
@@ -232,7 +232,7 @@ fn accurate_diagnostics_in_dependencies_with_parse_errors() {
         &std::env::current_dir().unwrap().join("xxx/bar.slint"),
         r#" export component Bar { in property <int> hello; } "#,
     );
-    assert_eq!(diag, HashMap::from_iter([(bar_url.clone(), vec![])]));
+    assert_eq!(diag, HashMap::from_iter([(bar_url.clone(), Vec::new())]));
 
     ctx.open_urls.borrow_mut().insert(bar_url.clone());
 
@@ -268,7 +268,7 @@ fn accurate_diagnostics_in_dependencies_with_parse_errors() {
     );
 
     // bar still don't have error
-    assert_eq!(diag[&bar_url], vec![]);
+    assert_eq!(diag[&bar_url], Vec::new());
     // But reexport_url still have the same syntax error as before
     assert!(diag[&reexport_url].iter().any(|d| d.message.contains("Syntax error:")));
 }

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -360,7 +360,7 @@ fn find_component_identifiers(
 ) -> Vec<syntax_nodes::DeclaredIdentifier> {
     let name = Some(i_slint_compiler::parser::normalize_identifier(name));
 
-    let mut result = vec![];
+    let mut result = Vec::new();
     for el in document.ExportsList() {
         if let Some(component) = el.Component() {
             let identifier = component.DeclaredIdentifier();
@@ -1926,7 +1926,7 @@ pub mod test {
         let path = main_test_file_name();
         let source_code = code.get(&path).unwrap().clone();
         let (diagnostics, component_definition, _, _) = spin_on::spin_on(super::parse_source(
-            vec![],
+            Vec::new(),
             std::collections::HashMap::new(),
             path,
             Some(24),

--- a/tools/lsp/preview/drop_location.rs
+++ b/tools/lsp/preview/drop_location.rs
@@ -1001,7 +1001,7 @@ pub fn drop_at(
 
 fn property_ranges(element: &common::ElementRcNode, remove_properties: &[&str]) -> Vec<TextRange> {
     element.with_element_node(|node| {
-        let mut result = vec![];
+        let mut result = Vec::new();
 
         for b in node.Binding() {
             let name = b.first_token().map(|t| t.text().to_string()).unwrap_or_default();

--- a/tools/lsp/preview/preview_data.rs
+++ b/tools/lsp/preview/preview_data.rs
@@ -225,7 +225,7 @@ pub fn set_json_preview_data(
 
     let definition = &component_instance.definition();
 
-    let mut failed_properties = vec![];
+    let mut failed_properties = Vec::new();
 
     let it =
         find_component_properties_and_callbacks(definition, &container).map_err(|e| vec![e])?;

--- a/tools/lsp/preview/ui.rs
+++ b/tools/lsp/preview/ui.rs
@@ -976,7 +976,7 @@ pub fn ui_set_preview_data(
         it: &mut dyn Iterator<Item = (&preview_data::PreviewDataKey, &preview_data::PreviewData)>,
     ) -> Option<PropertyContainer> {
         let (id, props) = it.filter_map(|(k, v)| Some((k, map_preview_data_property(k, v)?))).fold(
-            (None, vec![]),
+            (None, Vec::new()),
             move |mut acc, (key, value)| {
                 acc.0 = Some(acc.0.unwrap_or_else(|| key.container.clone()));
                 acc.1.push(value);
@@ -990,7 +990,7 @@ pub fn ui_set_preview_data(
         })
     }
 
-    let mut result: Vec<PropertyContainer> = vec![];
+    let mut result: Vec<PropertyContainer> = Vec::new();
 
     if let Some(c) = create_container(
         previewed_component.unwrap_or_else(|| "<MAIN>".to_string()),
@@ -1279,7 +1279,7 @@ fn insert_row_into_value_table(table: PropertyValueTable, insert_before: i32) {
     };
 
     let row_data = {
-        let mut result = vec![];
+        let mut result = Vec::new();
         if let Some(row) = vec_model.row_data(0) {
             result = row.iter().map(|pv| default_property_value(&pv)).collect::<Vec<_>>();
         }


### PR DESCRIPTION
vec![] expands to Vec::new(), but expanding macros takes a bit of time and takes memory in rust-analyzer. Also, the code was using a mix of vec![] and Vec::new(), so this is more consistent.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
