### PR TITLE
femtovg: fix panic in begin_surface_rendering error path

### DIFF
--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -61,12 +61,7 @@ impl GraphicsBackend for WGPUBackend {
                 let mut device = self.device.borrow_mut();
                 let device = device.as_mut().unwrap();
 
-                self.surface
-                    .borrow_mut()
-                    .as_mut()
-                    .unwrap()
-                    .configure(device, self.surface_config.borrow().as_ref().unwrap());
-
+                surface.configure(device, self.surface_config.borrow().as_ref().unwrap());
                 surface.get_current_texture()?
             }
         };


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

The following code used to always panic when opening the app on a tiling window manager which resized the app first chance it got. This fix just removes the double borrow which was always happening. Tested and works fine now.