### PR TITLE
Add @conic-gradient support to editor tooling

### DIFF
--- a/docs/common/src/utils/slint.tmLanguage.json
+++ b/docs/common/src/utils/slint.tmLanguage.json
@@ -627,7 +627,7 @@
                     "include": "#boolean"
                 },
                 {
-                    "begin": "(@(tr|linear-gradient|radial-gradient|image-url))\\s*(\\()",
+                    "begin": "(@(tr|linear-gradient|radial-gradient|conic-gradient|image-url))\\s*(\\()",
                     "end": "(\\))",
                     "beginCaptures": {
                         "1": {

--- a/editors/kate/slint.ksyntaxhighlighter.xml
+++ b/editors/kate/slint.ksyntaxhighlighter.xml
@@ -47,6 +47,7 @@
       <item>@image-url</item>
       <item>@linear-gradient</item>
       <item>@radial-gradient</item>
+      <item>@conic-gradient</item>
     </list>
     <contexts>
       <context attribute="Normal Text" lineEndContext="#stay" name="Normal Text">

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -553,9 +553,23 @@ module.exports = grammar({
           ),
           ")",
         ),
+        seq(
+          field("name", $.conic_gradient_identifier),
+          "(",
+          field(
+            "arguments",
+            seq(
+              optional(seq("from", field("from_angle", $.angle_value), ",")),
+              field("colors", commaSep2($.conic_gradient_color)),
+              optional(","),
+            ),
+          ),
+          ")",
+        ),
       ),
 
     gradient_color: ($) => seq($.argument, optional($.percent_value)),
+    conic_gradient_color: ($) => seq($.argument, $.angle_value),
 
     image_call: ($) =>
       seq(
@@ -712,6 +726,8 @@ module.exports = grammar({
     radial_gradient_identifier: (_) =>
       choice("@radial-gradient", "@radial_gradient"),
     radial_gradient_kind: (_) => choice("circle"),
+    conic_gradient_identifier: (_) =>
+      choice("@conic-gradient", "@conic_gradient"),
 
     reference_identifier: (_) => choice("parent", "root", "self"),
 

--- a/editors/zed/languages/slint/highlights.scm
+++ b/editors/zed/languages/slint/highlights.scm
@@ -177,6 +177,7 @@
   (linear_gradient_identifier)
   (radial_gradient_identifier)
   (radial_gradient_kind)
+  (conic_gradient_identifier)
 ] @attribute
 
 (image_call

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -209,6 +209,7 @@ pub(crate) fn completion_at(
                     ("image-url", "image-url(\"$1\")"),
                     ("linear-gradient", "linear-gradient($1)"),
                     ("radial-gradient", "radial-gradient(circle, $1)"),
+                    ("conic-gradient", "conic-gradient($1)"),
                 ]
                 .into_iter()
                 .map(|(label, insert)| {


### PR DESCRIPTION
- Tree-sitter grammar: conic_gradient_identifier and conic_gradient_color
- TextMate grammar: syntax highlighting for @conic-gradient
- LSP: completion support for @conic-gradient

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
