### PR TITLE
tests: Skip background thread spawn_local test on macOS

### DIFF
--- a/api/rs/slint/tests/spawn_local.rs
+++ b/api/rs/slint/tests/spawn_local.rs
@@ -42,6 +42,7 @@ fn main() {
     i_slint_backend_testing::init_integration_test_with_mock_time();
 
     // test_spawn_local_from_thread
+    #[cfg(not(target_os = "macos"))]
     std::thread::spawn(|| {
         assert_eq!(
             slint::spawn_local(async {


### PR DESCRIPTION
Winit 0.30+ strictly enforces that its EventLoop must be created on the main thread on macOS. Calling slint::spawn_local on a background thread without a prior context triggers lazy backend initialization, which causes Winit to panic.

This test doesn't fail in CI because CI runs with the Qt backend enabled and installed. The selector tries Qt first, which doesn't exhibit this panic behavior on macOS background threads. In local environments without Qt, Slint falls back to Winit and panics.

