### PR TITLE
Slint: Properly size Slint logo link in About dialog for Firefox

### DIFF
--- a/tools/slintpad/src/dialogs.ts
+++ b/tools/slintpad/src/dialogs.ts
@@ -147,7 +147,7 @@ export function about_dialog() {
           <center>
           <h1>Welcome to SlintPad</h1>
 
-          <a href="https://slint.dev/" target="_blank"><img src="https://slint.dev/logo/slint-logo-simple-light.svg"></a>
+          <a href="https://slint.dev/" target="_blank" class="slint-logo-link"><img src="https://slint.dev/logo/slint-logo-simple-light.svg" width="141" height="42"></a>
           </center>
 
           <p><a href="https://slint.dev/" target="_blank">Slint</a> is a toolkit to efficiently develop fluid graphical user interfaces for

--- a/tools/slintpad/styles/content.css
+++ b/tools/slintpad/styles/content.css
@@ -202,3 +202,7 @@
     content: "✓";
     padding-left: 5px;
 }
+
+.dialog.about_dialog .slint-logo-link {
+    display: inline-block;
+}


### PR DESCRIPTION
For some reason the link wasn't sized correctly, it's smaller than the logo and looks buggy. Setting this as an inline-block fixes this.

I tested this on Firefox and Chromium, it doesn't appear to be an issue on Chrome but this fix doesn't regress there either.

| Before | After |
|--------|--------|
| <img width="667" height="224" alt="Screenshot_20251216_082433" src="https://github.com/user-attachments/assets/ff8cfc9a-6432-4780-afac-12d5743b7ba3" /> | <img width="667" height="224" alt="Screenshot_20251216_082500" src="https://github.com/user-attachments/assets/b254b25c-f52d-4871-8024-bc1ec9e722b7" /> | 

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
