### PR TITLE
swapped red and blue channels because it was messed up in the first PR

### DIFF
--- a/internal/backends/linuxkms/renderer/sw.rs
+++ b/internal/backends/linuxkms/renderer/sw.rs
@@ -160,7 +160,9 @@ impl crate::fullscreenwindowadapter::FullscreenRenderer for SoftwareRendererAdap
             });
 
             match format {
-                drm::buffer::DrmFourcc::Xrgb8888 | drm::buffer::DrmFourcc::Argb8888 | drm::buffer::DrmFourcc::Bgra8888 => {
+                drm::buffer::DrmFourcc::Xrgb8888
+                | drm::buffer::DrmFourcc::Argb8888
+                | drm::buffer::DrmFourcc::Bgra8888 => {
                     let buffer: &mut [DumbBufferPixelXrgb888] =
                         bytemuck::cast_slice_mut(pixels.as_mut());
                     self.renderer.render(buffer, self.size.width as usize);


### PR DESCRIPTION
This is a follow up for #9914 which somehow seems to have messed up the red and blue channel (see attached screenshot vs [the original image](https://www.audible.de/pd/Benjamin-als-Wetterelefant-Hoerbuch/B004JVDIAU?qid=1766906305&sr=1-1)).

I hope this fixes the problem - I'm going to do more research if it does not.

![slint-colors](https://github.com/user-attachments/assets/d730bc3c-4ef0-4d24-811f-916221a459e6)





