### PR TITLE
Document to-float/is-float in string type documentation

### DIFF
--- a/docs/astro/src/content/docs/reference/primitive-types.mdx
+++ b/docs/astro/src/content/docs/reference/primitive-types.mdx
@@ -81,6 +81,16 @@ export component ChangeCaseOfString {
 }
 ```
 
+The `to-float` method can be used to convert `string` to a `float`. It returns 0 if the string isn’t a valid number. You can check with `is-float` if the string contains a valid number.
+
+```slint
+export component StringToFloat {
+    property<float> hello: "hello".to-float(); // 0
+    property<bool> goodbye: "goodbye".is-float(); // false
+    property<float> value: "1.5".to-float(); // 1.5
+}
+```
+
 </SlintProperty>
 
 ## Numeric Types


### PR DESCRIPTION
This is only mentioned briefly in the Type Conversions section, but if you were just looking at the string type section you would easily miss this.

See #2690

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
