### PR TITLE
Fixed docs for new_event_loop_proxy() fn of Platform trait

### DIFF
--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -79,8 +79,8 @@ pub trait Platform {
     /// not be possible to send event to the event loop and the function
     /// [`slint::invoke_from_event_loop()`](crate::api::invoke_from_event_loop) and
     /// [`slint::quit_event_loop()`](crate::api::quit_event_loop) will panic. These
-    /// functions are used internally by [`slint::spawn_local()`](crate::api::spawn_local)
-    /// and features like live_preview. So, implementaion of this function is necessary for
+    /// functions are used internally by `slint::spawn_local()`
+    /// and features like live_preview. Implementing this function is necessary for
     /// aforementioned functionalities to work.
     fn new_event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>> {
         None


### PR DESCRIPTION
This PR  creates a small change in docs of `new_event_loop_proxy()` function of `Platform` trait to better dictate its functionality.
Discussion for this PR is done here:
https://chat.slint.dev/public/pl/pmdftu3ketdbxya15fabb68p1e
