### PR TITLE
Use Rc<RefCell> to share GridLayoutCell

### DIFF
--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -549,8 +549,11 @@ fn lower_sub_component(
     .into();
     if let Some(grid_layout_cell) = component.root_element.borrow().grid_layout_cell.as_ref() {
         sub_component.grid_layout_input_for_repeated = Some(
-            super::lower_expression::get_grid_layout_input_for_repeated(&mut ctx, grid_layout_cell)
-                .into(),
+            super::lower_expression::get_grid_layout_input_for_repeated(
+                &mut ctx,
+                &grid_layout_cell.borrow(),
+            )
+            .into(),
         );
     }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -874,7 +874,7 @@ pub struct Element {
     pub inline_depth: i32,
 
     /// Information about the grid cell containing this element, if applicable
-    pub grid_layout_cell: Option<crate::layout::GridLayoutCell>,
+    pub grid_layout_cell: Option<Rc<RefCell<crate::layout::GridLayoutCell>>>,
 
     /// Debug information about this element.
     ///

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -500,13 +500,13 @@ impl GridLayout {
                 }
             };
 
-            let grid_layout_cell = GridLayoutCell {
+            let grid_layout_cell = Rc::new(RefCell::new(GridLayoutCell {
                 new_row,
                 col_expr: expr_or_default(col_expr, RowColExpr::Auto),
                 row_expr: expr_or_default(row_expr, RowColExpr::Auto),
                 colspan_expr: expr_or_default(colspan_expr, RowColExpr::Literal(1)),
                 rowspan_expr: expr_or_default(rowspan_expr, RowColExpr::Literal(1)),
-            };
+            }));
             let grid_layout_element = GridLayoutElement {
                 cell: grid_layout_cell.clone(),
                 item: layout_item.item.clone(),


### PR DESCRIPTION
It's needed in GridLayoutElement for most of the layouting code, and in the Element for the case of repeated components. Only GridLayout's visit_rowcol_named_references() visits the Expressions, no need to do it again from Element, given that they're shared.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
