### PR TITLE
Do not set the animation if the values are equal

### DIFF
--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -533,6 +533,12 @@ impl PropertyHandle {
         self.handle.set(if set { self.handle.get() | 0b1 } else { self.handle.get() & !0b1 })
     }
 
+    fn pointer_to_binding(handle: usize) -> bool {
+        const BINDING_BORROWED: usize = 0b01;
+        const BINDING_POINTER_TO_BINDING: usize = 0b10;
+        handle & BINDING_POINTER_TO_BINDING == BINDING_POINTER_TO_BINDING
+    }
+
     /// Access the value.
     /// Panics if the function try to recursively access the value
     fn access<R>(&self, f: impl FnOnce(Option<Pin<&mut BindingHolder>>) -> R) -> R {

--- a/internal/core/properties.rs
+++ b/internal/core/properties.rs
@@ -567,6 +567,7 @@ impl PropertyHandle {
         }
     }
 
+    /// Remove self from the dependency of another property
     fn remove_binding(&self) {
         assert!(!self.lock_flag(), "Recursion detected");
         let val = self.handle.get();

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -421,6 +421,11 @@ mod animation_tests {
 
         compo.width.set_animated_value(150, animation_details);
         assert_eq!(PropertyHandle::pointer_to_binding(compo.width.handle.handle.get()), false); // We stopped the previous binding and did not add a new one, because the values are equal
+
+        // run all animations
+        crate::animations::CURRENT_ANIMATION_DRIVER
+            .with(|driver| driver.update_animations(start_time + DURATION));
+        assert_eq!(get_prop_value(&compo.width), 150); // If we still have a binding, this value would be 200
     }
 
     #[test]

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -236,7 +236,7 @@ impl InterpolatedPropertyValue for LogicalLength {
     }
 }
 
-impl<T: Clone + InterpolatedPropertyValue + 'static> Property<T> {
+impl<T: Clone + InterpolatedPropertyValue + 'static + PartialEq> Property<T> {
     /// Change the value of this property, by animating (interpolating) from the current property's value
     /// to the specified parameter value. The animation is done according to the parameters described by
     /// the PropertyAnimation object.
@@ -245,6 +245,12 @@ impl<T: Clone + InterpolatedPropertyValue + 'static> Property<T> {
     /// be marked as dirty.
     pub fn set_animated_value(&self, value: T, animation_data: PropertyAnimation) {
         // FIXME if the current value is a dirty binding, we must run it, but we do not have the context
+        unsafe {
+            if *self.value.get() == value {
+                self.handle.remove_binding();
+                return;
+            }
+        }
         let d = RefCell::new(properties_animations::PropertyValueAnimationData::new(
             self.get_internal(),
             value,

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -412,14 +412,14 @@ mod animation_tests {
 
         assert_eq!(PropertyHandle::pointer_to_binding(compo.width.handle.handle.get()), false);
         let start_time = crate::animations::current_tick();
-        compo.width.set_animated_value(200, animation_data);
+        compo.width.set_animated_value(200, animation_details.clone());
         assert_eq!(PropertyHandle::pointer_to_binding(compo.width.handle.handle.get()), true);
 
         crate::animations::CURRENT_ANIMATION_DRIVER
             .with(|driver| driver.update_animations(start_time + DURATION / 2));
         assert_eq!(get_prop_value(&compo.width), 150);
 
-        compo.width.set_animated_value(150, animation_data);
+        compo.width.set_animated_value(150, animation_details);
         assert_eq!(PropertyHandle::pointer_to_binding(compo.width.handle.handle.get()), false); // We stopped the previous binding and did not add a new one, because the values are equal
     }
 


### PR DESCRIPTION

Relevant for example for the Flickable if scrolled only one dimension, there is no need two run two animations

- [ ] ~~If the change modifies a visible behavior, it changes the documentation accordingly~~
- [X] If possible, the change is auto-tested
- [ ] ~~If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`~~
- [ ] ~~If the change is noteworthy, the commit message should contain `ChangeLog: ...`~~
