### PR TITLE
Make cross-compiling more robust

### DIFF
--- a/api/cpp/CMakeLists.txt
+++ b/api/cpp/CMakeLists.txt
@@ -151,13 +151,6 @@ if(SLINT_FEATURE_COMPILER AND NOT SLINT_COMPILER)
     )
     list(APPEND slint_compiler_features "software-renderer")
 
-    # Switch to dlopening fontconfig in the slint-compiler to avoid the issue that
-    # for example in Yocto environments, PKG_CONFIG_PATH will be set to the target only
-    # and pkg-config in PATH doesn't permit lookups in the hots.
-    if(CMAKE_CROSSCOMPILING)
-        list(APPEND slint_compiler_features "fontconfig-dlopen")
-    endif()
-
     if (SLINT_FEATURE_SDF_FONTS)
         list(APPEND slint_compiler_features "sdf-fonts")
     endif()

--- a/api/rs/build/Cargo.toml
+++ b/api/rs/build/Cargo.toml
@@ -29,6 +29,7 @@ experimental-module-builds = ["i-slint-compiler/experimental-library-module"]
 
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "rust", "display-diagnostics", "software-renderer", "bundle-translations"] }
+i-slint-common = { workspace = true, features = ["fontconfig-dlopen"] }
 
 spin_on = { workspace = true }
 toml_edit = { workspace = true }

--- a/api/rs/macros/Cargo.toml
+++ b/api/rs/macros/Cargo.toml
@@ -23,6 +23,7 @@ default = []
 
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "proc_macro_span", "rust", "display-diagnostics"] }
+i-slint-common = { workspace = true, features = ["fontconfig-dlopen"] }
 proc-macro2 = "1.0.17"
 quote = "1.0"
 spin_on = { workspace = true }

--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -21,14 +21,13 @@ path = "main.rs"
 software-renderer = ["i-slint-compiler/software-renderer"]
 jemalloc = ["dep:tikv-jemallocator"]
 sdf-fonts = ["i-slint-compiler/sdf-fonts"]
-fontconfig-dlopen = ["i-slint-common/fontconfig-dlopen"]
 
 # Keep defaults in sync with defaults applied in api/cpp/CMakeLists.txt for slint-compiler
 default = ["software-renderer", "jemalloc"]
 
 [dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "display-diagnostics", "bundle-translations", "cpp", "rust", "python"] }
-i-slint-common = { workspace = true }
+i-slint-common = { workspace = true, features = ["fontconfig-dlopen"] }
 
 clap = { workspace = true }
 proc-macro2 = "1.0.11"


### PR DESCRIPTION
Always dlopen fontconfig for host tools.

This shoudl fix the build inside Yocto.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
