### PR TITLE
Add hide() function for Window

### DIFF
--- a/docs/astro/src/content/docs/reference/window/dialog.mdx
+++ b/docs/astro/src/content/docs/reference/window/dialog.mdx
@@ -42,3 +42,7 @@ Each of these automatically-generated callbacks is an alias for the `clicked` ca
 ## Properties
 
 Same as <Link type="Window"/>.
+
+## Functions
+
+Same as <Link type="Window"/>.

--- a/docs/astro/src/content/docs/reference/window/window.mdx
+++ b/docs/astro/src/content/docs/reference/window/window.mdx
@@ -107,3 +107,8 @@ On mobile devices, virtual keyboards (aka software keyboards or onscreen keyboar
 <SlintProperty propName="virtual-keyboard-height" typeName="length" propertyVisibility="out">
 On mobile devices, virtual keyboards (aka software keyboards or onscreen keyboards) are displayed on top of the application. When such a keyboard is shown, this property denotes the height of the rectangle covered by it in window coordinates or 0 otherwise.
 </SlintProperty>
+
+## Functions
+
+### hide()
+Hide this window.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -328,6 +328,8 @@ component WindowItem {
     in property <length> default-font-size;
     in property <int> default-font-weight;
     in property <image> icon;
+    function hide() {
+    }
 }
 
 export component Window inherits WindowItem {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1404,11 +1404,29 @@ impl WindowItem {
             italic: local_italic,
         }
     }
+
+    pub fn hide(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>) {
+        let _ = WindowInner::from_pub(window_adapter.window()).hide();
+    }
 }
 
 impl ItemConsts for WindowItem {
     const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
         Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
+}
+
+#[cfg(feature = "ffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_windowitem_hide(
+    window_item: Pin<&WindowItem>,
+    window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
+    _self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
+    _self_index: u32,
+) {
+    unsafe {
+        let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
+        window_item.hide(window_adapter);
+    }
 }
 
 declare_item_vtable! {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1571,6 +1571,13 @@ fn call_item_member_function(nr: &NamedReference, local_context: &mut EvalLocalC
                 panic!("internal: Unknown member function {name} called on ContextMenu")
             }
         }
+    } else if let Some(s) = ItemRef::downcast_pin::<corelib::items::WindowItem>(item_ref) {
+        match name {
+            "hide" => s.hide(&window_adapter),
+            _ => {
+                panic!("internal: Unknown member function {name} called on WindowItem")
+            }
+        }
     } else {
         panic!(
             "internal error: member function {name} called on element that doesn't have it: {}",


### PR DESCRIPTION
This was only callable in the native language (e.g. C++ or Rust) but not within Slint itself. I found this useful to avoid setting up a callback just to close a window.

<!--
- [X] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
