### PR TITLE
Use aqua provider for ruff

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -2,10 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 # cspell:ignore pipx
-
-[settings]
-disable_backends = ["aqua"]
-
 [tools]
 
 ## C++:

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -17,7 +17,7 @@ run = "cargo xtask check_license_headers --fix-it"
 ["fix:python:format"]
 description = "Run ruff format"
 run = "ruff format"
-tools = { "aqua:astral-sh/ruff" = "0.11.8" }
+tools = { "ruff" = "0.11.8" }
 
 ["fix:rust:format"]
 description = "Run cargo fmt --all"


### PR DESCRIPTION
The default ruff provider returned a 404 and seems unmaintained.

Note: We have the following in our .mise/config.toml
```toml
[settings]
disable_backends = ["aqua"]
```
So there might have been a reason for why we didn't use aqua, but I cannot get the autofix locally to work otherwise.
