### PR TITLE
C++: Fix NativeWindowHandle Win32 API being available on Linux

### DIFF
--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -949,7 +949,7 @@ public:
     }
 
 #    endif
-#    if (!defined(__APPLE__) && (defined(_WIN32) || !defined(_WIN64))) || defined(DOXYGEN)
+#    if (!defined(__APPLE__) && (defined(_WIN32) || defined(_WIN64))) || defined(DOXYGEN)
 
     /// Creates a new NativeWindowHandle from the given HWND \a hwnd, and HINSTANCE \a hinstance.
     static NativeWindowHandle from_win32(void *hwnd, void *hinstance)


### PR DESCRIPTION
This seems just be a typo, I think it's supposed check if _WIN32 *or* _WIN64 is defined. Before compilation for Linux could easily pass through because it doesn't have _WIN64 defined.

Shouldn't have any adverse affects since this was never going to work on Linux in the first place.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
