### PR TITLE
Compiler: make it an error to access properties from menus from outside

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -944,9 +944,12 @@ pub fn pretty_print(
         }
     }
     for (name, expr) in &e.bindings {
-        let expr = expr.borrow();
         indent!();
         write!(f, "{name}: ")?;
+        let Ok(expr) = expr.try_borrow() else {
+            writeln!(f, "<borrowed>")?;
+            continue;
+        };
         expression_tree::pretty_print(f, &expr.expression)?;
         if expr.analysis.as_ref().is_some_and(|a| a.is_const) {
             write!(f, "/*const*/")?;

--- a/internal/compiler/tests/syntax/basic/popup.slint
+++ b/internal/compiler/tests/syntax/basic/popup.slint
@@ -9,7 +9,7 @@ component Foo {
 
 component Issue5852 {
     p := PopupWindow {
-//       >          <error{Cannot access the inside of a PopupWindow from enclosing component}
+//       >          <error{Cannot access element 'input' inside of a PopupWindow from enclosing component}
         input := TextInput {}
     }
     TouchArea {
@@ -29,7 +29,7 @@ export X := PopupWindow {
 //  >        <error{Access to property 'inner.opacity' which is inlined into a PopupWindow via @children is forbidden}
 
         popup := PopupWindow {  // FIXME, the error should be located on property access (#4438)
-//               >          <error{Cannot access the inside of a PopupWindow from enclosing component}
+//               >          <error{Cannot access property or callback 'r.background' inside of a PopupWindow from enclosing component}
 
             r := Rectangle {
             }

--- a/internal/compiler/tests/syntax/elements/contextmenu3.slint
+++ b/internal/compiler/tests/syntax/elements/contextmenu3.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component A  {
+    cb := ContextMenuArea {
+//        >              <error{Cannot access property or callback 'inner-menu.title' inside of a ContextMenuArea from enclosing component}
+        Menu {
+            inner-menu := Menu { }
+        }
+    }
+
+    if true : TouchArea {
+        clicked => {
+            inner-menu.title = "Hi";
+        }
+    }
+}
+

--- a/internal/compiler/tests/syntax/elements/menubar4.slint
+++ b/internal/compiler/tests/syntax/elements/menubar4.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component B inherits Window {
+    callback activate <=> item.activated;
+    MenuBar {
+//  >      <error{Cannot access property or callback 'item.activated' inside of a MenuBar from enclosing component}
+        Menu {
+            title: "hello";
+            item := MenuItem {
+                title: "world";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Same reason why we can't do it with PopupWindow: the properties are in a different ItemTree and can't be accessed. This currently cause panic

Fixes #9443
CC #9299

