### PR TITLE
Fix NO_TTY error from pnpm launched by test-driver-nodejs

### DIFF
--- a/tests/driver/nodejs/nodejs.rs
+++ b/tests/driver/nodejs/nodejs.rs
@@ -22,12 +22,13 @@ static NODE_API_JS_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
 
     // On Windows pnpm is 'pnpm.cmd', which Rust's process::Command doesn't look for as extension, because
     // it tries to emulate CreateProcess.
-    let pnpm = which::which("pnpm").unwrap();
+    let pnpm = which::which("pnpm").expect("pnpm must be installed to run the nodejs tests");
 
     // installs the slint node package dependencies
     let o = std::process::Command::new(pnpm.clone())
         .arg("install")
         .arg("--ignore-scripts")
+        .arg("--config.confirmModulesPurge=false") // https://github.com/pnpm/pnpm/issues/9973 (and 7727 for the solution)
         .current_dir(node_dir.clone())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -45,7 +46,7 @@ static NODE_API_JS_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
-        .map_err(|err| format!("Could not launch pnpm install: {err}"))
+        .map_err(|err| format!("Could not launch pnpm run: {err}"))
         .unwrap();
 
     check_output(o);


### PR DESCRIPTION
Fix NO_TTY error from pnpm launched by test-driver-nodejs
    
I copied my slint checkout from one compter to another, and it ended up
in a different path. Running test-driver-nodejs on the new computer gave this error:
ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY  Aborted removal of modules directory due to no TTY
If you are running pnpm in CI, set the CI environment variable to "true".
    
This is because pnpm detects that the nodes-module directory isn't as
expected (wrong path in the storeDir key of .modules.yaml), and wants
to wipe it out. But first, it wants to ask for confirmation...
and it fails because there's no TTY (pnpm being launched indirectly).
    
This is fixed by --config.confirmModulesPurge=false
(or --force, or setting the env var CI to true)
    
See references in the comments