### PR TITLE
CI: Test with the lastest version of the dependencies regardless of MSRV

### DIFF
--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -87,6 +87,10 @@ jobs:
                   key: x-v3
                   save_if: ${{ inputs.save_if }}
                   cache: ${{ inputs.cache }}
+            - name: Cargo update
+              if: inputs.rust_version == 'stable' || inputs.rust_version == 'nightly'
+              # When runing with the lastest rust, ignore the rust_version field from the Cargo.toml because we want to test with the latest versions of the dependencies (that's what our users might get)
+              run: cargo update --ignore-rust-version
             - name: Run tests
               run:  cargo test --verbose --all-features --workspace --timings ${{ inputs.extra_args }} --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude slint-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python -- --skip=_qt::t
               env:


### PR DESCRIPTION
We have currently a MSRV of rust 1.88
Some dependencies have minor versions update that needs a newer rust version, and Cargo will not automatically update to these dependencies because our workspace has that MSRV

But our users might have a higher MSRV, and for them, Cargo will resolve the newer version of the crates.
So add `--ignore-rust-version` in the CI to test with the newer versions for the newer compiler
