### PR TITLE
Attempt to restore pixel alignment for layers introduced with bc2e97f…

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -334,8 +334,8 @@ impl<'a> SkiaItemRenderer<'a> {
                 )
             })
         }) {
-            let _saved_canvas = self.pixel_align_origin();
             self.canvas.translate(skia_safe::Vector::from((layer_offset.x, layer_offset.y)));
+            let _saved_canvas = self.pixel_align_origin();
             self.canvas.draw_image_with_sampling_options(
                 layer_image,
                 skia_safe::Point::default(),


### PR DESCRIPTION
…cefd4818f7157c434a4de96cf9b79e543

Commit 598f14573deaa4a77570bfa4cd0066fd96362266 added a translation for the layer but after the alignment, which needs to be swapped to still ensure pixel alignment for the layer.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
