### PR TITLE
Fix `with_global_context` creating a backend when one already exist in another thread

### DIFF
--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -117,6 +117,11 @@ pub fn with_global_context<R>(
     GLOBAL_CONTEXT.with(|p| match p.get() {
         Some(ctx) => Ok(f(ctx)),
         None => {
+            if crate::platform::with_event_loop_proxy(|proxy| proxy.is_some()) {
+                return Err(PlatformError::SetPlatformError(
+                    crate::platform::SetPlatformError::AlreadySet,
+                ));
+            }
             crate::platform::set_platform(factory()?).map_err(PlatformError::SetPlatformError)?;
             Ok(f(p.get().unwrap()))
         }


### PR DESCRIPTION
Before this patch, if one try to use the platform from another thread than the thread in which the global context lives, we would first create the Platform in and then return an error that the platform is already set in another thread.
But instead, we should check that it exist in another thread before creating the platform
