### PR TITLE
Fix showing a popup that is already shown from itself

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2832,7 +2832,7 @@ fn compile_builtin_function_call(
                 let popup = &current_sub_component.popup_windows[*popup_index as usize];
                 let popup_window_id =
                     inner_component_id(&ctx.compilation_unit.sub_components[popup.item_tree.root]);
-                let parent_component = access_item_rc(parent_ref, ctx);
+                let parent_item = access_item_rc(parent_ref, ctx);
 
                 let parent_ctx = ParentScope::new(ctx, None);
                 let popup_ctx = EvaluationContext::new_sub_component(
@@ -2847,6 +2847,7 @@ fn compile_builtin_function_call(
                 let window_adapter_tokens = access_window_adapter_field(ctx);
                 let popup_id_name = internal_popup_id(*popup_index as usize);
                 component_access_tokens.then(|component_access_tokens| quote!({
+                    let parent_item = #parent_item;
                     let popup_instance = #popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone()).unwrap();
                     let popup_instance_vrc = sp::VRc::map(popup_instance.clone(), |x| x);
                     let position = { let _self = popup_instance_vrc.as_pin_ref(); #position };
@@ -2858,7 +2859,7 @@ fn compile_builtin_function_call(
                             &sp::VRc::into_dyn(popup_instance.into()),
                             position,
                             #close_policy,
-                            #parent_component,
+                            parent_item,
                             false, // is_menu
                         ))
                     );

--- a/tests/cases/issues/issue_10923_popupwindow-reshow.slint
+++ b/tests/cases/issues/issue_10923_popupwindow-reshow.slint
@@ -1,0 +1,69 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Button } from "std-widgets.slint";
+
+export component TestCase inherits Window {
+    in property <int> foo: 0;
+    in-out property <int> result;
+
+    width: 100px;
+    height: 100px;
+
+    Button {
+        text: "Show popup";
+
+        clicked => popup.show();
+    }
+
+    popup := PopupWindow {
+        width: rect.preferred-width;
+        height: rect.preferred-height;
+
+        rect := Rectangle {
+            background: lightskyblue;
+
+            VerticalLayout {
+                if foo == 0: Button {
+                    text: "Click for crash";
+
+                    clicked => {
+                        result+=1;
+                        popup.show();
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 50., 50.);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_result(), 1);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq(instance.get_result(), 2);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 50., 50.);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_result(), 1);
+slint_testing::send_mouse_click(&instance, 5., 5.);
+assert_eq!(instance.get_result(), 2);
+```
+
+```js
+var instance = new slint.TestCase();
+slintlib.private_api.send_mouse_click(instance, 50., 50.);
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+assert.equal(instance.result, 1);
+slintlib.private_api.send_mouse_click(instance, 5., 5.);
+assert.equal(instance.result, 2);
+```
+*/


### PR DESCRIPTION
The code that close the popup may delete the parents which may cause the `parent_item` expression to become invalid. Store its result before closing the popup.

Fixes #10293
