### PR TITLE
Remove inline code block from some Reference documentation headings

### DIFF
--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -308,7 +308,7 @@ Specify that this is a button in a `Dialog`.
 
 ## Common Callbacks
 
-### `init()`
+### init()
 
 Every element implicitly declares an `init` callback. You can assign a code block to it that will be invoked when the
 element is instantiated and after all properties are initialized with the value of their final binding. The order of

--- a/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
@@ -65,12 +65,12 @@ When false, nothing can be entered.
 When set to true, text editing via keyboard and mouse is disabled but selecting text is still enabled as well as editing text programmatically.
 </SlintProperty>
 
-### `wrap`
+### wrap
 <SlintProperty propName="wrap" typeName="enum" enumName="TextWrap">
 The way the text wraps (default: word-wrap).
 </SlintProperty>
 
-### `horizontal-alignment`
+### horizontal-alignment
 <SlintProperty propName="horizontal-alignment" typeName="enum" enumName='TextHorizontalAlignment' >
 The horizontal alignment of the text.
 </SlintProperty>


### PR DESCRIPTION
There are a few headings in our Reference documentation that were marked as inline code, despite nothing else (elsewhere or surrounding) that did this. I remove them for stylistic consistency.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
