### PR TITLE
Docs: remove as_ref() usage in SampleComponent

### DIFF
--- a/api/rs/slint/docs.rs
+++ b/api/rs/slint/docs.rs
@@ -76,9 +76,9 @@ pub mod generated_code {
         /// ```ignore
         ///     let sample = SampleComponent::new().unwrap();
         ///     let sample_weak = sample.as_weak();
-        ///     sample.as_ref().on_hello(move || {
+        ///     sample.on_hello(move || {
         ///         let sample = sample_weak.unwrap();
-        ///         sample.as_ref().set_counter(42);
+        ///         sample.set_counter(42);
         ///     });
         /// ```
         pub fn on_hello(&self, f: impl Fn() + 'static) {}


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Since Rust-exported components do not implement `AsRef` trait, current example would fail to compile. Seems fixed on the main website (an example can be seen on `Tutorial/Game Logic` page.