### PR TITLE
test-driver-rust: skip rust-analyzer on the generated code

### DIFF
--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -57,6 +57,7 @@ fn main() -> std::io::Result<()> {
             write!(
                 output,
                 r"
+#[rust_analyzer::skip]
 #[test] {} fn t_{}() -> ::std::result::Result<(), ::std::boxed::Box<dyn ::std::error::Error>> {{
     use i_slint_backend_testing as slint_testing;
     slint_testing::init_no_event_loop();


### PR DESCRIPTION
Idea by Simon.
In my testing it reduces greatly the memory consumption from rust-anayzer.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
