### PR TITLE
llr::Expression: add support for owned arrays, split out Slice

### DIFF
--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -14,6 +14,13 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 
 #[derive(Debug, Clone)]
+pub enum ArrayOutput {
+    Slice,
+    Model,
+    Vector,
+}
+
+#[derive(Debug, Clone)]
 pub enum Expression {
     /// A string literal. The .0 is the content of the string, without the quotes
     StringLiteral(SmolStr),
@@ -137,8 +144,8 @@ pub enum Expression {
     Array {
         element_ty: Type,
         values: Vec<Expression>,
-        /// When true, this should be converted to a model. When false, this should stay as a slice
-        as_model: bool,
+        /// Choose what will be generated: a slice, a model, or a vector
+        output: ArrayOutput,
     },
     Struct {
         ty: Rc<crate::langtype::Struct>,
@@ -252,7 +259,7 @@ impl Expression {
             Type::Array(element_ty) => Expression::Array {
                 element_ty: (**element_ty).clone(),
                 values: Vec::new(),
-                as_model: true,
+                output: ArrayOutput::Model,
             },
             Type::Struct(s) => Expression::Struct {
                 ty: s.clone(),


### PR DESCRIPTION
Generating `Slice::from_slice(&[...])` is only valid for values being passed as function arguments. For a function's return type, for instance, this is invalid, the array will be deallocated immediately.

My first approach was to add a bool "owned" to Array, but it's getting messy (since there's already a bool "as_model"). So, instead, I split out Slice from the old "Array with as_model=false" case.

Before:
  Expression::Array, as_model=false => Slice::from_slice
  Expression::Array, as_model=true  => ModelRc<VecModel>

After:
  Expression::Slice => Slice::from_slice
  Expression::Array, as_model=false => Vec
  Expression::Array, as_model=true => ModelRc<VecModel>

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
