### PR TITLE
Remove unnecessary image default features from compiler

### DIFF
--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -61,7 +61,7 @@ linked_hash_set = "0.1.4"
 typed-index-collections = { workspace = true }
 
 # for processing and embedding the rendered image (texture)
-image = { workspace = true, optional = true, features = ["default"] }
+image = { workspace = true, optional = true }
 resvg = { workspace = true, optional = true }
 # font embedding
 fontdue = { workspace = true, optional = true, features = ["parallel"] }


### PR DESCRIPTION
The software-renderer feature only needs PNG/JPEG support by default, which is already provided by the workspace image dependency. Remove the explicit default features to reduce build dependencies (removes rav1e, ravif, etc). Users who need additional image formats can enable them via the image-default-formats feature.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
