### PR TITLE
Add a feature to enable the `Path` in the software renderer

### DIFF
--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -56,6 +56,10 @@ serde = ["i-slint-core/serde"]
 ## This feature enables the software renderer to pick up fonts from the operating system for text rendering.
 software-renderer-systemfonts = ["renderer-software", "i-slint-core/software-renderer-systemfonts"]
 
+## This feature enables the software renderer to render `Path` elements. Requires the "std" feature.
+## Enabled by default when the Winit or LinuxKMS backend is enabled.
+software-renderer-path = ["renderer-software", "i-slint-core/software-renderer-path"]
+
 ## Slint uses internally some `thread_local` state.
 ##
 ## When the `std` feature is enabled, Slint can use [`std::thread_local!`], but when in a `#![no_std]`

--- a/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
+++ b/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
@@ -78,11 +78,11 @@ The Qt renderer comes with the <Link type="QtBackend" label="Qt backend" /> and 
 - Supports line-by-line rendering (Rust only).
 - Suitable for Microcontrollers.
 - Some features haven't been implemented yet:
-  * No support for `Path`.
   * No support for rotations or scaling.
   * No support for `drop-shadow-*` properties.
   * No support for `border-radius` in combination with `clip: true`.
   * No text stroking/outlining.
+  * Rendering `Path` elements requires the `software-renderer-path` feature which needs the `std` feature.
 - Text rendering currently limited to western scripts.
 - Available in the <Link type="WinitBackend" label="Winit backend" />.
 - Public <LangRefLink lang="rust-slint" relpath="platform/software_renderer/">Rust</LangRefLink> and <LangRefLink lang="cpp" relpath="api/classslint_1_1platform_1_1SoftwareRenderer">C++</LangRefLink> API.

--- a/internal/backends/linuxkms/Cargo.toml
+++ b/internal/backends/linuxkms/Cargo.toml
@@ -20,7 +20,13 @@ renderer-skia = ["renderer-skia-opengl"]
 renderer-skia-vulkan = ["i-slint-renderer-skia/vulkan", "vulkano", "drm", "dep:memmap2"]
 renderer-skia-opengl = ["i-slint-renderer-skia/opengl", "drm", "gbm", "glutin", "raw-window-handle", "dep:memmap2"]
 renderer-femtovg = ["i-slint-renderer-femtovg/opengl", "drm", "gbm", "glutin", "raw-window-handle"]
-renderer-software = ["i-slint-core/software-renderer-systemfonts", "drm", "dep:bytemuck", "dep:memmap2"]
+renderer-software = [
+  "i-slint-core/software-renderer-systemfonts",
+  "i-slint-core/software-renderer-path",
+  "drm",
+  "dep:bytemuck",
+  "dep:memmap2",
+]
 libseat = ["dep:libseat"]
 
 #default = ["renderer-skia", "renderer-femtovg"]

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -50,6 +50,7 @@ renderer-software = [
   "dep:imgref",
   "dep:rgb",
   "i-slint-core/software-renderer-systemfonts",
+  "i-slint-core/software-renderer-path",
   "dep:bytemuck",
 ]
 accessibility = ["dep:accesskit", "dep:accesskit_winit"]

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -57,7 +57,7 @@ unsafe-single-threaded = []
 unicode = ["unicode-script", "unicode-linebreak"]
 
 software-renderer-systemfonts = ["shared-fontique", "dep:skrifa", "fontdue", "software-renderer", "shared-parley"]
-software-renderer-path = ["dep:zeno"]
+software-renderer-path = ["dep:zeno", "software-renderer"]
 software-renderer = ["bytemuck"]
 
 image-decoders = ["dep:image", "dep:clru"]


### PR DESCRIPTION
The PR #9894 implemented support for Path, made a public feature for it similar to `software-renderer-systemfonts`

Note that since the feature is enabled by default with winit, the "simulator" mode of the mcu examples also enable it. And it can't be disabled.

But there is still a warning in the compiler when using `Path` element and `EmbedForSoftwareRenderer` is used as this generally mean that this is for MCU which still can't render `Path`
