### PR TITLE
doc: There are no experimental renders anymore

### DIFF
--- a/api/cpp/docs/cmake.md
+++ b/api/cpp/docs/cmake.md
@@ -138,10 +138,6 @@ compile time. You can enable or disable back-ends using the
 you would disable the `SLINT_FEATURE_BACKEND_WINIT` option in your CMake
 project configuration.
 
-The winit back-end needs a renderer. `SLINT_FEATURE_RENDERER_FEMTOVG` and
-`SLINT_FEATURE_RENDERER_SKIA` are the only stable renderers, the other ones are
-experimental.
-
 ### Cross-compiling
 
 It's possible to cross-compile Slint to a different target architecture when

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -107,7 +107,7 @@ live-preview = ["dep:slint-interpreter"]
 #! with [`platform::set_platform()`].
 #!
 #! If you enable the Winit backend, you need to also include a renderer.
-#! `renderer-femtovg` is the only stable renderer, the other ones are experimental
+#! `renderer-femtovg` is the default renderer.
 #!
 #! It is also possible to select the backend and renderer at runtime when several
 #! are enabled, using the `SLINT_BACKEND`  environment variable.


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
