### PR TITLE
feat: add spawn_blocking in std environment

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -348,6 +348,15 @@ pub fn spawn_local<F: core::future::Future + 'static>(
         .map_err(|_| EventLoopError::NoEventLoopProvider)?
 }
 
+/// This function spawns a new std::thread and executes the provided closure `action` in that thread.
+/// It returns a handle that can be awaited as standard [`Future`](core::future::Future) (hence it's executor-agnostic).
+#[cfg(feature = "std")]
+pub fn spawn_blocking<T: Send + 'static, F: FnMut() -> T + Send + 'static>(
+    action: F,
+) -> SpawnBlockingJoinHandle<T> {
+    i_slint_core::future::spawn_blocking(action)
+}
+
 #[i_slint_core_macros::slint_doc]
 /// Include the code generated with the slint-build crate from the build script. After calling `slint_build::compile`
 /// in your `build.rs` build script, the use of this macro includes the generated Rust code and makes the exported types


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->

Lately I found myself dealing with large file dumps from my application.
The file-dump is triggered in a button callback, from within the slint event-loop.
I didn't want to build the "infrastructure" to pass my request to a tokio thread, there use the async file-syetem acceess and then go back to the slint event-loop with the action results.
I find that for this kind of operation, it's really practical to be able to:

```rust
main_window.on_export_data(move || {
            slint::spawn_local(async move {
                // This future will be executed in the slint-event loop

                let handle = slint::spawn_blocking(move || {
                    // This closure will be execute in a new std::thread
                    export_big_data()
                });

                match handle.await.expect("Spawn blocking should work") {
                    Ok(_) => info!("File exported successfully"),                    
                    Err(e) => error!("File export error: {e}"),
                }
            })
            .expect("Local spawn should work");
        })
```

Therefore, I added the possibility to run a blocking code into a newly spawned thread, allowing to `.await` it's completion from within the slint event-loop (in a `spawn_local` future).
This allows blocking operations (like large filesystem dump that for a reason or another aren't async) to not block the GUI while still being able to be awaited for proper results and error handling.

NOTE: I'm pretty sure that the code can't be merged as is due to lack of documentation and probably also the fact that this code has the chance to land in another module. Additionally, I'm not sure about the potential restrictions on using `std::sync::mutex` for example.
I placed the code there, where it seemed more appropriate (I took `spawn_local` as example), but since I'm not super familiar with the code base it might still be wrong.
I'm seeking for advice on how to polish this up, and also of course if you see issues or better alternatives to this approach.