### PR TITLE
fix(safe-ui): restore no_std compatibility for embedded builds

### DIFF
--- a/examples/safe-ui/core/Cargo.toml
+++ b/examples/safe-ui/core/Cargo.toml
@@ -23,7 +23,7 @@ pixel-rgb888 = []
 
 [dependencies]
 bytemuck = "1.24.0"
-slint = { path = "../../../api/rs/slint", features = ["compat-1-2", "renderer-software", "libm", "unsafe-single-threaded"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-2", "renderer-software", "libm", "unsafe-single-threaded"] }
 
 [build-dependencies]
 bindgen = "0.72.1"

--- a/examples/safe-ui/simulator/Cargo.toml
+++ b/examples/safe-ui/simulator/Cargo.toml
@@ -16,6 +16,6 @@ pixel-rgb888 = ["slint-safeui-core/pixel-rgb888"]
 
 [dependencies]
 bytemuck = "1.24.0"
-slint = { path = "../../../api/rs/slint", features = ["backend-winit"] }
+slint = { path = "../../../api/rs/slint" }
 slint-safeui-core = { path = "../core" }
 smol = "2.0.0"


### PR DESCRIPTION
In the workspace refactoring, `default-features = false` was accidentally omitted from the slint dependency in core/Cargo.toml in [this CI related fixup](https://github.com/slint-ui/slint/pull/10405#event-22020962189)

This caused the build to fail on no_std targets because slint's default features include std-dependent crates.

Restores the original configuration to ensure compatibility with embedded targets like thumbv8m.main-none-eabihf.

Fixes: #10405