### PR TITLE
compiler: properly detect dependency loops on `Image.source-clip`

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -680,8 +680,13 @@ fn visit_implicit_layout_info_dependencies(
     match base_type.as_str() {
         "Image" => {
             vis(&NamedReference::new(item, SmolStr::new_static("source")).into(), N);
+            vis(&NamedReference::new(item, SmolStr::new_static("source-clip-width")).into(), N);
             if orientation == Orientation::Vertical {
                 vis(&NamedReference::new(item, SmolStr::new_static("width")).into(), N);
+                vis(
+                    &NamedReference::new(item, SmolStr::new_static("source-clip-height")).into(),
+                    N,
+                );
             }
         }
         "Text" | "TextInput" => {

--- a/internal/compiler/tests/syntax/analysis/binding_loop_image.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_image.slint
@@ -1,0 +1,26 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue 10342
+
+export component MyPanel {
+//                       >error{The binding for the property 'layoutinfo-v' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+    fb := Image {
+        width: 100%;
+        source-clip-width: root.width / 0.531px;
+        source-clip-height: root.height / 0.531px;
+//                          >                    <error{The binding for the property 'source-clip-height' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+    }
+
+}
+//<<<error{The binding for the property 'layoutinfo-v' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+
+export component MainWindow inherits Window {
+    MyPanel {
+//  >      <error{The binding for the property 'preferred-height' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+//  >      <^error{The binding for the property 'height' is part of a binding loop (fb.source-clip-height -> layoutinfo-v -> preferred-height -> height)}
+        x: 30px;
+        y: 30px;
+        width: 200px;
+    }
+}


### PR DESCRIPTION
Fixes #10342

