### PR TITLE
fix viewer using the correct component

### DIFF
--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -135,6 +135,8 @@ fn main() -> Result<()> {
     if r.has_errors() {
         std::process::exit(-1);
     }
+    // If --component is used, r.compents contains only one element (filtered out in init_compiler())
+    // If no component name is specified, the last defined component is shown
     let Some(c) = r.components().next() else {
         match args.component {
             Some(name) => {


### PR DESCRIPTION
Reason: In the old version the last component in the slint file was used to show in the viewer and the args.component was not considered. It was only used to show a more concrete error message. Now if an component name was passed, it will be searched for that and if not found raising an error. Otherwise the last component will be used

- [ ] ~~If the change modifies a visible behavior, it changes the documentation accordingly~~
- [ ] ~~If possible, the change is auto-tested~~ Only documentation
- [ ] ~~If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`~~
- [ ] ~~If the change is noteworthy, the commit message should contain `ChangeLog: ...`~~
