### PR TITLE
[Slider] fix typo in doc. We can't use boolean for orientation

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/slider.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/slider.mdx
@@ -80,7 +80,7 @@ Slider {
 
 ### orientation
 <SlintProperty propName="orientation" typeName="enum" enumName="Orientation" defaultValue="horizontal">
-If set to true the Slider is displayed vertical.
+Describes the orientation of the Slider, vertical or horizontal.
 </SlintProperty>
 
 ## Callbacks


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
