### PR TITLE
Remove unnecessary image default features from docsnapper

### DIFF
--- a/tools/docsnapper/Cargo.toml
+++ b/tools/docsnapper/Cargo.toml
@@ -27,8 +27,7 @@ spin_on = { workspace = true }
 termcolor = { version = "1.4.1" }
 walkdir = { version = "2.5" }
 
-# Enable image-rs' default features to make all image formats available for preview
-image = { workspace = true, features = ["default"] }
+image = { workspace = true }
 
 [[bin]]
 name = "slint-docsnapper"


### PR DESCRIPTION
docsnapper only uses image::save_buffer() for PNG output, so it doesn't need the full set of image decoders enabled by default features.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
