### PR TITLE
Fall back to using spacing information from Punct tokens to deal with rust-analyzer's lack of span support in a more ergonomic way.

### DIFF
--- a/api/rs/macros/Cargo.toml
+++ b/api/rs/macros/Cargo.toml
@@ -27,5 +27,8 @@ proc-macro2 = "1.0.17"
 quote = "1.0"
 spin_on = { workspace = true }
 
+[dev-dependencies]
+slint = { path = "../slint" }
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -426,7 +426,11 @@ mod tests {
         spacing: Spacing,
     ) -> bool {
         // Simulate the logic from are_token_touching
-        if token1_end_line == 1 && token1_end_col == 1 && token2_start_line == 1 && token2_start_col == 1 {
+        if token1_end_line == 1
+            && token1_end_col == 1
+            && token2_start_line == 1
+            && token2_start_col == 1
+        {
             // Invalid span info - fall back to spacing
             return spacing == Spacing::Joint;
         }
@@ -460,7 +464,7 @@ mod tests {
         // Test case 4: Valid span info where tokens are not touching (gap between them)
         let result = mock_are_token_touching(5, 10, 5, 12, Spacing::Alone);
         assert!(!result, "tokens with gap should not be touching");
-        
+
         // Also test different lines
         let result = mock_are_token_touching(5, 10, 6, 1, Spacing::Joint);
         assert!(!result, "tokens on different lines should not be touching");
@@ -471,11 +475,11 @@ mod tests {
     // using documentation:
 
     /// Test case 5: fill_token_vec merges identifier and hyphen when touching
-    /// 
+    ///
     /// When given a token stream like: `foo-` (where the hyphen has Joint spacing or
     /// the spans indicate they're touching), fill_token_vec should merge them into
     /// a single identifier token "foo-".
-    /// 
+    ///
     /// Input: [Identifier("foo"), Punct('-', Joint)]
     /// Expected: [Token { kind: Identifier, text: "foo-" }]
     #[test]
@@ -490,10 +494,10 @@ mod tests {
     }
 
     /// Test case 5 (alternate): fill_token_vec keeps separate when not touching
-    /// 
+    ///
     /// When given a token stream like: `foo -` (where the hyphen has Alone spacing and
     /// span info indicates invalid spans), fill_token_vec should keep them separate.
-    /// 
+    ///
     /// Input: [Identifier("foo"), Punct('-', Alone)]
     /// Expected: [Token { kind: Identifier, text: "foo" }, Token { kind: Minus, text: "-" }]
     #[test]

--- a/api/rs/macros/tests/token_processing.rs
+++ b/api/rs/macros/tests/token_processing.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 //! Integration tests for token processing in the slint! macro
-//! 
+//!
 //! These tests verify that:
 //! 1. Identifiers with hyphens are correctly merged when touching (test case 5)
 //! 2. Identifiers and hyphens remain separate when not touching
@@ -22,7 +22,7 @@ fn test_identifier_with_hyphen_merged() {
             property <string> foo-bar: "test";
         }
     }
-    
+
     // If this compiles successfully, it means the tokens were merged correctly
     // into a single identifier "foo-bar" rather than "foo", "-", "bar"
 }
@@ -36,7 +36,7 @@ fn test_multiple_hyphenated_identifiers() {
             property <string> another-hyphenated-name: "value";
         }
     }
-    
+
     // Compilation success means both hyphenated identifiers were correctly processed
 }
 
@@ -48,7 +48,7 @@ fn test_hyphen_as_operator() {
             property <int> result: 10 - 5;
         }
     }
-    
+
     // Compilation success means the minus operator was correctly identified
     // (not merged with adjacent tokens)
 }
@@ -62,7 +62,7 @@ fn test_mixed_hyphen_usage() {
             property <int> computed: my-value - 10;
         }
     }
-    
+
     // Compilation success means both uses of hyphen were correctly distinguished:
     // - "my-value" was merged into a single identifier
     // - " - " was kept as a separate minus operator

--- a/api/rs/macros/tests/token_processing.rs
+++ b/api/rs/macros/tests/token_processing.rs
@@ -1,0 +1,69 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Integration tests for token processing in the slint! macro
+//! 
+//! These tests verify that:
+//! 1. Identifiers with hyphens are correctly merged when touching (test case 5)
+//! 2. Identifiers and hyphens remain separate when not touching
+//! 3. The macro correctly handles different spacing scenarios
+//!
+//! These are compilation tests - if the code compiles, the token processing worked correctly.
+
+use slint::slint;
+
+#[test]
+fn test_identifier_with_hyphen_merged() {
+    // Test case 5: This tests that fill_token_vec correctly merges
+    // an identifier and a hyphen when they are touching.
+    // In Slint, foo-bar is a valid identifier.
+    slint! {
+        component TestComponent {
+            property <string> foo-bar: "test";
+        }
+    }
+    
+    // If this compiles successfully, it means the tokens were merged correctly
+    // into a single identifier "foo-bar" rather than "foo", "-", "bar"
+}
+
+#[test]
+fn test_multiple_hyphenated_identifiers() {
+    // Additional test to verify multiple hyphenated identifiers work
+    slint! {
+        component MultiHyphen {
+            property <int> my-custom-property: 42;
+            property <string> another-hyphenated-name: "value";
+        }
+    }
+    
+    // Compilation success means both hyphenated identifiers were correctly processed
+}
+
+#[test]
+fn test_hyphen_as_operator() {
+    // Test that hyphens as minus operators (with spacing) are handled correctly
+    slint! {
+        component MathComponent {
+            property <int> result: 10 - 5;
+        }
+    }
+    
+    // Compilation success means the minus operator was correctly identified
+    // (not merged with adjacent tokens)
+}
+
+#[test]
+fn test_mixed_hyphen_usage() {
+    // Test mixing hyphenated identifiers and minus operators
+    slint! {
+        component MixedUsage {
+            property <int> my-value: 20;
+            property <int> computed: my-value - 10;
+        }
+    }
+    
+    // Compilation success means both uses of hyphen were correctly distinguished:
+    // - "my-value" was merged into a single identifier
+    // - " - " was kept as a separate minus operator
+}


### PR DESCRIPTION
rust-analyzer currently does not implement span.line() and span.column(), as per https://github.com/slint-ui/slint/issues/685 this leads to failures in parsing. While the feature is being implemented in RA, it'll be a while before it becomes available, and even when it does, line/colum and operating on spans generally will be slow, because it kills incremental parsing in RA. In rustc, none of this is a problem. This patch improves the situation with current RA, leaving only the case of "foo -bar" to be wrongly parsed as "foo-bar", but that's better than wrongly parsing "foo - bar" as we do currently. Once line/column comes online in RA, the fallback won't be hit anymore and we can assess the performance then.

